### PR TITLE
Raise empty local functions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -6574,6 +6574,12 @@ public sealed class DeclScopeLoopClient
 // it accepts. The declined ones must not print a call to a name they never declare.
 public static class UnraisedLocalFunctionSamples
 {
+    public static void CallsEmpty()
+    {
+        F();
+        static void F() { }
+    }
+
     // Declined: IsPrintableBody rejects a try body.
     public static int CallsUnraisedTry(int x)
     {

--- a/src/ILInspector.Decompiler.Tests/UnraisedLocalFunctionCallTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnraisedLocalFunctionCallTests.cs
@@ -158,12 +158,13 @@ public class UnraisedLocalFunctionCallTests
         var function = IrImporter.Import(
             source, type.FullName!, nameof(UnraisedLocalFunctionSamples.CallsRaisedIf));
         Assert.NotNull(function);
+        IrFunction? importedBody = null;
 
         var result = CSharpPrinter.PrintRaised(
             function!,
             method =>
             {
-                var importedBody = IrImporter.Import(source, method);
+                importedBody = IrImporter.Import(source, method);
                 Assert.NotNull(importedBody);
                 foreach (var statement in importedBody.Body.Blocks
                     .SelectMany(block => block.Children)
@@ -171,9 +172,16 @@ public class UnraisedLocalFunctionCallTests
                 {
                     statement.Detach();
                 }
+                // Preserve the admitted shape while changing only the return type.
+                var blocks = importedBody.Body.Blocks.ToArray();
+                foreach (var block in blocks.Skip(1))
+                    block.Detach();
+                blocks[0].Add(new Return(null));
                 return importedBody;
             });
         Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.NotNull(importedBody);
+        Assert.True(importedBody.Body.Blocks is [{ Children: [Return { Value: null }] }]);
         string output = result.Output!.ReplaceLineEndings("\n");
 
         Assert.DoesNotContain("static int F(", output);

--- a/src/ILInspector.Decompiler.Tests/UnraisedLocalFunctionCallTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnraisedLocalFunctionCallTests.cs
@@ -93,6 +93,95 @@ public class UnraisedLocalFunctionCallTests
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
     }
 
+    [Fact]
+    public void EmptyLocalFunction_IsRaisedAndKeepsFullFidelity()
+    {
+        var type = typeof(UnraisedLocalFunctionSamples);
+        using var source = MetadataSource.Open(type.Assembly.Location);
+        var function = IrImporter.Import(
+            source, type.FullName!, nameof(UnraisedLocalFunctionSamples.CallsEmpty));
+        Assert.NotNull(function);
+        IrFunction? importedBody = null;
+        bool importedAsSingleVoidReturn = false;
+
+        var result = CSharpPrinter.PrintRaised(
+            function!,
+            method =>
+            {
+                importedBody = IrImporter.Import(source, method);
+                importedAsSingleVoidReturn = importedBody?.Body.Blocks
+                    is [{ Children: [Return { Value: null }] }];
+                return importedBody;
+            });
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.True(importedAsSingleVoidReturn);
+        Assert.NotNull(importedBody);
+        string output = result.Output!.ReplaceLineEndings("\n").Trim();
+
+        Assert.Equal(
+            """
+            F();
+            return;
+            static void F()
+            {
+            }
+            """.ReplaceLineEndings("\n"),
+            output);
+        Assert.DoesNotContain("_g__F_", output);
+        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+    }
+
+    [Fact]
+    public void EmptyLocalFunction_WhenBodyImportFails_RemainsDeclined()
+    {
+        var type = typeof(UnraisedLocalFunctionSamples);
+        using var source = MetadataSource.Open(type.Assembly.Location);
+        var function = IrImporter.Import(
+            source, type.FullName!, nameof(UnraisedLocalFunctionSamples.CallsEmpty));
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, _ => null);
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        string output = result.Output!.ReplaceLineEndings("\n");
+
+        Assert.DoesNotContain("static void F(", output);
+        Assert.DoesNotContain("F();", output);
+        Assert.Contains("_g__F_", output);
+        Assert.Equal(DecompilationFidelity.Partial, function!.Fidelity);
+    }
+
+    [Fact]
+    public void EmptyNonVoidImportedBody_RemainsDeclined()
+    {
+        var type = typeof(UnraisedLocalFunctionSamples);
+        using var source = MetadataSource.Open(type.Assembly.Location);
+        var function = IrImporter.Import(
+            source, type.FullName!, nameof(UnraisedLocalFunctionSamples.CallsRaisedIf));
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(
+            function!,
+            method =>
+            {
+                var importedBody = IrImporter.Import(source, method);
+                Assert.NotNull(importedBody);
+                foreach (var statement in importedBody.Body.Blocks
+                    .SelectMany(block => block.Children)
+                    .ToArray())
+                {
+                    statement.Detach();
+                }
+                return importedBody;
+            });
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        string output = result.Output!.ReplaceLineEndings("\n");
+
+        Assert.DoesNotContain("static int F(", output);
+        Assert.DoesNotContain("return F(", output);
+        Assert.Contains("_g__F_", output);
+        Assert.Equal(DecompilationFidelity.Partial, function!.Fidelity);
+    }
+
     /// <summary>
     /// The gate for the no-seam boundary. Three shipped output paths print with no
     /// import seam — <c>CSharpBodyDiff</c> and two <c>ResearchViews</c> lenses — and

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -366,6 +366,11 @@ public sealed class LocalFunctionRaisingPass : IIrPass
             string name = candidate.Name;
 
             RewriteSelfCalls(body, method, name);
+            if (body.Body.Blocks is [{ Children: [Return { Value: null } trailingReturn] }]
+                && IsVoid(body.Signature.ReturnType))
+            {
+                trailingReturn.Detach();
+            }
             // The environment parameter is the last one; drop it from the source signature.
             var parameters = environment is null
                 ? body.Signature.Parameters
@@ -590,14 +595,16 @@ public sealed class LocalFunctionRaisingPass : IIrPass
 
     static bool IsPrintableBody(IrFunction body, bool allowLocalStatements = false)
     {
-        if (body.Body.Blocks is not [{ Children: var statements }] || statements.Count == 0)
+        if (body.Body.Blocks is not [{ Children: var statements }])
             return false;
 
         for (int i = 0; i < statements.Count; i++)
         {
             var statement = statements[i];
-            if (statement is Return { Value: not null })
-                return i == statements.Count - 1;
+            if (statement is Return returnStatement)
+                return i == statements.Count - 1
+                    && (returnStatement.Value is not null
+                        || i == 0 && IsVoid(body.Signature.ReturnType));
             if (statement is ExpressionStatement)
                 continue;
             if (allowLocalStatements && statement is StoreLocal)
@@ -612,6 +619,8 @@ public sealed class LocalFunctionRaisingPass : IIrPass
 
         return false;
     }
+
+    static bool IsVoid(TypeRef type) => type is { Namespace: "System", Name: "Void" };
 
     static IEnumerable<IrNode> Self(IrNode node)
     {


### PR DESCRIPTION
- Fixes #3666
- Raises compiler-produced empty `void` local functions instead of leaving an undeclared synthesized call
- Card revision: `c278e72c`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the pass now recognizes the compiler witness for an empty `void` body, while failed imports and empty non-void bodies remain declined.

### Benchmark target

Benchmark target: `ILInspector.Decompiler.Tests.dll` at `0ff89bef` / `c278e72c`

```bash
dotnet-inspect member ILInspector.Decompiler.Tests.UnraisedLocalFunctionSamples \
  --library artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll \
  -m CallsEmpty -S "Decompiled Source" --plaintext --bare
```

### Original source

```csharp
public static void CallsEmpty()
{
    F();
    static void F() { }
}
```

### Before

```csharp
public static void CallsEmpty() => __CallsEmpty_g__F_0_0();
```

- Valid: False (`CS0103`)
- Correct: False; the isolated method does not compile
- IL fidelity: not currently checkable; compile-back fails at binding
- Taste applied: None
- Commit: `0ff89bef`

### After

```csharp
public static void CallsEmpty()
{
    F();
    return;
    static void F()
    {
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: True (`Exact`, contract v3)
- Taste applied: None
- Commit: `c278e72c`

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused local-function tests | 31 passed, 1 expected red | 32 passed |
| Decompiler fast suite | 4,605 passed, 1 expected red, 8 skipped | 4,606 passed, 8 skipped |
| Pre-merge fidelity gates | Not run | 86 passed |
| Fixture compile-back | 1 Exact; `CallsEmpty` + 2 existing declined cases fail `CS0103` | 2 Exact; only the 2 existing declined cases fail `CS0103` |
| Real witness | `CallsEmpty` is an undeclared synthesized call at `Partial` | Empty `F` declaration at `Full` and `Exact` |

The positive test failed before the product change. Close negatives prove a missing import and a synthetic empty non-void body with the same terminal-null-return shape remain declined at `Partial`.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the exact-base PR quick card reports no regression.

### PR quick gate

Run: hash-stable 100 methods per assembly, 15 assemblies, 1,500 methods.

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Detected lowering residue (-) | 238 (15.87%) | 237 (15.80%) |
| Conditional-branch residue (-) | 44 (2.93%) | 43 (2.87%) |
| Forward-merge stops (-) | 28 (1.87%) | 27 (1.80%) |
| Pass bugs (-) | 0 | 0 |

The six delta rows are three added and three removed hash-sample identities in generated/self assemblies; there are no changed common-method rows.

### Render A/B

42,210 methods evaluated; 0 changed, 0 added, 0 removed, and no regressions. This sensor has no cross-method import seam, so it is population regression evidence rather than the positive local-function witness; the seam-enabled fixture and compile-back result prove the behavior change.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.UnraisedLocalFunctionCallTests -noColor`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- --gate fast -noColor`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- --gate pre-merge -noColor`
- Focused `DecompilerHarness --fidelity-check`
- Exact-base `DecompilerHarness --render-ab`
- Exact-base PR quick corpus card
