### PR TITLE
Make versioned caches self-cleaning

### DIFF
--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -173,6 +173,21 @@ transactions from older direct-copy writers, earlier layouts that did not
 scope entries by source, and payloads previously misattributed by a
 noncanonical NuGet.org URL shortcut.
 
+## Versioned cache retirement
+
+Each versioned cache family registers its prefix and current numeric contract.
+Registration starts best-effort background cleanup, and cache initialization
+rechecks every known family. Cleanup deletes only lower numeric contracts.
+Current, future, and malformed directory suffixes are preserved, so running an
+older dotnet-inspect cannot destroy a cache written by a newer one.
+
+Cleanup scans on every initialization rather than trusting a persisted
+high-water mark. An older executable can still be running and can recreate an
+old contract after a newer process removes it; the next initialization must
+therefore check again. Routine cleanup is silent. An explicit `cache clear`
+waits for in-flight maintenance and includes its reclaimed bytes in the
+reported total.
+
 ## Filesystem coordination
 
 `Directory.Move(stagingPath, targetPath)` delegates coordination to the

--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -28,16 +28,26 @@ public static class CoreCache
     public static void Initialize(string appName, string? basePath = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(appName);
-        _appName = appName;
-        _basePathOverride = basePath;
         lock (s_maintenanceLock)
         {
+            string? previousRoot = _appName is null ? null : GetBasePath();
             s_maintenanceCts?.Cancel();
+            WaitForMaintenanceTasksBestEffort();
+            CacheMaintenanceResult previousProgress =
+                s_maintenanceProgress?.TakeSnapshot() ?? default;
             s_maintenanceCts?.Dispose();
+            _appName = appName;
+            _basePathOverride = basePath;
             s_maintenanceCts = new CancellationTokenSource();
             s_maintenanceTask = null;
             s_maintenanceProgress = new CacheMaintenanceProgress();
             s_maintenanceTasks = [];
+            if (previousRoot is not null
+                && IsSamePath(previousRoot, GetBasePath()))
+            {
+                s_maintenanceProgress.Record(previousProgress);
+            }
+
             foreach (VersionedCacheCategory category in s_versionedCategories.Values)
                 ScheduleVersionedCategoryCleanup(category);
         }
@@ -515,14 +525,7 @@ public static class CoreCache
         if (s_maintenanceCts is not { IsCancellationRequested: true })
             return;
 
-        try
-        {
-            Task.WaitAll([.. s_maintenanceTasks.Values]);
-        }
-        catch
-        {
-            // The replacement generation still needs to run after best-effort maintenance.
-        }
+        WaitForMaintenanceTasksBestEffort();
 
         CacheMaintenanceResult carriedProgress =
             s_maintenanceProgress?.TakeSnapshot() ?? default;
@@ -532,6 +535,18 @@ public static class CoreCache
         s_maintenanceProgress = new CacheMaintenanceProgress();
         s_maintenanceProgress.Record(carriedProgress);
         s_maintenanceTasks = [];
+    }
+
+    private static void WaitForMaintenanceTasksBestEffort()
+    {
+        try
+        {
+            Task.WaitAll([.. s_maintenanceTasks.Values]);
+        }
+        catch
+        {
+            // Replacement and shutdown still proceed after best-effort maintenance.
+        }
     }
 
     private static async Task<CacheMaintenanceResult> AwaitMaintenanceAsync(
@@ -588,6 +603,9 @@ public static class CoreCache
                     continue;
 
                 var size = GetDirectorySizeBestEffort(directory);
+                if (cancellationToken.IsCancellationRequested)
+                    return;
+
                 Directory.Delete(directory, recursive: true);
                 progress.RecordDeletion(size);
             }
@@ -649,6 +667,12 @@ public static class CoreCache
             || fullPath.StartsWith(fullRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
             || fullPath.StartsWith(fullRoot + Path.AltDirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
     }
+
+    private static bool IsSamePath(string left, string right) =>
+        Path.TrimEndingDirectorySeparator(Path.GetFullPath(left))
+            .Equals(
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(right)),
+                StringComparison.OrdinalIgnoreCase);
 }
 
 public readonly record struct CacheMaintenanceResult(long BytesFreed, int DirectoriesDeleted);

