### PR TITLE
Add group-scoped Integrations query

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -587,7 +587,7 @@ Research overlay bridge, and the application layer:
 │  DotnetInspector.Queries (L1 inspection coordination)       │
 │                                                             │
 │  Workspace and binding-consistent assembly context groups   │
-│  Typed query contracts and metadata-query coordination       │
+│  Typed per-assembly and group-query coordination             │
 ├─────────────────────────────────────────────────────────────┤
 │  ILInspector.Research (Fact overlay bridge)                 │
 │                                                             │

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -56,7 +56,11 @@ executes metadata-image and direct assembly-reference queries through a typed,
 content-shaped registry over a host-owned `AssemblyInspectionSession`. The
 `References` section binds to its concrete query definition rather than a string
 scanner key, and the CLI and package convenience route lower section selection
-into that same registry.
+into that same registry. Separately, the first workspace query executes
+Integrations inspection across every participant in one binding-consistent
+assembly context group, reusing retained immutable content and returning
+per-participant evidence or failure. No command uses that group-scoped query
+yet.
 
 This is an incremental boundary, not the completed split. The remaining
 library scanners still use the transitional string-keyed `ScannerRegistry`,

--- a/docs/design/integrations.md
+++ b/docs/design/integrations.md
@@ -119,6 +119,32 @@ The model is deliberately curated. It should avoid claiming complete support
 from weak signals, and it should prefer stable, low-noise examples over exhaustive
 metadata inventory.
 
+## Group-scoped query
+
+`AssemblyContextIntegrationsQuery` is the first typed query that runs across an
+entire assembly context group. It scans each participant sequentially in group
+order and returns both ecosystem and OpenTelemetry evidence with the
+participant's opaque identity and resolution provenance. It does not deduplicate
+signals across assemblies: companion assemblies may expose different useful
+currency, and preserving the producing assembly lets later composition decide
+how to group or present it.
+
+Image acquisition rejection remains explicit beside available participant
+results, so a budget-limited group cannot look like a complete group with fewer
+integrations. Late malformed-metadata mapping is implemented but not yet
+independently gated. The query reuses the workspace's immutable snapshots and
+does not reopen paths or streams.
+`AssemblyContextIntegrationsQueryTests.RegistryRun_ScansEveryParticipantInOrderAndReusesSnapshots`
+and
+`AssemblyContextIntegrationsQueryTests.Execute_CarriesAcquisitionFailureBesideLaterResults`
+gate participant ordering, snapshot reuse, and general partial acquisition.
+`AssemblyContextIntegrationsQueryTests.Execute_ReportsBudgetExhaustionAsIncompleteEntry`
+gates the budget-limited case.
+
+This query does not yet drive `@Integrations` sections. Command migration,
+integration-opportunity composition, cancellation-aware execution, and optional
+concurrent execution remain later slices.
+
 ## Relationship to sections and categories
 
 The focused `Integration:` sections are members of the `@Integrations` section

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -21,11 +21,13 @@ prerequisite-aware registry, while the command still owns orchestration.
 `DotnetInspector.Queries` also contains the first workspace foundation: an
 ephemeral workspace can own binding-consistent assembly context groups, and a
 group retains lazily acquired immutable assembly snapshots behind
-callback-scoped and stack-only access. Existing commands have not migrated to
-that workspace owner yet. Other foundations include shared image and inspection
-session ownership, catalog generations, `CoreCache`, typed provenance and
-resolution currencies, and `InertString`; the remaining workspace model
-describes how those pieces will be composed.
+callback-scoped and stack-only access. The first group-scoped query scans
+Integrations evidence across every participant sequentially while preserving
+per-assembly identity, provenance, and failures. Existing commands have not
+migrated to that workspace owner yet. Other foundations include shared image
+and inspection session ownership, catalog generations, `CoreCache`, typed
+provenance and resolution currencies, and `InertString`; the remaining
+workspace model describes how those pieces will be composed.
 
 Mechanism-specific documents remain authoritative for the current behavior,
 target design, and verification they own. In particular:
@@ -275,8 +277,28 @@ isolation, callback and span lifetimes, concurrent disposal, bounded retention,
 per-participant single-flight acquisition, and typed acquisition failures.
 `LayeringTests.Metadata_FriendsOnlyTestAssemblies` gates the absence of
 production Metadata friends.
