### PR TITLE
Restore the CSharpText conditional corpus gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,10 +507,8 @@ jobs:
       - name: Run CLI tests (fast)
         run: dotnet run --project src/dotnet-inspect.Tests -c Release -- -trait- "Speed=Slow"
 
-      # #3887 tracks the lost conditional-corpus input. Keep the rest of the
-      # CSharpText suite gated while that non-vacuity failure remains visible.
       - name: Run CSharpText tests
-        run: dotnet run --project tests/CSharpText.Tests -c Release -- -method- "CSharpText.Tests.DeclarationIndexTests.InAConditionalFile_EveryDeclarationOutsideTheConditionals_IsStillVouchedFor"
+        run: dotnet run --project tests/CSharpText.Tests -c Release
 
       - name: Run instruction-substrate tests
         run: dotnet run --project src/ILInspector.Instructions.Tests -c Release
@@ -647,11 +645,9 @@ jobs:
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: dotnet run --project src/dotnet-inspect.Tests -c Release
 
-      # #3887 tracks the lost conditional-corpus input. Keep the rest of the
-      # CSharpText suite gated while that non-vacuity failure remains visible.
       - name: Run CSharpText tests
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project tests/CSharpText.Tests -c Release -- -method- "CSharpText.Tests.DeclarationIndexTests.InAConditionalFile_EveryDeclarationOutsideTheConditionals_IsStillVouchedFor"
+        run: dotnet run --project tests/CSharpText.Tests -c Release
 
       # Covers #3496 and #3509. Both classes involved (StringSwitchRaisingTests,
       # CorpusSensorComparisonTests) are in the fast subset, so the slow gates

--- a/tests/CSharpText.Tests/ConditionalCorpusFixture.cs
+++ b/tests/CSharpText.Tests/ConditionalCorpusFixture.cs
@@ -1,0 +1,23 @@
+namespace CSharpText.Tests;
+
+internal static class ConditionalCorpusFixture
+{
+    internal static int Before() => 0;
+
+#if CONDITIONAL_CORPUS_FEATURE
+    internal static int SelectedBranch() => 1;
+#else
+    internal static int SelectedBranch() => 2;
+#endif
+
+    internal static int After() => 3;
+
+    internal static int ContainsConditional()
+    {
+#if CONDITIONAL_CORPUS_FEATURE
+        return 4;
+#else
+        return 5;
+#endif
+    }
+}