--- a/src/DotnetInspector.Core/CoreCache.cs
+++ b/src/DotnetInspector.Core/CoreCache.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -13,12 +14,12 @@ public static class CoreCache
     private static string? _appName;
     private static string? _basePathOverride;
     private static readonly object s_maintenanceLock = new();
-    private static readonly List<VersionedCacheCategory> s_versionedCategories = [];
+    private static readonly Dictionary<string, VersionedCacheCategory> s_versionedCategories =
+        new(StringComparer.OrdinalIgnoreCase);
     private static CancellationTokenSource? s_maintenanceCts;
     private static Task<CacheMaintenanceResult>? s_maintenanceTask;
     private static CacheMaintenanceProgress? s_maintenanceProgress;
-    private static AsyncCache<string, CacheMaintenanceResult> s_maintenanceRequests =
-        new(StringComparer.Ordinal);
+    private static Dictionary<VersionedCacheCleanupKey, Task> s_maintenanceTasks = [];
 
     /// <summary>
     /// Initializes the cache with the application name used for the cache directory.
@@ -33,11 +34,12 @@ public static class CoreCache
         {
             s_maintenanceCts?.Cancel();
             s_maintenanceCts?.Dispose();
-            s_maintenanceCts = null;
+            s_maintenanceCts = new CancellationTokenSource();
             s_maintenanceTask = null;
-            s_maintenanceProgress = null;
-            s_maintenanceRequests = new AsyncCache<string, CacheMaintenanceResult>(
-                StringComparer.Ordinal);
+            s_maintenanceProgress = new CacheMaintenanceProgress();
+            s_maintenanceTasks = [];
+            foreach (VersionedCacheCategory category in s_versionedCategories.Values)
+                ScheduleVersionedCategoryCleanup(category);
         }
     }
 
@@ -151,23 +153,33 @@ public static class CoreCache
     /// <summary>
     /// Registers a versioned cache category family for best-effort cleanup.
     /// For example, prefix <c>pkg-index-v</c> with current <c>pkg-index-v8</c>
-    /// causes maintenance to delete sibling directories such as <c>pkg-index-v7</c>.
+    /// causes maintenance to delete older sibling directories such as
+    /// <c>pkg-index-v7</c> while preserving future versions.
     /// </summary>
     public static void RegisterVersionedCategory(string prefix, string current)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(prefix);
         ArgumentException.ThrowIfNullOrWhiteSpace(current);
+        VersionedCacheCategory category = CreateVersionedCacheCategory(prefix, current);
 
         lock (s_maintenanceLock)
         {
-            if (s_versionedCategories.Any(c =>
-                c.Prefix.Equals(prefix, StringComparison.OrdinalIgnoreCase)
-                && c.Current.Equals(current, StringComparison.OrdinalIgnoreCase)))
+            if (s_versionedCategories.TryGetValue(prefix, out VersionedCacheCategory registered))
             {
+                if (registered.CurrentVersion != category.CurrentVersion
+                    || !registered.Current.Equals(current, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new InvalidOperationException(
+                        $"Cache category prefix '{prefix}' is already registered "
+                        + $"with current category '{registered.Current}'.");
+                }
+
+                ScheduleVersionedCategoryCleanup(registered);
                 return;
             }
 
-            s_versionedCategories.Add(new(prefix, current));
+            s_versionedCategories.Add(prefix, category);
+            ScheduleVersionedCategoryCleanup(category);
         }
     }
 
