### PR TITLE
Validate default package projections before rendering

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -12021,6 +12021,34 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_MultiSectionColumns_AllMissReportsCleanError()
+    {
+        var (packagePath, tempDir) = CreateLocalLayoutPackage();
+        try
+        {
+            var (normalExit, normalOutput, normalError) = await RunAppAsync(
+                "package", packagePath, "-v:n", "--columns", "TFM", "--tips", "q");
+
+            Assert.Equal(1, normalExit);
+            Assert.Empty(normalOutput);
+            Assert.Contains("No columns matched projection: TFM", normalError);
+            Assert.DoesNotContain("System.InvalidOperationException", normalError);
+
+            var (overviewExit, overviewOutput, overviewError) = await RunAppAsync(
+                "package", packagePath, "-S", "--columns", "Path", "--tips", "q");
+
+            Assert.Equal(1, overviewExit);
+            Assert.Empty(overviewOutput);
+            Assert.Contains("No columns matched projection: Path", overviewError);
+            Assert.DoesNotContain("System.InvalidOperationException", overviewError);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Package_DiscoverSchema_ListsPublishedPackageInfoField()
     {
         var (exit, output, error) = await RunAppAsync("package", "-D", "Package Info", "--schema", "--tips", "q");

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -12021,11 +12021,13 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Package_MultiSectionColumns_AllMissReportsCleanError()
+    public async Task Package_MultiSectionPartialMatchReportsCleanRenderError()
     {
         var (packagePath, tempDir) = CreateLocalLayoutPackage();
         try
         {
+            // Markout applies the projection to each table independently, so a column that
+            // matches one section can still abort on an earlier heterogeneous section.
             var (normalExit, normalOutput, normalError) = await RunAppAsync(
                 "package", packagePath, "-v:n", "--columns", "TFM", "--tips", "q");
 
@@ -12041,6 +12043,73 @@ public partial class CommandExecutionTests
             Assert.Empty(overviewOutput);
             Assert.Contains("No columns matched projection: Path", overviewError);
             Assert.DoesNotContain("System.InvalidOperationException", overviewError);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_JsonIgnoresColumnProjection()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.Package.JsonProjection",
+            "README.md",
+            "# Test package");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", packagePath, "--json", "--columns", "Package", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            using var _ = JsonDocument.Parse(output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_DefaultFieldsWithoutDataRemainNonFatal()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.Package.EmptyFieldProjection",
+            "README.md",
+            "# Test package");
+        try
+        {
+            var (exit, _, error) = await RunAppAsync(
+                "package", packagePath, "--fields", "Downloads", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("Note: 1 field has no data: Downloads", error);
+            Assert.DoesNotContain("No fields matched projection", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiPackageFormatRefusalPrecedesProjectionHandling()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.Package.MultiProjection",
+            "README.md",
+            "# Test package");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", packagePath, packagePath, "--columns", "Missing", "--tips", "q");
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains("Multiple package output requires --json or a row format", error);
+            Assert.DoesNotContain("No columns matched projection", error);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -11972,6 +11972,54 @@ public partial class CommandExecutionTests
         }
     }
 
+    [Theory]
+    [InlineData("Name")]
+    [InlineData("Version")]
+    public async Task Package_DefaultColumns_AllMissReportsCleanError(string column)
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.Package.UnmatchedColumn",
+            "README.md",
+            "# Test package");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", packagePath, "--columns", column, "--tips", "q");
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains($"No columns matched projection: {column}", error);
+            Assert.DoesNotContain("System.InvalidOperationException", error);
+            Assert.DoesNotContain("MarkoutProjection.ComputeColumnMap", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_DefaultFields_ValidProjectionStillRenders()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.Package.ValidField",
+            "README.md",
+            "# Test package");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", packagePath, "--fields", "Authors", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("| Authors | tests |", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task Package_DiscoverSchema_ListsPublishedPackageInfoField()
     {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -174,19 +174,11 @@ public class PackageCommand
                     options = options with { Verbosity = requiredVerbosity };
             }
 
-            // Pre-render validation: check --fields/--columns names against every visible section
-            // the renderer can select. Without -S, IncludeSections is null, but Markout still
-            // projects the verbosity-selected document and throws when no name matches.
-            if ((options.Fields is { Length: > 0 } || options.Columns is { Length: > 0 })
-                && !rendersOwnPayload
-                && (options.IncludeSections is { Count: > 0 } || packageArgs.Length > 0))
+            // Pre-render validation: check --fields/--columns names against the section schema
+            if ((options.Fields is { Length: > 0 } || options.Columns is { Length: > 0 }) && options.IncludeSections is { Count: > 0 })
             {
-                var projectionSections = pipeline.GetCandidateSections(
-                    options.Verbosity, options.IncludeSections, options.FixedOverview);
-                projectionSections.IntersectWith(sectionNames);
                 var schemaMap = PackageDiscoverySchema();
-                if (!ValidatePackageProjection(
-                    schemaMap, projectionSections, options.Fields, options.Columns))
+                if (!ProjectionDiagnostics.ValidateProjection(schemaMap, options.IncludeSections, options.Fields, options.Columns))
                     return 1;
             }
         }
@@ -778,6 +770,13 @@ public class PackageCommand
             CommandError.WriteLine($"Failed to download package: {ex.Message}");
             return 1;
         }