-Catalogs, producer sessions, authorization, and command migration remain later
-slices.
+
+`AssemblyContextIntegrationsQuery` is the first query over a complete group. It
+visits participants in their immutable input order, borrows a narrow
+`AssemblyInspectionSession` over each retained snapshot without reopening the
+source, and returns the ecosystem and OpenTelemetry evidence owned by Metadata.
+Each entry carries an opaque participant registration, assembly identity,
+resolution provenance, and either materialized evidence or a typed failure.
+Partial inspection is therefore explicit and meaningful. The query is
+`Unbounded`: the group byte budget bounds retained content, but participant
+count and metadata scanning work still require explicit demand. The baseline
+executor remains sequential; cancellation-aware and concurrent group executors
+are later policy work. Late malformed-metadata mapping is implemented but not
+yet independently gated.
+`AssemblyContextIntegrationsQueryTests.RegistryRun_ScansEveryParticipantInOrderAndReusesSnapshots`
+and
+`AssemblyContextIntegrationsQueryTests.Execute_CarriesAcquisitionFailureBesideLaterResults`
+gate participant ordering, snapshot reuse, and general partial acquisition.
+`AssemblyContextIntegrationsQueryTests.Execute_ReportsBudgetExhaustionAsIncompleteEntry`
+gates the budget-limited case.
+
+Catalogs, query authorization, integration-opportunity composition, concurrent
+execution, and command migration remain later slices.
 
 Domain catalogs operate inside a group. A catalog may advance through
 progressive generations as new candidates or binding roots are discovered while

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,10 +11,11 @@ core: workspace contexts, typed query planning, acquisition and caching, shared
 identity and provenance, owner-issued correspondence, and safe presentation
 boundaries. The first typed query-planning slices are implemented for library
 metadata-image and direct-reference inspection. `DotnetInspector.Queries` also