@@ -343,21 +355,30 @@ public static class CoreCache
     /// <returns>The number of bytes freed.</returns>
     public static long Clear(string? category = null)
     {
-        var targetPath = category != null ? GetCategoryPath(category) : GetBasePath();
-        EnsurePathInCacheContext(targetPath);
-        if (!Directory.Exists(targetPath))
-            return 0;
+        lock (s_maintenanceLock)
+        {
+            CacheMaintenanceResult maintenance =
+                WaitForMaintenance(
+                    Timeout.InfiniteTimeSpan,
+                    consumeProgress: category is null);
+            var targetPath = category != null ? GetCategoryPath(category) : GetBasePath();
+            EnsurePathInCacheContext(targetPath);
+            long maintenanceBytes = category is null ? maintenance.BytesFreed : 0;
+            if (!Directory.Exists(targetPath))
+                return maintenanceBytes;
 
-        var size = GetDirectorySize(targetPath);
-        try
-        {
-            Directory.Delete(targetPath, recursive: true);
+            var size = GetDirectorySize(targetPath);
+            try
+            {
+                Directory.Delete(targetPath, recursive: true);
+            }
+            catch (DirectoryNotFoundException) when (!Directory.Exists(targetPath))
+            {
+                // Another process completed the same cache deletion.
+            }
+
+            return maintenanceBytes + size;
         }
-        catch
-        {
-            // Best-effort
-        }
-        return size;
     }
 
     /// <summary>
@@ -376,22 +397,21 @@ public static class CoreCache
 
     /// <summary>
     /// Waits briefly for in-flight cleanup to finish, cancels if it exceeds the timeout, and returns
-    /// the amount of obsolete cache data removed so far.
+    /// the amount of obsolete cache data removed since the previous drain.
     /// </summary>
     public static CacheMaintenanceResult CancelAndWaitForMaintenance(TimeSpan timeout)
+        => WaitForMaintenance(timeout, consumeProgress: true);
+
+    private static CacheMaintenanceResult WaitForMaintenance(
+        TimeSpan timeout,
+        bool consumeProgress)
     {
-        Task<CacheMaintenanceResult>? task;
-        CancellationTokenSource? cts;
-        CacheMaintenanceProgress? progress;
         lock (s_maintenanceLock)
         {
-            task = s_maintenanceTask;
-            cts = s_maintenanceCts;
-            progress = s_maintenanceProgress;
-        }
+            Task<CacheMaintenanceResult> task = RequestVersionedCategoryCleanupAsync();
+            CancellationTokenSource? cts = s_maintenanceCts;
+            CacheMaintenanceProgress? progress = s_maintenanceProgress;
 
-        if (task != null)
-        {
             try
             {
                 if (!task.Wait(timeout))
@@ -404,12 +424,14 @@ public static class CoreCache
             {
                 // Best-effort shutdown hook; cleanup must never affect command success.
             }
+
+            if (progress is null)
+                return default;
+
+            return consumeProgress
+                ? progress.TakeSnapshot()
+                : progress.Snapshot();
         }
-
-        if (task is { IsCompletedSuccessfully: true })
-            return task.Result;
-
-        return progress?.Snapshot() ?? default;
     }
 
     /// <summary>
@@ -435,95 +457,165 @@ public static class CoreCache
     private static void RecordCacheMiss()
     {
         InfoTracker.RecordCacheMiss();
-        _ = RequestVersionedCategoryCleanupAsync();
     }
 
     /// <summary>
-    /// Returns the single versioned-category cleanup task used by cache-miss
-    /// maintenance so callers can observe or drain the real operation.
+    /// Returns the aggregate versioned-category cleanup task so callers can
+    /// observe or drain the real operation.
     /// </summary>
     internal static Task<CacheMaintenanceResult> RequestVersionedCategoryCleanupAsync()
     {
         lock (s_maintenanceLock)
         {
-            if (s_versionedCategories.Count == 0)
+            if (_appName is null || s_versionedCategories.Count == 0)
                 return Task.FromResult(default(CacheMaintenanceResult));
 
-            string root = GetBasePath();
+            foreach (VersionedCacheCategory category in s_versionedCategories.Values)
+                ScheduleVersionedCategoryCleanup(category);
 
-            if (s_maintenanceTask is { IsFaulted: false, IsCanceled: false })
-                return s_maintenanceTask;
-
-            VersionedCacheCategory[] categories = [.. s_versionedCategories];
-            s_maintenanceCts?.Dispose();
-            s_maintenanceCts = new CancellationTokenSource();
-            s_maintenanceProgress = new CacheMaintenanceProgress();
-            var token = s_maintenanceCts.Token;
-            var progress = s_maintenanceProgress;
-            s_maintenanceTask = s_maintenanceRequests.GetOrAddAsync(
-                root,
-                _ => Task.Run(
-                    () => CleanupVersionedCategories(
-                        root,
-                        categories,
-                        token,
-                        progress),
-                    CancellationToken.None));
-            return s_maintenanceTask;
+            return s_maintenanceTask ??= AwaitMaintenanceAsync(
+                [.. s_maintenanceTasks.Values],
+                s_maintenanceProgress!);
         }
     }
 
-    private static CacheMaintenanceResult CleanupVersionedCategories(
+    private static void ScheduleVersionedCategoryCleanup(
+        VersionedCacheCategory category)
+    {
+        if (_appName is null)
+            return;
+
+        StartNewMaintenanceGenerationIfCanceled();
+        string root = GetBasePath();
+        var key = new VersionedCacheCleanupKey(
+            root,
+            category.Prefix,
+            category.CurrentVersion);
+        if (s_maintenanceTasks.ContainsKey(key))
+            return;
+
+        s_maintenanceCts ??= new CancellationTokenSource();
+        s_maintenanceProgress ??= new CacheMaintenanceProgress();
+        CancellationToken token = s_maintenanceCts.Token;
+        CacheMaintenanceProgress progress = s_maintenanceProgress;
+        s_maintenanceTasks.Add(
+            key,
+            Task.Run(
+                () => CleanupVersionedCategory(
+                    root,
+                    category,
+                    token,
+                    progress),
+                CancellationToken.None));
+        s_maintenanceTask = null;
+    }
+
+    private static void StartNewMaintenanceGenerationIfCanceled()
+    {
+        if (s_maintenanceCts is not { IsCancellationRequested: true })
+            return;
+
+        try
+        {
+            Task.WaitAll([.. s_maintenanceTasks.Values]);
+        }
+        catch
+        {
+            // The replacement generation still needs to run after best-effort maintenance.
+        }
+
+        CacheMaintenanceResult carriedProgress =
+            s_maintenanceProgress?.TakeSnapshot() ?? default;
+        s_maintenanceCts.Dispose();
+        s_maintenanceCts = new CancellationTokenSource();
+        s_maintenanceTask = null;
+        s_maintenanceProgress = new CacheMaintenanceProgress();
+        s_maintenanceProgress.Record(carriedProgress);
+        s_maintenanceTasks = [];
+    }
+
+    private static async Task<CacheMaintenanceResult> AwaitMaintenanceAsync(
+        Task[] tasks,
+        CacheMaintenanceProgress progress)
+    {
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+        return progress.Snapshot();
+    }
+
+    private static void CleanupVersionedCategory(
         string root,
-        IReadOnlyList<VersionedCacheCategory> categories,
+        VersionedCacheCategory category,
         CancellationToken cancellationToken,
         CacheMaintenanceProgress progress)
     {
         if (!Directory.Exists(root))
-            return progress.Snapshot();
+            return;
 
-        foreach (var category in categories)
+        string[] directories;
+        try
+        {
+            directories = Directory.GetDirectories(root);
+        }
+        catch
+        {
+            return;
+        }
+
+        foreach (string directory in directories)
         {
             if (cancellationToken.IsCancellationRequested)
-                return progress.Snapshot();
+                return;
 
-            string[] directories;
             try
             {
-                directories = Directory.GetDirectories(root, $"{category.Prefix}*");
-            }
-            catch
-            {
-                continue;
-            }
-
-            foreach (var directory in directories)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                    return progress.Snapshot();
-
                 var name = Path.GetFileName(directory);
-                if (name.Equals(category.Current, StringComparison.OrdinalIgnoreCase))
-                    continue;
                 if (!name.StartsWith(category.Prefix, StringComparison.OrdinalIgnoreCase))
                     continue;
+                ReadOnlySpan<char> suffix = name.AsSpan(category.Prefix.Length);
+                // A newer executable may run beside or before this one, so a
+                // downgrade must preserve contracts it does not understand.
+                if (!int.TryParse(
+                    suffix,
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out int version)
+                    || version >= category.CurrentVersion)
+                {
+                    continue;
+                }
+
                 if (!IsSameOrChildPath(directory, root))
                     continue;
 
                 var size = GetDirectorySizeBestEffort(directory);
-                try
-                {
-                    Directory.Delete(directory, recursive: true);
-                    progress.RecordDeletion(size);
-                }
-                catch
-                {
-                    // Cache cleanup is best-effort.
-                }
+                Directory.Delete(directory, recursive: true);
+                progress.RecordDeletion(size);
+            }
+            catch
+            {
+                // Cache cleanup is best-effort and retried on the next initialization.
             }
         }
+    }
 
-        return progress.Snapshot();
+    private static VersionedCacheCategory CreateVersionedCacheCategory(
+        string prefix,
+        string current)
+    {
+        if (!current.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            || !int.TryParse(
+                current.AsSpan(prefix.Length),
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out int currentVersion))
+        {
+            throw new ArgumentException(
+                $"Current cache category '{current}' must be the prefix '{prefix}' "
+                + "followed by a non-negative integer contract version.",
+                nameof(current));
+        }
+
+        return new VersionedCacheCategory(prefix, current, currentVersion);
     }
 
     private static long GetDirectorySizeBestEffort(string path)
@@ -561,7 +653,15 @@ public static class CoreCache
 
 public readonly record struct CacheMaintenanceResult(long BytesFreed, int DirectoriesDeleted);
 
-internal readonly record struct VersionedCacheCategory(string Prefix, string Current);
+internal readonly record struct VersionedCacheCategory(
+    string Prefix,
+    string Current,
+    int CurrentVersion);
+
+internal readonly record struct VersionedCacheCleanupKey(
+    string Root,
+    string Prefix,
+    int CurrentVersion);
 
 internal sealed class CacheMaintenanceProgress
 {
@@ -574,10 +674,21 @@ internal sealed class CacheMaintenanceProgress
         Interlocked.Increment(ref _directoriesDeleted);
     }
 
+    public void Record(CacheMaintenanceResult result)
+    {
+        Interlocked.Add(ref _bytesFreed, result.BytesFreed);
+        Interlocked.Add(ref _directoriesDeleted, result.DirectoriesDeleted);
+    }
+
     public CacheMaintenanceResult Snapshot()
         => new(
             Interlocked.Read(ref _bytesFreed),
             Volatile.Read(ref _directoriesDeleted));
+
+    public CacheMaintenanceResult TakeSnapshot()
+        => new(
+            Interlocked.Exchange(ref _bytesFreed, 0),
+            Interlocked.Exchange(ref _directoriesDeleted, 0));
 }
 
 /// <summary>

--- a/src/DotnetInspector.Services/PackageCacheService.cs
+++ b/src/DotnetInspector.Services/PackageCacheService.cs
@@ -65,9 +65,7 @@ public static class PackageCacheService
     /// </summary>
     public static long ClearCache()
     {
-        long totalFreed = 0;
-
-        totalFreed += DeleteCacheDirectory(NuGetCache.GetAppCacheBasePath());
+        long totalFreed = CoreCache.Clear();
 
         // Clean up legacy cache location (pre-XDG: ~/.local/share/dotnet-inspect)
         var legacyPath = CoreCache.GetLegacyBasePath();
@@ -84,7 +82,14 @@ public static class PackageCacheService
             return 0;
 
         var (size, _) = GetDirectoryStats(path);
-        Directory.Delete(path, recursive: true);
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch (DirectoryNotFoundException) when (!Directory.Exists(path))
+        {
+            // Another process completed the same cache deletion.
+        }
         return size;
     }
 

--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -208,6 +208,23 @@ public class CacheCommandTests : IDisposable
     }
 
     [Fact]