+        catch (InvalidOperationException ex) when (
+            options.Columns is { Length: > 0 }
+            && ex.Message.StartsWith("No columns matched projection:", StringComparison.Ordinal))
+        {
+            CommandError.Write(ex.Message);
+            return 1;
+        }
         finally
         {
             // Only clean up temp directory if we created one (not using cache)
@@ -947,44 +946,6 @@ public class PackageCommand
 
     private static DocumentSchema PackageDiscoverySchema()
         => AddPackageDynamicDiscoveryItems(InspectionContext.Default.GetSchemaInfo<InspectionResultView>()!.ToDocumentSchema());
-
-    private static bool ValidatePackageProjection(
-        DocumentSchema schema,
-        IReadOnlyCollection<string> sectionNames,
-        string[]? fields,
-        string[]? columns)
-    {
-        var valid = true;
-        if (fields is { Length: > 0 })
-            valid &= ValidatePackageProjectionNames(schema, sectionNames, fields, fieldsRequested: true);
-        if (columns is { Length: > 0 })
-            valid &= ValidatePackageProjectionNames(schema, sectionNames, columns, fieldsRequested: false);
-        return valid;
-    }
-
-    private static bool ValidatePackageProjectionNames(
-        DocumentSchema schema,
-        IReadOnlyCollection<string> sectionNames,
-        string[] names,
-        bool fieldsRequested)
-    {
-        var kind = fieldsRequested ? "field" : "column";
-        var matchingSections = sectionNames
-            .Where(name => string.Equals(
-                schema.GetSection(name)?.ItemKind, kind, StringComparison.OrdinalIgnoreCase))
-            .ToArray();
-        if (matchingSections.Length == 0)
-        {
-            CommandError.Write($"No {kind}s matched projection: {string.Join(", ", names)}");
-            return false;
-        }
-
-        return ProjectionDiagnostics.ValidateProjection(
-            schema,
-            matchingSections,
-            fieldsRequested ? names : null,
-            fieldsRequested ? null : names);
-    }
 
     private static DocumentSchema AddPackageDynamicDiscoveryItems(DocumentSchema schema)
     {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -174,11 +174,19 @@ public class PackageCommand
                     options = options with { Verbosity = requiredVerbosity };
             }
 
-            // Pre-render validation: check --fields/--columns names against the section schema
-            if ((options.Fields is { Length: > 0 } || options.Columns is { Length: > 0 }) && options.IncludeSections is { Count: > 0 })
+            // Pre-render validation: check --fields/--columns names against every visible section
+            // the renderer can select. Without -S, IncludeSections is null, but Markout still
+            // projects the verbosity-selected document and throws when no name matches.
+            if ((options.Fields is { Length: > 0 } || options.Columns is { Length: > 0 })
+                && !rendersOwnPayload
+                && (options.IncludeSections is { Count: > 0 } || packageArgs.Length > 0))
             {
+                var projectionSections = pipeline.GetCandidateSections(
+                    options.Verbosity, options.IncludeSections, options.FixedOverview);
+                projectionSections.IntersectWith(sectionNames);
                 var schemaMap = PackageDiscoverySchema();
-                if (!ProjectionDiagnostics.ValidateProjection(schemaMap, options.IncludeSections, options.Fields, options.Columns))
+                if (!ValidatePackageProjection(
+                    schemaMap, projectionSections, options.Fields, options.Columns))
                     return 1;
             }
         }
@@ -939,6 +947,44 @@ public class PackageCommand
 
     private static DocumentSchema PackageDiscoverySchema()
         => AddPackageDynamicDiscoveryItems(InspectionContext.Default.GetSchemaInfo<InspectionResultView>()!.ToDocumentSchema());
+
+    private static bool ValidatePackageProjection(
+        DocumentSchema schema,
+        IReadOnlyCollection<string> sectionNames,
+        string[]? fields,
+        string[]? columns)
+    {
+        var valid = true;
+        if (fields is { Length: > 0 })
+            valid &= ValidatePackageProjectionNames(schema, sectionNames, fields, fieldsRequested: true);
+        if (columns is { Length: > 0 })
+            valid &= ValidatePackageProjectionNames(schema, sectionNames, columns, fieldsRequested: false);
+        return valid;
+    }
+
+    private static bool ValidatePackageProjectionNames(
+        DocumentSchema schema,
+        IReadOnlyCollection<string> sectionNames,
+        string[] names,
+        bool fieldsRequested)
+    {
+        var kind = fieldsRequested ? "field" : "column";
+        var matchingSections = sectionNames
+            .Where(name => string.Equals(
+                schema.GetSection(name)?.ItemKind, kind, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        if (matchingSections.Length == 0)
+        {
+            CommandError.Write($"No {kind}s matched projection: {string.Join(", ", names)}");
+            return false;
+        }
+
+        return ProjectionDiagnostics.ValidateProjection(
+            schema,
+            matchingSections,
+            fieldsRequested ? names : null,
+            fieldsRequested ? null : names);
+    }
 
     private static DocumentSchema AddPackageDynamicDiscoveryItems(DocumentSchema schema)
     {


### PR DESCRIPTION
## Summary

- validate `package --fields`/`--columns` against the sections selected by default verbosity even when `-S` is absent
- keep package field and column schema kinds distinct so a same-named field cannot falsely validate an unmatched column
- return the existing projection diagnostic before Markout rendering instead of appending an exception stack trace

Closes #3686

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- focused projection regressions and adjacent member/library paths (6 passed)
- full CLI suite: 3095 passed, 14 skipped, one timing-sensitive cyclic-constraint benchmark exceeded its suite-load threshold; the benchmark passed immediately in isolation

## Compatibility

Valid default field projections continue to render. Explicit section validation retains its existing diagnostics, and lens/discovery payloads remain on their own projection paths.