### PR TITLE
Validate empty sections across all assemblies

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -12404,6 +12404,54 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_TfmAll_ExactSectionRendersRowsFromLaterAssembly()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"section-multitfm-{Guid.NewGuid():N}");
+        try
+        {
+            var emptyAssembly = FixtureCatalog.DiffPair.OldAssemblyPath();
+            var content = Path.Combine(tempDir, "content");
+            var net8Dir = Path.Combine(content, "lib", "net8.0");
+            var net10Dir = Path.Combine(content, "lib", "net10.0");
+            Directory.CreateDirectory(net8Dir);
+            Directory.CreateDirectory(net10Dir);
+            // --tfm all orders these paths ordinally, so net10 is inspected first.
+            File.Copy(TestAssemblyPath, Path.Combine(net8Dir, "Lib.dll"));
+            File.Copy(emptyAssembly, Path.Combine(net10Dir, "Lib.dll"));
+            var packagePath = Path.Combine(tempDir, "Section.MultiTfm.1.0.0.nupkg");
+            ZipFile.CreateFromDirectory(content, packagePath);
+
+            File.Copy(emptyAssembly, Path.Combine(net8Dir, "Lib.dll"), overwrite: true);
+            var emptyPackagePath = Path.Combine(tempDir, "Section.AllEmpty.MultiTfm.1.0.0.nupkg");
+            ZipFile.CreateFromDirectory(content, emptyPackagePath);
+            var (emptyExit, emptyOutput, emptyError) = await RunAppAsync(
+                "library", "Lib.dll", "--package", emptyPackagePath, "--tfm", "all",
+                "-S", "Async Methods", "--tsv", "--tips", "q");
+            Assert.Equal(1, emptyExit);
+            Assert.Empty(emptyOutput);
+            Assert.Equal(
+                "This section (Async Methods) produced no output.",
+                emptyError.Trim());
+
+            var (exit, output, error) = await RunAppAsync(
+                "library", "Lib.dll", "--package", packagePath, "--tfm", "all",
+                "-S", "Async Methods", "--tsv", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Contains(
+                nameof(LibraryCommand_TfmAll_ExactSectionRendersRowsFromLaterAssembly),
+                output);
+            Assert.DoesNotContain(
+                "This section (Async Methods) produced no output.",
+                error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task PackageCommand_AllLibraries_AggregatesIntegrationsWithLibraryProvenance()
     {
         var (packagePath, tempDir) = CreateLocalRefPackage(

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -682,7 +682,7 @@ public class LibraryCommand
                     return await WriteLibraryPrintProjectionAsync(inspections[0], options);
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspections[0], options);
-                if (RejectEmptyExactSection(inspections[0], options, pipeline))
+                if (RejectEmptyExactSection(inspections, options, pipeline))
                     return 1;
                 WarnEmptySections(inspections[0], options, pipeline);
                 if (assemblyPaths.Count > 0)
@@ -2159,17 +2159,30 @@ public class LibraryCommand
     }
 
     private static bool RejectEmptyExactSection(LibraryInspection inspection, LibraryOptions options,
+        SectionPipeline<LibraryInspection> pipeline) =>
+        RejectEmptyExactSection([inspection], options, pipeline);
+
+    private static bool RejectEmptyExactSection(IReadOnlyList<LibraryInspection> inspections, LibraryOptions options,
         SectionPipeline<LibraryInspection> pipeline)
     {
         if (options.Count || options.IncludeSections is not { Count: 1 })
             return false;
 
-        var (empty, requested) = pipeline.GetEmptySections(
-            inspection, options.Verbosity, options.IncludeSections);
-        if (requested != 1 || empty.Count != 1)
+        string? emptySection = null;
+        foreach (var inspection in inspections)
+        {
+            var (empty, requested) = pipeline.GetEmptySections(
+                inspection, options.Verbosity, options.IncludeSections);
+            if (requested != 1 || empty.Count != 1)
+                return false;
+
+            emptySection ??= empty[0];
+        }
+
+        if (emptySection is null)
             return false;
 
-        CommandError.WriteLine($"This section ({empty[0]}) produced no output.");
+        CommandError.WriteLine($"This section ({emptySection}) produced no output.");
         return true;
     }
 


### PR DESCRIPTION
Fixes #3884.

`library --tfm all -S <exact section>` now rejects an empty result only when that section is empty across every inspected assembly. If the first assembly is empty but a later assembly has rows, rendering proceeds and returns those rows instead of exiting before the multi-assembly renderer runs.

The regression test builds a deterministic two-TFM package whose ordinally first assembly has no `Async Methods` and whose later assembly does, then pairs it with an all-empty two-TFM package to preserve the rejection boundary.

**Evidence**
- Original runtime-package repro now exits 0 and emits 269 TSV lines from later assemblies.
- `dotnet build dotnet-inspect.slnx -c Release`
- Focused exact-empty and multi-TFM Release tests: 6 passed.
- Full CLI Release suite before the final unrelated `nuget.config` base update: 3,187 total, 0 failed, 14 environment skips. Current-head CI will validate the integrated base.

**Compatibility boundary**
- Single-assembly and all-empty exact selections still exit 1.
- Counts remain unchanged.
- This does not change the broader multi-assembly document renderer tracked by #3760 or tree rendering tracked by #3885.