+    public async Task InitializeSameRoot_PreservesMaintenanceAccounting()
+    {
+        string prefix = $"same-root-accounting-{Guid.NewGuid():N}-v";
+        string current = prefix + "2";
+        var oldDir = Path.Combine(_cacheBasePath, prefix + "1");
+        Directory.CreateDirectory(oldDir);
+        File.WriteAllText(Path.Combine(oldDir, "old.txt"), new string('x', 4096));
+
+        CoreCache.RegisterVersionedCategory(prefix, current);
+        await CoreCache.RequestVersionedCategoryCleanupAsync();
+
+        NuGetCache.Initialize(_appName, basePath: _cacheBasePath);
+
+        Assert.True(PackageCacheService.ClearCache() >= 4096);
+    }
+
+    [Fact]
     public async Task Initialize_CleansPriorPackageContentContract()
     {
         var oldDir = Path.Combine(_cacheBasePath, "package-content-v4");

--- a/src/dotnet-inspect.Tests/CacheCommandTests.cs
+++ b/src/dotnet-inspect.Tests/CacheCommandTests.cs
@@ -3,6 +3,7 @@ using DotnetInspector.Core;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Packages;
+using DotnetInspector.Services;
 using DotnetInspector.Views;
 using Markout;
 using System.Text.Json;
@@ -113,26 +114,122 @@ public class CacheCommandTests : IDisposable
     }
 
     [Fact]