--- a/tests/CSharpText.Tests/DeclarationIndexTests.cs
+++ b/tests/CSharpText.Tests/DeclarationIndexTests.cs
@@ -21,6 +21,8 @@ namespace CSharpText.Tests;
 /// </remarks>
 public class DeclarationIndexTests
 {
+    private const string StableConditionalCorpusFile = "ConditionalCorpusFixture.cs";
+
     [Fact]
     public void EveryDeclarationRoslynReports_IsReportedIdenticallyByTheIndex()
     {
@@ -92,6 +94,7 @@ public class DeclarationIndexTests
         int inside = 0;
         int containing = 0;
         int containingVouched = 0;
+        bool stableFixtureCovered = false;
 
         foreach (var file in ConditionalCorpus())
         {
@@ -101,6 +104,9 @@ public class DeclarationIndexTests
                 continue;
 
             files++;
+            stableFixtureCovered |= Path.GetFileName(file).Equals(
+                StableConditionalCorpusFile,
+                StringComparison.Ordinal);
 
             var actual = DeclarationIndex.Build(lines).Declarations.ToList();
 
@@ -159,11 +165,12 @@ public class DeclarationIndexTests
             }
         }
 
-        // Non-vacuity, and it is load-bearing twice over. The first two floors catch a corpus that
-        // stopped containing conditional files at all, which would make this gate pass by
-        // comparing nothing -- the precise way its predecessor failed. The third asserts the
-        // population it is *not* comparing is non-empty too, so a change that quietly widened the
-        // skip until every declaration fell inside a region could not pass here.
+        // Non-vacuity, and it is load-bearing twice over. The owned fixture keeps this gate from
+        // depending only on incidental directives elsewhere in the repository. The population
+        // floors prevent that fixture from replacing the broad real-source corpus, which would
+        // make a green result much weaker. The inside floor asserts the population this test is
+        // deliberately not comparing is non-empty too, so quietly widening the skip cannot pass.
+        Assert.True(stableFixtureCovered, $"{StableConditionalCorpusFile} was not compared");
         Assert.True(files >= 5, $"no conditional corpus to gate anything: {files} files");
         Assert.True(compared >= 300, $"conditional corpus too small to gate anything: {compared} declarations");
         Assert.True(inside > 0, $"the skip is vacuous: no declaration touched a conditional region");
@@ -3476,10 +3483,9 @@ public class DeclarationIndexTests
     /// <summary>
     /// <para>
     /// The files carrying a conditional directive, which is a different corpus from
-    /// <see cref="Corpus"/> and has to be, because this repository has almost none:
-    /// five files in fourteen hundred, and not one of them is in this test binary's
-    /// dependency closure, so the PDB-discovered corpus contains zero. A gate built on that
-    /// corpus would pass by comparing nothing.
+    /// <see cref="Corpus"/> and has to be, because this repository has almost none. The owned
+    /// fixture is in this test binary's dependency closure, but the broad population is not, so
+    /// the PDB-discovered corpus is too small to gate the recovery behavior on its own.
     /// </para>
     /// <para>
     /// The <c>#if</c> text search is a candidate filter, not the answer -- Roslyn confirms every

--- a/tests/CSharpText.Tests/ScanTokenTests.cs
+++ b/tests/CSharpText.Tests/ScanTokenTests.cs
@@ -1270,22 +1270,11 @@ public class ScanTokenTests
         // to be decomposed, and to have exercised every kind the corpus can produce.
         Assert.True(tokenCount > lineCount * 3, $"{tokenCount} tokens over {lineCount} lines is too coarse to be a real decomposition.");
 
-        var expected = Enum.GetValues<ScanTokenKind>().Except(KindsTheCorpusCannotReach).ToHashSet();
+        // ConditionalCorpusFixture makes directives part of the PDB-discovered corpus, so the
+        // real-source sweep must now exercise every token kind.
+        var expected = Enum.GetValues<ScanTokenKind>().ToHashSet();
         Assert.Equal(expected, kinds);
     }
-
-    /// <summary>
-    /// Kinds no corpus file happens to contain, so the corpus cannot be what proves the scanner
-    /// emits them.
-    /// <para>
-    /// This is compared for set equality rather than merely subtracted, so the entry cannot go
-    /// stale: if a corpus assembly later gains a preprocessor directive, this test fails and the
-    /// entry should be deleted. Directives are exercised instead by
-    /// <see cref="ConditionalDirective_MarksTheDepthUnknowable"/> and
-    /// <see cref="NonConditionalDirective_LeavesTheDepthKnown"/>.
-    /// </para>
-    /// </summary>
-    private static readonly ScanTokenKind[] KindsTheCorpusCannotReach = [ScanTokenKind.Directive];
 
     private static List<string> CorpusSourceFiles()
     {


### PR DESCRIPTION
## Summary

Restores the full CSharpText gate without weakening its non-vacuity floors:

- adds an owned, compiled conditional-source fixture with declarations before, inside, after, and containing balanced conditional groups;
- requires that stable fixture to participate while retaining the existing five-file and 300-declaration broad-corpus floors;
- strengthens the PDB-source lexer census to require every token kind now that the fixture makes directives reachable;
- removes the temporary #3887 method exclusion so all 553 CSharpText tests run in both Linux and Windows CI lanes.

The missing fifth file was incidental: `ValidityCoverageReportingTests.cs` stopped using `#if` when its underlying decompiler defect was fixed. This change replaces that accidental dependency with an owned specimen rather than lowering the floor or reintroducing an unrelated conditional.

## Validation

- Full CSharpText suite: 553/553.
- Changed declaration-index and lexer corpus gates: 2/2.
- `CSharpText.csproj` retains zero project references.
- Latest `main` integrated; its `Program.cs` cache cleanup does not change the existing conditional region.

Closes #3887
