### PR TITLE
Check exact-empty sections across all libraries

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -320,6 +320,28 @@ public partial class CommandExecutionTests
         return (packagePath, tempDir);
     }
 
+    private static (string PackagePath, string TempDir) CreateLocalMixedAsyncPackage()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
+        var libDir = Path.Combine(tempDir, "content", "lib", "net10.0");
+        Directory.CreateDirectory(libDir);
+
+        var assemblyName = new AssemblyName("Empty");
+        var assemblyBuilder = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            assemblyName, typeof(object).Assembly);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name!);
+        var typeBuilder = moduleBuilder.DefineType("Empty.Type", TypeAttributes.Public);
+        typeBuilder.DefineDefaultConstructor(MethodAttributes.Public);
+        typeBuilder.CreateType();
+        assemblyBuilder.Save(Path.Combine(libDir, "A.Empty.dll"));
+
+        File.Copy(TestAssemblyPath, Path.Combine(libDir, "Z.Async.dll"));
+
+        var packagePath = Path.Combine(tempDir, "Test.MixedAsync.1.0.0.nupkg");
+        ZipFile.CreateFromDirectory(Path.Combine(tempDir, "content"), packagePath);
+        return (packagePath, tempDir);
+    }
+
     private static (string PackagePath, string TempDir) CreateLocalReadmePackage(
         string id,
         string readmeFile,
@@ -12396,6 +12418,44 @@ public partial class CommandExecutionTests
             var dataRows = lines.Where(l => !l.StartsWith("kind\t", StringComparison.Ordinal)).ToArray();
             Assert.NotEmpty(dataRows);
             Assert.All(dataRows, l => Assert.Contains(l.Split('\t')[0], kindLabels));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryCommand_TfmAll_ExactSectionTestsEveryAssemblyForData()
+    {
+        var (packagePath, tempDir) = CreateLocalMixedAsyncPackage();
+        try
+        {
+            var (emptyExit, emptyOutput, emptyError) = await RunAppAsync(
+                "library", "A.Empty.dll", "--package", packagePath,
+                "-S", "Async Methods", "--count", "--tips", "q");
+
+            Assert.Equal(0, emptyExit);
+            Assert.Equal("0", emptyOutput.Trim());
+            Assert.Empty(emptyError);
+
+            var (exit, output, error) = await RunAppAsync(
+                "library", "--package", packagePath, "--tfm", "all",
+                "-S", "Async Methods", "--tsv", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("StateMachineAsync", output);
+            Assert.Empty(error);
+
+            var (allEmptyExit, allEmptyOutput, allEmptyError) = await RunAppAsync(
+                "library", "--package", packagePath, "--tfm", "all",
+                "-S", "Resources", "--tsv", "--tips", "q");
+
+            Assert.Equal(1, allEmptyExit);
+            Assert.Empty(allEmptyOutput);
+            Assert.Equal(
+                "This section (Resources) produced no output.",
+                allEmptyError.Trim());
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -12447,6 +12447,18 @@ public partial class CommandExecutionTests
             Assert.Contains("StateMachineAsync", output);
             Assert.Empty(error);
 
+            var (markdownExit, markdownOutput, markdownError) = await RunAppAsync(
+                "library", "--package", packagePath, "--tfm", "all",
+                "-S", "Async Methods", "--markdown", "--tips", "q");
+
+            Assert.Equal(0, markdownExit);
+            Assert.StartsWith("# A.Empty", markdownOutput);
+            Assert.Contains("StateMachineAsync", markdownOutput);
+            Assert.Contains("## Libraries", markdownOutput);
+            Assert.DoesNotContain("#### Library Info", markdownOutput);
+            Assert.DoesNotContain("#### Symbols", markdownOutput);
+            Assert.Empty(markdownError);
+
             var (allEmptyExit, allEmptyOutput, allEmptyError) = await RunAppAsync(
                 "library", "--package", packagePath, "--tfm", "all",
                 "-S", "Resources", "--tsv", "--tips", "q");

--- a/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
@@ -2,7 +2,9 @@ using System.Text.Json;
 using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
+using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Sections;
 using ILInspector.Findings;
 using ILInspector.Metadata;
 
@@ -317,6 +319,47 @@ public class LibraryFindingConsumerTests
             LibraryIntegrationCatalog.RollupName,
             IntegrationSectionNames.AI));
         Assert.False(LibraryCommand.FailureAffectsSection("Custom Attributes", "Type Forwarders"));
+    }
+
+    [Fact]
+    public async Task MultiLibraryFailureWarnings_AreCorrelatedPerAssembly()
+    {
+        var failed = new LibraryInspection
+        {
+            ClassifiedMethodInspection = new FindingInspection<ClassifiedMethodObservation>.Failed(
+                new InspectionError(
+                    FindingTestData.Subject,
+                    MetadataFindings.ClassifiedMethodDescriptor,
+                    "method scan failed")),
+        };
+        var populated = new LibraryInspection
+        {
+            AsyncMethods =
+            [
+                new AsyncMethodSummary
+                {
+                    MethodName = "M",
+                    DeclaringType = "Test.Type",
+                    Signature = "Task M()",
+                },
+            ],
+        };
+        var options = new LibraryOptions
+        {
+            IncludeSections = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                SectionNames.AsyncMethods,
+            },
+        };
+
+        var (_, error) = await ConsoleCapture.RunAsync(
+            () => LibraryCommand.WarnEmptySections(
+                [failed, populated],
+                options,
+                LibrarySections.CreatePipeline()));
+
+        Assert.Contains("method scan failed", error);
+        Assert.DoesNotContain("has no data", error);
     }
 
     static void AssertFailure<T>(

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -588,9 +588,9 @@ public class LibraryCommand
                     return await WriteLibraryPrintProjectionAsync(inspection, options);
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspection, options);
-                if (RejectEmptyExactSection(inspection, options, pipeline))
+                if (RejectEmptyExactSection([inspection], options, pipeline))
                     return 1;