-    public async Task CacheMiss_CleansObsoleteVersionedCategories()
+    public void ClearCache_CoordinatesWithVersionedMaintenance()
     {
-        var oldDir = Path.Combine(_cacheBasePath, "pkg-index-v9");
-        var currentDir = Path.Combine(_cacheBasePath, PackageIndexCache.Category);
+        string prefix = $"clear-race-{Guid.NewGuid():N}-v";
+        string current = prefix + "2";
+        var oldDir = Path.Combine(_cacheBasePath, prefix + "1");
+        var currentDir = Path.Combine(_cacheBasePath, current);
         Directory.CreateDirectory(oldDir);
         Directory.CreateDirectory(currentDir);
+        for (int i = 0; i < 256; i++)
+        {
+            File.WriteAllText(
+                Path.Combine(oldDir, $"{i}.txt"),
+                new string('x', 1024));
+        }
+        File.WriteAllText(Path.Combine(currentDir, "current.txt"), "keep");
+
+        CoreCache.RegisterVersionedCategory(prefix, current);
+        long freed = PackageCacheService.ClearCache();
+
+        Assert.False(Directory.Exists(_cacheBasePath));
+        Assert.True(freed >= 256 * 1024);
+        Assert.Equal(0, PackageCacheService.ClearCache());
+    }
+
+    [Fact]
+    public async Task CategoryClear_DoesNotConsumeMaintenanceAccounting()
+    {
+        string prefix = $"category-clear-accounting-{Guid.NewGuid():N}-v";
+        string current = prefix + "2";
+        var oldDir = Path.Combine(_cacheBasePath, prefix + "1");
+        Directory.CreateDirectory(oldDir);
+        File.WriteAllText(Path.Combine(oldDir, "old.txt"), new string('x', 4096));
+
+        CoreCache.RegisterVersionedCategory(prefix, current);
+        await CoreCache.RequestVersionedCategoryCleanupAsync();
+
+        Assert.Equal(0, CoreCache.Clear("metadata"));
+        Assert.True(CoreCache.Clear() >= 4096);
+    }
+
+    [Fact]
+    public async Task RegisteringVersionedCategory_CleansOnlyOlderContracts()
+    {
+        string prefix = $"registration-clean-{Guid.NewGuid():N}-v";
+        string current = prefix + "3";
+        var oldDir = Path.Combine(_cacheBasePath, prefix + "2");
+        var currentDir = Path.Combine(_cacheBasePath, current);
+        var futureDir = Path.Combine(_cacheBasePath, prefix + "4");
+        var malformedDir = Path.Combine(_cacheBasePath, prefix + "preview");
+        Directory.CreateDirectory(oldDir);
+        Directory.CreateDirectory(currentDir);
+        Directory.CreateDirectory(futureDir);
+        Directory.CreateDirectory(malformedDir);
         File.WriteAllText(Path.Combine(oldDir, "old.txt"), new string('x', 4096));
         File.WriteAllText(Path.Combine(currentDir, "current.txt"), "keep");
 
-        CoreCache.RegisterVersionedCategory("pkg-index-v", PackageIndexCache.Category);
+        CoreCache.RegisterVersionedCategory(prefix, current);
+        await WaitForDeletionAsync(oldDir);
 
-        Assert.Null(CoreCache.TryGet("versions", $"missing-{Guid.NewGuid():N}", extension: "txt"));
         var cleanup = CoreCache.RequestVersionedCategoryCleanupAsync();
         Assert.Same(cleanup, CoreCache.RequestVersionedCategoryCleanupAsync());
         var result = await cleanup;
 
         Assert.False(Directory.Exists(oldDir));
         Assert.True(Directory.Exists(currentDir));
+        Assert.True(Directory.Exists(futureDir));
+        Assert.True(Directory.Exists(malformedDir));
         Assert.True(result.BytesFreed > 0);
         Assert.True(result.DirectoriesDeleted >= 1);
+    }
+
+    [Fact]
+    public async Task Initialize_RechecksContractsRecreatedByAnOlderTool()
+    {
+        string prefix = $"recreated-contract-{Guid.NewGuid():N}-v";
+        string current = prefix + "2";
+        var oldDir = Path.Combine(_cacheBasePath, prefix + "1");
+        Directory.CreateDirectory(oldDir);
+
+        CoreCache.RegisterVersionedCategory(prefix, current);
+        await CoreCache.RequestVersionedCategoryCleanupAsync();
+        Assert.False(Directory.Exists(oldDir));
+
+        Directory.CreateDirectory(oldDir);
+        File.WriteAllText(Path.Combine(oldDir, "recreated.txt"), "stale");
+
+        NuGetCache.Initialize(_appName, basePath: _cacheBasePath);
+        await WaitForDeletionAsync(oldDir);
+        await CoreCache.RequestVersionedCategoryCleanupAsync();
+
+        Assert.False(Directory.Exists(oldDir));
+    }
+
+    [Fact]
+    public async Task Initialize_CleansPriorPackageContentContract()
+    {
+        var oldDir = Path.Combine(_cacheBasePath, "package-content-v4");
+        Directory.CreateDirectory(oldDir);
+        File.WriteAllText(Path.Combine(oldDir, "stale.txt"), "stale");
+
+        NuGetCache.Initialize(_appName, basePath: _cacheBasePath);
+        await WaitForDeletionAsync(oldDir);
+        await CoreCache.RequestVersionedCategoryCleanupAsync();
+
+        Assert.False(Directory.Exists(oldDir));
+    }
+
+    [Fact]
+    public void RegisterVersionedCategory_RequiresNumericContract()
+    {
+        string prefix = $"invalid-contract-{Guid.NewGuid():N}-v";
+
+        var error = Assert.Throws<ArgumentException>(
+            () => CoreCache.RegisterVersionedCategory(prefix, prefix + "preview"));
+
+        Assert.Contains("non-negative integer contract version", error.Message);
     }
 
     [Fact]