-contains the first workspace context foundation, but commands have not migrated
-to that owner and the remaining query families remain future work. The
-components below are the current hosts, shared substrates, and inspection
-producers that will extend that space.
+contains the first workspace context foundation and a sequential group-scoped
+Integrations query, but commands have not migrated to that owner and the
+remaining query families remain future work. The components below are the
+current hosts, shared substrates, and inspection producers that will extend
+that space.
 
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
 - `src/DotnetInspector.Queries/` contains host-neutral typed query definitions, deterministic sequential execution, prerequisite-aware cost, and the first content-shaped assembly queries. It has no Markout, console, or filesystem-path dependency.

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextIntegrationsQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextIntegrationsQueryTests.cs
@@ -1,0 +1,305 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class AssemblyContextIntegrationsQueryTests
+{
+    [Fact]
+    public void RegistryRun_ScansEveryParticipantInOrderAndReusesSnapshots()
+    {
+        var version = new AssemblyBindingPolicyVersion();
+        var policy = new TestBindingPolicy(version);
+        List<string> acquisitionOrder = [];
+        TestAssembly dependencyInjection = TestAssembly.Create(
+            "DependencyInjectionIntegration",
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            policy,
+            () => acquisitionOrder.Add("dependency injection"));
+        TestAssembly logging = TestAssembly.Create(
+            "LoggingIntegration",
+            "Microsoft.Extensions.Logging.CustomLogger",
+            policy,
+            () => acquisitionOrder.Add("logging"),
+            additionalIntegrationTypeName:
+                "OpenTelemetry.CustomTracer");
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [
+                    dependencyInjection.Participant,
+                    logging.Participant,
+                ]);
+        var registry =
+            new InspectionQueryRegistry<AssemblyContextGroup>()
+                .Add(
+                    AssemblyContextIntegrationsQuery.Definition,
+                    AssemblyContextIntegrationsQuery.Execute);
+        Assert.Equal(
+            InspectionCost.Unbounded,
+            registry.CostOf(
+                AssemblyContextIntegrationsQuery.Definition));
+
+        AssemblyContextIntegrationsResult first =
+            registry.Run(
+                    [AssemblyContextIntegrationsQuery.Definition],
+                    group)
+                .Get(AssemblyContextIntegrationsQuery.Definition);
+        AssemblyContextIntegrationsResult second =
+            registry.Run(
+                    [AssemblyContextIntegrationsQuery.Definition],
+                    group)
+                .Get(AssemblyContextIntegrationsQuery.Definition);
+
+        Assert.True(first.IsComplete);
+        Assert.True(second.IsComplete);
+        Assert.Equal(
+            ["dependency injection", "logging"],
+            acquisitionOrder);
+        Assert.Equal(1, dependencyInjection.OpenCount);
+        Assert.Equal(1, logging.OpenCount);
+
+        var dependencyInjectionResult =
+            Assert.IsType<AssemblyIntegrationsEntry.Available>(
+                first.Assemblies[0]);
+        AssertSubject(
+            dependencyInjection,
+            dependencyInjectionResult.Subject);
+        Assert.Contains(
+            dependencyInjectionResult.EcosystemSignals,
+            signal =>
+                signal.Integration
+                == EcosystemIntegrationNames.DependencyInjection);
+        Assert.Empty(
+            dependencyInjectionResult.OpenTelemetrySignals);
+
+        var loggingResult =
+            Assert.IsType<AssemblyIntegrationsEntry.Available>(
+                first.Assemblies[1]);
+        AssertSubject(logging, loggingResult.Subject);
+        Assert.Contains(
+            loggingResult.EcosystemSignals,
+            signal =>
+                signal.Integration
+                == EcosystemIntegrationNames.Logging);
+        Assert.Contains(
+            loggingResult.OpenTelemetrySignals,
+            signal =>
+                signal.Name == "OpenTelemetry.CustomTracer");
+    }
+
+    [Fact]
+    public void Execute_CarriesAcquisitionFailureBesideLaterResults()
+    {
+        var version = new AssemblyBindingPolicyVersion();
+        var policy = new TestBindingPolicy(version);
+        TestAssembly rejected = TestAssembly.Create(
+            "RejectedIntegration",
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            policy,
+            selectedName: "DifferentIdentity");
+        TestAssembly available = TestAssembly.Create(
+            "AvailableIntegration",
+            "Microsoft.Extensions.Logging.CustomLogger",
+            policy);
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [rejected.Participant, available.Participant]);
+
+        AssemblyContextIntegrationsResult result =
+            AssemblyContextIntegrationsQuery.Execute(group);
+
+        Assert.False(result.IsComplete);
+        var rejectedResult =
+            Assert.IsType<AssemblyIntegrationsEntry.Rejected>(
+                result.Assemblies[0]);
+        AssertSubject(rejected, rejectedResult.Subject);
+        Assert.Equal(
+            CandidateOpenFailureKind.InvalidImage,
+            rejectedResult.Failure.Kind);
+
+        var availableResult =
+            Assert.IsType<AssemblyIntegrationsEntry.Available>(
+                result.Assemblies[1]);
+        AssertSubject(available, availableResult.Subject);
+        Assert.Contains(
+            availableResult.EcosystemSignals,
+            signal =>
+                signal.Integration
+                == EcosystemIntegrationNames.Logging);
+        Assert.Equal(1, rejected.OpenCount);
+        Assert.Equal(1, available.OpenCount);
+    }
+
+    [Fact]
+    public void Execute_ReportsBudgetExhaustionAsIncompleteEntry()
+    {
+        var version = new AssemblyBindingPolicyVersion();
+        var policy = new TestBindingPolicy(version);
+        TestAssembly first = TestAssembly.Create(
+            "FirstIntegration",
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            policy);
+        TestAssembly second = TestAssembly.Create(
+            "SecondIntegration",
+            "Microsoft.Extensions.Logging.CustomLogger",
+            policy);
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [first.Participant, second.Participant],
+                new AssemblyContextGroupOptions
+                {
+                    MaxRetainedImageBytes = first.Bytes.Length,
+                });
+
+        AssemblyContextIntegrationsResult result =
+            AssemblyContextIntegrationsQuery.Execute(group);
+
+        Assert.False(result.IsComplete);
+        Assert.IsType<AssemblyIntegrationsEntry.Available>(
+            result.Assemblies[0]);
+        var rejected =
+            Assert.IsType<AssemblyIntegrationsEntry.Rejected>(
+                result.Assemblies[1]);
+        Assert.Equal(
+            CandidateOpenFailureKind.ResourceBudget,
+            rejected.Failure.Kind);
+    }
+
+    static void AssertSubject(
+        TestAssembly expected,
+        AssemblyContextSubject actual)
+    {
+        Assert.Same(
+            expected.Assembly.Registration,
+            actual.Registration);
+        Assert.Equal(expected.Assembly.Identity, actual.Identity);
+        Assert.Same(
+            expected.Assembly.Provenance,
+            actual.Provenance);
+    }
+
+    sealed class TestAssembly
+    {
+        int _openCount;
+        readonly Action? _onOpen;
+
+        TestAssembly(
+            byte[] bytes,
+            ResolvedAssemblyReference assembly,
+            TestBindingPolicy policy,
+            Action? onOpen)
+        {
+            Bytes = bytes;
+            Assembly = assembly;
+            Participant =
+                new AssemblyContextParticipant(assembly, policy);
+            _onOpen = onOpen;
+        }
+
+        internal byte[] Bytes { get; }
+        internal ResolvedAssemblyReference Assembly { get; }
+        internal AssemblyContextParticipant Participant { get; }
+        internal int OpenCount =>
+            Volatile.Read(ref _openCount);
+
+        internal static TestAssembly Create(
+            string assemblyName,
+            string integrationTypeName,
+            TestBindingPolicy policy,
+            Action? onOpen = null,
+            string? selectedName = null,
+            string? additionalIntegrationTypeName = null)
+        {
+            byte[] bytes =
+                BuildAssembly(
+                    assemblyName,
+                    integrationTypeName,
+                    additionalIntegrationTypeName);
+            AssemblyReferenceIdentity actualIdentity;
+            using (var peReader =
+                   new PEReader(new MemoryStream(bytes, writable: false)))
+            {
+                actualIdentity =
+                    AssemblyReferenceIdentity.FromAssemblyDefinition(
+                        peReader.GetMetadataReader());
+            }
+
+            var selectedIdentity = actualIdentity with
+            {
+                Name = selectedName ?? actualIdentity.Name,
+            };
+            TestAssembly? source = null;
+            ResolvedAssemblyReference assembly =
+                ResolvedAssemblyReference.Create(
+                    selectedIdentity,
+                    path: null,
+                    () =>
+                    {
+                        Interlocked.Increment(
+                            ref source!._openCount);
+                        source._onOpen?.Invoke();
+                        return new MemoryStream(
+                            source.Bytes,
+                            writable: false);
+                    },
+                    AssemblyResolutionProvenance.Local(
+                        assemblyName));
+            source = new TestAssembly(
+                bytes,
+                assembly,
+                policy,
+                onOpen);
+            return source;
+        }
+
+        static byte[] BuildAssembly(
+            string assemblyName,
+            string integrationTypeName,
+            string? additionalIntegrationTypeName)
+        {
+            var assemblyBuilder = new PersistedAssemblyBuilder(
+                new AssemblyName(assemblyName),
+                typeof(object).Assembly);
+            ModuleBuilder module =
+                assemblyBuilder.DefineDynamicModule(assemblyName);
+            DefineType(integrationTypeName);
+            if (additionalIntegrationTypeName is not null)
+                DefineType(additionalIntegrationTypeName);
+
+            using var stream = new MemoryStream();
+            assemblyBuilder.Save(stream);
+            return stream.ToArray();
+
+            void DefineType(string typeName)
+            {
+                TypeBuilder type = module.DefineType(
+                    typeName,
+                    TypeAttributes.Public | TypeAttributes.Class);
+                type.DefineDefaultConstructor(
+                    MethodAttributes.Public);
+                type.CreateType();
+            }
+        }
+    }
+
+    sealed class TestBindingPolicy(
+        AssemblyBindingPolicyVersion version)
+        : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } =
+            version;
+
+        public AssemblyBindingSelection Select(
+            AssemblyBindingRequest request) =>
+            AssemblyBindingSelection.CannotSelect(
+                new AssemblyBindingFailure(
+                    AssemblyBindingFailureKind.CandidateUnavailable));
+    }
+}