-                WarnEmptySections(inspection, options, pipeline);
+                WarnEmptySections([inspection], options, pipeline);
                 ExtractResourcesIfRequested(resolvedPath!, options);
                 OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
                 return IntegrityExitCode(inspection);
@@ -682,9 +682,9 @@ public class LibraryCommand
                     return await WriteLibraryPrintProjectionAsync(inspections[0], options);
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspections[0], options);
-                if (RejectEmptyExactSection(inspections[0], options, pipeline))
+                if (RejectEmptyExactSection(inspections, options, pipeline))
                     return 1;
-                WarnEmptySections(inspections[0], options, pipeline);
+                WarnEmptySections(inspections, options, pipeline);
                 if (assemblyPaths.Count > 0)
                     ExtractResourcesIfRequested(assemblyPaths[0], options);
 
@@ -762,9 +762,9 @@ public class LibraryCommand
                     return await WriteLibraryPrintProjectionAsync(inspection, options);
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspection, options);
-                if (RejectEmptyExactSection(inspection, options, pipeline))
+                if (RejectEmptyExactSection([inspection], options, pipeline))
                     return 1;
-                WarnEmptySections(inspection, options, pipeline);
+                WarnEmptySections([inspection], options, pipeline);
                 ExtractResourcesIfRequested(assemblyPath!, options);
                 OutputFormatter.WriteLibraryResult(inspection, options, pipeline);
                 return IntegrityExitCode(inspection);
@@ -2129,17 +2129,20 @@ public class LibraryCommand
             filteredSections);
     }
 