@@ -150,6 +247,18 @@ public class CacheCommandTests : IDisposable
         });
 
         Assert.Empty(error);
+    }
+
+    private static async Task WaitForDeletionAsync(string path)
+    {
+        for (int attempt = 0; attempt < 100 && Directory.Exists(path); attempt++)
+        {
+            await Task.Delay(
+                TimeSpan.FromMilliseconds(10),
+                TestContext.Current.CancellationToken);
+        }
+
+        Assert.False(Directory.Exists(path), $"Expected cache cleanup to delete '{path}'.");
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/PackageIndexCacheTests.cs
+++ b/src/dotnet-inspect.Tests/PackageIndexCacheTests.cs
@@ -7,6 +7,7 @@ using InertText;
 
 namespace DotnetInspector.Tests;
 
+[Collection("Console")]
 public sealed class PackageIndexCacheTests
 {
     public PackageIndexCacheTests()

--- a/src/dotnet-inspect.Tests/UntrustedArgumentDiagnosticContainmentTests.cs
+++ b/src/dotnet-inspect.Tests/UntrustedArgumentDiagnosticContainmentTests.cs
@@ -172,11 +172,16 @@ public class UntrustedArgumentDiagnosticContainmentTests : IDisposable
     /// diagnostic assertion order-dependent (#3726).
     /// </remarks>
     [Fact]
-    public void ChildCli_UsesThePerTestCache()
+    public void ChildCli_UsesThePerTestCacheAndCleansSilently()
     {
+        string obsolete = Path.Combine(_cacheDirectory, "package-content-v4");
+        Directory.CreateDirectory(obsolete);
+        File.WriteAllText(Path.Combine(obsolete, "stale.txt"), "stale");
+
         var (output, error) = RunCli(["cache", "--json", "-T:q"]);
 
         Assert.Empty(error);
+        Assert.False(Directory.Exists(obsolete));
         using var document = JsonDocument.Parse(output);
         Assert.Equal(
             _cacheDirectory,

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -286,12 +286,7 @@ try
         #pragma warning restore RS0030
     }
 
-    var cacheMaintenance = CoreCache.CancelAndWaitForMaintenance(TimeSpan.FromMilliseconds(100));
-    if (cacheMaintenance.BytesFreed > 0)
-    {
-        CommandError.WriteBlankLine();
-        CommandError.WriteLine($"Removed {CacheOutputFormatter.FormatSize(cacheMaintenance.BytesFreed)} from obsolete cache entries.");
-    }
+    _ = CoreCache.CancelAndWaitForMaintenance(TimeSpan.FromMilliseconds(100));
 
     return exitCode;
 }

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -324,7 +324,7 @@
 
 ### Cache
 
-- Cleans obsolete versioned cache categories, such as older package-index schema caches, in the background after cache misses.
+- Silently cleans older versioned cache categories in the background when each family registers, while preserving cache contracts created by newer tool versions.
 - Cache deletion paths are guarded so cache clearing and cleanup refuse to delete outside the active or legacy dotnet-inspect cache roots.
 
 ### Lowered C# output


### PR DESCRIPTION
## Summary

- start best-effort cleanup when each numeric versioned cache family registers
- recheck known families whenever the cache root initializes, without trusting a persisted watermark
- delete only lower contracts while preserving current, future, and malformed directory suffixes
- keep routine cleanup silent and coordinate explicit `cache clear` with in-flight maintenance
- preserve accurate reclaimed-byte accounting across background cleanup, category clears, repeated clears, cancellation rollover, and same-root reinitialization

## Why

Versioned cache contracts prevent incompatible reads, but the retired directories continued consuming disk until a later cache miss happened to trigger cleanup. A persisted high-water mark is not sufficient: an older dotnet-inspect process can recreate an old contract after a newer process removes it. Rechecking the small set of root-level category directories on initialization makes the cache self-cleaning without allowing an older executable to delete a future contract.

## Concurrency and process exit

Each registered cache family schedules one `Task.Run` cleanup for the active `(root, prefix, current contract)` generation. Family tasks may run concurrently, and an aggregate task represents the generation for draining and accounting. Registration, root changes, generation rollover, and active-root clearing use one lock so no task can be abandoned while another operation changes or deletes its root.

Routine commands do **not** wait for the whole cleanup to finish. At normal command exit, `Program`:

1. gives the aggregate cleanup task up to 100 ms to finish;
2. requests cancellation if it is still running; and
3. gives cancellation another 25 ms to settle.

Cleanup checks cancellation between category directories and again after sizing a directory but before deleting it. `Directory.Delete(..., recursive: true)` is synchronous and cannot itself be cancelled once entered. If that call is still running after the bounded shutdown grace, its thread-pool worker does not keep the process alive; process exit may leave partial stale content, which the next initialization safely retries. Routine cache maintenance therefore adds at most the bounded shutdown grace rather than making tool exit depend on deletion completion.

Two operations intentionally wait without that shutdown bound:

- `dotnet-inspect cache clear` drains maintenance before deleting the active root. The command promises that clearing is complete and must report bytes reclaimed by both paths accurately.
- A reusable host that calls `CoreCache.Initialize` again drains the prior generation before publishing a different root. The CLI initializes once, so this is not part of normal command exit.

## Safety

Only direct child directories with the registered prefix and a strictly lower numeric suffix are eligible. Current, future, and malformed suffixes are preserved, so an older executable cannot delete a newer contract. Cleanup scans on every initialization rather than trusting a watermark because an older concurrent process can recreate a stale contract after cleanup. Routine cleanup is silent; `cache clear` remains the explicit reporting surface.

## Validation

- full `dotnet-inspect.Tests`: 3,110 tests, 0 failures
- full `DotnetInspector.Services.Tests`: 408 tests, 0 failures
- Release solution build
- net10 fallback build
- markdownlint
- mutation gates for eager scheduling, future-version preservation, initialization recheck, and silent output
- 4,000-file out-of-process `cache clear` race/accounting stress
- multiple adversarial rounds; exact head finished with no actionable findings