--- a/src/DotnetInspector.Queries/AssemblyContextIntegrationsQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextIntegrationsQuery.cs
@@ -1,0 +1,137 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// Identity and provenance for one context-group participant without its
+/// content-opening capability.
+/// </summary>
+public sealed class AssemblyContextSubject
+{
+    internal AssemblyContextSubject(ResolvedAssemblyReference assembly)
+    {
+        Registration = assembly.Registration;
+        Identity = assembly.Identity;
+        Provenance = assembly.Provenance;
+    }
+
+    public AssemblyAcquisitionRegistration Registration { get; }
+    public AssemblyReferenceIdentity Identity { get; }
+    public AssemblyResolutionProvenance Provenance { get; }
+}
+
+/// <summary>One participant's outcome in a group-scoped Integrations query.</summary>
+public abstract record AssemblyIntegrationsEntry(
+    AssemblyContextSubject Subject)
+{
+    /// <summary>The participant produced its integration evidence.</summary>
+    public sealed record Available(
+        AssemblyContextSubject Subject,
+        ImmutableArray<EcosystemIntegrationSignalInfo> EcosystemSignals,
+        ImmutableArray<OpenTelemetrySignalInfo> OpenTelemetrySignals)
+        : AssemblyIntegrationsEntry(Subject);
+
+    /// <summary>The participant's immutable image could not be acquired.</summary>
+    public sealed record Rejected(
+        AssemblyContextSubject Subject,
+        CandidateOpenFailure Failure)
+        : AssemblyIntegrationsEntry(Subject);
+
+    /// <summary>The participant's acquired metadata was malformed.</summary>
+    /// <remarks>
+    /// Mapping late metadata decode failures independently of snapshot
+    /// acquisition is currently unverified.
+    /// </remarks>
+    public sealed record Failed(
+        AssemblyContextSubject Subject,
+        BadImageFormatException Error)
+        : AssemblyIntegrationsEntry(Subject);
+}
+
+/// <summary>
+/// Ordered Integrations outcomes for every participant in one assembly context
+/// group. Partial inspection is meaningful because each unavailable participant
+/// carries its failure beside the available entries.
+/// </summary>
+public sealed record AssemblyContextIntegrationsResult(
+    ImmutableArray<AssemblyIntegrationsEntry> Assemblies)
+{
+    public bool IsComplete =>
+        Assemblies.All(
+            static entry =>
+                entry is AssemblyIntegrationsEntry.Available);
+}
+
+/// <summary>
+/// Scans Integrations evidence across one binding-consistent assembly context
+/// group in deterministic participant order.
+/// </summary>
+/// <remarks>
+/// Ordering, snapshot reuse, and partial acquisition are gated by
+/// <c>RegistryRun_ScansEveryParticipantInOrderAndReusesSnapshots</c> and
+/// <c>Execute_CarriesAcquisitionFailureBesideLaterResults</c>. Budget-limited
+/// partial inspection is gated by
+/// <c>Execute_ReportsBudgetExhaustionAsIncompleteEntry</c>.
+/// </remarks>
+public static class AssemblyContextIntegrationsQuery
+{
+    public static InspectionQuery<AssemblyContextIntegrationsResult>
+        Definition { get; } =
+        new("Assembly context integrations", InspectionCost.Unbounded);
+
+    public static AssemblyContextIntegrationsResult Execute(
+        AssemblyContextGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        var entries =
+            ImmutableArray.CreateBuilder<AssemblyIntegrationsEntry>(
+                group.Participants.Length);
+        foreach (AssemblyContextParticipant participant
+            in group.Participants)
+        {
+            var subject =
+                new AssemblyContextSubject(participant.Assembly);
+            AssemblyImageAccessResult<AssemblyIntegrationsEntry> access =
+                group.UseAssemblySession(
+                    participant.Assembly,
+                    session => Inspect(subject, session));
+            entries.Add(
+                access switch
+                {
+                    AssemblyImageAccessResult<
+                        AssemblyIntegrationsEntry>.Available available =>
+                        available.Value,
+                    AssemblyImageAccessResult<
+                        AssemblyIntegrationsEntry>.Rejected rejected =>
+                        new AssemblyIntegrationsEntry.Rejected(
+                            subject,
+                            rejected.Failure),
+                    _ => throw new InvalidOperationException(
+                        "Unknown assembly image access result."),
+                });
+        }
+
+        return new AssemblyContextIntegrationsResult(
+            entries.MoveToImmutable());
+    }
+
+    static AssemblyIntegrationsEntry Inspect(
+        AssemblyContextSubject subject,
+        AssemblyInspectionSession session)
+    {
+        try
+        {
+            return new AssemblyIntegrationsEntry.Available(
+                subject,
+                session.EcosystemIntegrations().ToImmutableArray(),
+                session.OpenTelemetrySignals().ToImmutableArray());
+        }
+        catch (BadImageFormatException ex)
+        {
+            return new AssemblyIntegrationsEntry.Failed(subject, ex);
+        }
+    }
+}

