### PR TITLE
Expose product-owned accessibility facets

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -607,7 +607,7 @@ Research overlay bridge, and the application layer:
 │                                                             │
 │  Workspace and binding-consistent assembly context groups   │
 │  Typed per-assembly and group-query coordination             │
-│  ApiInventoryQuery          type/member inventory facets    │
+│  ApiInventoryQuery          kind/accessibility facets       │
 ├─────────────────────────────────────────────────────────────┤
 │  ILInspector.Research (Fact overlay bridge)                 │
 │                                                             │

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -109,14 +109,23 @@ disclosure mode used to select the property.
 
 Aggregate MethodImpl classification compares reader-local structural interface
 identity and substituted method signatures. Resolution scope, generic
-arguments, primitive metadata names, and array shape participate in the match;
-C# display spelling does not.
+arguments, primitive metadata names, raw type kind, nested-name segments, exact
+array shape, modifiers, and function-pointer signatures participate in the
+match. Assembly scopes use metadata-equivalent normalized identity, repeated
+scope decoding is cached, and oversized identity blobs fail visibly before
+materialization. C# display spelling does not participate in structural
+identity; narrowly owned aggregate aliases cover native-integer metadata names
+and compiler-synthesized `this[]` indexers.
 `MetadataDeclarationQueryTests.TypeSurface_ClassifiesGenericExplicitInterfaceAggregates`,
 `MetadataDeclarationQueryTests.ExplicitAggregateIdentity_RejectsSignatureIncompatibleMethodImplTargets`,
+`MetadataDeclarationQueryTests.ExplicitInterfaceTypeIdentity_DistinguishesArrayShapesAndAssemblyEquivalence`,
+`MetadataDeclarationQueryTests.ExplicitInterfaceTypeIdentity_RejectsOversizedAssemblyIdentityBlob`,
+`MetadataDeclarationQueryTests.ExplicitAggregateIdentity_AcceptsIndexerMetadataAlias`,
+`MetadataDeclarationQueryTests.TypeSurface_ClassifiesNativeIntegerExplicitInterfaceAggregates`,
 and
 `CSharpTypePrinterTests.GenericExplicitInterfaceAggregatesCompileBack` gate the
-generic, alias, array, close-negative, producer-parity, and C# projection
-contract.
+generic, alias, array, scope-coherence, close-negative, producer-parity, and C#
+projection contract.
 
 #### `ILInspector.Analysis`
 

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -97,15 +97,45 @@ intersect across kind and accessibility. Unknown IDs and unclassified producer
 values fail visibly rather than becoming an empty inventory. The contract is
 gated by `ApiInventoryQueryTests`. An explicit interface implementation retains
 its accessibility fact and typed MethodImpl identity in the model and structured
-output, including for aggregate properties and events. Human-facing renderers
-suppress metadata-private accessibility for explicit implementations, and
-suppress finalizer accessibility, because those prefixes are redundant with the
-product-owned identity or illegal in the corresponding C# spelling. Other raw
-accessibility values remain visible in lowered labels and structured output;
-C# projection fails closed for a non-private explicit implementation because
-C# has no legal spelling that preserves both facts. Property accessor
-accessibility is likewise a metadata fact and does not change with the
-disclosure mode used to select the property.
+output, including for aggregate properties and events.
+`InterfaceImplementationResolution` distinguishes a MethodImpl whose target is
+proven to belong to the implemented-interface closure from one whose external
+inherited-interface relationship cannot be decided from the inspected image.
+The latter remains visible as `Undetermined`; it is never silently reclassified
+as an ordinary method. Same-image non-generic interface inheritance is walked
+with the repository relationship bound. Constructed inherited interfaces are
+not conflated across type arguments: an exact direct identity is proven, while
+an inherited generic definition that cannot be proven without that
+substitution remains undetermined.
+
+Virtual-slot facts remain independent from MethodImpl identity.
+`IsNewSlot` and `IsFinal` retain the raw metadata flags; override is derived
+from `Virtual && !NewSlot`, and sealed override from `Final && Override`.
+Ordinary implicit-interface C# syntax requires proven interface membership,
+an ordinary method target rather than a property or event accessor, matching
+method names and signatures, and equivalent generic-parameter constraints for
+every target. An unresolved external MemberRef target cannot establish those
+semantics.
+
+Human-facing inventory uses an explicitly labeled metadata fallback when raw
+MethodImpl or accessor facts have no faithful C# declaration. Strict source
+projection still fails closed. A property may spell at most one strictly more
+restrictive accessor; incomparable accessor accessibilities are metadata-only.
+Event add/remove accessibility must be equal because C# has no accessor
+modifier syntax for events. `AccessorFacts` preserves the raw rows through the
+strict printer snapshot even when presentation accessors are reduced.
+`MetadataDeclarationQueryTests.MethodImplProjectionRequiresCategoryConstraintsAndInterfaceClosure`,
+`CommandExecutionTests.Member_VisualBasicMethodImplInventoryUsesMetadataFallback`,
+`CSharpDeclarationWriterTests.IncomparablePropertyAccessorAccessibilityFailsStrictProjection`,
+`CSharpDeclarationWriterTests.UnequalEventAccessorAccessibilityFailsStrictProjection`,
+and
+`CSharpTypePrinterTests.StrictPrinterSnapshotPreservesAccessorAccessibilityFacts`
+gate these boundaries.
+
+Effective public type extraction also walks the bounded declaring-type chain:
+a `NestedPublic` leaf is public only when every declaring type is externally
+visible. Include-all extraction retains the raw nested type, and focused
+metadata inspection keeps its leaf accessibility.
 
 Aggregate MethodImpl classification compares reader-local structural interface
 identity and substituted method signatures. Resolution scope, generic

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -107,6 +107,17 @@ C# has no legal spelling that preserves both facts. Property accessor
 accessibility is likewise a metadata fact and does not change with the
 disclosure mode used to select the property.
 
+Aggregate MethodImpl classification compares reader-local structural interface
+identity and substituted method signatures. Resolution scope, generic
+arguments, primitive metadata names, and array shape participate in the match;
+C# display spelling does not.
+`MetadataDeclarationQueryTests.TypeSurface_ClassifiesGenericExplicitInterfaceAggregates`,
+`MetadataDeclarationQueryTests.ExplicitAggregateIdentity_RejectsSignatureIncompatibleMethodImplTargets`,
+and
+`CSharpTypePrinterTests.GenericExplicitInterfaceAggregatesCompileBack` gate the
+generic, alias, array, close-negative, producer-parity, and C# projection
+contract.
+
 #### `ILInspector.Analysis`
 
 | Currency | Scope | Answers | Does not answer |

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -96,11 +96,14 @@ only default accessibility, while selections union within a facet axis and
 intersect across kind and accessibility. Unknown IDs and unclassified producer
 values fail visibly rather than becoming an empty inventory. The contract is
 gated by `ApiInventoryQueryTests`. An explicit interface implementation retains
-its accessibility fact in the typed model and structured output. Human-facing
-renderers suppress metadata-private accessibility for that kind, and suppress
-finalizer accessibility, because those prefixes are redundant with the
-product-owned kind or illegal in the corresponding C# spelling; other raw
-accessibility values remain visible.
+its accessibility fact and typed MethodImpl identity in the model and structured
+output, including for aggregate properties and events. Human-facing renderers
+suppress metadata-private accessibility for explicit implementations, and
+suppress finalizer accessibility, because those prefixes are redundant with the
+product-owned identity or illegal in the corresponding C# spelling; other raw
+accessibility values remain visible. Property accessor accessibility is likewise
+a metadata fact and does not change with the disclosure mode used to select the
+property.
 
 #### `ILInspector.Analysis`
 

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -100,10 +100,12 @@ its accessibility fact and typed MethodImpl identity in the model and structured
 output, including for aggregate properties and events. Human-facing renderers
 suppress metadata-private accessibility for explicit implementations, and
 suppress finalizer accessibility, because those prefixes are redundant with the
-product-owned identity or illegal in the corresponding C# spelling; other raw
-accessibility values remain visible. Property accessor accessibility is likewise
-a metadata fact and does not change with the disclosure mode used to select the
-property.
+product-owned identity or illegal in the corresponding C# spelling. Other raw
+accessibility values remain visible in lowered labels and structured output;
+C# projection fails closed for a non-private explicit implementation because
+C# has no legal spelling that preserves both facts. Property accessor
+accessibility is likewise a metadata fact and does not change with the
+disclosure mode used to select the property.
 
 #### `ILInspector.Analysis`
 

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -115,7 +115,12 @@ match. Assembly scopes use metadata-equivalent normalized identity, repeated
 scope decoding is cached, and oversized identity blobs fail visibly before
 materialization. C# display spelling does not participate in structural
 identity; narrowly owned aggregate aliases cover native-integer metadata names
-and compiler-synthesized `this[]` indexers.
+and compiler-synthesized `this[]` indexers. Whole-surface extraction indexes
+MethodImpl rows without decoding their targets, then performs charged structural
+projection only after the owning member passes the selected extraction scope.
+Projection credit commits only with the retained type, so discarded inventory
+cannot exhaust a public walk and one hostile candidate cannot finance its own
+expansion.
 `MetadataDeclarationQueryTests.TypeSurface_ClassifiesGenericExplicitInterfaceAggregates`,
 `MetadataDeclarationQueryTests.ExplicitAggregateIdentity_RejectsSignatureIncompatibleMethodImplTargets`,
 `MetadataDeclarationQueryTests.ExplicitInterfaceTypeIdentity_DistinguishesArrayShapesAndAssemblyEquivalence`,

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -96,9 +96,11 @@ only default accessibility, while selections union within a facet axis and
 intersect across kind and accessibility. Unknown IDs and unclassified producer
 values fail visibly rather than becoming an empty inventory. The contract is
 gated by `ApiInventoryQueryTests`. An explicit interface implementation retains
-its metadata-private accessibility fact in the typed model and structured
-output; human-facing renderers suppress that prefix where C# syntax or a
-product-owned kind label already carries the same meaning.
+its accessibility fact in the typed model and structured output. Human-facing
+renderers suppress metadata-private accessibility for that kind, and suppress
+finalizer accessibility, because those prefixes are redundant with the
+product-owned kind or illegal in the corresponding C# spelling; other raw
+accessibility values remain visible.
 
 #### `ILInspector.Analysis`
 

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -95,7 +95,10 @@ compound accessibilities retain distinct producer-owned facets. Public is the
 only default accessibility, while selections union within a facet axis and
 intersect across kind and accessibility. Unknown IDs and unclassified producer
 values fail visibly rather than becoming an empty inventory. The contract is
-gated by `ApiInventoryQueryTests`.
+gated by `ApiInventoryQueryTests`. An explicit interface implementation retains
+its metadata-private accessibility fact in the typed model and structured
+output; human-facing renderers suppress that prefix where C# syntax or a
+product-owned kind label already carries the same meaning.
 
 #### `ILInspector.Analysis`
 

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -80,17 +80,22 @@ of repeated in every row.
 
 | Currency | Scope | Answers | Does not answer |
 | --- | --- | --- | --- |
-| `ApiFacetDescriptor`, `ApiTypeInventoryResult`, `ApiMemberInventoryResult` | One materialized API inventory query | Stable filter identity, labels, ordering, defaults, counts, and the selected projection | Raw metadata kind or member identity |
+| `ApiFacetDescriptor`, `ApiTypeInventoryResult`, `ApiMemberInventoryResult` | One materialized API inventory query | Stable kind/accessibility filter identity, labels, ordering, defaults, counts, and the selected projection | Raw metadata kind, accessibility spelling, or member identity |
 | `InspectionGraphMemberIdentity.AcquiredApi` | One loaded workspace context | Which acquisition registration and `MemberAnchor` own a Metadata API member subject | Portable artifact identity or body evidence |
 | `InspectionGraphTypeIdentity.AcquiredDefinition` | One loaded workspace context | Which acquisition registration and exact `MetadataTypeDefinitionName` own a type subject | Cross-context correspondence or structural signature shape |
 | `InspectionGraphAssemblyIdentity.Acquired` | One loaded workspace context | Which acquisition registration, assembly identity, and provenance own an assembly subject in a session-bound graph | Portable artifact identity or correspondence outside that acquisition |
 | `InspectionGraphPackageIdentity.Realized` | One portable inspection-graph subject | Which exact package version, producer, framework, and RID own the package subject | Assembly membership without the workspace package-boundary projection |
 
-`ApiType.Kind` and `ApiMember.Kind` remain raw product facts. Consumers do not
-parse them or own a parallel grouping vocabulary: `ApiInventoryQuery` maps each
-item into one product-owned kind facet and accepts the returned opaque IDs for
-filtering. Unknown IDs and unclassified producer values fail visibly rather
-than becoming an empty inventory.
+`ApiType.Kind`, `ApiMember.Kind`, and their `Accessibility` values remain raw
+product facts. Consumers do not parse them or own a parallel grouping
+vocabulary: `ApiInventoryQuery` maps each item into exactly one product-owned
+kind facet and one accessibility facet, then accepts the returned opaque IDs
+for filtering. Missing accessibility is the public metadata projection;
+compound accessibilities retain distinct producer-owned facets. Public is the
+only default accessibility, while selections union within a facet axis and
+intersect across kind and accessibility. Unknown IDs and unclassified producer
+values fail visibly rather than becoming an empty inventory. The contract is
+gated by `ApiInventoryQueryTests`.
 
 #### `ILInspector.Analysis`
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -663,7 +663,12 @@ reallocating the index for each attribute. The same cache is used on the
 unbounded path, which is the public `AssemblyReader.ExtractApiSurface` route. Enum-default classification also
 charges base-type names before resolving them. Decode failures may skip malformed
 attributes, but a budget-observer failure must escape the decoder and produce
-typed truncation. The Browser separately applies the same bound while deriving
+typed truncation. MethodImpl rows are indexed without structural decoding;
+explicit-interface targets and signatures are projected only for members
+admitted by the extraction scope. Their projected text earns cumulative
+decode-work credit only after the owning type commits, so discarded inventory
+does not consume that work allowance and one candidate cannot finance its own
+amplification. The Browser separately applies the same bound while deriving
 type/member transport records, including canonical signatures, documentation
 IDs, and graph selectors that repeat declaring-type identity. It preflights
 each source model against the budget remaining after committed and pending
@@ -732,6 +737,9 @@ pre-decoding rejection.
 `EnclosingTypeNameChain_StopsBeforeLargeAllocationAmplification`,
 `EnclosingTypeReferenceChain_StopsBeforeLargeAllocationAmplification`,
 `RejectedTypes_SpendDecodeWorkAcrossTheExtraction`,
+`ExplicitInterfaceProjection_SpendsDecodeWorkBudget`,
+`DiscardedMethodImplBodies_DoNotSpendProjectionBudget`,
+`CoreLibraryPublicExtraction_CompletesWithinFiniteBounds`,
 `LargeTransformArray_StopsBeforeLargeAllocationAmplification`,
 `RepeatedMethodGenericContext_ReusesTypeParameterNames`,
 `OneHugeArrayRank_StopsBeforeLargeAllocationAmplification`,

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -252,6 +252,9 @@ public class ApiInventoryQueryTests
             Assert.All(
                 explicitMembers,
                 member => Assert.Equal("private", member.Accessibility));
+            Assert.All(
+                explicitMembers,
+                member => Assert.False(member.CanUseImplicitInterfaceSyntax));
             Assert.Contains(
                 explicitMembers,
                 member => member.Kind == "explicit-interface-implementation"

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -339,6 +339,12 @@ public class ApiInventoryQueryTests
         Assert.Equal("method", staticConstructor.Kind);
 
         var result = ApiInventoryQuery.Members(type);
+        var allAccessibilities = result.AccessibilityFacets
+            .Select(facet => facet.Id)
+            .ToList();
+        result = ApiInventoryQuery.Members(
+            type,
+            new ApiMemberInventoryRequest(AccessibilityFacetIds: allAccessibilities));
         var constructorFacet = Assert.Single(
             result.KindFacets,
             facet => facet.SingularLabel == "constructor");
@@ -349,13 +355,17 @@ public class ApiInventoryQueryTests
         Assert.Contains(
             ApiInventoryQuery.Members(
                 type,
-                new ApiMemberInventoryRequest([constructorFacet.Id]))
+                new ApiMemberInventoryRequest(
+                    [constructorFacet.Id],
+                    allAccessibilities))
             .Members,
             member => ReferenceEquals(member, staticConstructor));
         Assert.DoesNotContain(
             ApiInventoryQuery.Members(
                 type,
-                new ApiMemberInventoryRequest([methodFacet.Id]))
+                new ApiMemberInventoryRequest(
+                    [methodFacet.Id],
+                    allAccessibilities))
             .Members,
             member => ReferenceEquals(member, staticConstructor));
     }

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -1,5 +1,8 @@
 using DotnetInspector.Queries;
 using ILInspector.Metadata;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 namespace DotnetInspector.Queries.Tests;
@@ -379,6 +382,30 @@ public class ApiInventoryQueryTests
     }
 
     [Fact]
+    public void Members_PrivateScopeMetadataFlowsToPrivateFacet()
+    {
+        using var peReader = new PEReader(new MemoryStream(BuildPrivateScopeImage()));
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        ApiType type = Assert.Single(surface.Types, candidate => candidate.Name == "PrivateScopeHost");
+        ApiMemberInventoryResult catalog = ApiInventoryQuery.Members(type);
+        ApiFacetDescriptor privateFacet = Assert.Single(
+            catalog.AccessibilityFacets,
+            facet => facet.SingularLabel == "private");
+
+        ApiMemberInventoryResult result = ApiInventoryQuery.Members(
+            type,
+            new ApiMemberInventoryRequest(AccessibilityFacetIds: [privateFacet.Id]));
+
+        Assert.Equal(2, result.Members.Count);
+        Assert.Contains(result.Members, member => member.Name == "HiddenField");
+        Assert.Contains(result.Members, member => member.Name == "HiddenMethod");
+        Assert.All(result.Members, member => Assert.Equal("private", member.Accessibility));
+        Assert.DoesNotContain(
+            result.Members,
+            member => string.IsNullOrEmpty(member.Accessibility));
+    }
+
+    [Fact]
     public void Selection_RejectsUnknownFacetIds()
     {
         var surface = new ApiSurface
@@ -441,6 +468,67 @@ public class ApiInventoryQueryTests
         };
         Assert.Throws<InvalidOperationException>(
             () => ApiInventoryQuery.Types(unknownAccessibility));
+    }
+
+    private static byte[] BuildPrivateScopeImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("PrivateScope.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("PrivateScope"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Fixtures"),
+            metadata.GetOrAddString("PrivateScopeHost"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var fieldSignature = new BlobBuilder();
+        fieldSignature.WriteByte(0x06); // FIELD
+        fieldSignature.WriteByte(0x08); // ELEMENT_TYPE_I4
+        metadata.AddFieldDefinition(
+            FieldAttributes.PrivateScope,
+            metadata.GetOrAddString("HiddenField"),
+            metadata.GetOrAddBlob(fieldSignature));
+
+        var methodSignature = new BlobBuilder();
+        methodSignature.WriteByte(0x00); // DEFAULT
+        methodSignature.WriteByte(0x00); // parameter count
+        methodSignature.WriteByte(0x01); // ELEMENT_TYPE_VOID
+        metadata.AddMethodDefinition(
+            MethodAttributes.PrivateScope | MethodAttributes.Static,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("HiddenMethod"),
+            metadata.GetOrAddBlob(methodSignature),
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
     }
 }
 

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -473,25 +473,57 @@ public class ApiInventoryQueryTests
             candidate => candidate.Name == "ReservedAccessibilityHost");
         Assert.Contains(type.Members, member => member.Name == "GoodMethod");
         Assert.Contains(type.Members, member => member.Name == "GoodField");
-        Assert.DoesNotContain(type.Members, member => member.Name == "BadMethod");
+        Assert.DoesNotContain(type.Members, member => member.Name == "Contracts.IProbe.BadMethod");
         Assert.DoesNotContain(type.Members, member => member.Name == "BadField");
 
         MetadataReader reader = peReader.GetMetadataReader();
         TypeDefinitionHandle typeHandle = reader.TypeDefinitions.Single(handle =>
             reader.GetString(reader.GetTypeDefinition(handle).Name) == "ReservedAccessibilityHost");
         MethodDefinitionHandle badMethod = reader.GetTypeDefinition(typeHandle).GetMethods().Single(handle =>
-            reader.GetString(reader.GetMethodDefinition(handle).Name) == "BadMethod");
+            reader.GetString(reader.GetMethodDefinition(handle).Name) == "Contracts.IProbe.BadMethod");
+        MethodDefinitionHandle badGetter = reader.GetTypeDefinition(typeHandle).GetMethods().Single(handle =>
+            reader.GetString(reader.GetMethodDefinition(handle).Name) == "get_BadProperty");
+        MethodDefinitionHandle badAdder = reader.GetTypeDefinition(typeHandle).GetMethods().Single(handle =>
+            reader.GetString(reader.GetMethodDefinition(handle).Name) == "add_BadEvent");
         FieldDefinitionHandle badField = reader.GetTypeDefinition(typeHandle).GetFields().Single(handle =>
             reader.GetString(reader.GetFieldDefinition(handle).Name) == "BadField");
+        PropertyDefinitionHandle badProperty = reader.GetTypeDefinition(typeHandle).GetProperties().Single();
+        EventDefinitionHandle badEvent = reader.GetTypeDefinition(typeHandle).GetEvents().Single();
         Assert.Equal(
-            new Dictionary<string, int>
+            new[]
             {
-                ["method accessibility"] = MetadataTokens.GetToken(badMethod),
-                ["field accessibility"] = MetadataTokens.GetToken(badField)
+                ("event accessibility", MetadataTokens.GetToken(badEvent)),
+                ("field accessibility", MetadataTokens.GetToken(badField)),
+                ("method accessibility", MetadataTokens.GetToken(badMethod)),
+                ("method accessibility", MetadataTokens.GetToken(badGetter)),
+                ("method accessibility", MetadataTokens.GetToken(badAdder)),
+                ("property accessibility", MetadataTokens.GetToken(badProperty))
             },
-            surface.InspectionFailures.ToDictionary(
-                failure => failure.Operation,
-                failure => failure.SubjectToken));
+            surface.InspectionFailures
+                .Select(failure => (failure.Operation, failure.SubjectToken))
+                .OrderBy(failure => failure.Operation)
+                .ThenBy(failure => failure.SubjectToken));
+
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
+        ApiType summarized = Assert.Single(
+            summary.Types,
+            candidate => candidate.Name == "ReservedAccessibilityHost");
+        Assert.Contains(summarized.Members, member => member.Name == "GoodMethod");
+        Assert.Contains(summarized.Members, member => member.Name == "GoodField");
+        Assert.DoesNotContain(
+            summarized.Members,
+            member => member.Name == "Contracts.IProbe.BadMethod");
+        Assert.DoesNotContain(summarized.Members, member => member.Name == "BadField");
+        Assert.Equal(
+            surface.InspectionFailures
+                .Select(failure => (failure.Operation, failure.SubjectToken))
+                .OrderBy(failure => failure.Operation)
+                .ThenBy(failure => failure.SubjectToken),
+            summary.InspectionFailures
+                .Select(failure => (failure.Operation, failure.SubjectToken))
+                .OrderBy(failure => failure.Operation)
+                .ThenBy(failure => failure.SubjectToken));
+
         Assert.Throws<BadImageFormatException>(
             () => MetadataDeclarationQuery.GetTypeSurface(
                 reader,
@@ -755,13 +787,25 @@ public class ApiInventoryQueryTests
             baseType: default,
             fieldList: MetadataTokens.FieldDefinitionHandle(1),
             methodList: MetadataTokens.MethodDefinitionHandle(1));
-        metadata.AddTypeDefinition(
+        TypeDefinitionHandle type = metadata.AddTypeDefinition(
             TypeAttributes.Public,
             metadata.GetOrAddString("Fixtures"),
             metadata.GetOrAddString("ReservedAccessibilityHost"),
             baseType: default,
             fieldList: MetadataTokens.FieldDefinitionHandle(1),
             methodList: MetadataTokens.MethodDefinitionHandle(1));
+        AssemblyReferenceHandle contractsAssembly = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Contracts"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        TypeReferenceHandle interfaceType = metadata.AddTypeReference(
+            contractsAssembly,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("IProbe"));
+        metadata.AddInterfaceImplementation(type, interfaceType);
 
         var fieldSignature = new BlobBuilder();
         fieldSignature.WriteByte(0x06); // FIELD
@@ -788,13 +832,59 @@ public class ApiInventoryQueryTests
             methodSignatureHandle,
             bodyOffset: 0,
             parameterList: MetadataTokens.ParameterHandle(1));
-        metadata.AddMethodDefinition(
+        MethodDefinitionHandle badMethod = metadata.AddMethodDefinition(
             (MethodAttributes)0x0007 | MethodAttributes.Static,
             MethodImplAttributes.Runtime,
-            metadata.GetOrAddString("BadMethod"),
+            metadata.GetOrAddString("Contracts.IProbe.BadMethod"),
             methodSignatureHandle,
             bodyOffset: 0,
             parameterList: MetadataTokens.ParameterHandle(1));
+        MemberReferenceHandle interfaceMethod = metadata.AddMemberReference(
+            interfaceType,
+            metadata.GetOrAddString("BadMethod"),
+            methodSignatureHandle);
+        metadata.AddMethodImplementation(type, badMethod, interfaceMethod);
+
+        MethodDefinitionHandle badGetter = metadata.AddMethodDefinition(
+            (MethodAttributes)0x0007 | MethodAttributes.Static | MethodAttributes.SpecialName,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("get_BadProperty"),
+            metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x08 }),
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        PropertyDefinitionHandle badProperty = metadata.AddProperty(
+            PropertyAttributes.None,
+            metadata.GetOrAddString("BadProperty"),
+            metadata.GetOrAddBlob(new byte[] { 0x08, 0x00, 0x08 }));
+        metadata.AddPropertyMap(type, badProperty);
+        metadata.AddMethodSemantics(
+            badProperty,
+            MethodSemanticsAttributes.Getter,
+            badGetter);
+
+        var eventAccessorSignature = new BlobBuilder();
+        new BlobEncoder(eventAccessorSignature)
+            .MethodSignature()
+            .Parameters(
+                1,
+                returnType => returnType.Void(),
+                parameters => parameters.AddParameter().Type().Type(type, isValueType: false));
+        MethodDefinitionHandle badAdder = metadata.AddMethodDefinition(
+            (MethodAttributes)0x0007 | MethodAttributes.Static | MethodAttributes.SpecialName,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("add_BadEvent"),
+            metadata.GetOrAddBlob(eventAccessorSignature),
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        EventDefinitionHandle badEvent = metadata.AddEvent(
+            EventAttributes.None,
+            metadata.GetOrAddString("BadEvent"),
+            type);
+        metadata.AddEventMap(type, badEvent);
+        metadata.AddMethodSemantics(
+            badEvent,
+            MethodSemanticsAttributes.Adder,
+            badAdder);
 
         var pe = new ManagedPEBuilder(
             PEHeaderBuilder.CreateLibraryHeader(),

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -159,7 +159,8 @@ public class ApiInventoryQueryTests
         ApiMember finalizer = Assert.Single(type.Members, member => member.Kind == "finalizer");
         ApiMember explicitImplementation = Assert.Single(
             type.Members,
-            member => member.Kind == "explicit-interface-implementation");
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(".Explicit", StringComparison.Ordinal));
         Assert.Equal("protected", finalizer.Accessibility);
         Assert.Equal("private", explicitImplementation.Accessibility);
         Assert.DoesNotContain(finalizer, catalog.Members);
@@ -199,6 +200,48 @@ public class ApiInventoryQueryTests
             Assert.Single(
                 privateMethods.KindFacets,
                 facet => facet.Id == methodFacet.Id).Count);
+    }
+
+    [Fact]
+    public void ExtractSummary_PreservesExplicitInterfaceFacets()
+    {
+        using var stream = File.OpenRead(typeof(ApiInventoryQueryTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
+        ApiType type = Assert.Single(
+            summary.Types,
+            candidate => candidate.FullName == typeof(InventoryFixture).FullName);
+        ApiMember[] explicitMembers = type.Members
+            .Where(member => member.IsExplicitInterfaceImplementation)
+            .ToArray();
+
+        Assert.Equal(4, explicitMembers.Length);
+        Assert.All(
+            explicitMembers,
+            member => Assert.Equal("private", member.Accessibility));
+        Assert.Contains(
+            explicitMembers,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(".Explicit", StringComparison.Ordinal));
+        Assert.Contains(
+            explicitMembers,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(
+                    ".get_ExplicitProperty",
+                    StringComparison.Ordinal));
+        Assert.Contains(
+            explicitMembers,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(
+                    ".add_ExplicitChanged",
+                    StringComparison.Ordinal));
+        Assert.Contains(
+            explicitMembers,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(
+                    ".remove_ExplicitChanged",
+                    StringComparison.Ordinal));
     }
 
     [Fact]
@@ -459,6 +502,15 @@ public class ApiInventoryQueryTests
                 reader,
                 typeHandle,
                 includeNonPublicMembers: true));
+
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
+        ApiType summarized = Assert.Single(
+            summary.Types,
+            candidate => candidate.Name == "AccessorlessHost");
+        Assert.Empty(summarized.Members);
+        ApiSurfaceInspectionFailure summaryFailure =
+            Assert.Single(summary.InspectionFailures);
+        Assert.Equal("property accessors", summaryFailure.Operation);
     }
 
     [Fact]
@@ -531,6 +583,26 @@ public class ApiInventoryQueryTests
                 includeNonPublicMembers: true));
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void FocusedQuery_ValidatesGeneratedNameAccessibilityBeforeSkipping(
+        bool method)
+    {
+        using var peReader = new PEReader(
+            new MemoryStream(BuildReservedGeneratedNameImage(method)));
+        MetadataReader reader = peReader.GetMetadataReader();
+        TypeDefinitionHandle typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+                == "GeneratedNameHost");
+
+        Assert.Throws<BadImageFormatException>(
+            () => MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                typeHandle,
+                includeNonPublicMembers: true));
+    }
+
     [Fact]
     public void Extract_EventAccessibilityUsesBothAccessorsAndRetainsRemoveOnlyEvents()
     {
@@ -570,6 +642,34 @@ public class ApiInventoryQueryTests
             typeHandle,
             includeNonPublicMembers: true);
         Assert.Single(queried.Members, member => member.Name == "Broken");
+    }
+
+    [Fact]
+    public void ExtractSummary_InconsistentSealedAccessorsRecordVisibleFailures()
+    {
+        using var peReader = new PEReader(
+            new MemoryStream(BuildInconsistentSealedAccessorImage()));
+
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
+        ApiType type = Assert.Single(
+            summary.Types,
+            candidate => candidate.Name == "InconsistentSealedHost");
+
+        Assert.DoesNotContain(
+            type.Members,
+            member => member.Kind is "property" or "event");
+        Assert.Equal(
+            ["event modifiers", "property modifiers"],
+            summary.InspectionFailures
+                .Select(failure => failure.Operation)
+                .Order()
+                .ToArray());
+        Assert.All(
+            summary.InspectionFailures,
+            failure => Assert.Contains(
+                "inconsistent sealed accessor",
+                failure.Detail,
+                StringComparison.Ordinal));
     }
 
     [Fact]
@@ -990,11 +1090,201 @@ public class ApiInventoryQueryTests
         pe.Serialize(image);
         return image.ToArray();
     }
+
+    private static byte[] BuildReservedGeneratedNameImage(bool method)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("GeneratedName.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("GeneratedName"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Fixtures"),
+            metadata.GetOrAddString("GeneratedNameHost"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        if (method)
+        {
+            metadata.AddMethodDefinition(
+                (MethodAttributes)0x0007 | MethodAttributes.Static,
+                MethodImplAttributes.Runtime,
+                metadata.GetOrAddString("<HiddenMethod>"),
+                metadata.GetOrAddBlob(new byte[] { 0x00, 0x00, 0x01 }),
+                bodyOffset: 0,
+                parameterList: MetadataTokens.ParameterHandle(1));
+        }
+        else
+        {
+            metadata.AddFieldDefinition(
+                (FieldAttributes)0x0007 | FieldAttributes.Static,
+                metadata.GetOrAddString("<HiddenField>"),
+                metadata.GetOrAddBlob(new byte[] { 0x06, 0x08 }));
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    private static byte[] BuildInconsistentSealedAccessorImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("InconsistentSealed.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("InconsistentSealed"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle type = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Fixtures"),
+            metadata.GetOrAddString("InconsistentSealedHost"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        const MethodAttributes accessor =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+
+        var getterSignature = new BlobBuilder();
+        new BlobEncoder(getterSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(0, returnType => returnType.Type().Int32(), _ => { });
+        MethodDefinitionHandle getter = metadata.AddMethodDefinition(
+            accessor | MethodAttributes.Final,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("get_Value"),
+            metadata.GetOrAddBlob(getterSignature),
+            bodyOffset: 0,
+            MetadataTokens.ParameterHandle(1));
+        var setterSignature = new BlobBuilder();
+        new BlobEncoder(setterSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                1,
+                returnType => returnType.Void(),
+                parameters => parameters.AddParameter().Type().Int32());
+        MethodDefinitionHandle setter = metadata.AddMethodDefinition(
+            accessor,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("set_Value"),
+            metadata.GetOrAddBlob(setterSignature),
+            bodyOffset: 0,
+            MetadataTokens.ParameterHandle(1));
+        var propertySignature = new BlobBuilder();
+        new BlobEncoder(propertySignature)
+            .PropertySignature(isInstanceProperty: true)
+            .Parameters(0, returnType => returnType.Type().Int32(), _ => { });
+        PropertyDefinitionHandle property = metadata.AddProperty(
+            PropertyAttributes.None,
+            metadata.GetOrAddString("Value"),
+            metadata.GetOrAddBlob(propertySignature));
+        metadata.AddPropertyMap(type, property);
+        metadata.AddMethodSemantics(
+            property,
+            MethodSemanticsAttributes.Getter,
+            getter);
+        metadata.AddMethodSemantics(
+            property,
+            MethodSemanticsAttributes.Setter,
+            setter);
+
+        var eventSignature = new BlobBuilder();
+        new BlobEncoder(eventSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                1,
+                returnType => returnType.Void(),
+                parameters => parameters.AddParameter().Type().Type(
+                    type,
+                    isValueType: false));
+        BlobHandle eventSignatureHandle = metadata.GetOrAddBlob(eventSignature);
+        MethodDefinitionHandle adder = metadata.AddMethodDefinition(
+            accessor | MethodAttributes.Final,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("add_Changed"),
+            eventSignatureHandle,
+            bodyOffset: 0,
+            MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle remover = metadata.AddMethodDefinition(
+            accessor,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("remove_Changed"),
+            eventSignatureHandle,
+            bodyOffset: 0,
+            MetadataTokens.ParameterHandle(1));
+        EventDefinitionHandle changed = metadata.AddEvent(
+            EventAttributes.None,
+            metadata.GetOrAddString("Changed"),
+            type);
+        metadata.AddEventMap(type, changed);
+        metadata.AddMethodSemantics(
+            changed,
+            MethodSemanticsAttributes.Adder,
+            adder);
+        metadata.AddMethodSemantics(
+            changed,
+            MethodSemanticsAttributes.Remover,
+            remover);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
 }
 
 public interface IInventoryFixture
 {
     void Explicit();
+
+    int ExplicitProperty { get; }
+
+    event EventHandler ExplicitChanged;
 }
 
 public class InventoryFixture : IInventoryFixture
@@ -1025,6 +1315,14 @@ public class InventoryFixture : IInventoryFixture
     private int PrivateMethod() => s_privateField;
 
     void IInventoryFixture.Explicit() { }
+
+    int IInventoryFixture.ExplicitProperty => 42;
+
+    event EventHandler IInventoryFixture.ExplicitChanged
+    {
+        add { }
+        remove { }
+    }
 
     public static InventoryFixture operator +(InventoryFixture left, InventoryFixture right)
         => left;

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -203,45 +203,82 @@ public class ApiInventoryQueryTests
     }
 
     [Fact]
-    public void ExtractSummary_PreservesExplicitInterfaceFacets()
+    public void ExtractionModes_PreserveExplicitInterfaceFacets()
     {
-        using var stream = File.OpenRead(typeof(ApiInventoryQueryTests).Assembly.Location);
-        using var peReader = new PEReader(stream);
+        string path = typeof(ApiInventoryQueryTests).Assembly.Location;
+        using var summaryStream = File.OpenRead(path);
+        using var summaryReader = new PEReader(summaryStream);
+        using var fullStream = File.OpenRead(path);
+        using var fullReader = new PEReader(fullStream);
+        using var boundedStream = File.OpenRead(path);
+        using var boundedReader = new PEReader(boundedStream);
+        using var queryStream = File.OpenRead(path);
+        using var queryReader = new PEReader(queryStream);
 
-        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
-        ApiType type = Assert.Single(
-            summary.Types,
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(summaryReader);
+        ApiSurface full = ApiSurfaceExtractor.Extract(fullReader);
+        var bounded = Assert.IsType<ApiSurfaceExtractionResult.Extracted>(
+            ApiSurfaceExtractor.ExtractBounded(
+                boundedReader,
+                ApiSurfaceExtractionScope.Public,
+                new ApiSurfaceExtractionBounds(
+                    maxTypes: 100_000,
+                    maxMembers: 1_000_000,
+                    maxInspectionFailures: 1_024,
+                    maxTypeForwarders: 100_000,
+                    maxMetadataRows: 10_000_000)));
+        MetadataReader metadata = queryReader.GetMetadataReader();
+        TypeDefinitionHandle typeHandle = metadata.TypeDefinitions.Single(handle =>
+            metadata.GetString(metadata.GetTypeDefinition(handle).Name)
+                == nameof(InventoryFixture));
+        ApiType focused = MetadataDeclarationQuery.GetTypeSurface(
+            metadata,
+            typeHandle,
+            includeNonPublicMembers: false);
+
+        foreach (ApiType type in new[]
+        {
+            FindType(summary),
+            FindType(full),
+            FindType(bounded.Surface),
+            focused,
+        })
+        {
+            ApiMember[] explicitMembers = type.Members
+                .Where(member => member.IsExplicitInterfaceImplementation)
+                .ToArray();
+
+            Assert.Equal(4, explicitMembers.Length);
+            Assert.All(
+                explicitMembers,
+                member => Assert.Equal("private", member.Accessibility));
+            Assert.Contains(
+                explicitMembers,
+                member => member.Kind == "explicit-interface-implementation"
+                    && member.Name.EndsWith(".Explicit", StringComparison.Ordinal));
+            Assert.Contains(
+                explicitMembers,
+                member => member.Kind == "explicit-interface-implementation"
+                    && member.Name.EndsWith(
+                        ".get_ExplicitProperty",
+                        StringComparison.Ordinal));
+            Assert.Contains(
+                explicitMembers,
+                member => member.Kind == "explicit-interface-implementation"
+                    && member.Name.EndsWith(
+                        ".add_ExplicitChanged",
+                        StringComparison.Ordinal));
+            Assert.Contains(
+                explicitMembers,
+                member => member.Kind == "explicit-interface-implementation"
+                    && member.Name.EndsWith(
+                        ".remove_ExplicitChanged",
+                        StringComparison.Ordinal));
+        }
+
+        static ApiType FindType(ApiSurface surface) => Assert.Single(
+            surface.Types,
             candidate => candidate.FullName == typeof(InventoryFixture).FullName);
-        ApiMember[] explicitMembers = type.Members
-            .Where(member => member.IsExplicitInterfaceImplementation)
-            .ToArray();
-
-        Assert.Equal(4, explicitMembers.Length);
-        Assert.All(
-            explicitMembers,
-            member => Assert.Equal("private", member.Accessibility));
-        Assert.Contains(
-            explicitMembers,
-            member => member.Kind == "explicit-interface-implementation"
-                && member.Name.EndsWith(".Explicit", StringComparison.Ordinal));
-        Assert.Contains(
-            explicitMembers,
-            member => member.Kind == "explicit-interface-implementation"
-                && member.Name.EndsWith(
-                    ".get_ExplicitProperty",
-                    StringComparison.Ordinal));
-        Assert.Contains(
-            explicitMembers,
-            member => member.Kind == "explicit-interface-implementation"
-                && member.Name.EndsWith(
-                    ".add_ExplicitChanged",
-                    StringComparison.Ordinal));
-        Assert.Contains(
-            explicitMembers,
-            member => member.Kind == "explicit-interface-implementation"
-                && member.Name.EndsWith(
-                    ".remove_ExplicitChanged",
-                    StringComparison.Ordinal));
     }
 
     [Fact]
@@ -622,6 +659,16 @@ public class ApiInventoryQueryTests
         Assert.NotNull(brokenMember.RemoverToken);
         Assert.Empty(surface.InspectionFailures);
 
+        ApiSurface all = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        ApiType allType = Assert.Single(
+            all.Types,
+            candidate => candidate.Name == "EventAccessibilityHost");
+        Assert.Equal(
+            "protected internal",
+            Assert.Single(
+                allType.Members,
+                member => member.Name == "Mixed").Accessibility);
+
         ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
         ApiType summarized = Assert.Single(
             summary.Types,
@@ -642,6 +689,11 @@ public class ApiInventoryQueryTests
             typeHandle,
             includeNonPublicMembers: true);
         Assert.Single(queried.Members, member => member.Name == "Broken");
+        Assert.Equal(
+            "protected internal",
+            Assert.Single(
+                queried.Members,
+                member => member.Name == "Mixed").Accessibility);
     }
 
     [Fact]
@@ -1067,6 +1119,20 @@ public class ApiInventoryQueryTests
             accessorSignatureHandle,
             bodyOffset: 0,
             parameterList: MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle mixedAdder = metadata.AddMethodDefinition(
+            MethodAttributes.Assembly | MethodAttributes.SpecialName,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("add_Mixed"),
+            accessorSignatureHandle,
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle mixedRemover = metadata.AddMethodDefinition(
+            MethodAttributes.Family | MethodAttributes.SpecialName,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("remove_Mixed"),
+            accessorSignatureHandle,
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
 
         EventDefinitionHandle changed = metadata.AddEvent(
             EventAttributes.None,
@@ -1076,10 +1142,16 @@ public class ApiInventoryQueryTests
             EventAttributes.None,
             metadata.GetOrAddString("Broken"),
             type);
+        EventDefinitionHandle mixed = metadata.AddEvent(
+            EventAttributes.None,
+            metadata.GetOrAddString("Mixed"),
+            type);
         metadata.AddEventMap(type, changed);
         metadata.AddMethodSemantics(changed, MethodSemanticsAttributes.Adder, adder);
         metadata.AddMethodSemantics(changed, MethodSemanticsAttributes.Remover, remover);
         metadata.AddMethodSemantics(broken, MethodSemanticsAttributes.Remover, brokenRemover);
+        metadata.AddMethodSemantics(mixed, MethodSemanticsAttributes.Adder, mixedAdder);
+        metadata.AddMethodSemantics(mixed, MethodSemanticsAttributes.Remover, mixedRemover);
 
         var pe = new ManagedPEBuilder(
             PEHeaderBuilder.CreateLibraryHeader(),

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -588,6 +588,21 @@ public class ApiInventoryQueryTests
         };
         Assert.Throws<InvalidOperationException>(
             () => ApiInventoryQuery.Types(unknownAccessibility));
+
+        var emptyAccessibility = new ApiSurface
+        {
+            Types = [new ApiType { Name = "Future", Kind = "class", Accessibility = "" }]
+        };
+        var emptyMemberAccessibility = new ApiType
+        {
+            Name = "Future",
+            Kind = "class",
+            Members = [new ApiMember { Name = "Run", Kind = "method", Accessibility = "" }]
+        };
+        Assert.Throws<InvalidOperationException>(
+            () => ApiInventoryQuery.Types(emptyAccessibility));
+        Assert.Throws<InvalidOperationException>(
+            () => ApiInventoryQuery.Members(emptyMemberAccessibility));
     }
 
     private static byte[] BuildPrivateScopeImage()

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -517,6 +517,15 @@ public class ApiInventoryQueryTests
         Assert.Null(brokenMember.AdderToken);
         Assert.NotNull(brokenMember.RemoverToken);
         Assert.Empty(surface.InspectionFailures);
+
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
+        ApiType summarized = Assert.Single(
+            summary.Types,
+            candidate => candidate.Name == "EventAccessibilityHost");
+        Assert.Contains(summarized.Members, member => member is { Name: "Changed", Kind: "event" });
+        Assert.Contains(summarized.Members, member => member is { Name: "Broken", Kind: "event" });
+        Assert.Equal(2, summary.PublicEventCount);
+
         MetadataReader reader = peReader.GetMetadataReader();
         EventDefinitionHandle broken = reader.GetTypeDefinition(
                 reader.TypeDefinitions.Single(handle =>

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -523,6 +523,12 @@ public class ApiInventoryQueryTests
             .GetEvents()
             .Single(handle => reader.GetString(reader.GetEventDefinition(handle).Name) == "Broken");
         Assert.Equal(MetadataTokens.GetToken(broken), failure.SubjectToken);
+        TypeDefinitionHandle typeHandle = reader.GetEventDefinition(broken).GetDeclaringType();
+        Assert.Throws<BadImageFormatException>(
+            () => MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                typeHandle,
+                includeNonPublicMembers: true));
     }
 
     [Fact]

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -143,6 +143,27 @@ public class ApiInventoryQueryTests
             type,
             new ApiMemberInventoryRequest([extension.Id], allAccessibilityIds));
         Assert.Contains(extensions.Members, member => member.Name == nameof(InventoryExtensions.Extend));
+        Assert.Equal(
+            "internal",
+            Assert.Single(
+                type.Members,
+                member => member.Name == "InternalExtend"
+                    && member.Kind == "extension-method").Accessibility);
+        Assert.Equal(
+            "private",
+            Assert.Single(
+                type.Members,
+                member => member.Name == "PrivateExtend"
+                    && member.Kind == "extension-method").Accessibility);
+
+        ApiMember finalizer = Assert.Single(type.Members, member => member.Kind == "finalizer");
+        ApiMember explicitImplementation = Assert.Single(
+            type.Members,
+            member => member.Kind == "explicit-interface-implementation");
+        Assert.Equal("protected", finalizer.Accessibility);
+        Assert.Equal("private", explicitImplementation.Accessibility);
+        Assert.DoesNotContain(finalizer, catalog.Members);
+        Assert.DoesNotContain(explicitImplementation, catalog.Members);
 
         var privateFacet = Assert.Single(
             catalog.AccessibilityFacets,
@@ -416,6 +437,22 @@ public class ApiInventoryQueryTests
     }
 
     [Fact]
+    public void Extract_AccessorlessPropertyRecordsVisibleFailure()
+    {
+        using var peReader = new PEReader(new MemoryStream(BuildAccessorlessPropertyImage()));
+
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        ApiType type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "AccessorlessHost");
+        Assert.Empty(type.Members);
+        ApiSurfaceInspectionFailure failure = Assert.Single(surface.InspectionFailures);
+        Assert.Equal("property accessors", failure.Operation);
+        Assert.Contains("no getter or setter", failure.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Selection_RejectsUnknownFacetIds()
     {
         var surface = new ApiSurface
@@ -540,6 +577,57 @@ public class ApiInventoryQueryTests
         pe.Serialize(image);
         return image.ToArray();
     }
+
+    private static byte[] BuildAccessorlessPropertyImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Accessorless.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Accessorless"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle type = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Fixtures"),
+            metadata.GetOrAddString("AccessorlessHost"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var propertySignature = new BlobBuilder();
+        propertySignature.WriteByte(0x08); // PROPERTY
+        propertySignature.WriteByte(0x00); // parameter count
+        propertySignature.WriteByte(0x08); // ELEMENT_TYPE_I4
+        PropertyDefinitionHandle property = metadata.AddProperty(
+            PropertyAttributes.None,
+            metadata.GetOrAddString("Value"),
+            metadata.GetOrAddBlob(propertySignature));
+        metadata.AddPropertyMap(type, property);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
 }
 
 public interface IInventoryFixture
@@ -583,6 +671,10 @@ public class InventoryFixture : IInventoryFixture
 public static class InventoryExtensions
 {
     public static void Extend(this InventoryFixture fixture) => fixture.Method();
+
+    internal static void InternalExtend(this InventoryFixture fixture) => fixture.Method();
+
+    private static void PrivateExtend(this InventoryFixture fixture) => fixture.Method();
 
     public static void op_Addition(this InventoryFixture fixture) => fixture.Method();
 }

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Queries;
 using ILInspector.Metadata;
+using System.Reflection.PortableExecutable;
 
 namespace DotnetInspector.Queries.Tests;
 
@@ -30,6 +31,10 @@ public class ApiInventoryQueryTests
         Assert.True(result.KindFacets.Select(facet => facet.Weight).SequenceEqual(
             result.KindFacets.Select(facet => facet.Weight).Order()));
         Assert.All(result.KindFacets, facet => Assert.True(facet.IsDefault));
+        var publicAccessibility = Assert.Single(result.AccessibilityFacets);
+        Assert.Equal("public", publicAccessibility.SingularLabel);
+        Assert.Equal(surface.Types.Count, publicAccessibility.Count);
+        Assert.True(publicAccessibility.IsDefault);
         Assert.Equal(surface.Types, result.Types);
 
         foreach (var facet in result.KindFacets)
@@ -62,7 +67,35 @@ public class ApiInventoryQueryTests
             surface.Types,
             candidate => candidate.FullName == typeof(InventoryFixture).FullName);
 
-        var result = ApiInventoryQuery.Members(type);
+        var catalog = ApiInventoryQuery.Members(type);
+        Assert.Equal(
+            [
+                "public",
+                "protected",
+                "protected internal",
+                "private protected",
+                "internal",
+                "private",
+            ],
+            catalog.AccessibilityFacets.Select(facet => facet.SingularLabel));
+        Assert.True(Assert.Single(
+            catalog.AccessibilityFacets,
+            facet => facet.SingularLabel == "public").IsDefault);
+        Assert.All(
+            catalog.AccessibilityFacets.Where(facet => facet.SingularLabel != "public"),
+            facet => Assert.False(facet.IsDefault));
+        Assert.All(
+            catalog.Members,
+            member => Assert.True(
+                string.IsNullOrEmpty(member.Accessibility)
+                || member.Accessibility == "public"));
+
+        var allAccessibilityIds = catalog.AccessibilityFacets
+            .Select(facet => facet.Id)
+            .ToList();
+        var result = ApiInventoryQuery.Members(
+            type,
+            new ApiMemberInventoryRequest(AccessibilityFacetIds: allAccessibilityIds));
 
         Assert.Equal(
             [
@@ -83,22 +116,156 @@ public class ApiInventoryQueryTests
         {
             var filtered = ApiInventoryQuery.Members(
                 type,
-                new ApiMemberInventoryRequest([facet.Id]));
+                new ApiMemberInventoryRequest([facet.Id], allAccessibilityIds));
+            Assert.Equal(facet.Count, filtered.Members.Count);
+        }
+
+        foreach (var facet in catalog.AccessibilityFacets)
+        {
+            var filtered = ApiInventoryQuery.Members(
+                type,
+                new ApiMemberInventoryRequest(AccessibilityFacetIds: [facet.Id]));
             Assert.Equal(facet.Count, filtered.Members.Count);
         }
 
         var constant = Assert.Single(result.KindFacets, facet => facet.SingularLabel == "constant");
         var constants = ApiInventoryQuery.Members(
             type,
-            new ApiMemberInventoryRequest([constant.Id]));
+            new ApiMemberInventoryRequest([constant.Id], allAccessibilityIds));
         Assert.Contains(constants.Members, member => member.Name == nameof(InventoryFixture.Constant));
         Assert.All(constants.Members, member => Assert.True(member.IsConst));
 
         var extension = Assert.Single(result.KindFacets, facet => facet.SingularLabel == "extension method");
         var extensions = ApiInventoryQuery.Members(
             type,
-            new ApiMemberInventoryRequest([extension.Id]));
+            new ApiMemberInventoryRequest([extension.Id], allAccessibilityIds));
         Assert.Contains(extensions.Members, member => member.Name == nameof(InventoryExtensions.Extend));
+
+        var privateFacet = Assert.Single(
+            catalog.AccessibilityFacets,
+            facet => facet.SingularLabel == "private");
+        var privateMembers = ApiInventoryQuery.Members(
+            type,
+            new ApiMemberInventoryRequest(AccessibilityFacetIds: [privateFacet.Id]));
+        Assert.Contains(privateMembers.Members, member => member.Name == "s_privateField");
+        Assert.DoesNotContain(privateMembers.Members, member => member.Name == "s_publicField");
+
+        var publicFacet = Assert.Single(
+            catalog.AccessibilityFacets,
+            facet => facet.SingularLabel == "public");
+        var publicMembers = ApiInventoryQuery.Members(
+            type,
+            new ApiMemberInventoryRequest(AccessibilityFacetIds: [publicFacet.Id]));
+        Assert.Contains(publicMembers.Members, member => member.Name == "s_publicField");
+        Assert.DoesNotContain(publicMembers.Members, member => member.Name == "s_privateField");
+
+        var methodFacet = Assert.Single(
+            result.KindFacets,
+            facet => facet.SingularLabel == "method");
+        var privateMethods = ApiInventoryQuery.Members(
+            type,
+            new ApiMemberInventoryRequest([methodFacet.Id], [privateFacet.Id]));
+        Assert.All(privateMethods.Members, member =>
+        {
+            Assert.Equal("method", member.Kind);
+            Assert.Equal("private", member.Accessibility);
+        });
+        Assert.Equal(
+            privateMethods.Members.Count,
+            Assert.Single(
+                privateMethods.KindFacets,
+                facet => facet.Id == methodFacet.Id).Count);
+    }
+
+    [Fact]
+    public void Types_AccessibilityFacetsClassifyCompoundValues()
+    {
+        var surface = new ApiSurface
+        {
+            Types =
+            [
+                new ApiType { Name = "DefaultPublic", Kind = "class" },
+                new ApiType { Name = "ExplicitPublic", Kind = "class", Accessibility = "public" },
+                new ApiType { Name = "Protected", Kind = "class", Accessibility = "protected" },
+                new ApiType { Name = "ProtectedInternal", Kind = "class", Accessibility = "protected internal" },
+                new ApiType { Name = "PrivateProtected", Kind = "class", Accessibility = "private protected" },
+                new ApiType { Name = "Internal", Kind = "class", Accessibility = "internal" },
+                new ApiType { Name = "Private", Kind = "class", Accessibility = "private" },
+            ]
+        };
+
+        var result = ApiInventoryQuery.Types(surface);
+
+        Assert.Equal(
+            [
+                "public",
+                "protected",
+                "protected internal",
+                "private protected",
+                "internal",
+                "private",
+            ],
+            result.AccessibilityFacets.Select(facet => facet.SingularLabel));
+        Assert.Equal([2, 1, 1, 1, 1, 1], result.AccessibilityFacets.Select(facet => facet.Count));
+        Assert.True(result.AccessibilityFacets.Select(facet => facet.Weight).SequenceEqual(
+            result.AccessibilityFacets.Select(facet => facet.Weight).Order()));
+        Assert.Equal(["DefaultPublic", "ExplicitPublic"], result.Types.Select(type => type.Name));
+
+        foreach (var facet in result.AccessibilityFacets)
+        {
+            var filtered = ApiInventoryQuery.Types(
+                surface,
+                new ApiTypeInventoryRequest(AccessibilityFacetIds: [facet.Id]));
+            Assert.Equal(facet.Count, filtered.Types.Count);
+        }
+
+        var protectedFamily = result.AccessibilityFacets
+            .Where(facet => facet.SingularLabel.Contains("protected", StringComparison.Ordinal))
+            .Select(facet => facet.Id)
+            .ToList();
+        var combined = ApiInventoryQuery.Types(
+            surface,
+            new ApiTypeInventoryRequest(AccessibilityFacetIds: protectedFamily));
+        Assert.Equal(3, combined.Types.Count);
+    }
+
+    [Fact]
+    public void AccessibilityClassification_UsesMetadataFactsNotGeneratedNames()
+    {
+        using var stream = File.OpenRead(typeof(ApiInventoryQueryTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var extracted = ApiSurfaceExtractor.Extract(
+            peReader,
+            includeAll: true,
+            includeCompilerGenerated: true);
+        var generated = Assert.Single(
+            extracted.Types,
+            type => type.MetadataName == "ApiInventoryQueryTests+<>c");
+        var generatedLookingPublic = Assert.Single(
+            extracted.Types,
+            type => type.FullName == typeof(__PublicAccessibilityFixture).FullName);
+        var surface = new ApiSurface
+        {
+            Types = [generated, generatedLookingPublic]
+        };
+
+        var catalog = ApiInventoryQuery.Types(surface);
+        var privateFacet = Assert.Single(
+            catalog.AccessibilityFacets,
+            facet => facet.SingularLabel == "private");
+        var publicFacet = Assert.Single(
+            catalog.AccessibilityFacets,
+            facet => facet.SingularLabel == "public");
+
+        var privateTypes = ApiInventoryQuery.Types(
+            surface,
+            new ApiTypeInventoryRequest(AccessibilityFacetIds: [privateFacet.Id]));
+        var publicTypes = ApiInventoryQuery.Types(
+            surface,
+            new ApiTypeInventoryRequest(AccessibilityFacetIds: [publicFacet.Id]));
+
+        Assert.Contains(generated, privateTypes.Types);
+        Assert.Contains(generatedLookingPublic, publicTypes.Types);
     }
 
     [Fact]
@@ -225,6 +392,14 @@ public class ApiInventoryQueryTests
                 new ApiTypeInventoryRequest(["consumer-invented-kind"])));
 
         Assert.Contains("consumer-invented-kind", error.Message);
+
+        error = Assert.Throws<ArgumentException>(() =>
+            ApiInventoryQuery.Types(
+                surface,
+                new ApiTypeInventoryRequest(
+                    AccessibilityFacetIds: ["consumer-invented-accessibility"])));
+
+        Assert.Contains("consumer-invented-accessibility", error.Message);
     }
 
     [Fact]
@@ -251,6 +426,21 @@ public class ApiInventoryQueryTests
 
         Assert.Throws<InvalidOperationException>(() => ApiInventoryQuery.Types(surface));
         Assert.Throws<InvalidOperationException>(() => ApiInventoryQuery.Members(type));
+
+        var unknownAccessibility = new ApiSurface
+        {
+            Types =
+            [
+                new ApiType
+                {
+                    Name = "Future",
+                    Kind = "class",
+                    Accessibility = "future-accessibility"
+                }
+            ]
+        };
+        Assert.Throws<InvalidOperationException>(
+            () => ApiInventoryQuery.Types(unknownAccessibility));
     }
 }
 
@@ -259,10 +449,12 @@ public interface IInventoryFixture
     void Explicit();
 }
 
-public sealed class InventoryFixture : IInventoryFixture
+public class InventoryFixture : IInventoryFixture
 {
     public const int Constant = 1;
     public int Field;
+    public static int s_publicField;
+    private static int s_privateField = 1;
     public int Property { get; set; }
     public event EventHandler? Changed;
 
@@ -273,6 +465,16 @@ public sealed class InventoryFixture : IInventoryFixture
     ~InventoryFixture() { }
 
     public void Method() => Changed?.Invoke(this, EventArgs.Empty);
+
+    protected void ProtectedMethod() { }
+
+    protected internal void ProtectedInternalMethod() { }
+
+    private protected void PrivateProtectedMethod() { }
+
+    internal void InternalMethod() { }
+
+    private int PrivateMethod() => s_privateField;
 
     void IInventoryFixture.Explicit() { }
 
@@ -291,3 +493,4 @@ public struct InventoryStruct;
 public interface IInventoryType;
 public enum InventoryEnum;
 public delegate void InventoryDelegate();
+public class __PublicAccessibilityFixture;

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -500,7 +500,7 @@ public class ApiInventoryQueryTests
     }
 
     [Fact]
-    public void Extract_EventAccessibilityUsesBothAccessorsAndRejectsMissingPairs()
+    public void Extract_EventAccessibilityUsesBothAccessorsAndRetainsRemoveOnlyEvents()
     {
         using var peReader = new PEReader(new MemoryStream(BuildEventAccessibilityImage()));
 
@@ -513,22 +513,22 @@ public class ApiInventoryQueryTests
         Assert.Null(changed.Accessibility);
         Assert.NotNull(changed.AdderToken);
         Assert.NotNull(changed.RemoverToken);
-        Assert.DoesNotContain(type.Members, member => member.Name == "Broken");
-        ApiSurfaceInspectionFailure failure = Assert.Single(surface.InspectionFailures);
-        Assert.Equal("event accessors", failure.Operation);
+        ApiMember brokenMember = Assert.Single(type.Members, member => member.Name == "Broken");
+        Assert.Null(brokenMember.AdderToken);
+        Assert.NotNull(brokenMember.RemoverToken);
+        Assert.Empty(surface.InspectionFailures);
         MetadataReader reader = peReader.GetMetadataReader();
         EventDefinitionHandle broken = reader.GetTypeDefinition(
                 reader.TypeDefinitions.Single(handle =>
                     reader.GetString(reader.GetTypeDefinition(handle).Name) == "EventAccessibilityHost"))
             .GetEvents()
             .Single(handle => reader.GetString(reader.GetEventDefinition(handle).Name) == "Broken");
-        Assert.Equal(MetadataTokens.GetToken(broken), failure.SubjectToken);
         TypeDefinitionHandle typeHandle = reader.GetEventDefinition(broken).GetDeclaringType();
-        Assert.Throws<BadImageFormatException>(
-            () => MetadataDeclarationQuery.GetTypeSurface(
-                reader,
-                typeHandle,
-                includeNonPublicMembers: true));
+        ApiType queried = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        Assert.Single(queried.Members, member => member.Name == "Broken");
     }
 
     [Fact]

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -450,6 +450,79 @@ public class ApiInventoryQueryTests
         ApiSurfaceInspectionFailure failure = Assert.Single(surface.InspectionFailures);
         Assert.Equal("property accessors", failure.Operation);
         Assert.Contains("no getter or setter", failure.Detail, StringComparison.Ordinal);
+
+        MetadataReader reader = peReader.GetMetadataReader();
+        TypeDefinitionHandle typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "AccessorlessHost");
+        Assert.Throws<BadImageFormatException>(
+            () => MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                typeHandle,
+                includeNonPublicMembers: true));
+    }
+
+    [Fact]
+    public void Extract_ReservedAccessibilitySkipsOnlyMalformedMembers()
+    {
+        using var peReader = new PEReader(new MemoryStream(BuildReservedAccessibilityImage()));
+
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        ApiType type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "ReservedAccessibilityHost");
+        Assert.Contains(type.Members, member => member.Name == "GoodMethod");
+        Assert.Contains(type.Members, member => member.Name == "GoodField");
+        Assert.DoesNotContain(type.Members, member => member.Name == "BadMethod");
+        Assert.DoesNotContain(type.Members, member => member.Name == "BadField");
+
+        MetadataReader reader = peReader.GetMetadataReader();
+        TypeDefinitionHandle typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "ReservedAccessibilityHost");
+        MethodDefinitionHandle badMethod = reader.GetTypeDefinition(typeHandle).GetMethods().Single(handle =>
+            reader.GetString(reader.GetMethodDefinition(handle).Name) == "BadMethod");
+        FieldDefinitionHandle badField = reader.GetTypeDefinition(typeHandle).GetFields().Single(handle =>
+            reader.GetString(reader.GetFieldDefinition(handle).Name) == "BadField");
+        Assert.Equal(
+            new Dictionary<string, int>
+            {
+                ["method accessibility"] = MetadataTokens.GetToken(badMethod),
+                ["field accessibility"] = MetadataTokens.GetToken(badField)
+            },
+            surface.InspectionFailures.ToDictionary(
+                failure => failure.Operation,
+                failure => failure.SubjectToken));
+        Assert.Throws<BadImageFormatException>(
+            () => MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                typeHandle,
+                includeNonPublicMembers: true));
+    }
+
+    [Fact]
+    public void Extract_EventAccessibilityUsesBothAccessorsAndRejectsMissingPairs()
+    {
+        using var peReader = new PEReader(new MemoryStream(BuildEventAccessibilityImage()));
+
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader);
+
+        ApiType type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "EventAccessibilityHost");
+        ApiMember changed = Assert.Single(type.Members, member => member.Name == "Changed");
+        Assert.Null(changed.Accessibility);
+        Assert.NotNull(changed.AdderToken);
+        Assert.NotNull(changed.RemoverToken);
+        Assert.DoesNotContain(type.Members, member => member.Name == "Broken");
+        ApiSurfaceInspectionFailure failure = Assert.Single(surface.InspectionFailures);
+        Assert.Equal("event accessors", failure.Operation);
+        MetadataReader reader = peReader.GetMetadataReader();
+        EventDefinitionHandle broken = reader.GetTypeDefinition(
+                reader.TypeDefinitions.Single(handle =>
+                    reader.GetString(reader.GetTypeDefinition(handle).Name) == "EventAccessibilityHost"))
+            .GetEvents()
+            .Single(handle => reader.GetString(reader.GetEventDefinition(handle).Name) == "Broken");
+        Assert.Equal(MetadataTokens.GetToken(broken), failure.SubjectToken);
     }
 
     [Fact]
@@ -618,6 +691,175 @@ public class ApiInventoryQueryTests
             metadata.GetOrAddString("Value"),
             metadata.GetOrAddBlob(propertySignature));
         metadata.AddPropertyMap(type, property);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    private static byte[] BuildReservedAccessibilityImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("ReservedAccessibility.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("ReservedAccessibility"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Fixtures"),
+            metadata.GetOrAddString("ReservedAccessibilityHost"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var fieldSignature = new BlobBuilder();
+        fieldSignature.WriteByte(0x06); // FIELD
+        fieldSignature.WriteByte(0x08); // ELEMENT_TYPE_I4
+        BlobHandle fieldSignatureHandle = metadata.GetOrAddBlob(fieldSignature);
+        metadata.AddFieldDefinition(
+            FieldAttributes.Public | FieldAttributes.Static,
+            metadata.GetOrAddString("GoodField"),
+            fieldSignatureHandle);
+        metadata.AddFieldDefinition(
+            (FieldAttributes)0x0007 | FieldAttributes.Static,
+            metadata.GetOrAddString("BadField"),
+            fieldSignatureHandle);
+
+        var methodSignature = new BlobBuilder();
+        methodSignature.WriteByte(0x00); // DEFAULT
+        methodSignature.WriteByte(0x00); // parameter count
+        methodSignature.WriteByte(0x01); // ELEMENT_TYPE_VOID
+        BlobHandle methodSignatureHandle = metadata.GetOrAddBlob(methodSignature);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("GoodMethod"),
+            methodSignatureHandle,
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodDefinition(
+            (MethodAttributes)0x0007 | MethodAttributes.Static,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("BadMethod"),
+            methodSignatureHandle,
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    private static byte[] BuildEventAccessibilityImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("EventAccessibility.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("EventAccessibility"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle type = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Fixtures"),
+            metadata.GetOrAddString("EventAccessibilityHost"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var methodSignature = new BlobBuilder();
+        methodSignature.WriteByte(0x00); // DEFAULT
+        methodSignature.WriteByte(0x00); // parameter count
+        methodSignature.WriteByte(0x01); // ELEMENT_TYPE_VOID
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("GoodMethod"),
+            metadata.GetOrAddBlob(methodSignature),
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var accessorSignature = new BlobBuilder();
+        accessorSignature.WriteByte(0x20); // HASTHIS
+        accessorSignature.WriteByte(0x01); // parameter count
+        accessorSignature.WriteByte(0x01); // ELEMENT_TYPE_VOID
+        accessorSignature.WriteByte(0x12); // ELEMENT_TYPE_CLASS
+        accessorSignature.WriteByte(0x08); // TypeDef row 2
+        BlobHandle accessorSignatureHandle = metadata.GetOrAddBlob(accessorSignature);
+        MethodDefinitionHandle adder = metadata.AddMethodDefinition(
+            MethodAttributes.Private | MethodAttributes.SpecialName,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("add_Changed"),
+            accessorSignatureHandle,
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle remover = metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.SpecialName,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("remove_Changed"),
+            accessorSignatureHandle,
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle brokenRemover = metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.SpecialName,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("remove_Broken"),
+            accessorSignatureHandle,
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        EventDefinitionHandle changed = metadata.AddEvent(
+            EventAttributes.None,
+            metadata.GetOrAddString("Changed"),
+            type);
+        EventDefinitionHandle broken = metadata.AddEvent(
+            EventAttributes.None,
+            metadata.GetOrAddString("Broken"),
+            type);
+        metadata.AddEventMap(type, changed);
+        metadata.AddMethodSemantics(changed, MethodSemanticsAttributes.Adder, adder);
+        metadata.AddMethodSemantics(changed, MethodSemanticsAttributes.Remover, remover);
+        metadata.AddMethodSemantics(broken, MethodSemanticsAttributes.Remover, brokenRemover);
 
         var pe = new ManagedPEBuilder(
             PEHeaderBuilder.CreateLibraryHeader(),

--- a/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiInventoryQueryTests.cs
@@ -255,6 +255,11 @@ public class ApiInventoryQueryTests
             Assert.All(
                 explicitMembers,
                 member => Assert.False(member.CanUseImplicitInterfaceSyntax));
+            Assert.All(
+                explicitMembers,
+                member => Assert.Equal(
+                    InterfaceImplementationResolution.Proven,
+                    member.InterfaceImplementationResolution));
             Assert.Contains(
                 explicitMembers,
                 member => member.Kind == "explicit-interface-implementation"

--- a/src/DotnetInspector.Queries/ApiInventoryQuery.cs
+++ b/src/DotnetInspector.Queries/ApiInventoryQuery.cs
@@ -114,7 +114,7 @@ public static class ApiInventoryQuery
     static readonly IReadOnlyList<FacetDefinition<string?>> AccessibilityFacets =
     [
         new("api.accessibility.public", "public", "public", 100, true,
-            accessibility => string.IsNullOrEmpty(accessibility) || accessibility == "public"),
+            accessibility => accessibility is null || accessibility == "public"),
         new("api.accessibility.protected", "protected", "protected", 200, false,
             accessibility => accessibility == "protected"),
         new("api.accessibility.protected-internal", "protected internal", "protected internal", 300, false,

--- a/src/DotnetInspector.Queries/ApiInventoryQuery.cs
+++ b/src/DotnetInspector.Queries/ApiInventoryQuery.cs
@@ -11,7 +11,9 @@ namespace DotnetInspector.Queries;
 /// <param name="SingularLabel">Display label for one result.</param>
 /// <param name="PluralLabel">Display label for zero or multiple results.</param>
 /// <param name="Weight">Producer-owned display order.</param>
-/// <param name="Count">Number of items in the unfiltered inventory that belong to this facet.</param>
+/// <param name="Count">
+/// Number of items in the current opposite-axis scope that belong to this facet.
+/// </param>
 /// <param name="IsDefault">Whether this facet participates when no explicit selection is supplied.</param>
 public sealed record ApiFacetDescriptor(
     string Id,
@@ -22,39 +24,46 @@ public sealed record ApiFacetDescriptor(
     bool IsDefault);
 
 /// <summary>
-/// Selects type-kind facets. Null or empty means the producer-declared defaults.
+/// Selects type-kind and accessibility facets. Null or empty means the
+/// producer-declared defaults for that facet axis.
 /// </summary>
 public sealed record ApiTypeInventoryRequest(
-    IReadOnlyCollection<string>? KindFacetIds = null);
+    IReadOnlyCollection<string>? KindFacetIds = null,
+    IReadOnlyCollection<string>? AccessibilityFacetIds = null);
 
 /// <summary>
-/// Type inventory and the available type-kind facets for its unfiltered input.
+/// Type inventory plus the effective kind and accessibility facets for the current request.
 /// </summary>
 public sealed record ApiTypeInventoryResult(
     IReadOnlyList<ApiType> Types,
     IReadOnlyList<ApiFacetDescriptor> KindFacets,
+    IReadOnlyList<ApiFacetDescriptor> AccessibilityFacets,
     IReadOnlyList<ApiSurfaceInspectionFailure> InspectionFailures);
 
 /// <summary>
-/// Selects member-kind facets. Null or empty means the producer-declared defaults.
+/// Selects member-kind and accessibility facets. Null or empty means the
+/// producer-declared defaults for that facet axis.
 /// </summary>
 public sealed record ApiMemberInventoryRequest(
-    IReadOnlyCollection<string>? KindFacetIds = null);
+    IReadOnlyCollection<string>? KindFacetIds = null,
+    IReadOnlyCollection<string>? AccessibilityFacetIds = null);
 
 /// <summary>
-/// Member inventory and the available member-kind facets for its unfiltered input.
+/// Member inventory plus the effective kind and accessibility facets for the current request.
 /// </summary>
 public sealed record ApiMemberInventoryResult(
     IReadOnlyList<ApiMember> Members,
-    IReadOnlyList<ApiFacetDescriptor> KindFacets);
+    IReadOnlyList<ApiFacetDescriptor> KindFacets,
+    IReadOnlyList<ApiFacetDescriptor> AccessibilityFacets);
 
 /// <summary>
 /// Product-owned type and member inventory queries.
 /// </summary>
 /// <remarks>
-/// Raw <see cref="ApiType.Kind"/> and <see cref="ApiMember.Kind"/> values remain metadata facts.
-/// This query owns the filter identity, grouping, labels, order, defaults, and application so a
-/// consumer never has to parse or classify those facts.
+/// Raw <see cref="ApiType.Kind"/>, <see cref="ApiType.Accessibility"/>,
+/// <see cref="ApiMember.Kind"/>, and <see cref="ApiMember.Accessibility"/> values remain metadata
+/// facts. This query owns the filter identity, grouping, labels, order, defaults, and application
+/// so a consumer never has to parse or classify those facts.
 /// </remarks>
 public static class ApiInventoryQuery
 {
@@ -65,6 +74,8 @@ public static class ApiInventoryQuery
         int Weight,
         bool IsDefault,
         Func<T, bool> Matches);
+
+    sealed record ClassifiedItem<T>(T Item, string KindFacetId, string AccessibilityFacetId);
 
     static readonly IReadOnlyList<FacetDefinition<ApiType>> TypeKindFacets =
     [
@@ -100,9 +111,25 @@ public static class ApiInventoryQuery
             member => member.Kind == "event"),
     ];
 
+    static readonly IReadOnlyList<FacetDefinition<string?>> AccessibilityFacets =
+    [
+        new("api.accessibility.public", "public", "public", 100, true,
+            accessibility => string.IsNullOrEmpty(accessibility) || accessibility == "public"),
+        new("api.accessibility.protected", "protected", "protected", 200, false,
+            accessibility => accessibility == "protected"),
+        new("api.accessibility.protected-internal", "protected internal", "protected internal", 300, false,
+            accessibility => accessibility == "protected internal"),
+        new("api.accessibility.private-protected", "private protected", "private protected", 400, false,
+            accessibility => accessibility == "private protected"),
+        new("api.accessibility.internal", "internal", "internal", 500, false,
+            accessibility => accessibility == "internal"),
+        new("api.accessibility.private", "private", "private", 600, false,
+            accessibility => accessibility == "private"),
+    ];
+
     /// <summary>
-    /// Returns the available ordered type-kind descriptors and the projection selected by their
-    /// opaque IDs.
+    /// Returns effective ordered type-kind and accessibility descriptors and the projection
+    /// selected by their opaque IDs.
     /// </summary>
     public static ApiTypeInventoryResult Types(
         ApiSurface surface,
@@ -110,17 +137,41 @@ public static class ApiInventoryQuery
     {
         ArgumentNullException.ThrowIfNull(surface);
 
-        var descriptors = Describe(surface.Types, TypeKindFacets, "type");
-        var selected = SelectIds(request?.KindFacetIds, TypeKindFacets);
-        var types = surface.Types
-            .Where(type => selected.Contains(Classify(type, TypeKindFacets, "type")))
+        var inventory = surface.Types
+            .Select(type => new ClassifiedItem<ApiType>(
+                type,
+                Classify(type, TypeKindFacets, "type kind"),
+                Classify(type.Accessibility, AccessibilityFacets, "type accessibility")))
             .ToList();
-        return new ApiTypeInventoryResult(types, descriptors, [.. surface.InspectionFailures]);
+        var selectedKinds = SelectIds(request?.KindFacetIds, TypeKindFacets);
+        var selectedAccessibilities = SelectIds(
+            request?.AccessibilityFacetIds,
+            AccessibilityFacets);
+        var kindDescriptors = Describe(
+            inventory
+                .Where(item => selectedAccessibilities.Contains(item.AccessibilityFacetId))
+                .Select(item => item.KindFacetId),
+            TypeKindFacets);
+        var accessibilityDescriptors = Describe(
+            inventory
+                .Where(item => selectedKinds.Contains(item.KindFacetId))
+                .Select(item => item.AccessibilityFacetId),
+            AccessibilityFacets);
+        var types = inventory
+            .Where(item => selectedKinds.Contains(item.KindFacetId)
+                && selectedAccessibilities.Contains(item.AccessibilityFacetId))
+            .Select(item => item.Item)
+            .ToList();
+        return new ApiTypeInventoryResult(
+            types,
+            kindDescriptors,
+            accessibilityDescriptors,
+            [.. surface.InspectionFailures]);
     }
 
     /// <summary>
-    /// Returns the available ordered member-kind descriptors and the projection selected by their
-    /// opaque IDs.
+    /// Returns effective ordered member-kind and accessibility descriptors and the projection
+    /// selected by their opaque IDs.
     /// </summary>
     public static ApiMemberInventoryResult Members(
         ApiType type,
@@ -128,25 +179,41 @@ public static class ApiInventoryQuery
     {
         ArgumentNullException.ThrowIfNull(type);
 
-        var descriptors = Describe(type.Members, MemberKindFacets, "member");
-        var selected = SelectIds(request?.KindFacetIds, MemberKindFacets);
-        var members = type.Members
-            .Where(member => selected.Contains(Classify(member, MemberKindFacets, "member")))
+        var inventory = type.Members
+            .Select(member => new ClassifiedItem<ApiMember>(
+                member,
+                Classify(member, MemberKindFacets, "member kind"),
+                Classify(member.Accessibility, AccessibilityFacets, "member accessibility")))
             .ToList();
-        return new ApiMemberInventoryResult(members, descriptors);
+        var selectedKinds = SelectIds(request?.KindFacetIds, MemberKindFacets);
+        var selectedAccessibilities = SelectIds(
+            request?.AccessibilityFacetIds,
+            AccessibilityFacets);
+        var kindDescriptors = Describe(
+            inventory
+                .Where(item => selectedAccessibilities.Contains(item.AccessibilityFacetId))
+                .Select(item => item.KindFacetId),
+            MemberKindFacets);
+        var accessibilityDescriptors = Describe(
+            inventory
+                .Where(item => selectedKinds.Contains(item.KindFacetId))
+                .Select(item => item.AccessibilityFacetId),
+            AccessibilityFacets);
+        var members = inventory
+            .Where(item => selectedKinds.Contains(item.KindFacetId)
+                && selectedAccessibilities.Contains(item.AccessibilityFacetId))
+            .Select(item => item.Item)
+            .ToList();
+        return new ApiMemberInventoryResult(members, kindDescriptors, accessibilityDescriptors);
     }
 
     static IReadOnlyList<ApiFacetDescriptor> Describe<T>(
-        IReadOnlyList<T> items,
-        IReadOnlyList<FacetDefinition<T>> definitions,
-        string subject)
+        IEnumerable<string> classifiedIds,
+        IReadOnlyList<FacetDefinition<T>> definitions)
     {
         Dictionary<string, int> counts = new(StringComparer.Ordinal);
-        foreach (var item in items)
-        {
-            var id = Classify(item, definitions, subject);
+        foreach (var id in classifiedIds)
             counts[id] = counts.GetValueOrDefault(id) + 1;
-        }
 
         return definitions
             .Where(definition => counts.ContainsKey(definition.Id))

--- a/src/ILInspector.Analysis.Tests/CallGraphMemberResolverTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphMemberResolverTests.cs
@@ -377,14 +377,12 @@ public sealed class CallGraphMemberResolverTests
             candidate => candidate.Name == nameof(InitAccessorFixtures.Value));
         ApiAccessor signatureAccessor = Assert.Single(
             member.SignatureModel!.Accessors,
-            accessor => accessor.Kind == "set");
+            accessor => accessor.Kind == "init");
         ApiAccessor factAccessor = Assert.Single(
             member.AccessorFacts,
-            accessor => accessor.Kind == "set");
+            accessor => accessor.Kind == "init");
         Assert.Null(signatureAccessor.MethodName);
         Assert.False(string.IsNullOrEmpty(factAccessor.MethodName));
-        signatureAccessor.Kind = "init";
-        factAccessor.Kind = "init";
         CallGraphMemberBodySelector setter = Assert.Single(
             CallGraphMemberResolver.CreateBodySelectors(type, member),
             selector => selector.MemberName == "set_Value");

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1274,6 +1274,40 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Theory]
+    [InlineData(null)]
+    [InlineData("private")]
+    public void ExplicitInterfaceImplementation_UnqualifiedNameFailsClosed(
+        string? accessibility)
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class"
+        };
+        var member = new ApiMember
+        {
+            Name = "Read",
+            Kind = "explicit-interface-implementation",
+            Accessibility = accessibility,
+            Signature = "int Read()"
+        };
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
+
+        Assert.Contains(
+            "has no qualified metadata name",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "cannot represent its MethodImpl target",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(member.Name, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
     // A C# tuple type is parenthesized, so a parameter-list scan that takes the first
     // '(' mistakes a tuple-typed return for a parameter list and escapes each element's
     // trailing token. Unnamed elements end in the type keyword, so `(int, string)`

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1307,6 +1307,29 @@ public sealed class CSharpDeclarationWriterTests
         Assert.DoesNotContain(member.Name, exception.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ExplicitInterfaceImplementation_ImplicitSyntaxRendersOrdinaryDeclaration()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class"
+        };
+        var member = new ApiMember
+        {
+            Name = "Read",
+            Kind = "explicit-interface-implementation",
+            Signature = "int Read()",
+            CanUseImplicitInterfaceSyntax = true
+        };
+
+        string declaration =
+            CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public int Read()", declaration);
+    }
+
     [Theory]
     // A C# tuple type is parenthesized, so a parameter-list scan that takes the first
     // '(' mistakes a tuple-typed return for a parameter list and escapes each element's

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1449,6 +1449,41 @@ public sealed class CSharpDeclarationWriterTests
             formatter.FormatMember(type, member));
     }
 
+    [Fact]
+    public void MetadataAccessorFallback_ContainsHostileMemberName()
+    {
+        const string hazardousName = "Changed\u001B[31mINJECTED";
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class"
+        };
+        var member = new ApiMember
+        {
+            Name = hazardousName,
+            Kind = "event",
+            Accessibility = "public",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.Action",
+                MemberName = hazardousName
+            },
+            AccessorFacts =
+            [
+                new ApiAccessor { Kind = "add" },
+                new ApiAccessor { Kind = "remove", Accessibility = "private" }
+            ]
+        };
+        var formatter = new CSharpFormatter(
+            new CSharpFormatOptions { AllowMetadataFallback = true });
+
+        string declaration = formatter.FormatMember(type, member);
+
+        Assert.DoesNotContain('\u001B', declaration);
+        Assert.Contains("INJECTED", declaration, StringComparison.Ordinal);
+    }
+
     [Theory]
     // A C# tuple type is parenthesized, so a parameter-list scan that takes the first
     // '(' mistakes a tuple-typed return for a parameter list and escapes each element's

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1404,7 +1404,8 @@ public sealed class CSharpDeclarationWriterTests
         var formatter = new CSharpFormatter(
             new CSharpFormatOptions { AllowMetadataFallback = true });
         Assert.Equal(
-            "metadata property protected internal int Value (get: protected, set: internal)",
+            "metadata property protected internal int Value "
+                + "(accessors: get: protected, set: internal)",
             formatter.FormatMember(type, member));
     }
 
@@ -1445,7 +1446,8 @@ public sealed class CSharpDeclarationWriterTests
         var formatter = new CSharpFormatter(
             new CSharpFormatOptions { AllowMetadataFallback = true });
         Assert.Equal(
-            "metadata event public System.Action Changed (add: public, remove: private)",
+            "metadata event public System.Action Changed "
+                + "(accessors: add: public, remove: private)",
             formatter.FormatMember(type, member));
     }
 
@@ -1482,6 +1484,117 @@ public sealed class CSharpDeclarationWriterTests
 
         Assert.DoesNotContain('\u001B', declaration);
         Assert.Contains("INJECTED", declaration, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StrictAccessorFailure_DoesNotReflectHostileMemberName()
+    {
+        const string hazardousName = "Changed\u001B[31mINJECTED";
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class"
+        };
+        var member = new ApiMember
+        {
+            Name = hazardousName,
+            Kind = "event",
+            Accessibility = "public",
+            AccessorFacts =
+            [
+                new ApiAccessor { Kind = "add" },
+                new ApiAccessor { Kind = "remove", Accessibility = "private" }
+            ]
+        };
+
+        NotSupportedException exception =
+            Assert.Throws<NotSupportedException>(() =>
+                CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
+
+        Assert.DoesNotContain('\u001B', exception.Message);
+        Assert.DoesNotContain("INJECTED", exception.Message);
+    }
+
+    [Fact]
+    public void MetadataAccessorFallback_DistinguishesIndexerSignatures()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class"
+        };
+        var formatter = new CSharpFormatter(
+            new CSharpFormatOptions { AllowMetadataFallback = true });
+
+        string Render(string parameterType)
+        {
+            var member = new ApiMember
+            {
+                Name = "Item",
+                Kind = "property",
+                Accessibility = "protected internal",
+                Signature =
+                    $"int this[{parameterType} index] "
+                    + "{ get; protected set; }",
+                AccessorFacts =
+                [
+                    new ApiAccessor
+                    {
+                        Kind = "get",
+                        Accessibility = "protected"
+                    },
+                    new ApiAccessor
+                    {
+                        Kind = "set",
+                        Accessibility = "internal"
+                    }
+                ]
+            };
+            return formatter.FormatMember(type, member);
+        }
+
+        string intIndexer = Render("int");
+        string stringIndexer = Render("string");
+
+        Assert.NotEqual(intIndexer, stringIndexer);
+        Assert.Contains("int index", intIndexer);
+        Assert.Contains("string index", stringIndexer);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void InterfaceMethodImplReusingInterfaceSlot_IsRepresentable(
+        bool isAbstract)
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "IDerived",
+            Kind = "interface"
+        };
+        var member = new ApiMember
+        {
+            Name = "Samples.IBase.M",
+            Kind = "explicit-interface-implementation",
+            Signature = "void Samples.IBase.M()",
+            Accessibility = "private",
+            IsVirtual = true,
+            IsFinal = !isAbstract,
+            IsAbstract = isAbstract,
+            IsOverride = true,
+            IsExplicitInterfaceImplementation = true,
+            InterfaceImplementationResolution =
+                InterfaceImplementationResolution.Proven
+        };
+
+        string declaration =
+            CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Contains("void Samples.IBase.M()", declaration);
+        Assert.DoesNotContain("metadata MethodImpl", declaration);
     }
 
     [Theory]

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1330,6 +1330,125 @@ public sealed class CSharpDeclarationWriterTests
         Assert.Equal("public int Read()", declaration);
     }
 
+    [Fact]
+    public void MetadataFormatterFallsBackForUnqualifiedMethodImpl()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class"
+        };
+        var member = new ApiMember
+        {
+            Name = "Read",
+            Kind = "explicit-interface-implementation",
+            Signature = "int Read()",
+            Accessibility = "private",
+            IsVirtual = true,
+            IsNewSlot = true,
+            IsFinal = true,
+            IsExplicitInterfaceImplementation = true,
+            InterfaceImplementationResolution =
+                InterfaceImplementationResolution.Undetermined
+        };
+        var formatter = new CSharpFormatter(
+            new CSharpFormatOptions { AllowMetadataFallback = true });
+
+        string declaration = formatter.FormatMember(type, member);
+
+        Assert.Equal(
+            "metadata MethodImpl (undetermined) private final newslot virtual int Read()",
+            declaration);
+    }
+
+    [Fact]
+    public void IncomparablePropertyAccessorAccessibilityFailsStrictProjection()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class"
+        };
+        var member = new ApiMember
+        {
+            Name = "Value",
+            Kind = "property",
+            Accessibility = "protected internal",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Value",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get", Accessibility = "protected" },
+                    new ApiAccessor { Kind = "set", Accessibility = "internal" }
+                ]
+            },
+            AccessorFacts =
+            [
+                new ApiAccessor { Kind = "get", Accessibility = "protected" },
+                new ApiAccessor { Kind = "set", Accessibility = "internal" }
+            ]
+        };
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
+
+        Assert.Contains(
+            "incomparable metadata accessor accessibilities",
+            exception.Message,
+            StringComparison.Ordinal);
+
+        var formatter = new CSharpFormatter(
+            new CSharpFormatOptions { AllowMetadataFallback = true });
+        Assert.Equal(
+            "metadata property protected internal int Value (get: protected, set: internal)",
+            formatter.FormatMember(type, member));
+    }
+
+    [Fact]
+    public void UnequalEventAccessorAccessibilityFailsStrictProjection()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class"
+        };
+        var member = new ApiMember
+        {
+            Name = "Changed",
+            Kind = "event",
+            Accessibility = "public",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.Action",
+                MemberName = "Changed"
+            },
+            AccessorFacts =
+            [
+                new ApiAccessor { Kind = "add" },
+                new ApiAccessor { Kind = "remove", Accessibility = "private" }
+            ]
+        };
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
+
+        Assert.Contains(
+            "unequal metadata accessor accessibilities",
+            exception.Message,
+            StringComparison.Ordinal);
+
+        var formatter = new CSharpFormatter(
+            new CSharpFormatOptions { AllowMetadataFallback = true });
+        Assert.Equal(
+            "metadata event public System.Action Changed (add: public, remove: private)",
+            formatter.FormatMember(type, member));
+    }
+
     [Theory]
     // A C# tuple type is parenthesized, so a parameter-list scan that takes the first
     // '(' mistakes a tuple-typed return for a parameter list and escapes each element's

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1270,6 +1270,7 @@ public sealed class CSharpDeclarationWriterTests
             exception.Message,
             StringComparison.Ordinal);
         Assert.Contains("C# cannot represent", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(member.Name, exception.Message, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -807,6 +807,7 @@ public sealed class CSharpDeclarationWriterTests
         {
             Name = "Some.@event.IEvents.Changed",
             Kind = "explicit-interface-implementation",
+            Accessibility = "private",
             IsStatic = true,
             IsUnsafe = true,
             SignatureModel = new ApiSignature
@@ -836,6 +837,7 @@ public sealed class CSharpDeclarationWriterTests
         {
             Name = "Some.IEvents.Changed",
             Kind = "explicit-interface-implementation",
+            Accessibility = "private",
             SignatureModel = new ApiSignature
             {
                 ReturnType = "System.EventHandler",
@@ -1188,6 +1190,7 @@ public sealed class CSharpDeclarationWriterTests
         {
             Name = "Samples.ICounter.Count",
             Kind = "explicit-interface-implementation",
+            Accessibility = "private",
             IsStatic = true,
             SignatureModel = new ApiSignature
             {
@@ -1210,6 +1213,7 @@ public sealed class CSharpDeclarationWriterTests
         {
             Name = "IFoo.Bar",
             Kind = "explicit-interface-implementation",
+            Accessibility = "private",
             Signature = "void IFoo.Bar(int* p)",
             IsUnsafe = true
         };
@@ -1227,12 +1231,45 @@ public sealed class CSharpDeclarationWriterTests
         {
             Name = "event.class",
             Kind = "explicit-interface-implementation",
+            Accessibility = "private",
             Signature = "void event.class()"
         };
 
         var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
 
         Assert.Equal("void @event.@class()", declaration);
+    }
+
+    [Theory]
+    [InlineData(null, "public")]
+    [InlineData("internal", "internal")]
+    [InlineData("protected", "protected")]
+    public void ExplicitInterfaceImplementation_NonPrivateAccessibilityFailsClosed(
+        string? accessibility,
+        string expectedAccessibility)
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Samples.IValue.Value",
+            Kind = "explicit-interface-implementation",
+            Accessibility = accessibility,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Samples.IValue.Value",
+                Accessors = [new ApiAccessor { Kind = "get" }]
+            }
+        };
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
+
+        Assert.Contains(
+            $"metadata accessibility '{expectedAccessibility}'",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.Contains("C# cannot represent", exception.Message, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -1675,6 +1712,7 @@ public sealed class CSharpDeclarationWriterTests
         var (type, member) = CreateConstrainedGenericMethod();
         member.IsStatic = false;
         member.Kind = "explicit-interface-implementation";
+        member.Accessibility = "private";
         member.Name = "Samples.IComparer.Compare";
         member.Signature = "int Samples.IComparer.Compare<T>(T a, T b)";
         member.SignatureModel!.MemberName = "Samples.IComparer.Compare<T>";

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -720,6 +720,91 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void MixedDefaultInterfaceAccessorsCompileBack()
+    {
+        var type = new ApiType
+        {
+            Namespace = "ILInspector.CSharp.Tests",
+            Name = "IMixedDefaultAccessorSurface",
+            Kind = "interface",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Value",
+                    Kind = "property",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "int",
+                        MemberName = "Value",
+                        Accessors =
+                        [
+                            new ApiAccessor { Kind = "get", IsAbstract = true },
+                            new ApiAccessor { Kind = "set", IsAbstract = false }
+                        ]
+                    }
+                }
+            ]
+        };
+
+        Assert.False(type.Members[0].IsAbstract);
+        Assert.Contains(
+            type.Members[0].SignatureModel!.Accessors,
+            accessor => accessor is { Kind: "get", IsAbstract: true });
+        Assert.Contains(
+            type.Members[0].SignatureModel!.Accessors,
+            accessor => accessor is { Kind: "set", IsAbstract: false });
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains("get", result.Source, StringComparison.Ordinal);
+        Assert.Contains("set", result.Source, StringComparison.Ordinal);
+        Assert.Equal(2, result.Source.Split("throw null;", StringSplitOptions.None).Length - 1);
+        AssertCompiles(result.Source);
+    }
+
+    [Fact]
+    public void RefReturnExplicitInterfacePropertyUsesThrowAccessor()
+    {
+        using var peReader = new PEReader(
+            File.OpenRead(typeof(RefReturnExplicitSurface).Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+        {
+            var definition = reader.GetTypeDefinition(handle);
+            return reader.GetString(definition.Namespace) == "ILInspector.CSharp.Tests"
+                && reader.GetString(definition.Name) == nameof(RefReturnExplicitSurface);
+        });
+        var type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        type.Interfaces = [Assert.Single(type.Interfaces)];
+        type.Members =
+        [
+            Assert.Single(
+                type.Members,
+                member => member.Kind == "property"
+                    && member.IsExplicitInterfaceImplementation)
+        ];
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains("ref int", result.Source, StringComparison.Ordinal);
+        Assert.Contains("throw null;", result.Source, StringComparison.Ordinal);
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface IRefReturnSurface
+            {
+                ref int Value { get; }
+            }
+            """);
+    }
+
+    [Fact]
     public void ExplicitInterfaceEventSkeletonDoesNotDiscardCallerBody()
     {
         var type = CreateEmptyType("Samples", "Widget");
@@ -5244,4 +5329,16 @@ public interface IExplicitIndexerSurface
 public sealed class ExplicitIndexerSurface : IExplicitIndexerSurface
 {
     int IExplicitIndexerSurface.this[int index] => index;
+}
+
+public interface IRefReturnSurface
+{
+    ref int Value { get; }
+}
+
+public sealed class RefReturnExplicitSurface : IRefReturnSurface
+{
+    private int _value;
+
+    ref int IRefReturnSurface.Value => ref _value;
 }

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -454,6 +454,92 @@ public sealed class CSharpTypePrinterTests
         Assert.Contains("no legal C# class spelling", exception.Message, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// An explicit interface event is projected with both accessor bodies written
+    /// unconditionally, so a malformed Event row that declares only a remover would render an
+    /// <c>add</c> the metadata never declared. Retaining the truthful accessor identity means
+    /// failing: C# has no spelling for a half an event.
+    /// </summary>
+    [Fact]
+    public void ExplicitInterfaceEvent_WithoutBothAccessors_FailsVisibly()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        var removeOnlyEvent = new ApiMember
+        {
+            Name = "Samples.IEvents.Changed",
+            Kind = "event",
+            Accessibility = "private",
+            IsExplicitInterfaceImplementation = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "Samples.IEvents.Changed",
+                Accessors = [new ApiAccessor { Kind = "remove" }]
+            }
+        };
+        type.Members.Add(removeOnlyEvent);
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains("Samples.IEvents.Changed", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("remove", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("'add'", exception.Message, StringComparison.Ordinal);
+
+        // The close negative: the same event with both accessors still renders both bodies.
+        removeOnlyEvent.SignatureModel!.Accessors =
+        [
+            new ApiAccessor { Kind = "add" },
+            new ApiAccessor { Kind = "remove" }
+        ];
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+        Assert.Contains("add", result.Source, StringComparison.Ordinal);
+        Assert.Contains("remove", result.Source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Abstractness belongs to the member outside an interface, so a class aggregate whose
+    /// accessors disagree has no legal C# spelling and must not be rendered as the concrete
+    /// aggregate its non-abstract accessor suggests. Interfaces keep mixing, which
+    /// <see cref="MixedDefaultInterfaceAccessorsCompileBack"/> gates.
+    /// </summary>
+    [Fact]
+    public void MixedAccessorAbstractionInClass_FailsVisibly()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        type.IsAbstract = true;
+        type.Members.Add(new ApiMember
+        {
+            Name = "Value",
+            Kind = "property",
+            Accessibility = "public",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Value",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get", IsAbstract = true },
+                    new ApiAccessor { Kind = "set", IsAbstract = false }
+                ]
+            }
+        });
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains("disagree about abstractness", exception.Message, StringComparison.Ordinal);
+
+        // The close negative: uniform abstractness on the same class still renders.
+        type.Members[0].SignatureModel!.Accessors =
+        [
+            new ApiAccessor { Kind = "get", IsAbstract = false },
+            new ApiAccessor { Kind = "set", IsAbstract = false }
+        ];
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+        Assert.Contains("int Value", result.Source, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void FrameworkExplicitInterfaceEventSkeletonUsesThrowAccessors()
     {

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using ILInspector.Metadata;
@@ -367,12 +368,52 @@ public sealed class CSharpTypePrinterTests
                 Kind: "event",
                 IsExplicitInterfaceImplementation: true
             } && member.Name.EndsWith(".PropertyChanged", StringComparison.Ordinal));
+        type.Interfaces =
+        [
+            Assert.Single(
+                type.Interfaces,
+                interfaceName => interfaceName == "System.ComponentModel.INotifyPropertyChanged")
+        ];
         type.Members = [explicitEvent];
 
         var result = _printer.Print(new CSharpTypePrintRequest(type));
 
         Assert.Contains("INotifyPropertyChanged.PropertyChanged", result.Source, StringComparison.Ordinal);
         Assert.Contains("throw null;", result.Source, StringComparison.Ordinal);
+        AssertCompiles(result.Source);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceEventSkeletonDoesNotDiscardCallerBody()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Interfaces.Add("Samples.IEvents");
+        var explicitEvent = new ApiMember
+        {
+            Name = "Samples.IEvents.Changed",
+            Kind = "event",
+            ReturnType = "System.EventHandler",
+            IsExplicitInterfaceImplementation = true
+        };
+        type.Members.Add(explicitEvent);
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => _printer.Print(new CSharpTypePrintRequest(
+                type,
+                memberPolicyOverrides:
+                [
+                    new CSharpMemberPolicy(
+                        explicitEvent,
+                        CSharpBodyPolicy.Skeleton,
+                        new CSharpEventBody(
+                            CSharpAccessorBody.Throw,
+                            CSharpAccessorBody.Throw))
+                ])));
+
+        Assert.Contains(
+            "cannot carry an implementation body",
+            exception.Message,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -4703,6 +4744,57 @@ public sealed class CSharpTypePrinterTests
             Name = name,
             Kind = "class"
         };
+
+    static void AssertCompiles(string source)
+    {
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"csharp-type-printer-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(directory, "Generated.csproj"),
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net10.0</TargetFramework>
+                    <LangVersion>preview</LangVersion>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(Path.Combine(directory, "Generated.cs"), source);
+
+            var startInfo = new ProcessStartInfo("dotnet")
+            {
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            startInfo.ArgumentList.Add("build");
+            startInfo.ArgumentList.Add("Generated.csproj");
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add("Release");
+            startInfo.ArgumentList.Add("--nologo");
+            startInfo.ArgumentList.Add("--verbosity");
+            startInfo.ArgumentList.Add("quiet");
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Could not start dotnet build.");
+            string stdout = process.StandardOutput.ReadToEnd();
+            string stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            Assert.True(
+                process.ExitCode == 0,
+                $"Generated source did not compile.{Environment.NewLine}{stdout}{stderr}");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
 
     static ApiMember CreateMethod(string name)
         => new()

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -753,6 +753,54 @@ public sealed class CSharpTypePrinterTests
 
             public interface IReabstractedSurface
             {
+                void Reset();
+                int Value { get; }
+                event System.Action Changed;
+            }
+            """);
+    }
+
+    [Fact]
+    public void ReabstractedExplicitInterfaceMethodsCompileBack()
+    {
+        using var peReader = new PEReader(
+            File.OpenRead(typeof(ReabstractedExplicitSurface).Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+        {
+            var definition = reader.GetTypeDefinition(handle);
+            return reader.GetString(definition.Namespace) == "ILInspector.CSharp.Tests"
+                && reader.GetString(definition.Name) == nameof(ReabstractedExplicitSurface);
+        });
+        var type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        type.Interfaces = [Assert.Single(type.Interfaces)];
+        type.Members =
+        [
+            Assert.Single(type.Members, member =>
+                member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(".Reset", StringComparison.Ordinal)),
+        ];
+
+        ApiMember method = Assert.Single(type.Members);
+        Assert.True(method.IsAbstract);
+        Assert.True(method.IsVirtual);
+        Assert.False(method.IsOverride);
+        Assert.False(method.IsSealed);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains("abstract void", result.Source, StringComparison.Ordinal);
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface IReabstractedSurface
+            {
+                void Reset();
                 int Value { get; }
                 event System.Action Changed;
             }
@@ -5414,12 +5462,14 @@ public sealed class InitOnlyExplicitSurface : IInitOnlySurface
 
 public interface IReabstractedSurface
 {
+    void Reset();
     int Value { get; }
     event Action Changed;
 }
 
 public interface ReabstractedExplicitSurface : IReabstractedSurface
 {
+    abstract void IReabstractedSurface.Reset();
     abstract int IReabstractedSurface.Value { get; }
     abstract event Action IReabstractedSurface.Changed;
 }

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -742,22 +742,50 @@ public sealed class CSharpTypePrinterTests
         Assert.Equal(2, type.Members.Count);
         Assert.All(type.Members, member => Assert.True(member.IsAbstract));
 
-        var result = _printer.Print(new CSharpTypePrintRequest(type));
+        Assert.All(type.Members, member => Assert.True(member.IsOverride));
+        Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+    }
 
-        Assert.Contains("abstract int", result.Source, StringComparison.Ordinal);
-        Assert.Contains("abstract event", result.Source, StringComparison.Ordinal);
-        AssertCompiles(
-            result.Source,
-            """
-            namespace ILInspector.CSharp.Tests;
-
-            public interface IReabstractedSurface
+    [Fact]
+    public void StrictPrinterSnapshotPreservesAccessorAccessibilityFacts()
+    {
+        var property = new ApiMember
+        {
+            Name = "Value",
+            Kind = "property",
+            Accessibility = "protected internal",
+            SignatureModel = new ApiSignature
             {
-                void Reset();
-                int Value { get; }
-                event System.Action Changed;
-            }
-            """);
+                ReturnType = "int",
+                MemberName = "Value",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get", Accessibility = "protected" },
+                    new ApiAccessor { Kind = "set", Accessibility = "internal" }
+                ]
+            },
+            AccessorFacts =
+            [
+                new ApiAccessor { Kind = "get", Accessibility = "protected" },
+                new ApiAccessor { Kind = "set", Accessibility = "internal" }
+            ]
+        };
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "AccessorHost",
+            Kind = "class",
+            Members = [property]
+        };
+
+        NotSupportedException exception = Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains(
+            "incomparable metadata accessor accessibilities",
+            exception.Message,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -787,24 +815,13 @@ public sealed class CSharpTypePrinterTests
         ApiMember method = Assert.Single(type.Members);
         Assert.True(method.IsAbstract);
         Assert.True(method.IsVirtual);
-        Assert.False(method.IsOverride);
-        Assert.False(method.IsSealed);
+        Assert.True(method.IsOverride);
+        Assert.True(method.IsSealed);
+        Assert.True(method.IsFinal);
+        Assert.False(method.IsNewSlot);
 
-        var result = _printer.Print(new CSharpTypePrintRequest(type));
-
-        Assert.Contains("abstract void", result.Source, StringComparison.Ordinal);
-        AssertCompiles(
-            result.Source,
-            """
-            namespace ILInspector.CSharp.Tests;
-
-            public interface IReabstractedSurface
-            {
-                void Reset();
-                int Value { get; }
-                event System.Action Changed;
-            }
-            """);
+        Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
     }
 
     [Fact]
@@ -834,24 +851,13 @@ public sealed class CSharpTypePrinterTests
         ApiMember method = Assert.Single(type.Members);
         Assert.False(method.IsAbstract);
         Assert.True(method.IsVirtual);
-        Assert.False(method.IsOverride);
-        Assert.False(method.IsSealed);
+        Assert.True(method.IsOverride);
+        Assert.True(method.IsSealed);
+        Assert.True(method.IsFinal);
+        Assert.False(method.IsNewSlot);
 
-        var result = _printer.Print(new CSharpTypePrintRequest(type));
-
-        Assert.Contains("throw null;", result.Source, StringComparison.Ordinal);
-        AssertCompiles(
-            result.Source,
-            """
-            namespace ILInspector.CSharp.Tests;
-
-            public interface IReabstractedSurface
-            {
-                void Reset();
-                int Value { get; }
-                event System.Action Changed;
-            }
-            """);
+        Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
     }
 
     [Fact]

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -808,6 +808,53 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void ConcreteExplicitInterfaceMethodsCompileBack()
+    {
+        using var peReader = new PEReader(
+            File.OpenRead(typeof(ConcreteExplicitSurface).Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+        {
+            var definition = reader.GetTypeDefinition(handle);
+            return reader.GetString(definition.Namespace) == "ILInspector.CSharp.Tests"
+                && reader.GetString(definition.Name) == nameof(ConcreteExplicitSurface);
+        });
+        var type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        type.Interfaces = [Assert.Single(type.Interfaces)];
+        type.Members =
+        [
+            Assert.Single(type.Members, member =>
+                member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(".Reset", StringComparison.Ordinal)),
+        ];
+
+        ApiMember method = Assert.Single(type.Members);
+        Assert.False(method.IsAbstract);
+        Assert.True(method.IsVirtual);
+        Assert.False(method.IsOverride);
+        Assert.False(method.IsSealed);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains("throw null;", result.Source, StringComparison.Ordinal);
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface IReabstractedSurface
+            {
+                void Reset();
+                int Value { get; }
+                event System.Action Changed;
+            }
+            """);
+    }
+
+    [Fact]
     public void NullableExplicitInterfaceAggregatesCompileBack()
     {
         using var peReader = new PEReader(
@@ -5472,6 +5519,11 @@ public interface ReabstractedExplicitSurface : IReabstractedSurface
     abstract void IReabstractedSurface.Reset();
     abstract int IReabstractedSurface.Value { get; }
     abstract event Action IReabstractedSurface.Changed;
+}
+
+public interface ConcreteExplicitSurface : IReabstractedSurface
+{
+    void IReabstractedSurface.Reset() { }
 }
 
 public interface INullableAggregateSurface<T>

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -497,6 +497,40 @@ public sealed class CSharpTypePrinterTests
         Assert.Contains("remove", result.Source, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void RegularRemoveOnlyEvent_FailsVisibly()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        var removeOnlyEvent = new ApiMember
+        {
+            Name = "Changed",
+            Kind = "event",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "Changed",
+                Accessors = [new ApiAccessor { Kind = "remove" }]
+            }
+        };
+        type.Members.Add(removeOnlyEvent);
+
+        var exception = Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
+
+        Assert.Contains("Changed", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("remove", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("'add'", exception.Message, StringComparison.Ordinal);
+
+        removeOnlyEvent.SignatureModel!.Accessors =
+        [
+            new ApiAccessor { Kind = "add" },
+            new ApiAccessor { Kind = "remove" }
+        ];
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains("event EventHandler Changed;", result.Source, StringComparison.Ordinal);
+    }
+
     /// <summary>
     /// Abstractness belongs to the member outside an interface, so a class aggregate whose
     /// accessors disagree has no legal C# spelling and must not be rendered as the concrete

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -246,7 +246,9 @@ public sealed class CSharpTypePrinterTests
         var explicitEvent = new ApiMember
         {
             Name = "Samples.IEvents.Changed",
-            Kind = "explicit-interface-implementation",
+            Kind = "event",
+            Accessibility = "private",
+            IsExplicitInterfaceImplementation = true,
             IsStatic = true,
             SignatureModel = new ApiSignature
             {
@@ -3115,7 +3117,9 @@ public sealed class CSharpTypePrinterTests
         var property = new ApiMember
         {
             Name = "Samples.IValue.Value",
-            Kind = "explicit-interface-implementation",
+            Kind = "property",
+            Accessibility = "private",
+            IsExplicitInterfaceImplementation = true,
             SignatureModel = new ApiSignature
             {
                 ReturnType = "int",

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -384,6 +384,58 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void GenericExplicitInterfaceAggregatesCompileBack()
+    {
+        using var peReader = new PEReader(
+            File.OpenRead(typeof(GenericExplicitAggregateSurface<>).Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+        {
+            var definition = reader.GetTypeDefinition(handle);
+            return reader.GetString(definition.Namespace) == "ILInspector.CSharp.Tests"
+                && reader.GetString(definition.Name) == "GenericExplicitAggregateSurface`1";
+        });
+        var type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        type.Interfaces =
+        [
+            Assert.Single(
+                type.Interfaces,
+                interfaceName => interfaceName.EndsWith(
+                    ".IGenericAggregateSurface<T>",
+                    StringComparison.Ordinal))
+        ];
+        type.Members =
+        [
+            .. type.Members.Where(member =>
+                member.IsExplicitInterfaceImplementation
+                && member.Kind is "property" or "event")
+        ];
+
+        Assert.Equal(2, type.Members.Count);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain("private ", result.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain("virtual ", result.Source, StringComparison.Ordinal);
+        Assert.Contains("IGenericAggregateSurface<T>.Value", result.Source, StringComparison.Ordinal);
+        Assert.Contains("IGenericAggregateSurface<T>.Changed", result.Source, StringComparison.Ordinal);
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface IGenericAggregateSurface<T>
+            {
+                T Value { get; }
+                event System.Action<T> Changed;
+            }
+            """);
+    }
+
+    [Fact]
     public void ExplicitInterfaceEventSkeletonDoesNotDiscardCallerBody()
     {
         var type = CreateEmptyType("Samples", "Widget");
@@ -4745,7 +4797,7 @@ public sealed class CSharpTypePrinterTests
             Kind = "class"
         };
 
-    static void AssertCompiles(string source)
+    static void AssertCompiles(string source, string? additionalSource = null)
     {
         string directory = Path.Combine(
             Path.GetTempPath(),
@@ -4765,6 +4817,8 @@ public sealed class CSharpTypePrinterTests
                 </Project>
                 """);
             File.WriteAllText(Path.Combine(directory, "Generated.cs"), source);
+            if (additionalSource is not null)
+                File.WriteAllText(Path.Combine(directory, "Contract.cs"), additionalSource);
 
             var startInfo = new ProcessStartInfo("dotnet")
             {
@@ -4823,5 +4877,22 @@ public sealed class CSharpTypePrinterTests
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
             => GetEnumerator();
+    }
+}
+
+public interface IGenericAggregateSurface<T>
+{
+    T Value { get; }
+    event Action<T> Changed;
+}
+
+public sealed class GenericExplicitAggregateSurface<T> : IGenericAggregateSurface<T>
+{
+    T IGenericAggregateSurface<T>.Value => default!;
+
+    event Action<T> IGenericAggregateSurface<T>.Changed
+    {
+        add { }
+        remove { }
     }
 }

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -663,6 +663,53 @@ public sealed class CSharpTypePrinterTests
             """);
     }
 
+    [Fact]
+    public void NestedGenericExplicitInterfaceAggregatesCompileBack()
+    {
+        using var peReader = new PEReader(
+            File.OpenRead(typeof(NestedGenericExplicitAggregateSurface<,>).Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+        {
+            var definition = reader.GetTypeDefinition(handle);
+            return reader.GetString(definition.Namespace) == "ILInspector.CSharp.Tests"
+                && reader.GetString(definition.Name)
+                    == "NestedGenericExplicitAggregateSurface`2";
+        });
+        var type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        type.Members =
+        [
+            Assert.Single(type.Members, member =>
+                member.Kind == "property"
+                && member.Name.EndsWith(".Value", StringComparison.Ordinal))
+        ];
+
+        Assert.True(type.Members[0].IsExplicitInterfaceImplementation);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains(
+            "NestedGenericAggregateOuter<T>.I<U>.Value",
+            result.Source,
+            StringComparison.Ordinal);
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public class NestedGenericAggregateOuter<T>
+            {
+                public interface I<U>
+                {
+                    U Value { get; }
+                }
+            }
+            """);
+    }
+
     [Theory]
     [InlineData(typeof(SetterOnlyExplicitSurface), "set")]
     [InlineData(typeof(InitOnlyExplicitSurface), "init")]
@@ -5485,6 +5532,20 @@ public sealed class GenericExplicitAggregateSurface<T> : IGenericAggregateSurfac
         add { }
         remove { }
     }
+}
+
+public class NestedGenericAggregateOuter<T>
+{
+    public interface I<U>
+    {
+        U Value { get; }
+    }
+}
+
+public sealed class NestedGenericExplicitAggregateSurface<T, U>
+    : NestedGenericAggregateOuter<T>.I<U>
+{
+    U NestedGenericAggregateOuter<T>.I<U>.Value => default!;
 }
 
 public interface ISetterOnlySurface

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -347,17 +347,16 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Theory]
-    [InlineData("interface", false)]
-    [InlineData("class", true)]
-    public void ExplicitInterfaceEventSkeletonRemainsSkeletonWhenBodiesAreIllegal(
-        string typeKind,
-        bool isAbstract)
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExplicitInterfaceAggregatesInInterfaceCompileBack(bool isAbstract)
     {
         var type = CreateEmptyType("Samples", "Widget");
-        type.Kind = typeKind;
+        type.Kind = "interface";
+        type.Interfaces = ["Samples.IContract"];
         var explicitEvent = new ApiMember
         {
-            Name = "Samples.IEvents.Changed",
+            Name = "Samples.IContract.Changed",
             Kind = "event",
             Accessibility = "private",
             IsExplicitInterfaceImplementation = true,
@@ -365,7 +364,81 @@ public sealed class CSharpTypePrinterTests
             SignatureModel = new ApiSignature
             {
                 ReturnType = "System.EventHandler",
-                MemberName = "Samples.IEvents.Changed",
+                MemberName = "Samples.IContract.Changed",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "add" },
+                    new ApiAccessor { Kind = "remove" }
+                ]
+            }
+        };
+        var explicitProperty = new ApiMember
+        {
+            Name = "Samples.IContract.Value",
+            Kind = "property",
+            Accessibility = "private",
+            IsExplicitInterfaceImplementation = true,
+            IsAbstract = isAbstract,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Samples.IContract.Value",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" },
+                    new ApiAccessor { Kind = "set" }
+                ]
+            }
+        };
+        type.Members.Add(explicitEvent);
+        type.Members.Add(explicitProperty);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        if (isAbstract)
+        {
+            Assert.Contains(
+                "abstract event EventHandler Samples.IContract.Changed;",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "abstract int Samples.IContract.Value { get; set; }",
+                result.Source,
+                StringComparison.Ordinal);
+        }
+        else
+        {
+            Assert.Contains("throw null;", result.Source, StringComparison.Ordinal);
+        }
+        AssertCompiles(
+            result.Source,
+            """
+            namespace Samples;
+
+            public interface IContract
+            {
+                event System.EventHandler Changed;
+                int Value { get; set; }
+            }
+            """);
+    }
+
+    [Fact]
+    public void AbstractExplicitInterfaceAggregateInClassFailsClosed()
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        type.IsAbstract = true;
+        var explicitEvent = new ApiMember
+        {
+            Name = "Samples.IContract.Changed",
+            Kind = "event",
+            Accessibility = "private",
+            IsExplicitInterfaceImplementation = true,
+            IsAbstract = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "Samples.IContract.Changed",
                 Accessors =
                 [
                     new ApiAccessor { Kind = "add" },
@@ -375,10 +448,10 @@ public sealed class CSharpTypePrinterTests
         };
         type.Members.Add(explicitEvent);
 
-        var result = _printer.Print(new CSharpTypePrintRequest(type));
+        var exception = Assert.Throws<NotSupportedException>(
+            () => _printer.Print(new CSharpTypePrintRequest(type)));
 
-        Assert.Contains("Samples.IEvents.Changed", result.Source, StringComparison.Ordinal);
-        Assert.DoesNotContain("throw null;", result.Source, StringComparison.Ordinal);
+        Assert.Contains("no legal C# class spelling", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -790,8 +790,25 @@ public sealed class CSharpTypePrinterTests
         Assert.All(type.Members, member => Assert.True(member.IsAbstract));
 
         Assert.All(type.Members, member => Assert.True(member.IsOverride));
-        Assert.Throws<NotSupportedException>(
-            () => _printer.Print(new CSharpTypePrintRequest(type)));
+        CSharpTypePrintResult result =
+            _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain(
+            "metadata MethodImpl",
+            result.Source,
+            StringComparison.Ordinal);
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface IReabstractedSurface
+            {
+                void Reset();
+                int Value { get; }
+                event System.Action Changed;
+            }
+            """);
     }
 
     [Fact]
@@ -867,8 +884,25 @@ public sealed class CSharpTypePrinterTests
         Assert.True(method.IsFinal);
         Assert.False(method.IsNewSlot);
 
-        Assert.Throws<NotSupportedException>(
-            () => _printer.Print(new CSharpTypePrintRequest(type)));
+        CSharpTypePrintResult result =
+            _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain(
+            "metadata MethodImpl",
+            result.Source,
+            StringComparison.Ordinal);
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface IReabstractedSurface
+            {
+                void Reset();
+                int Value { get; }
+                event System.Action Changed;
+            }
+            """);
     }
 
     [Fact]
@@ -903,8 +937,25 @@ public sealed class CSharpTypePrinterTests
         Assert.True(method.IsFinal);
         Assert.False(method.IsNewSlot);
 
-        Assert.Throws<NotSupportedException>(
-            () => _printer.Print(new CSharpTypePrintRequest(type)));
+        CSharpTypePrintResult result =
+            _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.DoesNotContain(
+            "metadata MethodImpl",
+            result.Source,
+            StringComparison.Ordinal);
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface IReabstractedSurface
+            {
+                void Reset();
+                int Value { get; }
+                event System.Action Changed;
+            }
+            """);
     }
 
     [Fact]

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -1,4 +1,7 @@
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using ILInspector.Metadata;
 
 namespace ILInspector.CSharp.Tests;
@@ -295,14 +298,15 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
-    public void ExplicitInterfaceEventSkeletonFailsClosed()
+    public void ExplicitInterfaceEventSkeletonUsesThrowAccessors()
     {
         var type = CreateEmptyType("Samples", "Widget");
-        type.Members.Add(new ApiMember
+        var explicitEvent = new ApiMember
         {
             Name = "Samples.IEvents.Changed",
-            Kind = "explicit-interface-implementation",
+            Kind = "event",
             Accessibility = "private",
+            IsExplicitInterfaceImplementation = true,
             SignatureModel = new ApiSignature
             {
                 ReturnType = "System.EventHandler",
@@ -313,12 +317,62 @@ public sealed class CSharpTypePrinterTests
                     new ApiAccessor { Kind = "remove" }
                 ]
             }
+        };
+        type.Members.Add(explicitEvent);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(explicitEvent, CSharpBodyPolicy.Skeleton)
+            ]));
+
+        Assert.Contains(
+            """
+                event EventHandler Samples.IEvents.Changed
+                {
+                    add
+                    {
+                        throw null;
+                    }
+                    remove
+                    {
+                        throw null;
+                    }
+                }
+            """,
+            result.Units[0].Source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FrameworkExplicitInterfaceEventSkeletonUsesThrowAccessors()
+    {
+        using var peReader = new PEReader(File.OpenRead(typeof(ObservableCollection<>).Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+        {
+            var definition = reader.GetTypeDefinition(handle);
+            return reader.GetString(definition.Namespace) == "System.Collections.ObjectModel"
+                && reader.GetString(definition.Name) == "ObservableCollection`1";
         });
+        var type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        var explicitEvent = Assert.Single(
+            type.Members,
+            member => member is
+            {
+                Kind: "event",
+                IsExplicitInterfaceImplementation: true
+            } && member.Name.EndsWith(".PropertyChanged", StringComparison.Ordinal));
+        type.Members = [explicitEvent];
 
-        var exception = Assert.Throws<NotSupportedException>(
-            () => _printer.Print(new CSharpTypePrintRequest(type)));
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
 
-        Assert.Contains("requires add/remove bodies", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("INotifyPropertyChanged.PropertyChanged", result.Source, StringComparison.Ordinal);
+        Assert.Contains("throw null;", result.Source, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -3297,8 +3351,9 @@ public sealed class CSharpTypePrinterTests
         var property = new ApiMember
         {
             Name = "Samples.IValue.Value",
-            Kind = "explicit-interface-implementation",
+            Kind = "property",
             Accessibility = "private",
+            IsExplicitInterfaceImplementation = true,
             SignatureModel = new ApiSignature
             {
                 ReturnType = "int",

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -302,6 +302,7 @@ public sealed class CSharpTypePrinterTests
         {
             Name = "Samples.IEvents.Changed",
             Kind = "explicit-interface-implementation",
+            Accessibility = "private",
             SignatureModel = new ApiSignature
             {
                 ReturnType = "System.EventHandler",
@@ -3163,12 +3164,90 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void ExplicitInterfacePropertyWithNonPrivateAccessibilityFailsClosed()
+    {
+        var property = new ApiMember
+        {
+            Name = "Samples.IValue.Value",
+            Kind = "property",
+            Accessibility = "internal",
+            IsExplicitInterfaceImplementation = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Samples.IValue.Value",
+                Accessors = [new ApiAccessor { Kind = "get" }]
+            }
+        };
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Interfaces.Add("Samples.IValue");
+        type.Members.Add(property);
+        var request = new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(
+                    property,
+                    CSharpBodyPolicy.Full,
+                    new CSharpPropertyBody(
+                        CSharpAccessorBody.Block("return 42;"),
+                        null))
+            ]);
+
+        var exception = Assert.Throws<NotSupportedException>(() => _printer.Print(request));
+
+        Assert.Contains("metadata accessibility 'internal'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("C# cannot represent", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceEventWithNonPrivateAccessibilityFailsClosed()
+    {
+        var explicitEvent = new ApiMember
+        {
+            Name = "Samples.IEvents.Changed",
+            Kind = "event",
+            Accessibility = "protected",
+            IsExplicitInterfaceImplementation = true,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "Samples.IEvents.Changed",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "add" },
+                    new ApiAccessor { Kind = "remove" }
+                ]
+            }
+        };
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Members.Add(explicitEvent);
+        var request = new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides:
+            [
+                new CSharpMemberPolicy(
+                    explicitEvent,
+                    CSharpBodyPolicy.Full,
+                    new CSharpEventBody(
+                        CSharpAccessorBody.Block("_changed += value;"),
+                        CSharpAccessorBody.Block("_changed -= value;")))
+            ]);
+
+        var exception = Assert.Throws<NotSupportedException>(() => _printer.Print(request));
+
+        Assert.Contains("metadata accessibility 'protected'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("C# cannot represent", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ExplicitInterfaceIndexerPreservesQualifierAndOmitsAccessibility()
     {
         var indexer = new ApiMember
         {
             Name = "Samples.IValues.Item",
             Kind = "explicit-interface-implementation",
+            Accessibility = "private",
             SignatureModel = new ApiSignature
             {
                 ReturnType = "int",
@@ -3219,6 +3298,7 @@ public sealed class CSharpTypePrinterTests
         {
             Name = "Samples.IValue.Value",
             Kind = "explicit-interface-implementation",
+            Accessibility = "private",
             SignatureModel = new ApiSignature
             {
                 ReturnType = "int",
@@ -3506,6 +3586,7 @@ public sealed class CSharpTypePrinterTests
         {
             Name = "Contracts.IValue.Value",
             Kind = "explicit-interface-implementation",
+            Accessibility = "private",
             SignatureModel = new ApiSignature
             {
                 ReturnType = "Contracts.IValue",
@@ -3536,6 +3617,7 @@ public sealed class CSharpTypePrinterTests
         {
             Name = "Contracts.IValue.Value",
             Kind = "explicit-interface-implementation",
+            Accessibility = "private",
             SignatureModel = new ApiSignature
             {
                 ReturnType = "Other.IValue",

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -346,6 +346,41 @@ public sealed class CSharpTypePrinterTests
             StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("interface", false)]
+    [InlineData("class", true)]
+    public void ExplicitInterfaceEventSkeletonRemainsSkeletonWhenBodiesAreIllegal(
+        string typeKind,
+        bool isAbstract)
+    {
+        var type = CreateEmptyType("Samples", "Widget");
+        type.Kind = typeKind;
+        var explicitEvent = new ApiMember
+        {
+            Name = "Samples.IEvents.Changed",
+            Kind = "event",
+            Accessibility = "private",
+            IsExplicitInterfaceImplementation = true,
+            IsAbstract = isAbstract,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "Samples.IEvents.Changed",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "add" },
+                    new ApiAccessor { Kind = "remove" }
+                ]
+            }
+        };
+        type.Members.Add(explicitEvent);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains("Samples.IEvents.Changed", result.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain("throw null;", result.Source, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void FrameworkExplicitInterfaceEventSkeletonUsesThrowAccessors()
     {

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -543,6 +543,143 @@ public sealed class CSharpTypePrinterTests
             """);
     }
 
+    [Theory]
+    [InlineData(typeof(SetterOnlyExplicitSurface), "set")]
+    [InlineData(typeof(InitOnlyExplicitSurface), "init")]
+    public void SetterAndInitOnlyExplicitPropertiesCompileBack(
+        Type fixtureType,
+        string accessorKind)
+    {
+        using var peReader = new PEReader(File.OpenRead(fixtureType.Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+        {
+            var definition = reader.GetTypeDefinition(handle);
+            return reader.GetString(definition.Namespace) == fixtureType.Namespace
+                && reader.GetString(definition.Name) == fixtureType.Name;
+        });
+        var type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        type.Interfaces = [Assert.Single(type.Interfaces)];
+        type.Members =
+        [
+            Assert.Single(
+                type.Members,
+                member => member.Kind == "property"
+                    && member.IsExplicitInterfaceImplementation)
+        ];
+
+        Assert.Equal(
+            accessorKind,
+            Assert.Single(type.Members[0].SignatureModel!.Accessors).Kind);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains("throw null;", result.Source, StringComparison.Ordinal);
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface ISetterOnlySurface
+            {
+                int Value { set; }
+            }
+
+            public interface IInitOnlySurface
+            {
+                int Value { init; }
+            }
+            """);
+    }
+
+    [Fact]
+    public void ReabstractedExplicitInterfaceAggregatesCompileBack()
+    {
+        using var peReader = new PEReader(
+            File.OpenRead(typeof(ReabstractedExplicitSurface).Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+        {
+            var definition = reader.GetTypeDefinition(handle);
+            return reader.GetString(definition.Namespace) == "ILInspector.CSharp.Tests"
+                && reader.GetString(definition.Name) == nameof(ReabstractedExplicitSurface);
+        });
+        var type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        type.Interfaces = [Assert.Single(type.Interfaces)];
+        type.Members =
+        [
+            .. type.Members.Where(member =>
+                member.IsExplicitInterfaceImplementation
+                && member.Kind is "property" or "event")
+        ];
+
+        Assert.Equal(2, type.Members.Count);
+        Assert.All(type.Members, member => Assert.True(member.IsAbstract));
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        Assert.Contains("abstract int", result.Source, StringComparison.Ordinal);
+        Assert.Contains("abstract event", result.Source, StringComparison.Ordinal);
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface IReabstractedSurface
+            {
+                int Value { get; }
+                event System.Action Changed;
+            }
+            """);
+    }
+
+    [Fact]
+    public void NullableExplicitInterfaceAggregatesCompileBack()
+    {
+        using var peReader = new PEReader(
+            File.OpenRead(typeof(NullableExplicitAggregateSurface).Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+        {
+            var definition = reader.GetTypeDefinition(handle);
+            return reader.GetString(definition.Namespace) == "ILInspector.CSharp.Tests"
+                && reader.GetString(definition.Name) == nameof(NullableExplicitAggregateSurface);
+        });
+        var type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        type.Interfaces = [Assert.Single(type.Interfaces)];
+        type.Members =
+        [
+            .. type.Members.Where(member =>
+                member.IsExplicitInterfaceImplementation
+                && member.Kind is "property" or "event")
+        ];
+
+        Assert.Equal(2, type.Members.Count);
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface INullableAggregateSurface<T>
+            {
+                T Value { get; }
+                event System.Action Changed;
+            }
+            """);
+    }
+
     [Fact]
     public void ExplicitInterfaceEventSkeletonDoesNotDiscardCallerBody()
     {
@@ -4999,6 +5136,61 @@ public sealed class GenericExplicitAggregateSurface<T> : IGenericAggregateSurfac
     T IGenericAggregateSurface<T>.Value => default!;
 
     event Action<T> IGenericAggregateSurface<T>.Changed
+    {
+        add { }
+        remove { }
+    }
+}
+
+public interface ISetterOnlySurface
+{
+    int Value { set; }
+}
+
+public sealed class SetterOnlyExplicitSurface : ISetterOnlySurface
+{
+    int ISetterOnlySurface.Value
+    {
+        set { }
+    }
+}
+
+public interface IInitOnlySurface
+{
+    int Value { init; }
+}
+
+public sealed class InitOnlyExplicitSurface : IInitOnlySurface
+{
+    int IInitOnlySurface.Value
+    {
+        init { }
+    }
+}
+
+public interface IReabstractedSurface
+{
+    int Value { get; }
+    event Action Changed;
+}
+
+public interface ReabstractedExplicitSurface : IReabstractedSurface
+{
+    abstract int IReabstractedSurface.Value { get; }
+    abstract event Action IReabstractedSurface.Changed;
+}
+
+public interface INullableAggregateSurface<T>
+{
+    T Value { get; }
+    event Action Changed;
+}
+
+public sealed class NullableExplicitAggregateSurface : INullableAggregateSurface<int?>
+{
+    int? INullableAggregateSurface<int?>.Value => null;
+
+    event Action INullableAggregateSurface<int?>.Changed
     {
         add { }
         remove { }

--- a/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpTypePrinterTests.cs
@@ -681,6 +681,45 @@ public sealed class CSharpTypePrinterTests
     }
 
     [Fact]
+    public void GetterExplicitInterfaceIndexerCompilesBack()
+    {
+        using var peReader = new PEReader(
+            File.OpenRead(typeof(ExplicitIndexerSurface).Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+        {
+            var definition = reader.GetTypeDefinition(handle);
+            return reader.GetString(definition.Namespace) == "ILInspector.CSharp.Tests"
+                && reader.GetString(definition.Name) == nameof(ExplicitIndexerSurface);
+        });
+        var type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+        type.Interfaces = [Assert.Single(type.Interfaces)];
+        type.Members =
+        [
+            Assert.Single(
+                type.Members,
+                member => member.Kind == "property"
+                    && member.IsExplicitInterfaceImplementation)
+        ];
+
+        var result = _printer.Print(new CSharpTypePrintRequest(type));
+
+        AssertCompiles(
+            result.Source,
+            """
+            namespace ILInspector.CSharp.Tests;
+
+            public interface IExplicitIndexerSurface
+            {
+                int this[int index] { get; }
+            }
+            """);
+    }
+
+    [Fact]
     public void ExplicitInterfaceEventSkeletonDoesNotDiscardCallerBody()
     {
         var type = CreateEmptyType("Samples", "Widget");
@@ -5195,4 +5234,14 @@ public sealed class NullableExplicitAggregateSurface : INullableAggregateSurface
         add { }
         remove { }
     }
+}
+
+public interface IExplicitIndexerSurface
+{
+    int this[int index] { get; }
+}
+
+public sealed class ExplicitIndexerSurface : IExplicitIndexerSurface
+{
+    int IExplicitIndexerSurface.this[int index] => index;
 }

--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -272,6 +272,7 @@ public sealed class TypeShellProducerTests
         Assert.Equal(
             "T? Samples.IRunner.Run<T>(ref int value)",
             policy.Member.Signature);
+        Assert.Equal("private", policy.Member.Accessibility);
 
         var type = new ApiType
         {

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1175,7 +1175,8 @@ internal static class CSharpDeclarationWriter
             if (member.IsUnsafe || options.ForceUnsafe)
                 modifiers.Add("unsafe");
         }
-        else if (!IsExplicitInterfaceImplementation(member))
+        else if (!IsExplicitInterfaceImplementation(member)
+            || member.CanUseImplicitInterfaceSyntax)
         {
             var omitInterfaceModifiers = options.OmitInterfaceMemberModifiers
                 && type.Kind == "interface"
@@ -1649,7 +1650,9 @@ internal static class CSharpDeclarationWriter
         string declaration,
         ApiMember member,
         IReadOnlyList<TypeParameter> typeParameters)
-        => member.IsOverride || member.Kind == "explicit-interface-implementation"
+        => member.IsOverride
+            || IsExplicitInterfaceImplementation(member)
+                && !member.CanUseImplicitInterfaceSyntax
             ? AppendInheritedConstraintRestatement(declaration, typeParameters)
             : AppendTypeParameterConstraints(declaration, typeParameters);
 
@@ -1928,6 +1931,9 @@ internal static class CSharpDeclarationWriter
 
         if (!member.Name.Contains('.', StringComparison.Ordinal))
         {
+            if (member.CanUseImplicitInterfaceSyntax)
+                return;
+
             throw new NotSupportedException(
                 "An explicit interface member has no qualified metadata name, "
                 + "so C# cannot represent its MethodImpl target.");

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1278,7 +1278,8 @@ internal static class CSharpDeclarationWriter
 
     static IEnumerable<string> CollectExplicitInterfaceTypeReferences(ApiMember member)
     {
-        if (member.Kind != "explicit-interface-implementation")
+        if (member.Kind != "explicit-interface-implementation"
+            && !member.IsExplicitInterfaceImplementation)
             yield break;
 
         int memberSeparator = member.Name.LastIndexOf('.');

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1042,6 +1042,8 @@ internal static class CSharpDeclarationWriter
         CSharpDeclarationOptions options,
         IReadOnlyList<string>? methodParameters = null)
     {
+        EnsureExplicitInterfaceAccessibilityIsRepresentable(member);
+
         string signature;
         var renderedFromModel = false;
         if (member.Kind == "field" && member.Signature == null && !string.IsNullOrWhiteSpace(member.ReturnType))
@@ -1913,6 +1915,22 @@ internal static class CSharpDeclarationWriter
     static bool IsExplicitInterfaceImplementation(ApiMember member)
         => member.Kind == "explicit-interface-implementation"
             || member.IsExplicitInterfaceImplementation;
+
+    static void EnsureExplicitInterfaceAccessibilityIsRepresentable(ApiMember member)
+    {
+        if (member.IsFinalizer
+            || !IsExplicitInterfaceImplementation(member)
+            || !member.Name.Contains('.', StringComparison.Ordinal)
+            || string.Equals(member.Accessibility, "private", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        string accessibility = member.Accessibility ?? "public";
+        throw new NotSupportedException(
+            $"Explicit interface member '{member.Name}' has metadata accessibility "
+            + $"'{accessibility}', which C# cannot represent.");
+    }
 
     static bool IsEvent(ApiMember member)
         => member.Kind == "event" || IsExplicitInterfaceEvent(member);

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -41,6 +41,7 @@ internal sealed record CSharpDeclarationOptions
     public bool IncludeObsoleteAttribute { get; init; } = true;
     public bool OmitInterfaceMemberModifiers { get; init; }
     public bool OmitPropertyAccessors { get; init; }
+    public bool AllowMetadataFallback { get; init; }
 
     /// <summary>
     /// When true, a finalizer member (<see cref="ApiMember.IsFinalizer"/>) is
@@ -1042,7 +1043,23 @@ internal static class CSharpDeclarationWriter
         CSharpDeclarationOptions options,
         IReadOnlyList<string>? methodParameters = null)
     {
-        EnsureExplicitInterfaceAccessibilityIsRepresentable(member);
+        string? explicitInterfaceFailure =
+            ExplicitInterfaceRepresentabilityFailure(member);
+        if (explicitInterfaceFailure is not null
+            && !options.AllowMetadataFallback)
+        {
+            throw new NotSupportedException(explicitInterfaceFailure);
+        }
+        if (explicitInterfaceFailure is not null)
+            return RenderMetadataMethodImplFallback(member);
+        string? accessorFailure =
+            AccessorAccessibilityRepresentabilityFailure(member);
+        if (accessorFailure is not null)
+        {
+            if (!options.AllowMetadataFallback)
+                throw new NotSupportedException(accessorFailure);
+            return RenderMetadataAccessorFallback(member);
+        }
 
         string signature;
         var renderedFromModel = false;
@@ -1921,35 +1938,125 @@ internal static class CSharpDeclarationWriter
         => member.Kind == "explicit-interface-implementation"
             || member.IsExplicitInterfaceImplementation;
 
-    static void EnsureExplicitInterfaceAccessibilityIsRepresentable(ApiMember member)
+    static string? ExplicitInterfaceRepresentabilityFailure(ApiMember member)
     {
         if (member.IsFinalizer
             || !IsExplicitInterfaceImplementation(member))
         {
-            return;
+            return null;
+        }
+
+        if (member.IsOverride
+            && !member.CanUseImplicitInterfaceSyntax)
+        {
+            return
+                "A MethodImpl body also reuses a base virtual slot, "
+                + "which explicit-interface C# syntax cannot represent.";
         }
 
         if (!member.Name.Contains('.', StringComparison.Ordinal))
         {
             if (member.CanUseImplicitInterfaceSyntax)
-                return;
+                return null;
 
-            throw new NotSupportedException(
+            return
                 "An explicit interface member has no qualified metadata name, "
-                + "so C# cannot represent its MethodImpl target.");
+                + "so C# cannot represent its MethodImpl target.";
         }
         if (string.Equals(
                 member.Accessibility,
                 "private",
                 StringComparison.Ordinal))
         {
-            return;
+            return null;
         }
 
         string accessibility = member.Accessibility ?? "public";
-        throw new NotSupportedException(
+        return
             $"An explicit interface member has metadata accessibility '{accessibility}', "
-            + "which C# cannot represent.");
+            + "which C# cannot represent.";
+    }
+
+    static string? AccessorAccessibilityRepresentabilityFailure(
+        ApiMember member)
+    {
+        if (member.AccessorFacts.Count < 2)
+            return null;
+
+        string[] accessibilities = member.AccessorFacts
+            .Select(static accessor => accessor.Accessibility ?? "public")
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (accessibilities.Length <= 1)
+            return null;
+
+        if (IsEvent(member))
+        {
+            return
+                $"Event '{member.Name}' has unequal metadata accessor accessibilities, "
+                + "which C# cannot represent.";
+        }
+
+        string memberAccessibility = member.Accessibility ?? "public";
+        int differingAccessors = member.AccessorFacts.Count(accessor =>
+            !string.Equals(
+                accessor.Accessibility ?? "public",
+                memberAccessibility,
+                StringComparison.Ordinal));
+        if (differingAccessors <= 1)
+            return null;
+
+        return
+            $"Property '{member.Name}' has incomparable metadata accessor accessibilities, "
+            + "which C# cannot represent.";
+    }
+
+    static string RenderMetadataAccessorFallback(ApiMember member)
+    {
+        string accessibility = member.Accessibility ?? "public";
+        string memberType =
+            member.SignatureModel?.ReturnType
+            ?? member.ReturnType
+            ?? "<unknown>";
+        string accessors = string.Join(
+            ", ",
+            member.AccessorFacts.Select(accessor =>
+                $"{accessor.Kind}: {accessor.Accessibility ?? "public"}"));
+        return
+            $"metadata {member.Kind} {accessibility} {memberType} "
+            + $"{member.Name} ({accessors})";
+    }
+
+    static string RenderMetadataMethodImplFallback(ApiMember member)
+    {
+        var modifiers = new List<string>
+        {
+            member.Accessibility ?? "public"
+        };
+        if (member.IsStatic)
+            modifiers.Add("static");
+        if (member.IsFinal)
+            modifiers.Add("final");
+        if (member.IsNewSlot)
+            modifiers.Add("newslot");
+        if (member.IsOverride)
+            modifiers.Add("override");
+        else if (member.IsVirtual)
+            modifiers.Add("virtual");
+        if (member.IsAbstract)
+            modifiers.Add("abstract");
+        string signature =
+            member.Signature
+            ?? member.SignatureModel?.MemberName
+            ?? member.Name;
+        string resolution =
+            member.InterfaceImplementationResolution
+                ?.ToString()
+                .ToLowerInvariant()
+            ?? "unrepresentable";
+        return
+            $"metadata MethodImpl ({resolution}) "
+            + $"{string.Join(" ", modifiers)} {signature}";
     }
 
     static bool IsEvent(ApiMember member)

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1044,7 +1044,7 @@ internal static class CSharpDeclarationWriter
         IReadOnlyList<string>? methodParameters = null)
     {
         string? explicitInterfaceFailure =
-            ExplicitInterfaceRepresentabilityFailure(member);
+            ExplicitInterfaceRepresentabilityFailure(type, member);
         if (explicitInterfaceFailure is not null
             && !options.AllowMetadataFallback)
         {
@@ -1938,7 +1938,9 @@ internal static class CSharpDeclarationWriter
         => member.Kind == "explicit-interface-implementation"
             || member.IsExplicitInterfaceImplementation;
 
-    static string? ExplicitInterfaceRepresentabilityFailure(ApiMember member)
+    static string? ExplicitInterfaceRepresentabilityFailure(
+        ApiType type,
+        ApiMember member)
     {
         if (member.IsFinalizer
             || !IsExplicitInterfaceImplementation(member))
@@ -1946,7 +1948,11 @@ internal static class CSharpDeclarationWriter
             return null;
         }
 
-        if (member.IsOverride
+        if (!string.Equals(
+                type.Kind,
+                "interface",
+                StringComparison.Ordinal)
+            && member.IsOverride
             && !member.CanUseImplicitInterfaceSyntax)
         {
             return
@@ -1993,7 +1999,7 @@ internal static class CSharpDeclarationWriter
         if (IsEvent(member))
         {
             return
-                $"Event '{member.Name}' has unequal metadata accessor accessibilities, "
+                "The event has unequal metadata accessor accessibilities, "
                 + "which C# cannot represent.";
         }
 
@@ -2007,19 +2013,28 @@ internal static class CSharpDeclarationWriter
             return null;
 
         return
-            $"Property '{member.Name}' has incomparable metadata accessor accessibilities, "
+            "The property has incomparable metadata accessor accessibilities, "
             + "which C# cannot represent.";
     }
 
     static string RenderMetadataAccessorFallback(ApiMember member)
     {
-        string accessibility = ContainMetadataFallback(
-            member.Accessibility ?? "public");
-        string memberType =
-            ContainMetadataFallback(
-                member.SignatureModel?.ReturnType
-                ?? member.ReturnType
-                ?? "<unknown>");
+        var modifiers = new List<string>
+        {
+            ContainMetadataFallback(member.Accessibility ?? "public")
+        };
+        if (member.IsStatic)
+            modifiers.Add("static");
+        if (member.IsFinal)
+            modifiers.Add("final");
+        if (member.IsNewSlot)
+            modifiers.Add("newslot");
+        if (member.IsOverride)
+            modifiers.Add("override");
+        else if (member.IsVirtual)
+            modifiers.Add("virtual");
+        if (member.IsAbstract)
+            modifiers.Add("abstract");
         string accessors = string.Join(
             ", ",
             member.AccessorFacts.Select(accessor =>
@@ -2028,8 +2043,31 @@ internal static class CSharpDeclarationWriter
                     accessor.Accessibility ?? "public")));
         return
             $"metadata {ContainMetadataFallback(member.Kind)} "
-            + $"{accessibility} {memberType} "
-            + $"{ContainMetadataFallback(member.Name)} ({accessors})";
+            + $"{string.Join(" ", modifiers)} "
+            + $"{ContainMetadataFallback(MetadataAccessorSignature(member))} "
+            + $"(accessors: {accessors})";
+    }
+
+    static string MetadataAccessorSignature(ApiMember member)
+    {
+        if (!string.IsNullOrWhiteSpace(member.Signature))
+            return member.Signature;
+
+        ApiSignature? model = member.SignatureModel;
+        string memberType =
+            model?.ReturnType
+            ?? member.ReturnType
+            ?? "<unknown>";
+        string memberName =
+            model?.MemberName
+            ?? member.Name;
+        if (memberName == "this[]"
+            && model is { Parameters.Count: > 0 })
+        {
+            memberName =
+                $"this[{string.Join(", ", model.Parameters.Select(parameter => FormatParameter(parameter)))}]";
+        }
+        return $"{memberType} {memberName}";
     }
 
     static string RenderMetadataMethodImplFallback(ApiMember member)

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1204,10 +1204,11 @@ internal static class CSharpDeclarationWriter
         else
         {
             // Explicit interface implementations omit the access modifier but must still
-            // carry `static` (C# 11 static-abstract interface members implemented explicitly)
-            // and `unsafe`. Order mirrors the .cctor branch: static then unsafe.
+            // carry `static`, interface-owned `abstract`, and `unsafe`.
             if (member.IsStatic)
                 modifiers.Add("static");
+            if (member.IsAbstract)
+                modifiers.Add("abstract");
             if (member.IsUnsafe || options.ForceUnsafe)
                 modifiers.Add("unsafe");
         }

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1921,9 +1921,21 @@ internal static class CSharpDeclarationWriter
     static void EnsureExplicitInterfaceAccessibilityIsRepresentable(ApiMember member)
     {
         if (member.IsFinalizer
-            || !IsExplicitInterfaceImplementation(member)
-            || !member.Name.Contains('.', StringComparison.Ordinal)
-            || string.Equals(member.Accessibility, "private", StringComparison.Ordinal))
+            || !IsExplicitInterfaceImplementation(member))
+        {
+            return;
+        }
+
+        if (!member.Name.Contains('.', StringComparison.Ordinal))
+        {
+            throw new NotSupportedException(
+                "An explicit interface member has no qualified metadata name, "
+                + "so C# cannot represent its MethodImpl target.");
+        }
+        if (string.Equals(
+                member.Accessibility,
+                "private",
+                StringComparison.Ordinal))
         {
             return;
         }

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1173,7 +1173,7 @@ internal static class CSharpDeclarationWriter
             if (member.IsUnsafe || options.ForceUnsafe)
                 modifiers.Add("unsafe");
         }
-        else if (member.Kind != "explicit-interface-implementation")
+        else if (!IsExplicitInterfaceImplementation(member))
         {
             var omitInterfaceModifiers = options.OmitInterfaceMemberModifiers
                 && type.Kind == "interface"
@@ -1212,7 +1212,8 @@ internal static class CSharpDeclarationWriter
 
         if ((options.ForceAsync || member.IsAsync)
             && !member.IsFinalizer
-            && member.Kind is "method" or "extension-method" or "explicit-interface-implementation")
+            && (member.Kind is "method" or "extension-method" or "explicit-interface-implementation"
+                || member.IsExplicitInterfaceImplementation))
             modifiers.Add("async");
 
         if (modifiers.Count > 0)
@@ -1837,7 +1838,7 @@ internal static class CSharpDeclarationWriter
         if ((member.Kind == "property" || IsExplicitInterfaceProperty(member))
             && model.ReturnType is { Length: > 0 } propertyType
             && model.Accessors.Count > 0
-            && (member.Kind == "explicit-interface-implementation"
+            && (IsExplicitInterfaceProperty(member)
                 || IsOrdinaryPropertyName(member.Name)
                     && IsOrdinaryPropertyName(model.MemberName)))
         {
@@ -1900,14 +1901,18 @@ internal static class CSharpDeclarationWriter
     }
 
     static bool IsExplicitInterfaceProperty(ApiMember member)
-        => member.Kind == "explicit-interface-implementation"
+        => IsExplicitInterfaceImplementation(member)
             && member.Name.Contains('.', StringComparison.Ordinal)
             && HasOnlyAccessors(member, "get", "set", "init");
 
     static bool IsExplicitInterfaceEvent(ApiMember member)
-        => member.Kind == "explicit-interface-implementation"
+        => IsExplicitInterfaceImplementation(member)
             && member.Name.Contains('.', StringComparison.Ordinal)
             && HasOnlyAccessors(member, "add", "remove");
+
+    static bool IsExplicitInterfaceImplementation(ApiMember member)
+        => member.Kind == "explicit-interface-implementation"
+            || member.IsExplicitInterfaceImplementation;
 
     static bool IsEvent(ApiMember member)
         => member.Kind == "event" || IsExplicitInterfaceEvent(member);

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1928,8 +1928,8 @@ internal static class CSharpDeclarationWriter
 
         string accessibility = member.Accessibility ?? "public";
         throw new NotSupportedException(
-            $"Explicit interface member '{member.Name}' has metadata accessibility "
-            + $"'{accessibility}', which C# cannot represent.");
+            $"An explicit interface member has metadata accessibility '{accessibility}', "
+            + "which C# cannot represent.");
     }
 
     static bool IsEvent(ApiMember member)

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -2013,25 +2013,30 @@ internal static class CSharpDeclarationWriter
 
     static string RenderMetadataAccessorFallback(ApiMember member)
     {
-        string accessibility = member.Accessibility ?? "public";
+        string accessibility = ContainMetadataFallback(
+            member.Accessibility ?? "public");
         string memberType =
-            member.SignatureModel?.ReturnType
-            ?? member.ReturnType
-            ?? "<unknown>";
+            ContainMetadataFallback(
+                member.SignatureModel?.ReturnType
+                ?? member.ReturnType
+                ?? "<unknown>");
         string accessors = string.Join(
             ", ",
             member.AccessorFacts.Select(accessor =>
-                $"{accessor.Kind}: {accessor.Accessibility ?? "public"}"));
+                $"{ContainMetadataFallback(accessor.Kind)}: "
+                + ContainMetadataFallback(
+                    accessor.Accessibility ?? "public")));
         return
-            $"metadata {member.Kind} {accessibility} {memberType} "
-            + $"{member.Name} ({accessors})";
+            $"metadata {ContainMetadataFallback(member.Kind)} "
+            + $"{accessibility} {memberType} "
+            + $"{ContainMetadataFallback(member.Name)} ({accessors})";
     }
 
     static string RenderMetadataMethodImplFallback(ApiMember member)
     {
         var modifiers = new List<string>
         {
-            member.Accessibility ?? "public"
+            ContainMetadataFallback(member.Accessibility ?? "public")
         };
         if (member.IsStatic)
             modifiers.Add("static");
@@ -2056,8 +2061,12 @@ internal static class CSharpDeclarationWriter
             ?? "unrepresentable";
         return
             $"metadata MethodImpl ({resolution}) "
-            + $"{string.Join(" ", modifiers)} {signature}";
+            + $"{string.Join(" ", modifiers)} "
+            + ContainMetadataFallback(signature);
     }
+
+    static string ContainMetadataFallback(string value)
+        => CSharpIdentifier.ContainRenderedText(value);
 
     static bool IsEvent(ApiMember member)
         => member.Kind == "event" || IsExplicitInterfaceEvent(member);

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -50,6 +50,7 @@ public sealed record CSharpFormatOptions
     public bool IncludeObsoleteAttribute { get; init; } = true;
     public bool OmitInterfaceMemberModifiers { get; init; }
     public bool OmitPropertyAccessors { get; init; }
+    public bool AllowMetadataFallback { get; init; }
 }
 
 /// <summary>
@@ -774,7 +775,8 @@ public sealed class CSharpFormatter
             IncludeSignatureAttributes = options.IncludeSignatureAttributes,
             IncludeObsoleteAttribute = options.IncludeObsoleteAttribute,
             OmitInterfaceMemberModifiers = options.OmitInterfaceMemberModifiers,
-            OmitPropertyAccessors = options.OmitPropertyAccessors
+            OmitPropertyAccessors = options.OmitPropertyAccessors,
+            AllowMetadataFallback = options.AllowMetadataFallback
         };
 
     static CSharpFormattedDeclaration ToFormattedDeclaration(CSharpRenderedDeclaration declaration)

--- a/src/ILInspector.CSharp/CSharpFormatter.cs
+++ b/src/ILInspector.CSharp/CSharpFormatter.cs
@@ -188,8 +188,12 @@ public sealed class CSharpFormatter
             if (attributePrefix.Length > 0)
                 parts.Add(attributePrefix);
         }
-        if (!string.IsNullOrWhiteSpace(accessor?.Accessibility))
+        if (member.Kind != "explicit-interface-implementation"
+            && !member.IsExplicitInterfaceImplementation
+            && !string.IsNullOrWhiteSpace(accessor?.Accessibility))
+        {
             parts.Add(accessor.Accessibility!);
+        }
         parts.Add(kind);
         return string.Join(" ", parts);
     }

--- a/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
+++ b/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
@@ -267,13 +267,15 @@ public static class CSharpMemberShellProducer
             IsVirtual = spec.IsVirtual,
             IsOverride = spec.IsOverride,
             IsSealed = spec.IsSealed,
-            Accessibility = spec.Accessibility switch
-            {
-                CSharpShellAccessibility.Public => "public",
-                CSharpShellAccessibility.Protected => "protected",
-                _ => throw new NotSupportedException(
-                    $"Unsupported C# shell accessibility '{spec.Accessibility}'."),
-            },
+            Accessibility = isExplicitInterface
+                ? "private"
+                : spec.Accessibility switch
+                {
+                    CSharpShellAccessibility.Public => "public",
+                    CSharpShellAccessibility.Protected => "protected",
+                    _ => throw new NotSupportedException(
+                        $"Unsupported C# shell accessibility '{spec.Accessibility}'."),
+                },
             Attributes = spec.Attributes?.ToList() ?? [],
             IsUnsafe = spec.RequiresUnsafeModifier || RequiresUnsafe(spec),
             IsAsync = spec.IsAsync,

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -401,7 +401,7 @@ public sealed class CSharpTypePrinter
                 requestedPolicy,
                 request.PrimaryConstructorParameters.Count,
                 parameterName);
-            var policy = ResolveMemberPolicy(requestedPolicy, snapshot);
+            var policy = ResolveMemberPolicy(requestedPolicy, type, snapshot);
             ValidateResolvedBodyPolicy(
                 type,
                 snapshot,
@@ -434,8 +434,12 @@ public sealed class CSharpTypePrinter
 
     static CSharpMemberPolicy ResolveMemberPolicy(
         CSharpMemberPolicy policy,
+        ApiType type,
         ApiMember snapshot)
-        => policy.BodyPolicy == CSharpBodyPolicy.Skeleton && IsExplicitInterfaceEvent(snapshot)
+        => policy.BodyPolicy == CSharpBodyPolicy.Skeleton
+            && type.Kind != "interface"
+            && !snapshot.IsAbstract
+            && IsExplicitInterfaceEvent(snapshot)
             ? new CSharpMemberPolicy(
                 policy.Member,
                 CSharpBodyPolicy.Stub,

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -866,6 +866,7 @@ public sealed class CSharpTypePrinter
             IsOverride = member.IsOverride,
             IsSealed = member.IsSealed,
             IsFinalizer = member.IsFinalizer,
+            IsExplicitInterfaceImplementation = member.IsExplicitInterfaceImplementation,
             IsReadOnly = member.IsReadOnly,
             IsConst = member.IsConst,
             IsUnsafe = member.IsUnsafe,
@@ -1110,7 +1111,8 @@ public sealed class CSharpTypePrinter
 
     static bool IsProperty(ApiMember member)
         => member.Kind == "property"
-            || member.Kind == "explicit-interface-implementation"
+            || (member.Kind == "explicit-interface-implementation"
+                    || member.IsExplicitInterfaceImplementation)
                 && member.Name.Contains('.', StringComparison.Ordinal)
                 && HasOnlyAccessors(member, "get", "set", "init");
 
@@ -1119,7 +1121,8 @@ public sealed class CSharpTypePrinter
             || IsExplicitInterfaceEvent(member);
 
     static bool IsExplicitInterfaceEvent(ApiMember member)
-        => member.Kind == "explicit-interface-implementation"
+        => (member.Kind == "explicit-interface-implementation"
+                || member.IsExplicitInterfaceImplementation)
             && member.Name.Contains('.', StringComparison.Ordinal)
             && HasOnlyAccessors(member, "add", "remove");
 

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -1180,6 +1180,19 @@ public sealed class CSharpTypePrinter
                 $"Interface member '{member.Name}' must use skeleton body policy.",
                 parameterName);
         }
+        if (type.Kind != "interface" && HasMixedAccessorAbstraction(member))
+        {
+            throw new NotSupportedException(
+                $"Member '{member.Name}' has accessors that disagree about abstractness, "
+                + "which C# cannot represent outside an interface.");
+        }
+        if (IsExplicitInterfaceEvent(member) && !HasBothEventAccessors(member))
+        {
+            throw new NotSupportedException(
+                $"Explicit interface event '{member.Name}' declares only "
+                + $"'{string.Join("', '", member.SignatureModel!.Accessors.Select(accessor => accessor.Kind))}'; "
+                + "C# requires both an add and a remove accessor.");
+        }
     }
 
     static bool IsProperty(ApiMember member)
@@ -1214,6 +1227,21 @@ public sealed class CSharpTypePrinter
         => member.SignatureModel?.Accessors is { Count: > 1 } accessors
             && accessors.Any(accessor => accessor.IsAbstract == true)
             && accessors.Any(accessor => accessor.IsAbstract == false);
+
+    /// <summary>
+    /// True when an explicit interface event carries both of the accessors C# requires.
+    /// </summary>
+    /// <remarks>
+    /// An explicit interface event is projected with add/remove bodies, and both are written
+    /// unconditionally. A malformed or hostile Event row that declares only a remover has no
+    /// legal C# spelling, so it must fail rather than be completed with an adder metadata never
+    /// declared. Gated by
+    /// <c>CSharpTypePrinterTests.ExplicitInterfaceEvent_WithoutBothAccessors_FailsVisibly</c>.
+    /// </remarks>
+    static bool HasBothEventAccessors(ApiMember member)
+        => member.SignatureModel?.Accessors is { } accessors
+            && accessors.Any(accessor => accessor.Kind == "add")
+            && accessors.Any(accessor => accessor.Kind == "remove");
 
     static RenderedFragment Join(IEnumerable<RenderedFragment> fragments, string separator)
     {

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -393,8 +393,10 @@ public sealed class CSharpTypePrinter
             var original = memberArray[i];
             var snapshot = type.Members[i];
             var policy = overrides.TryGetValue(original, out var memberPolicy)
-                ? memberPolicy
-                : new CSharpMemberPolicy(original, request.BodyPolicy);
+                ? ResolveMemberPolicy(memberPolicy, snapshot)
+                : ResolveMemberPolicy(
+                    new CSharpMemberPolicy(original, request.BodyPolicy),
+                    snapshot);
             ValidateResolvedBodyPolicy(
                 type,
                 snapshot,
@@ -424,6 +426,16 @@ public sealed class CSharpTypePrinter
             primaryConstructorParameters,
             nestedTypes);
     }
+
+    static CSharpMemberPolicy ResolveMemberPolicy(
+        CSharpMemberPolicy policy,
+        ApiMember snapshot)
+        => policy.BodyPolicy == CSharpBodyPolicy.Skeleton && IsExplicitInterfaceEvent(snapshot)
+            ? new CSharpMemberPolicy(
+                policy.Member,
+                CSharpBodyPolicy.Stub,
+                new CSharpEventBody(CSharpAccessorBody.Throw, CSharpAccessorBody.Throw))
+            : policy;
 
     static Dictionary<ApiMember, CSharpMemberPolicy> ValidateAndIndexPolicies(
         CSharpTypePrintRequest request,
@@ -1030,11 +1042,6 @@ public sealed class CSharpTypePrinter
             throw new ArgumentException(
                 $"Abstract member '{member.Name}' must use skeleton body policy.",
                 parameterName);
-        }
-        if (IsExplicitInterfaceEvent(member) && policy.BodyPolicy == CSharpBodyPolicy.Skeleton)
-        {
-            throw new NotSupportedException(
-                $"Explicit interface event '{member.Name}' requires add/remove bodies.");
         }
         if (member.Kind == "event"
             && policy.BodyPolicy != CSharpBodyPolicy.Skeleton

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -440,6 +440,23 @@ public sealed class CSharpTypePrinter
         if (policy.BodyPolicy != CSharpBodyPolicy.Skeleton
             || !IsExplicitInterfaceAggregate(snapshot))
         {
+            if (policy.BodyPolicy == CSharpBodyPolicy.Skeleton
+                && type.Kind == "interface"
+                && IsProperty(snapshot)
+                && HasMixedAccessorAbstraction(snapshot))
+            {
+                var mixedAccessors = snapshot.SignatureModel!.Accessors;
+                return new CSharpMemberPolicy(
+                    policy.Member,
+                    CSharpBodyPolicy.Stub,
+                    new CSharpPropertyBody(
+                        mixedAccessors.Any(accessor => accessor.Kind == "get")
+                            ? CSharpAccessorBody.Throw
+                            : null,
+                        mixedAccessors.Any(accessor => accessor.Kind is "set" or "init")
+                            ? CSharpAccessorBody.Throw
+                            : null));
+            }
             return policy;
         }
 
@@ -463,7 +480,10 @@ public sealed class CSharpTypePrinter
         var accessors = snapshot.SignatureModel!.Accessors;
         if (type.Kind != "interface"
             && accessors.Any(accessor => accessor.Kind == "get")
-            && snapshot.SignatureModel.Parameters.Count == 0)
+            && snapshot.SignatureModel.Parameters.Count == 0
+            && !snapshot.SignatureModel.ReturnType!.StartsWith(
+                "ref ",
+                StringComparison.Ordinal))
         {
             return policy;
         }
@@ -988,7 +1008,8 @@ public sealed class CSharpTypePrinter
         {
             Kind = accessor.Kind,
             Accessibility = accessor.Accessibility,
-            ReturnAttributes = returnAttributes?.ToList()!
+            ReturnAttributes = returnAttributes?.ToList()!,
+            IsAbstract = accessor.IsAbstract
         };
     }
 
@@ -1152,7 +1173,8 @@ public sealed class CSharpTypePrinter
         }
         if (type.Kind == "interface"
             && policy.BodyPolicy != CSharpBodyPolicy.Skeleton
-            && !IsExplicitInterfaceAggregate(member))
+            && !IsExplicitInterfaceAggregate(member)
+            && !HasMixedAccessorAbstraction(member))
         {
             throw new ArgumentException(
                 $"Interface member '{member.Name}' must use skeleton body policy.",
@@ -1187,6 +1209,11 @@ public sealed class CSharpTypePrinter
     static bool HasOnlyAccessors(ApiMember member, params string[] kinds)
         => member.SignatureModel?.Accessors is { Count: > 0 } accessors
             && accessors.All(accessor => kinds.Contains(accessor.Kind, StringComparer.Ordinal));
+
+    static bool HasMixedAccessorAbstraction(ApiMember member)
+        => member.SignatureModel?.Accessors is { Count: > 1 } accessors
+            && accessors.Any(accessor => accessor.IsAbstract == true)
+            && accessors.Any(accessor => accessor.IsAbstract == false);
 
     static RenderedFragment Join(IEnumerable<RenderedFragment> fragments, string separator)
     {

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -951,6 +951,8 @@ public sealed class CSharpTypePrinter
             IsSealed = member.IsSealed,
             IsFinalizer = member.IsFinalizer,
             IsExplicitInterfaceImplementation = member.IsExplicitInterfaceImplementation,
+            CanUseImplicitInterfaceSyntax =
+                member.CanUseImplicitInterfaceSyntax,
             IsReadOnly = member.IsReadOnly,
             IsConst = member.IsConst,
             IsUnsafe = member.IsUnsafe,

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -436,15 +436,45 @@ public sealed class CSharpTypePrinter
         CSharpMemberPolicy policy,
         ApiType type,
         ApiMember snapshot)
-        => policy.BodyPolicy == CSharpBodyPolicy.Skeleton
-            && type.Kind != "interface"
-            && !snapshot.IsAbstract
-            && IsExplicitInterfaceEvent(snapshot)
-            ? new CSharpMemberPolicy(
+    {
+        if (policy.BodyPolicy != CSharpBodyPolicy.Skeleton
+            || !IsExplicitInterfaceAggregate(snapshot))
+        {
+            return policy;
+        }
+
+        if (snapshot.IsAbstract)
+        {
+            if (type.Kind == "interface")
+                return policy;
+
+            throw new NotSupportedException(
+                $"Abstract explicit interface aggregate '{snapshot.Name}' has no legal C# class spelling.");
+        }
+
+        if (IsExplicitInterfaceEvent(snapshot))
+        {
+            return new CSharpMemberPolicy(
                 policy.Member,
                 CSharpBodyPolicy.Stub,
-                new CSharpEventBody(CSharpAccessorBody.Throw, CSharpAccessorBody.Throw))
-            : policy;
+                new CSharpEventBody(CSharpAccessorBody.Throw, CSharpAccessorBody.Throw));
+        }
+
+        if (type.Kind != "interface")
+            return policy;
+
+        var accessors = snapshot.SignatureModel!.Accessors;
+        return new CSharpMemberPolicy(
+            policy.Member,
+            CSharpBodyPolicy.Stub,
+            new CSharpPropertyBody(
+                accessors.Any(accessor => accessor.Kind == "get")
+                    ? CSharpAccessorBody.Throw
+                    : null,
+                accessors.Any(accessor => accessor.Kind is "set" or "init")
+                    ? CSharpAccessorBody.Throw
+                    : null));
+    }
 
     static Dictionary<ApiMember, CSharpMemberPolicy> ValidateAndIndexPolicies(
         CSharpTypePrintRequest request,
@@ -1117,7 +1147,8 @@ public sealed class CSharpTypePrinter
                 parameterName);
         }
         if (type.Kind == "interface"
-            && policy.BodyPolicy != CSharpBodyPolicy.Skeleton)
+            && policy.BodyPolicy != CSharpBodyPolicy.Skeleton
+            && !IsExplicitInterfaceAggregate(member))
         {
             throw new ArgumentException(
                 $"Interface member '{member.Name}' must use skeleton body policy.",
@@ -1141,6 +1172,13 @@ public sealed class CSharpTypePrinter
                 || member.IsExplicitInterfaceImplementation)
             && member.Name.Contains('.', StringComparison.Ordinal)
             && HasOnlyAccessors(member, "add", "remove");
+
+    static bool IsExplicitInterfaceAggregate(ApiMember member)
+        => IsExplicitInterfaceEvent(member)
+            || IsProperty(member)
+                && (member.Kind == "explicit-interface-implementation"
+                    || member.IsExplicitInterfaceImplementation)
+                && member.Name.Contains('.', StringComparison.Ordinal);
 
     static bool HasOnlyAccessors(ApiMember member, params string[] kinds)
         => member.SignatureModel?.Accessors is { Count: > 0 } accessors

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -460,10 +460,13 @@ public sealed class CSharpTypePrinter
                 new CSharpEventBody(CSharpAccessorBody.Throw, CSharpAccessorBody.Throw));
         }
 
-        if (type.Kind != "interface")
-            return policy;
-
         var accessors = snapshot.SignatureModel!.Accessors;
+        if (type.Kind != "interface"
+            && accessors.Any(accessor => accessor.Kind == "get"))
+        {
+            return policy;
+        }
+
         return new CSharpMemberPolicy(
             policy.Member,
             CSharpBodyPolicy.Stub,

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -392,11 +392,16 @@ public sealed class CSharpTypePrinter
         {
             var original = memberArray[i];
             var snapshot = type.Members[i];
-            var policy = overrides.TryGetValue(original, out var memberPolicy)
-                ? ResolveMemberPolicy(memberPolicy, snapshot)
-                : ResolveMemberPolicy(
-                    new CSharpMemberPolicy(original, request.BodyPolicy),
-                    snapshot);
+            var requestedPolicy = overrides.TryGetValue(original, out var memberPolicy)
+                ? memberPolicy
+                : new CSharpMemberPolicy(original, request.BodyPolicy);
+            ValidateResolvedBodyPolicy(
+                type,
+                snapshot,
+                requestedPolicy,
+                request.PrimaryConstructorParameters.Count,
+                parameterName);
+            var policy = ResolveMemberPolicy(requestedPolicy, snapshot);
             ValidateResolvedBodyPolicy(
                 type,
                 snapshot,

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -1186,10 +1186,12 @@ public sealed class CSharpTypePrinter
                 $"Member '{member.Name}' has accessors that disagree about abstractness, "
                 + "which C# cannot represent outside an interface.");
         }
-        if (IsExplicitInterfaceEvent(member) && !HasBothEventAccessors(member))
+        if (IsEvent(member)
+            && member.SignatureModel?.Accessors is { Count: > 0 }
+            && !HasBothEventAccessors(member))
         {
             throw new NotSupportedException(
-                $"Explicit interface event '{member.Name}' declares only "
+                $"Event '{member.Name}' declares only "
                 + $"'{string.Join("', '", member.SignatureModel!.Accessors.Select(accessor => accessor.Kind))}'; "
                 + "C# requires both an add and a remove accessor.");
         }
@@ -1229,14 +1231,14 @@ public sealed class CSharpTypePrinter
             && accessors.Any(accessor => accessor.IsAbstract == false);
 
     /// <summary>
-    /// True when an explicit interface event carries both of the accessors C# requires.
+    /// True when an event carries both of the accessors C# requires.
     /// </summary>
     /// <remarks>
-    /// An explicit interface event is projected with add/remove bodies, and both are written
-    /// unconditionally. A malformed or hostile Event row that declares only a remover has no
-    /// legal C# spelling, so it must fail rather than be completed with an adder metadata never
-    /// declared. Gated by
-    /// <c>CSharpTypePrinterTests.ExplicitInterfaceEvent_WithoutBothAccessors_FailsVisibly</c>.
+    /// An event with declared accessors is projected with C# event syntax. A malformed or hostile
+    /// Event row that declares only a remover has no legal C# spelling, so it must fail rather than
+    /// be completed with an adder metadata never declared. Gated by
+    /// <c>CSharpTypePrinterTests.ExplicitInterfaceEvent_WithoutBothAccessors_FailsVisibly</c> and
+    /// <c>CSharpTypePrinterTests.RegularRemoveOnlyEvent_FailsVisibly</c>.
     /// </remarks>
     static bool HasBothEventAccessors(ApiMember member)
         => member.SignatureModel?.Accessors is { } accessors

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -437,6 +437,16 @@ public sealed class CSharpTypePrinter
         ApiType type,
         ApiMember snapshot)
     {
+        if (policy.BodyPolicy == CSharpBodyPolicy.Skeleton
+            && type.Kind == "interface"
+            && IsExplicitInterfaceMethod(snapshot)
+            && !snapshot.IsAbstract)
+        {
+            return new CSharpMemberPolicy(
+                policy.Member,
+                CSharpBodyPolicy.Stub);
+        }
+
         if (policy.BodyPolicy != CSharpBodyPolicy.Skeleton
             || !IsExplicitInterfaceAggregate(snapshot))
         {
@@ -653,8 +663,7 @@ public sealed class CSharpTypePrinter
         string memberDeclaration = member.Body is null
             ? formatter.FormatMember(type.Type, member.Member)
             : formatter.FormatMemberWithBody(type.Type, member.Member, member.Body);
-        if (type.Type.Kind == "interface"
-            || member.Member.IsAbstract
+        if (member.Member.IsAbstract
             || member.Policy == CSharpBodyPolicy.Skeleton)
         {
             return new RenderedFragment(PadDeclaration(EnsureTerminated(memberDeclaration), pad));
@@ -1173,7 +1182,7 @@ public sealed class CSharpTypePrinter
         }
         if (type.Kind == "interface"
             && policy.BodyPolicy != CSharpBodyPolicy.Skeleton
-            && !IsExplicitInterfaceAggregate(member)
+            && !IsExplicitInterfaceMember(member)
             && !HasMixedAccessorAbstraction(member))
         {
             throw new ArgumentException(
@@ -1220,6 +1229,14 @@ public sealed class CSharpTypePrinter
                 && (member.Kind == "explicit-interface-implementation"
                     || member.IsExplicitInterfaceImplementation)
                 && member.Name.Contains('.', StringComparison.Ordinal);
+
+    static bool IsExplicitInterfaceMethod(ApiMember member)
+        => member.Kind == "explicit-interface-implementation"
+            && !IsExplicitInterfaceAggregate(member);
+
+    static bool IsExplicitInterfaceMember(ApiMember member)
+        => IsExplicitInterfaceAggregate(member)
+            || IsExplicitInterfaceMethod(member);
 
     static bool HasOnlyAccessors(ApiMember member, params string[] kinds)
         => member.SignatureModel?.Accessors is { Count: > 0 } accessors

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -946,6 +946,8 @@ public sealed class CSharpTypePrinter
             SignatureDecodeStatus = member.SignatureDecodeStatus,
             IsStatic = member.IsStatic,
             IsVirtual = member.IsVirtual,
+            IsNewSlot = member.IsNewSlot,
+            IsFinal = member.IsFinal,
             IsAbstract = member.IsAbstract,
             IsOverride = member.IsOverride,
             IsSealed = member.IsSealed,
@@ -953,6 +955,11 @@ public sealed class CSharpTypePrinter
             IsExplicitInterfaceImplementation = member.IsExplicitInterfaceImplementation,
             CanUseImplicitInterfaceSyntax =
                 member.CanUseImplicitInterfaceSyntax,
+            InterfaceImplementationResolution =
+                member.InterfaceImplementationResolution,
+            AccessorFacts = member.AccessorFacts
+                .Select(SnapshotAccessor)
+                .ToList(),
             IsReadOnly = member.IsReadOnly,
             IsConst = member.IsConst,
             IsUnsafe = member.IsUnsafe,

--- a/src/ILInspector.CSharp/CSharpTypePrinter.cs
+++ b/src/ILInspector.CSharp/CSharpTypePrinter.cs
@@ -462,7 +462,8 @@ public sealed class CSharpTypePrinter
 
         var accessors = snapshot.SignatureModel!.Accessors;
         if (type.Kind != "interface"
-            && accessors.Any(accessor => accessor.Kind == "get"))
+            && accessors.Any(accessor => accessor.Kind == "get")
+            && snapshot.SignatureModel.Parameters.Count == 0)
         {
             return policy;
         }

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -957,6 +957,18 @@ public class ApiMember
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsExplicitInterfaceImplementation { get; set; }
 
+    /// <summary>
+    /// True when an unqualified public MethodImpl maps only to interface
+    /// declarations with the same method name, so ordinary C# member syntax
+    /// preserves the implementation contract.
+    /// </summary>
+    /// <remarks>
+    /// <c>ApiSurfaceExtractorTests.UnqualifiedMatchingMethodImplUsesImplicitInterfaceSyntax</c>
+    /// gates compiler-produced extraction and focused-query parity.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool CanUseImplicitInterfaceSyntax { get; set; }
+
     public bool IsReadOnly { get; set; }
     public bool IsConst { get; set; }
     public bool IsUnsafe { get; set; }

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -663,6 +663,13 @@ public enum SignatureDecodeStatus
     Degraded
 }
 
+[JsonConverter(typeof(JsonStringEnumConverter<InterfaceImplementationResolution>))]
+public enum InterfaceImplementationResolution
+{
+    Proven,
+    Undetermined
+}
+
 public class ApiType
 {
     public string? Namespace { get; set; }
@@ -924,6 +931,8 @@ public class ApiMember
 
     public bool IsStatic { get; set; }
     public bool IsVirtual { get; set; }
+    public bool IsNewSlot { get; set; }
+    public bool IsFinal { get; set; }
     public bool IsAbstract { get; set; }
     public bool IsOverride { get; set; }
     public bool IsSealed { get; set; }
@@ -956,6 +965,15 @@ public class ApiMember
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsExplicitInterfaceImplementation { get; set; }
+
+    /// <summary>
+    /// Whether this member's MethodImpl target was proven to belong to the declaring
+    /// type's interface closure. <see cref="InterfaceImplementationResolution.Undetermined"/>
+    /// preserves a raw external MethodImpl whose inherited-interface relationship cannot
+    /// be established from the inspected image alone.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public InterfaceImplementationResolution? InterfaceImplementationResolution { get; set; }
 
     /// <summary>
     /// True when an unqualified public MethodImpl maps only to interface

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -944,14 +944,15 @@ public class ApiMember
     public bool IsFinalizer { get; set; }
 
     /// <summary>
-    /// True when metadata MethodImpl rows and a qualified metadata name identify
-    /// this aggregate property or event as an explicit interface implementation.
-    /// This remains separate from <see cref="Kind"/> so the aggregate retains its
-    /// member shape.
+    /// True when metadata MethodImpl rows identify this member as an explicit
+    /// interface implementation. This remains separate from <see cref="Kind"/>
+    /// so aggregate properties and events retain their member shape.
     /// </summary>
     /// <remarks>
+    /// <c>ApiInventoryQueryTests.ExtractionModes_PreserveExplicitInterfaceFacets</c>
+    /// gates extraction-mode parity, and
     /// <c>ApiSignatureModelTests.ExplicitInterfaceAggregates_PreserveTypedIdentity</c>
-    /// gates extraction for properties and events.
+    /// gates properties and events.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsExplicitInterfaceImplementation { get; set; }

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -943,6 +943,19 @@ public class ApiMember
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsFinalizer { get; set; }
 
+    /// <summary>
+    /// True when metadata MethodImpl rows identify this member or one of its
+    /// accessors as an explicit interface implementation. This remains separate
+    /// from <see cref="Kind"/> so aggregate properties and events retain their
+    /// member shape.
+    /// </summary>
+    /// <remarks>
+    /// <c>ApiSignatureModelTests.ExplicitInterfaceAggregates_PreserveTypedIdentity</c>
+    /// gates extraction for methods, properties, and events.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool IsExplicitInterfaceImplementation { get; set; }
+
     public bool IsReadOnly { get; set; }
     public bool IsConst { get; set; }
     public bool IsUnsafe { get; set; }

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -944,14 +944,14 @@ public class ApiMember
     public bool IsFinalizer { get; set; }
 
     /// <summary>
-    /// True when metadata MethodImpl rows identify this member or one of its
-    /// accessors as an explicit interface implementation. This remains separate
-    /// from <see cref="Kind"/> so aggregate properties and events retain their
+    /// True when metadata MethodImpl rows and a qualified metadata name identify
+    /// this aggregate property or event as an explicit interface implementation.
+    /// This remains separate from <see cref="Kind"/> so the aggregate retains its
     /// member shape.
     /// </summary>
     /// <remarks>
     /// <c>ApiSignatureModelTests.ExplicitInterfaceAggregates_PreserveTypedIdentity</c>
-    /// gates extraction for methods, properties, and events.
+    /// gates extraction for properties and events.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsExplicitInterfaceImplementation { get; set; }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -975,6 +975,10 @@ public static class ApiSurfaceExtractor
                     isOverrideProperty |= setterOverride;
                     isSealedProperty |= setterOverride && (setterAttributes & MethodAttributes.Final) != 0;
                 }
+                isAbstractProperty = MetadataAccessorSemantics.IsUniformlyAbstract(
+                    reader,
+                    accessors.Getter,
+                    accessors.Setter);
 
                 if (!MetadataAccessibility.TryGet(bestAccess, out string? propertyAccessibility))
                 {
@@ -2157,6 +2161,9 @@ public static class ApiSurfaceExtractor
             return false;
 
         string interfaceName = name[..separator];
+        int aliasSeparator = interfaceName.IndexOf("::", StringComparison.Ordinal);
+        if (aliasSeparator >= 0)
+            interfaceName = interfaceName[(aliasSeparator + 2)..];
         string memberName = name[(separator + 1)..];
         string declarationMemberName = memberName == "this[]" ? "Item" : memberName;
         bool hasAccessor = false;
@@ -4366,6 +4373,9 @@ public static class ApiSurfaceExtractor
         MethodAttributes setterAccess = 0;
         bool hasGetter = !accessors.Getter.IsNil;
         bool hasSetter = !accessors.Setter.IsNil;
+        string setterKind = hasSetter
+            ? MetadataAccessorSemantics.Kind(reader, accessors.Setter, "set")
+            : "set";
 
         if (hasGetter)
         {
@@ -4382,7 +4392,7 @@ public static class ApiSurfaceExtractor
         int bestAccess = Math.Max((int)getterAccess, (int)setterAccess);
         var accessorModels = new List<ApiAccessor>();
         var getStr = hasGetter ? FormatAccessor("get", getterAccess, bestAccess) : null;
-        var setStr = hasSetter ? FormatAccessor("set", setterAccess, bestAccess) : null;
+        var setStr = hasSetter ? FormatAccessor(setterKind, setterAccess, bestAccess) : null;
         if (hasGetter)
         {
             var getter = reader.GetMethodDefinition(accessors.Getter);
@@ -4404,7 +4414,7 @@ public static class ApiSurfaceExtractor
             var setter = reader.GetMethodDefinition(accessors.Setter);
             accessorModels.Add(new ApiAccessor
             {
-                Kind = "set",
+                Kind = setterKind,
                 Accessibility = AccessorAccessibility(setterAccess, bestAccess),
                 ReturnAttributes = ReturnParameterAttributes(
                     reader,
@@ -4592,7 +4602,7 @@ public static class ApiSurfaceExtractor
         var method = reader.GetMethodDefinition(handle);
         return new ApiAccessor
         {
-            Kind = kind,
+            Kind = MetadataAccessorSemantics.Kind(reader, handle, kind),
             MethodName = DecodeString(reader, method.Name, beforeDecodeWork),
             Accessibility = GetAccessorAccessibility(method.Attributes),
             ReturnAttributes = ReturnParameterAttributes(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -759,6 +759,7 @@ public static class ApiSurfaceExtractor
                 {
                     AddInspectionFailure(
                         surface,
+                        budget,
                         "method accessibility",
                         methodHandle,
                         MetadataTypeNameFailure.Malformed(
@@ -928,6 +929,7 @@ public static class ApiSurfaceExtractor
                 {
                     AddInspectionFailure(
                         surface,
+                        budget,
                         "property accessors",
                         propHandle,
                         MetadataTypeNameFailure.Malformed(
@@ -974,6 +976,7 @@ public static class ApiSurfaceExtractor
                 {
                     AddInspectionFailure(
                         surface,
+                        budget,
                         "property accessibility",
                         propHandle,
                         MetadataTypeNameFailure.Malformed(
@@ -1123,6 +1126,7 @@ public static class ApiSurfaceExtractor
                 {
                     AddInspectionFailure(
                         surface,
+                        budget,
                         "field accessibility",
                         fieldHandle,
                         MetadataTypeNameFailure.Malformed(
@@ -1280,6 +1284,7 @@ public static class ApiSurfaceExtractor
                 {
                     AddInspectionFailure(
                         surface,
+                        budget,
                         "event accessors",
                         eventHandle,
                         MetadataTypeNameFailure.Malformed(
@@ -1304,6 +1309,7 @@ public static class ApiSurfaceExtractor
                     {
                         AddInspectionFailure(
                             surface,
+                            budget,
                             "event accessibility",
                             eventHandle,
                             MetadataTypeNameFailure.Malformed(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -755,6 +755,17 @@ public static class ApiSurfaceExtractor
                     method.Name,
                     observeDecodeWork);
                 var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
+                if (!MetadataAccessibility.TryGet(methodAccess, out string? methodAccessibility))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        "method accessibility",
+                        methodHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            methodHandle,
+                            $"The method has an unknown accessibility value 0x{(int)methodAccess:X}."));
+                    continue;
+                }
                 var isExplicitInterfaceImplementation = explicitImplementationBodies.Contains(methodHandle);
                 var isRetainedImplementationAccessor = isExplicitInterfaceImplementation
                     && (methodName.Contains('.', StringComparison.Ordinal)
@@ -879,7 +890,7 @@ public static class ApiSurfaceExtractor
                             reader,
                             method.GetCustomAttributes(),
                             observeDecodeWork),
-                    Accessibility = GetAccessibility(methodAccess),
+                    Accessibility = methodAccessibility,
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
                     Attributes = RenderMemberAttributes(
@@ -959,7 +970,19 @@ public static class ApiSurfaceExtractor
                     isSealedProperty |= setterOverride && (setterAttributes & MethodAttributes.Final) != 0;
                 }
 
-                bool isPublicProp = bestAccess == MethodAttributes.Public;
+                if (!MetadataAccessibility.TryGet(bestAccess, out string? propertyAccessibility))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        "property accessibility",
+                        propHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            propHandle,
+                            $"The property has an unknown accessibility value 0x{(int)bestAccess:X}."));
+                    continue;
+                }
+
+                bool isPublicProp = propertyAccessibility is null;
                 if (!isPublicProp && !includeAll)
                     continue;
 
@@ -1030,7 +1053,7 @@ public static class ApiSurfaceExtractor
                             reader,
                             prop.GetCustomAttributes(),
                             observeDecodeWork),
-                    Accessibility = GetAccessibility(bestAccess),
+                    Accessibility = propertyAccessibility,
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
                     IsCompilerGenerated = AttributeReader.HasAttribute(
@@ -1091,6 +1114,17 @@ public static class ApiSurfaceExtractor
             {
                 var field = reader.GetFieldDefinition(fieldHandle);
                 var fieldAccess = field.Attributes & FieldAttributes.FieldAccessMask;
+                if (!MetadataAccessibility.TryGet(fieldAccess, out string? fieldAccessibility))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        "field accessibility",
+                        fieldHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            fieldHandle,
+                            $"The field has an unknown accessibility value 0x{(int)fieldAccess:X}."));
+                    continue;
+                }
                 if (fieldAccess != FieldAttributes.Public && !includeAll)
                     continue;
 
@@ -1181,7 +1215,7 @@ public static class ApiSurfaceExtractor
                             reader,
                             field.GetCustomAttributes(),
                             observeDecodeWork),
-                    Accessibility = GetFieldAccessibility(fieldAccess),
+                    Accessibility = fieldAccessibility,
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
                     Attributes = RenderMemberAttributes(
@@ -1237,25 +1271,50 @@ public static class ApiSurfaceExtractor
             {
                 var evt = reader.GetEventDefinition(eventHandle);
                 var accessors = evt.GetAccessors();
-
                 if (accessors.Adder.IsNil && accessors.Remover.IsNil)
+                {
+                    AddInspectionFailure(
+                        surface,
+                        "event accessors",
+                        eventHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            eventHandle,
+                            "The event has no adder or remover."));
                     continue;
+                }
 
                 var primaryAccessorHandle = !accessors.Adder.IsNil
                     ? accessors.Adder
                     : accessors.Remover;
                 var primaryAccessor = reader.GetMethodDefinition(primaryAccessorHandle);
-                var bestAccess = primaryAccessor.Attributes & MethodAttributes.MemberAccessMask;
-                _ = GetAccessibility(bestAccess);
-                if (!accessors.Remover.IsNil)
+                MethodAttributes bestAccess = 0;
+                bool malformedAccessibility = false;
+                foreach (var accessorHandle in new[] { accessors.Adder, accessors.Remover })
                 {
-                    var remover = reader.GetMethodDefinition(accessors.Remover);
-                    var removerAccess = remover.Attributes & MethodAttributes.MemberAccessMask;
-                    _ = GetAccessibility(removerAccess);
-                    if (removerAccess > bestAccess)
-                        bestAccess = removerAccess;
+                    if (accessorHandle.IsNil)
+                        continue;
+                    var access = reader.GetMethodDefinition(accessorHandle).Attributes
+                        & MethodAttributes.MemberAccessMask;
+                    if (!MetadataAccessibility.TryGet(access, out _))
+                    {
+                        AddInspectionFailure(
+                            surface,
+                            "event accessibility",
+                            eventHandle,
+                            MetadataTypeNameFailure.Malformed(
+                                eventHandle,
+                                $"The event has an unknown accessibility value 0x{(int)access:X}."));
+                        malformedAccessibility = true;
+                        break;
+                    }
+                    if (access > bestAccess)
+                        bestAccess = access;
                 }
-                if (bestAccess != MethodAttributes.Public && !includeAll)
+                if (malformedAccessibility)
+                    continue;
+
+                string? eventAccessibility = MetadataAccessibility.Get(bestAccess);
+                if (eventAccessibility is not null && !includeAll)
                     continue;
 
                 // Skip EditorBrowsable(Never) events unless --all; obsolete are surfaced with marker.
@@ -1357,8 +1416,8 @@ public static class ApiSurfaceExtractor
                             observeAttributeMaterialize),
                         HasMethodBody = remover.RelativeVirtualAddress != 0,
                         IsAbstract = (remover.Attributes & MethodAttributes.Abstract) != 0
-                    });
-                }
+                    }
+                };
                 var accessorFacts = AccessorFacts(
                     reader,
                     observeText,
@@ -1425,7 +1484,7 @@ public static class ApiSurfaceExtractor
                             reader,
                             evt.GetCustomAttributes(),
                             observeDecodeWork),
-                    Accessibility = GetAccessibility(bestAccess),
+                    Accessibility = eventAccessibility,
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
                     AdderToken = accessors.Adder.IsNil
@@ -4985,36 +5044,14 @@ public static class ApiSurfaceExtractor
     /// <summary>
     /// Maps MethodAttributes access level to C# keyword. Returns null for public.
     /// </summary>
-    private static string? GetAccessibility(MethodAttributes access) => access switch
-    {
-        MethodAttributes.PrivateScope => "private",
-        MethodAttributes.Private => "private",
-        MethodAttributes.FamANDAssem => "private protected",
-        MethodAttributes.Assembly => "internal",
-        MethodAttributes.Family => "protected",
-        MethodAttributes.FamORAssem => "protected internal",
-        MethodAttributes.Public => null,
-        _ => throw new BadImageFormatException(
-            $"Invalid method accessibility value 0x{(int)access:X}.")
-    };
+    private static string? GetAccessibility(MethodAttributes access)
+        => MetadataAccessibility.Get(access);
 
     /// <summary>
     /// Maps FieldAttributes access level to C# keyword. Returns null for public.
     /// </summary>
-    private static string? GetFieldAccessibility(FieldAttributes access) => access switch
-    {
-        FieldAttributes.PrivateScope => "private",
-        FieldAttributes.Private => "private",
-        FieldAttributes.FamANDAssem => "private protected",
-        FieldAttributes.Assembly => "internal",
-        FieldAttributes.Family => "protected",
-        FieldAttributes.FamORAssem => "protected internal",
-        FieldAttributes.Public => null,
-        _ => throw new ArgumentOutOfRangeException(
-            nameof(access),
-            access,
-            "Unknown field accessibility.")
-    };
+    private static string? GetFieldAccessibility(FieldAttributes access)
+        => MetadataAccessibility.Get(access);
 
     sealed class TypeParameterConstraintResolution
     {

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1978,12 +1978,6 @@ public static class ApiSurfaceExtractor
                 continue;
             }
 
-            string propertyName = reader.GetString(property.Name);
-            bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
-                propertyName,
-                methodImplementations,
-                (accessors.Getter, "get_"),
-                (accessors.Setter, "set_"));
             if (propertyAccessibility is not null
                 || AttributeReader.HasEditorBrowsableNeverAttribute(
                     reader,
@@ -1991,6 +1985,12 @@ public static class ApiSurfaceExtractor
             {
                 continue;
             }
+            string propertyName = reader.GetString(property.Name);
+            bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
+                propertyName,
+                methodImplementations,
+                (accessors.Getter, "get_"),
+                (accessors.Setter, "set_"));
             if (isExplicitInterfaceImplementation
                 && ValidateExplicitPropertyRowSignature(
                     reader,
@@ -2142,12 +2142,6 @@ public static class ApiSurfaceExtractor
             }
             string? eventAccessibility = MetadataAccessibility.Get(bestAccess);
 
-            string eventName = reader.GetString(evt.Name);
-            bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
-                eventName,
-                methodImplementations,
-                (accessors.Adder, "add_"),
-                (accessors.Remover, "remove_"));
             if (eventAccessibility is not null
                 || AttributeReader.HasEditorBrowsableNeverAttribute(
                     reader,
@@ -2155,6 +2149,12 @@ public static class ApiSurfaceExtractor
             {
                 continue;
             }
+            string eventName = reader.GetString(evt.Name);
+            bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
+                eventName,
+                methodImplementations,
+                (accessors.Adder, "add_"),
+                (accessors.Remover, "remove_"));
             if (isExplicitInterfaceImplementation
                 && ValidateExplicitEventRowSignature(
                     reader,

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1120,6 +1120,21 @@ public static class ApiSurfaceExtractor
                                 : "The property has inconsistent abstract accessor metadata."));
                     continue;
                 }
+                if (!MetadataAccessorSemantics.HaveUniformMemberModifiers(
+                        reader,
+                        accessors.Getter,
+                        accessors.Setter))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "property modifiers",
+                        propHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            propHandle,
+                            "The property has inconsistent slot or static accessor metadata."));
+                    continue;
+                }
                 if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
                         reader,
                         out isSealedProperty,
@@ -1558,6 +1573,21 @@ public static class ApiSurfaceExtractor
                             eventAbstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
                                 ? "The event has an abstract accessor that declares an IL body."
                                 : "The event has inconsistent abstract accessor metadata."));
+                    continue;
+                }
+                if (!MetadataAccessorSemantics.HaveUniformMemberModifiers(
+                        reader,
+                        accessors.Adder,
+                        accessors.Remover))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "event modifiers",
+                        eventHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            eventHandle,
+                            "The event has inconsistent slot or static accessor metadata."));
                     continue;
                 }
                 if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
@@ -2074,6 +2104,21 @@ public static class ApiSurfaceExtractor
                             : "The property has inconsistent abstract accessor metadata."));
                 continue;
             }
+            if (!MetadataAccessorSemantics.HaveUniformMemberModifiers(
+                    reader,
+                    accessors.Getter,
+                    accessors.Setter))
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "property modifiers",
+                    propertyHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        propertyHandle,
+                        "The property has inconsistent slot or static accessor metadata."));
+                continue;
+            }
             if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
                     reader,
                     out bool isSealedProperty,
@@ -2256,6 +2301,21 @@ public static class ApiSurfaceExtractor
                         eventAbstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
                             ? "The event has an abstract accessor that declares an IL body."
                             : "The event has inconsistent abstract accessor metadata."));
+                continue;
+            }
+            if (!MetadataAccessorSemantics.HaveUniformMemberModifiers(
+                    reader,
+                    accessors.Adder,
+                    accessors.Remover))
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "event modifiers",
+                    eventHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        eventHandle,
+                        "The event has inconsistent slot or static accessor metadata."));
                 continue;
             }
             if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2717,6 +2717,10 @@ public static class ApiSurfaceExtractor
                 return cached;
 
             var body = reader.GetMethodDefinition(bodyHandle);
+            int genericParameterCount = ValidateGenericParameters(
+                bodyHandle,
+                body,
+                "body");
             var result = GuardedProviderDecode.MethodResult(
                 reader,
                 body,
@@ -2733,8 +2737,7 @@ public static class ApiSurfaceExtractor
                 throw new BadImageFormatException(
                     "The MethodImpl body signature could not be decoded.");
             }
-            if (result.Value.GenericParameterCount
-                != body.GetGenericParameters().Count)
+            if (result.Value.GenericParameterCount != genericParameterCount)
             {
                 throw new BadImageFormatException(
                     "The MethodImpl body generic arity does not match its GenericParam rows.");
@@ -2757,6 +2760,10 @@ public static class ApiSurfaceExtractor
                         return cachedMethod;
 
                     var method = reader.GetMethodDefinition(handle);
+                    int genericParameterCount = ValidateGenericParameters(
+                        handle,
+                        method,
+                        "declaration");
                     var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
                     var methodResult = GuardedProviderDecode.MethodResult(
                         reader,
@@ -2777,8 +2784,7 @@ public static class ApiSurfaceExtractor
                         throw new BadImageFormatException(
                             "The MethodImpl declaration signature could not be decoded.");
                     }
-                    if (methodResult.Value.GenericParameterCount
-                        != method.GetGenericParameters().Count)
+                    if (methodResult.Value.GenericParameterCount != genericParameterCount)
                     {
                         throw new BadImageFormatException(
                             "The MethodImpl declaration generic arity does not match its GenericParam rows.");
@@ -2822,6 +2828,28 @@ public static class ApiSurfaceExtractor
                     throw new BadImageFormatException(
                         "The MethodImpl declaration kind is unsupported.");
             }
+        }
+
+        int ValidateGenericParameters(
+            MethodDefinitionHandle methodHandle,
+            MethodDefinition method,
+            string role)
+        {
+            int expectedIndex = 0;
+            foreach (GenericParameterHandle parameterHandle in
+                method.GetGenericParameters())
+            {
+                GenericParameter parameter =
+                    reader.GetGenericParameter(parameterHandle);
+                if (parameter.Parent != methodHandle
+                    || parameter.Index != expectedIndex++)
+                {
+                    throw new BadImageFormatException(
+                        $"The MethodImpl {role} GenericParam rows are not a contiguous zero-based sequence.");
+                }
+            }
+
+            return expectedIndex;
         }
 
         HashSet<string> GetImplementedInterfaces()

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2248,6 +2248,9 @@ public static class ApiSurfaceExtractor
                 identityProvider))
             return false;
 
+        if (declaringTypeIdentity.IsInterface == false)
+            return false;
+
         if (declaringType.Kind == HandleKind.TypeDefinition
             && (reader.GetTypeDefinition((TypeDefinitionHandle)declaringType).Attributes
                 & TypeAttributes.Interface) == 0)

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -6905,6 +6905,8 @@ public static class ApiSurfaceExtractor
     {
         const int DecodeWorkWeight = 16;
         const int RetainedTextDecodeWorkCreditWeight = DecodeWorkWeight * 4;
+        // A MethodImpl projection decodes an interface identity plus two method signatures.
+        const int ProjectionTextDecodeWorkCreditWeight = DecodeWorkWeight * 5;
         // Small exact retention budgets still need enough work room to decode one ordinary type.
         // It is granted once per extraction; retained model text then earns bounded additional
         // work so rejected or amplification-heavy candidates cannot rearm the floor.
@@ -7037,13 +7039,14 @@ public static class ApiSurfaceExtractor
                 throw new ArgumentOutOfRangeException(nameof(encodedCharacters));
             long next =
                 (long)encodedCharacters * DecodeWorkWeight + _decodeWork;
-            long creditedCharacters =
+            long retainedTextCharacters =
                 (long)_retainedTextCharacters
-                + _pendingTextCharacters
-                + _committedProjectionTextCharacters;
+                + _pendingTextCharacters;
             long limit =
                 MinimumDecodeWorkLimit
-                + creditedCharacters * RetainedTextDecodeWorkCreditWeight;
+                + retainedTextCharacters * RetainedTextDecodeWorkCreditWeight
+                + _committedProjectionTextCharacters
+                    * ProjectionTextDecodeWorkCreditWeight;
             if (next > limit || next < 0)
             {
                 throw new ExtractionBoundExceededException(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1036,10 +1036,11 @@ public static class ApiSurfaceExtractor
                     typeContext,
                     observeText,
                     observeDecodeWork);
-                bool isExplicitInterfaceImplementation =
-                    propertyName.Contains('.', StringComparison.Ordinal)
-                    && (!accessors.Getter.IsNil && explicitImplementationBodies.Contains(accessors.Getter)
-                        || !accessors.Setter.IsNil && explicitImplementationBodies.Contains(accessors.Setter));
+                bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
+                    propertyName,
+                    explicitInterfaceImplementationBodies,
+                    accessors.Getter,
+                    accessors.Setter);
                 var member = new ApiMember
                 {
                     Name = propertyName,
@@ -1439,10 +1440,11 @@ public static class ApiSurfaceExtractor
                     observeAttributeMaterialize,
                     (accessors.Adder, "add"),
                     (accessors.Remover, "remove"));
-                bool isExplicitInterfaceImplementation =
-                    eventName.Contains('.', StringComparison.Ordinal)
-                    && (explicitImplementationBodies.Contains(accessors.Adder)
-                        || explicitImplementationBodies.Contains(accessors.Remover));
+                bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
+                    eventName,
+                    explicitInterfaceImplementationBodies,
+                    accessors.Adder,
+                    accessors.Remover);
 
                 var eventTypeNodeProvider = observeText is null
                     ? TypeNodeProvider.Instance
@@ -2130,6 +2132,27 @@ public static class ApiSurfaceExtractor
         }
 
         return handles;
+    }
+
+    internal static bool IsExplicitInterfaceAggregate(
+        string name,
+        IReadOnlySet<MethodDefinitionHandle> explicitInterfaceImplementationBodies,
+        params MethodDefinitionHandle[] accessors)
+    {
+        if (!name.Contains('.', StringComparison.Ordinal))
+            return false;
+
+        bool hasAccessor = false;
+        foreach (var accessor in accessors)
+        {
+            if (accessor.IsNil)
+                continue;
+            hasAccessor = true;
+            if (!explicitInterfaceImplementationBodies.Contains(accessor))
+                return false;
+        }
+
+        return hasAccessor;
     }
 
     private static bool IsInterfaceMethodDeclaration(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1208,11 +1208,15 @@ public static class ApiSurfaceExtractor
                     typeContext,
                     observeText,
                     observeDecodeWork);
-                bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
+                InterfaceImplementationResolution?
+                    interfaceImplementationResolution =
+                        GetExplicitInterfaceAggregateResolution(
                     propertyName,
                     methodImplementations,
                     (accessors.Getter, "get_"),
                     (accessors.Setter, "set_"));
+                bool isExplicitInterfaceImplementation =
+                    interfaceImplementationResolution is not null;
                 if (isExplicitInterfaceImplementation
                     && ValidateExplicitPropertyRowSignature(
                         reader,
@@ -1246,6 +1250,8 @@ public static class ApiSurfaceExtractor
                     IsOverride = isOverrideProperty,
                     IsSealed = isSealedProperty,
                     IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
+                    InterfaceImplementationResolution =
+                        interfaceImplementationResolution,
                     IsUnsafe = HasUnsafeSignature(reader, prop, observeDecodeWork)
                         || AttributeReader.HasRequiresUnsafeAttribute(
                             reader,
@@ -1690,11 +1696,15 @@ public static class ApiSurfaceExtractor
                     observeAttributeMaterialize,
                     (accessors.Adder, "add"),
                     (accessors.Remover, "remove"));
-                bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
+                InterfaceImplementationResolution?
+                    interfaceImplementationResolution =
+                        GetExplicitInterfaceAggregateResolution(
                     eventName,
                     methodImplementations,
                     (accessors.Adder, "add_"),
                     (accessors.Remover, "remove_"));
+                bool isExplicitInterfaceImplementation =
+                    interfaceImplementationResolution is not null;
                 if (isExplicitInterfaceImplementation
                     && ValidateExplicitEventRowSignature(
                         reader,
@@ -1761,6 +1771,8 @@ public static class ApiSurfaceExtractor
                     IsOverride = isOverrideEvent,
                     IsSealed = isSealedEvent,
                     IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
+                    InterfaceImplementationResolution =
+                        interfaceImplementationResolution,
                     IsUnsafe = HasUnsafeSignature(reader, evt, observeDecodeWork)
                         || AttributeReader.HasRequiresUnsafeAttribute(
                             reader,
@@ -1964,6 +1976,10 @@ public static class ApiSurfaceExtractor
                 IsStatic = (method.Attributes & MethodAttributes.Static) != 0,
                 IsFinalizer = isFinalizer,
                 IsExplicitInterfaceImplementation = isExplicitImplementation,
+                InterfaceImplementationResolution =
+                    isExplicitImplementation
+                        ? methodImplementations.GetResolution(methodHandle)
+                        : null,
                 CanUseImplicitInterfaceSyntax =
                     canUseImplicitInterfaceSyntax,
                 Accessibility = methodAccessibility
@@ -2097,11 +2113,15 @@ public static class ApiSurfaceExtractor
                 continue;
             }
             string propertyName = reader.GetString(property.Name);
-            bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
+            InterfaceImplementationResolution?
+                interfaceImplementationResolution =
+                    GetExplicitInterfaceAggregateResolution(
                 propertyName,
                 methodImplementations,
                 (accessors.Getter, "get_"),
                 (accessors.Setter, "set_"));
+            bool isExplicitInterfaceImplementation =
+                interfaceImplementationResolution is not null;
             if (isExplicitInterfaceImplementation
                 && ValidateExplicitPropertyRowSignature(
                     reader,
@@ -2127,6 +2147,8 @@ public static class ApiSurfaceExtractor
                 IsSealed = isSealedProperty,
                 IsExplicitInterfaceImplementation =
                     isExplicitInterfaceImplementation,
+                InterfaceImplementationResolution =
+                    interfaceImplementationResolution,
                 Accessibility = propertyAccessibility
             });
             surface.PublicPropertyCount++;
@@ -2262,11 +2284,15 @@ public static class ApiSurfaceExtractor
                 continue;
             }
             string eventName = reader.GetString(evt.Name);
-            bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
+            InterfaceImplementationResolution?
+                interfaceImplementationResolution =
+                    GetExplicitInterfaceAggregateResolution(
                 eventName,
                 methodImplementations,
                 (accessors.Adder, "add_"),
                 (accessors.Remover, "remove_"));
+            bool isExplicitInterfaceImplementation =
+                interfaceImplementationResolution is not null;
             if (isExplicitInterfaceImplementation
                 && ValidateExplicitEventRowSignature(
                     reader,
@@ -2292,6 +2318,8 @@ public static class ApiSurfaceExtractor
                 IsSealed = isSealedEvent,
                 IsExplicitInterfaceImplementation =
                     isExplicitInterfaceImplementation,
+                InterfaceImplementationResolution =
+                    interfaceImplementationResolution,
                 Accessibility = eventAccessibility
             });
             surface.PublicEventCount++;
@@ -3040,7 +3068,7 @@ public static class ApiSurfaceExtractor
                 new HashSet<TypeDefinitionHandle>();
             var pending = new Queue<TypeDefinitionHandle>();
             var closureIdentityProvider =
-                new ExplicitInterfaceTypeIdentityProvider();
+                new ExplicitInterfaceTypeIdentityProvider(observeDecodeWork);
             bool hasUnresolvedExternalInheritance = false;
             EntityHandle baseTypeHandle = typeDefinition.BaseType;
             int baseTypeCount = 0;
@@ -3518,25 +3546,36 @@ public static class ApiSurfaceExtractor
         IReadOnlyDictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
             explicitInterfaceImplementationTargets,
         params (MethodDefinitionHandle Handle, string DeclarationPrefix)[] accessors)
-        => IsExplicitInterfaceAggregate(
+        => GetExplicitInterfaceAggregateResolution(
             name,
             handle => explicitInterfaceImplementationTargets.TryGetValue(
                 handle,
                 out var targets)
                     ? targets
                     : null,
-            accessors);
+            accessors) is not null;
 
     internal static bool IsExplicitInterfaceAggregate(
         string name,
         MethodImplementationProjection methodImplementations,
         params (MethodDefinitionHandle Handle, string DeclarationPrefix)[] accessors)
-        => IsExplicitInterfaceAggregate(
+        => GetExplicitInterfaceAggregateResolution(
+            name,
+            methodImplementations,
+            accessors) is not null;
+
+    internal static InterfaceImplementationResolution?
+        GetExplicitInterfaceAggregateResolution(
+            string name,
+            MethodImplementationProjection methodImplementations,
+            params (MethodDefinitionHandle Handle, string DeclarationPrefix)[] accessors)
+        => GetExplicitInterfaceAggregateResolution(
             name,
             handle => methodImplementations.GetExplicitInterfaceTargets(handle),
             accessors);
 
-    private static bool IsExplicitInterfaceAggregate(
+    private static InterfaceImplementationResolution?
+        GetExplicitInterfaceAggregateResolution(
         string name,
         Func<MethodDefinitionHandle, IReadOnlyList<ExplicitInterfaceMethodTarget>?>
             getTargets,
@@ -3544,7 +3583,7 @@ public static class ApiSurfaceExtractor
     {
         int separator = name.LastIndexOf('.');
         if (separator <= 0 || separator == name.Length - 1)
-            return false;
+            return null;
 
         string interfaceName = name[..separator];
         int aliasSeparator = interfaceName.IndexOf("::", StringComparison.Ordinal);
@@ -3554,6 +3593,7 @@ public static class ApiSurfaceExtractor
         string declarationMemberName = memberName == "this[]" ? "Item" : memberName;
         bool hasAccessor = false;
         HashSet<string>? commonInterfaceKeys = null;
+        List<ExplicitInterfaceMethodTarget>? matchingTargets = null;
         foreach (var accessor in accessors)
         {
             if (accessor.Handle.IsNil)
@@ -3562,27 +3602,41 @@ public static class ApiSurfaceExtractor
             IReadOnlyList<ExplicitInterfaceMethodTarget>? targets =
                 getTargets(accessor.Handle);
             if (targets is null || targets.Count == 0)
-                return false;
+                return null;
 
-            var matchingKeys = targets
+            var accessorTargets = targets
                 .Where(target =>
                     (target.InterfaceType.MetadataName == interfaceName
                         || target.InterfaceType.AggregateAliasName == interfaceName)
                     && target.MethodName
                         == accessor.DeclarationPrefix + declarationMemberName)
+                .ToList();
+            var matchingKeys = accessorTargets
                 .Select(target => target.InterfaceType.Key)
                 .ToHashSet(StringComparer.Ordinal);
             if (matchingKeys.Count == 0)
-                return false;
+                return null;
+            (matchingTargets ??= []).AddRange(accessorTargets);
             if (commonInterfaceKeys is null)
                 commonInterfaceKeys = matchingKeys;
             else
                 commonInterfaceKeys.IntersectWith(matchingKeys);
             if (commonInterfaceKeys.Count == 0)
-                return false;
+                return null;
         }
 
-        return hasAccessor && commonInterfaceKeys is { Count: > 0 };
+        if (!hasAccessor
+            || commonInterfaceKeys is not { Count: > 0 }
+            || matchingTargets is null)
+        {
+            return null;
+        }
+
+        return matchingTargets.Any(target =>
+            commonInterfaceKeys.Contains(target.InterfaceType.Key)
+            && !target.InterfaceMembershipProven)
+                ? InterfaceImplementationResolution.Undetermined
+                : InterfaceImplementationResolution.Proven;
     }
 
     /// <summary>
@@ -6894,12 +6948,14 @@ public static class ApiSurfaceExtractor
     /// Members and retained text are counted as they are built but committed only when their type
     /// is, so a rejected type spends no retention budget. Structural MethodImpl text projected
     /// for admitted members likewise earns cumulative decode-work credit only when its owning type
-    /// commits; it does not inflate the reported retained-output total, and pending projection
-    /// cannot finance its own decode. The exact retained total is gated by
+    /// commits; it does not inflate the reported retained-output total, pending projection cannot
+    /// finance its own decode, and committed projection credit cannot exceed one additional unit
+    /// per retained model character. The exact retained total is gated by
     /// <c>ApiSurfaceExtractorBoundsTests.RetainedTextBudget_IsExact</c>. A separate monotonic
     /// extraction-wide decode-work estimate may reject allocation-amplifying input before its
-    /// expanded model exists; the hostile-shape allocation tests in that class gate that safety
-    /// boundary.
+    /// expanded model exists;
+    /// <c>ApiSurfaceExtractorBoundsTests.CommittedMethodImplProjection_DoesNotFinanceLaterAmplification</c>
+    /// and the other hostile-shape allocation tests in that class gate that safety boundary.
     /// </remarks>
     private sealed class ExtractionBudget(ApiSurfaceExtractionBounds bounds)
     {
@@ -6975,7 +7031,10 @@ public static class ApiSurfaceExtractor
             _types++;
             _members += _pendingMembers;
             _retainedTextCharacters += _pendingTextCharacters;
-            _committedProjectionTextCharacters += _pendingProjectionTextCharacters;
+            _committedProjectionTextCharacters = Math.Min(
+                bounds.MaxRetainedTextCharacters,
+                _committedProjectionTextCharacters
+                    + _pendingProjectionTextCharacters);
             _pendingMembers = 0;
             _pendingTextCharacters = 0;
             _pendingObservedTextCharacters = 0;
@@ -7042,11 +7101,14 @@ public static class ApiSurfaceExtractor
             long retainedTextCharacters =
                 (long)_retainedTextCharacters
                 + _pendingTextCharacters;
+            long projectionCredit = Math.Min(
+                _committedProjectionTextCharacters
+                    * ProjectionTextDecodeWorkCreditWeight,
+                retainedTextCharacters * DecodeWorkWeight);
             long limit =
                 MinimumDecodeWorkLimit
                 + retainedTextCharacters * RetainedTextDecodeWorkCreditWeight
-                + _committedProjectionTextCharacters
-                    * ProjectionTextDecodeWorkCreditWeight;
+                + projectionCredit;
             if (next > limit || next < 0)
             {
                 throw new ExtractionBoundExceededException(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -885,6 +885,7 @@ public static class ApiSurfaceExtractor
                     ReturnType = ApiMemberIdentity.IsConversionOperator(methodName) ? signature.Model?.ReturnType : null,
                     MetadataToken = MetadataTokens.GetToken(methodHandle),
                     HasMethodBody = method.RelativeVirtualAddress != 0,
+                    IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
                     IsUnsafe = HasUnsafeSignature(reader, method, observeDecodeWork)
                         || AttributeReader.HasRequiresUnsafeAttribute(
                             reader,
@@ -1006,7 +1007,6 @@ public static class ApiSurfaceExtractor
                     prop,
                     accessors,
                     typeNullableContext,
-                    includeAll,
                     observeText,
                     observeDecodeWork,
                     observeAttributeMaterialize);
@@ -1030,6 +1030,9 @@ public static class ApiSurfaceExtractor
                     typeContext,
                     observeText,
                     observeDecodeWork);
+                bool isExplicitInterfaceImplementation =
+                    !accessors.Getter.IsNil && explicitImplementationBodies.Contains(accessors.Getter)
+                    || !accessors.Setter.IsNil && explicitImplementationBodies.Contains(accessors.Setter);
                 var member = new ApiMember
                 {
                     Name = DecodeString(
@@ -1048,6 +1051,7 @@ public static class ApiSurfaceExtractor
                     IsAbstract = isAbstractProperty,
                     IsOverride = isOverrideProperty,
                     IsSealed = isSealedProperty,
+                    IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
                     IsUnsafe = HasUnsafeSignature(reader, prop, observeDecodeWork)
                         || AttributeReader.HasRequiresUnsafeAttribute(
                             reader,
@@ -1425,6 +1429,9 @@ public static class ApiSurfaceExtractor
                     observeAttributeMaterialize,
                     (accessors.Adder, "add"),
                     (accessors.Remover, "remove"));
+                bool isExplicitInterfaceImplementation =
+                    explicitImplementationBodies.Contains(accessors.Adder)
+                    || explicitImplementationBodies.Contains(accessors.Remover);
 
                 var eventTypeNodeProvider = observeText is null
                     ? TypeNodeProvider.Instance
@@ -1479,6 +1486,7 @@ public static class ApiSurfaceExtractor
                     IsOverride = isOverrideEvent,
                     IsSealed = isOverrideEvent
                         && (primaryAccessorAttributes & MethodAttributes.Final) != 0,
+                    IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
                     IsUnsafe = HasUnsafeSignature(reader, evt, observeDecodeWork)
                         || AttributeReader.HasRequiresUnsafeAttribute(
                             reader,
@@ -4125,7 +4133,6 @@ public static class ApiSurfaceExtractor
         PropertyDefinition prop,
         PropertyAccessors accessors,
         byte typeNullableContext,
-        bool includeAll = false,
         Action<string>? beforeRetainText = null,
         Action<int>? beforeDecodeWork = null,
         Action<int>? beforeAttributeMaterialize = null)
@@ -4183,129 +4190,49 @@ public static class ApiSurfaceExtractor
             setterAccess = setter.Attributes & MethodAttributes.MemberAccessMask;
         }
 
-        bool hasPublicGetter = hasGetter && getterAccess == MethodAttributes.Public;
-        bool hasPublicSetter = hasSetter && setterAccess == MethodAttributes.Public;
-
-        // Build accessor string
-        string accessorStr;
+        int bestAccess = Math.Max((int)getterAccess, (int)setterAccess);
         var accessorModels = new List<ApiAccessor>();
-        if (includeAll)
+        var getStr = hasGetter ? FormatAccessor("get", getterAccess, bestAccess) : null;
+        var setStr = hasSetter ? FormatAccessor("set", setterAccess, bestAccess) : null;
+        if (hasGetter)
         {
-            // Show explicit access levels for non-public accessors
-            var getStr = hasGetter ? FormatAccessor("get", getterAccess, Math.Max((int)getterAccess, (int)setterAccess)) : null;
-            var setStr = hasSetter ? FormatAccessor("set", setterAccess, Math.Max((int)getterAccess, (int)setterAccess)) : null;
-            if (hasGetter)
+            var getter = reader.GetMethodDefinition(accessors.Getter);
+            accessorModels.Add(new ApiAccessor
             {
-                var getter = reader.GetMethodDefinition(accessors.Getter);
-                accessorModels.Add(new ApiAccessor
-                {
-                    Kind = "get",
-                    Accessibility = AccessorAccessibility(getterAccess, Math.Max((int)getterAccess, (int)setterAccess)),
-                    ReturnAttributes = ReturnParameterAttributes(
-                        reader,
-                        getter.GetParameters(),
-                        beforeRetainText,
-                        attributeMaterialize),
-                    HasMethodBody = getter.RelativeVirtualAddress != 0,
-                    IsAbstract = (getter.Attributes & MethodAttributes.Abstract) != 0
-                });
-            }
-            if (hasSetter)
-            {
-                var setter = reader.GetMethodDefinition(accessors.Setter);
-                accessorModels.Add(new ApiAccessor
-                {
-                    Kind = "set",
-                    Accessibility = AccessorAccessibility(setterAccess, Math.Max((int)getterAccess, (int)setterAccess)),
-                    ReturnAttributes = ReturnParameterAttributes(
-                        reader,
-                        setter.GetParameters(),
-                        beforeRetainText,
-                        attributeMaterialize),
-                    HasMethodBody = setter.RelativeVirtualAddress != 0,
-                    IsAbstract = (setter.Attributes & MethodAttributes.Abstract) != 0
-                });
-            }
-            accessorStr = (getStr, setStr) switch
-            {
-                (not null, not null) => $"{{ {getStr}; {setStr}; }}",
-                (not null, null) => $"{{ {getStr}; }}",
-                (null, not null) => $"{{ {setStr}; }}",
-                _ => "{ get; }"
-            };
+                Kind = "get",
+                Accessibility = AccessorAccessibility(getterAccess, bestAccess),
+                ReturnAttributes = ReturnParameterAttributes(
+                    reader,
+                    getter.GetParameters(),
+                    beforeRetainText,
+                    attributeMaterialize),
+                HasMethodBody = getter.RelativeVirtualAddress != 0,
+                IsAbstract = (getter.Attributes & MethodAttributes.Abstract) != 0
+            });
         }
-        else
+        if (hasSetter)
         {
-            if (hasPublicGetter && hasPublicSetter)
+            var setter = reader.GetMethodDefinition(accessors.Setter);
+            accessorModels.Add(new ApiAccessor
             {
-                accessorStr = "{ get; set; }";
-                accessorModels.Add(AccessorModel(
+                Kind = "set",
+                Accessibility = AccessorAccessibility(setterAccess, bestAccess),
+                ReturnAttributes = ReturnParameterAttributes(
                     reader,
-                    accessors.Getter,
-                    "get",
+                    setter.GetParameters(),
                     beforeRetainText,
-                    beforeDecodeWork,
-                    attributeMaterialize));
-                accessorModels.Add(AccessorModel(
-                    reader,
-                    accessors.Setter,
-                    "set",
-                    beforeRetainText,
-                    beforeDecodeWork,
-                    attributeMaterialize));
-            }
-            else if (hasPublicGetter && hasSetter)
-            {
-                accessorStr = "{ get; private set; }";
-                accessorModels.Add(AccessorModel(
-                    reader,
-                    accessors.Getter,
-                    "get",
-                    beforeRetainText,
-                    beforeDecodeWork,
-                    attributeMaterialize));
-                var setter = reader.GetMethodDefinition(accessors.Setter);
-                accessorModels.Add(new ApiAccessor
-                {
-                    Kind = "set",
-                    Accessibility = "private",
-                    ReturnAttributes = ReturnParameterAttributes(
-                        reader,
-                        setter.GetParameters(),
-                        beforeRetainText,
-                        attributeMaterialize),
-                    HasMethodBody = setter.RelativeVirtualAddress != 0,
-                    IsAbstract = (setter.Attributes & MethodAttributes.Abstract) != 0
-                });
-            }
-            else if (hasPublicGetter)
-            {
-                accessorStr = "{ get; }";
-                accessorModels.Add(AccessorModel(
-                    reader,
-                    accessors.Getter,
-                    "get",
-                    beforeRetainText,
-                    beforeDecodeWork,
-                    attributeMaterialize));
-            }
-            else if (hasPublicSetter)
-            {
-                accessorStr = "{ set; }";
-                accessorModels.Add(AccessorModel(
-                    reader,
-                    accessors.Setter,
-                    "set",
-                    beforeRetainText,
-                    beforeDecodeWork,
-                    attributeMaterialize));
-            }
-            else
-            {
-                accessorStr = "{ get; }"; // Fallback
-                accessorModels.Add(new ApiAccessor { Kind = "get" });
-            }
+                    attributeMaterialize),
+                HasMethodBody = setter.RelativeVirtualAddress != 0,
+                IsAbstract = (setter.Attributes & MethodAttributes.Abstract) != 0
+            });
         }
+        string accessorStr = (getStr, setStr) switch
+        {
+            (not null, not null) => $"{{ {getStr}; {setStr}; }}",
+            (not null, null) => $"{{ {getStr}; }}",
+            (null, not null) => $"{{ {setStr}; }}",
+            _ => "{ get; }"
+        };
 
         ApplyAccessorStructuralReturns(
             accessorModels,

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1419,6 +1419,62 @@ public static class ApiSurfaceExtractor
                 if (malformedAccessibility)
                     continue;
 
+                bool isStaticEvent = false;
+                bool isVirtualEvent = false;
+                bool isOverrideEvent = false;
+                bool hasFinalEventAccessor = false;
+                foreach (var accessorHandle in new[] { accessors.Adder, accessors.Remover })
+                {
+                    if (accessorHandle.IsNil)
+                        continue;
+                    var accessorAttributes = reader.GetMethodDefinition(accessorHandle).Attributes;
+                    bool accessorVirtual = (accessorAttributes & MethodAttributes.Virtual) != 0;
+                    isStaticEvent |= (accessorAttributes & MethodAttributes.Static) != 0;
+                    isVirtualEvent |= accessorVirtual;
+                    isOverrideEvent |= accessorVirtual
+                        && (accessorAttributes & MethodAttributes.NewSlot) == 0;
+                    hasFinalEventAccessor |= (accessorAttributes & MethodAttributes.Final) != 0;
+                }
+                bool isAbstractEvent = MetadataAccessorSemantics.AreAllAbstract(
+                    reader,
+                    accessors.Adder,
+                    accessors.Remover);
+                if (MetadataAccessorSemantics.ValidateAbstraction(
+                        reader,
+                        requireUniformAbstraction: !isInterfaceTypeDefinition,
+                        accessors.Adder,
+                        accessors.Remover)
+                    is var eventAbstractionFault and not AccessorAbstractionFault.None)
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "event modifiers",
+                        eventHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            eventHandle,
+                            eventAbstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
+                                ? "The event has an abstract accessor that declares an IL body."
+                                : "The event has inconsistent abstract accessor metadata."));
+                    continue;
+                }
+                if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
+                        reader,
+                        out bool isSealedEvent,
+                        accessors.Adder,
+                        accessors.Remover))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "event modifiers",
+                        eventHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            eventHandle,
+                            "The event has inconsistent sealed accessor metadata."));
+                    continue;
+                }
+
                 string? eventAccessibility = MetadataAccessibility.Get(bestAccess);
                 if (eventAccessibility is not null && !includeAll)
                     continue;
@@ -1488,61 +1544,6 @@ public static class ApiSurfaceExtractor
                         eventNode.ApplyTupleNames(eventTupleNames);
                         eventType = eventNode.Render();
                     }
-                }
-                bool isStaticEvent = false;
-                bool isVirtualEvent = false;
-                bool isOverrideEvent = false;
-                bool hasFinalEventAccessor = false;
-                foreach (var accessorHandle in new[] { accessors.Adder, accessors.Remover })
-                {
-                    if (accessorHandle.IsNil)
-                        continue;
-                    var accessorAttributes = reader.GetMethodDefinition(accessorHandle).Attributes;
-                    bool accessorVirtual = (accessorAttributes & MethodAttributes.Virtual) != 0;
-                    isStaticEvent |= (accessorAttributes & MethodAttributes.Static) != 0;
-                    isVirtualEvent |= accessorVirtual;
-                    isOverrideEvent |= accessorVirtual
-                        && (accessorAttributes & MethodAttributes.NewSlot) == 0;
-                    hasFinalEventAccessor |= (accessorAttributes & MethodAttributes.Final) != 0;
-                }
-                bool isAbstractEvent = MetadataAccessorSemantics.AreAllAbstract(
-                    reader,
-                    accessors.Adder,
-                    accessors.Remover);
-                if (MetadataAccessorSemantics.ValidateAbstraction(
-                        reader,
-                        requireUniformAbstraction: !isInterfaceTypeDefinition,
-                        accessors.Adder,
-                        accessors.Remover)
-                    is var eventAbstractionFault and not AccessorAbstractionFault.None)
-                {
-                    AddInspectionFailure(
-                        surface,
-                        budget,
-                        "event modifiers",
-                        eventHandle,
-                        MetadataTypeNameFailure.Malformed(
-                            eventHandle,
-                            eventAbstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
-                                ? "The event has an abstract accessor that declares an IL body."
-                                : "The event has inconsistent abstract accessor metadata."));
-                    continue;
-                }
-                if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
-                        reader,
-                        out bool isSealedEvent,
-                        accessors.Adder,
-                        accessors.Remover))
-                {
-                    AddInspectionFailure(
-                        surface,
-                        budget,
-                        "event modifiers",
-                        eventHandle,
-                        MetadataTypeNameFailure.Malformed(
-                            eventHandle,
-                            "The event has inconsistent sealed accessor metadata."));
-                    continue;
                 }
                 bool isCSharpVirtualEvent =
                     apiType.Kind == "class"

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -155,7 +155,9 @@ public abstract record ApiSurfaceExtractionResult
 internal readonly record struct ExplicitInterfaceMethodTarget(
     EntityHandle Declaration,
     ExplicitInterfaceTypeIdentity InterfaceType,
-    string MethodName);
+    string MethodName,
+    bool InterfaceMembershipProven = true,
+    MethodDefinitionHandle SemanticDeclaration = default);
 
 /// <summary>
 /// Extracts public API surface from assemblies.
@@ -168,6 +170,71 @@ public static class ApiSurfaceExtractor
         MetadataReader,
         PrimitiveDefinitionClassification>
         PrimitiveDefinitionClassifications = new();
+
+    internal static bool IsEffectivelyPublicType(
+        MetadataReader reader,
+        TypeDefinitionHandle handle)
+    {
+        Span<TypeDefinitionHandle> chain =
+            stackalloc TypeDefinitionHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkTypeDefinitionDeclaringChain(
+                reader,
+                handle,
+                chain,
+                out int count,
+                out EntityHandle terminal,
+                out RelationshipTraversalRejection? rejection))
+        {
+            throw new MetadataRowRejectedException(
+                "type identity",
+                rejection is null
+                    ? MetadataTypeNameFailure.Malformed(
+                        handle,
+                        "The type declaring chain could not be traversed.")
+                    : MetadataTypeNameFailure.From(rejection));
+        }
+        if (count == 0 || !terminal.IsNil)
+        {
+            throw new MetadataRowRejectedException(
+                "type identity",
+                MetadataTypeNameFailure.Malformed(
+                    handle,
+                    "The type declaring chain does not terminate at a top-level type."));
+        }
+
+        for (int index = 0; index < count; index++)
+        {
+            TypeAttributes visibility =
+                reader.GetTypeDefinition(chain[index]).Attributes
+                & TypeAttributes.VisibilityMask;
+            if (index == 0)
+            {
+                if (visibility == TypeAttributes.Public)
+                    continue;
+                if (visibility == TypeAttributes.NotPublic)
+                    return false;
+                throw new MetadataRowRejectedException(
+                    "type identity",
+                    MetadataTypeNameFailure.Malformed(
+                        chain[index],
+                        "A top-level type has nested visibility metadata."));
+            }
+
+            if (visibility == TypeAttributes.NestedPublic)
+                continue;
+            if (visibility is TypeAttributes.Public or TypeAttributes.NotPublic)
+            {
+                throw new MetadataRowRejectedException(
+                    "type identity",
+                    MetadataTypeNameFailure.Malformed(
+                        chain[index],
+                        "A nested type has top-level visibility metadata."));
+            }
+            return false;
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// Extracts the public type identities and member-kind counts needed by the compact platform
@@ -191,7 +258,7 @@ public static class ApiSurfaceExtractor
             try
             {
                 var typeDef = reader.GetTypeDefinition(typeDefHandle);
-                if (!typeDef.IsPublic)
+                if (!IsEffectivelyPublicType(reader, typeDefHandle))
                     continue;
 
                 var typeAttributes = typeDef.Attributes;
@@ -510,7 +577,10 @@ public static class ApiSurfaceExtractor
             // non-public types, including nested private/internal types, so ranking/triage rows
             // that already surface non-public IL can be copied into type/member drill commands.
             // Compiler-generated types are still skipped below regardless.
-            if (!typeDef.IsPublic && scope == ApiSurfaceExtractionScope.Public)
+            bool isEffectivelyPublic =
+                IsEffectivelyPublicType(reader, typeDefHandle);
+            if (!isEffectivelyPublic
+                && scope == ApiSurfaceExtractionScope.Public)
                 continue;
 
             budget?.BeginTypeCandidate();
@@ -530,7 +600,7 @@ public static class ApiSurfaceExtractor
             // list while a non-public type carries its complete one.
             bool includeAll = scope == ApiSurfaceExtractionScope.IncludeAll
                 || (scope == ApiSurfaceExtractionScope.PublicWithNonPublicTypes
-                    && !typeDef.IsPublic);
+                    && !isEffectivelyPublic);
 
             // Skip EditorBrowsable(Never) and Obsolete types unless --all. A public type the
             // extractor hides stays hidden in the composed scope too: it is suppressed, not
@@ -862,7 +932,7 @@ public static class ApiSurfaceExtractor
                 var isOperator = IsOperatorMethodName(methodName);
                 var isVirtual = (methodAttributes & MethodAttributes.Virtual) != 0;
                 var isNewSlot = (methodAttributes & MethodAttributes.NewSlot) != 0;
-                var isOverride = isVirtual && !isNewSlot && !isExplicitInterfaceImplementation;
+                var isOverride = isVirtual && !isNewSlot;
 
                 // A class finalizer is the `object.Finalize` override the C#
                 // `~Type()` destructor compiles to. It is detected by the
@@ -900,12 +970,18 @@ public static class ApiSurfaceExtractor
                     },
                     IsStatic = (methodAttributes & MethodAttributes.Static) != 0,
                     IsVirtual = isVirtual,
+                    IsNewSlot = isNewSlot,
+                    IsFinal = (methodAttributes & MethodAttributes.Final) != 0,
                     IsAbstract = (methodAttributes & MethodAttributes.Abstract) != 0,
                     IsOverride = isOverride,
                     IsSealed = isOverride && (methodAttributes & MethodAttributes.Final) != 0,
                     IsFinalizer = isFinalizer,
                     IsExplicitInterfaceImplementation =
                         isExplicitInterfaceImplementation,
+                    InterfaceImplementationResolution =
+                        isExplicitInterfaceImplementation
+                            ? methodImplementations.GetResolution(methodHandle)
+                            : null,
                     CanUseImplicitInterfaceSyntax =
                         canUseImplicitInterfaceSyntax,
                     Signature = signature.Text,
@@ -2602,16 +2678,27 @@ public static class ApiSurfaceExtractor
         readonly Dictionary<MethodDefinitionHandle, bool> objectFinalizeOverrides = [];
         readonly Dictionary<MethodDefinitionHandle, MethodSignature<ExplicitInterfaceTypeIdentity>>
             bodySignatures = [];
-        readonly Dictionary<MethodDefinitionHandle, MethodSignature<ExplicitInterfaceTypeIdentity>>
+        readonly Dictionary<(MethodDefinitionHandle Handle, string DeclaringTypeKey),
+            MethodSignature<ExplicitInterfaceTypeIdentity>>
             methodDefinitionSignatures = [];
         readonly Dictionary<MemberReferenceSignatureCacheKey,
             MethodSignature<ExplicitInterfaceTypeIdentity>> memberReferenceSignatures = [];
         readonly HashSet<MethodDefinitionHandle> validatedBodies = [];
-        HashSet<string>? implementedInterfaces;
+        readonly Dictionary<TypeDefinitionHandle, HashSet<MethodDefinitionHandle>>
+            associatedMethodsByType = [];
+        ImplementedInterfaceSet? implementedInterfaces;
 
         readonly record struct MemberReferenceSignatureCacheKey(
             BlobHandle Signature,
             ExplicitInterfaceSignatureContext Context);
+
+        internal sealed record ImplementedInterfaceSet(
+            HashSet<string> Proven,
+            HashSet<string> KnownNonInterfaces,
+            HashSet<TypeDefinitionHandle> ProvenNonGenericDefinitions,
+            HashSet<TypeDefinitionHandle> UndeterminedGenericDefinitions,
+            HashSet<TypeDefinitionHandle> KnownNonInterfaceDefinitions,
+            bool HasUnresolvedExternalInheritance);
 
         internal MethodImplementationProjection(
             MetadataReader reader,
@@ -2659,6 +2746,13 @@ public static class ApiSurfaceExtractor
         public bool HasExplicitInterfaceTargets(MethodDefinitionHandle body) =>
             GetExplicitInterfaceTargets(body).Count > 0;
 
+        public InterfaceImplementationResolution GetResolution(
+            MethodDefinitionHandle body)
+            => GetExplicitInterfaceTargets(body).Any(
+                static target => !target.InterfaceMembershipProven)
+                ? InterfaceImplementationResolution.Undetermined
+                : InterfaceImplementationResolution.Proven;
+
         public bool CanUseImplicitInterfaceSyntax(
             MethodDefinitionHandle body,
             string bodyName,
@@ -2669,11 +2763,28 @@ public static class ApiSurfaceExtractor
             return targets.Count > 0
                 && bodyAccess == MethodAttributes.Public
                 && !bodyName.Contains('.', StringComparison.Ordinal)
+                && IsOrdinaryMethodDefinition(body)
                 && targets.All(target =>
-                    string.Equals(
-                        target.MethodName,
-                        bodyName,
-                        StringComparison.Ordinal));
+                {
+                    if (!target.InterfaceMembershipProven
+                        || !string.Equals(
+                            target.MethodName,
+                            bodyName,
+                            StringComparison.Ordinal))
+                    {
+                        return false;
+                    }
+                    ExplicitInterfaceMethodTarget semanticTarget =
+                        ResolveSemanticDeclaration(
+                            target,
+                            GetBodySignature(body));
+                    return !semanticTarget.SemanticDeclaration.IsNil
+                        && IsOrdinaryMethodDefinition(
+                            semanticTarget.SemanticDeclaration)
+                        && GenericConstraintsMatch(
+                            body,
+                            semanticTarget.SemanticDeclaration);
+                });
         }
 
         public List<ExplicitInterfaceMethodTarget> GetExplicitInterfaceTargets(
@@ -2687,7 +2798,7 @@ public static class ApiSurfaceExtractor
             if (!declarationsByBody.TryGetValue(body, out var declarations))
                 return targets;
 
-            IReadOnlySet<string> interfaces = GetImplementedInterfaces();
+            ImplementedInterfaceSet interfaces = GetImplementedInterfaces();
             MethodSignature<ExplicitInterfaceTypeIdentity> bodySignature =
                 GetBodySignature(body);
             foreach (EntityHandle declaration in declarations)
@@ -2707,7 +2818,8 @@ public static class ApiSurfaceExtractor
                     continue;
                 }
 
-                ObserveTarget(target);
+                if (target.InterfaceMembershipProven)
+                    ObserveTarget(target);
                 targets.Add(target);
             }
 
@@ -2723,7 +2835,7 @@ public static class ApiSurfaceExtractor
                 return;
             }
 
-            IReadOnlySet<string> interfaces = GetImplementedInterfaces();
+            ImplementedInterfaceSet interfaces = GetImplementedInterfaces();
             MethodSignature<ExplicitInterfaceTypeIdentity> bodySignature =
                 GetBodySignature(body);
             foreach (EntityHandle declaration in declarations)
@@ -2740,7 +2852,8 @@ public static class ApiSurfaceExtractor
                         GetDeclarationSignature,
                         out var target))
                 {
-                    ObserveTarget(target);
+                    if (target.InterfaceMembershipProven)
+                        ObserveTarget(target);
                 }
             }
         }
@@ -2810,7 +2923,10 @@ public static class ApiSurfaceExtractor
             {
                 case HandleKind.MethodDefinition:
                     var handle = (MethodDefinitionHandle)declaration;
-                    if (methodDefinitionSignatures.TryGetValue(handle, out var cachedMethod))
+                    var cacheKey = (handle, declaringTypeIdentity.Key);
+                    if (methodDefinitionSignatures.TryGetValue(
+                            cacheKey,
+                            out var cachedMethod))
                         return cachedMethod;
 
                     var method = reader.GetMethodDefinition(handle);
@@ -2823,15 +2939,19 @@ public static class ApiSurfaceExtractor
                         reader,
                         method,
                         identityProvider,
-                        ExplicitInterfaceSignatureContext.Open(
-                            GenericContext.ForMethod(
-                                reader,
-                                GenericContext.ForType(
+                        ExplicitInterfaceSignatureContext
+                            .Open(
+                                GenericContext.ForMethod(
                                     reader,
-                                    declaringType,
-                                    observeDecodeWork),
-                                method,
-                                observeDecodeWork)),
+                                    GenericContext.ForType(
+                                        reader,
+                                        declaringType,
+                                        observeDecodeWork),
+                                    method,
+                                    observeDecodeWork))
+                            .WithTypeArguments(
+                                declaringTypeIdentity.GenericArguments,
+                                declaringTypeIdentity.GenericArity),
                         DegradedExplicitInterfaceType);
                     if (methodResult.IsDegraded || HasDegradedType(methodResult.Value))
                     {
@@ -2844,7 +2964,7 @@ public static class ApiSurfaceExtractor
                             "The MethodImpl declaration generic arity does not match its GenericParam rows.");
                     }
 
-                    methodDefinitionSignatures.Add(handle, methodResult.Value);
+                    methodDefinitionSignatures.Add(cacheKey, methodResult.Value);
                     return methodResult.Value;
 
                 case HandleKind.MemberReference:
@@ -2906,31 +3026,441 @@ public static class ApiSurfaceExtractor
             return expectedIndex;
         }
 
-        HashSet<string> GetImplementedInterfaces()
+        ImplementedInterfaceSet GetImplementedInterfaces()
         {
             if (implementedInterfaces is not null)
                 return implementedInterfaces;
 
-            implementedInterfaces = [];
+            var proven = new HashSet<string>(StringComparer.Ordinal);
+            var knownNonInterfaces =
+                new HashSet<string>(StringComparer.Ordinal);
+            var provenNonGenericDefinitions =
+                new HashSet<TypeDefinitionHandle>();
+            var undeterminedGenericDefinitions =
+                new HashSet<TypeDefinitionHandle>();
+            var knownNonInterfaceDefinitions =
+                new HashSet<TypeDefinitionHandle>();
+            var pending = new Queue<TypeDefinitionHandle>();
+            var closureIdentityProvider =
+                new ExplicitInterfaceTypeIdentityProvider();
+            bool hasUnresolvedExternalInheritance = false;
+            EntityHandle baseTypeHandle = typeDefinition.BaseType;
+            int baseTypeCount = 0;
+            while (!baseTypeHandle.IsNil)
+            {
+                if (++baseTypeCount
+                    > MetadataSafetyPolicy.MaxRelationshipNodes)
+                {
+                    throw new BadImageFormatException(
+                        "The base-type relationship exceeds the metadata relationship limit.");
+                }
+                if (!TryGetLocalTypeDefinition(
+                        reader,
+                        baseTypeHandle,
+                        out TypeDefinitionHandle baseDefinition))
+                {
+                    ExplicitInterfaceTypeIdentity baseIdentity =
+                        DecodeInterfaceIdentity(
+                            baseTypeHandle,
+                            ExplicitInterfaceSignatureContext.Open(
+                                typeContext));
+                    if (baseIdentity.IsDegraded)
+                    {
+                        throw new BadImageFormatException(
+                            "The base-type identity could not be decoded.");
+                    }
+                    knownNonInterfaces.Add(baseIdentity.Key);
+                    break;
+                }
+                if (!knownNonInterfaceDefinitions.Add(baseDefinition))
+                {
+                    throw new BadImageFormatException(
+                        "The base-type relationship contains a cycle.");
+                }
+                TypeDefinition baseType =
+                    reader.GetTypeDefinition(baseDefinition);
+                baseTypeHandle = baseType.BaseType;
+            }
             foreach (var interfaceHandle
                 in typeDefinition.GetInterfaceImplementations())
             {
                 var interfaceType =
                     reader.GetInterfaceImplementation(interfaceHandle).Interface;
-                var interfaceIdentity = identityProvider.FromHandle(
-                    reader,
+                var interfaceIdentity = DecodeInterfaceIdentity(
                     interfaceType,
-                    typeContext);
+                    ExplicitInterfaceSignatureContext.Open(typeContext));
                 if (interfaceIdentity.IsDegraded)
                 {
                     throw new BadImageFormatException(
                         "The implemented interface identity could not be decoded.");
                 }
-                observeProjectionText?.Invoke(interfaceIdentity.Key);
-                implementedInterfaces.Add(interfaceIdentity.Key);
+                AddProven(interfaceIdentity);
+                if (TryGetLocalTypeDefinition(
+                        reader,
+                        interfaceType,
+                        out TypeDefinitionHandle definition))
+                {
+                    pending.Enqueue(definition);
+                }
+                else
+                {
+                    hasUnresolvedExternalInheritance = true;
+                }
             }
 
+            var expandedDefinitions =
+                new HashSet<TypeDefinitionHandle>();
+            while (pending.TryDequeue(out TypeDefinitionHandle current))
+            {
+                if (!expandedDefinitions.Add(current))
+                {
+                    continue;
+                }
+                if (expandedDefinitions.Count
+                    > MetadataSafetyPolicy.MaxRelationshipNodes)
+                {
+                    throw new BadImageFormatException(
+                        "The implemented-interface closure exceeds the metadata relationship limit.");
+                }
+
+                TypeDefinition definition =
+                    reader.GetTypeDefinition(current);
+                if ((definition.Attributes & TypeAttributes.Interface) == 0)
+                {
+                    throw new BadImageFormatException(
+                        "An InterfaceImpl row resolves to a non-interface type definition.");
+                }
+
+                foreach (InterfaceImplementationHandle implementationHandle
+                    in definition.GetInterfaceImplementations())
+                {
+                    EntityHandle baseInterface =
+                        reader.GetInterfaceImplementation(implementationHandle)
+                            .Interface;
+                    if (TryGetLocalTypeDefinition(
+                            reader,
+                            baseInterface,
+                            out TypeDefinitionHandle baseDefinition))
+                    {
+                        TypeDefinition baseDefinitionRow =
+                            reader.GetTypeDefinition(baseDefinition);
+                        if (baseDefinitionRow.GetGenericParameters().Count == 0)
+                        {
+                            ExplicitInterfaceTypeIdentity baseIdentity =
+                                closureIdentityProvider.FromHandle(
+                                    reader,
+                                    baseDefinition,
+                                    typeContext);
+                            if (baseIdentity.IsDegraded)
+                            {
+                                throw new BadImageFormatException(
+                                    "An inherited interface identity could not be decoded.");
+                            }
+                            AddProven(baseIdentity);
+                            provenNonGenericDefinitions.Add(baseDefinition);
+                        }
+                        else
+                        {
+                            undeterminedGenericDefinitions.Add(baseDefinition);
+                        }
+                        pending.Enqueue(baseDefinition);
+                    }
+                    else
+                    {
+                        hasUnresolvedExternalInheritance = true;
+                    }
+                }
+            }
+
+            implementedInterfaces = new ImplementedInterfaceSet(
+                proven,
+                knownNonInterfaces,
+                provenNonGenericDefinitions,
+                undeterminedGenericDefinitions,
+                knownNonInterfaceDefinitions,
+                hasUnresolvedExternalInheritance);
             return implementedInterfaces;
+
+            void AddProven(ExplicitInterfaceTypeIdentity identity)
+            {
+                proven.Add(identity.Key);
+                if (proven.Count > MetadataSafetyPolicy.MaxRelationshipNodes)
+                {
+                    throw new BadImageFormatException(
+                        "The implemented-interface closure exceeds the metadata relationship limit.");
+                }
+            }
+        }
+
+        ExplicitInterfaceTypeIdentity DecodeInterfaceIdentity(
+            EntityHandle handle,
+            ExplicitInterfaceSignatureContext context)
+            => handle.Kind == HandleKind.TypeSpecification
+                ? identityProvider.GetTypeFromSpecification(
+                    reader,
+                    context,
+                    (TypeSpecificationHandle)handle,
+                    rawTypeKind: 0)
+                : identityProvider.FromHandle(
+                    reader,
+                    handle,
+                    typeContext);
+
+        internal static bool TryGetLocalTypeDefinition(
+            MetadataReader reader,
+            EntityHandle handle,
+            out TypeDefinitionHandle definition)
+        {
+            if (handle.Kind == HandleKind.TypeDefinition)
+            {
+                definition = (TypeDefinitionHandle)handle;
+                return true;
+            }
+            if (handle.Kind != HandleKind.TypeSpecification)
+            {
+                definition = default;
+                return false;
+            }
+
+            try
+            {
+                BlobHandle signature = reader.GetTypeSpecification(
+                    (TypeSpecificationHandle)handle).Signature;
+                if (!SignatureBlobGuard.IsSafeAndCompleteToDecode(
+                        reader,
+                        signature,
+                        SignatureBlobGuard.Kind.TypeSpecification))
+                {
+                    throw new BadImageFormatException(
+                        "The generic interface TypeSpec is malformed.");
+                }
+                BlobReader blob = reader.GetBlobReader(signature);
+                if (blob.ReadSignatureTypeCode()
+                        != SignatureTypeCode.GenericTypeInstance)
+                {
+                    definition = default;
+                    return false;
+                }
+                byte kind = blob.ReadByte();
+                if (kind is not (0x11 or 0x12))
+                {
+                    throw new BadImageFormatException(
+                        "A generic interface TypeSpec has an invalid type kind.");
+                }
+                EntityHandle genericType = blob.ReadTypeHandle();
+                if (genericType.Kind == HandleKind.TypeDefinition)
+                {
+                    definition = (TypeDefinitionHandle)genericType;
+                    return true;
+                }
+                definition = default;
+                return false;
+            }
+            catch (BadImageFormatException)
+            {
+                throw;
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                throw new BadImageFormatException(
+                    "The generic interface TypeSpec is malformed.",
+                    ex);
+            }
+        }
+
+        bool IsOrdinaryMethodDefinition(MethodDefinitionHandle handle)
+        {
+            TypeDefinitionHandle declaringType =
+                reader.GetMethodDefinition(handle).GetDeclaringType();
+            if (!associatedMethodsByType.TryGetValue(
+                    declaringType,
+                    out HashSet<MethodDefinitionHandle>? associated))
+            {
+                associated = [];
+                TypeDefinition definition =
+                    reader.GetTypeDefinition(declaringType);
+                foreach (PropertyDefinitionHandle propertyHandle
+                    in definition.GetProperties())
+                {
+                    PropertyAccessors accessors =
+                        reader.GetPropertyDefinition(propertyHandle)
+                            .GetAccessors();
+                    Add(accessors.Getter);
+                    Add(accessors.Setter);
+                    foreach (MethodDefinitionHandle other
+                        in accessors.Others)
+                    {
+                        Add(other);
+                    }
+                }
+                foreach (EventDefinitionHandle eventHandle
+                    in definition.GetEvents())
+                {
+                    EventAccessors accessors =
+                        reader.GetEventDefinition(eventHandle)
+                            .GetAccessors();
+                    Add(accessors.Adder);
+                    Add(accessors.Remover);
+                    Add(accessors.Raiser);
+                    foreach (MethodDefinitionHandle other
+                        in accessors.Others)
+                    {
+                        Add(other);
+                    }
+                }
+                associatedMethodsByType.Add(declaringType, associated);
+
+                void Add(MethodDefinitionHandle candidate)
+                {
+                    if (!candidate.IsNil)
+                        associated.Add(candidate);
+                }
+            }
+
+            return !associated.Contains(handle);
+        }
+
+        bool GenericConstraintsMatch(
+            MethodDefinitionHandle bodyHandle,
+            MethodDefinitionHandle declarationHandle)
+        {
+            MethodDefinition body = reader.GetMethodDefinition(bodyHandle);
+            MethodDefinition declaration =
+                reader.GetMethodDefinition(declarationHandle);
+            ValidateGenericParameters(bodyHandle, body, "body");
+            ValidateGenericParameters(
+                declarationHandle,
+                declaration,
+                "declaration");
+            GenericParameterHandle[] bodyParameters =
+                [.. body.GetGenericParameters()];
+            GenericParameterHandle[] declarationParameters =
+                [.. declaration.GetGenericParameters()];
+            if (bodyParameters.Length != declarationParameters.Length)
+                return false;
+            if (bodyParameters.Length == 0)
+                return true;
+
+            GenericContext bodyContext = GenericContext.ForMethod(
+                reader,
+                reader.GetTypeDefinition(body.GetDeclaringType()),
+                body);
+            GenericContext declarationContext = GenericContext.ForMethod(
+                reader,
+                reader.GetTypeDefinition(declaration.GetDeclaringType()),
+                declaration);
+            for (int index = 0; index < bodyParameters.Length; index++)
+            {
+                GenericParameter bodyParameter =
+                    reader.GetGenericParameter(bodyParameters[index]);
+                GenericParameter declarationParameter =
+                    reader.GetGenericParameter(declarationParameters[index]);
+                if (bodyParameter.Attributes
+                    != declarationParameter.Attributes)
+                {
+                    return false;
+                }
+
+                string[] bodyConstraints = ConstraintKeys(
+                    bodyParameter,
+                    bodyContext);
+                string[] declarationConstraints = ConstraintKeys(
+                    declarationParameter,
+                    declarationContext);
+                if (!bodyConstraints.SequenceEqual(
+                        declarationConstraints,
+                        StringComparer.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+
+            string[] ConstraintKeys(
+                GenericParameter parameter,
+                GenericContext context)
+                => parameter.GetConstraints()
+                    .Select(handle =>
+                    {
+                        identityProvider.ObserveWork(
+                            MethodImplementationRowWorkChars);
+                        ExplicitInterfaceTypeIdentity identity =
+                            identityProvider.FromHandle(
+                                reader,
+                                reader.GetGenericParameterConstraint(handle)
+                                    .Type,
+                                context);
+                        if (identity.IsDegraded)
+                        {
+                            throw new BadImageFormatException(
+                                "A MethodImpl generic constraint could not be decoded.");
+                        }
+                        return identity.Key;
+                    })
+                    .Order(StringComparer.Ordinal)
+                    .ToArray();
+        }
+
+        ExplicitInterfaceMethodTarget ResolveSemanticDeclaration(
+            ExplicitInterfaceMethodTarget target,
+            MethodSignature<ExplicitInterfaceTypeIdentity> bodySignature)
+        {
+            if (target.Declaration.Kind == HandleKind.MethodDefinition)
+            {
+                return target with
+                {
+                    SemanticDeclaration =
+                        (MethodDefinitionHandle)target.Declaration
+                };
+            }
+            if (target.Declaration.Kind != HandleKind.MemberReference)
+                return target;
+
+            MemberReference memberReference = reader.GetMemberReference(
+                (MemberReferenceHandle)target.Declaration);
+            if (!TryGetLocalTypeDefinition(
+                    reader,
+                    memberReference.Parent,
+                    out TypeDefinitionHandle interfaceDefinition))
+            {
+                return target;
+            }
+
+            MethodDefinitionHandle semanticDeclaration = default;
+            foreach (MethodDefinitionHandle candidateHandle
+                in reader.GetTypeDefinition(interfaceDefinition).GetMethods())
+            {
+                MethodDefinition candidate =
+                    reader.GetMethodDefinition(candidateHandle);
+                if (!string.Equals(
+                        DecodeString(
+                            reader,
+                            candidate.Name,
+                            observeDecodeWork),
+                        target.MethodName,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                MethodSignature<ExplicitInterfaceTypeIdentity> signature =
+                    GetDeclarationSignature(
+                        candidateHandle,
+                        target.InterfaceType,
+                        bodySignature.GenericParameterCount);
+                if (!MethodSignaturesMatch(bodySignature, signature))
+                    continue;
+                if (!semanticDeclaration.IsNil)
+                    return target;
+                semanticDeclaration = candidateHandle;
+            }
+
+            return semanticDeclaration.IsNil
+                ? target
+                : target with
+                {
+                    SemanticDeclaration = semanticDeclaration
+                };
         }
 
         void ObserveTarget(ExplicitInterfaceMethodTarget target)
@@ -3259,7 +3789,7 @@ public static class ApiSurfaceExtractor
         MetadataReader reader,
         MethodSignature<ExplicitInterfaceTypeIdentity> bodySignature,
         EntityHandle declaration,
-        IReadOnlySet<string> implementedInterfaces,
+        MethodImplementationProjection.ImplementedInterfaceSet implementedInterfaces,
         GenericContext context,
         ExplicitInterfaceTypeIdentityProvider identityProvider,
         Action<int>? observeDecodeWork,
@@ -3299,8 +3829,41 @@ public static class ApiSurfaceExtractor
             context);
         if (declaringTypeIdentity.IsDegraded)
             throw new BadImageFormatException("The MethodImpl interface identity could not be decoded.");
-        if (!implementedInterfaces.Contains(declaringTypeIdentity.Key)
-            || !MethodImplSignaturesMatch(
+        bool membershipProven =
+            implementedInterfaces.Proven.Contains(declaringTypeIdentity.Key);
+        if (implementedInterfaces.KnownNonInterfaces.Contains(
+                declaringTypeIdentity.Key))
+        {
+            return false;
+        }
+        bool hasLocalDefinition =
+            MethodImplementationProjection.TryGetLocalTypeDefinition(
+                reader,
+                declaringType,
+                out TypeDefinitionHandle localDefinition);
+        if (hasLocalDefinition
+            && implementedInterfaces.KnownNonInterfaceDefinitions.Contains(
+                localDefinition))
+        {
+            return false;
+        }
+        if (!membershipProven
+            && hasLocalDefinition
+            && implementedInterfaces.ProvenNonGenericDefinitions.Contains(
+                localDefinition))
+        {
+            membershipProven = true;
+        }
+        bool membershipUndetermined =
+            hasLocalDefinition
+                ? implementedInterfaces.UndeterminedGenericDefinitions
+                    .Contains(localDefinition)
+                : implementedInterfaces.HasUnresolvedExternalInheritance;
+        if (!membershipProven && !membershipUndetermined)
+        {
+            return false;
+        }
+        if (!MethodImplSignaturesMatch(
                 bodySignature,
                 declaration,
                 declaringTypeIdentity,
@@ -3320,7 +3883,8 @@ public static class ApiSurfaceExtractor
         target = new ExplicitInterfaceMethodTarget(
             declaration,
             declaringTypeIdentity,
-            methodName);
+            methodName,
+            membershipProven);
         return true;
     }
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -152,6 +152,11 @@ public abstract record ApiSurfaceExtractionResult
     public sealed record Exceeded(ApiSurfaceExtractionBound Bound) : ApiSurfaceExtractionResult;
 }
 
+internal readonly record struct ExplicitInterfaceMethodTarget(
+    EntityHandle Declaration,
+    string InterfaceTypeName,
+    string MethodName);
+
 /// <summary>
 /// Extracts public API surface from assemblies.
 /// </summary>
@@ -721,11 +726,13 @@ public static class ApiSurfaceExtractor
             apiType.Members = [];
 
             var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
-            var explicitInterfaceImplementationBodies =
-                GetExplicitInterfaceImplementationBodies(
+            var explicitInterfaceImplementationTargets =
+                GetExplicitInterfaceImplementationTargets(
                     reader,
                     typeDef,
                     observeDecodeWork);
+            var explicitInterfaceImplementationBodies =
+                explicitInterfaceImplementationTargets.Keys.ToHashSet();
             var accessorMethods = GetAccessorMethods(reader, typeDef);
             var canonicalAccessorMethods =
                 GetCanonicalAccessorMethods(reader, typeDef, observeDecodeWork);
@@ -1038,9 +1045,9 @@ public static class ApiSurfaceExtractor
                     observeDecodeWork);
                 bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
                     propertyName,
-                    explicitInterfaceImplementationBodies,
-                    accessors.Getter,
-                    accessors.Setter);
+                    explicitInterfaceImplementationTargets,
+                    (accessors.Getter, "get_"),
+                    (accessors.Setter, "set_"));
                 var member = new ApiMember
                 {
                     Name = propertyName,
@@ -1442,9 +1449,9 @@ public static class ApiSurfaceExtractor
                     (accessors.Remover, "remove"));
                 bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
                     eventName,
-                    explicitInterfaceImplementationBodies,
-                    accessors.Adder,
-                    accessors.Remover);
+                    explicitInterfaceImplementationTargets,
+                    (accessors.Adder, "add_"),
+                    (accessors.Remover, "remove_"));
 
                 var eventTypeNodeProvider = observeText is null
                     ? TypeNodeProvider.Instance
@@ -2094,10 +2101,11 @@ public static class ApiSurfaceExtractor
         return handles;
     }
 
-    internal static HashSet<MethodDefinitionHandle> GetExplicitInterfaceImplementationBodies(
-        MetadataReader reader,
-        TypeDefinition typeDef,
-        Action<int>? beforeDecodeWork = null)
+    internal static Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
+        GetExplicitInterfaceImplementationTargets(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            Action<int>? beforeDecodeWork = null)
     {
         var context = GenericContext.ForType(reader, typeDef);
         HashSet<MetadataNamedTypeReference> implementedInterfaces = [];
@@ -2113,56 +2121,76 @@ public static class ApiSurfaceExtractor
                 implementedInterfaces.Add(interfaceIdentity);
         }
 
-        HashSet<MethodDefinitionHandle> handles = [];
         Dictionary<EntityHandle, MetadataNamedTypeReference?> declarationTypes = [];
+        Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>> targets = [];
         foreach (var implementationHandle in typeDef.GetMethodImplementations())
         {
             var implementation = reader.GetMethodImplementation(implementationHandle);
             if (implementation.MethodBody.Kind == HandleKind.MethodDefinition
-                && IsInterfaceMethodDeclaration(
+                && TryGetInterfaceMethodDeclaration(
                     reader,
                     implementation.MethodDeclaration,
                     implementedInterfaces,
                     context,
                     declarationTypes,
-                    beforeDecodeWork))
+                    beforeDecodeWork,
+                    out var target))
             {
-                handles.Add((MethodDefinitionHandle)implementation.MethodBody);
+                var body = (MethodDefinitionHandle)implementation.MethodBody;
+                if (!targets.TryGetValue(body, out var bodyTargets))
+                {
+                    bodyTargets = [];
+                    targets.Add(body, bodyTargets);
+                }
+                bodyTargets.Add(target);
             }
         }
 
-        return handles;
+        return targets;
     }
 
     internal static bool IsExplicitInterfaceAggregate(
         string name,
-        IReadOnlySet<MethodDefinitionHandle> explicitInterfaceImplementationBodies,
-        params MethodDefinitionHandle[] accessors)
+        IReadOnlyDictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
+            explicitInterfaceImplementationTargets,
+        params (MethodDefinitionHandle Handle, string DeclarationPrefix)[] accessors)
     {
-        if (!name.Contains('.', StringComparison.Ordinal))
+        int separator = name.LastIndexOf('.');
+        if (separator <= 0 || separator == name.Length - 1)
             return false;
 
+        string interfaceName = name[..separator];
+        string memberName = name[(separator + 1)..];
         bool hasAccessor = false;
         foreach (var accessor in accessors)
         {
-            if (accessor.IsNil)
+            if (accessor.Handle.IsNil)
                 continue;
             hasAccessor = true;
-            if (!explicitInterfaceImplementationBodies.Contains(accessor))
+            if (!explicitInterfaceImplementationTargets.TryGetValue(
+                    accessor.Handle,
+                    out var targets)
+                || !targets.Any(target =>
+                    target.InterfaceTypeName == interfaceName
+                    && target.MethodName == accessor.DeclarationPrefix + memberName))
+            {
                 return false;
+            }
         }
 
         return hasAccessor;
     }
 
-    private static bool IsInterfaceMethodDeclaration(
+    private static bool TryGetInterfaceMethodDeclaration(
         MetadataReader reader,
         EntityHandle declaration,
         IReadOnlySet<MetadataNamedTypeReference> implementedInterfaces,
         GenericContext context,
         Dictionary<EntityHandle, MetadataNamedTypeReference?> declarationTypes,
-        Action<int>? beforeDecodeWork)
+        Action<int>? beforeDecodeWork,
+        out ExplicitInterfaceMethodTarget target)
     {
+        target = default;
         EntityHandle declaringType = declaration.Kind switch
         {
             HandleKind.MethodDefinition =>
@@ -2172,11 +2200,16 @@ public static class ApiSurfaceExtractor
             _ => default,
         };
 
-        if (declaringType.Kind == HandleKind.TypeDefinition)
+        string? methodName = declaration.Kind switch
         {
-            return (reader.GetTypeDefinition((TypeDefinitionHandle)declaringType).Attributes
-                & TypeAttributes.Interface) != 0;
-        }
+            HandleKind.MethodDefinition => reader.GetString(
+                reader.GetMethodDefinition((MethodDefinitionHandle)declaration).Name),
+            HandleKind.MemberReference => reader.GetString(
+                reader.GetMemberReference((MemberReferenceHandle)declaration).Name),
+            _ => null,
+        };
+        if (methodName is null)
+            return false;
 
         if (!declarationTypes.TryGetValue(
                 declaringType,
@@ -2189,8 +2222,28 @@ public static class ApiSurfaceExtractor
                 beforeDecodeWork);
             declarationTypes.Add(declaringType, declaringTypeIdentity);
         }
-        return declaringTypeIdentity is not null
-            && implementedInterfaces.Contains(declaringTypeIdentity);
+        if (declaringTypeIdentity is null
+            || !implementedInterfaces.Contains(declaringTypeIdentity))
+        {
+            return false;
+        }
+
+        var declaringTypeName = TypeResolver.GetTypeName(reader, declaringType, context);
+        if (declaringTypeName is null)
+            return false;
+
+        if (declaringType.Kind == HandleKind.TypeDefinition
+            && (reader.GetTypeDefinition((TypeDefinitionHandle)declaringType).Attributes
+                & TypeAttributes.Interface) == 0)
+        {
+            return false;
+        }
+
+        target = new ExplicitInterfaceMethodTarget(
+            declaration,
+            declaringTypeName,
+            methodName);
+        return true;
     }
 
     /// <summary>
@@ -3386,7 +3439,7 @@ public static class ApiSurfaceExtractor
             || treeSignature.ParameterTypes.Any(parameter => parameter.IsDegraded));
     }
 
-    private static List<string> ReturnParameterAttributes(
+    internal static List<string> ReturnParameterAttributes(
         MetadataReader reader,
         ParameterHandleCollection handles,
         Action<string>? beforeRetain = null,

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -726,10 +726,20 @@ public static class ApiSurfaceExtractor
             apiType.Members = [];
 
             var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
+            var explicitInterfaceIdentityProvider =
+                new ExplicitInterfaceTypeIdentityProvider(observeDecodeWork);
             var explicitInterfaceImplementationTargets =
-                GetExplicitInterfaceImplementationTargets(reader, typeDef);
+                GetExplicitInterfaceImplementationTargets(
+                    reader,
+                    typeDef,
+                    explicitInterfaceIdentityProvider,
+                    observeDecodeWork,
+                    observeText,
+                    typeContext);
             var explicitInterfaceImplementationBodies =
                 explicitInterfaceImplementationTargets.Keys.ToHashSet();
+            bool isInterfaceTypeDefinition =
+                (typeDef.Attributes & TypeAttributes.Interface) != 0;
             var accessorMethods = GetAccessorMethods(reader, typeDef);
             var canonicalAccessorMethods =
                 GetCanonicalAccessorMethods(reader, typeDef, observeDecodeWork);
@@ -982,6 +992,25 @@ public static class ApiSurfaceExtractor
                     reader,
                     accessors.Getter,
                     accessors.Setter);
+                if (MetadataAccessorSemantics.ValidateAbstraction(
+                        reader,
+                        requireUniformAbstraction: !isInterfaceTypeDefinition,
+                        accessors.Getter,
+                        accessors.Setter)
+                    is var abstractionFault and not AccessorAbstractionFault.None)
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "property modifiers",
+                        propHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            propHandle,
+                            abstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
+                                ? "The property has an abstract accessor that declares an IL body."
+                                : "The property has inconsistent abstract accessor metadata."));
+                    continue;
+                }
                 if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
                         reader,
                         out isSealedProperty,
@@ -1075,6 +1104,23 @@ public static class ApiSurfaceExtractor
                     explicitInterfaceImplementationTargets,
                     (accessors.Getter, "get_"),
                     (accessors.Setter, "set_"));
+                if (isExplicitInterfaceImplementation
+                    && ValidateExplicitPropertyRowSignature(
+                        reader,
+                        prop,
+                        accessors,
+                        typeContext,
+                        explicitInterfaceIdentityProvider,
+                        observeDecodeWork) is { } propertyRowDetail)
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "property signature",
+                        propHandle,
+                        MetadataTypeNameFailure.Malformed(propHandle, propertyRowDetail));
+                    continue;
+                }
                 var member = new ApiMember
                 {
                     Name = propertyName,
@@ -1449,6 +1495,25 @@ public static class ApiSurfaceExtractor
                     reader,
                     accessors.Adder,
                     accessors.Remover);
+                if (MetadataAccessorSemantics.ValidateAbstraction(
+                        reader,
+                        requireUniformAbstraction: !isInterfaceTypeDefinition,
+                        accessors.Adder,
+                        accessors.Remover)
+                    is var eventAbstractionFault and not AccessorAbstractionFault.None)
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "event modifiers",
+                        eventHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            eventHandle,
+                            eventAbstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
+                                ? "The event has an abstract accessor that declares an IL body."
+                                : "The event has inconsistent abstract accessor metadata."));
+                    continue;
+                }
                 if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
                         reader,
                         out bool isSealedEvent,
@@ -1519,6 +1584,23 @@ public static class ApiSurfaceExtractor
                     explicitInterfaceImplementationTargets,
                     (accessors.Adder, "add_"),
                     (accessors.Remover, "remove_"));
+                if (isExplicitInterfaceImplementation
+                    && ValidateExplicitEventRowSignature(
+                        reader,
+                        evt,
+                        accessors,
+                        typeContext,
+                        explicitInterfaceIdentityProvider,
+                        observeDecodeWork) is { } eventRowDetail)
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "event signature",
+                        eventHandle,
+                        MetadataTypeNameFailure.Malformed(eventHandle, eventRowDetail));
+                    continue;
+                }
 
                 var eventTypeNodeProvider = observeText is null
                     ? TypeNodeProvider.Instance
@@ -1668,7 +1750,7 @@ public static class ApiSurfaceExtractor
     {
         var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
         var explicitInterfaceImplementationBodies =
-            GetExplicitInterfaceImplementationBodies(reader, typeDef);
+            GetExplicitInterfaceImplementationTargets(reader, typeDef).Keys.ToHashSet();
         var accessorMethods = GetAccessorMethods(reader, typeDef);
         var canonicalAccessorMethods = GetCanonicalAccessorMethods(reader, typeDef);
         var hiddenAggregateAccessorMethods =
@@ -2167,13 +2249,29 @@ public static class ApiSurfaceExtractor
         return handles;
     }
 
+    /// <summary>
+    /// Projects this type's explicit-interface MethodImpl rows, keyed by the implementing
+    /// method body.
+    /// </summary>
+    /// <remarks>
+    /// Every row this walks decodes an interface identity and two method signatures, so the
+    /// projection charges the same decode-work observer the rest of the extraction uses and
+    /// charges the strings it retains against the retained-text observer. A bounded extraction
+    /// therefore cannot be made to do unbounded MethodImpl work before its first member is
+    /// admitted; a <see langword="null"/> observer leaves the unbounded query paths unchanged.
+    /// Gated by <c>ApiSurfaceExtractorBoundsTests.ExplicitInterfaceProjection_SpendsDecodeWorkBudget</c>.
+    /// </remarks>
     internal static Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
         GetExplicitInterfaceImplementationTargets(
             MetadataReader reader,
-            TypeDefinition typeDef)
+            TypeDefinition typeDef,
+            ExplicitInterfaceTypeIdentityProvider? identityProvider = null,
+            Action<int>? observeDecodeWork = null,
+            Action<string>? observeText = null,
+            GenericContext? typeContext = null)
     {
-        var context = GenericContext.ForType(reader, typeDef);
-        var identityProvider = new ExplicitInterfaceTypeIdentityProvider();
+        var context = typeContext ?? GenericContext.ForType(reader, typeDef, observeDecodeWork);
+        identityProvider ??= new ExplicitInterfaceTypeIdentityProvider(observeDecodeWork);
         HashSet<string> implementedInterfaces = [];
         foreach (var interfaceHandle in typeDef.GetInterfaceImplementations())
         {
@@ -2184,6 +2282,7 @@ public static class ApiSurfaceExtractor
                 context);
             if (interfaceIdentity.IsDegraded)
                 throw new BadImageFormatException("The implemented interface identity could not be decoded.");
+            observeText?.Invoke(interfaceIdentity.Key);
             implementedInterfaces.Add(interfaceIdentity.Key);
         }
 
@@ -2194,12 +2293,12 @@ public static class ApiSurfaceExtractor
             if (implementation.MethodBody.Kind == HandleKind.MethodDefinition
                 && TryGetInterfaceMethodDeclaration(
                     reader,
-                    typeDef,
                     (MethodDefinitionHandle)implementation.MethodBody,
                     implementation.MethodDeclaration,
                     implementedInterfaces,
                     context,
                     identityProvider,
+                    observeDecodeWork,
                     out var target))
             {
                 var body = (MethodDefinitionHandle)implementation.MethodBody;
@@ -2208,6 +2307,11 @@ public static class ApiSurfaceExtractor
                     bodyTargets = [];
                     targets.Add(body, bodyTargets);
                 }
+                observeText?.Invoke(target.MethodName);
+                observeText?.Invoke(target.InterfaceType.Key);
+                observeText?.Invoke(target.InterfaceType.MetadataName);
+                if (target.InterfaceType.AggregateAliasName is { } alias)
+                    observeText?.Invoke(alias);
                 bodyTargets.Add(target);
             }
         }
@@ -2266,14 +2370,202 @@ public static class ApiSurfaceExtractor
         return hasAccessor && commonInterfaceKeys is { Count: > 0 };
     }
 
+    /// <summary>
+    /// Checks that a Property row's own signature agrees with the accessor MethodDefs that
+    /// <see cref="IsExplicitInterfaceAggregate"/> matched, returning the malformed detail when
+    /// it does not.
+    /// </summary>
+    /// <remarks>
+    /// Name matching plus the MethodImpl signature check proves each accessor body implements
+    /// the interface declaration it claims. Neither reads the aggregate row itself, so a
+    /// hostile image could pair a truthful <c>get_IFoo.Bar</c> returning <c>int</c> with a
+    /// Property row declaring <c>string</c> and have the surface render an explicit
+    /// <c>string IFoo.Bar</c> that no accessor implements. ECMA-335 II.22.34 and II.17.2 fix the
+    /// relationship this restates: the getter returns the property type over the index
+    /// parameters, and the setter takes those parameters plus a trailing value. Custom
+    /// modifiers are compared exactly except on the setter's return, where a legal
+    /// <c>init</c> accessor carries <c>modreq(IsExternalInit)</c> over <c>void</c>. The row's
+    /// <c>HASTHIS</c> bit is deliberately not compared: nothing in the projection reads it —
+    /// static-ness comes from the accessor's method attributes — and Reflection.Emit produces
+    /// otherwise-sound images whose Property rows omit it, so comparing it could only reject
+    /// members that project correctly.
+    /// Gated by
+    /// <c>MetadataDeclarationQueryTests.ExplicitAggregateRowSignature_MustMatchAccessors</c>.
+    /// </remarks>
+    internal static string? ValidateExplicitPropertyRowSignature(
+        MetadataReader reader,
+        PropertyDefinition property,
+        PropertyAccessors accessors,
+        GenericContext typeContext,
+        ExplicitInterfaceTypeIdentityProvider identityProvider,
+        Action<int>? observeDecodeWork)
+    {
+        var rowResult = GuardedProviderDecode.PropertyResult(
+            reader,
+            property,
+            identityProvider,
+            ExplicitInterfaceSignatureContext.Open(typeContext),
+            DegradedExplicitInterfaceType);
+        if (rowResult.IsDegraded || HasDegradedType(rowResult.Value))
+            return "The property row signature could not be decoded.";
+
+        var row = rowResult.Value;
+        if (!accessors.Getter.IsNil)
+        {
+            if (!TryDecodeAccessorSignature(
+                    reader,
+                    accessors.Getter,
+                    typeContext,
+                    identityProvider,
+                    observeDecodeWork,
+                    out var getter))
+            {
+                return "The property getter signature could not be decoded.";
+            }
+            if (getter.ReturnType.Key != row.ReturnType.Key)
+                return "The property row type does not match its getter return type.";
+            if (!ParameterKeysMatch(getter.ParameterTypes, row.ParameterTypes))
+                return "The property row parameters do not match its getter parameters.";
+        }
+
+        if (!accessors.Setter.IsNil)
+        {
+            if (!TryDecodeAccessorSignature(
+                    reader,
+                    accessors.Setter,
+                    typeContext,
+                    identityProvider,
+                    observeDecodeWork,
+                    out var setter))
+            {
+                return "The property setter signature could not be decoded.";
+            }
+            if (setter.ReturnType.UnmodifiedKey
+                != identityProvider.GetPrimitiveType(PrimitiveTypeCode.Void).UnmodifiedKey)
+            {
+                return "The property setter does not return void.";
+            }
+            if (setter.ParameterTypes.Length != row.ParameterTypes.Length + 1)
+                return "The property row parameters do not match its setter parameters.";
+            if (!ParameterKeysMatch(
+                    setter.ParameterTypes.RemoveAt(setter.ParameterTypes.Length - 1),
+                    row.ParameterTypes))
+            {
+                return "The property row parameters do not match its setter parameters.";
+            }
+            if (setter.ParameterTypes[^1].Key != row.ReturnType.Key)
+                return "The property row type does not match its setter value parameter.";
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Checks that an Event row's declared handler type agrees with the accessor MethodDefs
+    /// that <see cref="IsExplicitInterfaceAggregate"/> matched, returning the malformed detail
+    /// when it does not.
+    /// </summary>
+    /// <remarks>
+    /// The peer of <see cref="ValidateExplicitPropertyRowSignature"/> for the shape ECMA-335
+    /// II.18 fixes: <c>add_X</c> and <c>remove_X</c> each take the Event row's handler type and
+    /// return <c>void</c>. The row names its handler by handle, so it cannot say whether a
+    /// signature would have spelled that handle <c>ELEMENT_TYPE_CLASS</c> or
+    /// <c>ELEMENT_TYPE_VALUETYPE</c>; the comparison admits either rather than reading an
+    /// encoding the row never carried as a disagreement. Gated by
+    /// <c>MetadataDeclarationQueryTests.ExplicitAggregateRowSignature_MustMatchAccessors</c>.
+    /// </remarks>
+    internal static string? ValidateExplicitEventRowSignature(
+        MetadataReader reader,
+        EventDefinition eventDefinition,
+        EventAccessors accessors,
+        GenericContext typeContext,
+        ExplicitInterfaceTypeIdentityProvider identityProvider,
+        Action<int>? observeDecodeWork)
+    {
+        const byte ElementTypeValueType = 0x11;
+        const byte ElementTypeClass = 0x12;
+        var handlerAsValueType = identityProvider.FromHandle(
+            reader,
+            eventDefinition.Type,
+            typeContext,
+            ElementTypeValueType);
+        var handlerAsClass = identityProvider.FromHandle(
+            reader,
+            eventDefinition.Type,
+            typeContext,
+            ElementTypeClass);
+        if (handlerAsValueType.IsDegraded || handlerAsClass.IsDegraded)
+            return "The event row handler type could not be decoded.";
+
+        string voidKey = identityProvider.GetPrimitiveType(PrimitiveTypeCode.Void).UnmodifiedKey;
+        foreach (var (handle, role) in
+            new[] { (accessors.Adder, "adder"), (accessors.Remover, "remover") })
+        {
+            if (handle.IsNil)
+                continue;
+            if (!TryDecodeAccessorSignature(
+                    reader,
+                    handle,
+                    typeContext,
+                    identityProvider,
+                    observeDecodeWork,
+                    out var signature))
+            {
+                return $"The event {role} signature could not be decoded.";
+            }
+            if (signature.ReturnType.UnmodifiedKey != voidKey)
+                return $"The event {role} does not return void.";
+            if (signature.ParameterTypes is not [var handlerParameter]
+                || (handlerParameter.Key != handlerAsClass.Key
+                    && handlerParameter.Key != handlerAsValueType.Key))
+            {
+                return $"The event row handler type does not match its {role} parameter.";
+            }
+        }
+
+        return null;
+    }
+
+    static bool TryDecodeAccessorSignature(
+        MetadataReader reader,
+        MethodDefinitionHandle handle,
+        GenericContext typeContext,
+        ExplicitInterfaceTypeIdentityProvider identityProvider,
+        Action<int>? observeDecodeWork,
+        out MethodSignature<ExplicitInterfaceTypeIdentity> signature)
+    {
+        var accessor = reader.GetMethodDefinition(handle);
+        var result = GuardedProviderDecode.MethodResult(
+            reader,
+            accessor,
+            identityProvider,
+            ExplicitInterfaceSignatureContext.Open(
+                GenericContext.ForMethod(reader, typeContext, accessor, observeDecodeWork)),
+            DegradedExplicitInterfaceType);
+        signature = result.Value;
+        return !result.IsDegraded && !HasDegradedType(signature);
+    }
+
+    static bool ParameterKeysMatch(
+        ImmutableArray<ExplicitInterfaceTypeIdentity> left,
+        ImmutableArray<ExplicitInterfaceTypeIdentity> right)
+        => left.Length == right.Length
+            && left.Select(parameter => parameter.Key)
+                .SequenceEqual(right.Select(parameter => parameter.Key));
+
+    static ExplicitInterfaceTypeIdentity DegradedExplicitInterfaceType => new(
+        "<invalid>",
+        "<invalid>",
+        IsDegraded: true);
+
     private static bool TryGetInterfaceMethodDeclaration(
         MetadataReader reader,
-        TypeDefinition typeDef,
         MethodDefinitionHandle bodyHandle,
         EntityHandle declaration,
         IReadOnlySet<string> implementedInterfaces,
         GenericContext context,
         ExplicitInterfaceTypeIdentityProvider identityProvider,
+        Action<int>? observeDecodeWork,
         out ExplicitInterfaceMethodTarget target)
     {
         target = default;
@@ -2288,10 +2580,14 @@ public static class ApiSurfaceExtractor
 
         string? methodName = declaration.Kind switch
         {
-            HandleKind.MethodDefinition => reader.GetString(
-                reader.GetMethodDefinition((MethodDefinitionHandle)declaration).Name),
-            HandleKind.MemberReference => reader.GetString(
-                reader.GetMemberReference((MemberReferenceHandle)declaration).Name),
+            HandleKind.MethodDefinition => DecodeString(
+                reader,
+                reader.GetMethodDefinition((MethodDefinitionHandle)declaration).Name,
+                observeDecodeWork),
+            HandleKind.MemberReference => DecodeString(
+                reader,
+                reader.GetMemberReference((MemberReferenceHandle)declaration).Name,
+                observeDecodeWork),
             _ => null,
         };
         if (methodName is null)
@@ -2306,11 +2602,11 @@ public static class ApiSurfaceExtractor
         if (!implementedInterfaces.Contains(declaringTypeIdentity.Key)
             || !MethodImplSignaturesMatch(
                 reader,
-                typeDef,
                 bodyHandle,
                 declaration,
                 context,
-                identityProvider))
+                identityProvider,
+                observeDecodeWork))
             return false;
 
         if (declaringTypeIdentity.IsInterface == false)
@@ -2332,11 +2628,11 @@ public static class ApiSurfaceExtractor
 
     private static bool MethodImplSignaturesMatch(
         MetadataReader reader,
-        TypeDefinition typeDef,
         MethodDefinitionHandle bodyHandle,
         EntityHandle declaration,
         GenericContext typeContext,
-        ExplicitInterfaceTypeIdentityProvider identityProvider)
+        ExplicitInterfaceTypeIdentityProvider identityProvider,
+        Action<int>? observeDecodeWork)
     {
         var body = reader.GetMethodDefinition(bodyHandle);
         var bodyResult = GuardedProviderDecode.MethodResult(
@@ -2344,7 +2640,7 @@ public static class ApiSurfaceExtractor
             body,
             identityProvider,
             ExplicitInterfaceSignatureContext.Open(
-                GenericContext.ForMethod(reader, typeDef, body)),
+                GenericContext.ForMethod(reader, typeContext, body, observeDecodeWork)),
             new ExplicitInterfaceTypeIdentity(
                 "<invalid>",
                 "<invalid>",
@@ -2363,7 +2659,11 @@ public static class ApiSurfaceExtractor
                     method,
                     identityProvider,
                     ExplicitInterfaceSignatureContext.Open(
-                        GenericContext.ForMethod(reader, declaringType, method)),
+                        GenericContext.ForMethod(
+                            reader,
+                            GenericContext.ForType(reader, declaringType, observeDecodeWork),
+                            method,
+                            observeDecodeWork)),
                     new ExplicitInterfaceTypeIdentity(
                         "<invalid>",
                         "<invalid>",

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1106,7 +1106,7 @@ public static class ApiSurfaceExtractor
                     kind => kind switch
                     {
                         "get" => accessors.Getter,
-                        "set" => accessors.Setter,
+                        "set" or "init" => accessors.Setter,
                         _ => default,
                     },
                     new TypeNodeProvider(observeText, observeDecodeWork),

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -203,6 +203,12 @@ public static class ApiSurfaceExtractor
                     continue;
 
                 var (typeNamespace, typeName) = GetApiTypeNameParts(reader, typeDefHandle);
+                var typeContext = GenericContext.ForType(reader, typeDef);
+                string? baseTypeName =
+                    (typeAttributes & TypeAttributes.Interface) != 0
+                        || typeDef.BaseType.IsNil
+                    ? null
+                    : ResolveRequiredTypeName(reader, typeDef.BaseType, typeContext);
                 var apiType = new ApiType
                 {
                     Namespace = typeNamespace,
@@ -217,7 +223,7 @@ public static class ApiSurfaceExtractor
                         MetadataDeclarationQuery.GetIntroducedTypeParameterCounts(
                             reader,
                             typeDefHandle),
-                    Kind = "class",
+                    Kind = ClassifyTypeKind(typeAttributes, baseTypeName),
                     Members = []
                 };
 
@@ -612,13 +618,7 @@ public static class ApiSurfaceExtractor
                     observeText,
                     observeDecodeWork);
 
-                apiType.Kind = baseTypeName switch
-                {
-                    "System.Enum" => "enum",
-                    "System.ValueType" => "struct",
-                    "System.Delegate" or "System.MulticastDelegate" => "delegate",
-                    _ => "class"
-                };
+                apiType.Kind = ClassifyTypeKind(attributes, baseTypeName);
             }
             else
             {
@@ -1764,10 +1764,12 @@ public static class ApiSurfaceExtractor
     {
         var explicitInterfaceIdentityProvider =
             new ExplicitInterfaceTypeIdentityProvider();
+        var typeContext = GenericContext.ForType(reader, typeDef);
         var methodImplementations = new MethodImplementationProjection(
             reader,
             typeDef,
-            explicitInterfaceIdentityProvider);
+            explicitInterfaceIdentityProvider,
+            typeContext: typeContext);
         var accessorMethods = GetAccessorMethods(reader, typeDef);
         var canonicalAccessorMethods = GetCanonicalAccessorMethods(reader, typeDef);
         var hiddenAggregateAccessorMethods =
@@ -1894,11 +1896,28 @@ public static class ApiSurfaceExtractor
             }
 
             string propertyName = reader.GetString(property.Name);
-            IsExplicitInterfaceAggregate(
+            bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
                 propertyName,
                 methodImplementations,
                 (accessors.Getter, "get_"),
                 (accessors.Setter, "set_"));
+            if (isExplicitInterfaceImplementation
+                && ValidateExplicitPropertyRowSignature(
+                    reader,
+                    property,
+                    accessors,
+                    typeContext,
+                    explicitInterfaceIdentityProvider,
+                    observeDecodeWork: null) is { } propertyRowDetail)
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "property signature",
+                    propertyHandle,
+                    MetadataTypeNameFailure.Malformed(propertyHandle, propertyRowDetail));
+                continue;
+            }
             apiType.Members.Add(new ApiMember
             {
                 Name = propertyName,
@@ -1957,11 +1976,28 @@ public static class ApiSurfaceExtractor
             }
 
             string eventName = reader.GetString(evt.Name);
-            IsExplicitInterfaceAggregate(
+            bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
                 eventName,
                 methodImplementations,
                 (accessors.Adder, "add_"),
                 (accessors.Remover, "remove_"));
+            if (isExplicitInterfaceImplementation
+                && ValidateExplicitEventRowSignature(
+                    reader,
+                    evt,
+                    accessors,
+                    typeContext,
+                    explicitInterfaceIdentityProvider,
+                    observeDecodeWork: null) is { } eventRowDetail)
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "event signature",
+                    eventHandle,
+                    MetadataTypeNameFailure.Malformed(eventHandle, eventRowDetail));
+                continue;
+            }
             apiType.Members.Add(new ApiMember
             {
                 Name = eventName,
@@ -2869,6 +2905,7 @@ public static class ApiSurfaceExtractor
                 reader,
                 bodyHandle,
                 declaration,
+                declaringTypeIdentity,
                 context,
                 identityProvider,
                 observeDecodeWork))
@@ -2895,6 +2932,7 @@ public static class ApiSurfaceExtractor
         MetadataReader reader,
         MethodDefinitionHandle bodyHandle,
         EntityHandle declaration,
+        ExplicitInterfaceTypeIdentity declaringTypeIdentity,
         GenericContext typeContext,
         ExplicitInterfaceTypeIdentityProvider identityProvider,
         Action<int>? observeDecodeWork)
@@ -2940,15 +2978,6 @@ public static class ApiSurfaceExtractor
                 break;
             case HandleKind.MemberReference:
                 var member = reader.GetMemberReference((MemberReferenceHandle)declaration);
-                var parentIdentity = identityProvider.FromHandle(
-                    reader,
-                    member.Parent,
-                    typeContext);
-                if (parentIdentity.IsDegraded)
-                {
-                    throw new BadImageFormatException(
-                        "The MethodImpl declaration parent could not be decoded.");
-                }
                 declarationSignature = GuardedProviderDecode.MemberRefMethod(
                     reader,
                     member,
@@ -2956,8 +2985,8 @@ public static class ApiSurfaceExtractor
                     ExplicitInterfaceSignatureContext
                         .Open(typeContext)
                         .WithTypeArguments(
-                            parentIdentity.GenericArguments,
-                            parentIdentity.GenericArity),
+                            declaringTypeIdentity.GenericArguments,
+                            declaringTypeIdentity.GenericArity),
                     new ExplicitInterfaceTypeIdentity(
                         "<invalid>",
                         "<invalid>",
@@ -4858,6 +4887,22 @@ public static class ApiSurfaceExtractor
                 typeDef.BaseType,
                 context: null,
                 beforeMaterialize: beforeDecodeWork) == "System.Enum";
+
+    private static string ClassifyTypeKind(
+        TypeAttributes attributes,
+        string? baseTypeName)
+    {
+        if ((attributes & TypeAttributes.Interface) != 0)
+            return "interface";
+
+        return baseTypeName switch
+        {
+            "System.Enum" => "enum",
+            "System.ValueType" => "struct",
+            "System.Delegate" or "System.MulticastDelegate" => "delegate",
+            _ => "class",
+        };
+    }
 
     private sealed class MetadataRowRejectedException
         : InvalidOperationException

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1779,12 +1779,16 @@ public static class ApiSurfaceExtractor
                 reader,
                 typeDef)
             : [];
+        bool isInterfaceTypeDefinition =
+            (typeDef.Attributes & TypeAttributes.Interface) != 0;
 
         foreach (var methodHandle in typeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
             var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
-            if (!MetadataAccessibility.TryGet(methodAccess, out _))
+            if (!MetadataAccessibility.TryGet(
+                    methodAccess,
+                    out string? methodAccessibility))
             {
                 AddInspectionFailure(
                     surface,
@@ -1843,9 +1847,15 @@ public static class ApiSurfaceExtractor
             var member = new ApiMember
             {
                 Name = methodName,
-                Kind = isFinalizer ? "finalizer" : "method",
+                Kind = isFinalizer
+                    ? "finalizer"
+                    : isExplicitImplementation
+                        ? "explicit-interface-implementation"
+                        : "method",
                 IsStatic = (method.Attributes & MethodAttributes.Static) != 0,
-                IsFinalizer = isFinalizer
+                IsFinalizer = isFinalizer,
+                IsExplicitInterfaceImplementation = isExplicitImplementation,
+                Accessibility = methodAccessibility
             };
             if (isExtensionClass
                 && member.IsStatic
@@ -1887,6 +1897,19 @@ public static class ApiSurfaceExtractor
         {
             var property = reader.GetPropertyDefinition(propertyHandle);
             var accessors = property.GetAccessors();
+            if (accessors.Getter.IsNil && accessors.Setter.IsNil)
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "property accessors",
+                    propertyHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        propertyHandle,
+                        "The property has no getter or setter."));
+                continue;
+            }
+
             MethodAttributes bestAccess = 0;
             if (!accessors.Getter.IsNil)
             {
@@ -1900,7 +1923,48 @@ public static class ApiSurfaceExtractor
                 if (setterAccess > bestAccess)
                     bestAccess = setterAccess;
             }
-            if (!MetadataAccessibility.TryGet(bestAccess, out _))
+            bool isAbstractProperty = MetadataAccessorSemantics.AreAllAbstract(
+                reader,
+                accessors.Getter,
+                accessors.Setter);
+            if (MetadataAccessorSemantics.ValidateAbstraction(
+                    reader,
+                    requireUniformAbstraction: !isInterfaceTypeDefinition,
+                    accessors.Getter,
+                    accessors.Setter)
+                is var abstractionFault and not AccessorAbstractionFault.None)
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "property modifiers",
+                    propertyHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        propertyHandle,
+                        abstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
+                            ? "The property has an abstract accessor that declares an IL body."
+                            : "The property has inconsistent abstract accessor metadata."));
+                continue;
+            }
+            if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
+                    reader,
+                    out bool isSealedProperty,
+                    accessors.Getter,
+                    accessors.Setter))
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "property modifiers",
+                    propertyHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        propertyHandle,
+                        "The property has inconsistent sealed accessor metadata."));
+                continue;
+            }
+            if (!MetadataAccessibility.TryGet(
+                    bestAccess,
+                    out string? propertyAccessibility))
             {
                 AddInspectionFailure(
                     surface,
@@ -1913,18 +1977,19 @@ public static class ApiSurfaceExtractor
                 continue;
             }
 
-            if (bestAccess != MethodAttributes.Public
-                || AttributeReader.HasEditorBrowsableNeverAttribute(reader, property.GetCustomAttributes()))
-            {
-                continue;
-            }
-
             string propertyName = reader.GetString(property.Name);
             bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
                 propertyName,
                 methodImplementations,
                 (accessors.Getter, "get_"),
                 (accessors.Setter, "set_"));
+            if (propertyAccessibility is not null
+                || AttributeReader.HasEditorBrowsableNeverAttribute(
+                    reader,
+                    property.GetCustomAttributes()))
+            {
+                continue;
+            }
             if (isExplicitInterfaceImplementation
                 && ValidateExplicitPropertyRowSignature(
                     reader,
@@ -1945,7 +2010,12 @@ public static class ApiSurfaceExtractor
             apiType.Members.Add(new ApiMember
             {
                 Name = propertyName,
-                Kind = "property"
+                Kind = "property",
+                IsAbstract = isAbstractProperty,
+                IsSealed = isSealedProperty,
+                IsExplicitInterfaceImplementation =
+                    isExplicitInterfaceImplementation,
+                Accessibility = propertyAccessibility
             });
             surface.PublicPropertyCount++;
         }
@@ -1985,7 +2055,17 @@ public static class ApiSurfaceExtractor
             var evt = reader.GetEventDefinition(eventHandle);
             var accessors = evt.GetAccessors();
             if (accessors.Adder.IsNil && accessors.Remover.IsNil)
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "event accessors",
+                    eventHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        eventHandle,
+                        "The event has no adder or remover."));
                 continue;
+            }
 
             MethodAttributes bestAccess = 0;
             bool malformedAccessibility = false;
@@ -2020,11 +2100,46 @@ public static class ApiSurfaceExtractor
                 continue;
             }
 
-            if (bestAccess != MethodAttributes.Public
-                || AttributeReader.HasEditorBrowsableNeverAttribute(reader, evt.GetCustomAttributes()))
+            bool isAbstractEvent = MetadataAccessorSemantics.AreAllAbstract(
+                reader,
+                accessors.Adder,
+                accessors.Remover);
+            if (MetadataAccessorSemantics.ValidateAbstraction(
+                    reader,
+                    requireUniformAbstraction: !isInterfaceTypeDefinition,
+                    accessors.Adder,
+                    accessors.Remover)
+                is var eventAbstractionFault and not AccessorAbstractionFault.None)
             {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "event modifiers",
+                    eventHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        eventHandle,
+                        eventAbstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
+                            ? "The event has an abstract accessor that declares an IL body."
+                            : "The event has inconsistent abstract accessor metadata."));
                 continue;
             }
+            if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
+                    reader,
+                    out bool isSealedEvent,
+                    accessors.Adder,
+                    accessors.Remover))
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "event modifiers",
+                    eventHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        eventHandle,
+                        "The event has inconsistent sealed accessor metadata."));
+                continue;
+            }
+            string? eventAccessibility = MetadataAccessibility.Get(bestAccess);
 
             string eventName = reader.GetString(evt.Name);
             bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
@@ -2032,6 +2147,13 @@ public static class ApiSurfaceExtractor
                 methodImplementations,
                 (accessors.Adder, "add_"),
                 (accessors.Remover, "remove_"));
+            if (eventAccessibility is not null
+                || AttributeReader.HasEditorBrowsableNeverAttribute(
+                    reader,
+                    evt.GetCustomAttributes()))
+            {
+                continue;
+            }
             if (isExplicitInterfaceImplementation
                 && ValidateExplicitEventRowSignature(
                     reader,
@@ -2052,7 +2174,12 @@ public static class ApiSurfaceExtractor
             apiType.Members.Add(new ApiMember
             {
                 Name = eventName,
-                Kind = "event"
+                Kind = "event",
+                IsAbstract = isAbstractEvent,
+                IsSealed = isSealedEvent,
+                IsExplicitInterfaceImplementation =
+                    isExplicitInterfaceImplementation,
+                Accessibility = eventAccessibility
             });
             surface.PublicEventCount++;
         }
@@ -2606,6 +2733,12 @@ public static class ApiSurfaceExtractor
                 throw new BadImageFormatException(
                     "The MethodImpl body signature could not be decoded.");
             }
+            if (result.Value.GenericParameterCount
+                != body.GetGenericParameters().Count)
+            {
+                throw new BadImageFormatException(
+                    "The MethodImpl body generic arity does not match its GenericParam rows.");
+            }
 
             bodySignatures.Add(bodyHandle, result.Value);
             return result.Value;
@@ -2613,7 +2746,8 @@ public static class ApiSurfaceExtractor
 
         MethodSignature<ExplicitInterfaceTypeIdentity> GetDeclarationSignature(
             EntityHandle declaration,
-            ExplicitInterfaceTypeIdentity declaringTypeIdentity)
+            ExplicitInterfaceTypeIdentity declaringTypeIdentity,
+            int methodParameterCount)
         {
             switch (declaration.Kind)
             {
@@ -2643,6 +2777,12 @@ public static class ApiSurfaceExtractor
                         throw new BadImageFormatException(
                             "The MethodImpl declaration signature could not be decoded.");
                     }
+                    if (methodResult.Value.GenericParameterCount
+                        != method.GetGenericParameters().Count)
+                    {
+                        throw new BadImageFormatException(
+                            "The MethodImpl declaration generic arity does not match its GenericParam rows.");
+                    }
 
                     methodDefinitionSignatures.Add(handle, methodResult.Value);
                     return methodResult.Value;
@@ -2654,7 +2794,8 @@ public static class ApiSurfaceExtractor
                         .Open(typeContext)
                         .WithTypeArguments(
                             declaringTypeIdentity.GenericArguments,
-                            declaringTypeIdentity.GenericArity);
+                            declaringTypeIdentity.GenericArity)
+                        .WithMethodParameterCount(methodParameterCount);
                     var key = new MemberReferenceSignatureCacheKey(
                         member.Signature,
                         context);
@@ -3041,6 +3182,7 @@ public static class ApiSurfaceExtractor
         ExplicitInterfaceTypeIdentityProvider identityProvider,
         Action<int>? observeDecodeWork,
         Func<EntityHandle, ExplicitInterfaceTypeIdentity,
+            int,
             MethodSignature<ExplicitInterfaceTypeIdentity>> getDeclarationSignature,
         out ExplicitInterfaceMethodTarget target)
     {
@@ -3105,10 +3247,14 @@ public static class ApiSurfaceExtractor
         EntityHandle declaration,
         ExplicitInterfaceTypeIdentity declaringTypeIdentity,
         Func<EntityHandle, ExplicitInterfaceTypeIdentity,
+            int,
             MethodSignature<ExplicitInterfaceTypeIdentity>> getDeclarationSignature)
     {
         MethodSignature<ExplicitInterfaceTypeIdentity> declarationSignature =
-            getDeclarationSignature(declaration, declaringTypeIdentity);
+            getDeclarationSignature(
+                declaration,
+                declaringTypeIdentity,
+                bodySignature.GenericParameterCount);
         return MethodSignaturesMatch(bodySignature, declarationSignature);
     }
 
@@ -6227,8 +6373,11 @@ public static class ApiSurfaceExtractor
         void RetainPendingText(long characters)
         {
             long next = characters + _pendingTextCharacters;
-            if (next > bounds.MaxRetainedTextCharacters - _retainedTextCharacters
-                || next < 0)
+            long pendingTotal = next + _pendingProjectionTextCharacters;
+            if (pendingTotal
+                    > bounds.MaxRetainedTextCharacters - _retainedTextCharacters
+                || next < 0
+                || pendingTotal < 0)
             {
                 throw new ExtractionBoundExceededException(
                     ApiSurfaceExtractionBound.RetainedTextCharacters);

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1788,7 +1788,17 @@ public static class ApiSurfaceExtractor
 
             bool isExplicitImplementation =
                 methodImplementations.HasExplicitInterfaceTargets(methodHandle);
-            if (methodAccess != MethodAttributes.Public && !isExplicitImplementation)
+            bool isFinalizer = method.GetGenericParameters().Count == 0
+                && string.Equals(methodName, "Finalize", StringComparison.Ordinal)
+                && apiType.Kind == "class"
+                && (methodImplementations.OverridesObjectFinalize(methodHandle)
+                    || IsImplicitObjectFinalizeOverride(
+                        reader,
+                        method.GetDeclaringType(),
+                        method));
+            if (methodAccess != MethodAttributes.Public
+                && !isExplicitImplementation
+                && !isFinalizer)
                 continue;
 
             bool isNormallySkippedAccessor =
@@ -1819,8 +1829,9 @@ public static class ApiSurfaceExtractor
             var member = new ApiMember
             {
                 Name = methodName,
-                Kind = "method",
-                IsStatic = (method.Attributes & MethodAttributes.Static) != 0
+                Kind = isFinalizer ? "finalizer" : "method",
+                IsStatic = (method.Attributes & MethodAttributes.Static) != 0,
+                IsFinalizer = isFinalizer
             };
             if (isExtensionClass
                 && member.IsStatic
@@ -2627,8 +2638,8 @@ public static class ApiSurfaceExtractor
     /// <c>string IFoo.Bar</c> that no accessor implements. ECMA-335 II.22.34 and II.17.2 fix the
     /// relationship this restates: the getter returns the property type over the index
     /// parameters, and the setter takes those parameters plus a trailing value. Custom
-    /// modifiers are compared exactly except on the setter's return, where a legal
-    /// <c>init</c> accessor carries <c>modreq(IsExternalInit)</c> over <c>void</c>. The row's
+    /// modifiers are compared exactly except on the setter's return, where only a legal
+    /// <c>init</c> accessor's single <c>modreq(IsExternalInit)</c> over <c>void</c> is allowed. The row's
     /// <c>HASTHIS</c> bit is deliberately not compared: nothing in the projection reads it —
     /// static-ness comes from the accessor's method attributes — and Reflection.Emit produces
     /// otherwise-sound images whose Property rows omit it, so comparing it could only reject
@@ -2684,8 +2695,9 @@ public static class ApiSurfaceExtractor
             {
                 return "The property setter signature could not be decoded.";
             }
-            if (setter.ReturnType.UnmodifiedKey
-                != identityProvider.GetPrimitiveType(PrimitiveTypeCode.Void).UnmodifiedKey)
+            var voidType = identityProvider.GetPrimitiveType(PrimitiveTypeCode.Void);
+            if (setter.ReturnType.Key != voidType.Key
+                && !IsLegalInitOnlySetterReturn(setter.ReturnType, voidType))
             {
                 return "The property setter does not return void.";
             }
@@ -2712,7 +2724,7 @@ public static class ApiSurfaceExtractor
     /// <remarks>
     /// The peer of <see cref="ValidateExplicitPropertyRowSignature"/> for the shape ECMA-335
     /// II.18 fixes: <c>add_X</c> and <c>remove_X</c> each take the Event row's handler type and
-    /// return <c>void</c>. The row names its handler by handle, so it cannot say whether a
+    /// return exact, unmodified <c>void</c>. The row names its handler by handle, so it cannot say whether a
     /// signature would have spelled that handle <c>ELEMENT_TYPE_CLASS</c> or
     /// <c>ELEMENT_TYPE_VALUETYPE</c>; the comparison admits either rather than reading an
     /// encoding the row never carried as a disagreement. Gated by
@@ -2741,7 +2753,7 @@ public static class ApiSurfaceExtractor
         if (handlerAsValueType.IsDegraded || handlerAsClass.IsDegraded)
             return "The event row handler type could not be decoded.";
 
-        string voidKey = identityProvider.GetPrimitiveType(PrimitiveTypeCode.Void).UnmodifiedKey;
+        string voidKey = identityProvider.GetPrimitiveType(PrimitiveTypeCode.Void).Key;
         foreach (var (handle, role) in
             new[] { (accessors.Adder, "adder"), (accessors.Remover, "remover") })
         {
@@ -2757,7 +2769,7 @@ public static class ApiSurfaceExtractor
             {
                 return $"The event {role} signature could not be decoded.";
             }
-            if (signature.ReturnType.UnmodifiedKey != voidKey)
+            if (signature.ReturnType.Key != voidKey)
                 return $"The event {role} does not return void.";
             if (signature.ParameterTypes is not [var handlerParameter]
                 || (handlerParameter.Key != handlerAsClass.Key
@@ -2769,6 +2781,15 @@ public static class ApiSurfaceExtractor
 
         return null;
     }
+
+    static bool IsLegalInitOnlySetterReturn(
+        ExplicitInterfaceTypeIdentity returnType,
+        ExplicitInterfaceTypeIdentity voidType)
+        => returnType.UnmodifiedKey == voidType.Key
+            && returnType.CustomModifierCount == 1
+            && returnType.IsSingleCustomModifierRequired
+            && returnType.SingleCustomModifierMetadataName
+                == "System.Runtime.CompilerServices.IsExternalInit";
 
     static bool TryDecodeAccessorSignature(
         MetadataReader reader,

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1784,6 +1784,18 @@ public static class ApiSurfaceExtractor
         {
             var method = reader.GetMethodDefinition(methodHandle);
             var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
+            if (!MetadataAccessibility.TryGet(methodAccess, out _))
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "method accessibility",
+                    methodHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        methodHandle,
+                        $"The method has an unknown accessibility value 0x{(int)methodAccess:X}."));
+                continue;
+            }
             string methodName = reader.GetString(method.Name);
             if (methodName.StartsWith('<'))
                 continue;
@@ -1888,6 +1900,18 @@ public static class ApiSurfaceExtractor
                 if (setterAccess > bestAccess)
                     bestAccess = setterAccess;
             }
+            if (!MetadataAccessibility.TryGet(bestAccess, out _))
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "property accessibility",
+                    propertyHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        propertyHandle,
+                        $"The property has an unknown accessibility value 0x{(int)bestAccess:X}."));
+                continue;
+            }
 
             if (bestAccess != MethodAttributes.Public
                 || AttributeReader.HasEditorBrowsableNeverAttribute(reader, property.GetCustomAttributes()))
@@ -1929,7 +1953,20 @@ public static class ApiSurfaceExtractor
         foreach (var fieldHandle in typeDef.GetFields())
         {
             var field = reader.GetFieldDefinition(fieldHandle);
-            if ((field.Attributes & FieldAttributes.FieldAccessMask) != FieldAttributes.Public)
+            var fieldAccess = field.Attributes & FieldAttributes.FieldAccessMask;
+            if (!MetadataAccessibility.TryGet(fieldAccess, out _))
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "field accessibility",
+                    fieldHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        fieldHandle,
+                        $"The field has an unknown accessibility value 0x{(int)fieldAccess:X}."));
+                continue;
+            }
+            if (fieldAccess != FieldAttributes.Public)
                 continue;
 
             string fieldName = reader.GetString(field.Name);
@@ -1952,6 +1989,7 @@ public static class ApiSurfaceExtractor
 
             MethodAttributes bestAccess = 0;
             bool malformedAccessibility = false;
+            MethodAttributes malformedAccess = 0;
             foreach (var accessorHandle in new[] { accessors.Adder, accessors.Remover })
             {
                 if (accessorHandle.IsNil)
@@ -1962,14 +2000,27 @@ public static class ApiSurfaceExtractor
                 if (!MetadataAccessibility.TryGet(access, out _))
                 {
                     malformedAccessibility = true;
+                    malformedAccess = access;
                     break;
                 }
                 if (access > bestAccess)
                     bestAccess = access;
             }
 
-            if (malformedAccessibility
-                || bestAccess != MethodAttributes.Public
+            if (malformedAccessibility)
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget: null,
+                    "event accessibility",
+                    eventHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        eventHandle,
+                        $"The event has an unknown accessibility value 0x{(int)malformedAccess:X}."));
+                continue;
+            }
+
+            if (bestAccess != MethodAttributes.Public
                 || AttributeReader.HasEditorBrowsableNeverAttribute(reader, evt.GetCustomAttributes()))
             {
                 continue;
@@ -2372,7 +2423,7 @@ public static class ApiSurfaceExtractor
     /// admitted body on demand. Aggregate/accessor targets are cached for later classification;
     /// ordinary admitted methods are validated without retaining their target graph.
     /// </summary>
-    private sealed class MethodImplementationProjection
+    internal sealed class MethodImplementationProjection
     {
         const int MethodImplementationRowWorkChars = 256;
         readonly MetadataReader reader;
@@ -2398,7 +2449,7 @@ public static class ApiSurfaceExtractor
             BlobHandle Signature,
             ExplicitInterfaceSignatureContext Context);
 
-        public MethodImplementationProjection(
+        internal MethodImplementationProjection(
             MetadataReader reader,
             TypeDefinition typeDefinition,
             ExplicitInterfaceTypeIdentityProvider identityProvider,
@@ -2437,6 +2488,9 @@ public static class ApiSurfaceExtractor
 
         public IEnumerable<MethodDefinitionHandle> Bodies =>
             declarationsByBody.Keys;
+
+        public bool ContainsBody(MethodDefinitionHandle body) =>
+            declarationsByBody.ContainsKey(body);
 
         public bool HasExplicitInterfaceTargets(MethodDefinitionHandle body) =>
             GetExplicitInterfaceTargets(body).Count > 0;
@@ -2722,7 +2776,7 @@ public static class ApiSurfaceExtractor
                     : null,
             accessors);
 
-    private static bool IsExplicitInterfaceAggregate(
+    internal static bool IsExplicitInterfaceAggregate(
         string name,
         MethodImplementationProjection methodImplementations,
         params (MethodDefinitionHandle Handle, string DeclarationPrefix)[] accessors)

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -154,7 +154,7 @@ public abstract record ApiSurfaceExtractionResult
 
 internal readonly record struct ExplicitInterfaceMethodTarget(
     EntityHandle Declaration,
-    string InterfaceTypeName,
+    ExplicitInterfaceTypeIdentity InterfaceType,
     string MethodName);
 
 /// <summary>
@@ -727,10 +727,7 @@ public static class ApiSurfaceExtractor
 
             var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
             var explicitInterfaceImplementationTargets =
-                GetExplicitInterfaceImplementationTargets(
-                    reader,
-                    typeDef,
-                    observeDecodeWork);
+                GetExplicitInterfaceImplementationTargets(reader, typeDef);
             var explicitInterfaceImplementationBodies =
                 explicitInterfaceImplementationTargets.Keys.ToHashSet();
             var accessorMethods = GetAccessorMethods(reader, typeDef);
@@ -2104,24 +2101,21 @@ public static class ApiSurfaceExtractor
     internal static Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
         GetExplicitInterfaceImplementationTargets(
             MetadataReader reader,
-            TypeDefinition typeDef,
-            Action<int>? beforeDecodeWork = null)
+            TypeDefinition typeDef)
     {
         var context = GenericContext.ForType(reader, typeDef);
-        HashSet<MetadataNamedTypeReference> implementedInterfaces = [];
+        HashSet<string> implementedInterfaces = [];
         foreach (var interfaceHandle in typeDef.GetInterfaceImplementations())
         {
             var interfaceType = reader.GetInterfaceImplementation(interfaceHandle).Interface;
-            var interfaceIdentity = MetadataNamedTypeSignatureDecoder.DecodeType(
+            var interfaceIdentity = ExplicitInterfaceTypeIdentityProvider.FromHandle(
                 reader,
                 interfaceType,
-                context,
-                beforeDecodeWork);
-            if (interfaceIdentity is not null)
-                implementedInterfaces.Add(interfaceIdentity);
+                context);
+            if (!interfaceIdentity.IsDegraded)
+                implementedInterfaces.Add(interfaceIdentity.Key);
         }
 
-        Dictionary<EntityHandle, MetadataNamedTypeReference?> declarationTypes = [];
         Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>> targets = [];
         foreach (var implementationHandle in typeDef.GetMethodImplementations())
         {
@@ -2129,11 +2123,11 @@ public static class ApiSurfaceExtractor
             if (implementation.MethodBody.Kind == HandleKind.MethodDefinition
                 && TryGetInterfaceMethodDeclaration(
                     reader,
+                    typeDef,
+                    (MethodDefinitionHandle)implementation.MethodBody,
                     implementation.MethodDeclaration,
                     implementedInterfaces,
                     context,
-                    declarationTypes,
-                    beforeDecodeWork,
                     out var target))
             {
                 var body = (MethodDefinitionHandle)implementation.MethodBody;
@@ -2171,7 +2165,7 @@ public static class ApiSurfaceExtractor
                     accessor.Handle,
                     out var targets)
                 || !targets.Any(target =>
-                    target.InterfaceTypeName == interfaceName
+                    target.InterfaceType.MetadataName == interfaceName
                     && target.MethodName == accessor.DeclarationPrefix + memberName))
             {
                 return false;
@@ -2183,11 +2177,11 @@ public static class ApiSurfaceExtractor
 
     private static bool TryGetInterfaceMethodDeclaration(
         MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinitionHandle bodyHandle,
         EntityHandle declaration,
-        IReadOnlySet<MetadataNamedTypeReference> implementedInterfaces,
+        IReadOnlySet<string> implementedInterfaces,
         GenericContext context,
-        Dictionary<EntityHandle, MetadataNamedTypeReference?> declarationTypes,
-        Action<int>? beforeDecodeWork,
         out ExplicitInterfaceMethodTarget target)
     {
         target = default;
@@ -2211,25 +2205,18 @@ public static class ApiSurfaceExtractor
         if (methodName is null)
             return false;
 
-        if (!declarationTypes.TryGetValue(
-                declaringType,
-                out MetadataNamedTypeReference? declaringTypeIdentity))
-        {
-            declaringTypeIdentity = MetadataNamedTypeSignatureDecoder.DecodeType(
+        var declaringTypeIdentity = ExplicitInterfaceTypeIdentityProvider.FromHandle(
+            reader,
+            declaringType,
+            context);
+        if (declaringTypeIdentity.IsDegraded
+            || !implementedInterfaces.Contains(declaringTypeIdentity.Key)
+            || !MethodImplSignaturesMatch(
                 reader,
-                declaringType,
-                context,
-                beforeDecodeWork);
-            declarationTypes.Add(declaringType, declaringTypeIdentity);
-        }
-        if (declaringTypeIdentity is null
-            || !implementedInterfaces.Contains(declaringTypeIdentity))
-        {
-            return false;
-        }
-
-        var declaringTypeName = TypeResolver.GetTypeName(reader, declaringType, context);
-        if (declaringTypeName is null)
+                typeDef,
+                bodyHandle,
+                declaration,
+                context))
             return false;
 
         if (declaringType.Kind == HandleKind.TypeDefinition
@@ -2241,10 +2228,87 @@ public static class ApiSurfaceExtractor
 
         target = new ExplicitInterfaceMethodTarget(
             declaration,
-            declaringTypeName,
+            declaringTypeIdentity,
             methodName);
         return true;
     }
+
+    private static bool MethodImplSignaturesMatch(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinitionHandle bodyHandle,
+        EntityHandle declaration,
+        GenericContext typeContext)
+    {
+        var body = reader.GetMethodDefinition(bodyHandle);
+        var bodyResult = GuardedProviderDecode.MethodResult(
+            reader,
+            body,
+            ExplicitInterfaceTypeIdentityProvider.Instance,
+            ExplicitInterfaceSignatureContext.Open(
+                GenericContext.ForMethod(reader, typeDef, body)),
+            new ExplicitInterfaceTypeIdentity("<invalid>", "<invalid>"));
+        if (bodyResult.IsDegraded)
+            return false;
+
+        MethodSignature<ExplicitInterfaceTypeIdentity> declarationSignature;
+        switch (declaration.Kind)
+        {
+            case HandleKind.MethodDefinition:
+                var method = reader.GetMethodDefinition((MethodDefinitionHandle)declaration);
+                var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
+                var declarationResult = GuardedProviderDecode.MethodResult(
+                    reader,
+                    method,
+                    ExplicitInterfaceTypeIdentityProvider.Instance,
+                    ExplicitInterfaceSignatureContext.Open(
+                        GenericContext.ForMethod(reader, declaringType, method)),
+                    new ExplicitInterfaceTypeIdentity("<invalid>", "<invalid>"));
+                if (declarationResult.IsDegraded)
+                    return false;
+                declarationSignature = declarationResult.Value;
+                break;
+            case HandleKind.MemberReference:
+                var member = reader.GetMemberReference((MemberReferenceHandle)declaration);
+                declarationSignature = GuardedProviderDecode.MemberRefMethod(
+                    reader,
+                    member,
+                    ExplicitInterfaceTypeIdentityProvider.Instance,
+                    ExplicitInterfaceSignatureContext
+                        .Open(typeContext)
+                        .WithTypeArguments(
+                            ExplicitInterfaceTypeIdentityProvider.FromHandle(
+                                reader,
+                                member.Parent,
+                                typeContext)
+                            .GenericArguments),
+                    new ExplicitInterfaceTypeIdentity(
+                        "<invalid>",
+                        "<invalid>",
+                        IsDegraded: true));
+                break;
+            default:
+                return false;
+        }
+
+        return MethodSignaturesMatch(bodyResult.Value, declarationSignature);
+    }
+
+    private static bool MethodSignaturesMatch(
+        MethodSignature<ExplicitInterfaceTypeIdentity> left,
+        MethodSignature<ExplicitInterfaceTypeIdentity> right)
+        => left.Header.Equals(right.Header)
+            && left.GenericParameterCount == right.GenericParameterCount
+            && left.RequiredParameterCount == right.RequiredParameterCount
+            && !left.ReturnType.IsDegraded
+            && !right.ReturnType.IsDegraded
+            && left.ReturnType.Key == right.ReturnType.Key
+            && left.ParameterTypes.Length == right.ParameterTypes.Length
+            && !left.ParameterTypes.Any(parameter => parameter.IsDegraded)
+            && !right.ParameterTypes.Any(parameter => parameter.IsDegraded)
+            && left.ParameterTypes
+                .Select(parameter => parameter.Key)
+                .SequenceEqual(right.ParameterTypes.Select(parameter => parameter.Key));
 
     /// <summary>
     /// The set of methods on <paramref name="typeDef"/> whose explicit

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2818,8 +2818,7 @@ public static class ApiSurfaceExtractor
                     continue;
                 }
 
-                if (target.InterfaceMembershipProven)
-                    ObserveTarget(target);
+                ObserveTarget(target);
                 targets.Add(target);
             }
 
@@ -2852,8 +2851,7 @@ public static class ApiSurfaceExtractor
                         GetDeclarationSignature,
                         out var target))
                 {
-                    if (target.InterfaceMembershipProven)
-                        ObserveTarget(target);
+                    ObserveTarget(target);
                 }
             }
         }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -879,7 +879,7 @@ public static class ApiSurfaceExtractor
                             reader,
                             method.GetCustomAttributes(),
                             observeDecodeWork),
-                    Accessibility = isExplicitInterfaceImplementation && !isOperator ? null : GetAccessibility(methodAccess),
+                    Accessibility = GetAccessibility(methodAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
                     Attributes = RenderMemberAttributes(
@@ -913,6 +913,17 @@ public static class ApiSurfaceExtractor
             {
                 var prop = reader.GetPropertyDefinition(propHandle);
                 var accessors = prop.GetAccessors();
+                if (accessors.Getter.IsNil && accessors.Setter.IsNil)
+                {
+                    AddInspectionFailure(
+                        surface,
+                        "property accessors",
+                        propHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            propHandle,
+                            "The property has no getter or setter."));
+                    continue;
+                }
 
                 // Determine best accessor visibility
                 MethodAttributes bestAccess = 0;
@@ -2572,6 +2583,7 @@ public static class ApiSurfaceExtractor
                     IsOverride = extension.IsOverride,
                     IsSealed = extension.IsSealed,
                     IsUnsafe = extension.IsUnsafe,
+                    Accessibility = extension.Accessibility,
                     IsExtension = true,
                     ExtendedType = extension.ExtendedType,
                     DeclaringType = declaringType.FullName,

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -885,7 +885,6 @@ public static class ApiSurfaceExtractor
                     ReturnType = ApiMemberIdentity.IsConversionOperator(methodName) ? signature.Model?.ReturnType : null,
                     MetadataToken = MetadataTokens.GetToken(methodHandle),
                     HasMethodBody = method.RelativeVirtualAddress != 0,
-                    IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
                     IsUnsafe = HasUnsafeSignature(reader, method, observeDecodeWork)
                         || AttributeReader.HasRequiresUnsafeAttribute(
                             reader,
@@ -1001,6 +1000,10 @@ public static class ApiSurfaceExtractor
                     out var obsoleteMessage,
                     observeDecodeWork);
 
+                string propertyName = DecodeString(
+                    reader,
+                    prop.Name,
+                    observeDecodeWork);
                 var propertySignature = GetPropertySignature(
                     reader,
                     typeContext,
@@ -1031,14 +1034,12 @@ public static class ApiSurfaceExtractor
                     observeText,
                     observeDecodeWork);
                 bool isExplicitInterfaceImplementation =
-                    !accessors.Getter.IsNil && explicitImplementationBodies.Contains(accessors.Getter)
-                    || !accessors.Setter.IsNil && explicitImplementationBodies.Contains(accessors.Setter);
+                    propertyName.Contains('.', StringComparison.Ordinal)
+                    && (!accessors.Getter.IsNil && explicitImplementationBodies.Contains(accessors.Getter)
+                        || !accessors.Setter.IsNil && explicitImplementationBodies.Contains(accessors.Setter));
                 var member = new ApiMember
                 {
-                    Name = DecodeString(
-                        reader,
-                        prop.Name,
-                        observeDecodeWork),
+                    Name = propertyName,
                     Kind = "property",
                     Signature = propertySignature.Text,
                     SignatureModel = propertySignature.Model,
@@ -1391,6 +1392,10 @@ public static class ApiSurfaceExtractor
                 var isVirtualEvent = (primaryAccessorAttributes & MethodAttributes.Virtual) != 0;
                 var isOverrideEvent = isVirtualEvent
                     && (primaryAccessorAttributes & MethodAttributes.NewSlot) == 0;
+                string eventName = DecodeString(
+                    reader,
+                    evt.Name,
+                    observeDecodeWork);
                 var accessorModels = new List<ApiAccessor>();
                 if (!accessors.Adder.IsNil)
                 {
@@ -1420,8 +1425,7 @@ public static class ApiSurfaceExtractor
                             observeAttributeMaterialize),
                         HasMethodBody = remover.RelativeVirtualAddress != 0,
                         IsAbstract = (remover.Attributes & MethodAttributes.Abstract) != 0
-                    }
-                };
+                    });
                 var accessorFacts = AccessorFacts(
                     reader,
                     observeText,
@@ -1430,8 +1434,9 @@ public static class ApiSurfaceExtractor
                     (accessors.Adder, "add"),
                     (accessors.Remover, "remove"));
                 bool isExplicitInterfaceImplementation =
-                    explicitImplementationBodies.Contains(accessors.Adder)
-                    || explicitImplementationBodies.Contains(accessors.Remover);
+                    eventName.Contains('.', StringComparison.Ordinal)
+                    && (explicitImplementationBodies.Contains(accessors.Adder)
+                        || explicitImplementationBodies.Contains(accessors.Remover));
 
                 var eventTypeNodeProvider = observeText is null
                     ? TypeNodeProvider.Instance
@@ -1461,11 +1466,6 @@ public static class ApiSurfaceExtractor
                     eventTypeNodeProvider,
                     typeContext,
                     observeText,
-                    observeDecodeWork);
-
-                string eventName = DecodeString(
-                    reader,
-                    evt.Name,
                     observeDecodeWork);
                 var member = new ApiMember
                 {

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -771,13 +771,25 @@ public static class ApiSurfaceExtractor
                             $"The method has an unknown accessibility value 0x{(int)methodAccess:X}."));
                     continue;
                 }
-                var isExplicitInterfaceImplementation =
-                    methodImplementations.ContainsBody(methodHandle);
-                if (methodAccess != MethodAttributes.Public && !includeAll && !isExplicitInterfaceImplementation)
-                    continue;
-
                 // Skip compiler-generated methods (lambdas, state machines, etc.)
                 if (methodName.StartsWith("<"))
+                    continue;
+
+                var isExplicitInterfaceImplementation =
+                    methodImplementations.HasExplicitInterfaceTargets(methodHandle);
+                var isFinalizer = apiType.Kind == "class"
+                    && method.GetGenericParameters().Count == 0
+                    && string.Equals(methodName, "Finalize", StringComparison.Ordinal)
+                    && (methodImplementations.OverridesObjectFinalize(methodHandle)
+                        || IsImplicitObjectFinalizeOverride(
+                            reader,
+                            typeDefHandle,
+                            method,
+                            observeDecodeWork));
+                if (methodAccess != MethodAttributes.Public
+                    && !includeAll
+                    && !isExplicitInterfaceImplementation
+                    && !isFinalizer)
                     continue;
 
                 bool isNormallySkippedAccessor =
@@ -855,15 +867,6 @@ public static class ApiSurfaceExtractor
                 // A finalizer is never generic, so a method that overrides
                 // object.Finalize while declaring its own type parameters is still
                 // rejected — rendering it `~Type()` would erase `<T>`.
-                var isFinalizer = apiType.Kind == "class"
-                    && method.GetGenericParameters().Count == 0
-                    && (methodImplementations.OverridesObjectFinalize(methodHandle)
-                        || IsImplicitObjectFinalizeOverride(
-                            reader,
-                            typeDefHandle,
-                            method,
-                            observeDecodeWork));
-
                 var member = new ApiMember
                 {
                     Name = methodName,
@@ -1779,12 +1782,13 @@ public static class ApiSurfaceExtractor
         {
             var method = reader.GetMethodDefinition(methodHandle);
             var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
-            bool isExplicitImplementation =
-                methodImplementations.ContainsBody(methodHandle);
-            if (methodAccess != MethodAttributes.Public && !isExplicitImplementation)
-                continue;
             string methodName = reader.GetString(method.Name);
             if (methodName.StartsWith('<'))
+                continue;
+
+            bool isExplicitImplementation =
+                methodImplementations.HasExplicitInterfaceTargets(methodHandle);
+            if (methodAccess != MethodAttributes.Public && !isExplicitImplementation)
                 continue;
 
             bool isNormallySkippedAccessor =
@@ -1913,11 +1917,29 @@ public static class ApiSurfaceExtractor
         {
             var evt = reader.GetEventDefinition(eventHandle);
             var accessors = evt.GetAccessors();
-            if (accessors.Adder.IsNil)
+            if (accessors.Adder.IsNil && accessors.Remover.IsNil)
                 continue;
 
-            var adder = reader.GetMethodDefinition(accessors.Adder);
-            if ((adder.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
+            MethodAttributes bestAccess = 0;
+            bool malformedAccessibility = false;
+            foreach (var accessorHandle in new[] { accessors.Adder, accessors.Remover })
+            {
+                if (accessorHandle.IsNil)
+                    continue;
+
+                var access = reader.GetMethodDefinition(accessorHandle).Attributes
+                    & MethodAttributes.MemberAccessMask;
+                if (!MetadataAccessibility.TryGet(access, out _))
+                {
+                    malformedAccessibility = true;
+                    break;
+                }
+                if (access > bestAccess)
+                    bestAccess = access;
+            }
+
+            if (malformedAccessibility
+                || bestAccess != MethodAttributes.Public
                 || AttributeReader.HasEditorBrowsableNeverAttribute(reader, evt.GetCustomAttributes()))
             {
                 continue;
@@ -2358,9 +2380,6 @@ public static class ApiSurfaceExtractor
         public IEnumerable<MethodDefinitionHandle> Bodies =>
             declarationsByBody.Keys;
 
-        public bool ContainsBody(MethodDefinitionHandle body) =>
-            declarationsByBody.ContainsKey(body);
-
         public bool HasExplicitInterfaceTargets(MethodDefinitionHandle body) =>
             GetExplicitInterfaceTargets(body).Count > 0;
 
@@ -2432,6 +2451,9 @@ public static class ApiSurfaceExtractor
 
             bool result =
                 declarationsByBody.TryGetValue(body, out var declarations)
+                && HasVoidNullaryInstanceSignature(
+                    reader,
+                    reader.GetMethodDefinition(body))
                 && declarations.Any(declaration =>
                     ReferencesObjectFinalize(
                         reader,
@@ -2968,6 +2990,8 @@ public static class ApiSurfaceExtractor
             return false;
         if (method.GetGenericParameters().Count != 0)
             return false;
+        if (!HasVoidNullaryInstanceSignature(reader, method))
+            return false;
 
         var typeHandle = method.GetDeclaringType();
         var typeDef = reader.GetTypeDefinition(typeHandle);
@@ -3126,10 +3150,14 @@ public static class ApiSurfaceExtractor
     /// as a non-match (returns false) rather than throwing.
     /// </summary>
     private static bool HasVoidNullaryInstanceSignature(MetadataReader reader, MethodDefinition method)
+        => (method.Attributes & MethodAttributes.Static) == 0
+            && HasVoidNullaryInstanceSignature(reader, method.Signature);
+
+    private static bool HasVoidNullaryInstanceSignature(MetadataReader reader, BlobHandle signature)
     {
         try
         {
-            var blob = reader.GetBlobReader(method.Signature);
+            var blob = reader.GetBlobReader(signature);
             var header = blob.ReadSignatureHeader();
             // object.Finalize is `instance void ()` with the default managed calling convention.
             // Reject anything else: field/property sigs, vararg/unmanaged conventions, generic
@@ -3144,7 +3172,8 @@ public static class ApiSurfaceExtractor
                 return false;
             // Return type: a plain ELEMENT_TYPE_VOID. Any leading custom modifier or by-ref token is
             // read here instead of Void and correctly rejects.
-            return blob.ReadSignatureTypeCode() == SignatureTypeCode.Void;
+            return blob.ReadSignatureTypeCode() == SignatureTypeCode.Void
+                && blob.RemainingBytes == 0;
         }
         catch (BadImageFormatException)
         {
@@ -3154,10 +3183,13 @@ public static class ApiSurfaceExtractor
     }
 
     /// <summary>
-    /// <c>.override</c> MethodImpl) names <c>Finalize</c> on <c>System.Object</c>.
+    /// True when an explicit <c>.override</c> MethodImpl targets the exact
+    /// <c>instance void System.Object::Finalize()</c> slot.
     /// The target is a <see cref="MemberReferenceHandle"/> in the common case
     /// (object lives in another assembly) and a <see cref="MethodDefinitionHandle"/>
     /// only when inspecting the assembly that defines <c>System.Object</c>.
+    /// Gated by
+    /// <c>ApiSurfaceExtractorBoundsTests.ExplicitObjectFinalizeMethodImpl_RequiresInstanceVoidSignatures</c>.
     /// </summary>
     private static bool ReferencesObjectFinalize(
         MetadataReader reader,
@@ -3172,6 +3204,7 @@ public static class ApiSurfaceExtractor
                         DecodeString(reader, memberRef.Name, beforeDecodeWork),
                         "Finalize",
                         StringComparison.Ordinal)
+                    && HasVoidNullaryInstanceSignature(reader, memberRef.Signature)
                     && IsSystemObjectType(
                         reader,
                         memberRef.Parent,
@@ -3182,6 +3215,7 @@ public static class ApiSurfaceExtractor
                         DecodeString(reader, methodDef.Name, beforeDecodeWork),
                         "Finalize",
                         StringComparison.Ordinal)
+                    && HasVoidNullaryInstanceSignature(reader, methodDef)
                     && IsSystemObjectType(
                         reader,
                         methodDef.GetDeclaringType(),

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -862,7 +862,7 @@ public static class ApiSurfaceExtractor
                         // so it also lands in `explicitImplementationBodies`. Classify
                         // it as its own kind before the explicit-interface arm so it
                         // is not filed under Explicit Interface Implementations; the
-                        // MethodImpl still (correctly) suppresses its accessibility.
+                        // renderer suppresses its raw metadata accessibility.
                         _ when isFinalizer => "finalizer",
                         _ when isExplicitInterfaceImplementation => "explicit-interface-implementation",
                         _ => "method"

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -4997,7 +4997,11 @@ public static class ApiSurfaceExtractor
         FieldAttributes.Assembly => "internal",
         FieldAttributes.Family => "protected",
         FieldAttributes.FamORAssem => "protected internal",
-        _ => null // Public
+        FieldAttributes.Public => null,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(access),
+            access,
+            "Unknown field accessibility.")
     };
 
     sealed class TypeParameterConstraintResolution

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -741,6 +741,13 @@ public static class ApiSurfaceExtractor
             var accessorMethods = GetAccessorMethods(reader, typeDef);
             var canonicalAccessorMethods =
                 GetCanonicalAccessorMethods(reader, typeDef, observeDecodeWork);
+            var editorHiddenAggregateAccessorMethods = !includeAll
+                ? GetEditorBrowsableNeverAggregateAccessorMethods(
+                    reader,
+                    typeDef,
+                    canonicalAccessorMethods,
+                    observeDecodeWork)
+                : [];
             var hiddenAggregateAccessorMethods =
                 GetNonPublicAggregateAccessorMethods(reader, typeDef);
             var extensionPropertyImplementationMethods = isExtensionClass
@@ -773,6 +780,8 @@ public static class ApiSurfaceExtractor
                 }
                 // Skip compiler-generated methods (lambdas, state machines, etc.)
                 if (methodName.StartsWith("<"))
+                    continue;
+                if (editorHiddenAggregateAccessorMethods.Contains(methodHandle))
                     continue;
 
                 var isExplicitInterfaceImplementation =
@@ -1773,6 +1782,11 @@ public static class ApiSurfaceExtractor
             typeContext: typeContext);
         var accessorMethods = GetAccessorMethods(reader, typeDef);
         var canonicalAccessorMethods = GetCanonicalAccessorMethods(reader, typeDef);
+        var editorHiddenAggregateAccessorMethods =
+            GetEditorBrowsableNeverAggregateAccessorMethods(
+                reader,
+                typeDef,
+                canonicalAccessorMethods);
         var hiddenAggregateAccessorMethods =
             GetNonPublicAggregateAccessorMethods(reader, typeDef);
         var extensionPropertyImplementationMethods = isExtensionClass
@@ -1803,6 +1817,8 @@ public static class ApiSurfaceExtractor
             }
             string methodName = reader.GetString(method.Name);
             if (methodName.StartsWith('<'))
+                continue;
+            if (editorHiddenAggregateAccessorMethods.Contains(methodHandle))
                 continue;
 
             bool isExplicitImplementation =
@@ -3930,6 +3946,57 @@ public static class ApiSurfaceExtractor
             {
                 methods.Add(handle);
             }
+        }
+    }
+
+    internal static HashSet<MethodDefinitionHandle>
+        GetEditorBrowsableNeverAggregateAccessorMethods(
+            MetadataReader reader,
+            TypeDefinition type,
+            IReadOnlySet<MethodDefinitionHandle> canonicalAccessorMethods,
+            Action<int>? observeDecodeWork = null)
+    {
+        HashSet<MethodDefinitionHandle> methods = [];
+
+        foreach (var propertyHandle in type.GetProperties())
+        {
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            if (!AttributeReader.HasEditorBrowsableNeverAttribute(
+                    reader,
+                    property.GetCustomAttributes(),
+                    observeDecodeWork))
+            {
+                continue;
+            }
+
+            var accessors = property.GetAccessors();
+            AddIfCanonical(accessors.Getter);
+            AddIfCanonical(accessors.Setter);
+        }
+
+        foreach (var eventHandle in type.GetEvents())
+        {
+            var @event = reader.GetEventDefinition(eventHandle);
+            if (!AttributeReader.HasEditorBrowsableNeverAttribute(
+                    reader,
+                    @event.GetCustomAttributes(),
+                    observeDecodeWork))
+            {
+                continue;
+            }
+
+            var accessors = @event.GetAccessors();
+            AddIfCanonical(accessors.Adder);
+            AddIfCanonical(accessors.Remover);
+            AddIfCanonical(accessors.Raiser);
+        }
+
+        return methods;
+
+        void AddIfCanonical(MethodDefinitionHandle handle)
+        {
+            if (!handle.IsNil && canonicalAccessorMethods.Contains(handle))
+                methods.Add(handle);
         }
     }
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -474,6 +474,8 @@ public static class ApiSurfaceExtractor
         budget?.AdmitMetadataRows(reader);
         Action<string>? observeText =
             budget is null ? null : budget.ObservePendingText;
+        Action<string>? observeMethodImplementationText =
+            budget is null ? null : budget.ObservePendingProjectionText;
         var materializationContext = new AttributeDecoder.MaterializationContext(
             budget is null
                 ? static _ => { }
@@ -725,19 +727,15 @@ public static class ApiSurfaceExtractor
             {
             apiType.Members = [];
 
-            var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
             var explicitInterfaceIdentityProvider =
                 new ExplicitInterfaceTypeIdentityProvider(observeDecodeWork);
-            var explicitInterfaceImplementationTargets =
-                GetExplicitInterfaceImplementationTargets(
-                    reader,
-                    typeDef,
-                    explicitInterfaceIdentityProvider,
-                    observeDecodeWork,
-                    observeText,
-                    typeContext);
-            var explicitInterfaceImplementationBodies =
-                explicitInterfaceImplementationTargets.Keys.ToHashSet();
+            var methodImplementations = new MethodImplementationProjection(
+                reader,
+                typeDef,
+                explicitInterfaceIdentityProvider,
+                observeDecodeWork,
+                observeMethodImplementationText,
+                typeContext);
             bool isInterfaceTypeDefinition =
                 (typeDef.Attributes & TypeAttributes.Interface) != 0;
             var accessorMethods = GetAccessorMethods(reader, typeDef);
@@ -751,14 +749,6 @@ public static class ApiSurfaceExtractor
                     typeDef,
                     observeDecodeWork)
                 : [];
-
-            // Methods whose explicit `.override` MethodImpl targets
-            // `System.Object::Finalize` — i.e. genuine class finalizers, the
-            // slot the C# `~Type()` destructor compiles to.
-            var objectFinalizeOverrides = GetObjectFinalizeOverrides(
-                reader,
-                typeDef,
-                observeDecodeWork);
 
             // Methods
             foreach (var methodHandle in typeDef.GetMethods())
@@ -781,24 +771,34 @@ public static class ApiSurfaceExtractor
                             $"The method has an unknown accessibility value 0x{(int)methodAccess:X}."));
                     continue;
                 }
-                var isExplicitInterfaceImplementation = explicitImplementationBodies.Contains(methodHandle);
-                var isRetainedImplementationAccessor = isExplicitInterfaceImplementation
-                    && (methodName.Contains('.', StringComparison.Ordinal)
-                        || (explicitInterfaceImplementationBodies.Contains(methodHandle)
-                            && (!canonicalAccessorMethods.Contains(methodHandle)
-                                || (!includeAll
-                                    && hiddenAggregateAccessorMethods.Contains(methodHandle)))));
-                if (((accessorMethods.Contains(methodHandle)
-                            && canonicalAccessorMethods.Contains(methodHandle))
-                        || extensionPropertyImplementationMethods.Contains(methodHandle))
-                    && !isRetainedImplementationAccessor)
-                    continue;
+                var isExplicitInterfaceImplementation =
+                    methodImplementations.ContainsBody(methodHandle);
                 if (methodAccess != MethodAttributes.Public && !includeAll && !isExplicitInterfaceImplementation)
                     continue;
 
                 // Skip compiler-generated methods (lambdas, state machines, etc.)
                 if (methodName.StartsWith("<"))
                     continue;
+
+                bool isNormallySkippedAccessor =
+                    (accessorMethods.Contains(methodHandle)
+                        && canonicalAccessorMethods.Contains(methodHandle))
+                    || extensionPropertyImplementationMethods.Contains(methodHandle);
+                if (isNormallySkippedAccessor)
+                {
+                    bool canRetainStructuralImplementation =
+                        !canonicalAccessorMethods.Contains(methodHandle)
+                        || (!includeAll
+                            && hiddenAggregateAccessorMethods.Contains(methodHandle));
+                    bool isRetainedImplementationAccessor =
+                        isExplicitInterfaceImplementation
+                        && (methodName.Contains('.', StringComparison.Ordinal)
+                            || (canRetainStructuralImplementation
+                                && methodImplementations
+                                    .HasExplicitInterfaceTargets(methodHandle)));
+                    if (!isRetainedImplementationAccessor)
+                        continue;
+                }
 
                 // Skip EditorBrowsable(Never) methods unless --all; obsolete are surfaced with marker.
                 if (!includeAll
@@ -847,8 +847,7 @@ public static class ApiSurfaceExtractor
                 // `IFoo.Finalize()` implementation. There are two slot-anchored
                 // shapes:
                 //   * Roslyn (C#) emits an explicit `.override` MethodImpl
-                //     targeting `System.Object::Finalize`; `objectFinalizeOverrides`
-                //     carries those.
+                //     targeting `System.Object::Finalize`.
                 //   * The VB.NET compiler emits `Protected Overrides Sub Finalize()`
                 //     with NO MethodImpl — it reuses the inherited object.Finalize
                 //     slot implicitly; `IsImplicitObjectFinalizeOverride` proves
@@ -858,7 +857,7 @@ public static class ApiSurfaceExtractor
                 // rejected — rendering it `~Type()` would erase `<T>`.
                 var isFinalizer = apiType.Kind == "class"
                     && method.GetGenericParameters().Count == 0
-                    && (objectFinalizeOverrides.Contains(methodHandle)
+                    && (methodImplementations.OverridesObjectFinalize(methodHandle)
                         || IsImplicitObjectFinalizeOverride(
                             reader,
                             typeDefHandle,
@@ -874,7 +873,7 @@ public static class ApiSurfaceExtractor
                         _ when isOperator => "operator",
                         // A finalizer compiles to a `Finalize` method carrying an
                         // explicit `.override System.Object::Finalize` MethodImpl,
-                        // so it also lands in `explicitImplementationBodies`. Classify
+                        // so it is also an explicit MethodImpl body. Classify
                         // it as its own kind before the explicit-interface arm so it
                         // is not filed under Explicit Interface Implementations; the
                         // renderer suppresses its raw metadata accessibility.
@@ -930,6 +929,18 @@ public static class ApiSurfaceExtractor
                 }
 
                 budget?.RetainMember(member);
+                if (isExplicitInterfaceImplementation)
+                {
+                    if (accessorMethods.Contains(methodHandle)
+                        || extensionPropertyImplementationMethods.Contains(methodHandle))
+                    {
+                        methodImplementations.GetExplicitInterfaceTargets(methodHandle);
+                    }
+                    else
+                    {
+                        methodImplementations.ValidateExplicitInterfaceTargets(methodHandle);
+                    }
+                }
                 apiType.Members.Add(member);
                 surface.PublicMethodCount++;
             }
@@ -1101,7 +1112,7 @@ public static class ApiSurfaceExtractor
                     observeDecodeWork);
                 bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
                     propertyName,
-                    explicitInterfaceImplementationTargets,
+                    methodImplementations,
                     (accessors.Getter, "get_"),
                     (accessors.Setter, "set_"));
                 if (isExplicitInterfaceImplementation
@@ -1581,7 +1592,7 @@ public static class ApiSurfaceExtractor
                     (accessors.Remover, "remove"));
                 bool isExplicitInterfaceImplementation = IsExplicitInterfaceAggregate(
                     eventName,
-                    explicitInterfaceImplementationTargets,
+                    methodImplementations,
                     (accessors.Adder, "add_"),
                     (accessors.Remover, "remove_"));
                 if (isExplicitInterfaceImplementation
@@ -1748,9 +1759,12 @@ public static class ApiSurfaceExtractor
         bool isExtensionClass,
         Dictionary<ApiMember, MetadataTypeDefinitionName> extensionReceiverDefinitions)
     {
-        var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
-        var explicitInterfaceImplementationBodies =
-            GetExplicitInterfaceImplementationTargets(reader, typeDef).Keys.ToHashSet();
+        var explicitInterfaceIdentityProvider =
+            new ExplicitInterfaceTypeIdentityProvider();
+        var methodImplementations = new MethodImplementationProjection(
+            reader,
+            typeDef,
+            explicitInterfaceIdentityProvider);
         var accessorMethods = GetAccessorMethods(reader, typeDef);
         var canonicalAccessorMethods = GetCanonicalAccessorMethods(reader, typeDef);
         var hiddenAggregateAccessorMethods =
@@ -1765,22 +1779,32 @@ public static class ApiSurfaceExtractor
         {
             var method = reader.GetMethodDefinition(methodHandle);
             var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
-            bool isExplicitImplementation = explicitImplementationBodies.Contains(methodHandle);
+            bool isExplicitImplementation =
+                methodImplementations.ContainsBody(methodHandle);
             if (methodAccess != MethodAttributes.Public && !isExplicitImplementation)
                 continue;
             string methodName = reader.GetString(method.Name);
-            var isRetainedImplementationAccessor = isExplicitImplementation
-                && (methodName.Contains('.', StringComparison.Ordinal)
-                    || (explicitInterfaceImplementationBodies.Contains(methodHandle)
-                        && (!canonicalAccessorMethods.Contains(methodHandle)
-                            || hiddenAggregateAccessorMethods.Contains(methodHandle))));
-            if (((accessorMethods.Contains(methodHandle)
-                        && canonicalAccessorMethods.Contains(methodHandle))
-                    || extensionPropertyImplementationMethods.Contains(methodHandle))
-                && !isRetainedImplementationAccessor)
-                continue;
             if (methodName.StartsWith('<'))
                 continue;
+
+            bool isNormallySkippedAccessor =
+                (accessorMethods.Contains(methodHandle)
+                    && canonicalAccessorMethods.Contains(methodHandle))
+                || extensionPropertyImplementationMethods.Contains(methodHandle);
+            if (isNormallySkippedAccessor)
+            {
+                bool canRetainStructuralImplementation =
+                    !canonicalAccessorMethods.Contains(methodHandle)
+                    || hiddenAggregateAccessorMethods.Contains(methodHandle);
+                bool isRetainedImplementationAccessor =
+                    isExplicitImplementation
+                    && (methodName.Contains('.', StringComparison.Ordinal)
+                        || (canRetainStructuralImplementation
+                            && methodImplementations
+                                .HasExplicitInterfaceTargets(methodHandle)));
+                if (!isRetainedImplementationAccessor)
+                    continue;
+            }
 
             if (!isExplicitImplementation
                 && AttributeReader.HasEditorBrowsableNeverAttribute(reader, method.GetCustomAttributes()))
@@ -1813,6 +1837,19 @@ public static class ApiSurfaceExtractor
                 member.Signature = token.ToString("X8", CultureInfo.InvariantCulture);
             }
 
+            if (isExplicitImplementation)
+            {
+                if (accessorMethods.Contains(methodHandle)
+                    || extensionPropertyImplementationMethods.Contains(methodHandle))
+                {
+                    methodImplementations.GetExplicitInterfaceTargets(methodHandle);
+                }
+                else
+                {
+                    methodImplementations.ValidateExplicitInterfaceTargets(methodHandle);
+                }
+            }
+
             apiType.Members.Add(member);
             surface.PublicMethodCount++;
         }
@@ -1841,9 +1878,15 @@ public static class ApiSurfaceExtractor
                 continue;
             }
 
+            string propertyName = reader.GetString(property.Name);
+            IsExplicitInterfaceAggregate(
+                propertyName,
+                methodImplementations,
+                (accessors.Getter, "get_"),
+                (accessors.Setter, "set_"));
             apiType.Members.Add(new ApiMember
             {
-                Name = reader.GetString(property.Name),
+                Name = propertyName,
                 Kind = "property"
             });
             surface.PublicPropertyCount++;
@@ -1880,9 +1923,15 @@ public static class ApiSurfaceExtractor
                 continue;
             }
 
+            string eventName = reader.GetString(evt.Name);
+            IsExplicitInterfaceAggregate(
+                eventName,
+                methodImplementations,
+                (accessors.Adder, "add_"),
+                (accessors.Remover, "remove_"));
             apiType.Members.Add(new ApiMember
             {
-                Name = reader.GetString(evt.Name),
+                Name = eventName,
                 Kind = "event"
             });
             surface.PublicEventCount++;
@@ -2250,15 +2299,196 @@ public static class ApiSurfaceExtractor
     }
 
     /// <summary>
+    /// Indexes MethodImpl rows without decoding their structural targets, then projects one
+    /// admitted body on demand. Aggregate/accessor targets are cached for later classification;
+    /// ordinary admitted methods are validated without retaining their target graph.
+    /// </summary>
+    private sealed class MethodImplementationProjection
+    {
+        readonly MetadataReader reader;
+        readonly TypeDefinition typeDefinition;
+        readonly ExplicitInterfaceTypeIdentityProvider identityProvider;
+        readonly Action<int>? observeDecodeWork;
+        readonly Action<string>? observeProjectionText;
+        readonly GenericContext typeContext;
+        readonly Dictionary<MethodDefinitionHandle, List<EntityHandle>> declarationsByBody = [];
+        readonly Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
+            explicitInterfaceTargets = [];
+        readonly Dictionary<MethodDefinitionHandle, bool> objectFinalizeOverrides = [];
+        readonly HashSet<MethodDefinitionHandle> validatedBodies = [];
+        HashSet<string>? implementedInterfaces;
+
+        public MethodImplementationProjection(
+            MetadataReader reader,
+            TypeDefinition typeDefinition,
+            ExplicitInterfaceTypeIdentityProvider identityProvider,
+            Action<int>? observeDecodeWork = null,
+            Action<string>? observeProjectionText = null,
+            GenericContext? typeContext = null)
+        {
+            this.reader = reader;
+            this.typeDefinition = typeDefinition;
+            this.identityProvider = identityProvider;
+            this.observeDecodeWork = observeDecodeWork;
+            this.observeProjectionText = observeProjectionText;
+            this.typeContext =
+                typeContext
+                ?? GenericContext.ForType(
+                    reader,
+                    typeDefinition,
+                    observeDecodeWork);
+
+            foreach (var implementationHandle in typeDefinition.GetMethodImplementations())
+            {
+                var implementation =
+                    reader.GetMethodImplementation(implementationHandle);
+                if (implementation.MethodBody.Kind != HandleKind.MethodDefinition)
+                    continue;
+
+                var body = (MethodDefinitionHandle)implementation.MethodBody;
+                if (!declarationsByBody.TryGetValue(body, out var declarations))
+                {
+                    declarations = [];
+                    declarationsByBody.Add(body, declarations);
+                }
+                declarations.Add(implementation.MethodDeclaration);
+            }
+        }
+
+        public IEnumerable<MethodDefinitionHandle> Bodies =>
+            declarationsByBody.Keys;
+
+        public bool ContainsBody(MethodDefinitionHandle body) =>
+            declarationsByBody.ContainsKey(body);
+
+        public bool HasExplicitInterfaceTargets(MethodDefinitionHandle body) =>
+            GetExplicitInterfaceTargets(body).Count > 0;
+
+        public List<ExplicitInterfaceMethodTarget> GetExplicitInterfaceTargets(
+            MethodDefinitionHandle body)
+        {
+            if (explicitInterfaceTargets.TryGetValue(body, out var cached))
+                return cached;
+
+            List<ExplicitInterfaceMethodTarget> targets = [];
+            explicitInterfaceTargets.Add(body, targets);
+            if (!declarationsByBody.TryGetValue(body, out var declarations))
+                return targets;
+
+            IReadOnlySet<string> interfaces = GetImplementedInterfaces();
+            foreach (EntityHandle declaration in declarations)
+            {
+                if (!TryGetInterfaceMethodDeclaration(
+                        reader,
+                        body,
+                        declaration,
+                        interfaces,
+                        typeContext,
+                        identityProvider,
+                        observeDecodeWork,
+                        out var target))
+                {
+                    continue;
+                }
+
+                ObserveTarget(target);
+                targets.Add(target);
+            }
+
+            return targets;
+        }
+
+        public void ValidateExplicitInterfaceTargets(MethodDefinitionHandle body)
+        {
+            if (explicitInterfaceTargets.ContainsKey(body)
+                || !validatedBodies.Add(body)
+                || !declarationsByBody.TryGetValue(body, out var declarations))
+            {
+                return;
+            }
+
+            IReadOnlySet<string> interfaces = GetImplementedInterfaces();
+            foreach (EntityHandle declaration in declarations)
+            {
+                if (TryGetInterfaceMethodDeclaration(
+                        reader,
+                        body,
+                        declaration,
+                        interfaces,
+                        typeContext,
+                        identityProvider,
+                        observeDecodeWork,
+                        out var target))
+                {
+                    ObserveTarget(target);
+                }
+            }
+        }
+
+        public bool OverridesObjectFinalize(MethodDefinitionHandle body)
+        {
+            if (objectFinalizeOverrides.TryGetValue(body, out bool cached))
+                return cached;
+
+            bool result =
+                declarationsByBody.TryGetValue(body, out var declarations)
+                && declarations.Any(declaration =>
+                    ReferencesObjectFinalize(
+                        reader,
+                        declaration,
+                        observeDecodeWork));
+            objectFinalizeOverrides.Add(body, result);
+            return result;
+        }
+
+        HashSet<string> GetImplementedInterfaces()
+        {
+            if (implementedInterfaces is not null)
+                return implementedInterfaces;
+
+            implementedInterfaces = [];
+            foreach (var interfaceHandle
+                in typeDefinition.GetInterfaceImplementations())
+            {
+                var interfaceType =
+                    reader.GetInterfaceImplementation(interfaceHandle).Interface;
+                var interfaceIdentity = identityProvider.FromHandle(
+                    reader,
+                    interfaceType,
+                    typeContext);
+                if (interfaceIdentity.IsDegraded)
+                {
+                    throw new BadImageFormatException(
+                        "The implemented interface identity could not be decoded.");
+                }
+                observeProjectionText?.Invoke(interfaceIdentity.Key);
+                implementedInterfaces.Add(interfaceIdentity.Key);
+            }
+
+            return implementedInterfaces;
+        }
+
+        void ObserveTarget(ExplicitInterfaceMethodTarget target)
+        {
+            observeProjectionText?.Invoke(target.MethodName);
+            observeProjectionText?.Invoke(target.InterfaceType.Key);
+            observeProjectionText?.Invoke(target.InterfaceType.MetadataName);
+            if (target.InterfaceType.AggregateAliasName is { } alias)
+                observeProjectionText?.Invoke(alias);
+        }
+    }
+
+    /// <summary>
     /// Projects this type's explicit-interface MethodImpl rows, keyed by the implementing
     /// method body.
     /// </summary>
     /// <remarks>
-    /// Every row this walks decodes an interface identity and two method signatures, so the
+    /// Every projected row decodes an interface identity and two method signatures, so the
     /// projection charges the same decode-work observer the rest of the extraction uses and
-    /// charges the strings it retains against the retained-text observer. A bounded extraction
-    /// therefore cannot be made to do unbounded MethodImpl work before its first member is
-    /// admitted; a <see langword="null"/> observer leaves the unbounded query paths unchanged.
+    /// charges the strings it retains against the retained-text observer. API extraction uses
+    /// the same projection lazily after a member passes its scope filters; this eager helper is
+    /// retained for focused type queries and tests. A <see langword="null"/> observer leaves the
+    /// unbounded query paths unchanged.
     /// Gated by <c>ApiSurfaceExtractorBoundsTests.ExplicitInterfaceProjection_SpendsDecodeWorkBudget</c>.
     /// </remarks>
     internal static Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
@@ -2270,50 +2500,21 @@ public static class ApiSurfaceExtractor
             Action<string>? observeText = null,
             GenericContext? typeContext = null)
     {
-        var context = typeContext ?? GenericContext.ForType(reader, typeDef, observeDecodeWork);
         identityProvider ??= new ExplicitInterfaceTypeIdentityProvider(observeDecodeWork);
-        HashSet<string> implementedInterfaces = [];
-        foreach (var interfaceHandle in typeDef.GetInterfaceImplementations())
-        {
-            var interfaceType = reader.GetInterfaceImplementation(interfaceHandle).Interface;
-            var interfaceIdentity = identityProvider.FromHandle(
-                reader,
-                interfaceType,
-                context);
-            if (interfaceIdentity.IsDegraded)
-                throw new BadImageFormatException("The implemented interface identity could not be decoded.");
-            observeText?.Invoke(interfaceIdentity.Key);
-            implementedInterfaces.Add(interfaceIdentity.Key);
-        }
-
+        var projection = new MethodImplementationProjection(
+            reader,
+            typeDef,
+            identityProvider,
+            observeDecodeWork,
+            observeText,
+            typeContext);
         Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>> targets = [];
-        foreach (var implementationHandle in typeDef.GetMethodImplementations())
+        foreach (MethodDefinitionHandle body in projection.Bodies)
         {
-            var implementation = reader.GetMethodImplementation(implementationHandle);
-            if (implementation.MethodBody.Kind == HandleKind.MethodDefinition
-                && TryGetInterfaceMethodDeclaration(
-                    reader,
-                    (MethodDefinitionHandle)implementation.MethodBody,
-                    implementation.MethodDeclaration,
-                    implementedInterfaces,
-                    context,
-                    identityProvider,
-                    observeDecodeWork,
-                    out var target))
-            {
-                var body = (MethodDefinitionHandle)implementation.MethodBody;
-                if (!targets.TryGetValue(body, out var bodyTargets))
-                {
-                    bodyTargets = [];
-                    targets.Add(body, bodyTargets);
-                }
-                observeText?.Invoke(target.MethodName);
-                observeText?.Invoke(target.InterfaceType.Key);
-                observeText?.Invoke(target.InterfaceType.MetadataName);
-                if (target.InterfaceType.AggregateAliasName is { } alias)
-                    observeText?.Invoke(alias);
-                bodyTargets.Add(target);
-            }
+            List<ExplicitInterfaceMethodTarget> bodyTargets =
+                projection.GetExplicitInterfaceTargets(body);
+            if (bodyTargets.Count > 0)
+                targets.Add(body, bodyTargets);
         }
 
         return targets;
@@ -2323,6 +2524,29 @@ public static class ApiSurfaceExtractor
         string name,
         IReadOnlyDictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
             explicitInterfaceImplementationTargets,
+        params (MethodDefinitionHandle Handle, string DeclarationPrefix)[] accessors)
+        => IsExplicitInterfaceAggregate(
+            name,
+            handle => explicitInterfaceImplementationTargets.TryGetValue(
+                handle,
+                out var targets)
+                    ? targets
+                    : null,
+            accessors);
+
+    private static bool IsExplicitInterfaceAggregate(
+        string name,
+        MethodImplementationProjection methodImplementations,
+        params (MethodDefinitionHandle Handle, string DeclarationPrefix)[] accessors)
+        => IsExplicitInterfaceAggregate(
+            name,
+            handle => methodImplementations.GetExplicitInterfaceTargets(handle),
+            accessors);
+
+    private static bool IsExplicitInterfaceAggregate(
+        string name,
+        Func<MethodDefinitionHandle, IReadOnlyList<ExplicitInterfaceMethodTarget>?>
+            getTargets,
         params (MethodDefinitionHandle Handle, string DeclarationPrefix)[] accessors)
     {
         int separator = name.LastIndexOf('.');
@@ -2342,12 +2566,10 @@ public static class ApiSurfaceExtractor
             if (accessor.Handle.IsNil)
                 continue;
             hasAccessor = true;
-            if (!explicitInterfaceImplementationTargets.TryGetValue(
-                    accessor.Handle,
-                    out var targets))
-            {
+            IReadOnlyList<ExplicitInterfaceMethodTarget>? targets =
+                getTargets(accessor.Handle);
+            if (targets is null || targets.Count == 0)
                 return false;
-            }
 
             var matchingKeys = targets
                 .Where(target =>
@@ -2727,36 +2949,6 @@ public static class ApiSurfaceExtractor
             && left.ParameterTypes
                 .Select(parameter => parameter.Key)
                 .SequenceEqual(right.ParameterTypes.Select(parameter => parameter.Key));
-
-    /// <summary>
-    /// The set of methods on <paramref name="typeDef"/> whose explicit
-    /// <c>.override</c> MethodImpl targets <c>System.Object::Finalize</c> — the
-    /// slot a C# <c>~Type()</c> destructor compiles to. Keying on the overridden
-    /// declaration (not the method's own name/slot/signature) is what lets the
-    /// C# writer spell <c>~Type()</c> for real finalizers while excluding a
-    /// same-named override of an unrelated <c>Finalize</c> slot or an explicit
-    /// interface implementation.
-    /// </summary>
-    private static HashSet<MethodDefinitionHandle> GetObjectFinalizeOverrides(
-        MetadataReader reader,
-        TypeDefinition typeDef,
-        Action<int>? beforeDecodeWork = null)
-    {
-        HashSet<MethodDefinitionHandle> handles = [];
-        foreach (var implementationHandle in typeDef.GetMethodImplementations())
-        {
-            var implementation = reader.GetMethodImplementation(implementationHandle);
-            if (implementation.MethodBody.Kind != HandleKind.MethodDefinition)
-                continue;
-            if (ReferencesObjectFinalize(
-                    reader,
-                    implementation.MethodDeclaration,
-                    beforeDecodeWork))
-                handles.Add((MethodDefinitionHandle)implementation.MethodBody);
-        }
-
-        return handles;
-    }
 
     /// <summary>
     /// True when <paramref name="methodHandle"/> is a C# destructor / VB finalizer: a non-generic
@@ -4807,7 +4999,7 @@ public static class ApiSurfaceExtractor
             kind => kind switch
             {
                 "get" => accessors.Getter,
-                "set" => accessors.Setter,
+                "set" or "init" => accessors.Setter,
                 _ => default,
             },
             typeNodeProvider,
@@ -5644,7 +5836,10 @@ public static class ApiSurfaceExtractor
     /// </summary>
     /// <remarks>
     /// Members and retained text are counted as they are built but committed only when their type
-    /// is, so a rejected type spends no retention budget. The exact retained total is gated by
+    /// is, so a rejected type spends no retention budget. Structural MethodImpl text projected
+    /// for admitted members likewise earns cumulative decode-work credit only when its owning type
+    /// commits; it does not inflate the reported retained-output total, and pending projection
+    /// cannot finance its own decode. The exact retained total is gated by
     /// <c>ApiSurfaceExtractorBoundsTests.RetainedTextBudget_IsExact</c>. A separate monotonic
     /// extraction-wide decode-work estimate may reject allocation-amplifying input before its
     /// expanded model exists; the hostile-shape allocation tests in that class gate that safety
@@ -5666,6 +5861,8 @@ public static class ApiSurfaceExtractor
         int _retainedTextCharacters;
         int _pendingTextCharacters;
         int _pendingObservedTextCharacters;
+        int _pendingProjectionTextCharacters;
+        long _committedProjectionTextCharacters;
         long _decodeWork;
 
         public int MetadataRows { get; private set; }
@@ -5692,6 +5889,7 @@ public static class ApiSurfaceExtractor
             _pendingMembers = 0;
             _pendingTextCharacters = 0;
             _pendingObservedTextCharacters = 0;
+            _pendingProjectionTextCharacters = 0;
         }
 
         /// <summary>Admits a retained type before its model or members are built.</summary>
@@ -5719,9 +5917,11 @@ public static class ApiSurfaceExtractor
             _types++;
             _members += _pendingMembers;
             _retainedTextCharacters += _pendingTextCharacters;
+            _committedProjectionTextCharacters += _pendingProjectionTextCharacters;
             _pendingMembers = 0;
             _pendingTextCharacters = 0;
             _pendingObservedTextCharacters = 0;
+            _pendingProjectionTextCharacters = 0;
         }
 
         /// <summary>Counts one member attached to a type that is already committed.</summary>
@@ -5782,7 +5982,9 @@ public static class ApiSurfaceExtractor
             long next =
                 (long)encodedCharacters * DecodeWorkWeight + _decodeWork;
             long creditedCharacters =
-                (long)_retainedTextCharacters + _pendingTextCharacters;
+                (long)_retainedTextCharacters
+                + _pendingTextCharacters
+                + _committedProjectionTextCharacters;
             long limit =
                 MinimumDecodeWorkLimit
                 + creditedCharacters * RetainedTextDecodeWorkCreditWeight;
@@ -5792,6 +5994,27 @@ public static class ApiSurfaceExtractor
                     ApiSurfaceExtractionBound.RetainedTextCharacters);
             }
             _decodeWork = next;
+        }
+
+        /// <summary>
+        /// Accounts structural text projected for an admitted MethodImpl body. It can earn
+        /// decode-work credit only after the owning type commits, so one hostile candidate cannot
+        /// finance its own expansion.
+        /// </summary>
+        public void ObservePendingProjectionText(string text)
+        {
+            ArgumentNullException.ThrowIfNull(text);
+            long next = (long)text.Length + _pendingProjectionTextCharacters;
+            long pendingTotal = next + _pendingTextCharacters;
+            if (pendingTotal
+                    > bounds.MaxRetainedTextCharacters - _retainedTextCharacters
+                || next < 0
+                || pendingTotal < 0)
+            {
+                throw new ExtractionBoundExceededException(
+                    ApiSurfaceExtractionBound.RetainedTextCharacters);
+            }
+            _pendingProjectionTextCharacters = (int)next;
         }
 
         void RetainPendingText(long characters)

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -786,6 +786,11 @@ public static class ApiSurfaceExtractor
 
                 var isExplicitInterfaceImplementation =
                     methodImplementations.HasExplicitInterfaceTargets(methodHandle);
+                bool canUseImplicitInterfaceSyntax =
+                    methodImplementations.CanUseImplicitInterfaceSyntax(
+                        methodHandle,
+                        methodName,
+                        methodAccess);
                 var isFinalizer = apiType.Kind == "class"
                     && method.GetGenericParameters().Count == 0
                     && string.Equals(methodName, "Finalize", StringComparison.Ordinal)
@@ -901,6 +906,8 @@ public static class ApiSurfaceExtractor
                     IsFinalizer = isFinalizer,
                     IsExplicitInterfaceImplementation =
                         isExplicitInterfaceImplementation,
+                    CanUseImplicitInterfaceSyntax =
+                        canUseImplicitInterfaceSyntax,
                     Signature = signature.Text,
                     SignatureModel = signature.Model,
                     SignatureDecodeStatus = signature.IsDegraded
@@ -1827,6 +1834,11 @@ public static class ApiSurfaceExtractor
 
             bool isExplicitImplementation =
                 methodImplementations.HasExplicitInterfaceTargets(methodHandle);
+            bool canUseImplicitInterfaceSyntax =
+                methodImplementations.CanUseImplicitInterfaceSyntax(
+                    methodHandle,
+                    methodName,
+                    methodAccess);
             bool isFinalizer = method.GetGenericParameters().Count == 0
                 && string.Equals(methodName, "Finalize", StringComparison.Ordinal)
                 && apiType.Kind == "class"
@@ -1876,6 +1888,8 @@ public static class ApiSurfaceExtractor
                 IsStatic = (method.Attributes & MethodAttributes.Static) != 0,
                 IsFinalizer = isFinalizer,
                 IsExplicitInterfaceImplementation = isExplicitImplementation,
+                CanUseImplicitInterfaceSyntax =
+                    canUseImplicitInterfaceSyntax,
                 Accessibility = methodAccessibility
             };
             if (isExtensionClass
@@ -2644,6 +2658,23 @@ public static class ApiSurfaceExtractor
 
         public bool HasExplicitInterfaceTargets(MethodDefinitionHandle body) =>
             GetExplicitInterfaceTargets(body).Count > 0;
+
+        public bool CanUseImplicitInterfaceSyntax(
+            MethodDefinitionHandle body,
+            string bodyName,
+            MethodAttributes bodyAccess)
+        {
+            List<ExplicitInterfaceMethodTarget> targets =
+                GetExplicitInterfaceTargets(body);
+            return targets.Count > 0
+                && bodyAccess == MethodAttributes.Public
+                && !bodyName.Contains('.', StringComparison.Ordinal)
+                && targets.All(target =>
+                    string.Equals(
+                        target.MethodName,
+                        bodyName,
+                        StringComparison.Ordinal));
+        }
 
         public List<ExplicitInterfaceMethodTarget> GetExplicitInterfaceTargets(
             MethodDefinitionHandle body)

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2374,6 +2374,7 @@ public static class ApiSurfaceExtractor
     /// </summary>
     private sealed class MethodImplementationProjection
     {
+        const int MethodImplementationRowWorkChars = 256;
         readonly MetadataReader reader;
         readonly TypeDefinition typeDefinition;
         readonly ExplicitInterfaceTypeIdentityProvider identityProvider;
@@ -2384,8 +2385,18 @@ public static class ApiSurfaceExtractor
         readonly Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
             explicitInterfaceTargets = [];
         readonly Dictionary<MethodDefinitionHandle, bool> objectFinalizeOverrides = [];
+        readonly Dictionary<MethodDefinitionHandle, MethodSignature<ExplicitInterfaceTypeIdentity>>
+            bodySignatures = [];
+        readonly Dictionary<MethodDefinitionHandle, MethodSignature<ExplicitInterfaceTypeIdentity>>
+            methodDefinitionSignatures = [];
+        readonly Dictionary<MemberReferenceSignatureCacheKey,
+            MethodSignature<ExplicitInterfaceTypeIdentity>> memberReferenceSignatures = [];
         readonly HashSet<MethodDefinitionHandle> validatedBodies = [];
         HashSet<string>? implementedInterfaces;
+
+        readonly record struct MemberReferenceSignatureCacheKey(
+            BlobHandle Signature,
+            ExplicitInterfaceSignatureContext Context);
 
         public MethodImplementationProjection(
             MetadataReader reader,
@@ -2442,16 +2453,20 @@ public static class ApiSurfaceExtractor
                 return targets;
 
             IReadOnlySet<string> interfaces = GetImplementedInterfaces();
+            MethodSignature<ExplicitInterfaceTypeIdentity> bodySignature =
+                GetBodySignature(body);
             foreach (EntityHandle declaration in declarations)
             {
+                identityProvider.ObserveWork(MethodImplementationRowWorkChars);
                 if (!TryGetInterfaceMethodDeclaration(
                         reader,
-                        body,
+                        bodySignature,
                         declaration,
                         interfaces,
                         typeContext,
                         identityProvider,
                         observeDecodeWork,
+                        GetDeclarationSignature,
                         out var target))
                 {
                     continue;
@@ -2474,16 +2489,20 @@ public static class ApiSurfaceExtractor
             }
 
             IReadOnlySet<string> interfaces = GetImplementedInterfaces();
+            MethodSignature<ExplicitInterfaceTypeIdentity> bodySignature =
+                GetBodySignature(body);
             foreach (EntityHandle declaration in declarations)
             {
+                identityProvider.ObserveWork(MethodImplementationRowWorkChars);
                 if (TryGetInterfaceMethodDeclaration(
                         reader,
-                        body,
+                        bodySignature,
                         declaration,
                         interfaces,
                         typeContext,
                         identityProvider,
                         observeDecodeWork,
+                        GetDeclarationSignature,
                         out var target))
                 {
                     ObserveTarget(target);
@@ -2508,6 +2527,106 @@ public static class ApiSurfaceExtractor
                         observeDecodeWork));
             objectFinalizeOverrides.Add(body, result);
             return result;
+        }
+
+        MethodSignature<ExplicitInterfaceTypeIdentity> GetBodySignature(
+            MethodDefinitionHandle bodyHandle)
+        {
+            if (bodySignatures.TryGetValue(bodyHandle, out var cached))
+                return cached;
+
+            var body = reader.GetMethodDefinition(bodyHandle);
+            var result = GuardedProviderDecode.MethodResult(
+                reader,
+                body,
+                identityProvider,
+                ExplicitInterfaceSignatureContext.Open(
+                    GenericContext.ForMethod(
+                        reader,
+                        typeContext,
+                        body,
+                        observeDecodeWork)),
+                DegradedExplicitInterfaceType);
+            if (result.IsDegraded || HasDegradedType(result.Value))
+            {
+                throw new BadImageFormatException(
+                    "The MethodImpl body signature could not be decoded.");
+            }
+
+            bodySignatures.Add(bodyHandle, result.Value);
+            return result.Value;
+        }
+
+        MethodSignature<ExplicitInterfaceTypeIdentity> GetDeclarationSignature(
+            EntityHandle declaration,
+            ExplicitInterfaceTypeIdentity declaringTypeIdentity)
+        {
+            switch (declaration.Kind)
+            {
+                case HandleKind.MethodDefinition:
+                    var handle = (MethodDefinitionHandle)declaration;
+                    if (methodDefinitionSignatures.TryGetValue(handle, out var cachedMethod))
+                        return cachedMethod;
+
+                    var method = reader.GetMethodDefinition(handle);
+                    var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
+                    var methodResult = GuardedProviderDecode.MethodResult(
+                        reader,
+                        method,
+                        identityProvider,
+                        ExplicitInterfaceSignatureContext.Open(
+                            GenericContext.ForMethod(
+                                reader,
+                                GenericContext.ForType(
+                                    reader,
+                                    declaringType,
+                                    observeDecodeWork),
+                                method,
+                                observeDecodeWork)),
+                        DegradedExplicitInterfaceType);
+                    if (methodResult.IsDegraded || HasDegradedType(methodResult.Value))
+                    {
+                        throw new BadImageFormatException(
+                            "The MethodImpl declaration signature could not be decoded.");
+                    }
+
+                    methodDefinitionSignatures.Add(handle, methodResult.Value);
+                    return methodResult.Value;
+
+                case HandleKind.MemberReference:
+                    var member = reader.GetMemberReference(
+                        (MemberReferenceHandle)declaration);
+                    var context = ExplicitInterfaceSignatureContext
+                        .Open(typeContext)
+                        .WithTypeArguments(
+                            declaringTypeIdentity.GenericArguments,
+                            declaringTypeIdentity.GenericArity);
+                    var key = new MemberReferenceSignatureCacheKey(
+                        member.Signature,
+                        context);
+                    if (memberReferenceSignatures.TryGetValue(key, out var cachedReference))
+                        return cachedReference;
+
+                    MethodSignature<ExplicitInterfaceTypeIdentity> signature =
+                        GuardedProviderDecode.MemberRefMethod(
+                            reader,
+                            member,
+                            identityProvider,
+                            context,
+                            DegradedExplicitInterfaceType);
+                    if (HasDegradedType(signature))
+                    {
+                        throw new BadImageFormatException(
+                            "The MethodImpl declaration signature could not be decoded.");
+                    }
+
+                    memberReferenceSignatures.Add(key, signature);
+                    return signature;
+
+                default:
+                    throw new BadImageFormatException(
+                        "The MethodImpl declaration kind is unsupported.");
+            }
         }
 
         HashSet<string> GetImplementedInterfaces()
@@ -2861,12 +2980,14 @@ public static class ApiSurfaceExtractor
 
     private static bool TryGetInterfaceMethodDeclaration(
         MetadataReader reader,
-        MethodDefinitionHandle bodyHandle,
+        MethodSignature<ExplicitInterfaceTypeIdentity> bodySignature,
         EntityHandle declaration,
         IReadOnlySet<string> implementedInterfaces,
         GenericContext context,
         ExplicitInterfaceTypeIdentityProvider identityProvider,
         Action<int>? observeDecodeWork,
+        Func<EntityHandle, ExplicitInterfaceTypeIdentity,
+            MethodSignature<ExplicitInterfaceTypeIdentity>> getDeclarationSignature,
         out ExplicitInterfaceMethodTarget target)
     {
         target = default;
@@ -2902,13 +3023,10 @@ public static class ApiSurfaceExtractor
             throw new BadImageFormatException("The MethodImpl interface identity could not be decoded.");
         if (!implementedInterfaces.Contains(declaringTypeIdentity.Key)
             || !MethodImplSignaturesMatch(
-                reader,
-                bodyHandle,
+                bodySignature,
                 declaration,
                 declaringTypeIdentity,
-                context,
-                identityProvider,
-                observeDecodeWork))
+                getDeclarationSignature))
             return false;
 
         if (declaringTypeIdentity.IsInterface == false)
@@ -2929,80 +3047,15 @@ public static class ApiSurfaceExtractor
     }
 
     private static bool MethodImplSignaturesMatch(
-        MetadataReader reader,
-        MethodDefinitionHandle bodyHandle,
+        MethodSignature<ExplicitInterfaceTypeIdentity> bodySignature,
         EntityHandle declaration,
         ExplicitInterfaceTypeIdentity declaringTypeIdentity,
-        GenericContext typeContext,
-        ExplicitInterfaceTypeIdentityProvider identityProvider,
-        Action<int>? observeDecodeWork)
+        Func<EntityHandle, ExplicitInterfaceTypeIdentity,
+            MethodSignature<ExplicitInterfaceTypeIdentity>> getDeclarationSignature)
     {
-        var body = reader.GetMethodDefinition(bodyHandle);
-        var bodyResult = GuardedProviderDecode.MethodResult(
-            reader,
-            body,
-            identityProvider,
-            ExplicitInterfaceSignatureContext.Open(
-                GenericContext.ForMethod(reader, typeContext, body, observeDecodeWork)),
-            new ExplicitInterfaceTypeIdentity(
-                "<invalid>",
-                "<invalid>",
-                IsDegraded: true));
-        if (bodyResult.IsDegraded)
-            throw new BadImageFormatException("The MethodImpl body signature could not be decoded.");
-
-        MethodSignature<ExplicitInterfaceTypeIdentity> declarationSignature;
-        switch (declaration.Kind)
-        {
-            case HandleKind.MethodDefinition:
-                var method = reader.GetMethodDefinition((MethodDefinitionHandle)declaration);
-                var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
-                var declarationResult = GuardedProviderDecode.MethodResult(
-                    reader,
-                    method,
-                    identityProvider,
-                    ExplicitInterfaceSignatureContext.Open(
-                        GenericContext.ForMethod(
-                            reader,
-                            GenericContext.ForType(reader, declaringType, observeDecodeWork),
-                            method,
-                            observeDecodeWork)),
-                    new ExplicitInterfaceTypeIdentity(
-                        "<invalid>",
-                        "<invalid>",
-                        IsDegraded: true));
-                if (declarationResult.IsDegraded)
-                    throw new BadImageFormatException(
-                        "The MethodImpl declaration signature could not be decoded.");
-                declarationSignature = declarationResult.Value;
-                break;
-            case HandleKind.MemberReference:
-                var member = reader.GetMemberReference((MemberReferenceHandle)declaration);
-                declarationSignature = GuardedProviderDecode.MemberRefMethod(
-                    reader,
-                    member,
-                    identityProvider,
-                    ExplicitInterfaceSignatureContext
-                        .Open(typeContext)
-                        .WithTypeArguments(
-                            declaringTypeIdentity.GenericArguments,
-                            declaringTypeIdentity.GenericArity),
-                    new ExplicitInterfaceTypeIdentity(
-                        "<invalid>",
-                        "<invalid>",
-                        IsDegraded: true));
-                break;
-            default:
-                return false;
-        }
-
-        if (HasDegradedType(bodyResult.Value)
-            || HasDegradedType(declarationSignature))
-        {
-            throw new BadImageFormatException("The MethodImpl signature contains an unsupported type.");
-        }
-
-        return MethodSignaturesMatch(bodyResult.Value, declarationSignature);
+        MethodSignature<ExplicitInterfaceTypeIdentity> declarationSignature =
+            getDeclarationSignature(declaration, declaringTypeIdentity);
+        return MethodSignaturesMatch(bodySignature, declarationSignature);
     }
 
     private static bool HasDegradedType(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -236,6 +236,22 @@ public static class ApiSurfaceExtractor
         return true;
     }
 
+    internal static void ValidateTypeVisibility(
+        MetadataReader reader,
+        TypeDefinitionHandle handle)
+    {
+        try
+        {
+            _ = IsEffectivelyPublicType(reader, handle);
+        }
+        catch (MetadataRowRejectedException exception)
+        {
+            throw new BadImageFormatException(
+                exception.Failure.Detail,
+                exception);
+        }
+    }
+
     /// <summary>
     /// Extracts the public type identities and member-kind counts needed by the compact platform
     /// API view without materializing rich member models. Ordinary member signatures stay
@@ -1115,9 +1131,9 @@ public static class ApiSurfaceExtractor
                         propHandle,
                         MetadataTypeNameFailure.Malformed(
                             propHandle,
-                            abstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
-                                ? "The property has an abstract accessor that declares an IL body."
-                                : "The property has inconsistent abstract accessor metadata."));
+                            MetadataAccessorSemantics.AbstractionFailureDetail(
+                                "property",
+                                abstractionFault)));
                     continue;
                 }
                 if (!MetadataAccessorSemantics.HaveUniformMemberModifiers(
@@ -1570,9 +1586,9 @@ public static class ApiSurfaceExtractor
                         eventHandle,
                         MetadataTypeNameFailure.Malformed(
                             eventHandle,
-                            eventAbstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
-                                ? "The event has an abstract accessor that declares an IL body."
-                                : "The event has inconsistent abstract accessor metadata."));
+                            MetadataAccessorSemantics.AbstractionFailureDetail(
+                                "event",
+                                eventAbstractionFault)));
                     continue;
                 }
                 if (!MetadataAccessorSemantics.HaveUniformMemberModifiers(
@@ -2099,9 +2115,9 @@ public static class ApiSurfaceExtractor
                     propertyHandle,
                     MetadataTypeNameFailure.Malformed(
                         propertyHandle,
-                        abstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
-                            ? "The property has an abstract accessor that declares an IL body."
-                            : "The property has inconsistent abstract accessor metadata."));
+                        MetadataAccessorSemantics.AbstractionFailureDetail(
+                            "property",
+                            abstractionFault)));
                 continue;
             }
             if (!MetadataAccessorSemantics.HaveUniformMemberModifiers(
@@ -2298,9 +2314,9 @@ public static class ApiSurfaceExtractor
                     eventHandle,
                     MetadataTypeNameFailure.Malformed(
                         eventHandle,
-                        eventAbstractionFault == AccessorAbstractionFault.AbstractAccessorHasBody
-                            ? "The event has an abstract accessor that declares an IL body."
-                            : "The event has inconsistent abstract accessor metadata."));
+                        MetadataAccessorSemantics.AbstractionFailureDetail(
+                            "event",
+                            eventAbstractionFault)));
                 continue;
             }
             if (!MetadataAccessorSemantics.HaveUniformMemberModifiers(
@@ -6095,7 +6111,11 @@ public static class ApiSurfaceExtractor
         bool hasGetter = !accessors.Getter.IsNil;
         bool hasSetter = !accessors.Setter.IsNil;
         string setterKind = hasSetter
-            ? MetadataAccessorSemantics.Kind(reader, accessors.Setter, "set")
+            ? MetadataAccessorSemantics.Kind(
+                reader,
+                accessors.Setter,
+                "set",
+                beforeDecodeWork)
             : "set";
 
         if (hasGetter)
@@ -6325,7 +6345,11 @@ public static class ApiSurfaceExtractor
         var method = reader.GetMethodDefinition(handle);
         return new ApiAccessor
         {
-            Kind = MetadataAccessorSemantics.Kind(reader, handle, kind),
+            Kind = MetadataAccessorSemantics.Kind(
+                reader,
+                handle,
+                kind,
+                beforeDecodeWork),
             MethodName = DecodeString(reader, method.Name, beforeDecodeWork),
             Accessibility = GetAccessorAccessibility(method.Attributes),
             ReturnAttributes = ReturnParameterAttributes(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -899,6 +899,8 @@ public static class ApiSurfaceExtractor
                     IsOverride = isOverride,
                     IsSealed = isOverride && (methodAttributes & MethodAttributes.Final) != 0,
                     IsFinalizer = isFinalizer,
+                    IsExplicitInterfaceImplementation =
+                        isExplicitInterfaceImplementation,
                     Signature = signature.Text,
                     SignatureModel = signature.Model,
                     SignatureDecodeStatus = signature.IsDegraded
@@ -1000,8 +1002,9 @@ public static class ApiSurfaceExtractor
                     var setter = reader.GetMethodDefinition(accessors.Setter);
                     var setterAttributes = setter.Attributes;
                     var setterAccess = setterAttributes & MethodAttributes.MemberAccessMask;
-                    if (setterAccess > bestAccess)
-                        bestAccess = setterAccess;
+                    bestAccess = MetadataAccessibility.Join(
+                        bestAccess,
+                        setterAccess);
                     var setterVirtual = (setterAttributes & MethodAttributes.Virtual) != 0;
                     var setterOverride = setterVirtual && (setterAttributes & MethodAttributes.NewSlot) == 0;
                     isStaticProperty |= (setterAttributes & MethodAttributes.Static) != 0;
@@ -1422,8 +1425,9 @@ public static class ApiSurfaceExtractor
                         malformedAccessibility = true;
                         break;
                     }
-                    if (access > bestAccess)
-                        bestAccess = access;
+                    bestAccess = MetadataAccessibility.Join(
+                        bestAccess,
+                        access);
                 }
                 if (malformedAccessibility)
                     continue;
@@ -1937,8 +1941,9 @@ public static class ApiSurfaceExtractor
             {
                 var setterAccess = reader.GetMethodDefinition(accessors.Setter).Attributes
                     & MethodAttributes.MemberAccessMask;
-                if (setterAccess > bestAccess)
-                    bestAccess = setterAccess;
+                bestAccess = MetadataAccessibility.Join(
+                    bestAccess,
+                    setterAccess);
             }
             bool isAbstractProperty = MetadataAccessorSemantics.AreAllAbstract(
                 reader,
@@ -2100,8 +2105,9 @@ public static class ApiSurfaceExtractor
                     malformedAccess = access;
                     break;
                 }
-                if (access > bestAccess)
-                    bestAccess = access;
+                bestAccess = MetadataAccessibility.Join(
+                    bestAccess,
+                    access);
             }
 
             if (malformedAccessibility)
@@ -3878,8 +3884,7 @@ public static class ApiSurfaceExtractor
                     return;
                 var access = reader.GetMethodDefinition(handle).Attributes
                     & MethodAttributes.MemberAccessMask;
-                if (access > best)
-                    best = access;
+                best = MetadataAccessibility.Join(best, access);
             }
         }
 
@@ -5398,7 +5403,9 @@ public static class ApiSurfaceExtractor
             setterAccess = setter.Attributes & MethodAttributes.MemberAccessMask;
         }
 
-        int bestAccess = Math.Max((int)getterAccess, (int)setterAccess);
+        MethodAttributes bestAccess = MetadataAccessibility.Join(
+            getterAccess,
+            setterAccess);
         var accessorModels = new List<ApiAccessor>();
         var getStr = hasGetter ? FormatAccessor("get", getterAccess, bestAccess) : null;
         var setStr = hasSetter ? FormatAccessor(setterKind, setterAccess, bestAccess) : null;
@@ -5719,16 +5726,23 @@ public static class ApiSurfaceExtractor
     /// <summary>
     /// Formats a property accessor with its access level prefix when it differs from the property's overall level.
     /// </summary>
-    private static string FormatAccessor(string kind, MethodAttributes access, int bestAccess)
+    private static string FormatAccessor(
+        string kind,
+        MethodAttributes access,
+        MethodAttributes bestAccess)
     {
-        if ((int)access == bestAccess)
+        if (MetadataAccessibility.Equivalent(access, bestAccess))
             return kind;
         var prefix = GetAccessibility(access);
         return prefix != null ? $"{prefix} {kind}" : kind;
     }
 
-    private static string? AccessorAccessibility(MethodAttributes access, int bestAccess)
-        => (int)access == bestAccess ? null : GetAccessibility(access);
+    private static string? AccessorAccessibility(
+        MethodAttributes access,
+        MethodAttributes bestAccess)
+        => MetadataAccessibility.Equivalent(access, bestAccess)
+            ? null
+            : GetAccessibility(access);
 
     /// <summary>Gets the first parameter type for the lightweight extraction path.</summary>
     private static string? GetFirstParameterType(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -949,6 +949,7 @@ public static class ApiSurfaceExtractor
                 bool isAbstractProperty = false;
                 bool isOverrideProperty = false;
                 bool isSealedProperty = false;
+                bool hasFinalPropertyAccessor = false;
                 if (!accessors.Getter.IsNil)
                 {
                     var getter = reader.GetMethodDefinition(accessors.Getter);
@@ -959,6 +960,7 @@ public static class ApiSurfaceExtractor
                     isAbstractProperty = (getterAttributes & MethodAttributes.Abstract) != 0;
                     isOverrideProperty = isVirtualProperty && (getterAttributes & MethodAttributes.NewSlot) == 0;
                     isSealedProperty = isOverrideProperty && (getterAttributes & MethodAttributes.Final) != 0;
+                    hasFinalPropertyAccessor = (getterAttributes & MethodAttributes.Final) != 0;
                 }
                 if (!accessors.Setter.IsNil)
                 {
@@ -974,11 +976,35 @@ public static class ApiSurfaceExtractor
                     isAbstractProperty |= (setterAttributes & MethodAttributes.Abstract) != 0;
                     isOverrideProperty |= setterOverride;
                     isSealedProperty |= setterOverride && (setterAttributes & MethodAttributes.Final) != 0;
+                    hasFinalPropertyAccessor |= (setterAttributes & MethodAttributes.Final) != 0;
                 }
-                isAbstractProperty = MetadataAccessorSemantics.IsUniformlyAbstract(
+                isAbstractProperty = MetadataAccessorSemantics.AreAllAbstract(
                     reader,
                     accessors.Getter,
                     accessors.Setter);
+                if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
+                        reader,
+                        out isSealedProperty,
+                        accessors.Getter,
+                        accessors.Setter))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "property modifiers",
+                        propHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            propHandle,
+                            "The property has inconsistent sealed accessor metadata."));
+                    continue;
+                }
+                bool isCSharpVirtualProperty =
+                    apiType.Kind == "class"
+                    && !apiType.IsSealed
+                    && isVirtualProperty
+                    && !isAbstractProperty
+                    && !isOverrideProperty
+                    && !hasFinalPropertyAccessor;
 
                 if (!MetadataAccessibility.TryGet(bestAccess, out string? propertyAccessibility))
                 {
@@ -1060,7 +1086,7 @@ public static class ApiSurfaceExtractor
                         ? SignatureDecodeStatus.Degraded
                         : null,
                     IsStatic = isStaticProperty,
-                    IsVirtual = isVirtualProperty,
+                    IsVirtual = isCSharpVirtualProperty,
                     IsAbstract = isAbstractProperty,
                     IsOverride = isOverrideProperty,
                     IsSealed = isSealedProperty,
@@ -1403,10 +1429,49 @@ public static class ApiSurfaceExtractor
                         eventType = eventNode.Render();
                     }
                 }
-                var primaryAccessorAttributes = primaryAccessor.Attributes;
-                var isVirtualEvent = (primaryAccessorAttributes & MethodAttributes.Virtual) != 0;
-                var isOverrideEvent = isVirtualEvent
-                    && (primaryAccessorAttributes & MethodAttributes.NewSlot) == 0;
+                bool isStaticEvent = false;
+                bool isVirtualEvent = false;
+                bool isOverrideEvent = false;
+                bool hasFinalEventAccessor = false;
+                foreach (var accessorHandle in new[] { accessors.Adder, accessors.Remover })
+                {
+                    if (accessorHandle.IsNil)
+                        continue;
+                    var accessorAttributes = reader.GetMethodDefinition(accessorHandle).Attributes;
+                    bool accessorVirtual = (accessorAttributes & MethodAttributes.Virtual) != 0;
+                    isStaticEvent |= (accessorAttributes & MethodAttributes.Static) != 0;
+                    isVirtualEvent |= accessorVirtual;
+                    isOverrideEvent |= accessorVirtual
+                        && (accessorAttributes & MethodAttributes.NewSlot) == 0;
+                    hasFinalEventAccessor |= (accessorAttributes & MethodAttributes.Final) != 0;
+                }
+                bool isAbstractEvent = MetadataAccessorSemantics.AreAllAbstract(
+                    reader,
+                    accessors.Adder,
+                    accessors.Remover);
+                if (!MetadataAccessorSemantics.TryGetUniformSealedOverride(
+                        reader,
+                        out bool isSealedEvent,
+                        accessors.Adder,
+                        accessors.Remover))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "event modifiers",
+                        eventHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            eventHandle,
+                            "The event has inconsistent sealed accessor metadata."));
+                    continue;
+                }
+                bool isCSharpVirtualEvent =
+                    apiType.Kind == "class"
+                    && !apiType.IsSealed
+                    && isVirtualEvent
+                    && !isAbstractEvent
+                    && !isOverrideEvent
+                    && !hasFinalEventAccessor;
                 string eventName = DecodeString(
                     reader,
                     evt.Name,
@@ -1441,6 +1506,7 @@ public static class ApiSurfaceExtractor
                         HasMethodBody = remover.RelativeVirtualAddress != 0,
                         IsAbstract = (remover.Attributes & MethodAttributes.Abstract) != 0
                     });
+                }
                 var accessorFacts = AccessorFacts(
                     reader,
                     observeText,
@@ -1496,12 +1562,11 @@ public static class ApiSurfaceExtractor
                         Accessors = accessorModels
                     },
                     AccessorFacts = accessorFacts,
-                    IsStatic = (primaryAccessorAttributes & MethodAttributes.Static) != 0,
-                    IsVirtual = isVirtualEvent,
-                    IsAbstract = (primaryAccessorAttributes & MethodAttributes.Abstract) != 0,
+                    IsStatic = isStaticEvent,
+                    IsVirtual = isCSharpVirtualEvent,
+                    IsAbstract = isAbstractEvent,
                     IsOverride = isOverrideEvent,
-                    IsSealed = isOverrideEvent
-                        && (primaryAccessorAttributes & MethodAttributes.Final) != 0,
+                    IsSealed = isSealedEvent,
                     IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
                     IsUnsafe = HasUnsafeSignature(reader, evt, observeDecodeWork)
                         || AttributeReader.HasRequiresUnsafeAttribute(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2104,16 +2104,18 @@ public static class ApiSurfaceExtractor
             TypeDefinition typeDef)
     {
         var context = GenericContext.ForType(reader, typeDef);
+        var identityProvider = new ExplicitInterfaceTypeIdentityProvider();
         HashSet<string> implementedInterfaces = [];
         foreach (var interfaceHandle in typeDef.GetInterfaceImplementations())
         {
             var interfaceType = reader.GetInterfaceImplementation(interfaceHandle).Interface;
-            var interfaceIdentity = ExplicitInterfaceTypeIdentityProvider.FromHandle(
+            var interfaceIdentity = identityProvider.FromHandle(
                 reader,
                 interfaceType,
                 context);
-            if (!interfaceIdentity.IsDegraded)
-                implementedInterfaces.Add(interfaceIdentity.Key);
+            if (interfaceIdentity.IsDegraded)
+                throw new BadImageFormatException("The implemented interface identity could not be decoded.");
+            implementedInterfaces.Add(interfaceIdentity.Key);
         }
 
         Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>> targets = [];
@@ -2128,6 +2130,7 @@ public static class ApiSurfaceExtractor
                     implementation.MethodDeclaration,
                     implementedInterfaces,
                     context,
+                    identityProvider,
                     out var target))
             {
                 var body = (MethodDefinitionHandle)implementation.MethodBody;
@@ -2155,7 +2158,9 @@ public static class ApiSurfaceExtractor
 
         string interfaceName = name[..separator];
         string memberName = name[(separator + 1)..];
+        string declarationMemberName = memberName == "this[]" ? "Item" : memberName;
         bool hasAccessor = false;
+        HashSet<string>? commonInterfaceKeys = null;
         foreach (var accessor in accessors)
         {
             if (accessor.Handle.IsNil)
@@ -2163,16 +2168,30 @@ public static class ApiSurfaceExtractor
             hasAccessor = true;
             if (!explicitInterfaceImplementationTargets.TryGetValue(
                     accessor.Handle,
-                    out var targets)
-                || !targets.Any(target =>
-                    target.InterfaceType.MetadataName == interfaceName
-                    && target.MethodName == accessor.DeclarationPrefix + memberName))
+                    out var targets))
             {
                 return false;
             }
+
+            var matchingKeys = targets
+                .Where(target =>
+                    (target.InterfaceType.MetadataName == interfaceName
+                        || target.InterfaceType.AggregateAliasName == interfaceName)
+                    && target.MethodName
+                        == accessor.DeclarationPrefix + declarationMemberName)
+                .Select(target => target.InterfaceType.Key)
+                .ToHashSet(StringComparer.Ordinal);
+            if (matchingKeys.Count == 0)
+                return false;
+            if (commonInterfaceKeys is null)
+                commonInterfaceKeys = matchingKeys;
+            else
+                commonInterfaceKeys.IntersectWith(matchingKeys);
+            if (commonInterfaceKeys.Count == 0)
+                return false;
         }
 
-        return hasAccessor;
+        return hasAccessor && commonInterfaceKeys is { Count: > 0 };
     }
 
     private static bool TryGetInterfaceMethodDeclaration(
@@ -2182,6 +2201,7 @@ public static class ApiSurfaceExtractor
         EntityHandle declaration,
         IReadOnlySet<string> implementedInterfaces,
         GenericContext context,
+        ExplicitInterfaceTypeIdentityProvider identityProvider,
         out ExplicitInterfaceMethodTarget target)
     {
         target = default;
@@ -2205,18 +2225,20 @@ public static class ApiSurfaceExtractor
         if (methodName is null)
             return false;
 
-        var declaringTypeIdentity = ExplicitInterfaceTypeIdentityProvider.FromHandle(
+        var declaringTypeIdentity = identityProvider.FromHandle(
             reader,
             declaringType,
             context);
-        if (declaringTypeIdentity.IsDegraded
-            || !implementedInterfaces.Contains(declaringTypeIdentity.Key)
+        if (declaringTypeIdentity.IsDegraded)
+            throw new BadImageFormatException("The MethodImpl interface identity could not be decoded.");
+        if (!implementedInterfaces.Contains(declaringTypeIdentity.Key)
             || !MethodImplSignaturesMatch(
                 reader,
                 typeDef,
                 bodyHandle,
                 declaration,
-                context))
+                context,
+                identityProvider))
             return false;
 
         if (declaringType.Kind == HandleKind.TypeDefinition
@@ -2238,18 +2260,22 @@ public static class ApiSurfaceExtractor
         TypeDefinition typeDef,
         MethodDefinitionHandle bodyHandle,
         EntityHandle declaration,
-        GenericContext typeContext)
+        GenericContext typeContext,
+        ExplicitInterfaceTypeIdentityProvider identityProvider)
     {
         var body = reader.GetMethodDefinition(bodyHandle);
         var bodyResult = GuardedProviderDecode.MethodResult(
             reader,
             body,
-            ExplicitInterfaceTypeIdentityProvider.Instance,
+            identityProvider,
             ExplicitInterfaceSignatureContext.Open(
                 GenericContext.ForMethod(reader, typeDef, body)),
-            new ExplicitInterfaceTypeIdentity("<invalid>", "<invalid>"));
+            new ExplicitInterfaceTypeIdentity(
+                "<invalid>",
+                "<invalid>",
+                IsDegraded: true));
         if (bodyResult.IsDegraded)
-            return false;
+            throw new BadImageFormatException("The MethodImpl body signature could not be decoded.");
 
         MethodSignature<ExplicitInterfaceTypeIdentity> declarationSignature;
         switch (declaration.Kind)
@@ -2260,28 +2286,38 @@ public static class ApiSurfaceExtractor
                 var declarationResult = GuardedProviderDecode.MethodResult(
                     reader,
                     method,
-                    ExplicitInterfaceTypeIdentityProvider.Instance,
+                    identityProvider,
                     ExplicitInterfaceSignatureContext.Open(
                         GenericContext.ForMethod(reader, declaringType, method)),
-                    new ExplicitInterfaceTypeIdentity("<invalid>", "<invalid>"));
+                    new ExplicitInterfaceTypeIdentity(
+                        "<invalid>",
+                        "<invalid>",
+                        IsDegraded: true));
                 if (declarationResult.IsDegraded)
-                    return false;
+                    throw new BadImageFormatException(
+                        "The MethodImpl declaration signature could not be decoded.");
                 declarationSignature = declarationResult.Value;
                 break;
             case HandleKind.MemberReference:
                 var member = reader.GetMemberReference((MemberReferenceHandle)declaration);
+                var parentIdentity = identityProvider.FromHandle(
+                    reader,
+                    member.Parent,
+                    typeContext);
+                if (parentIdentity.IsDegraded)
+                {
+                    throw new BadImageFormatException(
+                        "The MethodImpl declaration parent could not be decoded.");
+                }
                 declarationSignature = GuardedProviderDecode.MemberRefMethod(
                     reader,
                     member,
-                    ExplicitInterfaceTypeIdentityProvider.Instance,
+                    identityProvider,
                     ExplicitInterfaceSignatureContext
                         .Open(typeContext)
                         .WithTypeArguments(
-                            ExplicitInterfaceTypeIdentityProvider.FromHandle(
-                                reader,
-                                member.Parent,
-                                typeContext)
-                            .GenericArguments),
+                            parentIdentity.GenericArguments,
+                            parentIdentity.GenericArity),
                     new ExplicitInterfaceTypeIdentity(
                         "<invalid>",
                         "<invalid>",
@@ -2291,8 +2327,19 @@ public static class ApiSurfaceExtractor
                 return false;
         }
 
+        if (HasDegradedType(bodyResult.Value)
+            || HasDegradedType(declarationSignature))
+        {
+            throw new BadImageFormatException("The MethodImpl signature contains an unsupported type.");
+        }
+
         return MethodSignaturesMatch(bodyResult.Value, declarationSignature);
     }
+
+    private static bool HasDegradedType(
+        MethodSignature<ExplicitInterfaceTypeIdentity> signature)
+        => signature.ReturnType.IsDegraded
+            || signature.ParameterTypes.Any(parameter => parameter.IsDegraded);
 
     private static bool MethodSignaturesMatch(
         MethodSignature<ExplicitInterfaceTypeIdentity> left,
@@ -2300,12 +2347,8 @@ public static class ApiSurfaceExtractor
         => left.Header.Equals(right.Header)
             && left.GenericParameterCount == right.GenericParameterCount
             && left.RequiredParameterCount == right.RequiredParameterCount
-            && !left.ReturnType.IsDegraded
-            && !right.ReturnType.IsDegraded
             && left.ReturnType.Key == right.ReturnType.Key
             && left.ParameterTypes.Length == right.ParameterTypes.Length
-            && !left.ParameterTypes.Any(parameter => parameter.IsDegraded)
-            && !right.ParameterTypes.Any(parameter => parameter.IsDegraded)
             && left.ParameterTypes
                 .Select(parameter => parameter.Key)
                 .SequenceEqual(right.ParameterTypes.Select(parameter => parameter.Key));

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -14,7 +14,19 @@ internal readonly record struct ExplicitInterfaceTypeIdentity(
     bool IsDegraded = false,
     bool? IsInterface = null,
     bool IsWellKnownNullable = false,
-    bool IsConstructedGeneric = false);
+    bool IsConstructedGeneric = false,
+    string? ModifiedTypeKey = null)
+{
+    /// <summary>
+    /// The identity key with every custom modifier stripped. Only a
+    /// <c>modreq</c>/<c>modopt</c> wrapper distinguishes it from <see cref="Key"/>,
+    /// so an aggregate-row comparison that must ignore the modifier a legal
+    /// accessor carries — a <c>void modreq(IsExternalInit)</c> init setter is the
+    /// motivating case — can compare identities without discarding the modifier
+    /// everywhere else.
+    /// </summary>
+    public string UnmodifiedKey => ModifiedTypeKey ?? Key;
+}
 
 internal readonly record struct ExplicitInterfaceSignatureContext(
     GenericContext? Names,
@@ -33,12 +45,34 @@ internal readonly record struct ExplicitInterfaceSignatureContext(
             typeParameterCount);
 }
 
-internal sealed class ExplicitInterfaceTypeIdentityProvider
+/// <remarks>
+/// Every identity this provider builds is charged to <paramref name="observeDecodeWork"/>
+/// before it is returned, so the explicit-interface MethodImpl projection spends the same
+/// bounded extraction work budget as the rest of the surface. Charging each composed node
+/// (rather than only the leaf blobs) is what bounds the amplifying shapes — a deeply nested
+/// generic instantiation grows its key multiplicatively — and a <see langword="null"/>
+/// observer keeps the unbounded query paths unchanged. Gated by
+/// <c>ApiSurfaceExtractorBoundsTests.ExplicitInterfaceProjection_SpendsDecodeWorkBudget</c>.
+/// </remarks>
+internal sealed class ExplicitInterfaceTypeIdentityProvider(
+    Action<int>? observeDecodeWork = null)
     : ISignatureTypeProvider<ExplicitInterfaceTypeIdentity, ExplicitInterfaceSignatureContext>
 {
     internal const int MaxAssemblyIdentityBlobBytes = 4096;
     readonly Dictionary<AssemblyReferenceHandle, string> assemblyScopeKeys = [];
     string? currentModuleKey;
+
+    /// <summary>Charges one decoded or composed identity against the extraction work budget.</summary>
+    internal ExplicitInterfaceTypeIdentity Observe(ExplicitInterfaceTypeIdentity identity)
+    {
+        observeDecodeWork?.Invoke(
+            checked(identity.Key.Length
+                + identity.MetadataName.Length
+                + (identity.AggregateAliasName?.Length ?? 0)));
+        return identity;
+    }
+
+    internal void ObserveWork(int characters) => observeDecodeWork?.Invoke(characters);
 
     public ExplicitInterfaceTypeIdentity GetPrimitiveType(PrimitiveTypeCode typeCode)
     {
@@ -70,11 +104,11 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             PrimitiveTypeCode.UIntPtr => "nuint",
             _ => null
         };
-        return new ExplicitInterfaceTypeIdentity(
+        return Observe(new ExplicitInterfaceTypeIdentity(
             Node("primitive", ((int)typeCode).ToString()),
             name,
             alias,
-            IsInterface: false);
+            IsInterface: false));
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromDefinition(
@@ -87,7 +121,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             throw new BadImageFormatException("The interface type definition name is malformed.");
 
         string name = TypeResolver.GetTypeNameFromDefinition(reader, handle);
-        return new ExplicitInterfaceTypeIdentity(
+        return Observe(new ExplicitInterfaceTypeIdentity(
             Node(
                 "named",
                 rawTypeKind.ToString(),
@@ -97,7 +131,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             GenericArity: reader.GetTypeDefinition(handle).GetGenericParameters().Count,
             IsInterface: (reader.GetTypeDefinition(handle).Attributes
                 & TypeAttributes.Interface) != 0,
-            IsWellKnownNullable: IsWellKnownNullable(reader, handle));
+            IsWellKnownNullable: IsWellKnownNullable(reader, handle)));
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromReference(
@@ -107,7 +141,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
     {
         var structuredName = ReferenceName(reader, handle);
         string name = TypeResolver.GetTypeNameFromReference(reader, handle);
-        return new ExplicitInterfaceTypeIdentity(
+        return Observe(new ExplicitInterfaceTypeIdentity(
             Node(
                 "named",
                 rawTypeKind.ToString(),
@@ -115,7 +149,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
                 structuredName.Key),
             name,
             GenericArity: structuredName.GenericArity,
-            IsWellKnownNullable: IsWellKnownNullable(reader, handle));
+            IsWellKnownNullable: IsWellKnownNullable(reader, handle)));
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromSpecification(
@@ -134,12 +168,12 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
                 IsDegraded: true));
 
     public ExplicitInterfaceTypeIdentity GetSZArrayType(ExplicitInterfaceTypeIdentity elementType)
-        => new(
+        => Observe(new(
             Node("szarray", elementType.Key),
             $"{elementType.MetadataName}[]",
             elementType.AggregateAliasName is { } alias ? $"{alias}[]" : null,
             IsDegraded: elementType.IsDegraded,
-            IsInterface: false);
+            IsInterface: false));
 
     public ExplicitInterfaceTypeIdentity GetArrayType(
         ExplicitInterfaceTypeIdentity elementType,
@@ -148,7 +182,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         string suffix = shape.Rank == 1
             ? "[*]"
             : $"[{new string(',', Math.Max(shape.Rank - 1, 0))}]";
-        return new ExplicitInterfaceTypeIdentity(
+        return Observe(new ExplicitInterfaceTypeIdentity(
             Node(
                 "array",
                 shape.Rank.ToString(),
@@ -158,32 +192,32 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             elementType.MetadataName + suffix,
             elementType.AggregateAliasName is { } alias ? alias + suffix : null,
             IsDegraded: elementType.IsDegraded,
-            IsInterface: false);
+            IsInterface: false));
     }
 
     public ExplicitInterfaceTypeIdentity GetByReferenceType(ExplicitInterfaceTypeIdentity elementType)
-        => new(
+        => Observe(new(
             Node("byref", elementType.Key),
             $"{elementType.MetadataName}&",
             elementType.AggregateAliasName is { } alias ? $"{alias}&" : null,
             IsDegraded: elementType.IsDegraded,
-            IsInterface: false);
+            IsInterface: false));
 
     public ExplicitInterfaceTypeIdentity GetPointerType(ExplicitInterfaceTypeIdentity elementType)
-        => new(
+        => Observe(new(
             Node("pointer", elementType.Key),
             $"{elementType.MetadataName}*",
             elementType.AggregateAliasName is { } alias ? $"{alias}*" : null,
             IsDegraded: elementType.IsDegraded,
-            IsInterface: false);
+            IsInterface: false));
 
     public ExplicitInterfaceTypeIdentity GetPinnedType(ExplicitInterfaceTypeIdentity elementType)
-        => new(
+        => Observe(new(
             Node("pinned", elementType.Key),
             elementType.MetadataName,
             elementType.AggregateAliasName,
             IsDegraded: elementType.IsDegraded,
-            IsInterface: false);
+            IsInterface: false));
 
     public ExplicitInterfaceTypeIdentity GetGenericInstantiation(
         ExplicitInterfaceTypeIdentity genericType,
@@ -210,7 +244,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
                             .Select(argument => argument.AggregateAliasName ?? argument.MetadataName)
                             .ToArray())
                     : null;
-        return new(
+        return Observe(new(
             Node(
                 "generic",
                 [genericType.Key, .. typeArguments.Select(argument => argument.Key)]),
@@ -224,7 +258,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
                 || typeArguments.Any(argument => argument.IsDegraded),
             IsInterface: genericType.IsInterface,
             IsWellKnownNullable: genericType.IsWellKnownNullable,
-            IsConstructedGeneric: true);
+            IsConstructedGeneric: true));
     }
 
     public ExplicitInterfaceTypeIdentity GetGenericMethodParameter(
@@ -234,7 +268,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         string name = context.Names is not null && index < context.Names.MethodParameters.Count
             ? context.Names.MethodParameters[index]
             : $"TM{index}";
-        return new ExplicitInterfaceTypeIdentity(Node("mvar", index.ToString()), name);
+        return Observe(new ExplicitInterfaceTypeIdentity(Node("mvar", index.ToString()), name));
     }
 
     public ExplicitInterfaceTypeIdentity GetGenericTypeParameter(
@@ -247,19 +281,19 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         string name = context.Names is not null && index < context.Names.TypeParameters.Count
             ? context.Names.TypeParameters[index]
             : $"T{index}";
-        return index < context.TypeParameterCount
+        return Observe(index < context.TypeParameterCount
             ? new ExplicitInterfaceTypeIdentity(Node("var", index.ToString()), name)
             : new ExplicitInterfaceTypeIdentity(
                 Node("invalid-var", index.ToString()),
                 name,
-                IsDegraded: true);
+                IsDegraded: true));
     }
 
     public ExplicitInterfaceTypeIdentity GetModifiedType(
         ExplicitInterfaceTypeIdentity modifier,
         ExplicitInterfaceTypeIdentity unmodifiedType,
         bool isRequired)
-        => new(
+        => Observe(new(
             Node(isRequired ? "modreq" : "modopt", modifier.Key, unmodifiedType.Key),
             unmodifiedType.MetadataName,
             unmodifiedType.AggregateAliasName,
@@ -268,7 +302,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             IsDegraded: modifier.IsDegraded || unmodifiedType.IsDegraded,
             IsInterface: unmodifiedType.IsInterface,
             IsWellKnownNullable: unmodifiedType.IsWellKnownNullable,
-            IsConstructedGeneric: unmodifiedType.IsConstructedGeneric);
+            IsConstructedGeneric: unmodifiedType.IsConstructedGeneric,
+            ModifiedTypeKey: unmodifiedType.UnmodifiedKey));
 
     public ExplicitInterfaceTypeIdentity GetFunctionPointerType(
         MethodSignature<ExplicitInterfaceTypeIdentity> signature)
@@ -285,37 +320,48 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         string name = $"method {signature.ReturnType.MetadataName} *("
             + string.Join(",", signature.ParameterTypes.Select(parameter => parameter.MetadataName))
             + ")";
-        return new ExplicitInterfaceTypeIdentity(
+        return Observe(new ExplicitInterfaceTypeIdentity(
             key,
             name,
             IsDegraded: signature.ReturnType.IsDegraded
                 || signature.ParameterTypes.Any(parameter => parameter.IsDegraded),
-            IsInterface: false);
+            IsInterface: false));
     }
 
+    /// <summary>
+    /// The identity of a type named by a handle rather than by a signature.
+    /// </summary>
+    /// <param name="rawTypeKind">
+    /// The ECMA-335 element type a signature would have spelled this handle with — <c>0x11</c>
+    /// for a value type and <c>0x12</c> for a class. A handle-valued row such as Event.EventType
+    /// carries no such byte, so the default <c>0</c> yields an identity that is deliberately not
+    /// comparable to a signature-decoded one; a caller comparing across the two must ask for
+    /// each candidate kind rather than assume one.
+    /// </param>
     internal ExplicitInterfaceTypeIdentity FromHandle(
         MetadataReader reader,
         EntityHandle handle,
-        GenericContext? context)
+        GenericContext? context,
+        byte rawTypeKind = 0)
         => handle.Kind switch
         {
             HandleKind.TypeDefinition => GetTypeFromDefinition(
                 reader,
                 (TypeDefinitionHandle)handle,
-                rawTypeKind: 0),
+                rawTypeKind),
             HandleKind.TypeReference => GetTypeFromReference(
                 reader,
                 (TypeReferenceHandle)handle,
-                rawTypeKind: 0),
+                rawTypeKind),
             HandleKind.TypeSpecification => GetTypeFromSpecification(
                 reader,
                 ExplicitInterfaceSignatureContext.Open(context),
                 (TypeSpecificationHandle)handle,
-                rawTypeKind: 0),
-            _ => new ExplicitInterfaceTypeIdentity(
+                rawTypeKind),
+            _ => Observe(new ExplicitInterfaceTypeIdentity(
                 "<invalid>",
                 "<invalid>",
-                IsDegraded: true)
+                IsDegraded: true))
         };
 
     static string ApplyGenericArguments(string typeName, IReadOnlyList<string> typeArguments)

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -730,7 +730,9 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         {
             segments[i] = BoundedString(reader, reader.GetTypeReference(chain[i]).Name);
             totalCharacters += segments[i].Length + 1;
-            genericArity += GenericArity(segments[i]);
+            genericArity = checked(
+                genericArity
+                + MetadataNameArity.OfSegment(segments[i]));
             if (totalCharacters > MetadataSafetyPolicy.MaxTypeNameCharacters)
             {
                 throw new BadImageFormatException(
@@ -748,15 +750,6 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         string @namespace,
         IEnumerable<string> segments)
         => Node("type-name", [@namespace, .. segments]);
-
-    static int GenericArity(string name)
-    {
-        int separator = name.LastIndexOf('`');
-        return separator >= 0
-            && int.TryParse(name[(separator + 1)..], out int arity)
-                ? arity
-                : 0;
-    }
 
     bool IsWellKnownNullable(
         MetadataReader reader,

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -179,6 +179,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         ExplicitInterfaceTypeIdentity elementType,
         ArrayShape shape)
     {
+        ObserveWork((int)Math.Min(16L + Math.Max(shape.Rank, 0), int.MaxValue));
         string suffix = shape.Rank == 1
             ? "[*]"
             : $"[{new string(',', Math.Max(shape.Rank - 1, 0))}]";

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -38,10 +38,15 @@ internal readonly record struct ExplicitInterfaceTypeIdentity(
 internal readonly record struct ExplicitInterfaceSignatureContext(
     GenericContext? Names,
     ImmutableArray<ExplicitInterfaceTypeIdentity> TypeArguments,
-    int TypeParameterCount)
+    int TypeParameterCount,
+    int MethodParameterCount = 0)
 {
     public static ExplicitInterfaceSignatureContext Open(GenericContext? names)
-        => new(names, [], names?.TypeParameters.Count ?? 0);
+        => new(
+            names,
+            [],
+            names?.TypeParameters.Count ?? 0,
+            names?.MethodParameters.Count ?? 0);
 
     public ExplicitInterfaceSignatureContext WithTypeArguments(
         ImmutableArray<ExplicitInterfaceTypeIdentity> typeArguments,
@@ -49,7 +54,12 @@ internal readonly record struct ExplicitInterfaceSignatureContext(
         => new(
             Names,
             typeArguments.IsDefault ? [] : typeArguments,
-            typeParameterCount);
+            typeParameterCount,
+            MethodParameterCount);
+
+    public ExplicitInterfaceSignatureContext WithMethodParameterCount(
+        int methodParameterCount)
+        => this with { MethodParameterCount = methodParameterCount };
 }
 
 /// <remarks>
@@ -62,7 +72,10 @@ internal readonly record struct ExplicitInterfaceSignatureContext(
 /// <see langword="null"/> observer keeps the unbounded query paths unchanged. Gated by
 /// <c>ApiSurfaceExtractorBoundsTests.ExplicitInterfaceProjection_SpendsDecodeWorkBudget</c>
 /// and
-/// <c>ApiSurfaceExtractorBoundsTests.RepeatedDeepGenericMethodImplParent_UsesBoundedUnboundedAllocation</c>.
+/// <c>ApiSurfaceExtractorBoundsTests.RepeatedDeepGenericMethodImplParent_UsesBoundedUnboundedAllocation</c>,
+/// while
+/// <c>ApiSurfaceExtractorBoundsTests.ExplicitInterfaceFunctionPointerDisplay_IsPreflightedBeforeAllocation</c>
+/// gates display construction before materialization.
 /// </remarks>
 internal sealed class ExplicitInterfaceTypeIdentityProvider(
     Action<int>? observeDecodeWork = null)
@@ -108,6 +121,15 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         }
 
         remainingProjectionWork -= characters;
+    }
+
+    void EnsureWorkAvailable(long characters)
+    {
+        if (characters < 0 || characters > remainingProjectionWork)
+        {
+            throw new BadImageFormatException(
+                "The explicit-interface projection exceeds the metadata safety limit.");
+        }
     }
 
     public ExplicitInterfaceTypeIdentity GetPrimitiveType(PrimitiveTypeCode typeCode)
@@ -329,7 +351,12 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         string name = context.Names is not null && index < context.Names.MethodParameters.Count
             ? context.Names.MethodParameters[index]
             : $"TM{index}";
-        return Observe(new ExplicitInterfaceTypeIdentity(Node("mvar", index.ToString()), name));
+        return Observe(index < context.MethodParameterCount
+            ? new ExplicitInterfaceTypeIdentity(Node("mvar", index.ToString()), name)
+            : new ExplicitInterfaceTypeIdentity(
+                Node("invalid-mvar", index.ToString()),
+                name,
+                IsDegraded: true));
     }
 
     public ExplicitInterfaceTypeIdentity GetGenericTypeParameter(
@@ -375,6 +402,21 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
     public ExplicitInterfaceTypeIdentity GetFunctionPointerType(
         MethodSignature<ExplicitInterfaceTypeIdentity> signature)
     {
+        long projectedCharacters =
+            "method ".Length
+            + signature.ReturnType.MetadataName.Length
+            + " *(".Length
+            + ")".Length
+            + signature.ReturnType.Key.Length
+            + 64;
+        foreach (ExplicitInterfaceTypeIdentity parameter in signature.ParameterTypes)
+        {
+            projectedCharacters +=
+                parameter.Key.Length + parameter.MetadataName.Length + 1L;
+            EnsureWorkAvailable(projectedCharacters);
+        }
+        EnsureWorkAvailable(projectedCharacters);
+
         string key = Node(
             "fnptr",
             [

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -402,27 +402,39 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
     public ExplicitInterfaceTypeIdentity GetFunctionPointerType(
         MethodSignature<ExplicitInterfaceTypeIdentity> signature)
     {
-        long projectedCharacters =
-            "method ".Length
+        string header = signature.Header.RawValue.ToString();
+        string genericParameterCount =
+            signature.GenericParameterCount.ToString();
+        string requiredParameterCount =
+            signature.RequiredParameterCount.ToString();
+        long projectedWork =
+            1L
+            + ProjectedNodePartWork("fnptr")
+            + ProjectedNodePartWork(header)
+            + ProjectedNodePartWork(genericParameterCount)
+            + ProjectedNodePartWork(requiredParameterCount)
+            + ProjectedNodePartWork(signature.ReturnType.Key)
+            + 64L
+            + "method ".Length
             + signature.ReturnType.MetadataName.Length
             + " *(".Length
-            + ")".Length
-            + signature.ReturnType.Key.Length
-            + 64;
+            + ")".Length;
         foreach (ExplicitInterfaceTypeIdentity parameter in signature.ParameterTypes)
         {
-            projectedCharacters +=
-                parameter.Key.Length + parameter.MetadataName.Length + 1L;
-            EnsureWorkAvailable(projectedCharacters);
+            projectedWork +=
+                ProjectedNodePartWork(parameter.Key)
+                + parameter.MetadataName.Length
+                + 1L;
+            EnsureWorkAvailable(projectedWork);
         }
-        EnsureWorkAvailable(projectedCharacters);
+        EnsureWorkAvailable(projectedWork);
 
         string key = Node(
             "fnptr",
             [
-                signature.Header.RawValue.ToString(),
-                signature.GenericParameterCount.ToString(),
-                signature.RequiredParameterCount.ToString(),
+                header,
+                genericParameterCount,
+                requiredParameterCount,
                 signature.ReturnType.Key,
                 .. signature.ParameterTypes.Select(parameter => parameter.Key)
             ]);
@@ -435,6 +447,15 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
             IsDegraded: signature.ReturnType.IsDegraded
                 || signature.ParameterTypes.Any(parameter => parameter.IsDegraded),
             IsInterface: false));
+    }
+
+    static long ProjectedNodePartWork(string value)
+    {
+        int byteCount = Encoding.UTF8.GetByteCount(value);
+        return value.Length
+            + (long)byteCount
+            - Math.Min(byteCount, value.Length)
+            + sizeof(int);
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -88,6 +88,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         namedIdentityCache = [];
     readonly Dictionary<TypeSpecificationIdentityCacheKey, ExplicitInterfaceTypeIdentity>
         typeSpecificationIdentityCache = [];
+    readonly Dictionary<string, StructuredDisplayName> structuredDisplayNames =
+        new(StringComparer.Ordinal);
     string? currentModuleKey;
     int? identityCacheEntryLimit;
     int remainingProjectionWork =
@@ -99,6 +101,10 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         BlobHandle Signature,
         byte RawTypeKind,
         ExplicitInterfaceSignatureContext Context);
+
+    readonly record struct StructuredDisplayName(
+        string Namespace,
+        IReadOnlyList<string> Segments);
 
     /// <summary>Charges one decoded or composed identity against the extraction work budget.</summary>
     internal ExplicitInterfaceTypeIdentity Observe(ExplicitInterfaceTypeIdentity identity)
@@ -194,6 +200,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
             IsInterface: (reader.GetTypeDefinition(handle).Attributes
                 & TypeAttributes.Interface) != 0,
             IsWellKnownNullable: IsWellKnownNullable(reader, handle)));
+        structuredDisplayNames[identity.Key] =
+            new(result.Name.Namespace, result.Name.Segments);
         CacheIdentity(reader, cacheKey, identity);
         return identity;
     }
@@ -218,6 +226,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
             name,
             GenericArity: structuredName.GenericArity,
             IsWellKnownNullable: IsWellKnownNullable(reader, handle)));
+        structuredDisplayNames[identity.Key] =
+            new(structuredName.Namespace, structuredName.Segments);
         CacheIdentity(reader, cacheKey, identity);
         return identity;
     }
@@ -322,7 +332,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
                 ? $"{nullableArgument.AggregateAliasName ?? nullableArgument.MetadataName}?"
                 : typeArguments.Any(argument => argument.AggregateAliasName is not null)
                     ? ApplyGenericArguments(
-                        genericType.MetadataName,
+                        genericType,
                         typeArguments
                             .Select(argument => argument.AggregateAliasName ?? argument.MetadataName)
                             .ToArray())
@@ -332,7 +342,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
                 "generic",
                 [genericType.Key, .. typeArguments.Select(argument => argument.Key)]),
             ApplyGenericArguments(
-                genericType.MetadataName,
+                genericType,
                 typeArguments.Select(argument => argument.MetadataName).ToArray()),
             aggregateAlias,
             GenericArguments: typeArguments,
@@ -527,8 +537,11 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
             Math.Min(int.MaxValue, identityHandles * 3));
     }
 
-    static string ApplyGenericArguments(string typeName, IReadOnlyList<string> typeArguments)
+    string ApplyGenericArguments(
+        ExplicitInterfaceTypeIdentity genericType,
+        IReadOnlyList<string> typeArguments)
     {
+        string typeName = genericType.MetadataName;
         long displayLength = typeName.Length + 2L;
         foreach (string argument in typeArguments)
         {
@@ -540,7 +553,21 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
             }
         }
 
-        return TypeResolver.ApplyGenericArguments(typeName, typeArguments)
+        bool hasStructuredName = structuredDisplayNames.TryGetValue(
+            genericType.Key,
+            out StructuredDisplayName structured);
+        string rendered = hasStructuredName
+            ? TypeResolver.ApplyGenericArguments(
+                structured.Segments,
+                typeArguments)
+            : TypeResolver.ApplyGenericArguments(typeName, typeArguments);
+        if (hasStructuredName
+            && !string.IsNullOrEmpty(structured.Namespace))
+        {
+            rendered = $"{structured.Namespace}.{rendered}";
+        }
+
+        return rendered
             .Replace(", ", ",", StringComparison.Ordinal);
     }
 
@@ -667,7 +694,12 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         return reader.GetString(handle);
     }
 
-    (string Key, int GenericArity) ReferenceName(
+    (
+        string Key,
+        int GenericArity,
+        string Namespace,
+        IReadOnlyList<string> Segments)
+        ReferenceName(
         MetadataReader reader,
         TypeReferenceHandle handle)
     {
@@ -707,7 +739,9 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         }
         return (
             StructuredNameKey(@namespace, segments),
-            genericArity);
+            genericArity,
+            @namespace,
+            segments);
     }
 
     string StructuredNameKey(

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -174,23 +174,35 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
     public ExplicitInterfaceTypeIdentity GetGenericInstantiation(
         ExplicitInterfaceTypeIdentity genericType,
         ImmutableArray<ExplicitInterfaceTypeIdentity> typeArguments)
-        => new(
+    {
+        string? aggregateAlias = (genericType.MetadataName == "System.Nullable"
+            || genericType.MetadataName.StartsWith(
+                "System.Nullable<",
+                StringComparison.Ordinal)
+            || genericType.MetadataName.StartsWith(
+                "System.Nullable`",
+                StringComparison.Ordinal))
+            && typeArguments is [var nullableArgument]
+                ? $"{nullableArgument.AggregateAliasName ?? nullableArgument.MetadataName}?"
+                : typeArguments.Any(argument => argument.AggregateAliasName is not null)
+                    ? ApplyGenericArguments(
+                        genericType.MetadataName,
+                        typeArguments
+                            .Select(argument => argument.AggregateAliasName ?? argument.MetadataName)
+                            .ToArray())
+                    : null;
+        return new(
             Node(
                 "generic",
                 [genericType.Key, .. typeArguments.Select(argument => argument.Key)]),
             ApplyGenericArguments(
                 genericType.MetadataName,
                 typeArguments.Select(argument => argument.MetadataName).ToArray()),
-            typeArguments.Any(argument => argument.AggregateAliasName is not null)
-                ? ApplyGenericArguments(
-                    genericType.MetadataName,
-                    typeArguments
-                        .Select(argument => argument.AggregateAliasName ?? argument.MetadataName)
-                        .ToArray())
-                : null,
+            aggregateAlias,
             typeArguments,
             genericType.GenericArity,
             genericType.IsDegraded || typeArguments.Any(argument => argument.IsDegraded));
+    }
 
     public ExplicitInterfaceTypeIdentity GetGenericMethodParameter(
         ExplicitInterfaceSignatureContext context,

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -77,25 +77,38 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         typeSpecificationIdentityCache = [];
     string? currentModuleKey;
     int? identityCacheEntryLimit;
+    int remainingProjectionWork =
+        MetadataSafetyPolicy.MaxExplicitInterfaceProjectionWorkChars;
 
     readonly record struct NamedIdentityCacheKey(EntityHandle Handle, byte RawTypeKind);
 
     readonly record struct TypeSpecificationIdentityCacheKey(
-        TypeSpecificationHandle Handle,
+        BlobHandle Signature,
         byte RawTypeKind,
         ExplicitInterfaceSignatureContext Context);
 
     /// <summary>Charges one decoded or composed identity against the extraction work budget.</summary>
     internal ExplicitInterfaceTypeIdentity Observe(ExplicitInterfaceTypeIdentity identity)
     {
-        observeDecodeWork?.Invoke(
+        ObserveWork(
             checked(identity.Key.Length
                 + identity.MetadataName.Length
                 + (identity.AggregateAliasName?.Length ?? 0)));
         return identity;
     }
 
-    internal void ObserveWork(int characters) => observeDecodeWork?.Invoke(characters);
+    internal void ObserveWork(int characters)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(characters);
+        observeDecodeWork?.Invoke(characters);
+        if (remainingProjectionWork < characters)
+        {
+            throw new BadImageFormatException(
+                "The explicit-interface projection exceeds the metadata safety limit.");
+        }
+
+        remainingProjectionWork -= characters;
+    }
 
     public ExplicitInterfaceTypeIdentity GetPrimitiveType(PrimitiveTypeCode typeCode)
     {
@@ -193,7 +206,11 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         TypeSpecificationHandle handle,
         byte rawTypeKind)
     {
-        var cacheKey = new TypeSpecificationIdentityCacheKey(handle, rawTypeKind, context);
+        BlobHandle signature = reader.GetTypeSpecification(handle).Signature;
+        var cacheKey = new TypeSpecificationIdentityCacheKey(
+            signature,
+            rawTypeKind,
+            context);
         if (typeSpecificationIdentityCache.TryGetValue(cacheKey, out var cached))
             return cached;
 

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -1,30 +1,40 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
+using System.Text;
 
 namespace ILInspector.Metadata;
 
 internal readonly record struct ExplicitInterfaceTypeIdentity(
     string Key,
     string MetadataName,
+    string? AggregateAliasName = null,
     ImmutableArray<ExplicitInterfaceTypeIdentity> GenericArguments = default,
+    int GenericArity = 0,
     bool IsDegraded = false);
 
 internal readonly record struct ExplicitInterfaceSignatureContext(
     GenericContext? Names,
-    ImmutableArray<ExplicitInterfaceTypeIdentity> TypeArguments)
+    ImmutableArray<ExplicitInterfaceTypeIdentity> TypeArguments,
+    int TypeParameterCount)
 {
     public static ExplicitInterfaceSignatureContext Open(GenericContext? names)
-        => new(names, []);
+        => new(names, [], names?.TypeParameters.Count ?? 0);
 
     public ExplicitInterfaceSignatureContext WithTypeArguments(
-        ImmutableArray<ExplicitInterfaceTypeIdentity> typeArguments)
-        => new(Names, typeArguments);
+        ImmutableArray<ExplicitInterfaceTypeIdentity> typeArguments,
+        int typeParameterCount)
+        => new(
+            Names,
+            typeArguments.IsDefault ? [] : typeArguments,
+            typeParameterCount);
 }
 
 internal sealed class ExplicitInterfaceTypeIdentityProvider
     : ISignatureTypeProvider<ExplicitInterfaceTypeIdentity, ExplicitInterfaceSignatureContext>
 {
-    public static ExplicitInterfaceTypeIdentityProvider Instance { get; } = new();
+    internal const int MaxAssemblyIdentityBlobBytes = 4096;
+    readonly Dictionary<AssemblyReferenceHandle, string> assemblyScopeKeys = [];
+    string? currentModuleKey;
 
     public ExplicitInterfaceTypeIdentity GetPrimitiveType(PrimitiveTypeCode typeCode)
     {
@@ -50,7 +60,16 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             PrimitiveTypeCode.TypedReference => "System.TypedReference",
             _ => typeCode.ToString()
         };
-        return new ExplicitInterfaceTypeIdentity(name, name);
+        string? alias = typeCode switch
+        {
+            PrimitiveTypeCode.IntPtr => "nint",
+            PrimitiveTypeCode.UIntPtr => "nuint",
+            _ => null
+        };
+        return new ExplicitInterfaceTypeIdentity(
+            Node("primitive", ((int)typeCode).ToString()),
+            name,
+            alias);
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromDefinition(
@@ -58,10 +77,19 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         TypeDefinitionHandle handle,
         byte rawTypeKind)
     {
+        var read = MetadataTypeDefinitionNameReader.Read(reader, handle);
+        if (read is not MetadataTypeDefinitionNameReadResult.Read result)
+            throw new BadImageFormatException("The interface type definition name is malformed.");
+
         string name = TypeResolver.GetTypeNameFromDefinition(reader, handle);
         return new ExplicitInterfaceTypeIdentity(
-            $"[{CurrentModuleKey(reader)}]{name}",
-            name);
+            Node(
+                "named",
+                rawTypeKind.ToString(),
+                CurrentModuleKey(reader),
+                StructuredNameKey(result.Name.Namespace, result.Name.Segments)),
+            name,
+            GenericArity: reader.GetTypeDefinition(handle).GetGenericParameters().Count);
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromReference(
@@ -69,10 +97,16 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         TypeReferenceHandle handle,
         byte rawTypeKind)
     {
+        var structuredName = ReferenceName(reader, handle);
         string name = TypeResolver.GetTypeNameFromReference(reader, handle);
         return new ExplicitInterfaceTypeIdentity(
-            $"[{ResolutionScopeKey(reader, handle)}]{name}",
-            name);
+            Node(
+                "named",
+                rawTypeKind.ToString(),
+                ResolutionScopeKey(reader, handle),
+                structuredName.Key),
+            name,
+            GenericArity: structuredName.GenericArity);
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromSpecification(
@@ -92,50 +126,70 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
 
     public ExplicitInterfaceTypeIdentity GetSZArrayType(ExplicitInterfaceTypeIdentity elementType)
         => new(
-            $"{elementType.Key}[]",
+            Node("szarray", elementType.Key),
             $"{elementType.MetadataName}[]",
+            elementType.AggregateAliasName is { } alias ? $"{alias}[]" : null,
             IsDegraded: elementType.IsDegraded);
 
     public ExplicitInterfaceTypeIdentity GetArrayType(
         ExplicitInterfaceTypeIdentity elementType,
         ArrayShape shape)
     {
-        string suffix = $"[{new string(',', Math.Max(shape.Rank - 1, 0))}]";
+        string suffix = shape.Rank == 1
+            ? "[*]"
+            : $"[{new string(',', Math.Max(shape.Rank - 1, 0))}]";
         return new ExplicitInterfaceTypeIdentity(
-            elementType.Key + suffix,
+            Node(
+                "array",
+                shape.Rank.ToString(),
+                string.Join(",", shape.Sizes),
+                string.Join(",", shape.LowerBounds),
+                elementType.Key),
             elementType.MetadataName + suffix,
+            elementType.AggregateAliasName is { } alias ? alias + suffix : null,
             IsDegraded: elementType.IsDegraded);
     }
 
     public ExplicitInterfaceTypeIdentity GetByReferenceType(ExplicitInterfaceTypeIdentity elementType)
         => new(
-            $"{elementType.Key}&",
+            Node("byref", elementType.Key),
             $"{elementType.MetadataName}&",
+            elementType.AggregateAliasName is { } alias ? $"{alias}&" : null,
             IsDegraded: elementType.IsDegraded);
 
     public ExplicitInterfaceTypeIdentity GetPointerType(ExplicitInterfaceTypeIdentity elementType)
         => new(
-            $"{elementType.Key}*",
+            Node("pointer", elementType.Key),
             $"{elementType.MetadataName}*",
+            elementType.AggregateAliasName is { } alias ? $"{alias}*" : null,
             IsDegraded: elementType.IsDegraded);
 
     public ExplicitInterfaceTypeIdentity GetPinnedType(ExplicitInterfaceTypeIdentity elementType)
         => new(
-            $"pinned {elementType.Key}",
+            Node("pinned", elementType.Key),
             elementType.MetadataName,
+            elementType.AggregateAliasName,
             IsDegraded: elementType.IsDegraded);
 
     public ExplicitInterfaceTypeIdentity GetGenericInstantiation(
         ExplicitInterfaceTypeIdentity genericType,
         ImmutableArray<ExplicitInterfaceTypeIdentity> typeArguments)
         => new(
-            ApplyGenericArguments(
-                genericType.Key,
-                typeArguments.Select(argument => argument.Key).ToArray()),
+            Node(
+                "generic",
+                [genericType.Key, .. typeArguments.Select(argument => argument.Key)]),
             ApplyGenericArguments(
                 genericType.MetadataName,
                 typeArguments.Select(argument => argument.MetadataName).ToArray()),
+            typeArguments.Any(argument => argument.AggregateAliasName is not null)
+                ? ApplyGenericArguments(
+                    genericType.MetadataName,
+                    typeArguments
+                        .Select(argument => argument.AggregateAliasName ?? argument.MetadataName)
+                        .ToArray())
+                : null,
             typeArguments,
+            genericType.GenericArity,
             genericType.IsDegraded || typeArguments.Any(argument => argument.IsDegraded));
 
     public ExplicitInterfaceTypeIdentity GetGenericMethodParameter(
@@ -145,20 +199,25 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         string name = context.Names is not null && index < context.Names.MethodParameters.Count
             ? context.Names.MethodParameters[index]
             : $"TM{index}";
-        return new ExplicitInterfaceTypeIdentity($"!!{index}", name);
+        return new ExplicitInterfaceTypeIdentity(Node("mvar", index.ToString()), name);
     }
 
     public ExplicitInterfaceTypeIdentity GetGenericTypeParameter(
         ExplicitInterfaceSignatureContext context,
         int index)
     {
-        if (index < context.TypeArguments.Length)
+        if (!context.TypeArguments.IsDefault && index < context.TypeArguments.Length)
             return context.TypeArguments[index];
 
         string name = context.Names is not null && index < context.Names.TypeParameters.Count
             ? context.Names.TypeParameters[index]
             : $"T{index}";
-        return new ExplicitInterfaceTypeIdentity($"!{index}", name);
+        return index < context.TypeParameterCount
+            ? new ExplicitInterfaceTypeIdentity(Node("var", index.ToString()), name)
+            : new ExplicitInterfaceTypeIdentity(
+                Node("invalid-var", index.ToString()),
+                name,
+                IsDegraded: true);
     }
 
     public ExplicitInterfaceTypeIdentity GetModifiedType(
@@ -166,18 +225,23 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         ExplicitInterfaceTypeIdentity unmodifiedType,
         bool isRequired)
         => new(
-            $"{(isRequired ? "modreq" : "modopt")}({modifier.Key}){unmodifiedType.Key}",
+            Node(isRequired ? "modreq" : "modopt", modifier.Key, unmodifiedType.Key),
             unmodifiedType.MetadataName,
+            unmodifiedType.AggregateAliasName,
             IsDegraded: modifier.IsDegraded || unmodifiedType.IsDegraded);
 
     public ExplicitInterfaceTypeIdentity GetFunctionPointerType(
         MethodSignature<ExplicitInterfaceTypeIdentity> signature)
     {
-        string key = $"method[{signature.Header.RawValue}:"
-            + $"{signature.GenericParameterCount}:{signature.RequiredParameterCount}] "
-            + $"{signature.ReturnType.Key} *("
-            + string.Join(",", signature.ParameterTypes.Select(parameter => parameter.Key))
-            + ")";
+        string key = Node(
+            "fnptr",
+            [
+                signature.Header.RawValue.ToString(),
+                signature.GenericParameterCount.ToString(),
+                signature.RequiredParameterCount.ToString(),
+                signature.ReturnType.Key,
+                .. signature.ParameterTypes.Select(parameter => parameter.Key)
+            ]);
         string name = $"method {signature.ReturnType.MetadataName} *("
             + string.Join(",", signature.ParameterTypes.Select(parameter => parameter.MetadataName))
             + ")";
@@ -188,21 +252,21 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
                 || signature.ParameterTypes.Any(parameter => parameter.IsDegraded));
     }
 
-    internal static ExplicitInterfaceTypeIdentity FromHandle(
+    internal ExplicitInterfaceTypeIdentity FromHandle(
         MetadataReader reader,
         EntityHandle handle,
         GenericContext? context)
         => handle.Kind switch
         {
-            HandleKind.TypeDefinition => Instance.GetTypeFromDefinition(
+            HandleKind.TypeDefinition => GetTypeFromDefinition(
                 reader,
                 (TypeDefinitionHandle)handle,
                 rawTypeKind: 0),
-            HandleKind.TypeReference => Instance.GetTypeFromReference(
+            HandleKind.TypeReference => GetTypeFromReference(
                 reader,
                 (TypeReferenceHandle)handle,
                 rawTypeKind: 0),
-            HandleKind.TypeSpecification => Instance.GetTypeFromSpecification(
+            HandleKind.TypeSpecification => GetTypeFromSpecification(
                 reader,
                 ExplicitInterfaceSignatureContext.Open(context),
                 (TypeSpecificationHandle)handle,
@@ -217,7 +281,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         => TypeResolver.ApplyGenericArguments(typeName, typeArguments)
             .Replace(", ", ",", StringComparison.Ordinal);
 
-    static string ResolutionScopeKey(MetadataReader reader, TypeReferenceHandle handle)
+    string ResolutionScopeKey(MetadataReader reader, TypeReferenceHandle handle)
     {
         Span<TypeReferenceHandle> chain =
             stackalloc TypeReferenceHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
@@ -238,29 +302,166 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         EntityHandle scope = reader.GetTypeReference(chain[0]).ResolutionScope;
         return scope.Kind switch
         {
-            HandleKind.AssemblyReference => AssemblyKey(
-                AssemblyReferenceIdentity.From(reader, (AssemblyReferenceHandle)scope)),
-            HandleKind.ModuleDefinition when reader.IsAssembly => AssemblyKey(
-                AssemblyReferenceIdentity.FromAssemblyDefinition(reader)),
+            HandleKind.AssemblyReference => AssemblyScopeKey(
+                reader,
+                (AssemblyReferenceHandle)scope),
             HandleKind.ModuleDefinition => CurrentModuleKey(reader),
-            HandleKind.ModuleReference => "module:"
-                + reader.GetString(reader.GetModuleReference((ModuleReferenceHandle)scope).Name),
-            _ => scope.Kind.ToString()
+            HandleKind.ModuleReference => Node(
+                "module",
+                BoundedString(
+                    reader,
+                    reader.GetModuleReference((ModuleReferenceHandle)scope).Name)),
+            _ => Node("scope", scope.Kind.ToString())
         };
     }
 
-    static string AssemblyKey(AssemblyReferenceIdentity identity)
-        => $"{identity.Name}|{identity.Version}|{identity.Culture}|{identity.PublicKeyToken}";
+    internal static string AssemblyKey(AssemblyReferenceIdentity identity)
+        => Node(
+            "assembly",
+            identity.Name.ToUpperInvariant(),
+            identity.Version?.ToString() ?? "",
+            NormalizeCulture(identity.Culture).ToUpperInvariant(),
+            (identity.PublicKeyToken ?? "").ToUpperInvariant());
 
-    static string CurrentModuleKey(MetadataReader reader)
+    string CurrentModuleKey(MetadataReader reader)
     {
+        if (currentModuleKey is not null)
+            return currentModuleKey;
+
         if (reader.IsAssembly)
-            return AssemblyKey(AssemblyReferenceIdentity.FromAssemblyDefinition(reader));
+        {
+            ValidateAssemblyIdentity(reader, reader.GetAssemblyDefinition());
+            return currentModuleKey = AssemblyKey(
+                AssemblyReferenceIdentity.FromAssemblyDefinition(reader));
+        }
 
         var module = reader.GetModuleDefinition();
-        return "module:"
-            + reader.GetString(module.Name)
-            + "|"
-            + reader.GetGuid(module.Mvid);
+        return currentModuleKey = Node(
+            "module",
+            BoundedString(reader, module.Name),
+            reader.GetGuid(module.Mvid).ToString());
+    }
+
+    string AssemblyScopeKey(MetadataReader reader, AssemblyReferenceHandle handle)
+    {
+        if (assemblyScopeKeys.TryGetValue(handle, out string? key))
+            return key;
+
+        var reference = reader.GetAssemblyReference(handle);
+        ValidateAssemblyIdentity(reader, reference);
+        key = AssemblyKey(AssemblyReferenceIdentity.From(reader, handle));
+        assemblyScopeKeys.Add(handle, key);
+        return key;
+    }
+
+    static void ValidateAssemblyIdentity(
+        MetadataReader reader,
+        System.Reflection.Metadata.AssemblyReference reference)
+    {
+        _ = BoundedString(reader, reference.Name);
+        if (!reference.Culture.IsNil)
+            _ = BoundedString(reader, reference.Culture);
+        ValidateAssemblyIdentityBlob(reader, reference.PublicKeyOrToken);
+    }
+
+    static void ValidateAssemblyIdentity(MetadataReader reader, AssemblyDefinition definition)
+    {
+        _ = BoundedString(reader, definition.Name);
+        if (!definition.Culture.IsNil)
+            _ = BoundedString(reader, definition.Culture);
+        ValidateAssemblyIdentityBlob(reader, definition.PublicKey);
+    }
+
+    static void ValidateAssemblyIdentityBlob(MetadataReader reader, BlobHandle handle)
+    {
+        if (!handle.IsNil
+            && reader.GetBlobReader(handle).Length > MaxAssemblyIdentityBlobBytes)
+        {
+            throw new BadImageFormatException(
+                "The assembly identity key blob exceeds the inspection limit.");
+        }
+    }
+
+    static string BoundedString(MetadataReader reader, StringHandle handle)
+    {
+        if (reader.GetBlobReader(handle).Length > MetadataSafetyPolicy.MaxTypeNameCharacters)
+            throw new BadImageFormatException("The metadata identity name exceeds the inspection limit.");
+        return reader.GetString(handle);
+    }
+
+    static (string Key, int GenericArity) ReferenceName(
+        MetadataReader reader,
+        TypeReferenceHandle handle)
+    {
+        Span<TypeReferenceHandle> chain =
+            stackalloc TypeReferenceHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkTypeReferenceResolutionScope(
+                reader,
+                handle,
+                chain,
+                out int consumed,
+                out _,
+                out var rejection)
+            || consumed == 0)
+        {
+            throw new BadImageFormatException(
+                rejection?.Detail
+                    ?? "The interface type has an invalid resolution-scope chain.");
+        }
+
+        var outer = reader.GetTypeReference(chain[0]);
+        string @namespace = outer.Namespace.IsNil
+            ? ""
+            : BoundedString(reader, outer.Namespace);
+        string[] segments = new string[consumed];
+        int totalCharacters = @namespace.Length;
+        int genericArity = 0;
+        for (int i = 0; i < consumed; i++)
+        {
+            segments[i] = BoundedString(reader, reader.GetTypeReference(chain[i]).Name);
+            totalCharacters += segments[i].Length + 1;
+            genericArity += GenericArity(segments[i]);
+            if (totalCharacters > MetadataSafetyPolicy.MaxTypeNameCharacters)
+            {
+                throw new BadImageFormatException(
+                    "The interface type name exceeds the inspection limit.");
+            }
+        }
+        return (
+            StructuredNameKey(@namespace, segments),
+            genericArity);
+    }
+
+    static string StructuredNameKey(
+        string @namespace,
+        IEnumerable<string> segments)
+        => Node("type-name", [@namespace, .. segments]);
+
+    static int GenericArity(string name)
+    {
+        int separator = name.LastIndexOf('`');
+        return separator >= 0
+            && int.TryParse(name[(separator + 1)..], out int arity)
+                ? arity
+                : 0;
+    }
+
+    static string NormalizeCulture(string? value)
+        => string.IsNullOrEmpty(value)
+            || value.Equals("neutral", StringComparison.OrdinalIgnoreCase)
+                ? ""
+                : value;
+
+    static string Node(string tag, params string[] parts)
+    {
+        var builder = new StringBuilder(tag);
+        foreach (string part in parts)
+        {
+            builder.Append('|');
+            builder.Append(part.Length);
+            builder.Append(':');
+            builder.Append(part);
+        }
+        return builder.ToString();
     }
 }

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -1,6 +1,10 @@
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace ILInspector.Metadata;
@@ -52,18 +56,34 @@ internal readonly record struct ExplicitInterfaceSignatureContext(
 /// Every identity this provider builds is charged to <paramref name="observeDecodeWork"/>
 /// before it is returned, so the explicit-interface MethodImpl projection spends the same
 /// bounded extraction work budget as the rest of the surface. Charging each composed node
-/// (rather than only the leaf blobs) is what bounds the amplifying shapes — a deeply nested
-/// generic instantiation grows its key multiplicatively — and a <see langword="null"/>
-/// observer keeps the unbounded query paths unchanged. Gated by
-/// <c>ApiSurfaceExtractorBoundsTests.ExplicitInterfaceProjection_SpendsDecodeWorkBudget</c>.
+/// (rather than only the leaf blobs) is what bounds amplifying shapes. Structural keys are
+/// fixed-width framed SHA-256 digests, and display names are separately capped, so nested
+/// generic composition cannot retain recursively growing identity keys. A
+/// <see langword="null"/> observer keeps the unbounded query paths unchanged. Gated by
+/// <c>ApiSurfaceExtractorBoundsTests.ExplicitInterfaceProjection_SpendsDecodeWorkBudget</c>
+/// and
+/// <c>ApiSurfaceExtractorBoundsTests.RepeatedDeepGenericMethodImplParent_UsesBoundedUnboundedAllocation</c>.
 /// </remarks>
 internal sealed class ExplicitInterfaceTypeIdentityProvider(
     Action<int>? observeDecodeWork = null)
     : ISignatureTypeProvider<ExplicitInterfaceTypeIdentity, ExplicitInterfaceSignatureContext>
 {
     internal const int MaxAssemblyIdentityBlobBytes = 4096;
+    const int MaxIdentityCacheEntries = 4096;
     readonly Dictionary<AssemblyReferenceHandle, string> assemblyScopeKeys = [];
+    readonly Dictionary<NamedIdentityCacheKey, ExplicitInterfaceTypeIdentity>
+        namedIdentityCache = [];
+    readonly Dictionary<TypeSpecificationIdentityCacheKey, ExplicitInterfaceTypeIdentity>
+        typeSpecificationIdentityCache = [];
     string? currentModuleKey;
+    int? identityCacheEntryLimit;
+
+    readonly record struct NamedIdentityCacheKey(EntityHandle Handle, byte RawTypeKind);
+
+    readonly record struct TypeSpecificationIdentityCacheKey(
+        TypeSpecificationHandle Handle,
+        byte RawTypeKind,
+        ExplicitInterfaceSignatureContext Context);
 
     /// <summary>Charges one decoded or composed identity against the extraction work budget.</summary>
     internal ExplicitInterfaceTypeIdentity Observe(ExplicitInterfaceTypeIdentity identity)
@@ -119,12 +139,16 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         TypeDefinitionHandle handle,
         byte rawTypeKind)
     {
+        var cacheKey = new NamedIdentityCacheKey(handle, rawTypeKind);
+        if (namedIdentityCache.TryGetValue(cacheKey, out var cached))
+            return cached;
+
         var read = MetadataTypeDefinitionNameReader.Read(reader, handle);
         if (read is not MetadataTypeDefinitionNameReadResult.Read result)
             throw new BadImageFormatException("The interface type definition name is malformed.");
 
         string name = TypeResolver.GetTypeNameFromDefinition(reader, handle);
-        return Observe(new ExplicitInterfaceTypeIdentity(
+        var identity = Observe(new ExplicitInterfaceTypeIdentity(
             Node(
                 "named",
                 rawTypeKind.ToString(),
@@ -135,6 +159,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
             IsInterface: (reader.GetTypeDefinition(handle).Attributes
                 & TypeAttributes.Interface) != 0,
             IsWellKnownNullable: IsWellKnownNullable(reader, handle)));
+        CacheIdentity(reader, cacheKey, identity);
+        return identity;
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromReference(
@@ -142,9 +168,13 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         TypeReferenceHandle handle,
         byte rawTypeKind)
     {
+        var cacheKey = new NamedIdentityCacheKey(handle, rawTypeKind);
+        if (namedIdentityCache.TryGetValue(cacheKey, out var cached))
+            return cached;
+
         var structuredName = ReferenceName(reader, handle);
         string name = TypeResolver.GetTypeNameFromReference(reader, handle);
-        return Observe(new ExplicitInterfaceTypeIdentity(
+        var identity = Observe(new ExplicitInterfaceTypeIdentity(
             Node(
                 "named",
                 rawTypeKind.ToString(),
@@ -153,6 +183,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
             name,
             GenericArity: structuredName.GenericArity,
             IsWellKnownNullable: IsWellKnownNullable(reader, handle)));
+        CacheIdentity(reader, cacheKey, identity);
+        return identity;
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromSpecification(
@@ -160,7 +192,12 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         ExplicitInterfaceSignatureContext context,
         TypeSpecificationHandle handle,
         byte rawTypeKind)
-        => GuardedProviderDecode.TypeSpec(
+    {
+        var cacheKey = new TypeSpecificationIdentityCacheKey(handle, rawTypeKind, context);
+        if (typeSpecificationIdentityCache.TryGetValue(cacheKey, out var cached))
+            return cached;
+
+        var identity = GuardedProviderDecode.TypeSpec(
             reader,
             handle,
             this,
@@ -169,6 +206,9 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
                 "<invalid>",
                 "<invalid>",
                 IsDegraded: true));
+        CacheIdentity(reader, cacheKey, identity);
+        return identity;
+    }
 
     public ExplicitInterfaceTypeIdentity GetSZArrayType(ExplicitInterfaceTypeIdentity elementType)
         => Observe(new(
@@ -374,9 +414,55 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
                 IsDegraded: true))
         };
 
+    void CacheIdentity(
+        MetadataReader reader,
+        NamedIdentityCacheKey key,
+        ExplicitInterfaceTypeIdentity identity)
+    {
+        if (CacheHasCapacity(reader))
+            namedIdentityCache.TryAdd(key, identity);
+    }
+
+    void CacheIdentity(
+        MetadataReader reader,
+        TypeSpecificationIdentityCacheKey key,
+        ExplicitInterfaceTypeIdentity identity)
+    {
+        if (CacheHasCapacity(reader))
+            typeSpecificationIdentityCache.TryAdd(key, identity);
+    }
+
+    bool CacheHasCapacity(MetadataReader reader)
+        => namedIdentityCache.Count + typeSpecificationIdentityCache.Count
+            < (identityCacheEntryLimit ??= GetIdentityCacheEntryLimit(reader));
+
+    static int GetIdentityCacheEntryLimit(MetadataReader reader)
+    {
+        long identityHandles =
+            (long)reader.TypeDefinitions.Count
+            + reader.TypeReferences.Count
+            + reader.GetTableRowCount(TableIndex.TypeSpec);
+        return (int)Math.Min(
+            MaxIdentityCacheEntries,
+            Math.Min(int.MaxValue, identityHandles * 3));
+    }
+
     static string ApplyGenericArguments(string typeName, IReadOnlyList<string> typeArguments)
-        => TypeResolver.ApplyGenericArguments(typeName, typeArguments)
+    {
+        long displayLength = typeName.Length + 2L;
+        foreach (string argument in typeArguments)
+        {
+            displayLength += argument.Length + 1L;
+            if (displayLength > MetadataSafetyPolicy.MaxTypeNameCharacters)
+            {
+                throw new BadImageFormatException(
+                    "The constructed generic interface type name exceeds the metadata safety limit.");
+            }
+        }
+
+        return TypeResolver.ApplyGenericArguments(typeName, typeArguments)
             .Replace(", ", ",", StringComparison.Ordinal);
+    }
 
     string ResolutionScopeKey(MetadataReader reader, TypeReferenceHandle handle)
     {
@@ -413,6 +499,15 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
     }
 
     internal static string AssemblyKey(AssemblyReferenceIdentity identity)
+        => HashNode(
+            beforeEncode: null,
+            "assembly",
+            identity.Name.ToUpperInvariant(),
+            identity.Version?.ToString() ?? "",
+            NormalizeCulture(identity.Culture).ToUpperInvariant(),
+            (identity.PublicKeyToken ?? "").ToUpperInvariant());
+
+    string ObservedAssemblyKey(AssemblyReferenceIdentity identity)
         => Node(
             "assembly",
             identity.Name.ToUpperInvariant(),
@@ -428,7 +523,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         if (reader.IsAssembly)
         {
             ValidateAssemblyIdentity(reader, reader.GetAssemblyDefinition());
-            return currentModuleKey = AssemblyKey(
+            return currentModuleKey = ObservedAssemblyKey(
                 AssemblyReferenceIdentity.FromAssemblyDefinition(reader));
         }
 
@@ -446,12 +541,12 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
 
         var reference = reader.GetAssemblyReference(handle);
         ValidateAssemblyIdentity(reader, reference);
-        key = AssemblyKey(AssemblyReferenceIdentity.From(reader, handle));
+        key = ObservedAssemblyKey(AssemblyReferenceIdentity.From(reader, handle));
         assemblyScopeKeys.Add(handle, key);
         return key;
     }
 
-    static void ValidateAssemblyIdentity(
+    void ValidateAssemblyIdentity(
         MetadataReader reader,
         System.Reflection.Metadata.AssemblyReference reference)
     {
@@ -461,7 +556,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         ValidateAssemblyIdentityBlob(reader, reference.PublicKeyOrToken);
     }
 
-    static void ValidateAssemblyIdentity(MetadataReader reader, AssemblyDefinition definition)
+    void ValidateAssemblyIdentity(MetadataReader reader, AssemblyDefinition definition)
     {
         _ = BoundedString(reader, definition.Name);
         if (!definition.Culture.IsNil)
@@ -469,24 +564,30 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
         ValidateAssemblyIdentityBlob(reader, definition.PublicKey);
     }
 
-    static void ValidateAssemblyIdentityBlob(MetadataReader reader, BlobHandle handle)
+    void ValidateAssemblyIdentityBlob(MetadataReader reader, BlobHandle handle)
     {
-        if (!handle.IsNil
-            && reader.GetBlobReader(handle).Length > MaxAssemblyIdentityBlobBytes)
+        if (handle.IsNil)
+            return;
+
+        int length = reader.GetBlobReader(handle).Length;
+        if (length > MaxAssemblyIdentityBlobBytes)
         {
             throw new BadImageFormatException(
                 "The assembly identity key blob exceeds the inspection limit.");
         }
+        ObserveWork(length);
     }
 
-    static string BoundedString(MetadataReader reader, StringHandle handle)
+    string BoundedString(MetadataReader reader, StringHandle handle)
     {
-        if (reader.GetBlobReader(handle).Length > MetadataSafetyPolicy.MaxTypeNameCharacters)
+        int length = reader.GetBlobReader(handle).Length;
+        if (length > MetadataSafetyPolicy.MaxTypeNameCharacters)
             throw new BadImageFormatException("The metadata identity name exceeds the inspection limit.");
+        ObserveWork(length);
         return reader.GetString(handle);
     }
 
-    static (string Key, int GenericArity) ReferenceName(
+    (string Key, int GenericArity) ReferenceName(
         MetadataReader reader,
         TypeReferenceHandle handle)
     {
@@ -529,7 +630,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
             genericArity);
     }
 
-    static string StructuredNameKey(
+    string StructuredNameKey(
         string @namespace,
         IEnumerable<string> segments)
         => Node("type-name", [@namespace, .. segments]);
@@ -543,7 +644,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
                 : 0;
     }
 
-    static bool IsWellKnownNullable(
+    bool IsWellKnownNullable(
         MetadataReader reader,
         TypeDefinitionHandle handle)
     {
@@ -562,7 +663,7 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
                 .PublicKeyToken);
     }
 
-    static bool IsWellKnownNullable(
+    bool IsWellKnownNullable(
         MetadataReader reader,
         TypeReferenceHandle handle)
     {
@@ -586,16 +687,49 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
                 ? ""
                 : value;
 
-    static string Node(string tag, params string[] parts)
+    string Node(string tag, params string[] parts)
+        => HashNode(ObserveWork, tag, parts);
+
+    static string HashNode(
+        Action<int>? beforeEncode,
+        string tag,
+        params string[] parts)
     {
-        var builder = new StringBuilder(tag);
+        beforeEncode?.Invoke(1);
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        AppendNodePart(hash, tag, beforeEncode);
         foreach (string part in parts)
         {
-            builder.Append('|');
-            builder.Append(part.Length);
-            builder.Append(':');
-            builder.Append(part);
+            AppendNodePart(hash, part, beforeEncode);
         }
-        return builder.ToString();
+        return Convert.ToHexString(hash.GetHashAndReset());
+    }
+
+    static void AppendNodePart(
+        IncrementalHash hash,
+        string value,
+        Action<int>? beforeEncode)
+    {
+        beforeEncode?.Invoke(value.Length);
+        int byteCount = Encoding.UTF8.GetByteCount(value);
+        beforeEncode?.Invoke(
+            checked(byteCount - Math.Min(byteCount, value.Length) + sizeof(int)));
+        byte[]? rented = null;
+        Span<byte> bytes = byteCount <= 256
+            ? stackalloc byte[byteCount]
+            : (rented = ArrayPool<byte>.Shared.Rent(byteCount));
+        Span<byte> length = stackalloc byte[sizeof(int)];
+        try
+        {
+            int written = Encoding.UTF8.GetBytes(value, bytes);
+            BinaryPrimitives.WriteInt32BigEndian(length, written);
+            hash.AppendData(length);
+            hash.AppendData(bytes[..written]);
+        }
+        finally
+        {
+            if (rented is not null)
+                ArrayPool<byte>.Shared.Return(rented);
+        }
     }
 }

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -1,0 +1,266 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+internal readonly record struct ExplicitInterfaceTypeIdentity(
+    string Key,
+    string MetadataName,
+    ImmutableArray<ExplicitInterfaceTypeIdentity> GenericArguments = default,
+    bool IsDegraded = false);
+
+internal readonly record struct ExplicitInterfaceSignatureContext(
+    GenericContext? Names,
+    ImmutableArray<ExplicitInterfaceTypeIdentity> TypeArguments)
+{
+    public static ExplicitInterfaceSignatureContext Open(GenericContext? names)
+        => new(names, []);
+
+    public ExplicitInterfaceSignatureContext WithTypeArguments(
+        ImmutableArray<ExplicitInterfaceTypeIdentity> typeArguments)
+        => new(Names, typeArguments);
+}
+
+internal sealed class ExplicitInterfaceTypeIdentityProvider
+    : ISignatureTypeProvider<ExplicitInterfaceTypeIdentity, ExplicitInterfaceSignatureContext>
+{
+    public static ExplicitInterfaceTypeIdentityProvider Instance { get; } = new();
+
+    public ExplicitInterfaceTypeIdentity GetPrimitiveType(PrimitiveTypeCode typeCode)
+    {
+        string name = typeCode switch
+        {
+            PrimitiveTypeCode.Void => "System.Void",
+            PrimitiveTypeCode.Boolean => "System.Boolean",
+            PrimitiveTypeCode.Char => "System.Char",
+            PrimitiveTypeCode.SByte => "System.SByte",
+            PrimitiveTypeCode.Byte => "System.Byte",
+            PrimitiveTypeCode.Int16 => "System.Int16",
+            PrimitiveTypeCode.UInt16 => "System.UInt16",
+            PrimitiveTypeCode.Int32 => "System.Int32",
+            PrimitiveTypeCode.UInt32 => "System.UInt32",
+            PrimitiveTypeCode.Int64 => "System.Int64",
+            PrimitiveTypeCode.UInt64 => "System.UInt64",
+            PrimitiveTypeCode.Single => "System.Single",
+            PrimitiveTypeCode.Double => "System.Double",
+            PrimitiveTypeCode.String => "System.String",
+            PrimitiveTypeCode.Object => "System.Object",
+            PrimitiveTypeCode.IntPtr => "System.IntPtr",
+            PrimitiveTypeCode.UIntPtr => "System.UIntPtr",
+            PrimitiveTypeCode.TypedReference => "System.TypedReference",
+            _ => typeCode.ToString()
+        };
+        return new ExplicitInterfaceTypeIdentity(name, name);
+    }
+
+    public ExplicitInterfaceTypeIdentity GetTypeFromDefinition(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        byte rawTypeKind)
+    {
+        string name = TypeResolver.GetTypeNameFromDefinition(reader, handle);
+        return new ExplicitInterfaceTypeIdentity(
+            $"[{CurrentModuleKey(reader)}]{name}",
+            name);
+    }
+
+    public ExplicitInterfaceTypeIdentity GetTypeFromReference(
+        MetadataReader reader,
+        TypeReferenceHandle handle,
+        byte rawTypeKind)
+    {
+        string name = TypeResolver.GetTypeNameFromReference(reader, handle);
+        return new ExplicitInterfaceTypeIdentity(
+            $"[{ResolutionScopeKey(reader, handle)}]{name}",
+            name);
+    }
+
+    public ExplicitInterfaceTypeIdentity GetTypeFromSpecification(
+        MetadataReader reader,
+        ExplicitInterfaceSignatureContext context,
+        TypeSpecificationHandle handle,
+        byte rawTypeKind)
+        => GuardedProviderDecode.TypeSpec(
+            reader,
+            handle,
+            this,
+            context,
+            new ExplicitInterfaceTypeIdentity(
+                "<invalid>",
+                "<invalid>",
+                IsDegraded: true));
+
+    public ExplicitInterfaceTypeIdentity GetSZArrayType(ExplicitInterfaceTypeIdentity elementType)
+        => new(
+            $"{elementType.Key}[]",
+            $"{elementType.MetadataName}[]",
+            IsDegraded: elementType.IsDegraded);
+
+    public ExplicitInterfaceTypeIdentity GetArrayType(
+        ExplicitInterfaceTypeIdentity elementType,
+        ArrayShape shape)
+    {
+        string suffix = $"[{new string(',', Math.Max(shape.Rank - 1, 0))}]";
+        return new ExplicitInterfaceTypeIdentity(
+            elementType.Key + suffix,
+            elementType.MetadataName + suffix,
+            IsDegraded: elementType.IsDegraded);
+    }
+
+    public ExplicitInterfaceTypeIdentity GetByReferenceType(ExplicitInterfaceTypeIdentity elementType)
+        => new(
+            $"{elementType.Key}&",
+            $"{elementType.MetadataName}&",
+            IsDegraded: elementType.IsDegraded);
+
+    public ExplicitInterfaceTypeIdentity GetPointerType(ExplicitInterfaceTypeIdentity elementType)
+        => new(
+            $"{elementType.Key}*",
+            $"{elementType.MetadataName}*",
+            IsDegraded: elementType.IsDegraded);
+
+    public ExplicitInterfaceTypeIdentity GetPinnedType(ExplicitInterfaceTypeIdentity elementType)
+        => new(
+            $"pinned {elementType.Key}",
+            elementType.MetadataName,
+            IsDegraded: elementType.IsDegraded);
+
+    public ExplicitInterfaceTypeIdentity GetGenericInstantiation(
+        ExplicitInterfaceTypeIdentity genericType,
+        ImmutableArray<ExplicitInterfaceTypeIdentity> typeArguments)
+        => new(
+            ApplyGenericArguments(
+                genericType.Key,
+                typeArguments.Select(argument => argument.Key).ToArray()),
+            ApplyGenericArguments(
+                genericType.MetadataName,
+                typeArguments.Select(argument => argument.MetadataName).ToArray()),
+            typeArguments,
+            genericType.IsDegraded || typeArguments.Any(argument => argument.IsDegraded));
+
+    public ExplicitInterfaceTypeIdentity GetGenericMethodParameter(
+        ExplicitInterfaceSignatureContext context,
+        int index)
+    {
+        string name = context.Names is not null && index < context.Names.MethodParameters.Count
+            ? context.Names.MethodParameters[index]
+            : $"TM{index}";
+        return new ExplicitInterfaceTypeIdentity($"!!{index}", name);
+    }
+
+    public ExplicitInterfaceTypeIdentity GetGenericTypeParameter(
+        ExplicitInterfaceSignatureContext context,
+        int index)
+    {
+        if (index < context.TypeArguments.Length)
+            return context.TypeArguments[index];
+
+        string name = context.Names is not null && index < context.Names.TypeParameters.Count
+            ? context.Names.TypeParameters[index]
+            : $"T{index}";
+        return new ExplicitInterfaceTypeIdentity($"!{index}", name);
+    }
+
+    public ExplicitInterfaceTypeIdentity GetModifiedType(
+        ExplicitInterfaceTypeIdentity modifier,
+        ExplicitInterfaceTypeIdentity unmodifiedType,
+        bool isRequired)
+        => new(
+            $"{(isRequired ? "modreq" : "modopt")}({modifier.Key}){unmodifiedType.Key}",
+            unmodifiedType.MetadataName,
+            IsDegraded: modifier.IsDegraded || unmodifiedType.IsDegraded);
+
+    public ExplicitInterfaceTypeIdentity GetFunctionPointerType(
+        MethodSignature<ExplicitInterfaceTypeIdentity> signature)
+    {
+        string key = $"method[{signature.Header.RawValue}:"
+            + $"{signature.GenericParameterCount}:{signature.RequiredParameterCount}] "
+            + $"{signature.ReturnType.Key} *("
+            + string.Join(",", signature.ParameterTypes.Select(parameter => parameter.Key))
+            + ")";
+        string name = $"method {signature.ReturnType.MetadataName} *("
+            + string.Join(",", signature.ParameterTypes.Select(parameter => parameter.MetadataName))
+            + ")";
+        return new ExplicitInterfaceTypeIdentity(
+            key,
+            name,
+            IsDegraded: signature.ReturnType.IsDegraded
+                || signature.ParameterTypes.Any(parameter => parameter.IsDegraded));
+    }
+
+    internal static ExplicitInterfaceTypeIdentity FromHandle(
+        MetadataReader reader,
+        EntityHandle handle,
+        GenericContext? context)
+        => handle.Kind switch
+        {
+            HandleKind.TypeDefinition => Instance.GetTypeFromDefinition(
+                reader,
+                (TypeDefinitionHandle)handle,
+                rawTypeKind: 0),
+            HandleKind.TypeReference => Instance.GetTypeFromReference(
+                reader,
+                (TypeReferenceHandle)handle,
+                rawTypeKind: 0),
+            HandleKind.TypeSpecification => Instance.GetTypeFromSpecification(
+                reader,
+                ExplicitInterfaceSignatureContext.Open(context),
+                (TypeSpecificationHandle)handle,
+                rawTypeKind: 0),
+            _ => new ExplicitInterfaceTypeIdentity(
+                "<invalid>",
+                "<invalid>",
+                IsDegraded: true)
+        };
+
+    static string ApplyGenericArguments(string typeName, IReadOnlyList<string> typeArguments)
+        => TypeResolver.ApplyGenericArguments(typeName, typeArguments)
+            .Replace(", ", ",", StringComparison.Ordinal);
+
+    static string ResolutionScopeKey(MetadataReader reader, TypeReferenceHandle handle)
+    {
+        Span<TypeReferenceHandle> chain =
+            stackalloc TypeReferenceHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkTypeReferenceResolutionScope(
+                reader,
+                handle,
+                chain,
+                out int consumed,
+                out _,
+                out var rejection)
+            || consumed == 0)
+        {
+            throw new BadImageFormatException(
+                rejection?.Detail
+                    ?? "The interface type has an invalid resolution-scope chain.");
+        }
+
+        EntityHandle scope = reader.GetTypeReference(chain[0]).ResolutionScope;
+        return scope.Kind switch
+        {
+            HandleKind.AssemblyReference => AssemblyKey(
+                AssemblyReferenceIdentity.From(reader, (AssemblyReferenceHandle)scope)),
+            HandleKind.ModuleDefinition when reader.IsAssembly => AssemblyKey(
+                AssemblyReferenceIdentity.FromAssemblyDefinition(reader)),
+            HandleKind.ModuleDefinition => CurrentModuleKey(reader),
+            HandleKind.ModuleReference => "module:"
+                + reader.GetString(reader.GetModuleReference((ModuleReferenceHandle)scope).Name),
+            _ => scope.Kind.ToString()
+        };
+    }
+
+    static string AssemblyKey(AssemblyReferenceIdentity identity)
+        => $"{identity.Name}|{identity.Version}|{identity.Culture}|{identity.PublicKeyToken}";
+
+    static string CurrentModuleKey(MetadataReader reader)
+    {
+        if (reader.IsAssembly)
+            return AssemblyKey(AssemblyReferenceIdentity.FromAssemblyDefinition(reader));
+
+        var module = reader.GetModuleDefinition();
+        return "module:"
+            + reader.GetString(module.Name)
+            + "|"
+            + reader.GetGuid(module.Mvid);
+    }
+}

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Text;
 
@@ -10,7 +11,9 @@ internal readonly record struct ExplicitInterfaceTypeIdentity(
     string? AggregateAliasName = null,
     ImmutableArray<ExplicitInterfaceTypeIdentity> GenericArguments = default,
     int GenericArity = 0,
-    bool IsDegraded = false);
+    bool IsDegraded = false,
+    bool? IsInterface = null,
+    bool IsWellKnownNullable = false);
 
 internal readonly record struct ExplicitInterfaceSignatureContext(
     GenericContext? Names,
@@ -89,7 +92,10 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
                 CurrentModuleKey(reader),
                 StructuredNameKey(result.Name.Namespace, result.Name.Segments)),
             name,
-            GenericArity: reader.GetTypeDefinition(handle).GetGenericParameters().Count);
+            GenericArity: reader.GetTypeDefinition(handle).GetGenericParameters().Count,
+            IsInterface: (reader.GetTypeDefinition(handle).Attributes
+                & TypeAttributes.Interface) != 0,
+            IsWellKnownNullable: IsWellKnownNullable(reader, handle));
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromReference(
@@ -106,7 +112,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
                 ResolutionScopeKey(reader, handle),
                 structuredName.Key),
             name,
-            GenericArity: structuredName.GenericArity);
+            GenericArity: structuredName.GenericArity,
+            IsWellKnownNullable: IsWellKnownNullable(reader, handle));
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromSpecification(
@@ -175,13 +182,13 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         ExplicitInterfaceTypeIdentity genericType,
         ImmutableArray<ExplicitInterfaceTypeIdentity> typeArguments)
     {
-        string? aggregateAlias = (genericType.MetadataName == "System.Nullable"
-            || genericType.MetadataName.StartsWith(
-                "System.Nullable<",
-                StringComparison.Ordinal)
-            || genericType.MetadataName.StartsWith(
-                "System.Nullable`",
-                StringComparison.Ordinal))
+        if (genericType.GenericArity != typeArguments.Length)
+        {
+            throw new BadImageFormatException(
+                "The generic interface type argument count does not match its declared arity.");
+        }
+
+        string? aggregateAlias = genericType.IsWellKnownNullable
             && typeArguments is [var nullableArgument]
                 ? $"{nullableArgument.AggregateAliasName ?? nullableArgument.MetadataName}?"
                 : typeArguments.Any(argument => argument.AggregateAliasName is not null)
@@ -199,9 +206,12 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
                 genericType.MetadataName,
                 typeArguments.Select(argument => argument.MetadataName).ToArray()),
             aggregateAlias,
-            typeArguments,
-            genericType.GenericArity,
-            genericType.IsDegraded || typeArguments.Any(argument => argument.IsDegraded));
+            GenericArguments: typeArguments,
+            GenericArity: genericType.GenericArity,
+            IsDegraded: genericType.IsDegraded
+                || typeArguments.Any(argument => argument.IsDegraded),
+            IsInterface: genericType.IsInterface,
+            IsWellKnownNullable: genericType.IsWellKnownNullable);
     }
 
     public ExplicitInterfaceTypeIdentity GetGenericMethodParameter(
@@ -456,6 +466,43 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             && int.TryParse(name[(separator + 1)..], out int arity)
                 ? arity
                 : 0;
+    }
+
+    static bool IsWellKnownNullable(
+        MetadataReader reader,
+        TypeDefinitionHandle handle)
+    {
+        var type = reader.GetTypeDefinition(handle);
+        if (!type.GetDeclaringType().IsNil
+            || BoundedString(reader, type.Name) != "Nullable`1"
+            || BoundedString(reader, type.Namespace) != "System"
+            || !reader.IsAssembly)
+        {
+            return false;
+        }
+
+        return PlatformKeys.IsPlatform(
+            AssemblyReferenceIdentity
+                .FromAssemblyDefinition(reader)
+                .PublicKeyToken);
+    }
+
+    static bool IsWellKnownNullable(
+        MetadataReader reader,
+        TypeReferenceHandle handle)
+    {
+        var type = reader.GetTypeReference(handle);
+        if (type.ResolutionScope.Kind != HandleKind.AssemblyReference
+            || BoundedString(reader, type.Name) != "Nullable`1"
+            || BoundedString(reader, type.Namespace) != "System")
+        {
+            return false;
+        }
+
+        return PlatformKeys.IsPlatform(
+            AssemblyReferenceIdentity
+                .From(reader, (AssemblyReferenceHandle)type.ResolutionScope)
+                .PublicKeyToken);
     }
 
     static string NormalizeCulture(string? value)

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -15,7 +15,10 @@ internal readonly record struct ExplicitInterfaceTypeIdentity(
     bool? IsInterface = null,
     bool IsWellKnownNullable = false,
     bool IsConstructedGeneric = false,
-    string? ModifiedTypeKey = null)
+    string? ModifiedTypeKey = null,
+    int CustomModifierCount = 0,
+    string? SingleCustomModifierMetadataName = null,
+    bool IsSingleCustomModifierRequired = false)
 {
     /// <summary>
     /// The identity key with every custom modifier stripped. Only a
@@ -304,7 +307,13 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider(
             IsInterface: unmodifiedType.IsInterface,
             IsWellKnownNullable: unmodifiedType.IsWellKnownNullable,
             IsConstructedGeneric: unmodifiedType.IsConstructedGeneric,
-            ModifiedTypeKey: unmodifiedType.UnmodifiedKey));
+            ModifiedTypeKey: unmodifiedType.UnmodifiedKey,
+            CustomModifierCount: checked(unmodifiedType.CustomModifierCount + 1),
+            SingleCustomModifierMetadataName: unmodifiedType.CustomModifierCount == 0
+                ? modifier.MetadataName
+                : null,
+            IsSingleCustomModifierRequired: unmodifiedType.CustomModifierCount == 0
+                && isRequired));
 
     public ExplicitInterfaceTypeIdentity GetFunctionPointerType(
         MethodSignature<ExplicitInterfaceTypeIdentity> signature)

--- a/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
+++ b/src/ILInspector.Metadata/ExplicitInterfaceTypeIdentity.cs
@@ -13,7 +13,8 @@ internal readonly record struct ExplicitInterfaceTypeIdentity(
     int GenericArity = 0,
     bool IsDegraded = false,
     bool? IsInterface = null,
-    bool IsWellKnownNullable = false);
+    bool IsWellKnownNullable = false,
+    bool IsConstructedGeneric = false);
 
 internal readonly record struct ExplicitInterfaceSignatureContext(
     GenericContext? Names,
@@ -72,7 +73,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
         return new ExplicitInterfaceTypeIdentity(
             Node("primitive", ((int)typeCode).ToString()),
             name,
-            alias);
+            alias,
+            IsInterface: false);
     }
 
     public ExplicitInterfaceTypeIdentity GetTypeFromDefinition(
@@ -136,7 +138,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             Node("szarray", elementType.Key),
             $"{elementType.MetadataName}[]",
             elementType.AggregateAliasName is { } alias ? $"{alias}[]" : null,
-            IsDegraded: elementType.IsDegraded);
+            IsDegraded: elementType.IsDegraded,
+            IsInterface: false);
 
     public ExplicitInterfaceTypeIdentity GetArrayType(
         ExplicitInterfaceTypeIdentity elementType,
@@ -154,7 +157,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
                 elementType.Key),
             elementType.MetadataName + suffix,
             elementType.AggregateAliasName is { } alias ? alias + suffix : null,
-            IsDegraded: elementType.IsDegraded);
+            IsDegraded: elementType.IsDegraded,
+            IsInterface: false);
     }
 
     public ExplicitInterfaceTypeIdentity GetByReferenceType(ExplicitInterfaceTypeIdentity elementType)
@@ -162,26 +166,34 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             Node("byref", elementType.Key),
             $"{elementType.MetadataName}&",
             elementType.AggregateAliasName is { } alias ? $"{alias}&" : null,
-            IsDegraded: elementType.IsDegraded);
+            IsDegraded: elementType.IsDegraded,
+            IsInterface: false);
 
     public ExplicitInterfaceTypeIdentity GetPointerType(ExplicitInterfaceTypeIdentity elementType)
         => new(
             Node("pointer", elementType.Key),
             $"{elementType.MetadataName}*",
             elementType.AggregateAliasName is { } alias ? $"{alias}*" : null,
-            IsDegraded: elementType.IsDegraded);
+            IsDegraded: elementType.IsDegraded,
+            IsInterface: false);
 
     public ExplicitInterfaceTypeIdentity GetPinnedType(ExplicitInterfaceTypeIdentity elementType)
         => new(
             Node("pinned", elementType.Key),
             elementType.MetadataName,
             elementType.AggregateAliasName,
-            IsDegraded: elementType.IsDegraded);
+            IsDegraded: elementType.IsDegraded,
+            IsInterface: false);
 
     public ExplicitInterfaceTypeIdentity GetGenericInstantiation(
         ExplicitInterfaceTypeIdentity genericType,
         ImmutableArray<ExplicitInterfaceTypeIdentity> typeArguments)
     {
+        if (genericType.IsConstructedGeneric)
+        {
+            throw new BadImageFormatException(
+                "A constructed generic interface type cannot be instantiated again.");
+        }
         if (genericType.GenericArity != typeArguments.Length)
         {
             throw new BadImageFormatException(
@@ -211,7 +223,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             IsDegraded: genericType.IsDegraded
                 || typeArguments.Any(argument => argument.IsDegraded),
             IsInterface: genericType.IsInterface,
-            IsWellKnownNullable: genericType.IsWellKnownNullable);
+            IsWellKnownNullable: genericType.IsWellKnownNullable,
+            IsConstructedGeneric: true);
     }
 
     public ExplicitInterfaceTypeIdentity GetGenericMethodParameter(
@@ -250,7 +263,12 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             Node(isRequired ? "modreq" : "modopt", modifier.Key, unmodifiedType.Key),
             unmodifiedType.MetadataName,
             unmodifiedType.AggregateAliasName,
-            IsDegraded: modifier.IsDegraded || unmodifiedType.IsDegraded);
+            GenericArguments: unmodifiedType.GenericArguments,
+            GenericArity: unmodifiedType.GenericArity,
+            IsDegraded: modifier.IsDegraded || unmodifiedType.IsDegraded,
+            IsInterface: unmodifiedType.IsInterface,
+            IsWellKnownNullable: unmodifiedType.IsWellKnownNullable,
+            IsConstructedGeneric: unmodifiedType.IsConstructedGeneric);
 
     public ExplicitInterfaceTypeIdentity GetFunctionPointerType(
         MethodSignature<ExplicitInterfaceTypeIdentity> signature)
@@ -271,7 +289,8 @@ internal sealed class ExplicitInterfaceTypeIdentityProvider
             key,
             name,
             IsDegraded: signature.ReturnType.IsDegraded
-                || signature.ParameterTypes.Any(parameter => parameter.IsDegraded));
+                || signature.ParameterTypes.Any(parameter => parameter.IsDegraded),
+            IsInterface: false);
     }
 
     internal ExplicitInterfaceTypeIdentity FromHandle(

--- a/src/ILInspector.Metadata/MetadataAccessibility.cs
+++ b/src/ILInspector.Metadata/MetadataAccessibility.cs
@@ -1,0 +1,82 @@
+using System.Reflection;
+
+namespace ILInspector.Metadata;
+
+internal static class MetadataAccessibility
+{
+    public static bool TryGet(MethodAttributes access, out string? value)
+    {
+        switch (access)
+        {
+            case MethodAttributes.PrivateScope:
+            case MethodAttributes.Private:
+                value = "private";
+                return true;
+            case MethodAttributes.FamANDAssem:
+                value = "private protected";
+                return true;
+            case MethodAttributes.Assembly:
+                value = "internal";
+                return true;
+            case MethodAttributes.Family:
+                value = "protected";
+                return true;
+            case MethodAttributes.FamORAssem:
+                value = "protected internal";
+                return true;
+            case MethodAttributes.Public:
+                value = null;
+                return true;
+            default:
+                value = null;
+                return false;
+        }
+    }
+
+    public static bool TryGet(FieldAttributes access, out string? value)
+    {
+        switch (access)
+        {
+            case FieldAttributes.PrivateScope:
+            case FieldAttributes.Private:
+                value = "private";
+                return true;
+            case FieldAttributes.FamANDAssem:
+                value = "private protected";
+                return true;
+            case FieldAttributes.Assembly:
+                value = "internal";
+                return true;
+            case FieldAttributes.Family:
+                value = "protected";
+                return true;
+            case FieldAttributes.FamORAssem:
+                value = "protected internal";
+                return true;
+            case FieldAttributes.Public:
+                value = null;
+                return true;
+            default:
+                value = null;
+                return false;
+        }
+    }
+
+    public static string? Get(MethodAttributes access)
+        => TryGet(access, out string? value)
+            ? value
+            : throw new BadImageFormatException(
+                $"Unknown method accessibility value 0x{(int)access:X}.");
+
+    public static string? Get(FieldAttributes access)
+        => TryGet(access, out string? value)
+            ? value
+            : throw new BadImageFormatException(
+                $"Unknown field accessibility value 0x{(int)access:X}.");
+
+    public static string Keyword(MethodAttributes access)
+        => Get(access) ?? "public";
+
+    public static string Keyword(FieldAttributes access)
+        => Get(access) ?? "public";
+}

--- a/src/ILInspector.Metadata/MetadataAccessibility.cs
+++ b/src/ILInspector.Metadata/MetadataAccessibility.cs
@@ -4,6 +4,58 @@ namespace ILInspector.Metadata;
 
 internal static class MetadataAccessibility
 {
+    public static MethodAttributes Join(
+        MethodAttributes left,
+        MethodAttributes right)
+    {
+        if (!TryGet(left, out _))
+            return left;
+        if (!TryGet(right, out _))
+            return right;
+
+        left = Normalize(left);
+        right = Normalize(right);
+        if (left == right)
+            return left;
+        if (left == MethodAttributes.Public
+            || right == MethodAttributes.Public)
+        {
+            return MethodAttributes.Public;
+        }
+        if (left == MethodAttributes.FamORAssem
+            || right == MethodAttributes.FamORAssem
+            || left is MethodAttributes.Assembly
+                && right is MethodAttributes.Family
+            || left is MethodAttributes.Family
+                && right is MethodAttributes.Assembly)
+        {
+            return MethodAttributes.FamORAssem;
+        }
+        if (left == MethodAttributes.Assembly
+            || right == MethodAttributes.Assembly)
+        {
+            return MethodAttributes.Assembly;
+        }
+        if (left == MethodAttributes.Family
+            || right == MethodAttributes.Family)
+        {
+            return MethodAttributes.Family;
+        }
+        if (left == MethodAttributes.FamANDAssem
+            || right == MethodAttributes.FamANDAssem)
+        {
+            return MethodAttributes.FamANDAssem;
+        }
+        return MethodAttributes.Private;
+    }
+
+    public static bool Equivalent(
+        MethodAttributes left,
+        MethodAttributes right) =>
+        TryGet(left, out string? leftValue)
+        && TryGet(right, out string? rightValue)
+        && string.Equals(leftValue, rightValue, StringComparison.Ordinal);
+
     public static bool TryGet(MethodAttributes access, out string? value)
     {
         switch (access)
@@ -79,4 +131,9 @@ internal static class MetadataAccessibility
 
     public static string Keyword(FieldAttributes access)
         => Get(access) ?? "public";
+
+    private static MethodAttributes Normalize(MethodAttributes access)
+        => access == MethodAttributes.PrivateScope
+            ? MethodAttributes.Private
+            : access;
 }

--- a/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
+++ b/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
@@ -14,30 +14,62 @@ internal static class MetadataAccessorSemantics
             ? "init"
             : defaultKind;
 
-    public static bool IsUniformlyAbstract(
+    public static bool AreAllAbstract(
         MetadataReader reader,
         params MethodDefinitionHandle[] handles)
     {
-        bool anyAbstract = false;
-        bool anyConcrete = false;
+        bool anyAccessor = false;
         foreach (var handle in handles)
         {
             if (handle.IsNil)
                 continue;
 
-            bool isAbstract =
-                (reader.GetMethodDefinition(handle).Attributes & MethodAttributes.Abstract) != 0;
-            anyAbstract |= isAbstract;
-            anyConcrete |= !isAbstract;
+            anyAccessor = true;
+            if ((reader.GetMethodDefinition(handle).Attributes & MethodAttributes.Abstract) == 0)
+                return false;
         }
 
-        if (anyAbstract && anyConcrete)
+        return anyAccessor;
+    }
+
+    public static bool TryGetUniformSealedOverride(
+        MetadataReader reader,
+        out bool isSealed,
+        params MethodDefinitionHandle[] handles)
+    {
+        bool? expected = null;
+        foreach (var handle in handles)
+        {
+            if (handle.IsNil)
+                continue;
+
+            var attributes = reader.GetMethodDefinition(handle).Attributes;
+            bool accessorSealed =
+                (attributes & MethodAttributes.Virtual) != 0
+                && (attributes & MethodAttributes.NewSlot) == 0
+                && (attributes & MethodAttributes.Final) != 0;
+            if (expected is not null && expected != accessorSealed)
+            {
+                isSealed = false;
+                return false;
+            }
+            expected = accessorSealed;
+        }
+
+        isSealed = expected == true;
+        return true;
+    }
+
+    public static bool IsUniformlySealedOverride(
+        MetadataReader reader,
+        params MethodDefinitionHandle[] handles)
+    {
+        if (!TryGetUniformSealedOverride(reader, out bool isSealed, handles))
         {
             throw new BadImageFormatException(
-                "The aggregate has inconsistent abstract accessor metadata.");
+                "The aggregate has inconsistent sealed accessor metadata.");
         }
-
-        return anyAbstract;
+        return isSealed;
     }
 
     static bool IsInitOnlySetter(
@@ -120,7 +152,19 @@ internal static class MetadataAccessorSemantics
             object? context,
             TypeSpecificationHandle handle,
             byte rawTypeKind)
-            => default;
+        {
+            var decoded = GuardedProviderDecode.TypeSpec(
+                reader,
+                handle,
+                this,
+                context,
+                new InitOnlyModifierState(false, false, true));
+            return decoded with
+            {
+                IsExternalInitType = false,
+                IsMalformed = true,
+            };
+        }
 
         public InitOnlyModifierState GetSZArrayType(InitOnlyModifierState elementType)
             => default;

--- a/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
+++ b/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
@@ -53,12 +53,15 @@ internal static class MetadataAccessorSemantics
             default(InitOnlyModifierState));
         if (result.IsDegraded)
             throw new BadImageFormatException("The property setter signature could not be decoded.");
+        if (result.Value.ReturnType.IsMalformed)
+            throw new BadImageFormatException("The init-only modifier type is malformed.");
         return result.Value.ReturnType.IsInitOnly;
     }
 
     readonly record struct InitOnlyModifierState(
         bool IsExternalInitType,
-        bool IsInitOnly);
+        bool IsInitOnly,
+        bool IsMalformed);
 
     sealed class InitOnlyModifierDetector
         : ISignatureTypeProvider<InitOnlyModifierState, object?>
@@ -75,7 +78,11 @@ internal static class MetadataAccessorSemantics
         {
             var type = reader.GetTypeDefinition(handle);
             return new(
-                IsExternalInit(reader.GetString(type.Name), reader.GetString(type.Namespace)),
+                type.GetDeclaringType().IsNil
+                    && IsExternalInit(
+                        reader.GetString(type.Name),
+                        reader.GetString(type.Namespace)),
+                false,
                 false);
         }
 
@@ -85,8 +92,26 @@ internal static class MetadataAccessorSemantics
             byte rawTypeKind)
         {
             var type = reader.GetTypeReference(handle);
+            if (type.ResolutionScope.Kind == HandleKind.TypeReference)
+            {
+                Span<TypeReferenceHandle> chain =
+                    stackalloc TypeReferenceHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+                if (!MetadataRelationshipTraversal.TryWalkTypeReferenceResolutionScope(
+                        reader,
+                        handle,
+                        chain,
+                        out _,
+                        out _,
+                        out _))
+                {
+                    return new(false, false, true);
+                }
+
+                return default;
+            }
             return new(
                 IsExternalInit(reader.GetString(type.Name), reader.GetString(type.Namespace)),
+                false,
                 false);
         }
 
@@ -133,7 +158,8 @@ internal static class MetadataAccessorSemantics
             => new(
                 false,
                 unmodifiedType.IsInitOnly
-                    || isRequired && modifier.IsExternalInitType);
+                    || isRequired && modifier.IsExternalInitType,
+                modifier.IsMalformed || unmodifiedType.IsMalformed);
 
         public InitOnlyModifierState GetPinnedType(InitOnlyModifierState elementType)
             => elementType;

--- a/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
+++ b/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
@@ -12,6 +12,9 @@ internal enum AccessorAbstractionFault
     /// <summary>An accessor is marked abstract yet declares an IL body.</summary>
     AbstractAccessorHasBody,
 
+    /// <summary>An accessor is marked abstract without also being virtual.</summary>
+    AbstractAccessorIsNotVirtual,
+
     /// <summary>The accessors of a class or struct aggregate disagree about abstractness.</summary>
     InconsistentAbstraction,
 }
@@ -21,8 +24,13 @@ internal static class MetadataAccessorSemantics
     public static string Kind(
         MetadataReader reader,
         MethodDefinitionHandle handle,
-        string defaultKind)
-        => defaultKind == "set" && IsInitOnlySetter(reader, handle)
+        string defaultKind,
+        Action<int>? beforeDecodeWork = null)
+        => defaultKind == "set"
+            && IsInitOnlySetter(
+                reader,
+                handle,
+                beforeDecodeWork)
             ? "init"
             : defaultKind;
 
@@ -45,8 +53,8 @@ internal static class MetadataAccessorSemantics
     }
 
     /// <summary>
-    /// Checks that an aggregate's accessors agree about abstractness and that no abstract
-    /// accessor claims an IL body.
+    /// Checks that an aggregate's accessors agree about abstractness and that every abstract
+    /// accessor is virtual and declares no IL body.
     /// </summary>
     /// <param name="requireUniformAbstraction">
     /// <see langword="true"/> for a class or struct aggregate, where C# owns abstractness at
@@ -56,11 +64,12 @@ internal static class MetadataAccessorSemantics
     /// <see langword="false"/> and keeps that shape.
     /// </param>
     /// <remarks>
-    /// ECMA-335 II.15.4.2.4 forbids an abstract method body, so the body-state half applies to
-    /// every declaring type. Gated by
+    /// ECMA-335 II.15.4.2.4 requires an abstract method to be virtual and forbids it from declaring
+    /// a body, so both method-shape checks apply to every declaring type. Gated by
     /// <c>MetadataDeclarationQueryTests.MixedAbstractionAggregates_FailVisibly</c>,
     /// <c>MetadataDeclarationQueryTests.MixedAbstractionInterfaceAggregates_AreRetained</c>, and
-    /// <c>MetadataDeclarationQueryTests.AbstractAccessorWithBody_FailsVisibly</c>.
+    /// <c>MetadataDeclarationQueryTests.AbstractAccessorWithBody_FailsVisibly</c>, and
+    /// <c>MetadataDeclarationQueryTests.AbstractNonVirtualAccessors_FailVisibly</c>.
     /// </remarks>
     public static AccessorAbstractionFault ValidateAbstraction(
         MetadataReader reader,
@@ -75,6 +84,11 @@ internal static class MetadataAccessorSemantics
 
             var method = reader.GetMethodDefinition(handle);
             bool isAbstract = (method.Attributes & MethodAttributes.Abstract) != 0;
+            if (isAbstract
+                && (method.Attributes & MethodAttributes.Virtual) == 0)
+            {
+                return AccessorAbstractionFault.AbstractAccessorIsNotVirtual;
+            }
             if (isAbstract && method.RelativeVirtualAddress != 0)
                 return AccessorAbstractionFault.AbstractAccessorHasBody;
             if (requireUniformAbstraction && expected is { } previous && previous != isAbstract)
@@ -84,6 +98,20 @@ internal static class MetadataAccessorSemantics
 
         return AccessorAbstractionFault.None;
     }
+
+    public static string AbstractionFailureDetail(
+        string aggregateKind,
+        AccessorAbstractionFault fault)
+        => fault switch
+        {
+            AccessorAbstractionFault.AbstractAccessorHasBody =>
+                $"The {aggregateKind} has an abstract accessor that declares an IL body.",
+            AccessorAbstractionFault.AbstractAccessorIsNotVirtual =>
+                $"The {aggregateKind} has an abstract accessor that is not virtual.",
+            AccessorAbstractionFault.InconsistentAbstraction =>
+                $"The {aggregateKind} has inconsistent abstract accessor metadata.",
+            _ => throw new ArgumentOutOfRangeException(nameof(fault)),
+        };
 
     /// <summary>
     /// Checks that accessors agree on static shape and that virtual accessors agree on slot
@@ -173,13 +201,14 @@ internal static class MetadataAccessorSemantics
 
     static bool IsInitOnlySetter(
         MetadataReader reader,
-        MethodDefinitionHandle handle)
+        MethodDefinitionHandle handle,
+        Action<int>? beforeDecodeWork)
     {
         var method = reader.GetMethodDefinition(handle);
         var result = GuardedProviderDecode.MethodResult(
             reader,
             method,
-            InitOnlyModifierDetector.Instance,
+            new InitOnlyModifierDetector(beforeDecodeWork),
             (object?)null,
             default(InitOnlyModifierState));
         if (result.IsDegraded)
@@ -197,7 +226,12 @@ internal static class MetadataAccessorSemantics
     sealed class InitOnlyModifierDetector
         : ISignatureTypeProvider<InitOnlyModifierState, object?>
     {
-        public static InitOnlyModifierDetector Instance { get; } = new();
+        readonly Action<int>? _beforeDecodeWork;
+
+        public InitOnlyModifierDetector(Action<int>? beforeDecodeWork)
+        {
+            _beforeDecodeWork = beforeDecodeWork;
+        }
 
         public InitOnlyModifierState GetPrimitiveType(PrimitiveTypeCode typeCode)
             => default;
@@ -211,8 +245,8 @@ internal static class MetadataAccessorSemantics
             return new(
                 type.GetDeclaringType().IsNil
                     && IsExternalInit(
-                        reader.GetString(type.Name),
-                        reader.GetString(type.Namespace)),
+                        DecodeName(reader, type.Name),
+                        DecodeName(reader, type.Namespace)),
                 false,
                 false);
         }
@@ -241,9 +275,25 @@ internal static class MetadataAccessorSemantics
                 return default;
             }
             return new(
-                IsExternalInit(reader.GetString(type.Name), reader.GetString(type.Namespace)),
+                IsExternalInit(
+                    DecodeName(reader, type.Name),
+                    DecodeName(reader, type.Namespace)),
                 false,
                 false);
+        }
+
+        string DecodeName(
+            MetadataReader reader,
+            StringHandle handle)
+        {
+            int length = reader.GetBlobReader(handle).Length;
+            if (length > MetadataSafetyPolicy.MaxTypeNameCharacters)
+            {
+                throw new BadImageFormatException(
+                    "The init-only modifier type name exceeds the inspection limit.");
+            }
+            _beforeDecodeWork?.Invoke(length);
+            return reader.GetString(handle);
         }
 
         public InitOnlyModifierState GetTypeFromSpecification(

--- a/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
+++ b/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
@@ -85,6 +85,52 @@ internal static class MetadataAccessorSemantics
         return AccessorAbstractionFault.None;
     }
 
+    /// <summary>
+    /// Checks that accessors agree on static shape and that virtual accessors agree on slot
+    /// ownership. A virtual accessor may have a non-virtual companion; CoreLib uses that metadata
+    /// shape, and accessor facts preserve it without treating the companion as another slot.
+    /// </summary>
+    /// <remarks>
+    /// Gated by
+    /// <c>MetadataDeclarationQueryTests.PropertySlots_RejectMixedNewSlotAndOverrideAccessors</c>.
+    /// </remarks>
+    public static bool HaveUniformMemberModifiers(
+        MetadataReader reader,
+        params MethodDefinitionHandle[] handles)
+    {
+        bool? expectedStatic = null;
+        bool? expectedVirtualNewSlot = null;
+        foreach (MethodDefinitionHandle handle in handles)
+        {
+            if (handle.IsNil)
+                continue;
+
+            MethodAttributes attributes =
+                reader.GetMethodDefinition(handle).Attributes;
+            bool isStatic =
+                (attributes & MethodAttributes.Static) != 0;
+            if (expectedStatic is { } previousStatic
+                && previousStatic != isStatic)
+            {
+                return false;
+            }
+            expectedStatic = isStatic;
+
+            if ((attributes & MethodAttributes.Virtual) == 0)
+                continue;
+            bool isNewSlot =
+                (attributes & MethodAttributes.NewSlot) != 0;
+            if (expectedVirtualNewSlot is { } previousNewSlot
+                && previousNewSlot != isNewSlot)
+            {
+                return false;
+            }
+            expectedVirtualNewSlot = isNewSlot;
+        }
+
+        return true;
+    }
+
     public static bool TryGetUniformSealedOverride(
         MetadataReader reader,
         out bool isSealed,

--- a/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
+++ b/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
@@ -4,6 +4,18 @@ using System.Reflection.Metadata;
 
 namespace ILInspector.Metadata;
 
+/// <summary>How an aggregate's accessor abstraction metadata is malformed, if at all.</summary>
+internal enum AccessorAbstractionFault
+{
+    None,
+
+    /// <summary>An accessor is marked abstract yet declares an IL body.</summary>
+    AbstractAccessorHasBody,
+
+    /// <summary>The accessors of a class or struct aggregate disagree about abstractness.</summary>
+    InconsistentAbstraction,
+}
+
 internal static class MetadataAccessorSemantics
 {
     public static string Kind(
@@ -30,6 +42,47 @@ internal static class MetadataAccessorSemantics
         }
 
         return anyAccessor;
+    }
+
+    /// <summary>
+    /// Checks that an aggregate's accessors agree about abstractness and that no abstract
+    /// accessor claims an IL body.
+    /// </summary>
+    /// <param name="requireUniformAbstraction">
+    /// <see langword="true"/> for a class or struct aggregate, where C# owns abstractness at
+    /// the member — not the accessor — so disagreeing accessors have no legal spelling and the
+    /// aggregate must not be projected as a concrete one. Interfaces legitimately mix an
+    /// abstract accessor with a defaulted one, so an interface aggregate passes
+    /// <see langword="false"/> and keeps that shape.
+    /// </param>
+    /// <remarks>
+    /// ECMA-335 II.15.4.2.4 forbids an abstract method body, so the body-state half applies to
+    /// every declaring type. Gated by
+    /// <c>MetadataDeclarationQueryTests.MixedAbstractionAggregates_FailVisibly</c>,
+    /// <c>MetadataDeclarationQueryTests.MixedAbstractionInterfaceAggregates_AreRetained</c>, and
+    /// <c>MetadataDeclarationQueryTests.AbstractAccessorWithBody_FailsVisibly</c>.
+    /// </remarks>
+    public static AccessorAbstractionFault ValidateAbstraction(
+        MetadataReader reader,
+        bool requireUniformAbstraction,
+        params MethodDefinitionHandle[] handles)
+    {
+        bool? expected = null;
+        foreach (var handle in handles)
+        {
+            if (handle.IsNil)
+                continue;
+
+            var method = reader.GetMethodDefinition(handle);
+            bool isAbstract = (method.Attributes & MethodAttributes.Abstract) != 0;
+            if (isAbstract && method.RelativeVirtualAddress != 0)
+                return AccessorAbstractionFault.AbstractAccessorHasBody;
+            if (requireUniformAbstraction && expected is { } previous && previous != isAbstract)
+                return AccessorAbstractionFault.InconsistentAbstraction;
+            expected ??= isAbstract;
+        }
+
+        return AccessorAbstractionFault.None;
     }
 
     public static bool TryGetUniformSealedOverride(

--- a/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
+++ b/src/ILInspector.Metadata/MetadataAccessorSemantics.cs
@@ -1,0 +1,145 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+internal static class MetadataAccessorSemantics
+{
+    public static string Kind(
+        MetadataReader reader,
+        MethodDefinitionHandle handle,
+        string defaultKind)
+        => defaultKind == "set" && IsInitOnlySetter(reader, handle)
+            ? "init"
+            : defaultKind;
+
+    public static bool IsUniformlyAbstract(
+        MetadataReader reader,
+        params MethodDefinitionHandle[] handles)
+    {
+        bool anyAbstract = false;
+        bool anyConcrete = false;
+        foreach (var handle in handles)
+        {
+            if (handle.IsNil)
+                continue;
+
+            bool isAbstract =
+                (reader.GetMethodDefinition(handle).Attributes & MethodAttributes.Abstract) != 0;
+            anyAbstract |= isAbstract;
+            anyConcrete |= !isAbstract;
+        }
+
+        if (anyAbstract && anyConcrete)
+        {
+            throw new BadImageFormatException(
+                "The aggregate has inconsistent abstract accessor metadata.");
+        }
+
+        return anyAbstract;
+    }
+
+    static bool IsInitOnlySetter(
+        MetadataReader reader,
+        MethodDefinitionHandle handle)
+    {
+        var method = reader.GetMethodDefinition(handle);
+        var result = GuardedProviderDecode.MethodResult(
+            reader,
+            method,
+            InitOnlyModifierDetector.Instance,
+            (object?)null,
+            default(InitOnlyModifierState));
+        if (result.IsDegraded)
+            throw new BadImageFormatException("The property setter signature could not be decoded.");
+        return result.Value.ReturnType.IsInitOnly;
+    }
+
+    readonly record struct InitOnlyModifierState(
+        bool IsExternalInitType,
+        bool IsInitOnly);
+
+    sealed class InitOnlyModifierDetector
+        : ISignatureTypeProvider<InitOnlyModifierState, object?>
+    {
+        public static InitOnlyModifierDetector Instance { get; } = new();
+
+        public InitOnlyModifierState GetPrimitiveType(PrimitiveTypeCode typeCode)
+            => default;
+
+        public InitOnlyModifierState GetTypeFromDefinition(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            byte rawTypeKind)
+        {
+            var type = reader.GetTypeDefinition(handle);
+            return new(
+                IsExternalInit(reader.GetString(type.Name), reader.GetString(type.Namespace)),
+                false);
+        }
+
+        public InitOnlyModifierState GetTypeFromReference(
+            MetadataReader reader,
+            TypeReferenceHandle handle,
+            byte rawTypeKind)
+        {
+            var type = reader.GetTypeReference(handle);
+            return new(
+                IsExternalInit(reader.GetString(type.Name), reader.GetString(type.Namespace)),
+                false);
+        }
+
+        public InitOnlyModifierState GetTypeFromSpecification(
+            MetadataReader reader,
+            object? context,
+            TypeSpecificationHandle handle,
+            byte rawTypeKind)
+            => default;
+
+        public InitOnlyModifierState GetSZArrayType(InitOnlyModifierState elementType)
+            => default;
+
+        public InitOnlyModifierState GetArrayType(
+            InitOnlyModifierState elementType,
+            ArrayShape shape)
+            => default;
+
+        public InitOnlyModifierState GetByReferenceType(InitOnlyModifierState elementType)
+            => default;
+
+        public InitOnlyModifierState GetPointerType(InitOnlyModifierState elementType)
+            => default;
+
+        public InitOnlyModifierState GetGenericInstantiation(
+            InitOnlyModifierState genericType,
+            ImmutableArray<InitOnlyModifierState> typeArguments)
+            => default;
+
+        public InitOnlyModifierState GetGenericMethodParameter(object? context, int index)
+            => default;
+
+        public InitOnlyModifierState GetGenericTypeParameter(object? context, int index)
+            => default;
+
+        public InitOnlyModifierState GetFunctionPointerType(
+            MethodSignature<InitOnlyModifierState> signature)
+            => default;
+
+        public InitOnlyModifierState GetModifiedType(
+            InitOnlyModifierState modifier,
+            InitOnlyModifierState unmodifiedType,
+            bool isRequired)
+            => new(
+                false,
+                unmodifiedType.IsInitOnly
+                    || isRequired && modifier.IsExternalInitType);
+
+        public InitOnlyModifierState GetPinnedType(InitOnlyModifierState elementType)
+            => elementType;
+
+        static bool IsExternalInit(string name, string @namespace)
+            => name == "IsExternalInit"
+                && @namespace == "System.Runtime.CompilerServices";
+    }
+}

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -215,9 +215,9 @@ public static class MetadataDeclarationQuery
         {
             var evt = reader.GetEventDefinition(eventHandle);
             var accessors = evt.GetAccessors();
-            if (accessors.Adder.IsNil || accessors.Remover.IsNil)
+            if (accessors.Adder.IsNil && accessors.Remover.IsNil)
                 throw new BadImageFormatException(
-                    "The event does not have both add and remove accessors.");
+                    "The event has no add or remove accessor.");
 
             MethodAttributes bestAccess = 0;
             bool isStatic = false;
@@ -239,12 +239,25 @@ public static class MetadataDeclarationQuery
                 isStatic |= (accessorAttributes & MethodAttributes.Static) != 0;
                 isVirtual |= accessorVirtual;
                 isOverride |= accessorOverride;
-                isSealed |= accessorOverride && (accessorAttributes & MethodAttributes.Final) != 0;
             }
-            isAbstract = MetadataAccessorSemantics.IsUniformlyAbstract(
+            isAbstract = MetadataAccessorSemantics.AreAllAbstract(
                 reader,
                 accessors.Adder,
                 accessors.Remover);
+            isSealed = MetadataAccessorSemantics.IsUniformlySealedOverride(
+                reader,
+                accessors.Adder,
+                accessors.Remover);
+            bool hasFinalAccessor = new[] { accessors.Adder, accessors.Remover }
+                .Where(handle => !handle.IsNil)
+                .Any(handle => (reader.GetMethodDefinition(handle).Attributes
+                    & MethodAttributes.Final) != 0);
+            isVirtual =
+                (typeDef.Attributes & (TypeAttributes.Interface | TypeAttributes.Sealed)) == 0
+                && isVirtual
+                && !isAbstract
+                && !isOverride
+                && !hasFinalAccessor;
 
             string accessibility = AccessibilityKeyword(bestAccess);
             if (!includeNonPublicMembers && accessibility != "public")
@@ -649,16 +662,27 @@ public static class MetadataDeclarationQuery
             && (getterAttributes & MethodAttributes.NewSlot) == 0;
         var setterOverride = setterVirtual
             && (setterAttributes & MethodAttributes.NewSlot) == 0;
-        var isVirtual = getterVirtual || setterVirtual;
+        var hasVirtualAccessor = getterVirtual || setterVirtual;
         var isOverride = getterOverride || setterOverride;
-        var isSealed =
-            getterOverride && (getterAttributes & MethodAttributes.Final) != 0
-            || setterOverride && (setterAttributes & MethodAttributes.Final) != 0;
-        var isPublicOrProtected = IsPublicOrProtected(bestAccess);
-        var isAbstract = MetadataAccessorSemantics.IsUniformlyAbstract(
+        var isSealed = MetadataAccessorSemantics.IsUniformlySealedOverride(
             reader,
             accessors.Getter,
             accessors.Setter);
+        var isPublicOrProtected = IsPublicOrProtected(bestAccess);
+        var isAbstract = MetadataAccessorSemantics.AreAllAbstract(
+            reader,
+            accessors.Getter,
+            accessors.Setter);
+        var hasFinalAccessor =
+            (getterAttributes & MethodAttributes.Final) != 0
+            || (setterAttributes & MethodAttributes.Final) != 0;
+        var isVirtual =
+            (typeDef.Attributes & (TypeAttributes.Interface | TypeAttributes.Sealed)) == 0
+            && isPublicOrProtected
+            && hasVirtualAccessor
+            && !isAbstract
+            && !isOverride
+            && !hasFinalAccessor;
         var setterKind = accessors.Setter.IsNil
             ? "set"
             : MetadataAccessorSemantics.Kind(reader, accessors.Setter, "set");

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -410,6 +410,12 @@ public static class MetadataDeclarationQuery
             bool isExplicitInterfaceImplementation =
                 canBeExplicitInterfaceImplementation
                 && methodImplementations.HasExplicitInterfaceTargets(methodHandle);
+            bool canUseImplicitInterfaceSyntax =
+                isExplicitInterfaceImplementation
+                && methodImplementations.CanUseImplicitInterfaceSyntax(
+                    methodHandle,
+                    methodName,
+                    methodAccess);
             var isRetainedImplementationAccessor = isExplicitInterfaceImplementation
                 && (methodName.Contains('.', StringComparison.Ordinal)
                     || (!canonicalAccessorMethods.Contains(methodHandle)
@@ -473,6 +479,8 @@ public static class MetadataDeclarationQuery
                     || AttributeReader.HasRequiresUnsafeAttribute(reader, method.GetCustomAttributes()),
                 Accessibility = NonPublicAccessibility(declaration.Accessibility),
                 IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
+                CanUseImplicitInterfaceSyntax =
+                    canUseImplicitInterfaceSyntax,
                 Attributes = declaration.Attributes.ToList(),
             });
         }

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -238,10 +238,13 @@ public static class MetadataDeclarationQuery
                 bool accessorOverride = accessorVirtual && (accessorAttributes & MethodAttributes.NewSlot) == 0;
                 isStatic |= (accessorAttributes & MethodAttributes.Static) != 0;
                 isVirtual |= accessorVirtual;
-                isAbstract |= (accessorAttributes & MethodAttributes.Abstract) != 0;
                 isOverride |= accessorOverride;
                 isSealed |= accessorOverride && (accessorAttributes & MethodAttributes.Final) != 0;
             }
+            isAbstract = MetadataAccessorSemantics.IsUniformlyAbstract(
+                reader,
+                accessors.Adder,
+                accessors.Remover);
 
             string accessibility = AccessibilityKeyword(bestAccess);
             if (!includeNonPublicMembers && accessibility != "public")
@@ -402,7 +405,7 @@ public static class MetadataDeclarationQuery
         var method = reader.GetMethodDefinition(handle);
         return new ApiAccessor
         {
-            Kind = kind,
+            Kind = MetadataAccessorSemantics.Kind(reader, handle, kind),
             MethodName = reader.GetString(method.Name),
             Accessibility = NonPublicAccessibility(
                 method.Attributes & MethodAttributes.MemberAccessMask),
@@ -637,14 +640,28 @@ public static class MetadataDeclarationQuery
         var setter = accessors.Setter.IsNil ? default : reader.GetMethodDefinition(accessors.Setter);
 
         var bestAccess = BestAccessorAccess(getter, setter, accessors);
-        var primaryAccessor = !accessors.Getter.IsNil ? getter : setter;
-        var accessorAttributes = !accessors.Getter.IsNil || !accessors.Setter.IsNil
-            ? primaryAccessor.Attributes
-            : default;
-        var isVirtual = (accessorAttributes & MethodAttributes.Virtual) != 0;
-        var isNewSlot = (accessorAttributes & MethodAttributes.NewSlot) != 0;
-        var isOverride = isVirtual && !isNewSlot;
+        var getterAttributes = accessors.Getter.IsNil ? default : getter.Attributes;
+        var setterAttributes = accessors.Setter.IsNil ? default : setter.Attributes;
+        var isStatic = ((getterAttributes | setterAttributes) & MethodAttributes.Static) != 0;
+        var getterVirtual = (getterAttributes & MethodAttributes.Virtual) != 0;
+        var setterVirtual = (setterAttributes & MethodAttributes.Virtual) != 0;
+        var getterOverride = getterVirtual
+            && (getterAttributes & MethodAttributes.NewSlot) == 0;
+        var setterOverride = setterVirtual
+            && (setterAttributes & MethodAttributes.NewSlot) == 0;
+        var isVirtual = getterVirtual || setterVirtual;
+        var isOverride = getterOverride || setterOverride;
+        var isSealed =
+            getterOverride && (getterAttributes & MethodAttributes.Final) != 0
+            || setterOverride && (setterAttributes & MethodAttributes.Final) != 0;
         var isPublicOrProtected = IsPublicOrProtected(bestAccess);
+        var isAbstract = MetadataAccessorSemantics.IsUniformlyAbstract(
+            reader,
+            accessors.Getter,
+            accessors.Setter);
+        var setterKind = accessors.Setter.IsNil
+            ? "set"
+            : MetadataAccessorSemantics.Kind(reader, accessors.Setter, "set");
 
         var accessorParameters = !accessors.Getter.IsNil
             ? getter.GetParameters()
@@ -674,7 +691,7 @@ public static class MetadataDeclarationQuery
         {
             accessorModels.Add(new ApiAccessor
             {
-                Kind = "set",
+                Kind = setterKind,
                 Accessibility = AccessorAccessibility(setter.Attributes & MethodAttributes.MemberAccessMask, bestAccess),
                 ReturnAttributes = ReturnAttributes(reader, setter.GetParameters()).ToList(),
                 HasMethodBody = setter.RelativeVirtualAddress != 0,
@@ -694,17 +711,11 @@ public static class MetadataDeclarationQuery
             csharpName,
             AccessibilityKeyword(bestAccess),
             isPublicOrProtected,
-            !accessors.Getter.IsNil || !accessors.Setter.IsNil
-                ? (accessorAttributes & MethodAttributes.Static) != 0
-                : false,
-            isPublicOrProtected && (accessorAttributes & MethodAttributes.Abstract) != 0,
-            isPublicOrProtected
-                && isVirtual
-                && (accessorAttributes & MethodAttributes.Abstract) == 0
-                && (accessorAttributes & MethodAttributes.Final) == 0
-                && isNewSlot,
+            isStatic,
+            isAbstract,
+            isVirtual,
             isOverride,
-            isOverride && (accessorAttributes & MethodAttributes.Final) != 0,
+            isSealed,
             new ApiSignature
             {
                 ReturnType = signature.ReturnType,

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -599,6 +599,9 @@ public static class MetadataDeclarationQuery
         MethodSignature<string> signature)
     {
         var accessors = property.GetAccessors();
+        if (accessors.Getter.IsNil && accessors.Setter.IsNil)
+            throw new BadImageFormatException("The property has no getter or setter.");
+
         var getter = accessors.Getter.IsNil ? default : reader.GetMethodDefinition(accessors.Getter);
         var setter = accessors.Setter.IsNil ? default : reader.GetMethodDefinition(accessors.Setter);
 
@@ -1152,38 +1155,16 @@ public static class MetadataDeclarationQuery
         => access == bestAccess ? null : NonPublicAccessibility(access);
 
     static string AccessibilityKeyword(MethodAttributes access)
-        => access == MethodAttributes.Public
-            ? "public"
-            : NonPublicAccessibility(access)
-                ?? throw new BadImageFormatException(
-                    $"Invalid method accessibility value 0x{(int)access:X}.");
+        => MetadataAccessibility.Keyword(access);
 
     static string AccessibilityKeyword(FieldAttributes access)
-        => NonPublicAccessibility(access) ?? "public";
+        => MetadataAccessibility.Keyword(access);
 
-    static string? NonPublicAccessibility(MethodAttributes access) => access switch
-    {
-        MethodAttributes.PrivateScope => "private",
-        MethodAttributes.Private => "private",
-        MethodAttributes.FamANDAssem => "private protected",
-        MethodAttributes.Assembly => "internal",
-        MethodAttributes.Family => "protected",
-        MethodAttributes.FamORAssem => "protected internal",
-        MethodAttributes.Public => null,
-        _ => throw new BadImageFormatException(
-            $"Invalid method accessibility value 0x{(int)access:X}."),
-    };
+    static string? NonPublicAccessibility(MethodAttributes access)
+        => MetadataAccessibility.Get(access);
 
-    static string? NonPublicAccessibility(FieldAttributes access) => access switch
-    {
-        FieldAttributes.PrivateScope => "private",
-        FieldAttributes.Private => "private",
-        FieldAttributes.FamANDAssem => "private protected",
-        FieldAttributes.Assembly => "internal",
-        FieldAttributes.Family => "protected",
-        FieldAttributes.FamORAssem => "protected internal",
-        _ => null,
-    };
+    static string? NonPublicAccessibility(FieldAttributes access)
+        => MetadataAccessibility.Get(access);
 
     static string? NonPublicAccessibility(string accessibility)
         => accessibility == "public" ? null : accessibility;

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -83,6 +83,9 @@ public static class MetadataDeclarationQuery
         bool includeNonPublicMembers = false)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
+        ApiSurfaceExtractor.ValidateTypeVisibility(
+            reader,
+            typeHandle);
         var attributes = typeDef.Attributes;
         var (ns, name) = GetApiTypeNameParts(reader, typeHandle);
         MetadataTypeDefinitionName definitionName =
@@ -1399,6 +1402,9 @@ public static class MetadataDeclarationQuery
             case AccessorAbstractionFault.AbstractAccessorHasBody:
                 throw new BadImageFormatException(
                     $"The {aggregateKind} has an abstract accessor that declares an IL body.");
+            case AccessorAbstractionFault.AbstractAccessorIsNotVirtual:
+                throw new BadImageFormatException(
+                    $"The {aggregateKind} has an abstract accessor that is not virtual.");
             case AccessorAbstractionFault.InconsistentAbstraction:
                 throw new BadImageFormatException(
                     $"The {aggregateKind} has inconsistent abstract accessor metadata.");

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -175,7 +175,7 @@ public static class MetadataDeclarationQuery
         {
             var property = reader.GetPropertyDefinition(propertyHandle);
             var declaration = GetProperty(reader, typeDef, property);
-            RejectMalformedAccessorAbstraction(
+            RejectMalformedAccessorModifiers(
                 reader,
                 isInterfaceTypeDefinition,
                 "property",
@@ -283,7 +283,7 @@ public static class MetadataDeclarationQuery
                 reader,
                 accessors.Adder,
                 accessors.Remover);
-            RejectMalformedAccessorAbstraction(
+            RejectMalformedAccessorModifiers(
                 reader,
                 isInterfaceTypeDefinition,
                 "event",
@@ -1385,7 +1385,7 @@ public static class MetadataDeclarationQuery
     /// aggregate as a concrete one. Gated by
     /// <c>MetadataDeclarationQueryTests.MixedAbstractionAggregates_FailVisibly</c>.
     /// </remarks>
-    static void RejectMalformedAccessorAbstraction(
+    static void RejectMalformedAccessorModifiers(
         MetadataReader reader,
         bool isInterfaceTypeDefinition,
         string aggregateKind,
@@ -1402,6 +1402,13 @@ public static class MetadataDeclarationQuery
             case AccessorAbstractionFault.InconsistentAbstraction:
                 throw new BadImageFormatException(
                     $"The {aggregateKind} has inconsistent abstract accessor metadata.");
+        }
+        if (!MetadataAccessorSemantics.HaveUniformMemberModifiers(
+                reader,
+                accessors))
+        {
+            throw new BadImageFormatException(
+                $"The {aggregateKind} has inconsistent slot or static accessor metadata.");
         }
     }
 

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -265,8 +265,9 @@ public static class MetadataDeclarationQuery
                 var accessor = reader.GetMethodDefinition(accessorHandle);
                 var accessorAttributes = accessor.Attributes;
                 var access = accessorAttributes & MethodAttributes.MemberAccessMask;
-                if (access > bestAccess)
-                    bestAccess = access;
+                bestAccess = MetadataAccessibility.Join(
+                    bestAccess,
+                    access);
                 bool accessorVirtual = (accessorAttributes & MethodAttributes.Virtual) != 0;
                 bool accessorOverride = accessorVirtual && (accessorAttributes & MethodAttributes.NewSlot) == 0;
                 isStatic |= (accessorAttributes & MethodAttributes.Static) != 0;
@@ -420,6 +421,15 @@ public static class MetadataDeclarationQuery
                 && !isRetainedImplementationAccessor)
                 continue;
 
+            if (!includeNonPublicMembers
+                && !isExplicitInterfaceImplementation
+                && AttributeReader.HasEditorBrowsableNeverAttribute(
+                    reader,
+                    method.GetCustomAttributes()))
+            {
+                continue;
+            }
+
             var declaration = GetMethod(reader, typeDef, method);
             if (!includeNonPublicMembers
                 && methodAccessibility != "public"
@@ -475,6 +485,13 @@ public static class MetadataDeclarationQuery
             var fieldName = reader.GetString(field.Name);
             if (fieldName.StartsWith("<", StringComparison.Ordinal))
                 continue;
+            if (!includeNonPublicMembers
+                && AttributeReader.HasEditorBrowsableNeverAttribute(
+                    reader,
+                    field.GetCustomAttributes()))
+            {
+                continue;
+            }
 
             var declaration = GetField(reader, typeDef, field);
             if (!includeNonPublicMembers && declaration.Accessibility != "public")
@@ -1306,15 +1323,18 @@ public static class MetadataDeclarationQuery
         if (!accessors.Setter.IsNil)
         {
             var setterAccess = setter.Attributes & MethodAttributes.MemberAccessMask;
-            if ((int)setterAccess > (int)best)
-                best = setterAccess;
+            best = MetadataAccessibility.Join(best, setterAccess);
         }
 
         return best;
     }
 
-    static string? AccessorAccessibility(MethodAttributes access, MethodAttributes bestAccess)
-        => access == bestAccess ? null : NonPublicAccessibility(access);
+    static string? AccessorAccessibility(
+        MethodAttributes access,
+        MethodAttributes bestAccess)
+        => MetadataAccessibility.Equivalent(access, bestAccess)
+            ? null
+            : NonPublicAccessibility(access);
 
     static string AccessibilityKeyword(MethodAttributes access)
         => MetadataAccessibility.Keyword(access);

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -469,16 +469,22 @@ public static class MetadataDeclarationQuery
                 IsVirtual = isExplicitInterfaceImplementation
                     ? explicitMethodIsVirtual
                     : declaration.IsVirtual,
-                IsOverride = !isExplicitInterfaceImplementation
-                    && declaration.IsOverride,
-                IsSealed = !isExplicitInterfaceImplementation
-                    && declaration.IsSealed,
+                IsNewSlot =
+                    (method.Attributes & MethodAttributes.NewSlot) != 0,
+                IsFinal =
+                    (method.Attributes & MethodAttributes.Final) != 0,
+                IsOverride = declaration.IsOverride,
+                IsSealed = declaration.IsSealed,
                 IsFinalizer = isFinalizer,
                 HasMethodBody = method.RelativeVirtualAddress != 0,
                 IsUnsafe = ApiSurfaceExtractor.HasUnsafeSignature(reader, method)
                     || AttributeReader.HasRequiresUnsafeAttribute(reader, method.GetCustomAttributes()),
                 Accessibility = NonPublicAccessibility(declaration.Accessibility),
                 IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
+                InterfaceImplementationResolution =
+                    isExplicitInterfaceImplementation
+                        ? methodImplementations.GetResolution(methodHandle)
+                        : null,
                 CanUseImplicitInterfaceSyntax =
                     canUseImplicitInterfaceSyntax,
                 Attributes = declaration.Attributes.ToList(),

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -167,16 +167,16 @@ public static class MetadataDeclarationQuery
         {
             var property = reader.GetPropertyDefinition(propertyHandle);
             var declaration = GetProperty(reader, typeDef, property);
-            if (!includeNonPublicMembers && declaration.Accessibility != "public")
-                continue;
-
-            string propertyName = declaration.MetadataName;
             RejectMalformedAccessorAbstraction(
                 reader,
                 isInterfaceTypeDefinition,
                 "property",
                 declaration.Getter,
                 declaration.Setter);
+            if (!includeNonPublicMembers && declaration.Accessibility != "public")
+                continue;
+
+            string propertyName = declaration.MetadataName;
             bool isExplicitInterfaceImplementation =
                 ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
                     propertyName,
@@ -404,6 +404,10 @@ public static class MetadataDeclarationQuery
                 continue;
 
             var signatureText = MethodSignatureText(declaration);
+            bool explicitMethodIsAbstract = isExplicitInterfaceImplementation
+                && (method.Attributes & MethodAttributes.Abstract) != 0;
+            bool explicitMethodIsVirtual = isExplicitInterfaceImplementation
+                && (method.Attributes & MethodAttributes.Virtual) != 0;
             type.Members.Add(new ApiMember
             {
                 Name = declaration.MetadataName,
@@ -419,10 +423,16 @@ public static class MetadataDeclarationQuery
                 SignatureDecodeStatus = declaration.SignatureDecodeStatus,
                 MetadataToken = MetadataTokens.GetToken(methodHandle),
                 IsStatic = declaration.IsStatic,
-                IsAbstract = declaration.IsAbstract,
-                IsVirtual = declaration.IsVirtual,
-                IsOverride = declaration.IsOverride,
-                IsSealed = declaration.IsSealed,
+                IsAbstract = isExplicitInterfaceImplementation
+                    ? explicitMethodIsAbstract
+                    : declaration.IsAbstract,
+                IsVirtual = isExplicitInterfaceImplementation
+                    ? explicitMethodIsVirtual
+                    : declaration.IsVirtual,
+                IsOverride = !isExplicitInterfaceImplementation
+                    && declaration.IsOverride,
+                IsSealed = !isExplicitInterfaceImplementation
+                    && declaration.IsSealed,
                 IsFinalizer = isFinalizer,
                 HasMethodBody = method.RelativeVirtualAddress != 0,
                 IsUnsafe = ApiSurfaceExtractor.HasUnsafeSignature(reader, method)

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -156,8 +156,6 @@ public static class MetadataDeclarationQuery
                 reader,
                 typeDef)
             : [];
-        var explicitImplementationBodies =
-            ApiSurfaceExtractor.GetExplicitImplementationBodies(reader, typeDef);
         var explicitInterfaceIdentityProvider = new ExplicitInterfaceTypeIdentityProvider();
         var explicitInterfaceImplementationTargets =
             ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(
@@ -371,12 +369,13 @@ public static class MetadataDeclarationQuery
             var method = reader.GetMethodDefinition(methodHandle);
             var methodName = reader.GetString(method.Name);
             var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
-            var isRetainedImplementationAccessor = explicitImplementationBodies.Contains(methodHandle)
+            bool isFinalizer = type.Kind == "class"
+                && ApiSurfaceExtractor.IsFinalizerMethod(reader, methodHandle);
+            var isRetainedImplementationAccessor = explicitInterfaceImplementationBodies.Contains(methodHandle)
                 && (methodName.Contains('.', StringComparison.Ordinal)
-                    || (explicitInterfaceImplementationBodies.Contains(methodHandle)
-                        && (!canonicalAccessorMethods.Contains(methodHandle)
-                            || (!includeNonPublicMembers
-                                && hiddenAggregateAccessorMethods.Contains(methodHandle)))));
+                    || (!canonicalAccessorMethods.Contains(methodHandle)
+                        || (!includeNonPublicMembers
+                            && hiddenAggregateAccessorMethods.Contains(methodHandle))));
             if (((accessorMethods.Contains(methodHandle)
                         && canonicalAccessorMethods.Contains(methodHandle))
                     || extensionPropertyImplementationMethods.Contains(methodHandle))
@@ -388,14 +387,17 @@ public static class MetadataDeclarationQuery
             var declaration = GetMethod(reader, typeDef, method);
             if (!includeNonPublicMembers
                 && declaration.Accessibility != "public"
-                && !explicitImplementationBodies.Contains(methodHandle))
+                && !explicitInterfaceImplementationBodies.Contains(methodHandle)
+                && !isFinalizer)
                 continue;
 
             var signatureText = MethodSignatureText(declaration);
             type.Members.Add(new ApiMember
             {
                 Name = declaration.MetadataName,
-                Kind = declaration.MetadataName == ".ctor" ? "constructor" : "method",
+                Kind = declaration.MetadataName == ".ctor"
+                    ? "constructor"
+                    : isFinalizer ? "finalizer" : "method",
                 SignatureModel = declaration.Signature,
                 Signature = signatureText,
                 SignatureDecodeStatus = declaration.SignatureDecodeStatus,
@@ -405,6 +407,7 @@ public static class MetadataDeclarationQuery
                 IsVirtual = declaration.IsVirtual,
                 IsOverride = declaration.IsOverride,
                 IsSealed = declaration.IsSealed,
+                IsFinalizer = isFinalizer,
                 HasMethodBody = method.RelativeVirtualAddress != 0,
                 IsUnsafe = ApiSurfaceExtractor.HasUnsafeSignature(reader, method)
                     || AttributeReader.HasRequiresUnsafeAttribute(reader, method.GetCustomAttributes()),

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -149,6 +149,14 @@ public static class MetadataDeclarationQuery
         var accessorMethods = ApiSurfaceExtractor.GetAccessorMethods(reader, typeDef);
         var canonicalAccessorMethods =
             ApiSurfaceExtractor.GetCanonicalAccessorMethods(reader, typeDef);
+        var editorHiddenAggregateAccessorMethods =
+            includeNonPublicMembers
+                ? []
+                : ApiSurfaceExtractor
+                    .GetEditorBrowsableNeverAggregateAccessorMethods(
+                        reader,
+                        typeDef,
+                        canonicalAccessorMethods);
         var hiddenAggregateAccessorMethods =
             ApiSurfaceExtractor.GetNonPublicAggregateAccessorMethods(reader, typeDef);
         var extensionPropertyImplementationMethods = isExtensionClass
@@ -175,6 +183,13 @@ public static class MetadataDeclarationQuery
                 declaration.Setter);
             if (!includeNonPublicMembers && declaration.Accessibility != "public")
                 continue;
+            if (!includeNonPublicMembers
+                && AttributeReader.HasEditorBrowsableNeverAttribute(
+                    reader,
+                    property.GetCustomAttributes()))
+            {
+                continue;
+            }
 
             string propertyName = declaration.MetadataName;
             bool isExplicitInterfaceImplementation =
@@ -286,6 +301,13 @@ public static class MetadataDeclarationQuery
             string accessibility = AccessibilityKeyword(bestAccess);
             if (!includeNonPublicMembers && accessibility != "public")
                 continue;
+            if (!includeNonPublicMembers
+                && AttributeReader.HasEditorBrowsableNeverAttribute(
+                    reader,
+                    evt.GetCustomAttributes()))
+            {
+                continue;
+            }
 
             var context = GenericContext.ForType(reader, typeDef);
             string? eventType = ConstraintTypeName(reader, evt.Type, context);
@@ -368,6 +390,8 @@ public static class MetadataDeclarationQuery
             string methodAccessibility = AccessibilityKeyword(methodAccess);
             var methodName = reader.GetString(method.Name);
             if (methodName.StartsWith('<'))
+                continue;
+            if (editorHiddenAggregateAccessorMethods.Contains(methodHandle))
                 continue;
 
             bool isFinalizer = type.Kind == "class"

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -192,12 +192,15 @@ public static class MetadataDeclarationQuery
             }
 
             string propertyName = declaration.MetadataName;
-            bool isExplicitInterfaceImplementation =
-                ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+            InterfaceImplementationResolution?
+                interfaceImplementationResolution =
+                    ApiSurfaceExtractor.GetExplicitInterfaceAggregateResolution(
                     propertyName,
                     methodImplementations,
                     (declaration.Getter, "get_"),
                     (declaration.Setter, "set_"));
+            bool isExplicitInterfaceImplementation =
+                interfaceImplementationResolution is not null;
             if (isExplicitInterfaceImplementation
                 && ApiSurfaceExtractor.ValidateExplicitPropertyRowSignature(
                     reader,
@@ -233,6 +236,8 @@ public static class MetadataDeclarationQuery
                 IsOverride = declaration.IsOverride,
                 IsSealed = declaration.IsSealed,
                 IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
+                InterfaceImplementationResolution =
+                    interfaceImplementationResolution,
                 IsUnsafe = ApiSurfaceExtractor.HasUnsafeSignature(reader, property)
                     || AttributeReader.HasRequiresUnsafeAttribute(reader, property.GetCustomAttributes()),
                 Accessibility = NonPublicAccessibility(declaration.Accessibility),
@@ -315,12 +320,15 @@ public static class MetadataDeclarationQuery
             bool degraded = eventType is null;
             eventType ??= "<unsupported: event type>";
             string eventName = reader.GetString(evt.Name);
-            bool isExplicitInterfaceImplementation =
-                ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+            InterfaceImplementationResolution?
+                interfaceImplementationResolution =
+                    ApiSurfaceExtractor.GetExplicitInterfaceAggregateResolution(
                     eventName,
                     methodImplementations,
                     (accessors.Adder, "add_"),
                     (accessors.Remover, "remove_"));
+            bool isExplicitInterfaceImplementation =
+                interfaceImplementationResolution is not null;
             if (isExplicitInterfaceImplementation
                 && ApiSurfaceExtractor.ValidateExplicitEventRowSignature(
                     reader,
@@ -370,6 +378,8 @@ public static class MetadataDeclarationQuery
                 IsOverride = isOverride,
                 IsSealed = isSealed,
                 IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
+                InterfaceImplementationResolution =
+                    interfaceImplementationResolution,
                 IsUnsafe = ApiSurfaceExtractor.HasUnsafeSignature(reader, evt)
                     || AttributeReader.HasRequiresUnsafeAttribute(reader, evt.GetCustomAttributes()),
                 Accessibility = NonPublicAccessibility(accessibility),

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -156,10 +156,17 @@ public static class MetadataDeclarationQuery
             if (!includeNonPublicMembers && declaration.Accessibility != "public")
                 continue;
 
+            string propertyName = declaration.MetadataName;
+            bool isExplicitInterfaceImplementation =
+                propertyName.Contains('.', StringComparison.Ordinal)
+                && (!declaration.Getter.IsNil
+                        && explicitImplementationBodies.Contains(declaration.Getter)
+                    || !declaration.Setter.IsNil
+                        && explicitImplementationBodies.Contains(declaration.Setter));
             var signatureText = PropertySignatureText(declaration);
             type.Members.Add(new ApiMember
             {
-                Name = declaration.MetadataName,
+                Name = propertyName,
                 Kind = "property",
                 ReturnType = declaration.Signature.ReturnType,
                 SignatureModel = declaration.Signature,
@@ -179,6 +186,7 @@ public static class MetadataDeclarationQuery
                 IsVirtual = declaration.IsVirtual,
                 IsOverride = declaration.IsOverride,
                 IsSealed = declaration.IsSealed,
+                IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
                 IsUnsafe = ApiSurfaceExtractor.HasUnsafeSignature(reader, property)
                     || AttributeReader.HasRequiresUnsafeAttribute(reader, property.GetCustomAttributes()),
                 Accessibility = NonPublicAccessibility(declaration.Accessibility),
@@ -194,8 +202,9 @@ public static class MetadataDeclarationQuery
         {
             var evt = reader.GetEventDefinition(eventHandle);
             var accessors = evt.GetAccessors();
-            if (accessors.Adder.IsNil && accessors.Remover.IsNil)
-                continue;
+            if (accessors.Adder.IsNil || accessors.Remover.IsNil)
+                throw new BadImageFormatException(
+                    "The event does not have both add and remove accessors.");
 
             MethodAttributes bestAccess = 0;
             bool isStatic = false;
@@ -230,6 +239,10 @@ public static class MetadataDeclarationQuery
             bool degraded = eventType is null;
             eventType ??= "<unsupported: event type>";
             string eventName = reader.GetString(evt.Name);
+            bool isExplicitInterfaceImplementation =
+                eventName.Contains('.', StringComparison.Ordinal)
+                && (explicitImplementationBodies.Contains(accessors.Adder)
+                    || explicitImplementationBodies.Contains(accessors.Remover));
             type.Members.Add(new ApiMember
             {
                 Name = eventName,
@@ -267,6 +280,7 @@ public static class MetadataDeclarationQuery
                 IsAbstract = isAbstract,
                 IsOverride = isOverride,
                 IsSealed = isSealed,
+                IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
                 IsUnsafe = ApiSurfaceExtractor.HasUnsafeSignature(reader, evt)
                     || AttributeReader.HasRequiresUnsafeAttribute(reader, evt.GetCustomAttributes()),
                 Accessibility = NonPublicAccessibility(accessibility),

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -364,12 +364,12 @@ public static class MetadataDeclarationQuery
         foreach (var methodHandle in typeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
-            var methodName = reader.GetString(method.Name);
             var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
+            string methodAccessibility = AccessibilityKeyword(methodAccess);
+            var methodName = reader.GetString(method.Name);
             if (methodName.StartsWith('<'))
                 continue;
 
-            string methodAccessibility = AccessibilityKeyword(methodAccess);
             bool isFinalizer = type.Kind == "class"
                 && ApiSurfaceExtractor.IsFinalizerMethod(reader, methodHandle);
             bool canBeExplicitInterfaceImplementation =
@@ -409,7 +409,11 @@ public static class MetadataDeclarationQuery
                 Name = declaration.MetadataName,
                 Kind = declaration.MetadataName == ".ctor"
                     ? "constructor"
-                    : isFinalizer ? "finalizer" : "method",
+                    : isFinalizer
+                        ? "finalizer"
+                        : isExplicitInterfaceImplementation
+                            ? "explicit-interface-implementation"
+                            : "method",
                 SignatureModel = declaration.Signature,
                 Signature = signatureText,
                 SignatureDecodeStatus = declaration.SignatureDecodeStatus,
@@ -432,6 +436,8 @@ public static class MetadataDeclarationQuery
         foreach (var fieldHandle in typeDef.GetFields())
         {
             var field = reader.GetFieldDefinition(fieldHandle);
+            var fieldAccess = field.Attributes & FieldAttributes.FieldAccessMask;
+            _ = AccessibilityKeyword(fieldAccess);
             var fieldName = reader.GetString(field.Name);
             if (fieldName.StartsWith("<", StringComparison.Ordinal))
                 continue;

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -157,14 +157,11 @@ public static class MetadataDeclarationQuery
                 typeDef)
             : [];
         var explicitInterfaceIdentityProvider = new ExplicitInterfaceTypeIdentityProvider();
-        var explicitInterfaceImplementationTargets =
-            ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(
-                reader,
-                typeDef,
-                explicitInterfaceIdentityProvider,
-                typeContext: typeContext);
-        var explicitInterfaceImplementationBodies =
-            explicitInterfaceImplementationTargets.Keys.ToHashSet();
+        var methodImplementations = new ApiSurfaceExtractor.MethodImplementationProjection(
+            reader,
+            typeDef,
+            explicitInterfaceIdentityProvider,
+            typeContext: typeContext);
         bool isInterfaceTypeDefinition = (attributes & TypeAttributes.Interface) != 0;
         foreach (var propertyHandle in typeDef.GetProperties())
         {
@@ -183,7 +180,7 @@ public static class MetadataDeclarationQuery
             bool isExplicitInterfaceImplementation =
                 ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
                     propertyName,
-                    explicitInterfaceImplementationTargets,
+                    methodImplementations,
                     (declaration.Getter, "get_"),
                     (declaration.Setter, "set_"));
             if (isExplicitInterfaceImplementation
@@ -298,7 +295,7 @@ public static class MetadataDeclarationQuery
             bool isExplicitInterfaceImplementation =
                 ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
                     eventName,
-                    explicitInterfaceImplementationTargets,
+                    methodImplementations,
                     (accessors.Adder, "add_"),
                     (accessors.Remover, "remove_"));
             if (isExplicitInterfaceImplementation
@@ -369,9 +366,26 @@ public static class MetadataDeclarationQuery
             var method = reader.GetMethodDefinition(methodHandle);
             var methodName = reader.GetString(method.Name);
             var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
+            if (methodName.StartsWith('<'))
+                continue;
+
+            string methodAccessibility = AccessibilityKeyword(methodAccess);
             bool isFinalizer = type.Kind == "class"
                 && ApiSurfaceExtractor.IsFinalizerMethod(reader, methodHandle);
-            var isRetainedImplementationAccessor = explicitInterfaceImplementationBodies.Contains(methodHandle)
+            bool canBeExplicitInterfaceImplementation =
+                methodImplementations.ContainsBody(methodHandle);
+            if (!includeNonPublicMembers
+                && methodAccessibility != "public"
+                && !canBeExplicitInterfaceImplementation
+                && !isFinalizer)
+            {
+                continue;
+            }
+
+            bool isExplicitInterfaceImplementation =
+                canBeExplicitInterfaceImplementation
+                && methodImplementations.HasExplicitInterfaceTargets(methodHandle);
+            var isRetainedImplementationAccessor = isExplicitInterfaceImplementation
                 && (methodName.Contains('.', StringComparison.Ordinal)
                     || (!canonicalAccessorMethods.Contains(methodHandle)
                         || (!includeNonPublicMembers
@@ -381,13 +395,11 @@ public static class MetadataDeclarationQuery
                     || extensionPropertyImplementationMethods.Contains(methodHandle))
                 && !isRetainedImplementationAccessor)
                 continue;
-            if (methodName.StartsWith('<'))
-                continue;
 
             var declaration = GetMethod(reader, typeDef, method);
             if (!includeNonPublicMembers
-                && declaration.Accessibility != "public"
-                && !explicitInterfaceImplementationBodies.Contains(methodHandle)
+                && methodAccessibility != "public"
+                && !isExplicitInterfaceImplementation
                 && !isFinalizer)
                 continue;
 
@@ -412,6 +424,7 @@ public static class MetadataDeclarationQuery
                 IsUnsafe = ApiSurfaceExtractor.HasUnsafeSignature(reader, method)
                     || AttributeReader.HasRequiresUnsafeAttribute(reader, method.GetCustomAttributes()),
                 Accessibility = NonPublicAccessibility(declaration.Accessibility),
+                IsExplicitInterfaceImplementation = isExplicitInterfaceImplementation,
                 Attributes = declaration.Attributes.ToList(),
             });
         }

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -158,11 +158,11 @@ public static class MetadataDeclarationQuery
 
             string propertyName = declaration.MetadataName;
             bool isExplicitInterfaceImplementation =
-                propertyName.Contains('.', StringComparison.Ordinal)
-                && (!declaration.Getter.IsNil
-                        && explicitImplementationBodies.Contains(declaration.Getter)
-                    || !declaration.Setter.IsNil
-                        && explicitImplementationBodies.Contains(declaration.Setter));
+                ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+                    propertyName,
+                    explicitInterfaceImplementationBodies,
+                    declaration.Getter,
+                    declaration.Setter);
             var signatureText = PropertySignatureText(declaration);
             type.Members.Add(new ApiMember
             {
@@ -240,9 +240,11 @@ public static class MetadataDeclarationQuery
             eventType ??= "<unsupported: event type>";
             string eventName = reader.GetString(evt.Name);
             bool isExplicitInterfaceImplementation =
-                eventName.Contains('.', StringComparison.Ordinal)
-                && (explicitImplementationBodies.Contains(accessors.Adder)
-                    || explicitImplementationBodies.Contains(accessors.Remover));
+                ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+                    eventName,
+                    explicitInterfaceImplementationBodies,
+                    accessors.Adder,
+                    accessors.Remover);
             type.Members.Add(new ApiMember
             {
                 Name = eventName,

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -158,10 +158,16 @@ public static class MetadataDeclarationQuery
             : [];
         var explicitImplementationBodies =
             ApiSurfaceExtractor.GetExplicitImplementationBodies(reader, typeDef);
+        var explicitInterfaceIdentityProvider = new ExplicitInterfaceTypeIdentityProvider();
         var explicitInterfaceImplementationTargets =
-            ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(reader, typeDef);
+            ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(
+                reader,
+                typeDef,
+                explicitInterfaceIdentityProvider,
+                typeContext: typeContext);
         var explicitInterfaceImplementationBodies =
             explicitInterfaceImplementationTargets.Keys.ToHashSet();
+        bool isInterfaceTypeDefinition = (attributes & TypeAttributes.Interface) != 0;
         foreach (var propertyHandle in typeDef.GetProperties())
         {
             var property = reader.GetPropertyDefinition(propertyHandle);
@@ -170,12 +176,29 @@ public static class MetadataDeclarationQuery
                 continue;
 
             string propertyName = declaration.MetadataName;
+            RejectMalformedAccessorAbstraction(
+                reader,
+                isInterfaceTypeDefinition,
+                "property",
+                declaration.Getter,
+                declaration.Setter);
             bool isExplicitInterfaceImplementation =
                 ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
                     propertyName,
                     explicitInterfaceImplementationTargets,
                     (declaration.Getter, "get_"),
                     (declaration.Setter, "set_"));
+            if (isExplicitInterfaceImplementation
+                && ApiSurfaceExtractor.ValidateExplicitPropertyRowSignature(
+                    reader,
+                    property,
+                    property.GetAccessors(),
+                    typeContext,
+                    explicitInterfaceIdentityProvider,
+                    observeDecodeWork: null) is { } propertyRowDetail)
+            {
+                throw new BadImageFormatException(propertyRowDetail);
+            }
             var signatureText = PropertySignatureText(declaration);
             type.Members.Add(new ApiMember
             {
@@ -244,6 +267,12 @@ public static class MetadataDeclarationQuery
                 reader,
                 accessors.Adder,
                 accessors.Remover);
+            RejectMalformedAccessorAbstraction(
+                reader,
+                isInterfaceTypeDefinition,
+                "event",
+                accessors.Adder,
+                accessors.Remover);
             isSealed = MetadataAccessorSemantics.IsUniformlySealedOverride(
                 reader,
                 accessors.Adder,
@@ -274,6 +303,17 @@ public static class MetadataDeclarationQuery
                     explicitInterfaceImplementationTargets,
                     (accessors.Adder, "add_"),
                     (accessors.Remover, "remove_"));
+            if (isExplicitInterfaceImplementation
+                && ApiSurfaceExtractor.ValidateExplicitEventRowSignature(
+                    reader,
+                    evt,
+                    accessors,
+                    typeContext,
+                    explicitInterfaceIdentityProvider,
+                    observeDecodeWork: null) is { } eventRowDetail)
+            {
+                throw new BadImageFormatException(eventRowDetail);
+            }
             type.Members.Add(new ApiMember
             {
                 Name = eventName,
@@ -1234,6 +1274,36 @@ public static class MetadataDeclarationQuery
 
     static string? NonPublicAccessibility(string accessibility)
         => accessibility == "public" ? null : accessibility;
+
+    /// <summary>
+    /// Rejects an aggregate whose accessors disagree about abstractness on a class or struct,
+    /// or whose abstract accessor declares an IL body.
+    /// </summary>
+    /// <remarks>
+    /// The query peer of the extractor's inspection failure for the same shape, so the two
+    /// projections classify identical metadata identically and neither renders a mixed
+    /// aggregate as a concrete one. Gated by
+    /// <c>MetadataDeclarationQueryTests.MixedAbstractionAggregates_FailVisibly</c>.
+    /// </remarks>
+    static void RejectMalformedAccessorAbstraction(
+        MetadataReader reader,
+        bool isInterfaceTypeDefinition,
+        string aggregateKind,
+        params MethodDefinitionHandle[] accessors)
+    {
+        switch (MetadataAccessorSemantics.ValidateAbstraction(
+            reader,
+            requireUniformAbstraction: !isInterfaceTypeDefinition,
+            accessors))
+        {
+            case AccessorAbstractionFault.AbstractAccessorHasBody:
+                throw new BadImageFormatException(
+                    $"The {aggregateKind} has an abstract accessor that declares an IL body.");
+            case AccessorAbstractionFault.InconsistentAbstraction:
+                throw new BadImageFormatException(
+                    $"The {aggregateKind} has inconsistent abstract accessor metadata.");
+        }
+    }
 
     static T ProjectDecode<T>(
         SignatureDecodeResult<T> result,

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -94,6 +94,7 @@ public static class MetadataDeclarationQuery
                 _ => throw new InvalidOperationException(
                     "Unexpected metadata type-name result."),
             };
+        var typeContext = GenericContext.ForType(reader, typeDef);
         var type = new ApiType
         {
             Namespace = ns,
@@ -106,7 +107,7 @@ public static class MetadataDeclarationQuery
             IsSealed = (attributes & TypeAttributes.Sealed) != 0,
             IsAbstract = (attributes & TypeAttributes.Abstract) != 0,
             Attributes = AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true),
-            TypeParameters = TypeParameters(reader, typeDef.GetGenericParameters(), GenericContext.ForType(reader, typeDef)).ToList(),
+            TypeParameters = TypeParameters(reader, typeDef.GetGenericParameters(), typeContext).ToList(),
         };
 
         if ((attributes & TypeAttributes.Interface) != 0)
@@ -115,7 +116,7 @@ public static class MetadataDeclarationQuery
         }
         else if (!typeDef.BaseType.IsNil)
         {
-            var baseTypeName = TypeResolver.GetTypeName(reader, typeDef.BaseType);
+            var baseTypeName = TypeResolver.GetTypeName(reader, typeDef.BaseType, typeContext);
             type.BaseType = baseTypeName;
             type.Kind = baseTypeName switch
             {
@@ -129,12 +130,22 @@ public static class MetadataDeclarationQuery
         {
             type.Kind = "class";
         }
-
         type.IsStatic = type.IsSealed && type.IsAbstract;
         bool isExtensionClass = type.IsStatic
             && AttributeReader.HasExtensionAttribute(
                 reader,
                 typeDef.GetCustomAttributes());
+        foreach (var interfaceHandle in typeDef.GetInterfaceImplementations())
+        {
+            var implementation = reader.GetInterfaceImplementation(interfaceHandle);
+            var interfaceName = TypeResolver.GetTypeName(
+                reader,
+                implementation.Interface,
+                typeContext);
+            if (interfaceName is not null)
+                type.Interfaces.Add(interfaceName);
+        }
+
         var accessorMethods = ApiSurfaceExtractor.GetAccessorMethods(reader, typeDef);
         var canonicalAccessorMethods =
             ApiSurfaceExtractor.GetCanonicalAccessorMethods(reader, typeDef);
@@ -147,8 +158,10 @@ public static class MetadataDeclarationQuery
             : [];
         var explicitImplementationBodies =
             ApiSurfaceExtractor.GetExplicitImplementationBodies(reader, typeDef);
+        var explicitInterfaceImplementationTargets =
+            ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(reader, typeDef);
         var explicitInterfaceImplementationBodies =
-            ApiSurfaceExtractor.GetExplicitInterfaceImplementationBodies(reader, typeDef);
+            explicitInterfaceImplementationTargets.Keys.ToHashSet();
         foreach (var propertyHandle in typeDef.GetProperties())
         {
             var property = reader.GetPropertyDefinition(propertyHandle);
@@ -160,9 +173,9 @@ public static class MetadataDeclarationQuery
             bool isExplicitInterfaceImplementation =
                 ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
                     propertyName,
-                    explicitInterfaceImplementationBodies,
-                    declaration.Getter,
-                    declaration.Setter);
+                    explicitInterfaceImplementationTargets,
+                    (declaration.Getter, "get_"),
+                    (declaration.Setter, "set_"));
             var signatureText = PropertySignatureText(declaration);
             type.Members.Add(new ApiMember
             {
@@ -242,9 +255,9 @@ public static class MetadataDeclarationQuery
             bool isExplicitInterfaceImplementation =
                 ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
                     eventName,
-                    explicitInterfaceImplementationBodies,
-                    accessors.Adder,
-                    accessors.Remover);
+                    explicitInterfaceImplementationTargets,
+                    (accessors.Adder, "add_"),
+                    (accessors.Remover, "remove_"));
             type.Members.Add(new ApiMember
             {
                 Name = eventName,
@@ -393,7 +406,9 @@ public static class MetadataDeclarationQuery
             MethodName = reader.GetString(method.Name),
             Accessibility = NonPublicAccessibility(
                 method.Attributes & MethodAttributes.MemberAccessMask),
-            ReturnAttributes = ReturnAttributes(reader, method.GetParameters()).ToList(),
+            ReturnAttributes = ApiSurfaceExtractor.ReturnParameterAttributes(
+                reader,
+                method.GetParameters()),
             HasMethodBody = method.RelativeVirtualAddress != 0,
             IsAbstract = (method.Attributes & MethodAttributes.Abstract) != 0,
             StructuralReturnType = AccessorStructuralReturnType(reader, typeDef, handle),

--- a/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
@@ -51,6 +51,20 @@ public static class MetadataSafetyPolicy
         MaxStructuralSignatureWorkChars;
 
     /// <summary>
+    /// Maximum cumulative identity, signature, and row work used to validate one
+    /// type's explicit-interface MethodImpl projection. The projection caches
+    /// repeated body, declaration-signature, and TypeSpec blobs, while this
+    /// ceiling bounds genuinely distinct or numerous well-formed rows on the
+    /// unbounded extraction path. Gated by
+    /// <c>RepeatedWideMethodImplDeclarations_UseBoundedUnboundedAllocation</c>,
+    /// <c>RepeatedDeepGenericMethodImplUniqueParents_UseBoundedUnboundedAllocation</c>,
+    /// <c>DistinctMethodImplSignatures_FailClosedWithinProjectionBudget</c>, and
+    /// <c>CachedMethodImplRowFlood_FailsClosedWithinProjectionBudget</c>.
+    /// </summary>
+    public const int MaxExplicitInterfaceProjectionWorkChars =
+        8 * 1024 * 1024;
+
+    /// <summary>
     /// Maximum type nodes examined before decoding one metadata signature.
     /// This bounds the iterative guard stack and SRM's decoded parameter/type
     /// materialization for structurally shallow but hostile signatures. Gated by

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -934,6 +934,22 @@ public class ApiOutputFormatterTests
                     Signature = "void IFoo.Stop()",
                     Accessibility = "internal"
                 },
+                new ApiMember
+                {
+                    Name = "IFoo.Value",
+                    Kind = "property",
+                    Signature = "int IFoo.Value { get; }",
+                    Accessibility = "private",
+                    IsExplicitInterfaceImplementation = true
+                },
+                new ApiMember
+                {
+                    Name = "IFoo.Changed",
+                    Kind = "event",
+                    Signature = "System.Action IFoo.Changed",
+                    Accessibility = "private",
+                    IsExplicitInterfaceImplementation = true
+                },
             ]
         };
 
@@ -945,6 +961,8 @@ public class ApiOutputFormatterTests
         Assert.Equal(
             "internal explicit-interface-implementation",
             Assert.Single(view.Rows!, row => row.Name == "IFoo.Stop").Kind);
+        Assert.Equal("property", Assert.Single(view.Rows!, row => row.Name == "IFoo.Value").Kind);
+        Assert.Equal("event", Assert.Single(view.Rows!, row => row.Name == "IFoo.Changed").Kind);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -193,6 +193,48 @@ public class ApiOutputFormatterTests
     }
 
     [Fact]
+    public void AccessorMethods_MatchInitFactsToSetterToken()
+    {
+        var property = new ApiMember
+        {
+            Name = "Value",
+            Kind = "property",
+            SetterToken = 0x06000002,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                MemberName = "Value",
+                Accessors = [new ApiAccessor { Kind = "init" }],
+            },
+            AccessorFacts =
+            [
+                new ApiAccessor
+                {
+                    Kind = "init",
+                    MethodName = "set_Value",
+                    Accessibility = "private",
+                    HasMethodBody = false,
+                    IsAbstract = true,
+                }
+            ],
+        };
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class",
+            Members = [property],
+        };
+
+        var accessor = Assert.Single(ApiOutputFormatter.AccessorMethods(property, type));
+
+        Assert.Equal("set_Value", accessor.Name);
+        Assert.Equal("private", accessor.Accessibility);
+        Assert.False(accessor.HasMethodBody);
+        Assert.True(accessor.IsAbstract);
+    }
+
+    [Fact]
     public void SameType_NestedType_StillMatches()
     {
         // A genuinely nested type: analysis TypeRef uses the metadata '+'

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -903,6 +903,31 @@ public class ApiOutputFormatterTests
     }
 
     [Fact]
+    public void TableView_ExplicitImplementation_SuppressesMetadataAccessibilityPrefix()
+    {
+        var type = new ApiType
+        {
+            Name = "Implementation",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "IFoo.Run",
+                    Kind = "explicit-interface-implementation",
+                    Signature = "void IFoo.Run()",
+                    Accessibility = "private"
+                },
+            ]
+        };
+
+        var (view, _) = ApiOutputFormatter.BuildTypeTableView(type, new ApiOptions());
+
+        var row = Assert.Single(view.Rows!);
+        Assert.Equal("explicit-interface-implementation", row.Kind);
+    }
+
+    [Fact]
     public void ApiTypeJson_OmitsIsFinalizerOnNonFinalizers_KeepsItTrueOnFinalizer()
     {
         // Regression guard (adversarial review of #3168): the finalizer identity

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -893,12 +893,21 @@ public class ApiOutputFormatterTests
             Kind = "class",
             Members =
             [
-                new ApiMember { Name = "Finalize", Kind = "finalizer", Signature = "void Finalize()", ReturnType = "void", IsFinalizer = true },
+                new ApiMember
+                {
+                    Name = "Finalize",
+                    Kind = "finalizer",
+                    Signature = "void Finalize()",
+                    ReturnType = "void",
+                    IsFinalizer = true,
+                    Accessibility = "protected"
+                },
             ]
         };
 
         var (view, _) = ApiOutputFormatter.BuildTypeTableView(type, new ApiOptions());
         var row = Assert.Single(view.Rows!, r => r.Kind.Contains("finalizer", System.StringComparison.Ordinal));
+        Assert.Equal("finalizer", row.Kind);
         Assert.Equal("", row.ReturnType);
     }
 
@@ -918,13 +927,24 @@ public class ApiOutputFormatterTests
                     Signature = "void IFoo.Run()",
                     Accessibility = "private"
                 },
+                new ApiMember
+                {
+                    Name = "IFoo.Stop",
+                    Kind = "explicit-interface-implementation",
+                    Signature = "void IFoo.Stop()",
+                    Accessibility = "internal"
+                },
             ]
         };
 
         var (view, _) = ApiOutputFormatter.BuildTypeTableView(type, new ApiOptions());
 
-        var row = Assert.Single(view.Rows!);
-        Assert.Equal("explicit-interface-implementation", row.Kind);
+        Assert.Equal(
+            "explicit-interface-implementation",
+            Assert.Single(view.Rows!, row => row.Name == "IFoo.Run").Kind);
+        Assert.Equal(
+            "internal explicit-interface-implementation",
+            Assert.Single(view.Rows!, row => row.Name == "IFoo.Stop").Kind);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1247,6 +1247,55 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void UnqualifiedMatchingMethodImplUsesImplicitInterfaceSyntax()
+    {
+        string assemblyPath = typeof(int).Assembly.Location;
+        using var fullStream = File.OpenRead(assemblyPath);
+        using var fullReader = new PEReader(fullStream);
+        using var summaryStream = File.OpenRead(assemblyPath);
+        using var summaryReader = new PEReader(summaryStream);
+        using var focusedStream = File.OpenRead(assemblyPath);
+        using var focusedReader = new PEReader(focusedStream);
+
+        ApiType full = Assert.Single(
+            ApiSurfaceExtractor.Extract(fullReader, includeAll: true).Types,
+            type => type.FullName == typeof(int).FullName);
+        ApiType summary = Assert.Single(
+            ApiSurfaceExtractor.ExtractSummary(summaryReader).Types,
+            type => type.FullName == typeof(int).FullName);
+        MetadataReader metadata = focusedReader.GetMetadataReader();
+        TypeDefinitionHandle typeHandle = metadata.TypeDefinitions.Single(handle =>
+        {
+            TypeDefinition definition = metadata.GetTypeDefinition(handle);
+            return metadata.GetString(definition.Namespace) == "System"
+                && metadata.GetString(definition.Name) == nameof(Int32);
+        });
+        ApiType focused = MetadataDeclarationQuery.GetTypeSurface(
+            metadata,
+            typeHandle,
+            includeNonPublicMembers: false);
+
+        foreach (ApiType type in new[] { full, summary, focused })
+        {
+            ApiMember[] parseMethods = type.Members
+                .Where(member =>
+                    member.Name == nameof(int.Parse)
+                    && member.IsExplicitInterfaceImplementation)
+                .ToArray();
+            Assert.NotEmpty(parseMethods);
+            Assert.All(
+                parseMethods,
+                member => Assert.True(member.CanUseImplicitInterfaceSyntax));
+            Assert.All(
+                type.Members.Where(member =>
+                    member.Name.StartsWith(
+                        "System.IConvertible.",
+                        StringComparison.Ordinal)),
+                member => Assert.False(member.CanUseImplicitInterfaceSyntax));
+        }
+    }
+
+    [Fact]
     public void Extract_FoldsFieldLikeEventBackingFieldIntoEvent()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1296,6 +1296,37 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void PublicExtractionUsesEffectiveNestedVisibility()
+    {
+        string assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var publicStream = File.OpenRead(assemblyPath);
+        using var publicReader = new PEReader(publicStream);
+        using var allStream = File.OpenRead(assemblyPath);
+        using var allReader = new PEReader(allStream);
+
+        ApiSurface publicSurface =
+            ApiSurfaceExtractor.Extract(publicReader, includeAll: false);
+        ApiSurface allSurface =
+            ApiSurfaceExtractor.Extract(allReader, includeAll: true);
+
+        Assert.Contains(
+            publicSurface.Types,
+            type => type.FullName.EndsWith(
+                ".VisibleNestedContainer.VisibleNested",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            publicSurface.Types,
+            type => type.FullName.EndsWith(
+                ".HiddenNestedContainer.LeakedNested",
+                StringComparison.Ordinal));
+        Assert.Contains(
+            allSurface.Types,
+            type => type.FullName.EndsWith(
+                ".HiddenNestedContainer.LeakedNested",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_FoldsFieldLikeEventBackingFieldIntoEvent()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
@@ -1921,6 +1952,20 @@ public class SampleObsoleteHost
 public class SampleRequiredHost
 {
     public required bool Active { get; set; }
+}
+
+public class VisibleNestedContainer
+{
+    public class VisibleNested
+    {
+    }
+}
+
+internal class HiddenNestedContainer
+{
+    public class LeakedNested
+    {
+    }
 }
 
 public ref struct SampleRefStruct

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1127,6 +1127,9 @@ public class ApiSurfaceExtractorTests
         // EditorBrowsable(Never) is still filtered out by default.
         var hidden = testType.Members.FirstOrDefault(m => m.Name == "HiddenMethod");
         Assert.Null(hidden);
+        Assert.DoesNotContain(
+            testType.Members,
+            member => member.Name == "HiddenField");
     }
 
     [Fact]
@@ -1213,6 +1216,34 @@ public class ApiSurfaceExtractorTests
         var hidden = testType.Members.FirstOrDefault(m => m.Name == "HiddenMethod");
         Assert.NotNull(hidden);
         Assert.False(hidden.IsObsolete);
+        Assert.Contains(testType.Members, member => member.Name == "HiddenField");
+    }
+
+    [Fact]
+    public void FocusedSurface_EditorBrowsableNeverMatchesFullExtraction()
+    {
+        string assemblyPath = typeof(SampleObsoleteHost).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+        MetadataReader reader = peReader.GetMetadataReader();
+        TypeDefinitionHandle typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+                == nameof(SampleObsoleteHost));
+
+        ApiType focused = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: false);
+        ApiType focusedAll = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+
+        Assert.DoesNotContain(
+            focused.Members,
+            member => member.Name is "HiddenMethod" or "HiddenField");
+        Assert.Contains(focusedAll.Members, member => member.Name == "HiddenMethod");
+        Assert.Contains(focusedAll.Members, member => member.Name == "HiddenField");
     }
 
     [Fact]
@@ -1833,6 +1864,9 @@ public class SampleObsoleteHost
 
     [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public void HiddenMethod() { }
+
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+    public int HiddenField;
 }
 
 public class SampleRequiredHost

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -90,6 +90,25 @@ public class ApiSurfaceExtractorTests
         Assert.Equal(
             full.Types.Select(type => type.FullName).Order(),
             summary.Types.Select(type => type.FullName).Order());
+
+        var fullFinalizerType = Assert.Single(
+            full.Types,
+            type => type.Name == nameof(SummaryFinalizerFixture));
+        var summaryFinalizerType = Assert.Single(
+            summary.Types,
+            type => type.Name == nameof(SummaryFinalizerFixture));
+        var fullFinalizer = Assert.Single(
+            fullFinalizerType.Members,
+            member => member is { Name: "Finalize", Kind: "finalizer", IsFinalizer: true });
+        var summaryFinalizer = Assert.Single(
+            summaryFinalizerType.Members,
+            member => member is { Name: "Finalize", Kind: "finalizer", IsFinalizer: true });
+
+        Assert.Equal(fullFinalizer.Name, summaryFinalizer.Name);
+        Assert.Equal(fullFinalizerType.Members.Count, summaryFinalizerType.Members.Count);
+        Assert.Equal(
+            fullFinalizerType.Members.Select(member => member.Name).Order(),
+            summaryFinalizerType.Members.Select(member => member.Name).Order());
     }
 
     [Fact]
@@ -2000,4 +2019,11 @@ public class SampleImplementation : ISampleInterface
 internal class InternalTopLevelSurfaceFixture
 {
     public int Value() => 1;
+}
+
+public sealed class SummaryFinalizerFixture
+{
+    ~SummaryFinalizerFixture()
+    {
+    }
 }

--- a/src/dotnet-inspect.Tests/BodyShapeSearchMetadataTests.cs
+++ b/src/dotnet-inspect.Tests/BodyShapeSearchMetadataTests.cs
@@ -116,6 +116,7 @@ public sealed class BodyShapeSearchMetadataTests
             baseType: default,
             fieldList: MetadataTokens.FieldDefinitionHandle(1),
             methodList: MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddInterfaceImplementation(implementationType, probe);
         var (methodBodies, bodyOffset) = Int32Body(1);
         var body = metadata.AddMethodDefinition(
             MethodAttributes.Private | MethodAttributes.Final

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -5178,7 +5178,7 @@ public partial class CommandExecutionTests
 
         // Structured resolution reaches ParamCollectionAttribute through the
         // platform policy instead of dropping it with the sibling-only probe.
-        Assert.Contains("Types: 90", fieldsOutput, StringComparison.Ordinal);
+        Assert.Contains("Types: 88", fieldsOutput, StringComparison.Ordinal);
         Assert.DoesNotContain("Methods:", fieldsOutput, StringComparison.Ordinal);
 
         // --columns is the same surface and was the case the first fix missed: it does not filter
@@ -5195,7 +5195,7 @@ public partial class CommandExecutionTests
             "type", "--platform", "System.Text.Json", "-v:q", "-S", SectionNames.ApiInfo, "--tips", "q");
 
         Assert.Equal(0, bothExit);
-        Assert.Contains("| Types | 90 |", bothOutput, StringComparison.Ordinal);
+        Assert.Contains("| Types | 88 |", bothOutput, StringComparison.Ordinal);
         Assert.DoesNotContain("Library: System.Text.Json.dll |", bothOutput, StringComparison.Ordinal);
     }
 
@@ -12792,14 +12792,14 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task TypeListing_NestedDelegate_ShowsFullDeclaringTypeContext()
+    public async Task TypeListing_NestedDelegateUnderInternalDeclaringType_IsOmitted()
     {
         var (exit, output, error) = await RunAppAsync(
             "type", "System.Text.Json", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.Contains("`System.Text.Json.Serialization.Metadata.FSharpCoreReflectionProxy.StructGetter<TStruct, TResult>`", output);
+        Assert.DoesNotContain("FSharpCoreReflectionProxy.StructGetter", output);
         Assert.DoesNotContain("| `StructGetter<TStruct, TResult>` |", output);
     }
 
@@ -12897,6 +12897,35 @@ public partial class CommandExecutionTests
         Assert.Empty(error);
         Assert.Contains("Chars\tpublic char this[int index] { get; }", output);
         Assert.Contains("Gets the Char object at a specified position in the current String object.", output);
+    }
+
+    [Fact]
+    public async Task Member_VisualBasicMethodImplInventoryUsesMetadataFallback()
+    {
+        string library = Path.Combine(
+            Path.GetDirectoryName(typeof(object).Assembly.Location)!,
+            "Microsoft.VisualBasic.Core.dll");
+
+        var (exit, output, error) = await RunAppAsync(
+            "member",
+            "Microsoft.VisualBasic.Collection",
+            "--library",
+            library,
+            "-S",
+            "Explicit Interface Implementations",
+            "--tips",
+            "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains(
+            "metadata MethodImpl (proven) private final newslot virtual",
+            output,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "metadata MethodImpl (undetermined) private final newslot virtual System.Collections.IEnumerator ICollectionGetEnumerator()",
+            output,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -8131,6 +8131,34 @@ public partial class CommandExecutionTests
         Assert.Contains(expected, output, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Facts needs an IL body, and the selected accessor has none — but that is a reason to omit
+    /// the Facts section, not to abandon the document. Sections that do apply still render, and
+    /// the omission is stated rather than silent.
+    /// </summary>
+    [Fact]
+    public async Task Member_Facts_BodylessAccessor_WithOtherSections_RendersRemainingSections()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member",
+            "System.Collections.Generic.ICollection<T>",
+            "--platform",
+            "System.Runtime",
+            "-m",
+            "Count:1",
+            "-S",
+            "Facts,Original Source",
+            "--tips",
+            "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Original Source", output);
+        Assert.Contains("no authored source to show", output);
+        Assert.DoesNotContain("## Facts", output);
+        Assert.Contains("Note: The selected accessor has no IL body.", error);
+        Assert.Contains("has no IL body", error);
+    }
+
     [Fact]
     public async Task Member_OriginalSource_MemberWithBody_DoesNotClaimTheMemberIsBodyless()
     {

--- a/src/dotnet-inspect.Tests/InspectionViewDescriptorTests.cs
+++ b/src/dotnet-inspect.Tests/InspectionViewDescriptorTests.cs
@@ -375,8 +375,16 @@ public class InspectionViewDescriptorTests
         Assert.Equal(hasExecutableBodyViews, ids.Contains(SectionNames.Facts));
     }
 
+    /// <summary>
+    /// Selecting an accessor never filters the accessor list, so ordinal 2 still addresses the
+    /// setter when ordinal 1 is bodyless. What the selection does decide is whether the
+    /// requested sections can run at all: <c>Facts</c> alone on a bodyless accessor resolves to
+    /// no body methods, so the command fails visibly rather than rendering an empty document,
+    /// while <c>Facts</c> alongside an applicable section keeps the document and drops only
+    /// <c>Facts</c>.
+    /// </summary>
     [Fact]
-    public void BodyExecution_RetainsSelectedAbstractAccessorFactsWithoutShiftingOrdinal()
+    public void BodyExecution_DropsSelectedBodylessAccessorFactsWithoutShiftingOrdinal()
     {
         var type = new ApiType
         {
@@ -415,9 +423,13 @@ public class InspectionViewDescriptorTests
             ]
         };
 
-        Assert.Equal(2, ApiOutputFormatter.ResolveBodyMethods(
+        Assert.Empty(ApiOutputFormatter.ResolveBodyMethods(
             type,
             new HashSet<string> { SectionNames.Facts },
+            selectedOrdinal: 1));
+        Assert.Equal(2, ApiOutputFormatter.ResolveBodyMethods(
+            type,
+            new HashSet<string> { SectionNames.Facts, SectionNames.CustomAttributes },
             selectedOrdinal: 1).Count);
         Assert.Equal(2, ApiOutputFormatter.ResolveBodyMethods(
             type,
@@ -427,8 +439,29 @@ public class InspectionViewDescriptorTests
             type,
             new HashSet<string> { SectionNames.UnsafeOperations },
             selectedOrdinal: 1).Count);
+
+        Assert.DoesNotContain(
+            SectionNames.Facts,
+            ApiOutputFormatter.ResolveExecutionSections(
+                type,
+                new HashSet<string> { SectionNames.Facts, SectionNames.CustomAttributes },
+                selectedOrdinal: 1));
+        Assert.Contains(
+            SectionNames.Facts,
+            ApiOutputFormatter.ResolveExecutionSections(
+                type,
+                new HashSet<string> { SectionNames.Facts },
+                selectedOrdinal: 2));
     }
 
+    /// <summary>
+    /// The accessor an ordinal selects comes from the complete <c>AccessorFacts</c> list, not
+    /// the presentation list a lens may have truncated. Here ordinal 1 is therefore the
+    /// bodyless abstract getter that presentation omitted, so the IL-derived sections drop and
+    /// only <c>Unsafe Operations</c> survives. Reading the presentation list instead would
+    /// select the setter and retain every requested section, so the exact expected set is what
+    /// distinguishes the two.
+    /// </summary>
     [Fact]
     public void BodyExecution_UsesCompleteFactsWhenPresentationOmitsAccessor()
     {
@@ -489,7 +522,7 @@ public class InspectionViewDescriptorTests
             ApiOutputFormatter.ResolveExecutionSections(type, requested, selectedOrdinal: 1);
 
         Assert.Equal(
-            [SectionNames.Facts, SectionNames.UnsafeOperations],
+            [SectionNames.UnsafeOperations],
             executionSections.Order(StringComparer.Ordinal));
         var methods = ApiOutputFormatter.ResolveBodyMethods(
             type,

--- a/src/dotnet-inspect.Tests/InspectionViewDescriptorTests.cs
+++ b/src/dotnet-inspect.Tests/InspectionViewDescriptorTests.cs
@@ -376,7 +376,7 @@ public class InspectionViewDescriptorTests
     }
 
     [Fact]
-    public void BodyExecution_SkipsSelectedAbstractAccessorWithoutShiftingOrdinal()
+    public void BodyExecution_RetainsSelectedAbstractAccessorFactsWithoutShiftingOrdinal()
     {
         var type = new ApiType
         {
@@ -415,10 +415,10 @@ public class InspectionViewDescriptorTests
             ]
         };
 
-        Assert.Empty(ApiOutputFormatter.ResolveBodyMethods(
+        Assert.Equal(2, ApiOutputFormatter.ResolveBodyMethods(
             type,
             new HashSet<string> { SectionNames.Facts },
-            selectedOrdinal: 1));
+            selectedOrdinal: 1).Count);
         Assert.Equal(2, ApiOutputFormatter.ResolveBodyMethods(
             type,
             new HashSet<string> { SectionNames.Facts },
@@ -488,7 +488,9 @@ public class InspectionViewDescriptorTests
         IReadOnlySet<string> executionSections =
             ApiOutputFormatter.ResolveExecutionSections(type, requested, selectedOrdinal: 1);
 
-        Assert.Equal([SectionNames.UnsafeOperations], executionSections);
+        Assert.Equal(
+            [SectionNames.Facts, SectionNames.UnsafeOperations],
+            executionSections.Order(StringComparer.Ordinal));
         var methods = ApiOutputFormatter.ResolveBodyMethods(
             type,
             executionSections,

--- a/src/dotnet-inspect.Tests/UntrustedMemberSignatureTests.cs
+++ b/src/dotnet-inspect.Tests/UntrustedMemberSignatureTests.cs
@@ -77,6 +77,13 @@ public class UntrustedMemberSignatureTests
                 [typeof(EventHandler)]);
             adder.GetILGenerator().Emit(OpCodes.Ret);
             @event.SetAddOnMethod(adder);
+            var remover = tb.DefineMethod(
+                "remove_" + hostile,
+                MethodAttributes.Public | MethodAttributes.SpecialName,
+                typeof(void),
+                [typeof(EventHandler)]);
+            remover.GetILGenerator().Emit(OpCodes.Ret);
+            @event.SetRemoveOnMethod(remover);
 
             tb.CreateType();
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -3417,7 +3417,9 @@ public static class ApiOutputFormatter
                 "constructor" or "method" or "operator" or "explicit-interface-implementation" or "extension-method" when e.members.Count == 1 => MemberParameterTypes(m),
                 _ => ""
             };
-            var kindLabel = m.Accessibility != null ? $"{m.Accessibility} {e.kind}" : e.kind;
+            var kindLabel = m.Accessibility != null && e.kind != "explicit-interface-implementation"
+                ? $"{m.Accessibility} {e.kind}"
+                : e.kind;
             return new ApiTableRow(kindLabel, OperatorNames.FormatDisplayName(m.Name), returnType, detail);
         }).ToList();
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -3418,7 +3418,9 @@ public static class ApiOutputFormatter
                 _ => ""
             };
             bool suppressAccessibility = e.kind == "finalizer"
-                || e.kind == "explicit-interface-implementation" && m.Accessibility == "private";
+                || m.Accessibility == "private"
+                    && (e.kind == "explicit-interface-implementation"
+                        || m.IsExplicitInterfaceImplementation);
             var kindLabel = m.Accessibility != null && !suppressAccessibility
                 ? $"{m.Accessibility} {e.kind}"
                 : e.kind;

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -3417,7 +3417,9 @@ public static class ApiOutputFormatter
                 "constructor" or "method" or "operator" or "explicit-interface-implementation" or "extension-method" when e.members.Count == 1 => MemberParameterTypes(m),
                 _ => ""
             };
-            var kindLabel = m.Accessibility != null && e.kind != "explicit-interface-implementation"
+            bool suppressAccessibility = e.kind == "finalizer"
+                || e.kind == "explicit-interface-implementation" && m.Accessibility == "private";
+            var kindLabel = m.Accessibility != null && !suppressAccessibility
                 ? $"{m.Accessibility} {e.kind}"
                 : e.kind;
             return new ApiTableRow(kindLabel, OperatorNames.FormatDisplayName(m.Name), returnType, detail);

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -24,13 +24,26 @@ namespace DotnetInspector.Output;
 /// </summary>
 public static class ApiOutputFormatter
 {
-    static readonly CSharpFormatter DefaultCSharpFormatter = new();
+    static readonly CSharpFormatter DefaultCSharpFormatter = new(
+        new CSharpFormatOptions { AllowMetadataFallback = true });
     static readonly CSharpFormatter AnnotatedCSharpFormatter = new(
-        new CSharpFormatOptions { IncludeCustomAttributes = true });
+        new CSharpFormatOptions
+        {
+            IncludeCustomAttributes = true,
+            AllowMetadataFallback = true
+        });
     static readonly CSharpFormatter AbbreviatedCSharpFormatter = new(
-        new CSharpFormatOptions { AbbreviateSignature = true });
+        new CSharpFormatOptions
+        {
+            AbbreviateSignature = true,
+            AllowMetadataFallback = true
+        });
     static readonly CSharpFormatter CSharpFormatterWithoutObsolete = new(
-        new CSharpFormatOptions { IncludeObsoleteAttribute = false });
+        new CSharpFormatOptions
+        {
+            IncludeObsoleteAttribute = false,
+            AllowMetadataFallback = true
+        });
 
     // ===== Full API View Model Factory =====
 
@@ -3278,7 +3291,8 @@ public static class ApiOutputFormatter
             {
                 AbbreviateSignature = abbreviate,
                 ForceAsync = forceAsync,
-                ForceUnsafe = forceUnsafe
+                ForceUnsafe = forceUnsafe,
+                AllowMetadataFallback = true
             });
         return formatter.FormatMember(type, member, methodParameters);
     }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1632,10 +1632,10 @@ public static class ApiOutputFormatter
             parameters.Add(new ApiParameter { Name = "value", Type = valueType });
         }
 
-        var accessorFact = owner.AccessorFacts.FirstOrDefault(
-            accessor => accessor.Kind == accessorKind);
-        var presentationAccessor = ownerModel?.Accessors.FirstOrDefault(
-            accessor => accessor.Kind == accessorKind);
+        var accessorFact = FindAccessor(owner.AccessorFacts, accessorKind);
+        var presentationAccessor = ownerModel is null
+            ? null
+            : FindAccessor(ownerModel.Accessors, accessorKind);
         var accessibility = accessorFact is not null
             ? accessorFact.Accessibility
             : presentationAccessor is not null
@@ -1718,6 +1718,14 @@ public static class ApiOutputFormatter
         + (owner.SetterToken.HasValue ? 1 : 0)
         + (owner.AdderToken.HasValue ? 1 : 0)
         + (owner.RemoverToken.HasValue ? 1 : 0);
+
+    static ApiAccessor? FindAccessor(
+        IEnumerable<ApiAccessor> accessors,
+        string accessorKind)
+        => accessors.FirstOrDefault(accessor => accessor.Kind == accessorKind)
+            ?? (accessorKind == "set"
+                ? accessors.FirstOrDefault(accessor => accessor.Kind == "init")
+                : null);
 
     static ApiParameter CloneAccessorParameter(ApiParameter parameter) => new()
     {

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -212,10 +212,21 @@ public sealed class ApiSignatureModelTests
     {
         var type = GetType(nameof(ExplicitInterfaceAggregateFixture));
 
-        Assert.True(Assert.Single(type.Members, member => member.Name.EndsWith(".Value", StringComparison.Ordinal))
-            .IsExplicitInterfaceImplementation);
-        Assert.True(Assert.Single(type.Members, member => member.Name.EndsWith(".Changed", StringComparison.Ordinal))
-            .IsExplicitInterfaceImplementation);
+        var property = Assert.Single(
+            type.Members,
+            member => member.Name.EndsWith(".Value", StringComparison.Ordinal));
+        var @event = Assert.Single(
+            type.Members,
+            member => member.Name.EndsWith(".Changed", StringComparison.Ordinal));
+
+        Assert.True(property.IsExplicitInterfaceImplementation);
+        Assert.Equal(
+            InterfaceImplementationResolution.Proven,
+            property.InterfaceImplementationResolution);
+        Assert.True(@event.IsExplicitInterfaceImplementation);
+        Assert.Equal(
+            InterfaceImplementationResolution.Proven,
+            @event.InterfaceImplementationResolution);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -123,7 +123,7 @@ public sealed class ApiSignatureModelTests
         Assert.NotNull(member.SignatureModel);
         ApiAccessor setter = Assert.Single(
             member.SignatureModel.Accessors,
-            accessor => accessor.Kind == "set");
+            accessor => accessor.Kind == "init");
         Assert.Equal(
             StructuralTypeIdentity.Modified(
                 required: true,

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -191,6 +191,34 @@ public sealed class ApiSignatureModelTests
     }
 
     [Fact]
+    public void DefaultSurface_PreservesActualNonPublicAccessorAccessibility()
+    {
+        using var stream = File.OpenRead(typeof(ApiSignatureModelTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var member = surface.Types
+            .Single(type => type.Name == nameof(ApiSignatureFixtures))
+            .Members
+            .Single(candidate => candidate.Name == nameof(ApiSignatureFixtures.MixedAccess));
+
+        Assert.Contains("internal set", member.Signature, StringComparison.Ordinal);
+        Assert.Equal(
+            "internal",
+            member.SignatureModel!.Accessors.Single(accessor => accessor.Kind == "set").Accessibility);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceAggregates_PreserveTypedIdentity()
+    {
+        var type = GetType(nameof(ExplicitInterfaceAggregateFixture));
+
+        Assert.True(Assert.Single(type.Members, member => member.Name.EndsWith(".Value", StringComparison.Ordinal))
+            .IsExplicitInterfaceImplementation);
+        Assert.True(Assert.Single(type.Members, member => member.Name.EndsWith(".Changed", StringComparison.Ordinal))
+            .IsExplicitInterfaceImplementation);
+    }
+
+    [Fact]
     public void ConstructorSignatureModel_ExposesParameterFacts()
     {
         var ctor = GetType(nameof(ApiSignatureFixtures)).Members
@@ -501,6 +529,7 @@ public sealed class ApiSignatureModelTests
 public sealed class ApiSignatureFixtures
 {
     public int Count;
+    public int MixedAccess { get; internal set; }
 
     public event EventHandler? Changed;
 
@@ -614,6 +643,23 @@ public class Outer<TOuter>
 
 public class Flat<T1, T2>
 {
+}
+
+public interface IExplicitInterfaceAggregate
+{
+    int Value { get; }
+    event EventHandler Changed;
+}
+
+public sealed class ExplicitInterfaceAggregateFixture : IExplicitInterfaceAggregate
+{
+    int IExplicitInterfaceAggregate.Value => 42;
+
+    event EventHandler IExplicitInterfaceAggregate.Changed
+    {
+        add { }
+        remove { }
+    }
 }
 
 [AttributeUsage(AttributeTargets.Parameter)]

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -132,7 +132,7 @@ public sealed class ApiSignatureModelTests
             setter.StructuralReturnType);
         Assert.Equal(
             setter.StructuralReturnType,
-            member.AccessorFacts.Single(accessor => accessor.Kind == "set")
+            member.AccessorFacts.Single(accessor => accessor.Kind is "set" or "init")
                 .StructuralReturnType);
         Assert.Null(
             member.SignatureModel.Accessors.Single(accessor => accessor.Kind == "get")
@@ -154,7 +154,7 @@ public sealed class ApiSignatureModelTests
                 required: true,
                 "System.Runtime.CompilerServices.IsExternalInit",
                 "System.Void"),
-            member.AccessorFacts.Single(accessor => accessor.Kind == "set")
+            member.AccessorFacts.Single(accessor => accessor.Kind is "set" or "init")
                 .StructuralReturnType);
     }
 

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -813,6 +813,70 @@ public sealed class ApiSurfaceExtractorBoundsTests
                 poison: true));
     }
 
+    /// <summary>
+    /// The explicit-interface MethodImpl projection runs once per type, before any member is
+    /// admitted, and it decodes an interface identity and two method signatures for every row
+    /// it walks. It therefore has to spend the same budget the rest of the walk spends, or a
+    /// MethodImpl flood buys unbounded decoding and retention that no bound can stop.
+    /// </summary>
+    /// <remarks>
+    /// The A/B is the gate: the two images differ only by their MethodImpl rows, so the second
+    /// half would still pass if the projection charged nothing, and the first half would not.
+    /// </remarks>
+    [Fact]
+    public void ExplicitInterfaceProjection_SpendsDecodeWorkBudget()
+    {
+        byte[] probe = BuildMethodImplFloodImage(
+            methodImplCount: 4,
+            nameLength: 64,
+            includeMethodImpls: true);
+        using (var probeStream = new MemoryStream(probe, writable: false))
+        using (var probeReader = new PEReader(probeStream))
+        {
+            var reader = probeReader.GetMetadataReader();
+            var typeDef = reader.GetTypeDefinition(
+                reader.TypeDefinitions.Single(handle =>
+                    reader.GetString(reader.GetTypeDefinition(handle).Name) == "Implementer"));
+            int decodeWork = 0;
+            int retainedText = 0;
+            var targets = ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(
+                reader,
+                typeDef,
+                identityProvider: null,
+                observeDecodeWork: work => decodeWork += work,
+                observeText: text => retainedText += text.Length);
+
+            Assert.Equal(4, targets.Count);
+            Assert.True(decodeWork > 0, "the projection charged no decode work");
+            Assert.True(retainedText > 0, "the projection charged no retained text");
+        }
+
+        AssertTextAmplificationIsBounded(
+            BuildMethodImplFloodImage(
+                methodImplCount: 4_000,
+                nameLength: 4_000,
+                includeMethodImpls: true));
+
+        using var stream = new MemoryStream(
+            BuildMethodImplFloodImage(
+                methodImplCount: 4_000,
+                nameLength: 4_000,
+                includeMethodImpls: false),
+            writable: false);
+        using var peReader = new PEReader(stream);
+        Assert.IsType<ApiSurfaceExtractionResult.Extracted>(
+            ApiSurfaceExtractor.ExtractBounded(
+                peReader,
+                ApiSurfaceExtractionScope.Public,
+                new ApiSurfaceExtractionBounds(
+                    maxTypes: 100_000,
+                    maxMembers: 1_000_000,
+                    maxInspectionFailures: 1_024,
+                    maxTypeForwarders: 100_000,
+                    maxMetadataRows: 250_000,
+                    maxRetainedTextCharacters: 8_000_000)));
+    }
+
     [Theory]
     [InlineData(TransformArrayKind.TupleElementNames)]
     [InlineData(TransformArrayKind.Nullable)]
@@ -1743,6 +1807,72 @@ public sealed class ApiSurfaceExtractorBoundsTests
             returnParameter,
             constructor,
             metadata.GetOrAddBlob(value));
+        return Serialize(metadata);
+    }
+
+    /// <summary>
+    /// A type with <paramref name="methodImplCount"/> MethodImpl rows against one long-named
+    /// interface, or the same image with those rows omitted. The two differ in nothing else, so
+    /// a budget that notices the first and not the second is measuring the MethodImpl
+    /// projection and not the surrounding walk.
+    /// </summary>
+    static byte[] BuildMethodImplFloodImage(
+        int methodImplCount,
+        int nameLength,
+        bool includeMethodImpls)
+    {
+        var metadata = Metadata("MethodImplFlood");
+        AssemblyReferenceHandle assembly = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Other"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        TypeReferenceHandle interfaceType = metadata.AddTypeReference(
+            assembly,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString(new string('I', nameLength)));
+        TypeDefinitionHandle type = AddModuleAndPublicType(
+            metadata,
+            "Implementer",
+            TypeAttributes.Public);
+        metadata.AddInterfaceImplementation(type, interfaceType);
+
+        var accessorSignature = new BlobBuilder();
+        new BlobEncoder(accessorSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(0, returnType => returnType.Void(), _ => { });
+        BlobHandle signature = metadata.GetOrAddBlob(accessorSignature);
+
+        var bodies = new List<MethodDefinitionHandle>(methodImplCount);
+        for (int index = 0; index < methodImplCount; index++)
+        {
+            bodies.Add(metadata.AddMethodDefinition(
+                MethodAttributes.Private
+                    | MethodAttributes.Virtual
+                    | MethodAttributes.Final
+                    | MethodAttributes.NewSlot
+                    | MethodAttributes.HideBySig,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString($"M{index}"),
+                signature,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1)));
+        }
+
+        if (includeMethodImpls)
+        {
+            for (int index = 0; index < methodImplCount; index++)
+            {
+                MemberReferenceHandle declaration = metadata.AddMemberReference(
+                    interfaceType,
+                    metadata.GetOrAddString($"M{index}"),
+                    signature);
+                metadata.AddMethodImplementation(type, bodies[index], declaration);
+            }
+        }
+
         return Serialize(metadata);
     }
 

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -1230,6 +1230,33 @@ public sealed class ApiSurfaceExtractorBoundsTests
             $"failed extraction allocated {allocated:N0} bytes");
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Summary_FilteredExplicitAggregate_DoesNotProjectMethodImplFlood(
+        bool isEvent)
+    {
+        AccessorOwner owner = isEvent
+            ? AccessorOwner.Event
+            : AccessorOwner.Property;
+        byte[] image = BuildFilteredAggregateMethodImplFloodImage(
+            methodImplCount: 32_769,
+            owner);
+        using var fullStream = new MemoryStream(image, writable: false);
+        using var fullReader = new PEReader(fullStream);
+        ApiSurface full = ApiSurfaceExtractor.Extract(fullReader);
+
+        using var summaryStream = new MemoryStream(image, writable: false);
+        using var summaryReader = new PEReader(summaryStream);
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(summaryReader);
+
+        foreach (ApiSurface surface in new[] { full, summary })
+        {
+            Assert.Empty(surface.InspectionFailures);
+            Assert.Empty(Assert.Single(surface.Types).Members);
+        }
+    }
+
     [Fact]
     public void DiscardedMethodImplBodies_DoNotSpendProjectionBudget()
     {
@@ -2564,6 +2591,101 @@ public sealed class ApiSurfaceExtractorBoundsTests
                 signature);
             metadata.AddMethodImplementation(type, body, declaration);
         }
+
+        return Serialize(metadata);
+    }
+
+    static byte[] BuildFilteredAggregateMethodImplFloodImage(
+        int methodImplCount,
+        AccessorOwner owner)
+    {
+        var metadata = Metadata("FilteredAggregateMethodImplFlood");
+        AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Contracts"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        TypeReferenceHandle interfaceType = metadata.AddTypeReference(
+            contracts,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("IFoo"));
+        TypeDefinitionHandle host = AddModuleAndPublicType(
+            metadata,
+            "Host",
+            TypeAttributes.Public);
+        metadata.AddInterfaceImplementation(host, interfaceType);
+
+        var accessorSignature = new BlobBuilder();
+        new BlobEncoder(accessorSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                0,
+                returnType =>
+                {
+                    if (owner == AccessorOwner.Property)
+                        returnType.Type().Int32();
+                    else
+                        returnType.Void();
+                },
+                _ => { });
+        BlobHandle accessorSignatureHandle =
+            metadata.GetOrAddBlob(accessorSignature);
+        MethodDefinitionHandle accessor = metadata.AddMethodDefinition(
+            MethodAttributes.Private
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot
+                | MethodAttributes.HideBySig
+                | MethodAttributes.SpecialName,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("<hidden>"),
+            accessorSignatureHandle,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+
+        string declarationName;
+        if (owner == AccessorOwner.Property)
+        {
+            var propertySignature = new BlobBuilder();
+            new BlobEncoder(propertySignature)
+                .PropertySignature(isInstanceProperty: true)
+                .Parameters(
+                    0,
+                    returnType => returnType.Type().Int32(),
+                    _ => { });
+            PropertyDefinitionHandle property = metadata.AddProperty(
+                PropertyAttributes.None,
+                metadata.GetOrAddString("IFoo.P"),
+                metadata.GetOrAddBlob(propertySignature));
+            metadata.AddPropertyMap(host, property);
+            metadata.AddMethodSemantics(
+                property,
+                MethodSemanticsAttributes.Getter,
+                accessor);
+            declarationName = "get_P";
+        }
+        else
+        {
+            EventDefinitionHandle @event = metadata.AddEvent(
+                EventAttributes.None,
+                metadata.GetOrAddString("IFoo.Changed"),
+                interfaceType);
+            metadata.AddEventMap(host, @event);
+            metadata.AddMethodSemantics(
+                @event,
+                MethodSemanticsAttributes.Adder,
+                accessor);
+            declarationName = "add_Changed";
+        }
+
+        MemberReferenceHandle declaration = metadata.AddMemberReference(
+            interfaceType,
+            metadata.GetOrAddString(declarationName),
+            accessorSignatureHandle);
+        for (int index = 0; index < methodImplCount; index++)
+            metadata.AddMethodImplementation(host, accessor, declaration);
 
         return Serialize(metadata);
     }

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -936,7 +936,10 @@ public sealed class ApiSurfaceExtractorBoundsTests
     {
         const int depth = 192;
         const int methodImplCount = 256;
-        byte[] image = BuildDeepGenericMethodImplImage(depth, methodImplCount);
+        byte[] image = BuildDeepGenericMethodImplImage(
+            depth,
+            methodImplCount,
+            uniqueParents: false);
         using var stream = new MemoryStream(image, writable: false);
         using var peReader = new PEReader(stream);
         long before = GC.GetAllocatedBytesForCurrentThread();
@@ -974,6 +977,112 @@ public sealed class ApiSurfaceExtractorBoundsTests
         Assert.Equal(
             unboundedType.Members.Select(member => (member.Name, member.Kind)),
             boundedType.Members.Select(member => (member.Name, member.Kind)));
+    }
+
+    [Fact]
+    public void RepeatedDeepGenericMethodImplUniqueParents_UseBoundedUnboundedAllocation()
+    {
+        const int depth = 192;
+        const int methodImplCount = 256;
+        byte[] image = BuildDeepGenericMethodImplImage(
+            depth,
+            methodImplCount,
+            uniqueParents: true);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader);
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        ApiType type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "DeepGenericImplementer");
+        Assert.Equal(methodImplCount, type.Members.Count);
+        Assert.True(
+            allocated < 32L * 1024 * 1024,
+            $"unbounded extraction allocated {allocated:N0} bytes");
+    }
+
+    [Fact]
+    public void RepeatedWideMethodImplDeclarations_UseBoundedUnboundedAllocation()
+    {
+        const int parameterCount = 5_000;
+        const int methodImplCount = 500;
+        byte[] image = BuildWideMethodImplImage(parameterCount, methodImplCount);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader);
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        ApiType type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementer");
+        Assert.Single(type.Members);
+        Assert.True(
+            allocated < 32L * 1024 * 1024,
+            $"unbounded extraction allocated {allocated:N0} bytes");
+
+        using var queryStream = new MemoryStream(image, writable: false);
+        using var queryReader = new PEReader(queryStream);
+        MetadataReader reader = queryReader.GetMetadataReader();
+        TypeDefinitionHandle typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "Implementer");
+        before = GC.GetAllocatedBytesForCurrentThread();
+
+        ApiType queried = MetadataDeclarationQuery.GetTypeSurface(reader, typeHandle);
+
+        allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Single(queried.Members);
+        Assert.True(
+            allocated < 32L * 1024 * 1024,
+            $"type query allocated {allocated:N0} bytes");
+    }
+
+    [Fact]
+    public void DistinctMethodImplSignatures_FailClosedWithinProjectionBudget()
+    {
+        byte[] image = BuildDistinctMethodImplSignatureImage(
+            methodCount: 256,
+            minimumParameterCount: 768);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader);
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Contains(
+            surface.InspectionFailures,
+            candidate => candidate.Detail.Contains(
+                "explicit-interface projection exceeds",
+                StringComparison.Ordinal));
+        Assert.True(
+            allocated < 96L * 1024 * 1024,
+            $"failed extraction allocated {allocated:N0} bytes");
+    }
+
+    [Fact]
+    public void CachedMethodImplRowFlood_FailsClosedWithinProjectionBudget()
+    {
+        byte[] image = BuildWideMethodImplImage(
+            parameterCount: 0,
+            methodImplCount: 32_769);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader);
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Contains(
+            surface.InspectionFailures,
+            candidate => candidate.Detail.Contains(
+                "explicit-interface projection exceeds",
+                StringComparison.Ordinal));
+        Assert.True(
+            allocated < 96L * 1024 * 1024,
+            $"failed extraction allocated {allocated:N0} bytes");
     }
 
     [Fact]
@@ -2121,7 +2230,10 @@ public sealed class ApiSurfaceExtractorBoundsTests
         return Serialize(metadata);
     }
 
-    static byte[] BuildDeepGenericMethodImplImage(int depth, int methodImplCount)
+    static byte[] BuildDeepGenericMethodImplImage(
+        int depth,
+        int methodImplCount,
+        bool uniqueParents)
     {
         var metadata = Metadata("DeepGenericMethodImpl");
         AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
@@ -2141,8 +2253,8 @@ public sealed class ApiSurfaceExtractorBoundsTests
             metadata.GetOrAddString("Leaf"));
         var parentSignature = new BlobBuilder();
         WriteDeepGenericType(parentSignature, depth, genericInterface, leaf);
-        TypeSpecificationHandle parent = metadata.AddTypeSpecification(
-            metadata.GetOrAddBlob(parentSignature));
+        BlobHandle parentBlob = metadata.GetOrAddBlob(parentSignature);
+        TypeSpecificationHandle parent = metadata.AddTypeSpecification(parentBlob);
         TypeDefinitionHandle type = AddModuleAndPublicType(
             metadata,
             "DeepGenericImplementer",
@@ -2167,14 +2279,120 @@ public sealed class ApiSurfaceExtractorBoundsTests
                 signature,
                 bodyOffset: -1,
                 MetadataTokens.ParameterHandle(1));
+            EntityHandle declarationParent = uniqueParents
+                ? metadata.AddTypeSpecification(parentBlob)
+                : parent;
             MemberReferenceHandle declaration = metadata.AddMemberReference(
-                parent,
+                declarationParent,
                 metadata.GetOrAddString($"M{index}"),
                 signature);
             metadata.AddMethodImplementation(type, body, declaration);
         }
 
         return Serialize(metadata);
+    }
+
+    static byte[] BuildWideMethodImplImage(int parameterCount, int methodImplCount)
+    {
+        var metadata = Metadata("WideMethodImpl");
+        AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Contracts"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        TypeReferenceHandle interfaceType = metadata.AddTypeReference(
+            contracts,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("IProbe"));
+        TypeDefinitionHandle type = AddModuleAndPublicType(
+            metadata,
+            "Implementer",
+            TypeAttributes.Public);
+        metadata.AddInterfaceImplementation(type, interfaceType);
+        BlobHandle signature = AddWideMethodSignature(metadata, parameterCount);
+        MethodDefinitionHandle body = metadata.AddMethodDefinition(
+            MethodAttributes.Private
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot
+                | MethodAttributes.HideBySig,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Contracts.IProbe.M"),
+            signature,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        for (int index = 0; index < methodImplCount; index++)
+        {
+            MemberReferenceHandle declaration = metadata.AddMemberReference(
+                interfaceType,
+                metadata.GetOrAddString($"M{index}"),
+                signature);
+            metadata.AddMethodImplementation(type, body, declaration);
+        }
+
+        return Serialize(metadata);
+    }
+
+    static byte[] BuildDistinctMethodImplSignatureImage(
+        int methodCount,
+        int minimumParameterCount)
+    {
+        var metadata = Metadata("DistinctMethodImplSignatures");
+        AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Contracts"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        TypeReferenceHandle interfaceType = metadata.AddTypeReference(
+            contracts,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("IProbe"));
+        TypeDefinitionHandle type = AddModuleAndPublicType(
+            metadata,
+            "Implementer",
+            TypeAttributes.Public);
+        metadata.AddInterfaceImplementation(type, interfaceType);
+        for (int index = 0; index < methodCount; index++)
+        {
+            BlobHandle signature = AddWideMethodSignature(
+                metadata,
+                minimumParameterCount + index);
+            MethodDefinitionHandle body = metadata.AddMethodDefinition(
+                MethodAttributes.Private
+                    | MethodAttributes.Virtual
+                    | MethodAttributes.Final
+                    | MethodAttributes.NewSlot
+                    | MethodAttributes.HideBySig,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString($"M{index}"),
+                signature,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+            MemberReferenceHandle declaration = metadata.AddMemberReference(
+                interfaceType,
+                metadata.GetOrAddString($"M{index}"),
+                signature);
+            metadata.AddMethodImplementation(type, body, declaration);
+        }
+
+        return Serialize(metadata);
+    }
+
+    static BlobHandle AddWideMethodSignature(
+        MetadataBuilder metadata,
+        int parameterCount)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20); // HASTHIS
+        signature.WriteCompressedInteger(parameterCount);
+        signature.WriteByte(0x01); // VOID
+        for (int index = 0; index < parameterCount; index++)
+            signature.WriteByte(0x08); // I4
+        return metadata.GetOrAddBlob(signature);
     }
 
     static void WriteDeepGenericType(

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -932,6 +932,51 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
+    public void RepeatedDeepGenericMethodImplParent_UsesBoundedUnboundedAllocation()
+    {
+        const int depth = 192;
+        const int methodImplCount = 256;
+        byte[] image = BuildDeepGenericMethodImplImage(depth, methodImplCount);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        ApiSurface unbounded = ApiSurfaceExtractor.Extract(peReader);
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        ApiType unboundedType = Assert.Single(
+            unbounded.Types,
+            type => type.Name == "DeepGenericImplementer");
+        Assert.Equal(methodImplCount, unboundedType.Members.Count);
+        Assert.All(
+            unboundedType.Members,
+            member => Assert.Equal("explicit-interface-implementation", member.Kind));
+        Assert.True(
+            allocated < 48L * 1024 * 1024,
+            $"unbounded extraction allocated {allocated:N0} bytes");
+
+        using var boundedStream = new MemoryStream(image, writable: false);
+        using var boundedReader = new PEReader(boundedStream);
+        var bounded = Assert.IsType<ApiSurfaceExtractionResult.Extracted>(
+            ApiSurfaceExtractor.ExtractBounded(
+                boundedReader,
+                ApiSurfaceExtractionScope.Public,
+                new ApiSurfaceExtractionBounds(
+                    maxTypes: 100_000,
+                    maxMembers: 1_000_000,
+                    maxInspectionFailures: 1_024,
+                    maxTypeForwarders: 100_000,
+                    maxMetadataRows: 250_000,
+                    maxRetainedTextCharacters: 8_000_000)));
+        ApiType boundedType = Assert.Single(
+            bounded.Surface.Types,
+            type => type.Name == "DeepGenericImplementer");
+        Assert.Equal(
+            unboundedType.Members.Select(member => (member.Name, member.Kind)),
+            boundedType.Members.Select(member => (member.Name, member.Kind)));
+    }
+
+    [Fact]
     public void DiscardedMethodImplBodies_DoNotSpendProjectionBudget()
     {
         using var stream = new MemoryStream(
@@ -1442,6 +1487,33 @@ public sealed class ApiSurfaceExtractorBoundsTests
             reader.GetTypeDefinition(type).GetMethods());
 
         Assert.False(ApiSurfaceExtractor.IsFinalizerMethod(reader, method));
+    }
+
+    [Fact]
+    public void SummaryAndFull_ExcludeValueTypeObjectFinalizeMethodImpl()
+    {
+        byte[] image = BuildValueTypeObjectFinalizeMethodImplImage();
+        using var fullStream = new MemoryStream(image, writable: false);
+        using var fullReader = new PEReader(fullStream);
+        ApiSurface full = ApiSurfaceExtractor.Extract(fullReader);
+
+        using var summaryStream = new MemoryStream(image, writable: false);
+        using var summaryReader = new PEReader(summaryStream);
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(summaryReader);
+
+        foreach (ApiType type in new[]
+        {
+            Assert.Single(full.Types),
+            Assert.Single(summary.Types)
+        })
+        {
+            Assert.Equal("struct", type.Kind);
+            Assert.DoesNotContain(type.Members, member => member.Name == "Finalize");
+        }
+        Assert.Equal(full.PublicMethodCount, summary.PublicMethodCount);
+        Assert.Equal(
+            Assert.Single(full.Types).Members.Select(member => member.Name),
+            Assert.Single(summary.Types).Members.Select(member => member.Name));
     }
 
     [Fact]
@@ -2047,6 +2119,82 @@ public sealed class ApiSurfaceExtractorBoundsTests
         }
 
         return Serialize(metadata);
+    }
+
+    static byte[] BuildDeepGenericMethodImplImage(int depth, int methodImplCount)
+    {
+        var metadata = Metadata("DeepGenericMethodImpl");
+        AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Contracts"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        TypeReferenceHandle genericInterface = metadata.AddTypeReference(
+            contracts,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("IProbe`1"));
+        TypeReferenceHandle leaf = metadata.AddTypeReference(
+            contracts,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("Leaf"));
+        var parentSignature = new BlobBuilder();
+        WriteDeepGenericType(parentSignature, depth, genericInterface, leaf);
+        TypeSpecificationHandle parent = metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(parentSignature));
+        TypeDefinitionHandle type = AddModuleAndPublicType(
+            metadata,
+            "DeepGenericImplementer",
+            TypeAttributes.Public);
+        metadata.AddInterfaceImplementation(type, parent);
+
+        var methodSignature = new BlobBuilder();
+        new BlobEncoder(methodSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(0, returnType => returnType.Type().Int32(), _ => { });
+        BlobHandle signature = metadata.GetOrAddBlob(methodSignature);
+        for (int index = 0; index < methodImplCount; index++)
+        {
+            MethodDefinitionHandle body = metadata.AddMethodDefinition(
+                MethodAttributes.Private
+                    | MethodAttributes.Virtual
+                    | MethodAttributes.Final
+                    | MethodAttributes.NewSlot
+                    | MethodAttributes.HideBySig,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString($"M{index}"),
+                signature,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+            MemberReferenceHandle declaration = metadata.AddMemberReference(
+                parent,
+                metadata.GetOrAddString($"M{index}"),
+                signature);
+            metadata.AddMethodImplementation(type, body, declaration);
+        }
+
+        return Serialize(metadata);
+    }
+
+    static void WriteDeepGenericType(
+        BlobBuilder signature,
+        int depth,
+        TypeReferenceHandle genericInterface,
+        TypeReferenceHandle leaf)
+    {
+        if (depth == 0)
+        {
+            signature.WriteByte(0x12); // ELEMENT_TYPE_CLASS
+            WriteTypeDefOrRef(signature, leaf);
+            return;
+        }
+
+        signature.WriteByte(0x15); // ELEMENT_TYPE_GENERICINST
+        signature.WriteByte(0x12); // ELEMENT_TYPE_CLASS
+        WriteTypeDefOrRef(signature, genericInterface);
+        signature.WriteCompressedInteger(1);
+        WriteDeepGenericType(signature, depth - 1, genericInterface, leaf);
     }
 
     static byte[] BuildInterfaceFloodImage(int interfaceCount, int nameLength)
@@ -4216,6 +4364,64 @@ public sealed class ApiSurfaceExtractorBoundsTests
             objectType,
             metadata.GetOrAddString("Finalize"),
             declarationSignature);
+        metadata.AddMethodImplementation(type, body, declaration);
+        return Serialize(metadata);
+    }
+
+    static byte[] BuildValueTypeObjectFinalizeMethodImplImage()
+    {
+        var metadata = Metadata("ValueTypeObjectFinalizeMethodImpl");
+        AssemblyReferenceHandle coreLibrary = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Private.CoreLib"),
+            new Version(11, 0, 0, 0),
+            default,
+            metadata.GetOrAddBlob(new byte[]
+            {
+                0x7c, 0xec, 0x85, 0xd7,
+                0xbe, 0xa7, 0x79, 0x8e
+            }),
+            default,
+            default);
+        TypeReferenceHandle objectType = metadata.AddTypeReference(
+            coreLibrary,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+        TypeReferenceHandle valueType = metadata.AddTypeReference(
+            coreLibrary,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("ValueType"));
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle type = metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Sealed,
+            metadata.GetOrAddString("Samples"),
+            metadata.GetOrAddString("ValueTypeFinalizerHost"),
+            valueType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        BlobHandle signature = AddFinalizeSignature(
+            metadata,
+            FinalizerSignatureShape.InstanceVoid);
+        MethodDefinitionHandle body = metadata.AddMethodDefinition(
+            MethodAttributes.Private
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot
+                | MethodAttributes.HideBySig,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Finalize"),
+            signature,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        MemberReferenceHandle declaration = metadata.AddMemberReference(
+            objectType,
+            metadata.GetOrAddString("Finalize"),
+            signature);
         metadata.AddMethodImplementation(type, body, declaration);
         return Serialize(metadata);
     }

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -1231,16 +1231,19 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void Summary_FilteredExplicitAggregate_DoesNotProjectMethodImplFlood(
-        bool isEvent)
+    [InlineData(false, 0)]
+    [InlineData(false, 32_769)]
+    [InlineData(true, 0)]
+    [InlineData(true, 32_769)]
+    public void EditorHiddenCanonicalAggregate_DoesNotProjectMethodImplRows(
+        bool isEvent,
+        int methodImplCount)
     {
         AccessorOwner owner = isEvent
             ? AccessorOwner.Event
             : AccessorOwner.Property;
         byte[] image = BuildFilteredAggregateMethodImplFloodImage(
-            methodImplCount: 32_769,
+            methodImplCount,
             owner);
         using var fullStream = new MemoryStream(image, writable: false);
         using var fullReader = new PEReader(fullStream);
@@ -1250,11 +1253,90 @@ public sealed class ApiSurfaceExtractorBoundsTests
         using var summaryReader = new PEReader(summaryStream);
         ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(summaryReader);
 
-        foreach (ApiSurface surface in new[] { full, summary })
+        using var boundedStream = new MemoryStream(image, writable: false);
+        using var boundedReader = new PEReader(boundedStream);
+        var bounded = Assert.IsType<ApiSurfaceExtractionResult.Extracted>(
+            ApiSurfaceExtractor.ExtractBounded(
+                boundedReader,
+                ApiSurfaceExtractionScope.Public,
+                new ApiSurfaceExtractionBounds(
+                    maxTypes: 10,
+                    maxMembers: 10,
+                    maxInspectionFailures: 10,
+                    maxTypeForwarders: 10,
+                    maxMetadataRows: 100_000,
+                    maxRetainedTextCharacters: 1_000_000)));
+
+        foreach (ApiSurface surface in new[]
+            {
+                full,
+                summary,
+                bounded.Surface,
+            })
         {
             Assert.Empty(surface.InspectionFailures);
             Assert.Empty(Assert.Single(surface.Types).Members);
         }
+
+        using var queryStream = new MemoryStream(image, writable: false);
+        using var queryReader = new PEReader(queryStream);
+        MetadataReader metadata = queryReader.GetMetadataReader();
+        TypeDefinitionHandle host = metadata.TypeDefinitions.Single(handle =>
+            metadata.GetString(metadata.GetTypeDefinition(handle).Name) == "Host");
+        ApiType queried = MetadataDeclarationQuery.GetTypeSurface(
+            metadata,
+            host,
+            includeNonPublicMembers: false);
+        Assert.Empty(queried.Members);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void EditorHiddenAggregate_PreservesNoncanonicalExplicitImplementation(
+        bool isEvent)
+    {
+        AccessorOwner owner = isEvent
+            ? AccessorOwner.Event
+            : AccessorOwner.Property;
+        byte[] image = BuildFilteredAggregateMethodImplFloodImage(
+            methodImplCount: 1,
+            owner,
+            canonicalAccessor: false);
+        string expectedName = isEvent
+            ? "IFoo.add_Changed"
+            : "IFoo.get_P";
+
+        using var fullStream = new MemoryStream(image, writable: false);
+        using var fullReader = new PEReader(fullStream);
+        ApiSurface full = ApiSurfaceExtractor.Extract(fullReader);
+        using var summaryStream = new MemoryStream(image, writable: false);
+        using var summaryReader = new PEReader(summaryStream);
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(summaryReader);
+
+        foreach (ApiSurface surface in new[] { full, summary })
+        {
+            Assert.Empty(surface.InspectionFailures);
+            ApiMember member = Assert.Single(
+                Assert.Single(surface.Types).Members);
+            Assert.Equal(expectedName, member.Name);
+            Assert.Equal(
+                "explicit-interface-implementation",
+                member.Kind);
+        }
+
+        using var queryStream = new MemoryStream(image, writable: false);
+        using var queryReader = new PEReader(queryStream);
+        MetadataReader metadata = queryReader.GetMetadataReader();
+        TypeDefinitionHandle host = metadata.TypeDefinitions.Single(handle =>
+            metadata.GetString(metadata.GetTypeDefinition(handle).Name) == "Host");
+        ApiMember queried = Assert.Single(
+            MetadataDeclarationQuery.GetTypeSurface(
+                metadata,
+                host,
+                includeNonPublicMembers: false).Members);
+        Assert.Equal(expectedName, queried.Name);
+        Assert.True(queried.IsExplicitInterfaceImplementation);
     }
 
     [Fact]
@@ -2597,7 +2679,8 @@ public sealed class ApiSurfaceExtractorBoundsTests
 
     static byte[] BuildFilteredAggregateMethodImplFloodImage(
         int methodImplCount,
-        AccessorOwner owner)
+        AccessorOwner owner,
+        bool canonicalAccessor = true)
     {
         var metadata = Metadata("FilteredAggregateMethodImplFlood");
         AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
@@ -2616,6 +2699,34 @@ public sealed class ApiSurfaceExtractorBoundsTests
             "Host",
             TypeAttributes.Public);
         metadata.AddInterfaceImplementation(host, interfaceType);
+        AssemblyReferenceHandle runtime = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Runtime"),
+            new Version(11, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        TypeReferenceHandle editorBrowsable = metadata.AddTypeReference(
+            runtime,
+            metadata.GetOrAddString("System.ComponentModel"),
+            metadata.GetOrAddString("EditorBrowsableAttribute"));
+        var attributeConstructorSignature = new BlobBuilder();
+        new BlobEncoder(attributeConstructorSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                1,
+                returnType => returnType.Void(),
+                parameters => parameters.AddParameter().Type().Int32());
+        MemberReferenceHandle attributeConstructor = metadata.AddMemberReference(
+            editorBrowsable,
+            metadata.GetOrAddString(".ctor"),
+            metadata.GetOrAddBlob(attributeConstructorSignature));
+        var attributeValue = new BlobBuilder();
+        attributeValue.WriteUInt16(1);
+        attributeValue.WriteInt32(1);
+        attributeValue.WriteUInt16(0);
+        BlobHandle attributeValueHandle =
+            metadata.GetOrAddBlob(attributeValue);
 
         var accessorSignature = new BlobBuilder();
         new BlobEncoder(accessorSignature)
@@ -2632,20 +2743,26 @@ public sealed class ApiSurfaceExtractorBoundsTests
                 _ => { });
         BlobHandle accessorSignatureHandle =
             metadata.GetOrAddBlob(accessorSignature);
+        string declarationName = owner == AccessorOwner.Property
+            ? "get_P"
+            : "add_Changed";
+        string bodyName = canonicalAccessor
+            ? declarationName
+            : "IFoo." + declarationName;
         MethodDefinitionHandle accessor = metadata.AddMethodDefinition(
-            MethodAttributes.Private
+            MethodAttributes.Public
                 | MethodAttributes.Virtual
                 | MethodAttributes.Final
                 | MethodAttributes.NewSlot
                 | MethodAttributes.HideBySig
                 | MethodAttributes.SpecialName,
             MethodImplAttributes.IL,
-            metadata.GetOrAddString("<hidden>"),
+            metadata.GetOrAddString(bodyName),
             accessorSignatureHandle,
             bodyOffset: -1,
             MetadataTokens.ParameterHandle(1));
 
-        string declarationName;
+        EntityHandle aggregate;
         if (owner == AccessorOwner.Property)
         {
             var propertySignature = new BlobBuilder();
@@ -2657,28 +2774,32 @@ public sealed class ApiSurfaceExtractorBoundsTests
                     _ => { });
             PropertyDefinitionHandle property = metadata.AddProperty(
                 PropertyAttributes.None,
-                metadata.GetOrAddString("IFoo.P"),
+                metadata.GetOrAddString("P"),
                 metadata.GetOrAddBlob(propertySignature));
             metadata.AddPropertyMap(host, property);
             metadata.AddMethodSemantics(
                 property,
                 MethodSemanticsAttributes.Getter,
                 accessor);
-            declarationName = "get_P";
+            aggregate = property;
         }
         else
         {
             EventDefinitionHandle @event = metadata.AddEvent(
                 EventAttributes.None,
-                metadata.GetOrAddString("IFoo.Changed"),
+                metadata.GetOrAddString("Changed"),
                 interfaceType);
             metadata.AddEventMap(host, @event);
             metadata.AddMethodSemantics(
                 @event,
                 MethodSemanticsAttributes.Adder,
                 accessor);
-            declarationName = "add_Changed";
+            aggregate = @event;
         }
+        metadata.AddCustomAttribute(
+            aggregate,
+            attributeConstructor,
+            attributeValueHandle);
 
         MemberReferenceHandle declaration = metadata.AddMemberReference(
             interfaceType,

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -939,6 +939,40 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
+    public void InheritedInterfaceClosure_SpendsDecodeWorkBudget()
+    {
+        int baselineWork = MeasureDecodeWork(
+            BuildInheritedInterfaceClosureImage(depth: 0, nameLength: 1_024));
+        int inheritedWork = MeasureDecodeWork(
+            BuildInheritedInterfaceClosureImage(depth: 32, nameLength: 1_024));
+
+        Assert.True(
+            inheritedWork > baselineWork + 32 * 1_024,
+            $"inherited closure charged {inheritedWork - baselineWork:N0} additional characters");
+
+        static int MeasureDecodeWork(byte[] image)
+        {
+            using var stream = new MemoryStream(image, writable: false);
+            using var peReader = new PEReader(stream);
+            MetadataReader reader = peReader.GetMetadataReader();
+            TypeDefinitionHandle type = reader.TypeDefinitions.Single(handle =>
+                reader.GetString(reader.GetTypeDefinition(handle).Name)
+                    == "Implementer");
+            int decodeWork = 0;
+
+            Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
+                targets =
+                    ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(
+                        reader,
+                        reader.GetTypeDefinition(type),
+                        observeDecodeWork: work => decodeWork += work);
+
+            Assert.Single(Assert.Single(targets).Value);
+            return decodeWork;
+        }
+    }
+
+    [Fact]
     public void UndeterminedInterfaceProjection_EarnsCommittedDecodeWorkCredit()
     {
         byte[] image = BuildMethodImplFloodImage(
@@ -966,6 +1000,17 @@ public sealed class ApiSurfaceExtractorBoundsTests
         Assert.True(
             retainedText > 0,
             "an undetermined retained MethodImpl target earned no decode-work credit");
+    }
+
+    [Fact]
+    public void CommittedMethodImplProjection_DoesNotFinanceLaterAmplification()
+    {
+        AssertTextAmplificationIsBounded(
+            BuildMethodImplFloodImage(
+                methodImplCount: 1_900,
+                nameLength: 4_000,
+                includeMethodImpls: true,
+                trailingArrayRank: 20_000_000));
     }
 
     [Fact]
@@ -2555,7 +2600,8 @@ public sealed class ApiSurfaceExtractorBoundsTests
         int nameLength,
         bool includeMethodImpls,
         bool hideBodies = false,
-        bool declarationOnUnresolvedInheritedInterface = false)
+        bool declarationOnUnresolvedInheritedInterface = false,
+        int? trailingArrayRank = null)
     {
         var metadata = Metadata("MethodImplFlood");
         AssemblyReferenceHandle assembly = metadata.AddAssemblyReference(
@@ -2581,6 +2627,16 @@ public sealed class ApiSurfaceExtractorBoundsTests
             "Implementer",
             TypeAttributes.Public);
         metadata.AddInterfaceImplementation(type, interfaceType);
+        if (trailingArrayRank is not null)
+        {
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("Samples"),
+                metadata.GetOrAddString("HugeArray"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(methodImplCount + 1));
+        }
 
         var accessorSignature = new BlobBuilder();
         new BlobEncoder(accessorSignature)
@@ -2616,6 +2672,112 @@ public sealed class ApiSurfaceExtractorBoundsTests
                 metadata.AddMethodImplementation(type, bodies[index], declaration);
             }
         }
+
+        if (trailingArrayRank is { } rank)
+        {
+            var fieldSignature = new BlobBuilder();
+            fieldSignature.WriteByte(0x06);
+            fieldSignature.WriteByte(0x14);
+            fieldSignature.WriteByte(0x08);
+            fieldSignature.WriteCompressedInteger(rank);
+            fieldSignature.WriteCompressedInteger(0);
+            fieldSignature.WriteCompressedInteger(0);
+            metadata.AddFieldDefinition(
+                FieldAttributes.Public,
+                metadata.GetOrAddString("Value"),
+                metadata.GetOrAddBlob(fieldSignature));
+        }
+
+        return Serialize(metadata);
+    }
+
+    static byte[] BuildInheritedInterfaceClosureImage(
+        int depth,
+        int nameLength)
+    {
+        var metadata = Metadata("InheritedInterfaceClosure");
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var inheritedInterfaces = new List<TypeDefinitionHandle>(depth);
+        for (int index = 0; index < depth; index++)
+        {
+            inheritedInterfaces.Add(metadata.AddTypeDefinition(
+                TypeAttributes.Public
+                    | TypeAttributes.Interface
+                    | TypeAttributes.Abstract,
+                metadata.GetOrAddString("Samples"),
+                metadata.GetOrAddString(
+                    $"{new string('I', nameLength)}{index}"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1)));
+        }
+
+        TypeDefinitionHandle leaf = metadata.AddTypeDefinition(
+            TypeAttributes.Public
+                | TypeAttributes.Interface
+                | TypeAttributes.Abstract,
+            metadata.GetOrAddString("Samples"),
+            metadata.GetOrAddString("ILeaf"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle implementer = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Samples"),
+            metadata.GetOrAddString("Implementer"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+
+        for (int index = 1; index < inheritedInterfaces.Count; index++)
+        {
+            metadata.AddInterfaceImplementation(
+                inheritedInterfaces[index],
+                inheritedInterfaces[index - 1]);
+        }
+        if (inheritedInterfaces.Count > 0)
+        {
+            metadata.AddInterfaceImplementation(
+                leaf,
+                inheritedInterfaces[^1]);
+        }
+        metadata.AddInterfaceImplementation(implementer, leaf);
+
+        var signatureBuilder = new BlobBuilder();
+        new BlobEncoder(signatureBuilder)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(0, returnType => returnType.Void(), _ => { });
+        BlobHandle signature = metadata.GetOrAddBlob(signatureBuilder);
+        MethodDefinitionHandle declaration = metadata.AddMethodDefinition(
+            MethodAttributes.Public
+                | MethodAttributes.Abstract
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot
+                | MethodAttributes.HideBySig,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("M"),
+            signature,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle body = metadata.AddMethodDefinition(
+            MethodAttributes.Private
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot
+                | MethodAttributes.HideBySig,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Body"),
+            signature,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(implementer, body, declaration);
 
         return Serialize(metadata);
     }

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -1006,18 +1006,51 @@ public sealed class ApiSurfaceExtractorBoundsTests
             $"function-pointer rejection allocated {allocated:N0} bytes");
     }
 
+    [Fact]
+    public void ExplicitInterfaceFunctionPointerDisplay_PreflightsNodeFramingAtBoundary()
+    {
+        var provider = new ExplicitInterfaceTypeIdentityProvider();
+        var parameter = new ExplicitInterfaceTypeIdentity(
+            new string('K', 64),
+            new string('P', 4_095));
+        ImmutableArray<ExplicitInterfaceTypeIdentity> parameters =
+            ImmutableArray.CreateRange(
+                Enumerable.Repeat(parameter, 2_014));
+        var signature = new MethodSignature<ExplicitInterfaceTypeIdentity>(
+            new SignatureHeader(
+                SignatureKind.Method,
+                SignatureCallingConvention.Default,
+                SignatureAttributes.None),
+            parameter,
+            requiredParameterCount: parameters.Length,
+            genericParameterCount: 0,
+            parameters);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Throws<BadImageFormatException>(
+            () => provider.GetFunctionPointerType(signature));
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.True(
+            allocated < 8L * 1024 * 1024,
+            $"function-pointer boundary rejection allocated {allocated:N0} bytes");
+    }
+
     [Theory]
-    [InlineData(0, 0, false)]
-    [InlineData(1, 1, false)]
-    [InlineData(1, 0, true)]
+    [InlineData(0, 0, 0, false)]
+    [InlineData(1, 1, 0, false)]
+    [InlineData(1, 0, 0, true)]
+    [InlineData(1, 0, 1, false)]
     public void MethodImplGenericSignature_AuthenticatesOnlyOwnedGenericParameters(
         int genericParameterRows,
         int methodParameterIndex,
+        int genericParameterNumberOffset,
         bool expectedMatch)
     {
         byte[] image = BuildMalformedGenericMethodImplImage(
             genericParameterRows,
-            methodParameterIndex);
+            methodParameterIndex,
+            genericParameterNumberOffset);
         using var stream = new MemoryStream(image, writable: false);
         using var peReader = new PEReader(stream);
         MetadataReader reader = peReader.GetMetadataReader();
@@ -2313,7 +2346,8 @@ public sealed class ApiSurfaceExtractorBoundsTests
     /// </summary>
     static byte[] BuildMalformedGenericMethodImplImage(
         int genericParameterRows,
-        int methodParameterIndex)
+        int methodParameterIndex,
+        int genericParameterNumberOffset)
     {
         var metadata = Metadata("MalformedGenericMethodImpl");
         AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
@@ -2357,7 +2391,7 @@ public sealed class ApiSurfaceExtractorBoundsTests
                 body,
                 GenericParameterAttributes.None,
                 metadata.GetOrAddString($"T{index}"),
-                index);
+                genericParameterNumberOffset + index);
         }
         MemberReferenceHandle declaration = metadata.AddMemberReference(
             interfaceType,

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -152,6 +152,53 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
+    public void CoreLibraryPublicExtraction_CompletesWithinFiniteBounds()
+    {
+        const int MaxTypes = 25_000;
+        const int MaxMembers = 500_000;
+        const int MaxInspectionFailures = 16_384;
+        const int MaxTypeForwarders = 25_000;
+        const int MaxMetadataRows = 5_000_000;
+        const int MaxRetainedTextCharacters = 128_000_000;
+        string path = typeof(object).Assembly.Location;
+        using var stream = File.OpenRead(path);
+        using var peReader = new PEReader(stream);
+        MetadataReader reader = peReader.GetMetadataReader();
+        int metadataRows = Enum.GetValues<TableIndex>()
+            .Sum(reader.GetTableRowCount);
+        var bounds = new ApiSurfaceExtractionBounds(
+            MaxTypes,
+            MaxMembers,
+            MaxInspectionFailures,
+            MaxTypeForwarders,
+            MaxMetadataRows,
+            MaxRetainedTextCharacters);
+
+        ApiSurfaceExtractionResult result = ApiSurfaceExtractor.ExtractBounded(
+            peReader,
+            ApiSurfaceExtractionScope.Public,
+            bounds);
+
+        if (result is not ApiSurfaceExtractionResult.Extracted extracted)
+        {
+            Assert.Fail(
+                $"Bounded Public CoreLib extraction did not complete: {result}; "
+                + $"runtime={Environment.Version}; path={path}; bytes={stream.Length}; "
+                + $"metadataRows={metadataRows}; bounds={bounds}");
+            return;
+        }
+
+        Assert.True(extracted.MetadataRows > 0);
+        Assert.True(extracted.RetainedTextCharacters > 0);
+        Assert.Contains(
+            extracted.Surface.Types,
+            type => type.FullName == "System.Object");
+        Assert.True(
+            extracted.Surface.Types.Sum(type => type.Members.Count) > 0,
+            "CoreLib extraction completed without any public members.");
+    }
+
+    [Fact]
     public void NoncanonicalAssociatedMethods_AreRetainedAcrossInventoriesAndBudgets()
     {
         byte[] image = BuildNoncanonicalAccessorInventoryImage();
@@ -814,10 +861,10 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     /// <summary>
-    /// The explicit-interface MethodImpl projection runs once per type, before any member is
-    /// admitted, and it decodes an interface identity and two method signatures for every row
-    /// it walks. It therefore has to spend the same budget the rest of the walk spends, or a
-    /// MethodImpl flood buys unbounded decoding and retention that no bound can stop.
+    /// The explicit-interface MethodImpl projection decodes an interface identity and two
+    /// method signatures for every admitted row it walks. It therefore has to spend the same
+    /// budget the rest of the walk spends, or a retained MethodImpl flood buys unbounded
+    /// decoding that no bound can stop.
     /// </summary>
     /// <remarks>
     /// The A/B is the gate: the two images differ only by their MethodImpl rows, so the second
@@ -875,6 +922,35 @@ public sealed class ApiSurfaceExtractorBoundsTests
                     maxTypeForwarders: 100_000,
                     maxMetadataRows: 250_000,
                     maxRetainedTextCharacters: 8_000_000)));
+    }
+
+    [Fact]
+    public void DiscardedMethodImplBodies_DoNotSpendProjectionBudget()
+    {
+        using var stream = new MemoryStream(
+            BuildMethodImplFloodImage(
+                methodImplCount: 4_000,
+                nameLength: 4_000,
+                includeMethodImpls: true,
+                hideBodies: true),
+            writable: false);
+        using var peReader = new PEReader(stream);
+
+        var extracted = Assert.IsType<ApiSurfaceExtractionResult.Extracted>(
+            ApiSurfaceExtractor.ExtractBounded(
+                peReader,
+                ApiSurfaceExtractionScope.Public,
+                new ApiSurfaceExtractionBounds(
+                    maxTypes: 100_000,
+                    maxMembers: 1_000_000,
+                    maxInspectionFailures: 1_024,
+                    maxTypeForwarders: 100_000,
+                    maxMetadataRows: 250_000,
+                    maxRetainedTextCharacters: 8_000_000)));
+
+        ApiType type = Assert.Single(extracted.Surface.Types);
+        Assert.Equal("Samples.Implementer", type.FullName);
+        Assert.Empty(type.Members);
     }
 
     [Theory]
@@ -1819,7 +1895,8 @@ public sealed class ApiSurfaceExtractorBoundsTests
     static byte[] BuildMethodImplFloodImage(
         int methodImplCount,
         int nameLength,
-        bool includeMethodImpls)
+        bool includeMethodImpls,
+        bool hideBodies = false)
     {
         var metadata = Metadata("MethodImplFlood");
         AssemblyReferenceHandle assembly = metadata.AddAssemblyReference(
@@ -1855,7 +1932,8 @@ public sealed class ApiSurfaceExtractorBoundsTests
                     | MethodAttributes.NewSlot
                     | MethodAttributes.HideBySig,
                 MethodImplAttributes.IL,
-                metadata.GetOrAddString($"M{index}"),
+                metadata.GetOrAddString(
+                    hideBodies ? $"<M{index}>" : $"M{index}"),
                 signature,
                 bodyOffset: -1,
                 MetadataTokens.ParameterHandle(1)));

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -706,9 +706,19 @@ public sealed class ApiSurfaceExtractorBoundsTests
         }
 
         long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        ApiSurfaceInspectionFailure failure = Assert.Single(surface.InspectionFailures);
+        ApiSurfaceInspectionFailure failure = Assert.Single(
+            surface.InspectionFailures,
+            candidate => candidate.Operation == "enum attribute type index");
         Assert.Equal("enum attribute type index", failure.Operation);
         Assert.Equal(MetadataTypeNameFailureMechanism.Metadata, failure.Mechanism);
+        Assert.Contains(
+            surface.InspectionFailures,
+            candidate => candidate is
+            {
+                Operation: "type identity",
+                Mechanism: MetadataTypeNameFailureMechanism.Relationship,
+                Kind: "Cycle"
+            });
         ApiType attributed = Assert.Single(surface.Types, type => type.Name == "Attributed");
         Assert.Empty(attributed.Attributes);
         Assert.True(

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -939,6 +939,36 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
+    public void UndeterminedInterfaceProjection_EarnsCommittedDecodeWorkCredit()
+    {
+        byte[] image = BuildMethodImplFloodImage(
+            methodImplCount: 1,
+            nameLength: 64,
+            includeMethodImpls: true,
+            declarationOnUnresolvedInheritedInterface: true);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        MetadataReader reader = peReader.GetMetadataReader();
+        TypeDefinition typeDef = reader.GetTypeDefinition(
+            reader.TypeDefinitions.Single(handle =>
+                reader.GetString(reader.GetTypeDefinition(handle).Name) == "Implementer"));
+        int retainedText = 0;
+
+        Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>> targets =
+            ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(
+                reader,
+                typeDef,
+                observeText: text => retainedText += text.Length);
+
+        ExplicitInterfaceMethodTarget target =
+            Assert.Single(Assert.Single(targets).Value);
+        Assert.False(target.InterfaceMembershipProven);
+        Assert.True(
+            retainedText > 0,
+            "an undetermined retained MethodImpl target earned no decode-work credit");
+    }
+
+    [Fact]
     public void PendingProjectionAndRetainedMemberText_ShareOneOrderIndependentBound()
     {
         byte[] image = BuildMethodImplFloodImage(
@@ -2524,7 +2554,8 @@ public sealed class ApiSurfaceExtractorBoundsTests
         int methodImplCount,
         int nameLength,
         bool includeMethodImpls,
-        bool hideBodies = false)
+        bool hideBodies = false,
+        bool declarationOnUnresolvedInheritedInterface = false)
     {
         var metadata = Metadata("MethodImplFlood");
         AssemblyReferenceHandle assembly = metadata.AddAssemblyReference(
@@ -2538,6 +2569,13 @@ public sealed class ApiSurfaceExtractorBoundsTests
             assembly,
             metadata.GetOrAddString("Contracts"),
             metadata.GetOrAddString(new string('I', nameLength)));
+        TypeReferenceHandle declarationInterface =
+            declarationOnUnresolvedInheritedInterface
+                ? metadata.AddTypeReference(
+                    assembly,
+                    metadata.GetOrAddString("Contracts"),
+                    metadata.GetOrAddString(new string('B', nameLength)))
+                : interfaceType;
         TypeDefinitionHandle type = AddModuleAndPublicType(
             metadata,
             "Implementer",
@@ -2572,7 +2610,7 @@ public sealed class ApiSurfaceExtractorBoundsTests
             for (int index = 0; index < methodImplCount; index++)
             {
                 MemberReferenceHandle declaration = metadata.AddMemberReference(
-                    interfaceType,
+                    declarationInterface,
                     metadata.GetOrAddString($"M{index}"),
                     signature);
                 metadata.AddMethodImplementation(type, bodies[index], declaration);

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -925,6 +925,13 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
+    public void ExplicitInterfaceMethodImplHugeArrayRank_StopsBeforeLargeAllocationAmplification()
+    {
+        AssertTextAmplificationIsBounded(
+            BuildMethodImplArrayRankImage(rank: 40_000_000));
+    }
+
+    [Fact]
     public void DiscardedMethodImplBodies_DoNotSpendProjectionBudget()
     {
         using var stream = new MemoryStream(
@@ -1347,6 +1354,94 @@ public sealed class ApiSurfaceExtractorBoundsTests
             BuildRepeatedFinalizerImage(
                 typeCount: 64,
                 publicKeyLength: 2_100_000));
+    }
+
+    [Theory]
+    [InlineData(
+        FinalizerSignatureShape.InstanceVoid,
+        FinalizerSignatureShape.InstanceVoid,
+        true)]
+    [InlineData(
+        FinalizerSignatureShape.StaticVoid,
+        FinalizerSignatureShape.InstanceVoid,
+        false)]
+    [InlineData(
+        FinalizerSignatureShape.StaticAttributeInstanceVoid,
+        FinalizerSignatureShape.InstanceVoid,
+        false)]
+    [InlineData(
+        FinalizerSignatureShape.InstanceVoidInt32,
+        FinalizerSignatureShape.InstanceVoid,
+        false)]
+    [InlineData(
+        FinalizerSignatureShape.InstanceVoid,
+        FinalizerSignatureShape.InstanceVoidInt32,
+        false)]
+    [InlineData(
+        FinalizerSignatureShape.InstanceVoid,
+        FinalizerSignatureShape.StaticVoid,
+        false)]
+    [InlineData(
+        FinalizerSignatureShape.InstanceVoid,
+        FinalizerSignatureShape.Malformed,
+        false)]
+    public void ExplicitObjectFinalizeMethodImpl_RequiresInstanceVoidSignatures(
+        FinalizerSignatureShape bodyShape,
+        FinalizerSignatureShape declarationShape,
+        bool isFinalizer)
+    {
+        using var stream = new MemoryStream(
+            BuildObjectFinalizeMethodImplImage(bodyShape, declarationShape),
+            writable: false);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        TypeDefinitionHandle type = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+                == "FinalizerMethodImplHost");
+        MethodDefinitionHandle method = Assert.Single(
+            reader.GetTypeDefinition(type).GetMethods());
+
+        Assert.Equal(
+            isFinalizer,
+            ApiSurfaceExtractor.IsFinalizerMethod(reader, method));
+
+        if (isFinalizer)
+        {
+            ApiType publicSurface = Assert.Single(
+                ApiSurfaceExtractor.Extract(peReader).Types,
+                candidate => candidate.Name == "FinalizerMethodImplHost");
+            Assert.Contains(
+                publicSurface.Members,
+                candidate => candidate is { Name: "Finalize", Kind: "finalizer" });
+        }
+
+        ApiType extracted = Assert.Single(
+            ApiSurfaceExtractor.Extract(peReader, includeAll: true).Types,
+            candidate => candidate.Name == "FinalizerMethodImplHost");
+        ApiMember member = Assert.Single(
+            extracted.Members,
+            candidate => candidate.Name == "Finalize");
+        Assert.Equal(isFinalizer, member.IsFinalizer);
+        Assert.Equal(isFinalizer ? "finalizer" : "method", member.Kind);
+    }
+
+    [Fact]
+    public void ExplicitObjectFinalizeMethodImpl_WithMalformedBodySignatureIsNotFinalizer()
+    {
+        using var stream = new MemoryStream(
+            BuildObjectFinalizeMethodImplImage(
+                FinalizerSignatureShape.Malformed,
+                FinalizerSignatureShape.InstanceVoid),
+            writable: false);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        TypeDefinitionHandle type = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+                == "FinalizerMethodImplHost");
+        MethodDefinitionHandle method = Assert.Single(
+            reader.GetTypeDefinition(type).GetMethods());
+
+        Assert.False(ApiSurfaceExtractor.IsFinalizerMethod(reader, method));
     }
 
     [Fact]
@@ -4079,6 +4174,79 @@ public sealed class ApiSurfaceExtractorBoundsTests
         return Serialize(metadata);
     }
 
+    static byte[] BuildObjectFinalizeMethodImplImage(
+        FinalizerSignatureShape bodyShape,
+        FinalizerSignatureShape declarationShape)
+    {
+        var metadata = Metadata("ObjectFinalizeMethodImpl");
+        AssemblyReferenceHandle coreLibrary = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Private.CoreLib"),
+            new Version(11, 0, 0, 0),
+            default,
+            metadata.GetOrAddBlob(new byte[]
+            {
+                0x7c, 0xec, 0x85, 0xd7,
+                0xbe, 0xa7, 0x79, 0x8e
+            }),
+            default,
+            default);
+        TypeReferenceHandle objectType = metadata.AddTypeReference(
+            coreLibrary,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+        TypeDefinitionHandle type = AddModuleAndPublicType(
+            metadata,
+            "FinalizerMethodImplHost",
+            TypeAttributes.Public);
+        BlobHandle bodySignature = AddFinalizeSignature(metadata, bodyShape);
+        BlobHandle declarationSignature = AddFinalizeSignature(metadata, declarationShape);
+        MethodAttributes attributes = MethodAttributes.Private | MethodAttributes.HideBySig;
+        attributes |= bodyShape is FinalizerSignatureShape.StaticVoid
+                or FinalizerSignatureShape.StaticAttributeInstanceVoid
+            ? MethodAttributes.Static
+            : MethodAttributes.Virtual;
+        MethodDefinitionHandle body = metadata.AddMethodDefinition(
+            attributes,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Finalize"),
+            bodySignature,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        MemberReferenceHandle declaration = metadata.AddMemberReference(
+            objectType,
+            metadata.GetOrAddString("Finalize"),
+            declarationSignature);
+        metadata.AddMethodImplementation(type, body, declaration);
+        return Serialize(metadata);
+    }
+
+    static BlobHandle AddFinalizeSignature(
+        MetadataBuilder metadata,
+        FinalizerSignatureShape shape)
+    {
+        var signature = new BlobBuilder();
+        if (shape == FinalizerSignatureShape.Malformed)
+        {
+            signature.WriteByte(0x20); // HASTHIS without the required parameter count or return type
+            return metadata.GetOrAddBlob(signature);
+        }
+
+        bool isInstance = shape != FinalizerSignatureShape.StaticVoid;
+        bool hasParameter = shape == FinalizerSignatureShape.InstanceVoidInt32;
+        new BlobEncoder(signature).MethodSignature(
+            SignatureCallingConvention.Default,
+            genericParameterCount: 0,
+            isInstanceMethod: isInstance).Parameters(
+            hasParameter ? 1 : 0,
+            returnType => returnType.Void(),
+            parameters =>
+            {
+                if (hasParameter)
+                    parameters.AddParameter().Type().Int32();
+            });
+        return metadata.GetOrAddBlob(signature);
+    }
+
     static byte[] BuildForwarderImage(string typeName, string assemblyName)
     {
         var metadata = Metadata("ForwarderBomb");
@@ -4519,6 +4687,15 @@ public sealed class ApiSurfaceExtractorBoundsTests
         Dynamic,
     }
 
+    public enum FinalizerSignatureShape
+    {
+        InstanceVoid,
+        StaticVoid,
+        StaticAttributeInstanceVoid,
+        InstanceVoidInt32,
+        Malformed,
+    }
+
     static MetadataBuilder Metadata(
         string assemblyName,
         byte[]? publicKey = null)
@@ -4575,5 +4752,52 @@ public sealed class ApiSurfaceExtractorBoundsTests
         var image = new BlobBuilder();
         pe.Serialize(image);
         return image.ToArray();
+    }
+
+    static byte[] BuildMethodImplArrayRankImage(int rank)
+    {
+        var metadata = Metadata("MethodImplArrayRank");
+        AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Contracts"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        TypeReferenceHandle interfaceType = metadata.AddTypeReference(
+            contracts,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("IRank"));
+        TypeDefinitionHandle type = AddModuleAndPublicType(metadata, "RankImplementer");
+        metadata.AddInterfaceImplementation(type, interfaceType);
+
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20); // HASTHIS
+        signature.WriteByte(0x01); // parameter count
+        signature.WriteByte(0x01); // ELEMENT_TYPE_VOID
+        signature.WriteByte(0x14); // ELEMENT_TYPE_ARRAY
+        signature.WriteByte(0x08); // ELEMENT_TYPE_I4
+        signature.WriteCompressedInteger(rank);
+        signature.WriteCompressedInteger(0); // sizes
+        signature.WriteCompressedInteger(0); // lower bounds
+        BlobHandle signatureHandle = metadata.GetOrAddBlob(signature);
+        MethodDefinitionHandle body = metadata.AddMethodDefinition(
+            MethodAttributes.Private
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot
+                | MethodAttributes.HideBySig,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("M"),
+            signatureHandle,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        MemberReferenceHandle declaration = metadata.AddMemberReference(
+            interfaceType,
+            metadata.GetOrAddString("M"),
+            signatureHandle);
+        metadata.AddMethodImplementation(type, body, declaration);
+
+        return Serialize(metadata);
     }
 }

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -1115,6 +1115,37 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void TypeSurface_HiddenMethodImplBodies_DoNotSpendProjectionBudget(
+        bool includeNonPublicMembers)
+    {
+        using var stream = new MemoryStream(
+            BuildMethodImplFloodImage(
+                methodImplCount: 32_769,
+                nameLength: 64,
+                includeMethodImpls: true,
+                hideBodies: true),
+            writable: false);
+        using var peReader = new PEReader(stream);
+        MetadataReader reader = peReader.GetMetadataReader();
+        TypeDefinitionHandle typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "Implementer");
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        ApiType type = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers);
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Empty(type.Members);
+        Assert.True(
+            allocated < 96L * 1024 * 1024,
+            $"focused query allocated {allocated:N0} bytes");
+    }
+
+    [Theory]
     [InlineData(TransformArrayKind.TupleElementNames)]
     [InlineData(TransformArrayKind.Nullable)]
     [InlineData(TransformArrayKind.Dynamic)]

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -510,7 +511,10 @@ public sealed class ApiSurfaceExtractorBoundsTests
                 maxRetainedTextCharacters: 1_024));
 
         long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        Assert.IsType<ApiSurfaceExtractionResult.Extracted>(result);
+        var exceeded = Assert.IsType<ApiSurfaceExtractionResult.Exceeded>(result);
+        Assert.Equal(
+            ApiSurfaceExtractionBound.RetainedTextCharacters,
+            exceeded.Bound);
         Assert.True(
             allocated < 64L * 1024 * 1024,
             $"bounded extraction allocated {allocated:N0} bytes");
@@ -925,10 +929,118 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
+    public void PendingProjectionAndRetainedMemberText_ShareOneOrderIndependentBound()
+    {
+        byte[] image = BuildMethodImplFloodImage(
+            methodImplCount: 1,
+            nameLength: 64,
+            includeMethodImpls: true);
+        using var baselineStream = new MemoryStream(image, writable: false);
+        using var baselineReader = new PEReader(baselineStream);
+        var baseline = Assert.IsType<ApiSurfaceExtractionResult.Extracted>(
+            ApiSurfaceExtractor.ExtractBounded(
+                baselineReader,
+                ApiSurfaceExtractionScope.Public,
+                new ApiSurfaceExtractionBounds(
+                    maxTypes: 100,
+                    maxMembers: 100,
+                    maxInspectionFailures: 100,
+                    maxTypeForwarders: 100,
+                    maxMetadataRows: 1_000,
+                    maxRetainedTextCharacters: 8_000_000)));
+        int retainedText = baseline.RetainedTextCharacters;
+        using var boundedStream = new MemoryStream(image, writable: false);
+        using var boundedReader = new PEReader(boundedStream);
+
+        ApiSurfaceExtractionResult result = ApiSurfaceExtractor.ExtractBounded(
+            boundedReader,
+            ApiSurfaceExtractionScope.Public,
+            new ApiSurfaceExtractionBounds(
+                maxTypes: 100,
+                maxMembers: 100,
+                maxInspectionFailures: 100,
+                maxTypeForwarders: 100,
+                maxMetadataRows: 1_000,
+                maxRetainedTextCharacters: retainedText));
+
+        var exceeded = Assert.IsType<ApiSurfaceExtractionResult.Exceeded>(result);
+        Assert.Equal(
+            ApiSurfaceExtractionBound.RetainedTextCharacters,
+            exceeded.Bound);
+    }
+
+    [Fact]
     public void ExplicitInterfaceMethodImplHugeArrayRank_StopsBeforeLargeAllocationAmplification()
     {
         AssertTextAmplificationIsBounded(
             BuildMethodImplArrayRankImage(rank: 40_000_000));
+    }
+
+    [Fact]
+    public void ExplicitInterfaceFunctionPointerDisplay_IsPreflightedBeforeAllocation()
+    {
+        var provider = new ExplicitInterfaceTypeIdentityProvider();
+        var parameter = new ExplicitInterfaceTypeIdentity(
+            "parameter-key",
+            new string('P', 256));
+        ImmutableArray<ExplicitInterfaceTypeIdentity> parameters =
+            ImmutableArray.CreateRange(
+                Enumerable.Repeat(parameter, 100_000));
+        var signature = new MethodSignature<ExplicitInterfaceTypeIdentity>(
+            new SignatureHeader(
+                SignatureKind.Method,
+                SignatureCallingConvention.Default,
+                SignatureAttributes.None),
+            new ExplicitInterfaceTypeIdentity("void-key", "void"),
+            requiredParameterCount: parameters.Length,
+            genericParameterCount: 0,
+            parameters);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Throws<BadImageFormatException>(
+            () => provider.GetFunctionPointerType(signature));
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.True(
+            allocated < 8L * 1024 * 1024,
+            $"function-pointer rejection allocated {allocated:N0} bytes");
+    }
+
+    [Theory]
+    [InlineData(0, 0, false)]
+    [InlineData(1, 1, false)]
+    [InlineData(1, 0, true)]
+    public void MethodImplGenericSignature_AuthenticatesOnlyOwnedGenericParameters(
+        int genericParameterRows,
+        int methodParameterIndex,
+        bool expectedMatch)
+    {
+        byte[] image = BuildMalformedGenericMethodImplImage(
+            genericParameterRows,
+            methodParameterIndex);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        MetadataReader reader = peReader.GetMetadataReader();
+        TypeDefinition type = reader.GetTypeDefinition(
+            reader.TypeDefinitions.Single(handle =>
+                reader.GetString(reader.GetTypeDefinition(handle).Name)
+                    == "Implementer"));
+        MethodDefinitionHandle body = Assert.Single(type.GetMethods());
+        var projection = new ApiSurfaceExtractor.MethodImplementationProjection(
+            reader,
+            type,
+            new ExplicitInterfaceTypeIdentityProvider(),
+            typeContext: GenericContext.ForType(reader, type));
+
+        if (expectedMatch)
+        {
+            Assert.True(projection.HasExplicitInterfaceTargets(body));
+        }
+        else
+        {
+            Assert.Throws<BadImageFormatException>(
+                () => projection.HasExplicitInterfaceTargets(body));
+        }
     }
 
     [Fact]
@@ -2199,6 +2311,62 @@ public sealed class ApiSurfaceExtractorBoundsTests
     /// a budget that notices the first and not the second is measuring the MethodImpl
     /// projection and not the surrounding walk.
     /// </summary>
+    static byte[] BuildMalformedGenericMethodImplImage(
+        int genericParameterRows,
+        int methodParameterIndex)
+    {
+        var metadata = Metadata("MalformedGenericMethodImpl");
+        AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Contracts"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        TypeReferenceHandle interfaceType = metadata.AddTypeReference(
+            contracts,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("IContract"));
+        TypeDefinitionHandle type = AddModuleAndPublicType(
+            metadata,
+            "Implementer");
+        metadata.AddInterfaceImplementation(type, interfaceType);
+        BlobHandle signature = metadata.GetOrAddBlob(
+            new byte[]
+            {
+                0x30, // GENERIC | HASTHIS
+                0x01, // generic parameter count
+                0x00, // parameter count
+                0x1E, // MVAR
+                checked((byte)methodParameterIndex),
+            });
+        MethodDefinitionHandle body = metadata.AddMethodDefinition(
+            MethodAttributes.Private
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot
+                | MethodAttributes.HideBySig,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("M"),
+            signature,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        for (int index = 0; index < genericParameterRows; index++)
+        {
+            metadata.AddGenericParameter(
+                body,
+                GenericParameterAttributes.None,
+                metadata.GetOrAddString($"T{index}"),
+                index);
+        }
+        MemberReferenceHandle declaration = metadata.AddMemberReference(
+            interfaceType,
+            metadata.GetOrAddString("M"),
+            signature);
+        metadata.AddMethodImplementation(type, body, declaration);
+        return Serialize(metadata);
+    }
+
     static byte[] BuildMethodImplFloodImage(
         int methodImplCount,
         int nameLength,

--- a/tests/ILInspector.Metadata.Tests/MetadataAccessibilityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataAccessibilityTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+
+namespace ILInspector.Metadata.Tests;
+
+public class MetadataAccessibilityTests
+{
+    [Theory]
+    [InlineData(
+        MethodAttributes.Private,
+        MethodAttributes.FamANDAssem,
+        MethodAttributes.FamANDAssem)]
+    [InlineData(
+        MethodAttributes.FamANDAssem,
+        MethodAttributes.Assembly,
+        MethodAttributes.Assembly)]
+    [InlineData(
+        MethodAttributes.FamANDAssem,
+        MethodAttributes.Family,
+        MethodAttributes.Family)]
+    [InlineData(
+        MethodAttributes.Assembly,
+        MethodAttributes.Family,
+        MethodAttributes.FamORAssem)]
+    [InlineData(
+        MethodAttributes.Assembly,
+        MethodAttributes.FamORAssem,
+        MethodAttributes.FamORAssem)]
+    [InlineData(
+        MethodAttributes.Family,
+        MethodAttributes.Public,
+        MethodAttributes.Public)]
+    public void Join_UsesAccessibilityLattice(
+        MethodAttributes left,
+        MethodAttributes right,
+        MethodAttributes expected)
+    {
+        Assert.Equal(expected, MetadataAccessibility.Join(left, right));
+        Assert.Equal(expected, MetadataAccessibility.Join(right, left));
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -853,6 +853,14 @@ public sealed class MetadataDeclarationQueryTests
                 ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(reader, typeDef),
                 (accessors.Adder, "add_"),
                 (accessors.Remover, "remove_")));
+
+            ApiType extracted = Assert.Single(
+                ApiSurfaceExtractor.Extract(peReader).Types,
+                candidate => candidate.Name == "DerivedEvent");
+            Assert.DoesNotContain(
+                extracted.Members,
+                member => member.Name is "add_BaseChanged" or "remove_BaseChanged"
+                    || member.Kind == "explicit-interface-implementation");
         }
         finally
         {

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -945,6 +945,72 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void MetadataAccessorSemantics_BoundsAndChargesInitModifierNames()
+    {
+        using (var chargedReader = new PEReader(new MemoryStream(
+                   BuildHostileInitModifierImage(
+                       cyclicScope: false,
+                       nestedModifier: false,
+                       modifierNamespace:
+                           "System.Runtime.CompilerServices",
+                       modifierName: "IsExternalInit"))))
+        {
+            int decodeWork = 0;
+            string kind = MetadataAccessorSemantics.Kind(
+                chargedReader.GetMetadataReader(),
+                MetadataTokens.MethodDefinitionHandle(1),
+                "set",
+                amount => decodeWork += amount);
+
+            Assert.Equal("init", kind);
+            Assert.True(decodeWork > 0);
+        }
+
+        using var oversizedReader = new PEReader(new MemoryStream(
+            BuildHostileInitModifierImage(
+                cyclicScope: false,
+                nestedModifier: false,
+                modifierNamespace: "Contracts",
+                modifierName: new string(
+                    'M',
+                    MetadataSafetyPolicy.MaxTypeNameCharacters + 1))));
+        Assert.Throws<BadImageFormatException>(() =>
+            MetadataAccessorSemantics.Kind(
+                oversizedReader.GetMetadataReader(),
+                MetadataTokens.MethodDefinitionHandle(1),
+                "set",
+                _ => throw new Xunit.Sdk.XunitException(
+                    "Oversized names must fail before decode work is credited.")));
+    }
+
+    [Fact]
+    public void TypeSurface_RejectsContextInvalidTypeVisibility()
+    {
+        using var peReader = new PEReader(new MemoryStream(
+            BuildContextInvalidVisibilityImage()));
+        MetadataReader reader = peReader.GetMetadataReader();
+        TypeDefinitionHandle invalid =
+            MetadataTokens.TypeDefinitionHandle(2);
+
+        Assert.Throws<BadImageFormatException>(() =>
+            MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                invalid,
+                includeNonPublicMembers: true));
+
+        ApiSurface full =
+            ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        Assert.DoesNotContain(
+            full.Types,
+            type => type.Name == "InvalidTopLevel");
+        Assert.Contains(
+            full.InspectionFailures,
+            failure => failure.Detail.Contains(
+                "top-level type has nested visibility metadata",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void ExplicitAggregateIdentity_RejectsBaseClassMethodImplTargets()
     {
         string path = EmitBaseClassMethodImplEvent();
@@ -1157,6 +1223,53 @@ public sealed class MetadataDeclarationQueryTests
                 reader,
                 GetTypeDefinitionHandle(reader, "Fixtures.AbstractBody"),
                 includeNonPublicMembers: true));
+    }
+
+    [Fact]
+    public void AbstractNonVirtualAccessors_FailVisibly()
+    {
+        string path = EmitAbstractNonVirtualProperty();
+        try
+        {
+            using var peReader = new PEReader(File.OpenRead(path));
+            MetadataReader reader = peReader.GetMetadataReader();
+            ApiSurface full =
+                ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            ApiType extracted = Assert.Single(
+                full.Types,
+                type => type.Name == "AbstractNonVirtual");
+
+            Assert.DoesNotContain(
+                extracted.Members,
+                member => member.Kind == "property");
+            Assert.Contains(
+                full.InspectionFailures,
+                failure => failure.Operation == "property modifiers"
+                    && failure.Detail.Contains(
+                        "abstract accessor that is not virtual",
+                        StringComparison.Ordinal));
+
+            ApiSurface summary =
+                ApiSurfaceExtractor.ExtractSummary(peReader);
+            Assert.Contains(
+                summary.InspectionFailures,
+                failure => failure.Operation == "property modifiers"
+                    && failure.Detail.Contains(
+                        "abstract accessor that is not virtual",
+                        StringComparison.Ordinal));
+
+            Assert.Throws<BadImageFormatException>(() =>
+                MetadataDeclarationQuery.GetTypeSurface(
+                    reader,
+                    GetTypeDefinitionHandle(
+                        reader,
+                        "AbstractNonVirtual"),
+                    includeNonPublicMembers: true));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     /// <summary>
@@ -2517,9 +2630,57 @@ public sealed class MetadataDeclarationQueryTests
         return path;
     }
 
+    static string EmitAbstractNonVirtualProperty()
+    {
+        var assemblyName =
+            new AssemblyName("AbstractNonVirtualProperty");
+        var assembly =
+            new PersistedAssemblyBuilder(
+                assemblyName,
+                typeof(object).Assembly);
+        ModuleBuilder module =
+            assembly.DefineDynamicModule(assemblyName.Name!);
+        TypeBuilder type = module.DefineType(
+            "AbstractNonVirtual",
+            TypeAttributes.Public | TypeAttributes.Abstract);
+        const MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Abstract
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+        MethodBuilder getter = type.DefineMethod(
+            "get_Value",
+            attributes,
+            typeof(int),
+            Type.EmptyTypes);
+        MethodBuilder setter = type.DefineMethod(
+            "set_Value",
+            attributes,
+            typeof(void),
+            [typeof(int)]);
+        PropertyBuilder property = type.DefineProperty(
+            "Value",
+            PropertyAttributes.None,
+            typeof(int),
+            Type.EmptyTypes);
+        property.SetGetMethod(getter);
+        property.SetSetMethod(setter);
+        type.CreateType();
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"AbstractNonVirtualProperty-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
     static byte[] BuildHostileInitModifierImage(
         bool cyclicScope,
-        bool typeSpecModifier = false)
+        bool typeSpecModifier = false,
+        bool nestedModifier = true,
+        string modifierNamespace =
+            "System.Runtime.CompilerServices",
+        string modifierName = "IsExternalInit")
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -2570,9 +2731,11 @@ public sealed class MetadataDeclarationQueryTests
             default,
             metadata.GetOrAddString("MarkerHost"));
         TypeReferenceHandle modifier = metadata.AddTypeReference(
-            cyclicScope ? outer : (EntityHandle)outer,
-            metadata.GetOrAddString("System.Runtime.CompilerServices"),
-            metadata.GetOrAddString("IsExternalInit"));
+            cyclicScope || nestedModifier
+                ? outer
+                : outerScope,
+            metadata.GetOrAddString(modifierNamespace),
+            metadata.GetOrAddString(modifierName));
         EntityHandle modifierHandle = modifier;
         if (typeSpecModifier)
         {
@@ -2607,6 +2770,46 @@ public sealed class MetadataDeclarationQueryTests
         var image = new BlobBuilder();
         pe.Serialize(image);
         return image.ToArray();
+    }
+
+    static byte[] BuildContextInvalidVisibilityImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName:
+                metadata.GetOrAddString(
+                    "ContextInvalidVisibility.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(
+                "ContextInvalidVisibility"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList:
+                MetadataTokens.FieldDefinitionHandle(1),
+            methodList:
+                MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.NestedPrivate,
+            metadata.GetOrAddString("Fixtures"),
+            metadata.GetOrAddString("InvalidTopLevel"),
+            baseType: default,
+            fieldList:
+                MetadataTokens.FieldDefinitionHandle(1),
+            methodList:
+                MetadataTokens.MethodDefinitionHandle(1));
+        return Serialize(metadata);
     }
 
     static byte[] BuildModifiedVoidExplicitAggregateImage(

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -583,6 +583,20 @@ public sealed class MetadataDeclarationQueryTests
             index: 0);
         Assert.True(invalidVariable.IsDegraded);
 
+        var nullable = provider.GetGenericInstantiation(
+            new ExplicitInterfaceTypeIdentity(
+                "nullable",
+                "System.Nullable",
+                GenericArity: 1),
+            [element]);
+        var nullableInterface = provider.GetGenericInstantiation(
+            new ExplicitInterfaceTypeIdentity(
+                "interface",
+                "Samples.IContract",
+                GenericArity: 1),
+            [nullable]);
+        Assert.Equal("Samples.IContract<System.Int32?>", nullableInterface.AggregateAliasName);
+
         Assert.NotNull(typeof(Dictionary<,>.KeyCollection));
         var nestedReference = PeReader.GetMetadataReader()
             .TypeReferences
@@ -672,6 +686,20 @@ public sealed class MetadataDeclarationQueryTests
                 ]
             },
             (accessor, "get_")));
+
+        Assert.True(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+            "Alias::System.Collections.IList.this[]",
+            new Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
+            {
+                [accessor] =
+                [
+                    new ExplicitInterfaceMethodTarget(
+                        default,
+                        interfaceType,
+                        "get_Item")
+                ]
+            },
+            (accessor, "get_")));
     }
 
     [Fact]
@@ -690,6 +718,51 @@ public sealed class MetadataDeclarationQueryTests
             queried.Members,
             member => member.IsExplicitInterfaceImplementation
                 && member.Name.Contains("IMinMaxValue<nint>.MinValue", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TypeSurface_ClassifiesNullableExplicitInterfaceAggregates()
+    {
+        var typeHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.NullableExplicitAggregateMetadataFixture));
+        var queried = MetadataDeclarationQuery.GetTypeSurface(
+            Reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+
+        var aggregates = queried.Members.Where(member =>
+                member.IsExplicitInterfaceImplementation
+                && member.Kind is "property" or "event").ToArray();
+
+        Assert.Equal(2, aggregates.Length);
+        Assert.All(
+            aggregates,
+            member => Assert.Contains("System.Int32?", member.Name, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MetadataAccessorSemantics_DistinguishesInitAndRejectsMixedAbstraction()
+    {
+        var fixture = Reader.GetTypeDefinition(GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.NullableExplicitAggregateMetadataFixture)));
+        var contract = Reader.GetTypeDefinition(GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.INullableExplicitAggregateMetadataFixture<>)));
+        var ordinarySetter = fixture.GetMethods().Single(handle =>
+            Reader.GetString(Reader.GetMethodDefinition(handle).Name) == "set_Ordinary");
+        var initSetter = fixture.GetMethods().Single(handle =>
+            Reader.GetString(Reader.GetMethodDefinition(handle).Name) == "set_Initial");
+        var abstractGetter = contract.GetMethods().Single(handle =>
+            Reader.GetString(Reader.GetMethodDefinition(handle).Name) == "get_Value");
+
+        Assert.Equal("set", MetadataAccessorSemantics.Kind(Reader, ordinarySetter, "set"));
+        Assert.Equal("init", MetadataAccessorSemantics.Kind(Reader, initSetter, "set"));
+        Assert.False(MetadataAccessorSemantics.IsUniformlyAbstract(Reader, ordinarySetter));
+        Assert.True(MetadataAccessorSemantics.IsUniformlyAbstract(Reader, abstractGetter));
+        Assert.Throws<BadImageFormatException>(() =>
+            MetadataAccessorSemantics.IsUniformlyAbstract(
+                Reader,
+                abstractGetter,
+                ordinarySetter));
     }
 
     [Fact]
@@ -1567,6 +1640,28 @@ public class MetadataDeclarationQueryFixtures
         global::@event mode = (global::@event)1,
         string text = "a\"b.class")
     {
+    }
+
+    public interface INullableExplicitAggregateMetadataFixture<T>
+    {
+        T Value { get; }
+        event Action Changed;
+    }
+
+    public sealed class NullableExplicitAggregateMetadataFixture
+        : INullableExplicitAggregateMetadataFixture<int?>
+    {
+        public int Ordinary { get; set; }
+
+        public int Initial { get; init; }
+
+        int? INullableExplicitAggregateMetadataFixture<int?>.Value => null;
+
+        event Action INullableExplicitAggregateMetadataFixture<int?>.Changed
+        {
+            add { }
+            remove { }
+        }
     }
 
     public int get_Orphan() => 0;

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -507,7 +507,9 @@ public sealed class MetadataDeclarationQueryTests
                 [
                     removerTarget with
                     {
-                        InterfaceTypeName = "Other.IExplicitSurface"
+                        InterfaceType = new ExplicitInterfaceTypeIdentity(
+                            "Other.IExplicitSurface",
+                            "Other.IExplicitSurface")
                     }
                 ]
             },
@@ -534,6 +536,73 @@ public sealed class MetadataDeclarationQueryTests
                 ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(reader, typeDef),
                 (accessors.Adder, "add_"),
                 (accessors.Remover, "remove_")));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void TypeSurface_ClassifiesGenericExplicitInterfaceAggregates()
+    {
+        Type[] fixtureTypes =
+        [
+            typeof(MetadataDeclarationQueryFixtures.GenericSurface<,>),
+            typeof(MetadataDeclarationQueryFixtures.StringSurface),
+            typeof(MetadataDeclarationQueryFixtures.StringArraySurface)
+        ];
+
+        foreach (Type fixtureType in fixtureTypes)
+        {
+            var queried = MetadataDeclarationQuery.GetTypeSurface(
+                Reader,
+                GetTypeDefinitionHandle(fixtureType),
+                includeNonPublicMembers: true);
+            var extracted = Assert.Single(
+                ApiSurfaceExtractor.Extract(PeReader, includeAll: true).Types,
+                type => StripGenericArity(type.FullName).EndsWith(
+                    "." + StripGenericArity(fixtureType.Name),
+                    StringComparison.Ordinal));
+
+            foreach (var surface in new[] { queried, extracted })
+            {
+                Assert.Contains(
+                    surface.Members,
+                    member => member is
+                    {
+                        Kind: "property",
+                        IsExplicitInterfaceImplementation: true
+                    } && member.Name.EndsWith(".Value", StringComparison.Ordinal));
+                Assert.Contains(
+                    surface.Members,
+                    member => member is
+                    {
+                        Kind: "event",
+                        IsExplicitInterfaceImplementation: true
+                    } && member.Name.EndsWith(".Changed", StringComparison.Ordinal));
+            }
+        }
+    }
+
+    [Fact]
+    public void ExplicitAggregateIdentity_RejectsSignatureIncompatibleMethodImplTargets()
+    {
+        string path = EmitSignatureIncompatibleMethodImplProperty();
+        try
+        {
+            using var peReader = new PEReader(File.OpenRead(path));
+            var reader = peReader.GetMetadataReader();
+            var typeHandle = GetTypeDefinitionHandle(reader, "BadProperty");
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var property = reader.GetPropertyDefinition(Assert.Single(typeDef.GetProperties()));
+            var accessors = property.GetAccessors();
+
+            Assert.False(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+                reader.GetString(property.Name),
+                ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(reader, typeDef),
+                (accessors.Getter, "get_"),
+                (accessors.Setter, "set_")));
         }
         finally
         {
@@ -1163,6 +1232,57 @@ public sealed class MetadataDeclarationQueryTests
         return path;
     }
 
+    static string EmitSignatureIncompatibleMethodImplProperty()
+    {
+        var assemblyName = new AssemblyName("SignatureIncompatibleMethodImplProperty");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+
+        var interfaceBuilder = module.DefineType(
+            "IBadProperty",
+            TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract);
+        var interfaceGetter = interfaceBuilder.DefineMethod(
+            "get_Value",
+            MethodAttributes.Public
+                | MethodAttributes.Abstract
+                | MethodAttributes.Virtual
+                | MethodAttributes.SpecialName
+                | MethodAttributes.HideBySig,
+            typeof(int),
+            Type.EmptyTypes);
+        interfaceBuilder
+            .DefineProperty("Value", PropertyAttributes.None, typeof(int), null)
+            .SetGetMethod(interfaceGetter);
+        var interfaceType = interfaceBuilder.CreateType();
+
+        var type = module.DefineType("BadProperty", TypeAttributes.Public);
+        type.AddInterfaceImplementation(interfaceType);
+        var getter = type.DefineMethod(
+            "IBadProperty.get_Value",
+            MethodAttributes.Private
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot
+                | MethodAttributes.SpecialName
+                | MethodAttributes.HideBySig,
+            typeof(string),
+            Type.EmptyTypes);
+        var il = getter.GetILGenerator();
+        il.Emit(OpCodes.Ldstr, "bad");
+        il.Emit(OpCodes.Ret);
+        type
+            .DefineProperty("IBadProperty.Value", PropertyAttributes.None, typeof(string), null)
+            .SetGetMethod(getter);
+        type.DefineMethodOverride(getter, interfaceType.GetMethod("get_Value")!);
+        type.CreateType();
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"SignatureIncompatibleMethodImplProperty-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
     static TypeDefinition GetTypeDefinition(Type type)
         => Reader.GetTypeDefinition(GetTypeDefinitionHandle(type));
 
@@ -1292,6 +1412,51 @@ public class MetadataDeclarationQueryFixtures
             add { }
 
             [return: System.Diagnostics.CodeAnalysis.MaybeNull]
+            remove { }
+        }
+    }
+
+    public interface IGenericSurface<TLeft, TRight>
+    {
+        TRight Value { get; }
+        event Action<TLeft> Changed;
+    }
+
+    public sealed class GenericSurface<TLeft, TRight> : IGenericSurface<TLeft, TRight>
+    {
+        TRight IGenericSurface<TLeft, TRight>.Value => default!;
+
+        event Action<TLeft> IGenericSurface<TLeft, TRight>.Changed
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    public interface IAliasSurface<T>
+    {
+        T Value { get; }
+        event Action<T> Changed;
+    }
+
+    public sealed class StringSurface : IAliasSurface<string>
+    {
+        string IAliasSurface<string>.Value => "";
+
+        event Action<string> IAliasSurface<string>.Changed
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    public sealed class StringArraySurface : IAliasSurface<string[]>
+    {
+        string[] IAliasSurface<string[]>.Value => [];
+
+        event Action<string[]> IAliasSurface<string[]>.Changed
+        {
+            add { }
             remove { }
         }
     }

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -1441,6 +1441,67 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void MethodImplProjectionRequiresCategoryConstraintsAndInterfaceClosure()
+    {
+        string path = EmitMethodImplSemanticCases();
+        try
+        {
+            using var peReader = new PEReader(File.OpenRead(path));
+            MetadataReader reader = peReader.GetMetadataReader();
+            TypeDefinitionHandle typeHandle =
+                GetTypeDefinitionHandle(reader, "SemanticImplementation");
+            ApiType queried = MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                typeHandle,
+                includeNonPublicMembers: false);
+            ApiType extracted = Assert.Single(
+                ApiSurfaceExtractor.Extract(
+                    peReader,
+                    includeAll: false).Types,
+                type => type.FullName == "SemanticImplementation");
+
+            foreach (ApiType surface in new[] { queried, extracted })
+            {
+                ApiMember propertyShapedBody = Assert.Single(
+                    surface.Members,
+                    member => member.Name == "get_Value");
+                Assert.True(
+                    propertyShapedBody.IsExplicitInterfaceImplementation);
+                Assert.False(
+                    propertyShapedBody.CanUseImplicitInterfaceSyntax);
+
+                ApiMember constraintMismatch = Assert.Single(
+                    surface.Members,
+                    member => member.Name == "Convert");
+                Assert.True(
+                    constraintMismatch.IsExplicitInterfaceImplementation);
+                Assert.False(
+                    constraintMismatch.CanUseImplicitInterfaceSyntax);
+
+                ApiMember constraintMatch = Assert.Single(
+                    surface.Members,
+                    member => member.Name == "Transform");
+                Assert.True(
+                    constraintMatch.IsExplicitInterfaceImplementation);
+                Assert.True(
+                    constraintMatch.CanUseImplicitInterfaceSyntax);
+
+                ApiMember inheritedTarget = Assert.Single(
+                    surface.Members,
+                    member => member.Name == "InheritedBody");
+                Assert.True(inheritedTarget.IsExplicitInterfaceImplementation);
+                Assert.Equal(
+                    InterfaceImplementationResolution.Proven,
+                    inheritedTarget.InterfaceImplementationResolution);
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void TypeSurface_FoldsPublicInterfaceMethodImplAccessors()
     {
         using var stream = File.OpenRead(typeof(Half).Assembly.Location);
@@ -1502,6 +1563,13 @@ public sealed class MetadataDeclarationQueryTests
         {
             Assert.DoesNotContain(surface.Members, member => member.Name == "ICollectionCount");
             Assert.Contains(surface.Members, member => member.Name == "get_ICollectionCount");
+            ApiMember inheritedTarget = Assert.Single(
+                surface.Members,
+                member => member.Name == "ICollectionGetEnumerator");
+            Assert.True(inheritedTarget.IsExplicitInterfaceImplementation);
+            Assert.Equal(
+                InterfaceImplementationResolution.Undetermined,
+                inheritedTarget.InterfaceImplementationResolution);
         }
     }
 
@@ -1883,6 +1951,191 @@ public sealed class MetadataDeclarationQueryTests
         string path = Path.Combine(
             Path.GetTempPath(),
             $"UnqualifiedMethodImplAccessor-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitMethodImplSemanticCases()
+    {
+        var assemblyName = new AssemblyName("MethodImplSemanticCases");
+        var assembly = new PersistedAssemblyBuilder(
+            assemblyName,
+            typeof(object).Assembly);
+        ModuleBuilder module =
+            assembly.DefineDynamicModule(assemblyName.Name!);
+
+        TypeBuilder propertyInterface = module.DefineType(
+            "IPropertyContract",
+            TypeAttributes.Public
+                | TypeAttributes.Interface
+                | TypeAttributes.Abstract);
+        MethodBuilder interfaceGetter = propertyInterface.DefineMethod(
+            "get_Value",
+            MethodAttributes.Public
+                | MethodAttributes.Abstract
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot
+                | MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        propertyInterface
+            .DefineProperty(
+                "Value",
+                PropertyAttributes.None,
+                typeof(int),
+                null)
+            .SetGetMethod(interfaceGetter);
+        Type propertyInterfaceType = propertyInterface.CreateType();
+
+        TypeBuilder genericInterface = module.DefineType(
+            "IGenericContract",
+            TypeAttributes.Public
+                | TypeAttributes.Interface
+                | TypeAttributes.Abstract);
+        MethodBuilder interfaceGeneric = genericInterface.DefineMethod(
+            "Convert",
+            MethodAttributes.Public
+                | MethodAttributes.Abstract
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot);
+        GenericTypeParameterBuilder interfaceParameter =
+            Assert.Single(interfaceGeneric.DefineGenericParameters("T"));
+        interfaceParameter.SetGenericParameterAttributes(
+            GenericParameterAttributes.ReferenceTypeConstraint);
+        interfaceGeneric.SetReturnType(typeof(void));
+        interfaceGeneric.SetParameters(Type.EmptyTypes);
+        MethodBuilder interfaceTransform = genericInterface.DefineMethod(
+            "Transform",
+            MethodAttributes.Public
+                | MethodAttributes.Abstract
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot);
+        GenericTypeParameterBuilder interfaceTransformParameter =
+            Assert.Single(interfaceTransform.DefineGenericParameters("T"));
+        interfaceTransformParameter.SetGenericParameterAttributes(
+            GenericParameterAttributes.ReferenceTypeConstraint);
+        interfaceTransform.SetReturnType(typeof(void));
+        interfaceTransform.SetParameters(Type.EmptyTypes);
+        Type genericInterfaceType = genericInterface.CreateType();
+
+        TypeBuilder structInterface = module.DefineType(
+            "IStructContract",
+            TypeAttributes.Public
+                | TypeAttributes.Interface
+                | TypeAttributes.Abstract);
+        MethodBuilder structGeneric = structInterface.DefineMethod(
+            "Convert",
+            MethodAttributes.Public
+                | MethodAttributes.Abstract
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot);
+        GenericTypeParameterBuilder structParameter =
+            Assert.Single(structGeneric.DefineGenericParameters("T"));
+        structParameter.SetGenericParameterAttributes(
+            GenericParameterAttributes.NotNullableValueTypeConstraint);
+        structGeneric.SetReturnType(typeof(void));
+        structGeneric.SetParameters(Type.EmptyTypes);
+        Type structInterfaceType = structInterface.CreateType();
+
+        TypeBuilder rootInterface = module.DefineType(
+            "IRootContract",
+            TypeAttributes.Public
+                | TypeAttributes.Interface
+                | TypeAttributes.Abstract);
+        MethodBuilder rootMethod = rootInterface.DefineMethod(
+            "Run",
+            MethodAttributes.Public
+                | MethodAttributes.Abstract
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot,
+            typeof(void),
+            Type.EmptyTypes);
+        Type rootInterfaceType = rootInterface.CreateType();
+        TypeBuilder childInterface = module.DefineType(
+            "IChildContract",
+            TypeAttributes.Public
+                | TypeAttributes.Interface
+                | TypeAttributes.Abstract);
+        childInterface.AddInterfaceImplementation(rootInterfaceType);
+        Type childInterfaceType = childInterface.CreateType();
+
+        TypeBuilder implementation = module.DefineType(
+            "SemanticImplementation",
+            TypeAttributes.Public);
+        implementation.AddInterfaceImplementation(propertyInterfaceType);
+        implementation.AddInterfaceImplementation(genericInterfaceType);
+        implementation.AddInterfaceImplementation(structInterfaceType);
+        implementation.AddInterfaceImplementation(childInterfaceType);
+
+        MethodBuilder getterBody = implementation.DefineMethod(
+            "get_Value",
+            MethodAttributes.Public
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot
+                | MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        getterBody.GetILGenerator().Emit(OpCodes.Ldc_I4_1);
+        getterBody.GetILGenerator().Emit(OpCodes.Ret);
+        implementation.DefineMethodOverride(
+            getterBody,
+            propertyInterfaceType.GetMethod("get_Value")!);
+
+        MethodBuilder genericBody = implementation.DefineMethod(
+            "Convert",
+            MethodAttributes.Public
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot);
+        GenericTypeParameterBuilder bodyParameter =
+            Assert.Single(genericBody.DefineGenericParameters("T"));
+        bodyParameter.SetGenericParameterAttributes(
+            GenericParameterAttributes.NotNullableValueTypeConstraint);
+        genericBody.SetReturnType(typeof(void));
+        genericBody.SetParameters(Type.EmptyTypes);
+        genericBody.GetILGenerator().Emit(OpCodes.Ret);
+        implementation.DefineMethodOverride(
+            genericBody,
+            genericInterfaceType.GetMethod("Convert")!);
+        implementation.DefineMethodOverride(
+            genericBody,
+            structInterfaceType.GetMethod("Convert")!);
+
+        MethodBuilder transformBody = implementation.DefineMethod(
+            "Transform",
+            MethodAttributes.Public
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot);
+        GenericTypeParameterBuilder transformParameter =
+            Assert.Single(transformBody.DefineGenericParameters("T"));
+        transformParameter.SetGenericParameterAttributes(
+            GenericParameterAttributes.ReferenceTypeConstraint);
+        transformBody.SetReturnType(typeof(void));
+        transformBody.SetParameters(Type.EmptyTypes);
+        transformBody.GetILGenerator().Emit(OpCodes.Ret);
+        implementation.DefineMethodOverride(
+            transformBody,
+            genericInterfaceType.GetMethod("Transform")!);
+
+        MethodBuilder inheritedBody = implementation.DefineMethod(
+            "InheritedBody",
+            MethodAttributes.Private
+                | MethodAttributes.Virtual
+                | MethodAttributes.Final
+                | MethodAttributes.NewSlot,
+            typeof(void),
+            Type.EmptyTypes);
+        inheritedBody.GetILGenerator().Emit(OpCodes.Ret);
+        implementation.DefineMethodOverride(
+            inheritedBody,
+            rootInterfaceType.GetMethod("Run")!);
+        implementation.CreateType();
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"MethodImplSemanticCases-{Guid.NewGuid():N}.dll");
         assembly.Save(path);
         return path;
     }

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -649,6 +649,58 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void ExplicitInterfaceTypeSpecCache_DistinguishesSubstitutedContexts()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("Synthetic.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x13); // ELEMENT_TYPE_VAR
+        signature.WriteCompressedInteger(0);
+        TypeSpecificationHandle typeSpec = metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(signature));
+        using var peReader = new PEReader(
+            new MemoryStream(Serialize(metadata), writable: false));
+        MetadataReader reader = peReader.GetMetadataReader();
+        var provider = new ExplicitInterfaceTypeIdentityProvider();
+        var intType = provider.GetPrimitiveType(PrimitiveTypeCode.Int32);
+        var stringType = provider.GetPrimitiveType(PrimitiveTypeCode.String);
+
+        ExplicitInterfaceTypeIdentity first = provider.GetTypeFromSpecification(
+            reader,
+            new ExplicitInterfaceSignatureContext(null, [intType], 1),
+            typeSpec,
+            rawTypeKind: 0x12);
+        ExplicitInterfaceTypeIdentity second = provider.GetTypeFromSpecification(
+            reader,
+            new ExplicitInterfaceSignatureContext(null, [stringType], 1),
+            typeSpec,
+            rawTypeKind: 0x12);
+
+        Assert.Equal("System.Int32", first.MetadataName);
+        Assert.Equal("System.String", second.MetadataName);
+        Assert.NotEqual(first.Key, second.Key);
+    }
+
+    [Fact]
     public void ExplicitInterfaceTypeIdentity_RejectsOversizedAssemblyIdentityBlob()
     {
         var metadata = new MetadataBuilder();

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using ILInspector.Metadata;
@@ -515,6 +516,180 @@ public sealed class MetadataDeclarationQueryTests
             },
             (accessors.Adder, "add_"),
             (accessors.Remover, "remove_")));
+
+        Assert.False(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+            eventName,
+            new Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
+            {
+                [accessors.Adder] =
+                [
+                    adderTarget with
+                    {
+                        InterfaceType = adderTarget.InterfaceType with
+                        {
+                            Key = "assembly-a"
+                        }
+                    }
+                ],
+                [accessors.Remover] =
+                [
+                    removerTarget with
+                    {
+                        InterfaceType = removerTarget.InterfaceType with
+                        {
+                            Key = "assembly-b"
+                        }
+                    }
+                ]
+            },
+            (accessors.Adder, "add_"),
+            (accessors.Remover, "remove_")));
+    }
+
+    [Fact]
+    public void ExplicitInterfaceTypeIdentity_DistinguishesArrayShapesAndAssemblyEquivalence()
+    {
+        var provider = new ExplicitInterfaceTypeIdentityProvider();
+        var element = provider.GetPrimitiveType(PrimitiveTypeCode.Int32);
+        var vector = provider.GetSZArrayType(element);
+        var variableBound = provider.GetArrayType(
+            element,
+            new ArrayShape(1, [], []));
+        var sized = provider.GetArrayType(
+            element,
+            new ArrayShape(1, [4], [1]));
+
+        Assert.NotEqual(vector.Key, variableBound.Key);
+        Assert.NotEqual(variableBound.Key, sized.Key);
+        Assert.Equal(
+            ExplicitInterfaceTypeIdentityProvider.AssemblyKey(
+                new AssemblyReferenceIdentity(
+                    "Dependency",
+                    new Version(1, 0, 0, 0),
+                    "neutral",
+                    "AABBCC")),
+            ExplicitInterfaceTypeIdentityProvider.AssemblyKey(
+                new AssemblyReferenceIdentity(
+                    "dependency",
+                    new Version(1, 0, 0, 0),
+                    null,
+                    "aabbcc")));
+
+        var invalidVariable = provider.GetGenericTypeParameter(
+            new ExplicitInterfaceSignatureContext(
+                Names: null,
+                TypeArguments: default,
+                TypeParameterCount: 0),
+            index: 0);
+        Assert.True(invalidVariable.IsDegraded);
+
+        Assert.NotNull(typeof(Dictionary<,>.KeyCollection));
+        var nestedReference = PeReader.GetMetadataReader()
+            .TypeReferences
+            .Single(handle =>
+                PeReader.GetMetadataReader().GetString(
+                    PeReader.GetMetadataReader().GetTypeReference(handle).Name)
+                    == "KeyCollection");
+        Assert.Equal(
+            2,
+            provider.FromHandle(
+                PeReader.GetMetadataReader(),
+                nestedReference,
+                context: null).GenericArity);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceTypeIdentity_RejectsOversizedAssemblyIdentityBlob()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var assemblyReference = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Dependency"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: metadata.GetOrAddBlob(
+                new byte[ExplicitInterfaceTypeIdentityProvider.MaxAssemblyIdentityBlobBytes + 1]),
+            flags: default,
+            hashValue: default);
+        var typeReference = metadata.AddTypeReference(
+            assemblyReference,
+            metadata.GetOrAddString("Samples"),
+            metadata.GetOrAddString("IContract"));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        using var peReader = new PEReader(new MemoryStream(image.ToArray()));
+
+        Assert.Throws<BadImageFormatException>(() =>
+            new ExplicitInterfaceTypeIdentityProvider().FromHandle(
+                peReader.GetMetadataReader(),
+                typeReference,
+                context: null));
+    }
+
+    [Fact]
+    public void ExplicitAggregateIdentity_AcceptsIndexerMetadataAlias()
+    {
+        var accessor = MetadataTokens.MethodDefinitionHandle(1);
+        var interfaceType = new ExplicitInterfaceTypeIdentity(
+            "ilist",
+            "System.Collections.IList");
+
+        Assert.True(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+            "System.Collections.IList.this[]",
+            new Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
+            {
+                [accessor] =
+                [
+                    new ExplicitInterfaceMethodTarget(
+                        default,
+                        interfaceType,
+                        "get_Item")
+                ]
+            },
+            (accessor, "get_")));
+    }
+
+    [Fact]
+    public void TypeSurface_ClassifiesNativeIntegerExplicitInterfaceAggregates()
+    {
+        using var peReader = new PEReader(File.OpenRead(typeof(nint).Assembly.Location));
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = GetTypeDefinitionHandle(reader, "System.IntPtr");
+
+        var queried = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle,
+            includeNonPublicMembers: true);
+
+        Assert.Contains(
+            queried.Members,
+            member => member.IsExplicitInterfaceImplementation
+                && member.Name.Contains("IMinMaxValue<nint>.MinValue", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -561,6 +561,10 @@ public sealed class MetadataDeclarationQueryTests
 
         Assert.NotEqual(vector.Key, variableBound.Key);
         Assert.NotEqual(variableBound.Key, sized.Key);
+        Assert.False(vector.IsInterface);
+        Assert.False(variableBound.IsInterface);
+        Assert.False(provider.GetPointerType(element).IsInterface);
+        Assert.False(provider.GetByReferenceType(element).IsInterface);
         Assert.Equal(
             ExplicitInterfaceTypeIdentityProvider.AssemblyKey(
                 new AssemblyReferenceIdentity(
@@ -618,6 +622,16 @@ public sealed class MetadataDeclarationQueryTests
                 GenericArity: 1,
                 IsInterface: false),
             [element]).IsInterface);
+        var constructed = provider.GetGenericInstantiation(
+            new ExplicitInterfaceTypeIdentity(
+                "definition",
+                "Samples.IContract`1",
+                GenericArity: 1,
+                IsInterface: true),
+            [element]);
+        Assert.True(constructed.IsConstructedGeneric);
+        Assert.Throws<BadImageFormatException>(
+            () => provider.GetGenericInstantiation(constructed, [element]));
 
         Assert.NotNull(typeof(Dictionary<,>.KeyCollection));
         var nestedReference = PeReader.GetMetadataReader()
@@ -763,7 +777,7 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
-    public void MetadataAccessorSemantics_DistinguishesInitAndRejectsMixedAbstraction()
+    public void MetadataAccessorSemantics_DistinguishesInitAndRetainsMixedAbstraction()
     {
         var fixture = Reader.GetTypeDefinition(GetTypeDefinitionHandle(
             typeof(MetadataDeclarationQueryFixtures.NullableExplicitAggregateMetadataFixture)));
@@ -778,13 +792,12 @@ public sealed class MetadataDeclarationQueryTests
 
         Assert.Equal("set", MetadataAccessorSemantics.Kind(Reader, ordinarySetter, "set"));
         Assert.Equal("init", MetadataAccessorSemantics.Kind(Reader, initSetter, "set"));
-        Assert.False(MetadataAccessorSemantics.IsUniformlyAbstract(Reader, ordinarySetter));
-        Assert.True(MetadataAccessorSemantics.IsUniformlyAbstract(Reader, abstractGetter));
-        Assert.Throws<BadImageFormatException>(() =>
-            MetadataAccessorSemantics.IsUniformlyAbstract(
-                Reader,
-                abstractGetter,
-                ordinarySetter));
+        Assert.False(MetadataAccessorSemantics.AreAllAbstract(Reader, ordinarySetter));
+        Assert.True(MetadataAccessorSemantics.AreAllAbstract(Reader, abstractGetter));
+        Assert.False(MetadataAccessorSemantics.AreAllAbstract(
+            Reader,
+            abstractGetter,
+            ordinarySetter));
     }
 
     [Fact]
@@ -807,6 +820,16 @@ public sealed class MetadataDeclarationQueryTests
         Assert.Throws<BadImageFormatException>(() =>
             MetadataAccessorSemantics.Kind(
                 cyclicReader.GetMetadataReader(),
+                MetadataTokens.MethodDefinitionHandle(1),
+                "set"));
+
+        using var typeSpecReader = new PEReader(new MemoryStream(
+            BuildHostileInitModifierImage(
+                cyclicScope: false,
+                typeSpecModifier: true)));
+        Assert.Throws<BadImageFormatException>(() =>
+            MetadataAccessorSemantics.Kind(
+                typeSpecReader.GetMetadataReader(),
                 MetadataTokens.MethodDefinitionHandle(1),
                 "set"));
     }
@@ -838,7 +861,7 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
-    public void EventSealing_DoesNotCombineDifferentAccessors()
+    public void EventSealing_RejectsMixedAccessorState()
     {
         string path = EmitIncoherentEventSealing();
         try
@@ -846,23 +869,20 @@ public sealed class MetadataDeclarationQueryTests
             using var peReader = new PEReader(File.OpenRead(path));
             var reader = peReader.GetMetadataReader();
             var typeHandle = GetTypeDefinitionHandle(reader, "DerivedEventSealing");
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
             var extracted = Assert.Single(
-                ApiSurfaceExtractor.Extract(peReader, includeAll: true).Types,
+                surface.Types,
                 type => type.Name == "DerivedEventSealing");
-            var queried = MetadataDeclarationQuery.GetTypeSurface(
-                reader,
-                typeHandle,
-                includeNonPublicMembers: true);
 
-            var extractedEvent = Assert.Single(
-                extracted.Members,
-                member => member.Kind == "event");
-            var queriedEvent = Assert.Single(
-                queried.Members,
-                member => member.Kind == "event");
-
-            Assert.False(extractedEvent.IsSealed);
-            Assert.Equal(queriedEvent.IsSealed, extractedEvent.IsSealed);
+            Assert.DoesNotContain(extracted.Members, member => member.Kind == "event");
+            Assert.Contains(
+                surface.InspectionFailures,
+                failure => failure.Operation == "event modifiers");
+            Assert.Throws<BadImageFormatException>(() =>
+                MetadataDeclarationQuery.GetTypeSurface(
+                    reader,
+                    typeHandle,
+                    includeNonPublicMembers: true));
         }
         finally
         {
@@ -909,6 +929,31 @@ public sealed class MetadataDeclarationQueryTests
                         IsExplicitInterfaceImplementation: true
                     } && member.Name.EndsWith(".Changed", StringComparison.Ordinal));
             }
+        }
+    }
+
+    [Theory]
+    [InlineData(typeof(MetadataDeclarationQueryFixtures.SealedImplicitSurface))]
+    [InlineData(typeof(MetadataDeclarationQueryFixtures.StructImplicitSurface))]
+    public void TypeSurface_DoesNotProjectMetadataVirtualAsCSharpVirtual(Type fixtureType)
+    {
+        var queried = MetadataDeclarationQuery.GetTypeSurface(
+            Reader,
+            GetTypeDefinitionHandle(fixtureType),
+            includeNonPublicMembers: true);
+        var extracted = Assert.Single(
+            ApiSurfaceExtractor.Extract(PeReader, includeAll: true).Types,
+            type => type.FullName.EndsWith(
+                "." + fixtureType.Name,
+                StringComparison.Ordinal));
+
+        foreach (var surface in new[] { queried, extracted })
+        {
+            var property = Assert.Single(
+                surface.Members,
+                member => member.Kind == "property" && member.Name == "Value");
+
+            Assert.False(property.IsVirtual);
         }
     }
 
@@ -1057,9 +1102,9 @@ public sealed class MetadataDeclarationQueryTests
             var typeHandle = GetTypeDefinitionHandle(reader, "Derived");
             var typeDef = reader.GetTypeDefinition(typeHandle);
 
-            var bodies = ApiSurfaceExtractor.GetExplicitInterfaceImplementationBodies(
+            var bodies = ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(
                 reader,
-                typeDef);
+                typeDef).Keys;
             var names = bodies
                 .Select(handle => reader.GetString(reader.GetMethodDefinition(handle).Name))
                 .ToList();
@@ -1600,7 +1645,7 @@ public sealed class MetadataDeclarationQueryTests
         adder.GetILGenerator().Emit(OpCodes.Ret);
         var remover = derivedBuilder.DefineMethod(
             "remove_Changed",
-            accessorAttributes | MethodAttributes.NewSlot | MethodAttributes.Final,
+            accessorAttributes | MethodAttributes.Final,
             typeof(void),
             [typeof(Action)]);
         remover.GetILGenerator().Emit(OpCodes.Ret);
@@ -1608,6 +1653,7 @@ public sealed class MetadataDeclarationQueryTests
         @event.SetAddOnMethod(adder);
         @event.SetRemoveOnMethod(remover);
         derivedBuilder.DefineMethodOverride(adder, baseType.GetMethod("add_Changed")!);
+        derivedBuilder.DefineMethodOverride(remover, baseType.GetMethod("remove_Changed")!);
         derivedBuilder.CreateType();
 
         string path = Path.Combine(
@@ -1617,7 +1663,9 @@ public sealed class MetadataDeclarationQueryTests
         return path;
     }
 
-    static byte[] BuildHostileInitModifierImage(bool cyclicScope)
+    static byte[] BuildHostileInitModifierImage(
+        bool cyclicScope,
+        bool typeSpecModifier = false)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -1671,12 +1719,22 @@ public sealed class MetadataDeclarationQueryTests
             cyclicScope ? outer : (EntityHandle)outer,
             metadata.GetOrAddString("System.Runtime.CompilerServices"),
             metadata.GetOrAddString("IsExternalInit"));
+        EntityHandle modifierHandle = modifier;
+        if (typeSpecModifier)
+        {
+            var typeSpec = new BlobBuilder();
+            typeSpec.WriteByte(0x12); // CLASS
+            typeSpec.WriteByte((byte)(MetadataTokens.GetRowNumber(modifier) << 2 | 1));
+            modifierHandle = metadata.AddTypeSpecification(metadata.GetOrAddBlob(typeSpec));
+        }
 
         var signature = new BlobBuilder();
         signature.WriteByte(0x00); // DEFAULT
         signature.WriteByte(0x01); // parameter count
         signature.WriteByte(0x1F); // CMOD_REQD
-        signature.WriteByte((byte)(MetadataTokens.GetRowNumber(modifier) << 2 | 1));
+        signature.WriteByte((byte)(
+            MetadataTokens.GetRowNumber(modifierHandle) << 2
+            | (modifierHandle.Kind == HandleKind.TypeSpecification ? 2 : 1)));
         signature.WriteByte(0x01); // VOID
         signature.WriteByte(0x08); // I4
         metadata.AddMethodDefinition(
@@ -1901,6 +1959,21 @@ public class MetadataDeclarationQueryFixtures
             [return: System.Diagnostics.CodeAnalysis.MaybeNull]
             remove { }
         }
+    }
+
+    public interface IImplicitSurface
+    {
+        int Value { get; }
+    }
+
+    public sealed class SealedImplicitSurface : IImplicitSurface
+    {
+        public int Value => 42;
+    }
+
+    public readonly struct StructImplicitSurface : IImplicitSurface
+    {
+        public int Value => 42;
     }
 
     public interface IGenericSurface<TLeft, TRight>

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -410,6 +410,11 @@ public sealed class MetadataDeclarationQueryTests
                 StringComparison.Ordinal));
 
         Assert.Contains(
+            queried.Interfaces,
+            interfaceName => interfaceName.EndsWith(
+                ".IExplicitSurface",
+                StringComparison.Ordinal));
+        Assert.Contains(
             queried.Members,
             member => member.Name.EndsWith(".get_Value", StringComparison.Ordinal));
         Assert.Contains(
@@ -429,6 +434,19 @@ public sealed class MetadataDeclarationQueryTests
                 Kind: "event",
                 IsExplicitInterfaceImplementation: true
             } && member.Name.EndsWith(".Changed", StringComparison.Ordinal));
+        var queriedEvent = Assert.Single(
+            queried.Members,
+            member => member is
+            {
+                Kind: "event",
+                IsExplicitInterfaceImplementation: true
+            } && member.Name.EndsWith(".Changed", StringComparison.Ordinal));
+        Assert.Equal(
+            ["System.Diagnostics.CodeAnalysis.NotNull"],
+            queriedEvent.SignatureModel!.Accessors[0].ReturnAttributes);
+        Assert.Equal(
+            ["System.Diagnostics.CodeAnalysis.MaybeNull"],
+            queriedEvent.SignatureModel.Accessors[1].ReturnAttributes);
         Assert.Contains(
             extracted.Members,
             member => member.Kind == "explicit-interface-implementation"
@@ -453,25 +471,74 @@ public sealed class MetadataDeclarationQueryTests
     {
         var typeDef = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures.ExplicitSurface));
         var eventHandle = Assert.Single(typeDef.GetEvents());
-        var accessors = Reader.GetEventDefinition(eventHandle).GetAccessors();
-        var interfaceBodies =
-            ApiSurfaceExtractor.GetExplicitInterfaceImplementationBodies(Reader, typeDef);
+        var eventDefinition = Reader.GetEventDefinition(eventHandle);
+        var accessors = eventDefinition.GetAccessors();
+        string eventName = Reader.GetString(eventDefinition.Name);
+        var interfaceTargets =
+            ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(Reader, typeDef);
+        var adderTarget = Assert.Single(interfaceTargets[accessors.Adder]);
+        var removerTarget = Assert.Single(interfaceTargets[accessors.Remover]);
 
         Assert.True(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
-            "IExplicitSurface.Changed",
-            interfaceBodies,
-            accessors.Adder,
-            accessors.Remover));
+            eventName,
+            interfaceTargets,
+            (accessors.Adder, "add_"),
+            (accessors.Remover, "remove_")));
         Assert.False(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
-            "IExplicitSurface.Changed",
-            new HashSet<MethodDefinitionHandle> { accessors.Adder },
-            accessors.Adder,
-            accessors.Remover));
+            eventName,
+            new Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
+            {
+                [accessors.Adder] = [adderTarget]
+            },
+            (accessors.Adder, "add_"),
+            (accessors.Remover, "remove_")));
+        int separator = eventName.LastIndexOf('.');
         Assert.False(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
-            "Base.Changed",
-            new HashSet<MethodDefinitionHandle>(),
-            accessors.Adder,
-            accessors.Remover));
+            eventName[..(separator + 1)] + "Other",
+            interfaceTargets,
+            (accessors.Adder, "add_"),
+            (accessors.Remover, "remove_")));
+        Assert.False(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+            eventName,
+            new Dictionary<MethodDefinitionHandle, List<ExplicitInterfaceMethodTarget>>
+            {
+                [accessors.Adder] = [adderTarget],
+                [accessors.Remover] =
+                [
+                    removerTarget with
+                    {
+                        InterfaceTypeName = "Other.IExplicitSurface"
+                    }
+                ]
+            },
+            (accessors.Adder, "add_"),
+            (accessors.Remover, "remove_")));
+    }
+
+    [Fact]
+    public void ExplicitAggregateIdentity_RejectsBaseClassMethodImplTargets()
+    {
+        string path = EmitBaseClassMethodImplEvent();
+        try
+        {
+            using var peReader = new PEReader(File.OpenRead(path));
+            var reader = peReader.GetMetadataReader();
+            var typeHandle = GetTypeDefinitionHandle(reader, "DerivedEvent");
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var eventHandle = Assert.Single(typeDef.GetEvents());
+            var eventDefinition = reader.GetEventDefinition(eventHandle);
+            var accessors = eventDefinition.GetAccessors();
+
+            Assert.False(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+                reader.GetString(eventDefinition.Name),
+                ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(reader, typeDef),
+                (accessors.Adder, "add_"),
+                (accessors.Remover, "remove_")));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     [Theory]
@@ -1030,6 +1097,72 @@ public sealed class MetadataDeclarationQueryTests
         return path;
     }
 
+    static string EmitBaseClassMethodImplEvent()
+    {
+        var assemblyName = new AssemblyName("BaseClassMethodImplEvent");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        const MethodAttributes baseAttributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+        var baseType = module.DefineType("BaseEvent", TypeAttributes.Public);
+        var baseAdder = baseType.DefineMethod(
+            "add_Changed",
+            baseAttributes,
+            typeof(void),
+            [typeof(EventHandler)]);
+        baseAdder.GetILGenerator().Emit(OpCodes.Ret);
+        var baseRemover = baseType.DefineMethod(
+            "remove_Changed",
+            baseAttributes,
+            typeof(void),
+            [typeof(EventHandler)]);
+        baseRemover.GetILGenerator().Emit(OpCodes.Ret);
+        var baseEvent = baseType.DefineEvent("Changed", EventAttributes.None, typeof(EventHandler));
+        baseEvent.SetAddOnMethod(baseAdder);
+        baseEvent.SetRemoveOnMethod(baseRemover);
+        var createdBase = baseType.CreateType();
+
+        const MethodAttributes derivedAttributes =
+            MethodAttributes.Private
+            | MethodAttributes.Virtual
+            | MethodAttributes.Final
+            | MethodAttributes.NewSlot
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+        var derivedType = module.DefineType("DerivedEvent", TypeAttributes.Public, createdBase);
+        var adder = derivedType.DefineMethod(
+            "add_BaseChanged",
+            derivedAttributes,
+            typeof(void),
+            [typeof(EventHandler)]);
+        adder.GetILGenerator().Emit(OpCodes.Ret);
+        var remover = derivedType.DefineMethod(
+            "remove_BaseChanged",
+            derivedAttributes,
+            typeof(void),
+            [typeof(EventHandler)]);
+        remover.GetILGenerator().Emit(OpCodes.Ret);
+        var derivedEvent = derivedType.DefineEvent(
+            "BaseEvent.Changed",
+            EventAttributes.None,
+            typeof(EventHandler));
+        derivedEvent.SetAddOnMethod(adder);
+        derivedEvent.SetRemoveOnMethod(remover);
+        derivedType.DefineMethodOverride(adder, createdBase.GetMethod("add_Changed")!);
+        derivedType.DefineMethodOverride(remover, createdBase.GetMethod("remove_Changed")!);
+        derivedType.CreateType();
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"BaseClassMethodImplEvent-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
     static TypeDefinition GetTypeDefinition(Type type)
         => Reader.GetTypeDefinition(GetTypeDefinitionHandle(type));
 
@@ -1155,7 +1288,10 @@ public class MetadataDeclarationQueryFixtures
 
         event EventHandler IExplicitSurface.Changed
         {
+            [return: System.Diagnostics.CodeAnalysis.NotNull]
             add { }
+
+            [return: System.Diagnostics.CodeAnalysis.MaybeNull]
             remove { }
         }
     }

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -174,12 +174,12 @@ public sealed class MetadataDeclarationQueryTests
 
         Assert.Equal(
             structuralReturn,
-            declaration.Signature.Accessors.Single(accessor => accessor.Kind == "set")
+            declaration.Signature.Accessors.Single(accessor => accessor.Kind is "set" or "init")
                 .StructuralReturnType);
         Assert.Equal(
             structuralReturn,
             surface.Members.Single(member => member.Name == nameof(MetadataDeclarationQueryFixtures.InitValue))
-                .AccessorFacts.Single(accessor => accessor.Kind == "set")
+                .AccessorFacts.Single(accessor => accessor.Kind is "set" or "init")
                 .StructuralReturnType);
     }
 

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -861,6 +861,14 @@ public sealed class MetadataDeclarationQueryTests
                 extracted.Members,
                 member => member.Name is "add_BaseChanged" or "remove_BaseChanged"
                     || member.Kind == "explicit-interface-implementation");
+
+            ApiType queried = MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                typeHandle,
+                includeNonPublicMembers: false);
+            Assert.DoesNotContain(
+                queried.Members,
+                member => member.Name is "add_BaseChanged" or "remove_BaseChanged");
         }
         finally
         {
@@ -1071,9 +1079,9 @@ public sealed class MetadataDeclarationQueryTests
     [Fact]
     public void ExplicitAggregateRowSignature_RejectsModifiedVoidAccessorReturns()
     {
-        using var stream = new MemoryStream(
-            BuildModifiedVoidExplicitAggregateImage(),
-            writable: false);
+        byte[] privateImage =
+            BuildModifiedVoidExplicitAggregateImage(MethodAttributes.Private);
+        using var stream = new MemoryStream(privateImage, writable: false);
         using var peReader = new PEReader(stream);
 
         ApiSurface surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
@@ -1089,6 +1097,26 @@ public sealed class MetadataDeclarationQueryTests
             surface.InspectionFailures.Count(failure =>
                 failure.Operation == "event signature"
                 && failure.Detail == "The event adder does not return void."));
+
+        byte[] publicImage =
+            BuildModifiedVoidExplicitAggregateImage(MethodAttributes.Public);
+        using var publicStream = new MemoryStream(publicImage, writable: false);
+        using var publicReader = new PEReader(publicStream);
+        ApiSurface publicSurface = ApiSurfaceExtractor.Extract(publicReader);
+        using var summaryStream = new MemoryStream(publicImage, writable: false);
+        using var summaryReader = new PEReader(summaryStream);
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(summaryReader);
+        ApiType summaryHost = Assert.Single(summary.Types, type => type.Name == "Host");
+        Assert.DoesNotContain(
+            summaryHost.Members,
+            member => member.Kind is "property" or "event");
+        Assert.Equal(publicSurface.PublicMethodCount, summary.PublicMethodCount);
+        Assert.Equal(publicSurface.PublicPropertyCount, summary.PublicPropertyCount);
+        Assert.Equal(publicSurface.PublicEventCount, summary.PublicEventCount);
+        Assert.Equal(
+            publicSurface.InspectionFailures.Select(
+                failure => (failure.Operation, failure.Detail)),
+            summary.InspectionFailures.Select(failure => (failure.Operation, failure.Detail)));
     }
 
     /// <summary>
@@ -1376,6 +1404,13 @@ public sealed class MetadataDeclarationQueryTests
 
             Assert.Contains("ImplementInterface", names);
             Assert.DoesNotContain("OverrideBase", names);
+
+            ApiType queried = MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                typeHandle,
+                includeNonPublicMembers: false);
+            Assert.Contains(queried.Members, member => member.Name == "ImplementInterface");
+            Assert.DoesNotContain(queried.Members, member => member.Name == "OverrideBase");
         }
         finally
         {
@@ -2020,7 +2055,8 @@ public sealed class MetadataDeclarationQueryTests
         return image.ToArray();
     }
 
-    static byte[] BuildModifiedVoidExplicitAggregateImage()
+    static byte[] BuildModifiedVoidExplicitAggregateImage(
+        MethodAttributes accessorAccessibility)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -2089,7 +2125,7 @@ public sealed class MetadataDeclarationQueryTests
                 parameterType: default,
                 parameterTypeCode: 0x08);
             MethodDefinitionHandle setter = metadata.AddMethodDefinition(
-                ExplicitAccessorAttributes,
+                accessorAccessibility | ExplicitAccessorFlags,
                 MethodImplAttributes.IL,
                 metadata.GetOrAddString($"Contracts.IRow.set_{name}"),
                 signature,
@@ -2122,14 +2158,14 @@ public sealed class MetadataDeclarationQueryTests
                 interfaceType,
                 parameterTypeCode: 0x12);
             MethodDefinitionHandle adder = metadata.AddMethodDefinition(
-                ExplicitAccessorAttributes,
+                accessorAccessibility | ExplicitAccessorFlags,
                 MethodImplAttributes.IL,
                 metadata.GetOrAddString($"Contracts.IRow.add_{name}"),
                 signature,
                 bodyOffset: -1,
                 parameterList: MetadataTokens.ParameterHandle(1));
             MethodDefinitionHandle remover = metadata.AddMethodDefinition(
-                ExplicitAccessorAttributes,
+                accessorAccessibility | ExplicitAccessorFlags,
                 MethodImplAttributes.IL,
                 metadata.GetOrAddString($"Contracts.IRow.remove_{name}"),
                 signature,
@@ -2187,9 +2223,8 @@ public sealed class MetadataDeclarationQueryTests
         }
     }
 
-    const MethodAttributes ExplicitAccessorAttributes =
-        MethodAttributes.Private
-        | MethodAttributes.Virtual
+    const MethodAttributes ExplicitAccessorFlags =
+        MethodAttributes.Virtual
         | MethodAttributes.Final
         | MethodAttributes.NewSlot
         | MethodAttributes.SpecialName

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -1091,6 +1091,11 @@ public sealed class MetadataDeclarationQueryTests
             MetadataDeclarationQuery.GetTypeSurface(
                 reader,
                 GetTypeDefinitionHandle(reader, "Fixtures.AbstractBody"),
+                includeNonPublicMembers: false));
+        Assert.Throws<BadImageFormatException>(() =>
+            MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                GetTypeDefinitionHandle(reader, "Fixtures.AbstractBody"),
                 includeNonPublicMembers: true));
     }
 
@@ -2511,7 +2516,7 @@ public sealed class MetadataDeclarationQueryTests
             .MethodSignature(isInstanceMethod: true)
             .Parameters(0, returnType => returnType.Type().Int32(), _ => { });
         MethodDefinitionHandle getter = metadata.AddMethodDefinition(
-            MethodAttributes.Public
+            MethodAttributes.Private
                 | MethodAttributes.Abstract
                 | MethodAttributes.Virtual
                 | MethodAttributes.NewSlot

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -860,6 +860,230 @@ public sealed class MetadataDeclarationQueryTests
         }
     }
 
+    /// <summary>
+    /// A class or struct aggregate whose accessors disagree about abstractness has no legal C#
+    /// spelling: abstractness belongs to the member, not the accessor. Projecting it as the
+    /// concrete aggregate the majority of its accessors suggest would invent a member the
+    /// metadata does not declare, so both projections reject it and say so.
+    /// </summary>
+    [Fact]
+    public void MixedAbstractionAggregates_FailVisibly()
+    {
+        string path = EmitMixedAbstractionAggregates();
+        try
+        {
+            using var peReader = new PEReader(File.OpenRead(path));
+            var reader = peReader.GetMetadataReader();
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            var mixed = Assert.Single(surface.Types, type => type.Name == "MixedAbstraction");
+
+            Assert.DoesNotContain(
+                mixed.Members,
+                member => member.Kind is "property" or "event");
+            Assert.Contains(
+                surface.InspectionFailures,
+                failure => failure.Operation == "property modifiers");
+            Assert.Contains(
+                surface.InspectionFailures,
+                failure => failure.Operation == "event modifiers");
+            Assert.Throws<BadImageFormatException>(() =>
+                MetadataDeclarationQuery.GetTypeSurface(
+                    reader,
+                    GetTypeDefinitionHandle(reader, "MixedAbstraction"),
+                    includeNonPublicMembers: true));
+
+            // The close negatives: uniform abstractness either way is ordinary metadata and
+            // must keep projecting, or the guard has eaten the shape it exists to protect.
+            foreach (string uniform in new[] { "UniformAbstract", "UniformConcrete" })
+            {
+                var extracted = Assert.Single(surface.Types, type => type.Name == uniform);
+                Assert.Contains(
+                    extracted.Members,
+                    member => member.Kind == "property" && member.Name == "Value");
+                Assert.Contains(
+                    extracted.Members,
+                    member => member.Kind == "event" && member.Name == "Changed");
+                var queried = MetadataDeclarationQuery.GetTypeSurface(
+                    reader,
+                    GetTypeDefinitionHandle(reader, uniform),
+                    includeNonPublicMembers: true);
+                Assert.Contains(
+                    queried.Members,
+                    member => member.Kind == "property" && member.Name == "Value");
+                Assert.Contains(
+                    queried.Members,
+                    member => member.Kind == "event" && member.Name == "Changed");
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// An interface aggregate legitimately mixes an abstract accessor with a defaulted one
+    /// (C# 8 default interface members), so the uniformity requirement applies to classes and
+    /// structs only. C# has no syntax for the mixed property — <c>{ get; set { } }</c> is read
+    /// as an auto-property — so the shape is emitted, and the compiler-produced peer below
+    /// covers the uniformly abstract interface it must not be confused with.
+    /// </summary>
+    [Fact]
+    public void MixedAbstractionInterfaceAggregates_AreRetained()
+    {
+        string path = EmitMixedAbstractionAggregates();
+        try
+        {
+            using var peReader = new PEReader(File.OpenRead(path));
+            var reader = peReader.GetMetadataReader();
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            var extracted = Assert.Single(
+                surface.Types,
+                type => type.Name == "MixedAbstractionInterface");
+
+            Assert.Contains(
+                extracted.Members,
+                member => member.Kind == "property" && member.Name == "Value");
+
+            var queried = MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                GetTypeDefinitionHandle(reader, "MixedAbstractionInterface"),
+                includeNonPublicMembers: true);
+            Assert.Contains(
+                queried.Members,
+                member => member.Kind == "property" && member.Name == "Value");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+
+        var uniformInterface = MetadataDeclarationQuery.GetTypeSurface(
+            Reader,
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures.IMixedAbstractionSurface)),
+            includeNonPublicMembers: true);
+        Assert.Contains(
+            uniformInterface.Members,
+            member => member.Kind == "property" && member.Name == "Value");
+        Assert.Contains(
+            uniformInterface.Members,
+            member => member.Kind == "event" && member.Name == "Changed");
+    }
+
+    /// <summary>
+    /// ECMA-335 II.15.4.2.4 forbids an abstract method from declaring a body, so an accessor
+    /// that claims both is malformed whatever its declaring type. The image is synthetic
+    /// because no compiler emits the shape.
+    /// </summary>
+    [Fact]
+    public void AbstractAccessorWithBody_FailsVisibly()
+    {
+        byte[] image = BuildAbstractAccessorWithBodyImage();
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var extracted = Assert.Single(surface.Types, type => type.Name == "AbstractBody");
+
+        Assert.DoesNotContain(extracted.Members, member => member.Kind == "property");
+        var failure = Assert.Single(
+            surface.InspectionFailures,
+            candidate => candidate.Operation == "property modifiers");
+        Assert.Contains("abstract accessor", failure.Detail, StringComparison.Ordinal);
+        Assert.Throws<BadImageFormatException>(() =>
+            MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                GetTypeDefinitionHandle(reader, "Fixtures.AbstractBody"),
+                includeNonPublicMembers: true));
+    }
+
+    /// <summary>
+    /// Explicit aggregate classification matches accessor names against the MethodImpl target
+    /// map, and the MethodImpl check proves each accessor body implements the interface method
+    /// it names. Neither reads the Property or Event row itself, so the row's own signature has
+    /// to be validated against the accessors or a hostile image renders an explicit member no
+    /// accessor implements.
+    /// </summary>
+    [Fact]
+    public void ExplicitAggregateRowSignature_MustMatchAccessors()
+    {
+        string path = EmitRowSignatureMismatchedExplicitAggregates();
+        try
+        {
+            using var peReader = new PEReader(File.OpenRead(path));
+            var reader = peReader.GetMetadataReader();
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+            var mismatched = Assert.Single(
+                surface.Types,
+                type => type.Name == "RowSignatureMismatch");
+            Assert.DoesNotContain(
+                mismatched.Members,
+                member => member.Kind is "property" or "event");
+            Assert.Contains(
+                surface.InspectionFailures,
+                failure => failure.Operation == "property signature");
+            Assert.Contains(
+                surface.InspectionFailures,
+                failure => failure.Operation == "event signature");
+            Assert.Throws<BadImageFormatException>(() =>
+                MetadataDeclarationQuery.GetTypeSurface(
+                    reader,
+                    GetTypeDefinitionHandle(reader, "RowSignatureMismatch"),
+                    includeNonPublicMembers: true));
+
+            // The close negative differs only in that its rows tell the truth.
+            var truthful = Assert.Single(
+                surface.Types,
+                type => type.Name == "RowSignatureMatch");
+            Assert.Contains(
+                truthful.Members,
+                member => member.Kind == "property" && member.IsExplicitInterfaceImplementation);
+            Assert.Contains(
+                truthful.Members,
+                member => member.Kind == "event" && member.IsExplicitInterfaceImplementation);
+            var queried = MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                GetTypeDefinitionHandle(reader, "RowSignatureMatch"),
+                includeNonPublicMembers: true);
+            Assert.Contains(
+                queried.Members,
+                member => member.Kind == "property" && member.IsExplicitInterfaceImplementation);
+            Assert.Contains(
+                queried.Members,
+                member => member.Kind == "event" && member.IsExplicitInterfaceImplementation);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// The compiler-produced close negatives for the row-signature check: an explicit
+    /// <c>init</c> setter carries <c>modreq(IsExternalInit)</c> over its <c>void</c> return, and
+    /// an explicit indexer's row parameters live on the row rather than only on its accessors.
+    /// Both must keep classifying and projecting as explicit aggregates.
+    /// </summary>
+    [Fact]
+    public void ExplicitAggregateRowSignature_AcceptsInitAndIndexerShapes()
+    {
+        var queried = MetadataDeclarationQuery.GetTypeSurface(
+            Reader,
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures.ExplicitRowSignatureSurface)),
+            includeNonPublicMembers: true);
+
+        var aggregates = queried.Members
+            .Where(member => member.IsExplicitInterfaceImplementation)
+            .ToArray();
+
+        Assert.Contains(aggregates, member => member.Name.EndsWith(".Value", StringComparison.Ordinal));
+        Assert.Contains(aggregates, member => member.Name.EndsWith(".Item", StringComparison.Ordinal));
+        Assert.Contains(aggregates, member => member.Kind == "event");
+    }
+
     [Fact]
     public void EventSealing_RejectsMixedAccessorState()
     {
@@ -1755,6 +1979,298 @@ public sealed class MetadataDeclarationQueryTests
         return image.ToArray();
     }
 
+    static string EmitMixedAbstractionAggregates()
+    {
+        var assemblyName = new AssemblyName("MixedAbstractionAggregates");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        const MethodAttributes Shared =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+
+        void DefineAggregates(string typeName, bool abstractGetter, bool abstractSetter)
+        {
+            var builder = module.DefineType(
+                typeName,
+                TypeAttributes.Public | TypeAttributes.Abstract);
+
+            var getter = builder.DefineMethod(
+                "get_Value",
+                abstractGetter ? Shared | MethodAttributes.Abstract : Shared,
+                typeof(int),
+                Type.EmptyTypes);
+            if (!abstractGetter)
+            {
+                var getterIl = getter.GetILGenerator();
+                getterIl.Emit(OpCodes.Ldc_I4_0);
+                getterIl.Emit(OpCodes.Ret);
+            }
+
+            var setter = builder.DefineMethod(
+                "set_Value",
+                abstractSetter ? Shared | MethodAttributes.Abstract : Shared,
+                typeof(void),
+                [typeof(int)]);
+            if (!abstractSetter)
+                setter.GetILGenerator().Emit(OpCodes.Ret);
+
+            var property = builder.DefineProperty(
+                "Value",
+                PropertyAttributes.None,
+                typeof(int),
+                null);
+            property.SetGetMethod(getter);
+            property.SetSetMethod(setter);
+
+            var adder = builder.DefineMethod(
+                "add_Changed",
+                abstractGetter ? Shared | MethodAttributes.Abstract : Shared,
+                typeof(void),
+                [typeof(Action)]);
+            if (!abstractGetter)
+                adder.GetILGenerator().Emit(OpCodes.Ret);
+
+            var remover = builder.DefineMethod(
+                "remove_Changed",
+                abstractSetter ? Shared | MethodAttributes.Abstract : Shared,
+                typeof(void),
+                [typeof(Action)]);
+            if (!abstractSetter)
+                remover.GetILGenerator().Emit(OpCodes.Ret);
+
+            var @event = builder.DefineEvent("Changed", EventAttributes.None, typeof(Action));
+            @event.SetAddOnMethod(adder);
+            @event.SetRemoveOnMethod(remover);
+            builder.CreateType();
+        }
+
+        DefineAggregates("MixedAbstraction", abstractGetter: true, abstractSetter: false);
+        DefineAggregates("UniformAbstract", abstractGetter: true, abstractSetter: true);
+        DefineAggregates("UniformConcrete", abstractGetter: false, abstractSetter: false);
+
+        // The legitimate peer: an interface may pair an abstract accessor with a defaulted one.
+        var interfaceBuilder = module.DefineType(
+            "MixedAbstractionInterface",
+            TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract);
+        var interfaceGetter = interfaceBuilder.DefineMethod(
+            "get_Value",
+            Shared | MethodAttributes.Abstract,
+            typeof(int),
+            Type.EmptyTypes);
+        var interfaceSetter = interfaceBuilder.DefineMethod(
+            "set_Value",
+            Shared,
+            typeof(void),
+            [typeof(int)]);
+        interfaceSetter.GetILGenerator().Emit(OpCodes.Ret);
+        var interfaceProperty = interfaceBuilder.DefineProperty(
+            "Value",
+            PropertyAttributes.None,
+            typeof(int),
+            null);
+        interfaceProperty.SetGetMethod(interfaceGetter);
+        interfaceProperty.SetSetMethod(interfaceSetter);
+        interfaceBuilder.CreateType();
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"MixedAbstractionAggregates-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    /// <summary>
+    /// A property whose getter carries <see cref="MethodAttributes.Abstract"/> and a nonzero
+    /// method RVA. No compiler emits it, and Reflection.Emit refuses to, so the image is built
+    /// row by row with a body offset that resolves to a real RVA.
+    /// </summary>
+    static byte[] BuildAbstractAccessorWithBodyImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("AbstractAccessorBody.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("AbstractAccessorBody"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle type = metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Abstract,
+            metadata.GetOrAddString("Fixtures"),
+            metadata.GetOrAddString("AbstractBody"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var il = new BlobBuilder();
+        var bodies = new MethodBodyStreamEncoder(il);
+        var body = new InstructionEncoder(new BlobBuilder());
+        body.LoadConstantI4(0);
+        body.OpCode(ILOpCode.Ret);
+        int bodyOffset = bodies.AddMethodBody(body);
+
+        var getterSignature = new BlobBuilder();
+        new BlobEncoder(getterSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(0, returnType => returnType.Type().Int32(), _ => { });
+        MethodDefinitionHandle getter = metadata.AddMethodDefinition(
+            MethodAttributes.Public
+                | MethodAttributes.Abstract
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot
+                | MethodAttributes.SpecialName
+                | MethodAttributes.HideBySig,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("get_Value"),
+            metadata.GetOrAddBlob(getterSignature),
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var propertySignature = new BlobBuilder();
+        new BlobEncoder(propertySignature)
+            .PropertySignature(isInstanceProperty: true)
+            .Parameters(0, returnType => returnType.Type().Int32(), _ => { });
+        PropertyDefinitionHandle property = metadata.AddProperty(
+            PropertyAttributes.None,
+            metadata.GetOrAddString("Value"),
+            metadata.GetOrAddBlob(propertySignature));
+        metadata.AddPropertyMap(type, property);
+        metadata.AddMethodSemantics(property, MethodSemanticsAttributes.Getter, getter);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            il,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    /// <summary>
+    /// Two explicit-interface implementers whose accessors and MethodImpl rows are identical
+    /// and truthful. The first declares Property and Event rows that disagree with those
+    /// accessors; the second declares rows that agree.
+    /// </summary>
+    static string EmitRowSignatureMismatchedExplicitAggregates()
+    {
+        var assemblyName = new AssemblyName("RowSignatureExplicitAggregates");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        const MethodAttributes InterfaceAccessor =
+            MethodAttributes.Public
+            | MethodAttributes.Abstract
+            | MethodAttributes.Virtual
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+        const MethodAttributes ExplicitAccessor =
+            MethodAttributes.Private
+            | MethodAttributes.Virtual
+            | MethodAttributes.Final
+            | MethodAttributes.NewSlot
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+
+        var interfaceBuilder = module.DefineType(
+            "IRowSignature",
+            TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract);
+        var interfaceGetter = interfaceBuilder.DefineMethod(
+            "get_Value",
+            InterfaceAccessor,
+            typeof(int),
+            Type.EmptyTypes);
+        interfaceBuilder
+            .DefineProperty("Value", PropertyAttributes.None, typeof(int), null)
+            .SetGetMethod(interfaceGetter);
+        var interfaceAdder = interfaceBuilder.DefineMethod(
+            "add_Changed",
+            InterfaceAccessor,
+            typeof(void),
+            [typeof(Action)]);
+        var interfaceRemover = interfaceBuilder.DefineMethod(
+            "remove_Changed",
+            InterfaceAccessor,
+            typeof(void),
+            [typeof(Action)]);
+        var interfaceEvent = interfaceBuilder.DefineEvent(
+            "Changed",
+            EventAttributes.None,
+            typeof(Action));
+        interfaceEvent.SetAddOnMethod(interfaceAdder);
+        interfaceEvent.SetRemoveOnMethod(interfaceRemover);
+        var interfaceType = interfaceBuilder.CreateType();
+
+        void DefineImplementer(string typeName, bool truthfulRows)
+        {
+            var builder = module.DefineType(typeName, TypeAttributes.Public);
+            builder.AddInterfaceImplementation(interfaceType);
+
+            var getter = builder.DefineMethod(
+                "IRowSignature.get_Value",
+                ExplicitAccessor,
+                typeof(int),
+                Type.EmptyTypes);
+            var getterIl = getter.GetILGenerator();
+            getterIl.Emit(OpCodes.Ldc_I4_0);
+            getterIl.Emit(OpCodes.Ret);
+            builder
+                .DefineProperty(
+                    "IRowSignature.Value",
+                    PropertyAttributes.None,
+                    truthfulRows ? typeof(int) : typeof(string),
+                    null)
+                .SetGetMethod(getter);
+            builder.DefineMethodOverride(getter, interfaceType.GetMethod("get_Value")!);
+
+            var adder = builder.DefineMethod(
+                "IRowSignature.add_Changed",
+                ExplicitAccessor,
+                typeof(void),
+                [typeof(Action)]);
+            adder.GetILGenerator().Emit(OpCodes.Ret);
+            var remover = builder.DefineMethod(
+                "IRowSignature.remove_Changed",
+                ExplicitAccessor,
+                typeof(void),
+                [typeof(Action)]);
+            remover.GetILGenerator().Emit(OpCodes.Ret);
+            var @event = builder.DefineEvent(
+                "IRowSignature.Changed",
+                EventAttributes.None,
+                truthfulRows ? typeof(Action) : typeof(EventHandler));
+            @event.SetAddOnMethod(adder);
+            @event.SetRemoveOnMethod(remover);
+            builder.DefineMethodOverride(adder, interfaceType.GetMethod("add_Changed")!);
+            builder.DefineMethodOverride(remover, interfaceType.GetMethod("remove_Changed")!);
+            builder.CreateType();
+        }
+
+        DefineImplementer("RowSignatureMismatch", truthfulRows: false);
+        DefineImplementer("RowSignatureMatch", truthfulRows: true);
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"RowSignatureExplicitAggregates-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
     static string EmitSignatureIncompatibleMethodImplProperty()
     {
         var assemblyName = new AssemblyName("SignatureIncompatibleMethodImplProperty");
@@ -1921,6 +2437,39 @@ public class MetadataDeclarationQueryFixtures
     {
         T Value { get; }
         event Action Changed;
+    }
+
+    public interface IMixedAbstractionSurface
+    {
+        int Value { get; }
+
+        event Action Changed;
+    }
+
+    public interface IExplicitRowSignature
+    {
+        int Value { get; init; }
+
+        string this[int index] { get; }
+
+        event Action Changed;
+    }
+
+    public sealed class ExplicitRowSignatureSurface : IExplicitRowSignature
+    {
+        int IExplicitRowSignature.Value
+        {
+            get => 0;
+            init { }
+        }
+
+        string IExplicitRowSignature.this[int index] => index.ToString();
+
+        event Action IExplicitRowSignature.Changed
+        {
+            add { }
+            remove { }
+        }
     }
 
     public sealed class NullableExplicitAggregateMetadataFixture

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -417,10 +417,12 @@ public sealed class MetadataDeclarationQueryTests
                 StringComparison.Ordinal));
         Assert.Contains(
             queried.Members,
-            member => member.Name.EndsWith(".get_Value", StringComparison.Ordinal));
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(".get_Value", StringComparison.Ordinal));
         Assert.Contains(
             queried.Members,
-            member => member.Name.EndsWith(".add_Changed", StringComparison.Ordinal));
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(".add_Changed", StringComparison.Ordinal));
         Assert.Contains(
             queried.Members,
             member => member is
@@ -954,6 +956,19 @@ public sealed class MetadataDeclarationQueryTests
             Assert.Contains(
                 surface.InspectionFailures,
                 failure => failure.Operation == "event modifiers");
+            ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
+            ApiType summarized = Assert.Single(
+                summary.Types,
+                type => type.Name == "MixedAbstraction");
+            Assert.DoesNotContain(
+                summarized.Members,
+                member => member.Kind is "property" or "event");
+            Assert.Contains(
+                summary.InspectionFailures,
+                failure => failure.Operation == "property modifiers");
+            Assert.Contains(
+                summary.InspectionFailures,
+                failure => failure.Operation == "event modifiers");
             Assert.Throws<BadImageFormatException>(() =>
                 MetadataDeclarationQuery.GetTypeSurface(
                     reader,
@@ -1059,6 +1074,19 @@ public sealed class MetadataDeclarationQueryTests
             surface.InspectionFailures,
             candidate => candidate.Operation == "property modifiers");
         Assert.Contains("abstract accessor", failure.Detail, StringComparison.Ordinal);
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
+        ApiType summarized = Assert.Single(
+            summary.Types,
+            type => type.Name == "AbstractBody");
+        Assert.DoesNotContain(
+            summarized.Members,
+            member => member.Kind == "property");
+        Assert.Contains(
+            summary.InspectionFailures,
+            candidate => candidate.Operation == "property modifiers"
+                && candidate.Detail.Contains(
+                    "abstract accessor",
+                    StringComparison.Ordinal));
         Assert.Throws<BadImageFormatException>(() =>
             MetadataDeclarationQuery.GetTypeSurface(
                 reader,
@@ -1169,6 +1197,34 @@ public sealed class MetadataDeclarationQueryTests
             publicSurface.InspectionFailures.Select(
                 failure => (failure.Operation, failure.Detail)),
             summary.InspectionFailures.Select(failure => (failure.Operation, failure.Detail)));
+    }
+
+    [Fact]
+    public void ExtractSummary_PreservesPublicExplicitAggregateFacets()
+    {
+        byte[] image = BuildModifiedVoidExplicitAggregateImage(
+            MethodAttributes.Public,
+            modifiedReturns: false);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+
+        ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
+        ApiType host = Assert.Single(
+            summary.Types,
+            type => type.Name == "Host");
+        ApiMember[] aggregates = host.Members
+            .Where(member => member.Kind is "property" or "event")
+            .ToArray();
+
+        Assert.Equal(4, aggregates.Length);
+        Assert.All(
+            aggregates,
+            member =>
+            {
+                Assert.True(member.IsExplicitInterfaceImplementation);
+                Assert.Null(member.Accessibility);
+            });
+        Assert.Empty(summary.InspectionFailures);
     }
 
     /// <summary>
@@ -1355,7 +1411,11 @@ public sealed class MetadataDeclarationQueryTests
                 // Association alone must not hide it as compiler extension-property plumbing.
                 Assert.Contains(
                     surface.Members,
-                    member => member is { Name: "Read", Kind: "method" });
+                    member => member is
+                    {
+                        Name: "Read",
+                        Kind: "explicit-interface-implementation"
+                    });
             }
             Assert.Contains(
                 extracted.Members,
@@ -2108,7 +2168,8 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     static byte[] BuildModifiedVoidExplicitAggregateImage(
-        MethodAttributes accessorAccessibility)
+        MethodAttributes accessorAccessibility,
+        bool modifiedReturns = true)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -2264,8 +2325,13 @@ public sealed class MetadataDeclarationQueryTests
             var signature = new BlobBuilder();
             signature.WriteByte(0x20); // HASTHIS
             signature.WriteByte(0x01); // parameter count
-            signature.WriteByte(isRequiredModifier ? (byte)0x1F : (byte)0x20);
-            signature.WriteCompressedInteger(MetadataTokens.GetRowNumber(modifier) << 2 | 1);
+            if (modifiedReturns)
+            {
+                signature.WriteByte(
+                    isRequiredModifier ? (byte)0x1F : (byte)0x20);
+                signature.WriteCompressedInteger(
+                    MetadataTokens.GetRowNumber(modifier) << 2 | 1);
+            }
             signature.WriteByte(0x01); // VOID
             signature.WriteByte(parameterTypeCode);
             if (!parameterType.IsNil)

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -703,6 +703,62 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void ExplicitInterfaceTypeIdentity_RejectsNoncanonicalTypeRefArity()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("Synthetic.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        AssemblyReferenceHandle assemblyReference =
+            metadata.AddAssemblyReference(
+                metadata.GetOrAddString("Contracts"),
+                new Version(1, 0, 0, 0),
+                default,
+                default,
+                default,
+                default);
+        metadata.AddTypeReference(
+            assemblyReference,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("I`01"));
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x15); // ELEMENT_TYPE_GENERICINST
+        signature.WriteByte(0x12); // ELEMENT_TYPE_CLASS
+        signature.WriteByte(0x05); // TypeRef row 1
+        signature.WriteCompressedInteger(1);
+        signature.WriteByte(0x08); // ELEMENT_TYPE_I4
+        TypeSpecificationHandle typeSpec = metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(signature));
+        using var peReader = new PEReader(
+            new MemoryStream(Serialize(metadata), writable: false));
+
+        Assert.Throws<BadImageFormatException>(
+            () => new ExplicitInterfaceTypeIdentityProvider()
+                .GetTypeFromSpecification(
+                    peReader.GetMetadataReader(),
+                    ExplicitInterfaceSignatureContext.Open(names: null),
+                    typeSpec,
+                    rawTypeKind: 0x12));
+    }
+
+    [Fact]
     public void ExplicitInterfaceTypeIdentity_RejectsOversizedAssemblyIdentityBlob()
     {
         var metadata = new MetadataBuilder();
@@ -1293,6 +1349,54 @@ public sealed class MetadataDeclarationQueryTests
                     reader,
                     typeHandle,
                     includeNonPublicMembers: true));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void PropertySlots_RejectMixedNewSlotAndOverrideAccessors()
+    {
+        string path = EmitIncoherentPropertySlots();
+        try
+        {
+            using var peReader = new PEReader(File.OpenRead(path));
+            MetadataReader reader = peReader.GetMetadataReader();
+            TypeDefinitionHandle typeHandle =
+                GetTypeDefinitionHandle(reader, "DerivedPropertySlots");
+            ApiSurface surface =
+                ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            ApiType extracted = Assert.Single(
+                surface.Types,
+                type => type.Name == "DerivedPropertySlots");
+
+            Assert.DoesNotContain(
+                extracted.Members,
+                member => member.Kind == "property");
+            Assert.Contains(
+                surface.InspectionFailures,
+                failure => failure.Operation == "property modifiers");
+            Assert.Throws<BadImageFormatException>(() =>
+                MetadataDeclarationQuery.GetTypeSurface(
+                    reader,
+                    typeHandle,
+                    includeNonPublicMembers: true));
+
+            using var summaryReader =
+                new PEReader(File.OpenRead(path));
+            ApiSurface summary =
+                ApiSurfaceExtractor.ExtractSummary(summaryReader);
+            ApiType summarized = Assert.Single(
+                summary.Types,
+                type => type.Name == "DerivedPropertySlots");
+            Assert.DoesNotContain(
+                summarized.Members,
+                member => member.Kind == "property");
+            Assert.Contains(
+                summary.InspectionFailures,
+                failure => failure.Operation == "property modifiers");
         }
         finally
         {
@@ -2333,6 +2437,82 @@ public sealed class MetadataDeclarationQueryTests
         string path = Path.Combine(
             Path.GetTempPath(),
             $"IncoherentEventSealing-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitIncoherentPropertySlots()
+    {
+        var assemblyName = new AssemblyName("IncoherentPropertySlots");
+        var assembly =
+            new PersistedAssemblyBuilder(
+                assemblyName,
+                typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        const MethodAttributes accessorAttributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+
+        var baseBuilder =
+            module.DefineType(
+                "BasePropertySlots",
+                TypeAttributes.Public);
+        var baseGetter = baseBuilder.DefineMethod(
+            "get_P",
+            accessorAttributes | MethodAttributes.NewSlot,
+            typeof(int),
+            Type.EmptyTypes);
+        baseGetter.GetILGenerator().Emit(OpCodes.Ldc_I4_0);
+        baseGetter.GetILGenerator().Emit(OpCodes.Ret);
+        var baseSetter = baseBuilder.DefineMethod(
+            "set_P",
+            accessorAttributes | MethodAttributes.NewSlot,
+            typeof(void),
+            [typeof(int)]);
+        baseSetter.GetILGenerator().Emit(OpCodes.Ret);
+        var baseProperty = baseBuilder.DefineProperty(
+            "P",
+            PropertyAttributes.None,
+            typeof(int),
+            Type.EmptyTypes);
+        baseProperty.SetGetMethod(baseGetter);
+        baseProperty.SetSetMethod(baseSetter);
+        Type baseType = baseBuilder.CreateType();
+
+        var derivedBuilder = module.DefineType(
+            "DerivedPropertySlots",
+            TypeAttributes.Public,
+            baseType);
+        var getter = derivedBuilder.DefineMethod(
+            "get_P",
+            accessorAttributes | MethodAttributes.NewSlot,
+            typeof(int),
+            Type.EmptyTypes);
+        getter.GetILGenerator().Emit(OpCodes.Ldc_I4_0);
+        getter.GetILGenerator().Emit(OpCodes.Ret);
+        var setter = derivedBuilder.DefineMethod(
+            "set_P",
+            accessorAttributes,
+            typeof(void),
+            [typeof(int)]);
+        setter.GetILGenerator().Emit(OpCodes.Ret);
+        var property = derivedBuilder.DefineProperty(
+            "P",
+            PropertyAttributes.None,
+            typeof(int),
+            Type.EmptyTypes);
+        property.SetGetMethod(getter);
+        property.SetSetMethod(setter);
+        derivedBuilder.DefineMethodOverride(
+            setter,
+            baseType.GetMethod("set_P")!);
+        derivedBuilder.CreateType();
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"IncoherentPropertySlots-{Guid.NewGuid():N}.dll");
         assembly.Save(path);
         return path;
     }

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -593,7 +593,7 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
-    public void PrivateScopeAccessors_AreNotClassifiedAsPublic()
+    public void AccessibilityMapping_HandlesPrivateScopeAndRejectsReservedValues()
     {
         var methodAccessibility = typeof(MetadataDeclarationQuery).GetMethod(
             "AccessibilityKeyword",
@@ -606,6 +606,14 @@ public sealed class MetadataDeclarationQueryTests
 
         Assert.Equal("private", methodAccessibility!.Invoke(null, [MethodAttributes.PrivateScope]));
         Assert.Equal("private", fieldAccessibility!.Invoke(null, [FieldAttributes.PrivateScope]));
+        Assert.IsType<BadImageFormatException>(
+            Assert.Throws<TargetInvocationException>(
+                () => methodAccessibility.Invoke(null, [(MethodAttributes)0x0007]))
+                .InnerException);
+        Assert.IsType<BadImageFormatException>(
+            Assert.Throws<TargetInvocationException>(
+                () => fieldAccessibility.Invoke(null, [(FieldAttributes)0x0007]))
+                .InnerException);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -416,6 +416,20 @@ public sealed class MetadataDeclarationQueryTests
             queried.Members,
             member => member.Name.EndsWith(".add_Changed", StringComparison.Ordinal));
         Assert.Contains(
+            queried.Members,
+            member => member is
+            {
+                Kind: "property",
+                IsExplicitInterfaceImplementation: true
+            } && member.Name.EndsWith(".Value", StringComparison.Ordinal));
+        Assert.Contains(
+            queried.Members,
+            member => member is
+            {
+                Kind: "event",
+                IsExplicitInterfaceImplementation: true
+            } && member.Name.EndsWith(".Changed", StringComparison.Ordinal));
+        Assert.Contains(
             extracted.Members,
             member => member.Kind == "explicit-interface-implementation"
                 && member.Name.EndsWith(".get_Value", StringComparison.Ordinal));

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -448,6 +448,32 @@ public sealed class MetadataDeclarationQueryTests
         Assert.EndsWith(".get_Value", factAccessor.MethodName, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ExplicitAggregateIdentity_RequiresEveryAccessorToTargetAnInterface()
+    {
+        var typeDef = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures.ExplicitSurface));
+        var eventHandle = Assert.Single(typeDef.GetEvents());
+        var accessors = Reader.GetEventDefinition(eventHandle).GetAccessors();
+        var interfaceBodies =
+            ApiSurfaceExtractor.GetExplicitInterfaceImplementationBodies(Reader, typeDef);
+
+        Assert.True(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+            "IExplicitSurface.Changed",
+            interfaceBodies,
+            accessors.Adder,
+            accessors.Remover));
+        Assert.False(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+            "IExplicitSurface.Changed",
+            new HashSet<MethodDefinitionHandle> { accessors.Adder },
+            accessors.Adder,
+            accessors.Remover));
+        Assert.False(ApiSurfaceExtractor.IsExplicitInterfaceAggregate(
+            "Base.Changed",
+            new HashSet<MethodDefinitionHandle>(),
+            accessors.Adder,
+            accessors.Remover));
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -1068,6 +1068,29 @@ public sealed class MetadataDeclarationQueryTests
         }
     }
 
+    [Fact]
+    public void ExplicitAggregateRowSignature_RejectsModifiedVoidAccessorReturns()
+    {
+        using var stream = new MemoryStream(
+            BuildModifiedVoidExplicitAggregateImage(),
+            writable: false);
+        using var peReader = new PEReader(stream);
+
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        ApiType host = Assert.Single(surface.Types, type => type.Name == "Host");
+        Assert.DoesNotContain(host.Members, member => member.Kind is "property" or "event");
+        Assert.Equal(
+            2,
+            surface.InspectionFailures.Count(failure =>
+                failure.Operation == "property signature"
+                && failure.Detail == "The property setter does not return void."));
+        Assert.Equal(
+            2,
+            surface.InspectionFailures.Count(failure =>
+                failure.Operation == "event signature"
+                && failure.Detail == "The event adder does not return void."));
+    }
+
     /// <summary>
     /// The compiler-produced close negatives for the row-signature check: an explicit
     /// <c>init</c> setter carries <c>modreq(IsExternalInit)</c> over its <c>void</c> return, and
@@ -1090,6 +1113,16 @@ public sealed class MetadataDeclarationQueryTests
         Assert.Contains(aggregates, member => member.Name.EndsWith(".Value", StringComparison.Ordinal));
         Assert.Contains(aggregates, member => member.Name.EndsWith(".Item", StringComparison.Ordinal));
         Assert.Contains(aggregates, member => member.Kind == "event");
+
+        var extracted = Assert.Single(
+            ApiSurfaceExtractor.Extract(PeReader, includeAll: true).Types,
+            type => type.FullName.EndsWith(
+                "." + nameof(MetadataDeclarationQueryFixtures.ExplicitRowSignatureSurface),
+                StringComparison.Ordinal));
+        Assert.Contains(
+            extracted.Members,
+            member => member is { Kind: "property", IsExplicitInterfaceImplementation: true }
+                && member.Name.EndsWith(".Value", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -1977,6 +2010,193 @@ public sealed class MetadataDeclarationQueryTests
             bodyOffset: 0,
             parameterList: MetadataTokens.ParameterHandle(1));
 
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static byte[] BuildModifiedVoidExplicitAggregateImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("ModifiedVoidExplicitAggregate.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("ModifiedVoidExplicitAggregate"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle host = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Fixtures"),
+            metadata.GetOrAddString("Host"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Contracts"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        TypeReferenceHandle interfaceType = metadata.AddTypeReference(
+            contracts,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("IRow"));
+        TypeReferenceHandle modifier = metadata.AddTypeReference(
+            contracts,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString("ArbitraryModifier"));
+        metadata.AddInterfaceImplementation(host, interfaceType);
+
+        var propertySignature = new BlobBuilder();
+        new BlobEncoder(propertySignature)
+            .PropertySignature(isInstanceProperty: true)
+            .Parameters(0, returnType => returnType.Type().Int32(), _ => { });
+        BlobHandle propertySignatureHandle = metadata.GetOrAddBlob(propertySignature);
+        bool propertyMapAdded = false;
+        AddProperty("RequiredValue", isRequiredModifier: true);
+        AddProperty("OptionalValue", isRequiredModifier: false);
+
+        bool eventMapAdded = false;
+        AddEvent("RequiredChanged", isRequiredModifier: true);
+        AddEvent("OptionalChanged", isRequiredModifier: false);
+
+        return Serialize(metadata);
+
+        void AddProperty(string name, bool isRequiredModifier)
+        {
+            BlobHandle signature = AddModifiedVoidAccessorSignature(
+                isRequiredModifier,
+                parameterType: default,
+                parameterTypeCode: 0x08);
+            MethodDefinitionHandle setter = metadata.AddMethodDefinition(
+                ExplicitAccessorAttributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString($"Contracts.IRow.set_{name}"),
+                signature,
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+            MemberReferenceHandle declaration = metadata.AddMemberReference(
+                interfaceType,
+                metadata.GetOrAddString($"set_{name}"),
+                signature);
+            metadata.AddMethodImplementation(host, setter, declaration);
+            PropertyDefinitionHandle property = metadata.AddProperty(
+                PropertyAttributes.None,
+                metadata.GetOrAddString($"Contracts.IRow.{name}"),
+                propertySignatureHandle);
+            if (!propertyMapAdded)
+            {
+                metadata.AddPropertyMap(host, property);
+                propertyMapAdded = true;
+            }
+            metadata.AddMethodSemantics(
+                property,
+                MethodSemanticsAttributes.Setter,
+                setter);
+        }
+
+        void AddEvent(string name, bool isRequiredModifier)
+        {
+            BlobHandle signature = AddModifiedVoidAccessorSignature(
+                isRequiredModifier,
+                interfaceType,
+                parameterTypeCode: 0x12);
+            MethodDefinitionHandle adder = metadata.AddMethodDefinition(
+                ExplicitAccessorAttributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString($"Contracts.IRow.add_{name}"),
+                signature,
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+            MethodDefinitionHandle remover = metadata.AddMethodDefinition(
+                ExplicitAccessorAttributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString($"Contracts.IRow.remove_{name}"),
+                signature,
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+            metadata.AddMethodImplementation(
+                host,
+                adder,
+                metadata.AddMemberReference(
+                    interfaceType,
+                    metadata.GetOrAddString($"add_{name}"),
+                    signature));
+            metadata.AddMethodImplementation(
+                host,
+                remover,
+                metadata.AddMemberReference(
+                    interfaceType,
+                    metadata.GetOrAddString($"remove_{name}"),
+                    signature));
+            EventDefinitionHandle @event = metadata.AddEvent(
+                EventAttributes.None,
+                metadata.GetOrAddString($"Contracts.IRow.{name}"),
+                interfaceType);
+            if (!eventMapAdded)
+            {
+                metadata.AddEventMap(host, @event);
+                eventMapAdded = true;
+            }
+            metadata.AddMethodSemantics(
+                @event,
+                MethodSemanticsAttributes.Adder,
+                adder);
+            metadata.AddMethodSemantics(
+                @event,
+                MethodSemanticsAttributes.Remover,
+                remover);
+        }
+
+        BlobHandle AddModifiedVoidAccessorSignature(
+            bool isRequiredModifier,
+            EntityHandle parameterType,
+            byte parameterTypeCode)
+        {
+            var signature = new BlobBuilder();
+            signature.WriteByte(0x20); // HASTHIS
+            signature.WriteByte(0x01); // parameter count
+            signature.WriteByte(isRequiredModifier ? (byte)0x1F : (byte)0x20);
+            signature.WriteCompressedInteger(MetadataTokens.GetRowNumber(modifier) << 2 | 1);
+            signature.WriteByte(0x01); // VOID
+            signature.WriteByte(parameterTypeCode);
+            if (!parameterType.IsNil)
+                signature.WriteCompressedInteger(
+                    MetadataTokens.GetRowNumber(parameterType) << 2 | 1);
+            return metadata.GetOrAddBlob(signature);
+        }
+    }
+
+    const MethodAttributes ExplicitAccessorAttributes =
+        MethodAttributes.Private
+        | MethodAttributes.Virtual
+        | MethodAttributes.Final
+        | MethodAttributes.NewSlot
+        | MethodAttributes.SpecialName
+        | MethodAttributes.HideBySig;
+
+    static byte[] Serialize(MetadataBuilder metadata)
+    {
         var pe = new ManagedPEBuilder(
             PEHeaderBuilder.CreateLibraryHeader(),
             new MetadataRootBuilder(metadata, suppressValidation: true),

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -587,7 +587,8 @@ public sealed class MetadataDeclarationQueryTests
             new ExplicitInterfaceTypeIdentity(
                 "nullable",
                 "System.Nullable",
-                GenericArity: 1),
+                GenericArity: 1,
+                IsWellKnownNullable: true),
             [element]);
         var nullableInterface = provider.GetGenericInstantiation(
             new ExplicitInterfaceTypeIdentity(
@@ -596,6 +597,27 @@ public sealed class MetadataDeclarationQueryTests
                 GenericArity: 1),
             [nullable]);
         Assert.Equal("Samples.IContract<System.Int32?>", nullableInterface.AggregateAliasName);
+        var spoofNullable = provider.GetGenericInstantiation(
+            new ExplicitInterfaceTypeIdentity(
+                "spoof-nullable",
+                "System.Nullable`1",
+                GenericArity: 1),
+            [element]);
+        Assert.Null(spoofNullable.AggregateAliasName);
+        Assert.Throws<BadImageFormatException>(() =>
+            provider.GetGenericInstantiation(
+                new ExplicitInterfaceTypeIdentity(
+                    "generic",
+                    "Samples.IContract`1",
+                    GenericArity: 1),
+                [element, element]));
+        Assert.False(provider.GetGenericInstantiation(
+            new ExplicitInterfaceTypeIdentity(
+                "class",
+                "Samples.NotAnInterface`1",
+                GenericArity: 1,
+                IsInterface: false),
+            [element]).IsInterface);
 
         Assert.NotNull(typeof(Dictionary<,>.KeyCollection));
         var nestedReference = PeReader.GetMetadataReader()
@@ -766,6 +788,30 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void MetadataAccessorSemantics_RejectsNestedAndMalformedInitModifiers()
+    {
+        using (var peReader = new PEReader(new MemoryStream(
+                   BuildHostileInitModifierImage(cyclicScope: false))))
+        {
+            var reader = peReader.GetMetadataReader();
+            Assert.Equal(
+                "set",
+                MetadataAccessorSemantics.Kind(
+                    reader,
+                    MetadataTokens.MethodDefinitionHandle(1),
+                    "set"));
+        }
+
+        using var cyclicReader = new PEReader(new MemoryStream(
+            BuildHostileInitModifierImage(cyclicScope: true)));
+        Assert.Throws<BadImageFormatException>(() =>
+            MetadataAccessorSemantics.Kind(
+                cyclicReader.GetMetadataReader(),
+                MetadataTokens.MethodDefinitionHandle(1),
+                "set"));
+    }
+
+    [Fact]
     public void ExplicitAggregateIdentity_RejectsBaseClassMethodImplTargets()
     {
         string path = EmitBaseClassMethodImplEvent();
@@ -784,6 +830,39 @@ public sealed class MetadataDeclarationQueryTests
                 ApiSurfaceExtractor.GetExplicitInterfaceImplementationTargets(reader, typeDef),
                 (accessors.Adder, "add_"),
                 (accessors.Remover, "remove_")));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void EventSealing_DoesNotCombineDifferentAccessors()
+    {
+        string path = EmitIncoherentEventSealing();
+        try
+        {
+            using var peReader = new PEReader(File.OpenRead(path));
+            var reader = peReader.GetMetadataReader();
+            var typeHandle = GetTypeDefinitionHandle(reader, "DerivedEventSealing");
+            var extracted = Assert.Single(
+                ApiSurfaceExtractor.Extract(peReader, includeAll: true).Types,
+                type => type.Name == "DerivedEventSealing");
+            var queried = MetadataDeclarationQuery.GetTypeSurface(
+                reader,
+                typeHandle,
+                includeNonPublicMembers: true);
+
+            var extractedEvent = Assert.Single(
+                extracted.Members,
+                member => member.Kind == "event");
+            var queriedEvent = Assert.Single(
+                queried.Members,
+                member => member.Kind == "event");
+
+            Assert.False(extractedEvent.IsSealed);
+            Assert.Equal(queriedEvent.IsSealed, extractedEvent.IsSealed);
         }
         finally
         {
@@ -1478,6 +1557,144 @@ public sealed class MetadataDeclarationQueryTests
             $"BaseClassMethodImplEvent-{Guid.NewGuid():N}.dll");
         assembly.Save(path);
         return path;
+    }
+
+    static string EmitIncoherentEventSealing()
+    {
+        var assemblyName = new AssemblyName("IncoherentEventSealing");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        const MethodAttributes accessorAttributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+
+        var baseBuilder = module.DefineType("BaseEventSealing", TypeAttributes.Public);
+        var baseAdder = baseBuilder.DefineMethod(
+            "add_Changed",
+            accessorAttributes | MethodAttributes.NewSlot,
+            typeof(void),
+            [typeof(Action)]);
+        baseAdder.GetILGenerator().Emit(OpCodes.Ret);
+        var baseRemover = baseBuilder.DefineMethod(
+            "remove_Changed",
+            accessorAttributes | MethodAttributes.NewSlot,
+            typeof(void),
+            [typeof(Action)]);
+        baseRemover.GetILGenerator().Emit(OpCodes.Ret);
+        var baseEvent = baseBuilder.DefineEvent("Changed", EventAttributes.None, typeof(Action));
+        baseEvent.SetAddOnMethod(baseAdder);
+        baseEvent.SetRemoveOnMethod(baseRemover);
+        var baseType = baseBuilder.CreateType();
+
+        var derivedBuilder = module.DefineType(
+            "DerivedEventSealing",
+            TypeAttributes.Public,
+            baseType);
+        var adder = derivedBuilder.DefineMethod(
+            "add_Changed",
+            accessorAttributes,
+            typeof(void),
+            [typeof(Action)]);
+        adder.GetILGenerator().Emit(OpCodes.Ret);
+        var remover = derivedBuilder.DefineMethod(
+            "remove_Changed",
+            accessorAttributes | MethodAttributes.NewSlot | MethodAttributes.Final,
+            typeof(void),
+            [typeof(Action)]);
+        remover.GetILGenerator().Emit(OpCodes.Ret);
+        var @event = derivedBuilder.DefineEvent("Changed", EventAttributes.None, typeof(Action));
+        @event.SetAddOnMethod(adder);
+        @event.SetRemoveOnMethod(remover);
+        derivedBuilder.DefineMethodOverride(adder, baseType.GetMethod("add_Changed")!);
+        derivedBuilder.CreateType();
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"IncoherentEventSealing-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static byte[] BuildHostileInitModifierImage(bool cyclicScope)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("HostileInitModifier.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("HostileInitModifier"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Fixtures"),
+            metadata.GetOrAddString("Host"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        EntityHandle outerScope;
+        if (cyclicScope)
+        {
+            outerScope = MetadataTokens.TypeReferenceHandle(2);
+        }
+        else
+        {
+            outerScope = metadata.AddAssemblyReference(
+                metadata.GetOrAddString("Dependency"),
+                new Version(1, 0, 0, 0),
+                culture: default,
+                publicKeyOrToken: default,
+                flags: default,
+                hashValue: default);
+        }
+        TypeReferenceHandle outer = metadata.AddTypeReference(
+            outerScope,
+            default,
+            metadata.GetOrAddString("MarkerHost"));
+        TypeReferenceHandle modifier = metadata.AddTypeReference(
+            cyclicScope ? outer : (EntityHandle)outer,
+            metadata.GetOrAddString("System.Runtime.CompilerServices"),
+            metadata.GetOrAddString("IsExternalInit"));
+
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00); // DEFAULT
+        signature.WriteByte(0x01); // parameter count
+        signature.WriteByte(0x1F); // CMOD_REQD
+        signature.WriteByte((byte)(MetadataTokens.GetRowNumber(modifier) << 2 | 1));
+        signature.WriteByte(0x01); // VOID
+        signature.WriteByte(0x08); // I4
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString("set_Value"),
+            metadata.GetOrAddBlob(signature),
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
     }
 
     static string EmitSignatureIncompatibleMethodImplProperty()

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -956,6 +956,10 @@ public sealed class MetadataDeclarationQueryTests
             Assert.Contains(
                 surface.InspectionFailures,
                 failure => failure.Operation == "event modifiers");
+            ApiSurface publicSurface = ApiSurfaceExtractor.Extract(peReader);
+            Assert.Contains(
+                publicSurface.InspectionFailures,
+                failure => failure.Operation == "event modifiers");
             ApiSurface summary = ApiSurfaceExtractor.ExtractSummary(peReader);
             ApiType summarized = Assert.Single(
                 summary.Types,
@@ -2377,7 +2381,11 @@ public sealed class MetadataDeclarationQueryTests
             | MethodAttributes.SpecialName
             | MethodAttributes.HideBySig;
 
-        void DefineAggregates(string typeName, bool abstractGetter, bool abstractSetter)
+        void DefineAggregates(
+            string typeName,
+            bool abstractGetter,
+            bool abstractSetter,
+            bool publicEvent = true)
         {
             var builder = module.DefineType(
                 typeName,
@@ -2411,9 +2419,15 @@ public sealed class MetadataDeclarationQueryTests
             property.SetGetMethod(getter);
             property.SetSetMethod(setter);
 
+            MethodAttributes eventAttributes = publicEvent
+                ? Shared
+                : (Shared & ~MethodAttributes.MemberAccessMask)
+                    | MethodAttributes.Private;
             var adder = builder.DefineMethod(
                 "add_Changed",
-                abstractGetter ? Shared | MethodAttributes.Abstract : Shared,
+                abstractGetter
+                    ? eventAttributes | MethodAttributes.Abstract
+                    : eventAttributes,
                 typeof(void),
                 [typeof(Action)]);
             if (!abstractGetter)
@@ -2421,7 +2435,9 @@ public sealed class MetadataDeclarationQueryTests
 
             var remover = builder.DefineMethod(
                 "remove_Changed",
-                abstractSetter ? Shared | MethodAttributes.Abstract : Shared,
+                abstractSetter
+                    ? eventAttributes | MethodAttributes.Abstract
+                    : eventAttributes,
                 typeof(void),
                 [typeof(Action)]);
             if (!abstractSetter)
@@ -2433,7 +2449,11 @@ public sealed class MetadataDeclarationQueryTests
             builder.CreateType();
         }
 
-        DefineAggregates("MixedAbstraction", abstractGetter: true, abstractSetter: false);
+        DefineAggregates(
+            "MixedAbstraction",
+            abstractGetter: true,
+            abstractSetter: false,
+            publicEvent: false);
         DefineAggregates("UniformAbstract", abstractGetter: true, abstractSetter: true);
         DefineAggregates("UniformConcrete", abstractGetter: false, abstractSetter: false);
 


### PR DESCRIPTION
## Summary

- add product-owned accessibility facets to type and member inventory requests/results
- classify missing/public, protected, protected internal, private protected, internal, and private accessibilities in one shared catalog
- default to public while supporting opaque-ID unions within an axis and intersections across kind/accessibility
- cross-filter descriptor counts against the opposite axis so listing and application remain consistent
- prove accessibility comes from metadata facts rather than `s_`, compiler-generated, or generated-looking names

## Stack

**Slice 3 of 3** for #3863, #3864, and #3865.

- Slice 1: #3875 — product-owned kind facets
- Parent/slice 2: #3877 — effective inspection-view descriptors
- This slice: product-owned accessibility facets (#3865)
- Deferred residual: adopt the stack and delete `ACCESS_ORDER`, `accessBucket`, client-side defaulting/filtering, lens catalogs, and body-kind inference on `prototype/wasm-command-ui`; the prototype is intentionally outside this `main`-based product stack

## Validation

- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release`: 6 passed
- `dotnet build dotnet-inspect.slnx -c Release`
- MAI-Code quick read: clean, with no default/count/filter, compound-accessibility, metadata-boundary, or API-contract blockers