-    private static void WarnEmptySections(LibraryInspection inspection, LibraryOptions options,
+    private static void WarnEmptySections(IReadOnlyList<LibraryInspection> inspections, LibraryOptions options,
         SectionPipeline<LibraryInspection> pipeline)
     {
         if (options.Count)
             return;
 
-        var (empty, requested) = pipeline.GetEmptySections(inspection, options.Verbosity, options.IncludeSections);
-        var failures = inspection.InspectionFailures;
-        List<LibraryInspectionFailureJson> relevantFailures = failures?
+        var (empty, requested) = GetEmptySections(inspections, options, pipeline);
+        var failures = inspections
+            .SelectMany(inspection => inspection.InspectionFailures ?? [])
+            .Distinct()
+            .ToList();
+        List<LibraryInspectionFailureJson> relevantFailures = failures
             .Where(failure => empty.Any(section => FailureAffectsSection(failure.Section, section)))
-            .ToList() ?? [];
+            .ToList();
         foreach (var failure in relevantFailures)
         {
             CommandError.WriteWarning(
@@ -2158,19 +2161,45 @@ public class LibraryCommand
         }
     }
 
-    private static bool RejectEmptyExactSection(LibraryInspection inspection, LibraryOptions options,
+    private static bool RejectEmptyExactSection(IReadOnlyList<LibraryInspection> inspections, LibraryOptions options,
         SectionPipeline<LibraryInspection> pipeline)
     {
         if (options.Count || options.IncludeSections is not { Count: 1 })
             return false;
 
-        var (empty, requested) = pipeline.GetEmptySections(
-            inspection, options.Verbosity, options.IncludeSections);
+        var (empty, requested) = GetEmptySections(inspections, options, pipeline);
         if (requested != 1 || empty.Count != 1)
             return false;
 
         CommandError.WriteLine($"This section ({empty[0]}) produced no output.");
         return true;
+    }
+
+    private static (List<string> Empty, int RequestedCount) GetEmptySections(
+        IReadOnlyList<LibraryInspection> inspections,
+        LibraryOptions options,
+        SectionPipeline<LibraryInspection> pipeline)
+    {
+        if (inspections.Count == 0)
+            return ([], 0);
+
+        var (firstEmpty, requested) = pipeline.GetEmptySections(
+            inspections[0], options.Verbosity, options.IncludeSections);
+        if (inspections.Count == 1 || firstEmpty.Count == 0)
+            return (firstEmpty, requested);
+
+        var emptyInEveryInspection = firstEmpty.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        for (int i = 1; i < inspections.Count && emptyInEveryInspection.Count > 0; i++)
+        {
+            var (empty, currentRequested) = pipeline.GetEmptySections(
+                inspections[i], options.Verbosity, options.IncludeSections);
+            emptyInEveryInspection.IntersectWith(empty);
+            requested = Math.Max(requested, currentRequested);
+        }
+
+        return (
+            firstEmpty.Where(emptyInEveryInspection.Contains).ToList(),
+            requested);
     }
 
     internal static bool FailureAffectsSection(string failureSection, string section)

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -2129,7 +2129,7 @@ public class LibraryCommand
             filteredSections);
     }
 
-    private static void WarnEmptySections(IReadOnlyList<LibraryInspection> inspections, LibraryOptions options,
+    internal static void WarnEmptySections(IReadOnlyList<LibraryInspection> inspections, LibraryOptions options,
         SectionPipeline<LibraryInspection> pipeline)
     {
         if (options.Count)
@@ -2137,20 +2137,24 @@ public class LibraryCommand
 
         var (empty, requested) = GetEmptySections(inspections, options, pipeline);
         var failures = inspections
-            .SelectMany(inspection => inspection.InspectionFailures ?? [])
+            .SelectMany(inspection =>
+            {
+                var (inspectionEmpty, _) = pipeline.GetEmptySections(
+                    inspection, options.Verbosity, options.IncludeSections);
+                return (inspection.InspectionFailures ?? [])
+                    .Where(failure => inspectionEmpty.Any(
+                        section => FailureAffectsSection(failure.Section, section)));
+            })
             .Distinct()
             .ToList();
-        List<LibraryInspectionFailureJson> relevantFailures = failures
-            .Where(failure => empty.Any(section => FailureAffectsSection(failure.Section, section)))
-            .ToList();
-        foreach (var failure in relevantFailures)
+        foreach (var failure in failures)
         {
             CommandError.WriteWarning(
                 $"{failure.Section} inspection failed ({failure.Finding}): {failure.Reason}");
         }
 
         var unexplained = empty
-            .Where(section => !relevantFailures.Any(
+            .Where(section => !failures.Any(
                 failure => FailureAffectsSection(failure.Section, section)))
             .ToList();
         if (unexplained.Count > 0 && empty.Count == requested)

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -522,21 +522,11 @@ public static class OutputFormatter
     {
         bool selectAll = SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
         bool topFieldsOnly = ShouldRenderLibraryContext(options);
-        var report = new LibraryInspectionReport
-        {
-            Title = Path.GetFileNameWithoutExtension(inspections[0].FileName),
-            Assemblies = inspections.Select(a => new LibraryInspectionView(a, topFieldsOnly)).ToList()
-        };
-        var writerOptions = new MarkoutWriterOptions
-        {
-            IncludeSections = pipeline.ComputeIncludeSections(
-                inspections[0], options.Verbosity, options.IncludeSections, selectAll, options.FixedOverview),
-            Projection = BuildProjection(options.Columns, options.Fields)
-        };
 
         if (options.Count)
         {
-            var markdown = MarkoutSerializer.Serialize(report, InspectionContext.Default, writerOptions);
+            var markdown = SerializeLibraryResultsMarkdown(
+                inspections, options, pipeline, selectAll, topFieldsOnly);
             markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.AlphabeticalSectionOrder);
             markdown = MarkdownTableRowLimiter.Apply(markdown, options.Rows);
             var ordered = ResolveCountMapSections(pipeline, options.IncludeSections, options.FixedOverview);
@@ -559,7 +549,8 @@ public static class OutputFormatter
 
         if (options.VerbosityEnabled)
         {
-            var markdown = MarkoutSerializer.Serialize(report, InspectionContext.Default, writerOptions).TrimEnd();
+            var markdown = SerializeLibraryResultsMarkdown(
+                inspections, options, pipeline, selectAll, topFieldsOnly);
             markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.AlphabeticalSectionOrder);
             Console.WriteLine(MarkdownTableRowLimiter.Apply(markdown, options.Rows));
         }
@@ -579,6 +570,41 @@ public static class OutputFormatter
                 WriteLibraryTabular(auditView, inspection, writerOpts, options);
             }
         }
+    }
+
+    private static string SerializeLibraryResultsMarkdown(
+        IReadOnlyList<LibraryInspection> inspections,
+        LibraryOptions options,
+        SectionPipeline<LibraryInspection> pipeline,
+        bool selectAll,
+        bool topFieldsOnly)
+    {
+        var header = new StringWriter { NewLine = "\n" };
+        var writer = MarkoutWriter.Create(header, new MarkdownFormatter());
+        writer.WriteHeading(
+            1,
+            LibraryViewText.Contain(Path.GetFileNameWithoutExtension(inspections[0].FileName))
+                ?? string.Empty);
+        writer.WriteHeading(2, "Libraries");
+
+        List<string> documents = [header.ToString().TrimEnd()];
+        foreach (var inspection in inspections)
+        {
+            var auditView = new LibraryInspectionView(inspection, topFieldsOnly);
+            var writerOptions = new MarkoutWriterOptions
+            {
+                IncludeSections = pipeline.ComputeIncludeSections(
+                    inspection, options.Verbosity, options.IncludeSections, selectAll, options.FixedOverview),
+                Projection = BuildProjection(options.Columns, options.Fields),
+                HeadingLevelOffset = 2,
+            };
+            documents.Add(
+                MarkoutSerializer.Serialize(
+                    auditView, InspectionContext.Default, writerOptions)
+                    .TrimEnd());
+        }
+
+        return string.Join("\n\n", documents);
     }
 
     /// <summary>


### PR DESCRIPTION
Exact-empty validation now evaluates the whole multi-assembly document instead of only its first inspection. A selected section renders when any assembly has rows, and fails only when every assembly is empty.

Markdown output now composes each assembly with its own effective section filter under the package's `Libraries` heading. This preserves the report hierarchy while ensuring a populated later assembly renders without leaking unrequested sections. Row-oriented formats retain their existing per-assembly rendering.

The same document-level decision governs empty-section notes: a populated later assembly no longer appears alongside a false note that the selected section has no data. Inspection failures remain correlated per assembly, so a failure in one assembly is still visible even when another assembly renders the requested section. Duplicate identical failures are reported once.

A deterministic local package fixture puts an empty assembly first and the test assembly with async methods second. It pins both sides:

- `-S "Async Methods" --tsv` and `--markdown` exit 0 and emit the later assembly's rows.
- Markdown retains the package/library hierarchy and does not leak `Library Info` or `Symbols`.
- `-S Resources --tsv` still exits 1 with empty stdout when every assembly is empty.
- The first assembly's zero count is asserted to keep the regression fixture non-vacuous.
- A synthetic mixed-inspection test pins failure visibility when a later assembly has data.

Compatibility boundary: single-assembly behavior is unchanged. Singleton `--count`, wildcard provenance (#3886), and multi-assembly reference trees (#3885) are separate paths and remain out of scope.

Validation:

- Release solution build succeeds.
- Full CLI and inspection-workspace query suites pass.
- Real package canary: `Microsoft.NETCore.App.Runtime.linux-x64@10.0.0 --tfm all -S "Async Methods" --tsv` exits 0 with 269 lines and no stderr (regressed head exited 1 with empty stdout).

Closes #3884.