--- a/src/DotnetInspector.Queries/InspectionWorkspace.cs
+++ b/src/DotnetInspector.Queries/InspectionWorkspace.cs
@@ -233,6 +233,35 @@ public sealed class AssemblyContextGroup : IDisposable
         ArgumentNullException.ThrowIfNull(assembly);
         ArgumentNullException.ThrowIfNull(callback);
 
+        return UseSnapshot(
+            assembly,
+            snapshot => callback(
+                new AssemblyImageView(
+                    assembly,
+                    snapshot.Content.AsSpan())));
+    }
+
+    internal AssemblyImageAccessResult<TResult> UseAssemblySession<TResult>(
+        ResolvedAssemblyReference assembly,
+        Func<AssemblyInspectionSession, TResult> callback)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        ArgumentNullException.ThrowIfNull(callback);
+
+        return UseSnapshot(
+            assembly,
+            snapshot =>
+            {
+                using AssemblyInspectionSession session =
+                    AssemblyInspectionSession.Open(snapshot);
+                return callback(session);
+            });
+    }
+
+    AssemblyImageAccessResult<TResult> UseSnapshot<TResult>(
+        ResolvedAssemblyReference assembly,
+        Func<AssemblyImageSnapshot, TResult> callback)
+    {
         BeginCallback();
         try
         {
@@ -245,10 +274,7 @@ public sealed class AssemblyContextGroup : IDisposable
                     failure);
             }
 
-            TResult value = callback(
-                new AssemblyImageView(
-                    assembly,
-                    access.Snapshot!.Content.AsSpan()));
+            TResult value = callback(access.Snapshot!);
             return new AssemblyImageAccessResult<TResult>.Available(value);
         }
         finally

--- a/src/ILInspector.Metadata/AssemblyImage.cs
+++ b/src/ILInspector.Metadata/AssemblyImage.cs
@@ -68,6 +68,15 @@ public sealed class AssemblyImage : IDisposable
     /// </summary>
     public static AssemblyImage Open(ResolvedAssemblyReference reference) => FromStream(reference.OpenRead());
 
+    internal static AssemblyImage Open(AssemblyImageSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        return new AssemblyImage(
+            stream: null,
+            new PEReader(snapshot.Content),
+            ownsReader: true);
+    }
+
     internal static AssemblyImage OpenPrefetched(Stream stream)
     {
         ArgumentNullException.ThrowIfNull(stream);

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -23,6 +23,16 @@ public sealed class AssemblyInspectionSession : IDisposable
     /// <summary>Opens a session from a resolved assembly reference (path or stream opener).</summary>
     public static AssemblyInspectionSession Open(ResolvedAssemblyReference reference) => new(AssemblyImage.Open(reference));
 
+    /// <summary>
+    /// Opens a session over an immutable image snapshot without reopening its acquisition source.
+    /// </summary>
+    /// <remarks>
+    /// Gated by
+    /// <c>RegistryRun_ScansEveryParticipantInOrderAndReusesSnapshots</c>.
+    /// </remarks>
+    public static AssemblyInspectionSession Open(AssemblyImageSnapshot snapshot) =>
+        new(AssemblyImage.Open(snapshot));
+
     internal static AssemblyInspectionSession OpenPrefetched(Stream stream) =>
         new(AssemblyImage.OpenPrefetched(stream));
 


### PR DESCRIPTION
## Summary

Adds the first typed query over an entire binding-consistent assembly context
group. `AssemblyContextIntegrationsQuery` scans ecosystem and OpenTelemetry
integration evidence sequentially in participant order, reuses the workspace's
retained immutable snapshots without reopening acquisition sources, and
preserves per-participant identity, provenance, and typed failures.

The result keeps partial group inspection explicit: every participant produces
an available, rejected, or malformed-metadata entry, and `IsComplete` exposes
whether the group was fully inspected. The query declares `Unbounded` cost
because participant fan-out and metadata work require explicit demand even
though retained image bytes are budgeted.

## Architecture

- Adds snapshot-backed `AssemblyInspectionSession` creation without exposing raw
  PE readers or granting Queries friend access to Metadata.
- Keeps snapshot ownership inside `AssemblyContextGroup`; query callbacks
  receive a group-owned session, not a heap-escapable snapshot.
- Returns an opaque acquisition registration plus assembly identity and
  resolution provenance, not the source-opening `ResolvedAssemblyReference`.
- Preserves the deterministic sequential baseline required by Browser/Wasm.

## Boundary

This slice does not migrate CLI sections, compose integration opportunities, add
catalogs or query authorization, or add cancellation-aware/concurrent executors.
Late malformed-metadata mapping is implemented but not yet independently gated.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release` (20/20)
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` (1289/1289)
- `npx markdownlint-cli docs/inspection-space.md docs/design/inspection-layers.md docs/design/integrations.md docs/overview.md docs/architecture.md`
- Non-gating MAI-Code quick read: clean
