### PR TITLE
Honor NuGet package source mapping

### DIFF
--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -65,10 +65,9 @@ eligible source that appears earlier in configuration. This preserves
 cache-first and offline operation and matches NuGet's contract: package source
 mapping, not declaration order, limits which feed may serve an id.
 
-"Authorized" currently means the source appears in the caller's active sources
-and, for a discovered coordinate, reported the selected version. After
-`<packageSourceMapping>` is implemented, the payload producer must also be
-selected by the winning mapping pattern. See the
+"Authorized" means the source appears in the caller's active sources, is selected
+by the package id's winning package-source-mapping pattern when mapping is
+enabled, and, for a discovered coordinate, reported the selected version. See the
 [package source model](package-source-model.md) for the end-to-end contract.
 
 A source is identified by a digest of its canonical URL, and canonicalization is
@@ -76,10 +75,8 @@ shared with the credential scope's `IsSameEndpoint` rather than reimplemented, s
 one URL cannot mean two things in one tool. Scheme, host, default port,
 percent-escape casing, and an empty root path versus `/` fold because the URI
 grammar defines them as equivalent. Path and query case do not fold:
-`/FeedA` and `/feeda` can name different resources. A non-root trailing slash
-must likewise remain distinct, but the current cache identity incorrectly folds
-`/feed` and `/feed/`. Correcting it requires a cache namespace migration and is
-tracked by [#3737](https://github.com/richlander/dotnet-inspect/issues/3737).
+`/FeedA` and `/feeda` can name different resources. Exactly one optional trailing
+path slash folds, while repeated trailing slashes and fragments remain distinct.
 The digest keeps source URLs out of cache paths and makes every identity a
 valid path segment. It is a path-safe identifier, not a security boundary;
 source authorization comes from the source policy, not from hiding cache keys.

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -44,7 +44,9 @@ Source identity has two parts with different purposes:
   caches.
 
 Names do not prove two feeds are the same. HTTP endpoint canonicalization does
-not make path or query case-insensitive or discard a non-root trailing slash.
+not make path or query case-insensitive. It folds exactly one optional trailing
+path slash because `/feed` and `/feed/` are alternate spellings of one endpoint;
+repeated trailing slashes and fragments remain distinct.
 Local sources use a separate identity: config-relative paths resolve from the
 declaring config's directory, CLI-relative paths resolve from the working
 directory, and path and `file://` spellings normalize to one absolute directory.
@@ -422,21 +424,14 @@ symbols should consume that shared result.
 The current implementation source-scopes downloaded package content and
 candidate metadata, aggregates versions across sources while retaining the
 reporting feeds, uses global-folder payloads only when their recorded producer
-is authorized, and threads caller options through routing probes. The remaining
+is authorized, applies layered `<packageSourceMapping>` configuration per
+package id, preserves aliases through mapping before collapsing producers, and
+threads caller options through routing and platform-pack probes. The remaining
 implementation work includes:
 
-- honoring `<packageSourceMapping>` across every operation
-  ([#3722](https://github.com/richlander/dotnet-inspect/issues/3722));
 - completing config and override semantics, including the complete NuGet config
-  hierarchy, disabled-source merging, and preservation of all configured-name
-  aliases for explicit endpoints
+  hierarchy and config-relative local source paths
   ([#3739](https://github.com/richlander/dotnet-inspect/issues/3739));
-- preserving non-root trailing slashes in producer identity and fencing cache
-  entries written under the currently aliased identity
-  ([#3737](https://github.com/richlander/dotnet-inspect/issues/3737));
-- representing configured order structurally for stable presentation and
-  diagnostics, without treating it as precedence
-  ([#3724](https://github.com/richlander/dotnet-inspect/issues/3724));
 - carrying payload producer provenance through package inspection indexes,
   projected platform packs, and package-associated symbols
   ([#3738](https://github.com/richlander/dotnet-inspect/issues/3738));

--- a/docs/private-feeds.md
+++ b/docs/private-feeds.md
@@ -113,6 +113,26 @@ Both `Username` and `ClearTextPassword` are required, even for feeds that ignore
 The source name inside `<packageSourceCredentials>` must match the `key` of the entry in
 `<packageSources>`.
 
+### Restrict package ids to feeds
+
+dotnet-inspect honors NuGet package source mapping from the selected configuration:
+
+```xml
+<packageSourceMapping>
+  <packageSource key="contoso">
+    <package pattern="Contoso.*" />
+  </packageSource>
+  <packageSource key="nuget.org">
+    <package pattern="*" />
+  </packageSource>
+</packageSourceMapping>
+```
+
+Exact package ids take priority over prefixes, and the longest matching prefix wins. Mapping
+is applied independently to top-level packages, dependencies, RID companions, platform packs,
+tool redirects, search results, and routing probes. If mapping is present, an unmatched package
+id or a mapping whose named source is not active is an error.
+
 Four forms look like they should work here and do not:
 
 | Form | What happens |

--- a/src/DotnetInspector.Packages/NuGetCredentialScope.cs
+++ b/src/DotnetInspector.Packages/NuGetCredentialScope.cs
@@ -67,10 +67,9 @@ public static class NuGetCredentialScope
     ///
     /// Trailing-slash tolerance is a candidacy test, not an authorization decision. It can make a
     /// URL match more than one configured entry, and entries that differ only by a trailing slash
-    /// may carry different credentials, so callers that adopt credentials from a match must
-    /// require the match to be unambiguous. <see cref="NuGetSourceResolver"/> does that by
-    /// preferring an exact spelling and accepting a slash-tolerant match only when exactly one
-    /// configured source matches.
+    /// may carry different credentials. <see cref="NuGetSourceResolver"/> therefore retains every
+    /// matching alias until package source mapping selects eligible names, then rejects conflicting
+    /// credentials instead of choosing one.
     /// </remarks>
     public static bool IsSameEndpoint(string? a, string? b)
     {

--- a/src/DotnetInspector.Packages/NuGetSourceCompat.cs
+++ b/src/DotnetInspector.Packages/NuGetSourceCompat.cs
@@ -23,6 +23,34 @@ public record NuGetSourceOptions
 }
 
 /// <summary>
+/// Identifies why package source mapping could not authorize a producer.
+/// </summary>
+public enum PackageSourceMappingFailure
+{
+    /// <summary>The package id matched no configured pattern.</summary>
+    NoPattern,
+
+    /// <summary>No active source carries a configured name selected by mapping.</summary>
+    InactiveSource,
+
+    /// <summary>Eligible aliases for one producer use different credentials.</summary>
+    ConflictingCredentials,
+}
+
+/// <summary>
+/// Thrown when package source mapping cannot authorize a producer for a package id.
+/// </summary>
+public sealed class PackageSourceMappingException(
+    PackageSourceMappingFailure failure,
+    string message) : InvalidOperationException(message)
+{
+    /// <summary>
+    /// Gets the mapping failure category.
+    /// </summary>
+    public PackageSourceMappingFailure Failure { get; } = failure;
+}
+
+/// <summary>
 /// Resolves NuGet sources by delegating to NuGetFetch.SourceResolver.
 /// </summary>
 public static class NuGetSourceResolver
@@ -79,6 +107,16 @@ public static class NuGetSourceResolver
         => SourceKeys(ResolveSources(options, workingDirectory));
 
     /// <summary>
+    /// Resolves the producers eligible to serve <paramref name="packageId"/> and reduces them to
+    /// the identities recorded by the package-content cache.
+    /// </summary>
+    public static IReadOnlyList<string> ResolveSourceKeysForPackage(
+        NuGetSourceOptions? options,
+        string packageId,
+        string? workingDirectory = null)
+        => SourceKeys(ResolveSourcesForPackage(options, packageId, workingDirectory));
+
+    /// <summary>
     /// Reduces already-resolved sources to their cache identities, preserving
     /// configured order.
     /// </summary>
@@ -114,18 +152,120 @@ public static class NuGetSourceResolver
             ValidateExplicitConfig(options.ConfigFile);
         }
 
-        if (options.Sources.Length > 0)
-        {
-            return SelectExplicitSources(options, workingDirectory);
-        }
-
-        IReadOnlyList<NuGetSource> sources = SourceResolver.ResolveSources(
+        IReadOnlyList<NuGetSource> configured = SourceResolver.ResolveSources(
             explicitSource: null,
             configPath: options.ConfigFile,
-            additionalSources: options.AdditionalSources.Length > 0 ? options.AdditionalSources : null,
+            additionalSources: null,
             workingDirectory: workingDirectory);
+        IReadOnlyList<NuGetSource> configuredAliases =
+            options.Sources.Length > 0 || options.AdditionalSources.Length > 0
+                ? SourceResolver.ResolveConfiguredSourceAliases(
+                    options.ConfigFile,
+                    workingDirectory)
+                : configured;
 
-        return [.. sources];
+        List<NuGetSource> selected = options.Sources.Length > 0
+            ? SelectExplicitSources(options.Sources, configuredAliases)
+            : [.. configured];
+        AddExplicitSources(selected, options.AdditionalSources, configuredAliases);
+        return selected;
+    }
+
+    /// <summary>
+    /// Resolves active source aliases, applies package source mapping for
+    /// <paramref name="packageId"/>, and collapses eligible aliases to canonical producers.
+    /// </summary>
+    /// <remarks>
+    /// Mapping names configured aliases, while package payloads and caches name canonical
+    /// producer endpoints. Aliases therefore remain distinct until mapping has selected the
+    /// package-specific set. Eligible aliases for one producer must agree on credentials.
+    /// </remarks>
+    /// <exception cref="PackageSourceMappingException">
+    /// Mapping is enabled but the package id matches no pattern, none of the mapped names is
+    /// active, or eligible aliases for one producer disagree on credentials.
+    /// </exception>
+    public static List<NuGetSource> ResolveSourcesForPackage(
+        NuGetSourceOptions? options,
+        string packageId,
+        string? workingDirectory = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        List<NuGetSource> activeAliases = ResolveSources(options, workingDirectory);
+        PackageSourceMapping mapping = ResolvePackageSourceMapping(options, workingDirectory);
+
+        IReadOnlyList<NuGetSource> eligibleAliases = activeAliases;
+        if (mapping.IsEnabled)
+        {
+            IReadOnlyList<string> mappedNames =
+                mapping.GetConfiguredPackageSources(packageId);
+            if (mappedNames.Count == 0)
+            {
+                throw new PackageSourceMappingException(
+                    PackageSourceMappingFailure.NoPattern,
+                    $"Package source mapping has no pattern for package '{packageId}'.");
+            }
+
+            var allowedNames = new HashSet<string>(
+                mappedNames,
+                StringComparer.OrdinalIgnoreCase);
+            eligibleAliases =
+            [
+                .. activeAliases.Where(source => allowedNames.Contains(source.Name)),
+            ];
+            if (eligibleAliases.Count == 0)
+            {
+                throw new PackageSourceMappingException(
+                    PackageSourceMappingFailure.InactiveSource,
+                    $"Package '{packageId}' maps to source"
+                    + $"{(mappedNames.Count == 1 ? "" : "s")} "
+                    + $"'{string.Join("', '", mappedNames)}', but "
+                    + $"{(mappedNames.Count == 1 ? "it is not" : "none are")} active.");
+            }
+        }
+
+        return CollapseAliases(eligibleAliases, packageId);
+    }
+
+    internal static PackageSourceMapping ResolvePackageSourceMapping(
+        NuGetSourceOptions? options,
+        string? workingDirectory = null)
+        => SourceResolver.ResolvePackageSourceMapping(
+            options?.ConfigFile,
+            workingDirectory);
+
+    internal static bool IsAliasEligibleForPackage(
+        NuGetSource source,
+        IReadOnlyList<NuGetSource> activeAliases,
+        PackageSourceMapping mapping,
+        string packageId)
+    {
+        if (!mapping.IsEnabled)
+        {
+            return true;
+        }
+
+        IReadOnlyList<string> mappedNames =
+            mapping.GetConfiguredPackageSources(packageId);
+        if (mappedNames.Count == 0)
+        {
+            return false;
+        }
+
+        var allowedNames = new HashSet<string>(
+            mappedNames,
+            StringComparer.OrdinalIgnoreCase);
+        List<NuGetSource> eligibleAliases =
+        [
+            .. activeAliases.Where(alias => allowedNames.Contains(alias.Name)),
+        ];
+        if (eligibleAliases.Count == 0)
+        {
+            return false;
+        }
+
+        _ = CollapseAliases(eligibleAliases, packageId);
+        return allowedNames.Contains(source.Name);
     }
 
     /// <summary>
@@ -168,7 +308,7 @@ public static class NuGetSourceResolver
         // layer rather than inheriting the ambient NuGet.org default.
         try
         {
-            if (SourceResolver.ResolveConfiguredSources(configFile).Count == 0)
+            if (SourceResolver.ResolveConfiguredSourceAliases(configFile).Count == 0)
             {
                 return $"NuGet config file '{configFile}' declares no usable package sources.";
             }
@@ -222,15 +362,29 @@ public static class NuGetSourceResolver
     /// same URL, and NuGet's own client matches them the same way.
     /// </remarks>
     private static List<NuGetSource> SelectExplicitSources(
-        NuGetSourceOptions options,
-        string? workingDirectory)
+        IEnumerable<string> urls,
+        IReadOnlyList<NuGetSource> configured)
     {
-        IReadOnlyList<NuGetSource> configured =
-            SourceResolver.ResolveConfiguredSources(options.ConfigFile, workingDirectory);
-
-        List<NuGetSource> selected = [.. options.Sources.Select(url => Match(url, configured))];
-        selected.AddRange(options.AdditionalSources.Select(url => Match(url, configured)));
+        List<NuGetSource> selected = [];
+        AddExplicitSources(selected, urls, configured);
         return selected;
+    }
+
+    private static void AddExplicitSources(
+        List<NuGetSource> selected,
+        IEnumerable<string> urls,
+        IReadOnlyList<NuGetSource> configured)
+    {
+        foreach (string url in urls)
+        {
+            foreach (NuGetSource match in Match(url, configured))
+            {
+                if (!selected.Contains(match))
+                {
+                    selected.Add(match);
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -244,29 +398,50 @@ public static class NuGetSourceResolver
     /// case-insensitively because scheme and host are case-insensitive by definition; path and
     /// query are compared ordinally on their escaped form because they are not.
     ///
-    /// An exact spelling wins outright. A trailing slash is not a distinction any feed makes, so
-    /// it is tolerated only as a fallback, and only when exactly one configured source matches
-    /// that way: if two entries differ solely by a trailing slash they are separate entries with
-    /// potentially separate credentials, and picking either one would be a guess that could send
-    /// one entry's secret to the other's spelling.
+    /// Every configured alias for the endpoint is retained. Package source mapping names those
+    /// aliases, so selecting one before the package id is known would either bypass mapping or
+    /// discard the credential attached to the alias mapping later selects.
     ///
     /// On a match only the credentials are adopted. The URL stays exactly as the user spelled it,
     /// so a request never silently goes somewhere other than where it was pointed.
     /// </remarks>
-    private static NuGetSource Match(string url, IReadOnlyList<NuGetSource> configured)
+    private static IReadOnlyList<NuGetSource> Match(
+        string url,
+        IReadOnlyList<NuGetSource> configured)
     {
-        NuGetSource? match = configured.FirstOrDefault(
-            s => string.Equals(s.Url, url, StringComparison.Ordinal));
+        List<NuGetSource> matches =
+        [
+            .. configured
+                .Where(source => NuGetCredentialScope.IsSameEndpoint(source.Url, url))
+                .Select(source => source with { Url = url }),
+        ];
+        return matches.Count == 0
+            ? [new NuGetSource(url, url)]
+            : matches;
+    }
 
-        if (match is null)
+    private static List<NuGetSource> CollapseAliases(
+        IReadOnlyList<NuGetSource> eligibleAliases,
+        string packageId)
+    {
+        List<NuGetSource> producers = [];
+        foreach (IGrouping<string, NuGetSource> aliases in eligibleAliases.GroupBy(
+            source => NuGetCache.GetSourceKey(source.Url),
+            StringComparer.Ordinal))
         {
-            List<NuGetSource> tolerant =
-                [.. configured.Where(s => NuGetCredentialScope.IsSameEndpoint(s.Url, url))];
+            NuGetSource first = aliases.First();
+            if (aliases.Any(alias => alias.Credential != first.Credential))
+            {
+                throw new PackageSourceMappingException(
+                    PackageSourceMappingFailure.ConflictingCredentials,
+                    $"Package '{packageId}' is eligible from multiple configured names for "
+                    + $"'{first.Url}', but those names use conflicting credentials.");
+            }
 
-            match = tolerant.Count == 1 ? tolerant[0] : null;
+            producers.Add(first);
         }
 
-        return match is null ? new NuGetSource("explicit", url) : match with { Url = url };
+        return producers;
     }
 }
 
@@ -316,9 +491,12 @@ public static class NuGetSearchService
         NuGetSourceOptions? sourceOptions = null)
     {
         List<NuGetSource> sources = NuGetSourceResolver.ResolveSources(sourceOptions);
+        PackageSourceMapping mapping =
+            NuGetSourceResolver.ResolvePackageSourceMapping(sourceOptions);
         return await SearchResolvedAsync(
             client,
             sources,
+            mapping,
             query,
             take,
             prerelease,
@@ -329,6 +507,7 @@ public static class NuGetSearchService
     private static async Task<NuGetSearchOutcome> SearchResolvedAsync(
         HttpClient client,
         List<NuGetSource> sources,
+        PackageSourceMapping mapping,
         string query,
         int take,
         bool prerelease,
@@ -354,7 +533,13 @@ public static class NuGetSearchService
                 ? await service.SearchAsync(query, take, prerelease)
                 : await service.SearchByPrefixAsync(query, take, prerelease);
             IEnumerable<NuGetSearchResult> projected = results
-                .Where(result => resultFilter?.Invoke(result) ?? true)
+                .Where(result =>
+                    (resultFilter?.Invoke(result) ?? true)
+                    && NuGetSourceResolver.IsAliasEligibleForPackage(
+                        only,
+                        sources,
+                        mapping,
+                        result.Id))
                 .Select(NuGetSearchResult.From);
             if (resultFilter is not null)
             {
@@ -371,6 +556,7 @@ public static class NuGetSearchService
         return await SearchSourcesAsync(
             client,
             sources,
+            mapping,
             query,
             take,
             prerelease,
@@ -381,6 +567,7 @@ public static class NuGetSearchService
     private static async Task<NuGetSearchOutcome> SearchSourcesAsync(
         HttpClient client,
         List<NuGetSource> sources,
+        PackageSourceMapping mapping,
         string query,
         int take,
         bool prerelease,
@@ -442,6 +629,11 @@ public static class NuGetSearchService
             foreach (SearchResult result in found)
             {
                 if ((resultFilter?.Invoke(result) ?? true)
+                    && NuGetSourceResolver.IsAliasEligibleForPackage(
+                        source,
+                        sources,
+                        mapping,
+                        result.Id)
                     && seen.Add((result.Id, result.Version)))
                 {
                     results.Add(NuGetSearchResult.From(result));
@@ -496,9 +688,12 @@ public static class NuGetSearchService
     {
         log?.Invoke($"Searching packages by prefix: {prefix}");
         List<NuGetSource> sources = NuGetSourceResolver.ResolveSources(sourceOptions);
+        PackageSourceMapping mapping =
+            NuGetSourceResolver.ResolvePackageSourceMapping(sourceOptions);
         NuGetSearchOutcome outcome = await SearchResolvedAsync(
             client,
             sources,
+            mapping,
             prefix,
             take,
             prerelease,

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -242,7 +242,9 @@ public static class PackageExtractor
         }
 
         // Resolve NuGet sources
-        var sources = NuGetSourceResolver.ResolveSources(sourceOptions);
+        var sources = NuGetSourceResolver.ResolveSourcesForPackage(
+            sourceOptions,
+            packageName);
         IReadOnlyList<NuGetSource> authorizedSources =
             NuGetSourceResolver.ResolveAuthorizedSources(
                 sourceOptions,
@@ -706,7 +708,9 @@ public static class PackageExtractor
         var cachedPath = NuGetCache.TryGetCachedPackage(
             normalizedName,
             normalizedVersion,
-            NuGetSourceResolver.ResolveSourceKeys(sourceOptions));
+            NuGetSourceResolver.ResolveSourceKeysForPackage(
+                sourceOptions,
+                packageId));
         if (cachedPath != null && NuGetCache.IsCachedPackageValid(cachedPath))
         {
             var cachedNuspec = Directory
@@ -716,7 +720,9 @@ public static class PackageExtractor
                 return await File.ReadAllTextAsync(cachedNuspec).ConfigureAwait(false);
         }
 
-        foreach (var source in NuGetSourceResolver.ResolveSources(sourceOptions))
+        foreach (var source in NuGetSourceResolver.ResolveSourcesForPackage(
+            sourceOptions,
+            packageId))
         {
             var url = await GetNuspecUrlAsync(client, source, normalizedName, normalizedVersion, log).ConfigureAwait(false);
             if (url == null)
@@ -1785,7 +1791,9 @@ public static class PackageExtractor
         NuGetSourceOptions? sourceOptions = null)
     {
         string normalizedName = packageName.ToLowerInvariant();
-        var sources = NuGetSourceResolver.ResolveSources(sourceOptions);
+        var sources = NuGetSourceResolver.ResolveSourcesForPackage(
+            sourceOptions,
+            packageName);
 
         var allVersions = await GetAllVersionsWithCacheAsync(client, normalizedName, sources, log).ConfigureAwait(false);
         if (allVersions.Versions == null)
@@ -1824,7 +1832,9 @@ public static class PackageExtractor
     {
         string normalizedName = packageName.ToLowerInvariant();
         List<NuGetSource> sources =
-            NuGetSourceResolver.ResolveSources(sourceOptions);
+            NuGetSourceResolver.ResolveSourcesForPackage(
+                sourceOptions,
+                packageName);
         NuGet.Versioning.NuGetVersion? best = null;
         string? bestVersion = null;
         bool sawMetadata = false;
@@ -1892,7 +1902,9 @@ public static class PackageExtractor
     {
         string normalizedName = packageName.ToLowerInvariant();
         List<NuGetSource> sources =
-            NuGetSourceResolver.ResolveSources(sourceOptions);
+            NuGetSourceResolver.ResolveSourcesForPackage(
+                sourceOptions,
+                packageName);
         var perSource = await FetchListingsPerSourceAsync(
             client,
             normalizedName,
@@ -1959,7 +1971,9 @@ public static class PackageExtractor
         NuGetSourceOptions? sourceOptions = null)
     {
         string normalizedName = packageName.ToLowerInvariant();
-        var sources = NuGetSourceResolver.ResolveSources(sourceOptions);
+        var sources = NuGetSourceResolver.ResolveSourcesForPackage(
+            sourceOptions,
+            packageName);
 
         var allListings = await GetAllVersionListingsWithCacheAsync(client, normalizedName, sources, log).ConfigureAwait(false);
         if (allListings == null)
@@ -2050,7 +2064,9 @@ public static class PackageExtractor
         NuGetSourceOptions? sourceOptions = null)
     {
         string normalizedName = packageName.ToLowerInvariant();
-        var sources = NuGetSourceResolver.ResolveSources(sourceOptions);
+        var sources = NuGetSourceResolver.ResolveSourcesForPackage(
+            sourceOptions,
+            packageName);
 
         var perSource = await FetchListingsPerSourceAsync(client, normalizedName, sources, log).ConfigureAwait(false);
         if (perSource == null)
@@ -2115,17 +2131,17 @@ public static class PackageExtractor
     /// Chooses a short, unambiguous label for each source, keyed by source URL.
     /// </summary>
     /// <remarks>
-    /// Configured sources have useful names, but a source named on the command line that matches
-    /// nothing in configuration is called "explicit", and every such source shares that name. A
-    /// label must distinguish feeds, so the name is used only when it is meaningful, the host is
-    /// used otherwise, and the full URL is used when even that would collide.
+    /// Configured sources have useful names, while a source named on the command line that matches
+    /// nothing in configuration uses its URL as the mapping alias. A label must stay short and
+    /// distinguish feeds, so a configured name is used when present, the host is used for literal
+    /// URL aliases, and the full URL is used when even that would collide.
     /// </remarks>
     private static Dictionary<string, string> BuildFeedLabels(List<NuGetSource> sources)
     {
         static string Candidate(NuGetSource source)
         {
             if (!string.IsNullOrEmpty(source.Name)
-                && !string.Equals(source.Name, "explicit", StringComparison.Ordinal))
+                && !string.Equals(source.Name, source.Url, StringComparison.Ordinal))
             {
                 return source.Name;
             }

--- a/src/DotnetInspector.Packages/SymbolPackageDownloader.cs
+++ b/src/DotnetInspector.Packages/SymbolPackageDownloader.cs
@@ -79,6 +79,7 @@ public class SymbolPackageDownloader
         Action<string>? log = null,
         bool isPlatformAssembly = false,
         bool cacheOnly = false,
+        NuGetSourceOptions? sourceOptions = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -114,7 +115,9 @@ public class SymbolPackageDownloader
         }
 
         // Try downloading symbol package (.snupkg)
-        if (!string.IsNullOrEmpty(packageName) && !string.IsNullOrEmpty(packageVersion))
+        if (!string.IsNullOrEmpty(packageName)
+            && !string.IsNullOrEmpty(packageVersion)
+            && IsNuGetOrgEligibleForPackage(sourceOptions, packageName))
         {
             var snupkgResult = await TryLocateFromSymbolPackageAsync(
                 packageName, packageVersion, assemblyPath, symbolKey, pdbGuid, log, cacheOnly, cancellationToken).ConfigureAwait(false);
@@ -137,6 +140,26 @@ public class SymbolPackageDownloader
 
         log?.Invoke(cacheOnly ? "No cached Portable PDB available" : "No Portable PDB available");
         return new PdbDownloadResult(null, windowsPdbDetected);
+    }
+
+    private static bool IsNuGetOrgEligibleForPackage(
+        NuGetSourceOptions? sourceOptions,
+        string packageName)
+    {
+        try
+        {
+            return NuGetSourceResolver.ResolveSourcesForPackage(
+                    sourceOptions,
+                    packageName)
+                .Any(source => source.IsNuGetOrg);
+        }
+        catch (PackageSourceMappingException ex)
+            when (ex.Failure is
+                PackageSourceMappingFailure.NoPattern
+                or PackageSourceMappingFailure.InactiveSource)
+        {
+            return false;
+        }
     }
 
     private async Task<PdbDownloadResult> TryLocateFromMsdlAsync(

--- a/src/DotnetInspector.Queries/DotnetInspector.Queries.csproj
+++ b/src/DotnetInspector.Queries/DotnetInspector.Queries.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DotnetInspector.Packages\DotnetInspector.Packages.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />

--- a/src/DotnetInspector.Queries/SourceLinkQueries.cs
+++ b/src/DotnetInspector.Queries/SourceLinkQueries.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Services;
+using DotnetInspector.Packages;
 using ILInspector.Findings;
 using ILInspector.SourceLink;
 
@@ -18,7 +19,8 @@ public sealed class SourceLinkQueryContext
         string? packageVersion = null,
         bool isPlatformAssembly = false,
         ISourceLinkQueryCache? cache = null,
-        Action<string>? log = null)
+        Action<string>? log = null,
+        NuGetSourceOptions? sourceOptions = null)
     {
         Source = source ?? throw new ArgumentNullException(nameof(source));
         Subject = subject ?? throw new ArgumentNullException(nameof(subject));
@@ -29,6 +31,7 @@ public sealed class SourceLinkQueryContext
         IsPlatformAssembly = isPlatformAssembly;
         Cache = cache;
         Log = log;
+        SourceOptions = sourceOptions;
     }
 
     public SourceLinkService Source { get; }
@@ -40,6 +43,7 @@ public sealed class SourceLinkQueryContext
     public bool IsPlatformAssembly { get; }
     public ISourceLinkQueryCache? Cache { get; }
     public Action<string>? Log { get; }
+    public NuGetSourceOptions? SourceOptions { get; }
 }
 
 /// <summary>Registers the shared SourceLink query family on a host registry.</summary>
@@ -139,6 +143,7 @@ public static class SourceLinkDocumentsQuery
                 context.PackageVersion,
                 context.IsPlatformAssembly,
                 context.Log,
+                sourceOptions: context.SourceOptions,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (!context.Source.HasPdb)

--- a/src/DotnetInspector.Services.Tests/DependencyResolutionServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/DependencyResolutionServiceTests.cs
@@ -92,6 +92,50 @@ public class DependencyResolutionServiceTests
     }
 
     [Fact]
+    public async Task ResolveDependencyTree_UnmappedTransitivePackagePropagatesMappingFailure()
+    {
+        string configPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dependency-mapping-{Guid.NewGuid():N}.config");
+        File.WriteAllText(configPath, """
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="private" value="https://private.example/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="private">
+                  <package pattern="Other.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+        var dependencies = new List<PackageDependency>
+        {
+            new() { Id = "Unmapped.Dependency", Version = "1.0.0" }
+        };
+
+        try
+        {
+            PackageSourceMappingException exception =
+                await Assert.ThrowsAsync<PackageSourceMappingException>(
+                    () => DependencyResolutionService.ResolveDependencyTreeAsync(
+                        new HttpClient(),
+                        dependencies,
+                        "net10.0",
+                        new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                        log: null,
+                        sourceOptions: new NuGetSourceOptions { ConfigFile = configPath }));
+
+            Assert.Equal(PackageSourceMappingFailure.NoPattern, exception.Failure);
+        }
+        finally
+        {
+            File.Delete(configPath);
+        }
+    }
+
+    [Fact]
     public async Task ResolveDependencyTree_UsesCallerSourcesForEveryTransitiveNuspec()
     {
         CoreCache.Initialize("dotnet-inspect-test");

--- a/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
@@ -169,7 +169,7 @@ public class PackageMetadataServiceTests : IDisposable
         Assert.Equal(0, handler.RequestCount);
         Assert.Null(result.Published);
         Assert.Contains(messages, message => message.Contains(
-            "configured package sources do not include api.nuget.org",
+            "does not authorize api.nuget.org",
             StringComparison.Ordinal));
     }
 
@@ -205,7 +205,50 @@ public class PackageMetadataServiceTests : IDisposable
             Sources = [sourceUrl],
         };
 
-        Assert.False(PackageMetadataService.SupportsNuGetOrgMetadata(sourceOptions));
+        Assert.False(PackageMetadataService.SupportsNuGetOrgMetadata(
+            sourceOptions,
+            "Private.Package"));
+    }
+
+    [Fact]
+    public void SupportsNuGetOrgMetadata_RequiresPackageMappingToAuthorizeNuGetOrg()
+    {
+        string configPath = Path.Combine(
+            Path.GetTempPath(),
+            $"metadata-mapping-{Guid.NewGuid():N}.config");
+        File.WriteAllText(configPath, """
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                <add key="private" value="https://private.example/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="private">
+                  <package pattern="Private.*" />
+                </packageSource>
+                <packageSource key="nuget.org">
+                  <package pattern="Public.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        try
+        {
+            var sourceOptions = new NuGetSourceOptions { ConfigFile = configPath };
+
+            Assert.False(PackageMetadataService.SupportsNuGetOrgMetadata(
+                sourceOptions,
+                "Private.Package"));
+            Assert.True(PackageMetadataService.SupportsNuGetOrgMetadata(
+                sourceOptions,
+                "Public.Package"));
+        }
+        finally
+        {
+            File.Delete(configPath);
+        }
     }
 
     private sealed class FailingHandler : HttpMessageHandler

--- a/src/DotnetInspector.Services.Tests/SourcePrecedenceTests.cs
+++ b/src/DotnetInspector.Services.Tests/SourcePrecedenceTests.cs
@@ -259,6 +259,140 @@ public class SourcePrecedenceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetVersions_PackageSourceMappingQueriesOnlyEligibleSource()
+    {
+        var handler = CreateHandler(
+            feedAVersions: ["0.31.0", "0.32.0"],
+            feedBVersions: ["0.32.99"]);
+        using var client = new HttpClient(handler);
+        string configPath = Path.Combine(
+            Path.GetTempPath(),
+            $"mapping-{Guid.NewGuid():N}.config");
+        File.WriteAllText(configPath, $$"""
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="feed-a" value="https://{{FeedAIndex}}" />
+                <add key="feed-b" value="https://{{FeedBIndex}}" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="feed-a">
+                  <package pattern="Markout" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        try
+        {
+            List<string>? versions = await PackageExtractor.GetVersionsAsync(
+                client,
+                "Markout",
+                includePrerelease: false,
+                limit: null,
+                log: null,
+                sourceOptions: new NuGetSourceOptions { ConfigFile = configPath });
+
+            Assert.Equal(["0.32.0", "0.31.0"], versions);
+            Assert.DoesNotContain(
+                handler.Requests,
+                request => request.Url.Contains(FeedBIndex, StringComparison.Ordinal));
+        }
+        finally
+        {
+            File.Delete(configPath);
+        }
+    }
+
+    [Fact]
+    public async Task PlatformPackVersionResolution_UsesPackageSourceMapping()
+    {
+        var handler = CreateHandler(
+            feedAVersions: ["0.31.0", "0.32.0"],
+            feedBVersions: ["0.32.99"]);
+        using var client = new HttpClient(handler);
+        string configPath = Path.Combine(
+            Path.GetTempPath(),
+            $"pack-mapping-{Guid.NewGuid():N}.config");
+        File.WriteAllText(configPath, $$"""
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="feed-a" value="https://{{FeedAIndex}}" />
+                <add key="feed-b" value="https://{{FeedBIndex}}" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="feed-a">
+                  <package pattern="Markout" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        try
+        {
+            string? version = await PlatformPackService.GetLatestPackVersionAsync(
+                "Markout",
+                client,
+                sourceOptions: new NuGetSourceOptions { ConfigFile = configPath });
+
+            Assert.Equal("0.32.0", version);
+            Assert.DoesNotContain(
+                handler.Requests,
+                request => request.Url.Contains(FeedBIndex, StringComparison.Ordinal));
+        }
+        finally
+        {
+            File.Delete(configPath);
+        }
+    }
+
+    [Fact]
+    public async Task NuspecResolution_UsesDependencyPackageMapping()
+    {
+        var handler = CreateHandler(feedAVersions: null, feedBVersions: null);
+        handler.Add(
+            "b-content.example.test/flat/contoso.dependency/1.0.0/contoso.dependency.nuspec",
+            "<package><metadata><id>Contoso.Dependency</id></metadata></package>");
+        using var client = new HttpClient(handler);
+        string configPath = Path.Combine(
+            Path.GetTempPath(),
+            $"nuspec-mapping-{Guid.NewGuid():N}.config");
+        File.WriteAllText(configPath, $$"""
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="feed-a" value="https://{{FeedAIndex}}" />
+                <add key="feed-b" value="https://{{FeedBIndex}}" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="feed-b">
+                  <package pattern="Contoso.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        try
+        {
+            string? nuspec = await PackageExtractor.TryGetNuspecXmlAsync(
+                client,
+                "Contoso.Dependency",
+                "1.0.0",
+                sourceOptions: new NuGetSourceOptions { ConfigFile = configPath });
+
+            Assert.Contains("<id>Contoso.Dependency</id>", nuspec);
+            Assert.DoesNotContain(
+                handler.Requests,
+                request => request.Url.Contains(FeedAIndex, StringComparison.Ordinal));
+        }
+        finally
+        {
+            File.Delete(configPath);
+        }
+    }
+
+    [Fact]
     public async Task WildcardResolution_RetainsOnlySelectedVersionReporters()
     {
         var handler = CreateHandler(

--- a/src/DotnetInspector.Services/AssemblySetResolver.cs
+++ b/src/DotnetInspector.Services/AssemblySetResolver.cs
@@ -236,7 +236,8 @@ public static class AssemblySetResolver
                     platformAsm,
                     httpClient,
                     log,
-                    request.PlatformAssemblyFrameworkHint);
+                    request.PlatformAssemblyFrameworkHint,
+                    sourceOptions: request.SourceOptions);
 
                 if (error != null)
                 {
@@ -259,7 +260,11 @@ public static class AssemblySetResolver
                 var requests = PlatformPackService.GetMissingPackRequests(request.PlatformFrameworks);
                 if (requests.Count > 0)
                 {
-                    await foreach (var _ in PlatformPackService.EnsurePacksAsync(requests, httpClient, log))
+                    await foreach (var _ in PlatformPackService.EnsurePacksAsync(
+                        requests,
+                        httpClient,
+                        log,
+                        sourceOptions: request.SourceOptions))
                     {
                     }
                 }

--- a/src/DotnetInspector.Services/DependencyResolutionService.cs
+++ b/src/DotnetInspector.Services/DependencyResolutionService.cs
@@ -146,6 +146,10 @@ public static class DependencyResolutionService
         {
             throw;
         }
+        catch (PackageSourceMappingException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             log?.Invoke($"Error resolving dependencies: {ex.Message}");

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -22,7 +22,7 @@ public static class PackageMetadataService
     {
         var normalizedName = packageName.ToLowerInvariant();
         var cacheKey = $"{normalizedName}@{version}";
-        if (!SupportsNuGetOrgMetadata(sourceOptions, log))
+        if (!SupportsNuGetOrgMetadata(sourceOptions, packageName, log))
             return null;
         PackageMetadata? cached;
         using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageMetadata))
@@ -79,7 +79,7 @@ public static class PackageMetadataService
     {
         var normalizedName = packageName.ToLowerInvariant();
         string cacheKey = $"{normalizedName}@{version}";
-        if (!SupportsNuGetOrgMetadata(sourceOptions, log))
+        if (!SupportsNuGetOrgMetadata(sourceOptions, packageName, log))
             return new PackageMetadata();
 
         // Try cache first (unless @latest forces refresh)
@@ -110,14 +110,30 @@ public static class PackageMetadataService
 
     internal static bool SupportsNuGetOrgMetadata(
         NuGetSourceOptions? sourceOptions,
+        string packageId,
         Action<string>? log = null)
     {
-        bool supported = NuGetSourceResolver.ResolveSources(sourceOptions)
-            .Any(source => source.IsNuGetOrg);
+        bool supported;
+        try
+        {
+            supported = NuGetSourceResolver.ResolveSourcesForPackage(
+                    sourceOptions,
+                    packageId)
+                .Any(source => source.IsNuGetOrg);
+        }
+        catch (PackageSourceMappingException ex)
+            when (ex.Failure is
+                PackageSourceMappingFailure.NoPattern
+                or PackageSourceMappingFailure.InactiveSource)
+        {
+            supported = false;
+        }
+
         if (!supported)
         {
             log?.Invoke(
-                "NuGet.org aggregate metadata is unavailable because the configured package sources do not include api.nuget.org.");
+                $"NuGet.org aggregate metadata is unavailable for '{packageId}' because "
+                + "package source policy does not authorize api.nuget.org.");
         }
         return supported;
     }

--- a/src/DotnetInspector.Services/PdbAcquisitionService.cs
+++ b/src/DotnetInspector.Services/PdbAcquisitionService.cs
@@ -16,6 +16,7 @@ public static class PdbAcquisitionService
         bool isPlatformAssembly,
         Action<string>? log,
         bool cacheOnly = false,
+        NuGetSourceOptions? sourceOptions = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -43,6 +44,7 @@ public static class PdbAcquisitionService
             log,
             isPlatformAssembly,
             cacheOnly,
+            sourceOptions,
             cancellationToken).ConfigureAwait(false);
 
         if (result.PdbFilePath != null)
@@ -57,6 +59,7 @@ public static class PdbAcquisitionService
         HttpClient httpClient,
         Action<string>? log,
         bool cacheOnly = false,
+        NuGetSourceOptions? sourceOptions = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(assembly);
@@ -83,6 +86,7 @@ public static class PdbAcquisitionService
             isPlatformAssembly,
             log,
             cacheOnly,
+            sourceOptions,
             cancellationToken);
     }
 }

--- a/src/DotnetInspector.Services/PlatformPackService.cs
+++ b/src/DotnetInspector.Services/PlatformPackService.cs
@@ -53,14 +53,20 @@ public static class PlatformPackService
         string frameworkShortName,
         string version,
         HttpClient client,
-        Action<string>? log = null)
+        Action<string>? log = null,
+        NuGetSourceOptions? sourceOptions = null)
     {
         if (!PlatformResolver.FrameworkMappings.TryGetValue(frameworkShortName, out var packName))
         {
             return null;
         }
 
-        return await EnsurePackAsync(packName, version, client, log).ConfigureAwait(false);
+        return await EnsurePackAsync(
+            packName,
+            version,
+            client,
+            log,
+            sourceOptions).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -150,14 +156,21 @@ public static class PlatformPackService
         IEnumerable<PackRequest> requests,
         HttpClient client,
         Action<string>? log = null,
-        bool forceLatest = false)
+        bool forceLatest = false,
+        NuGetSourceOptions? sourceOptions = null)
     {
         var downloader = new Downloader<PackResult>();
         foreach (var req in requests)
         {
             var packName = req.PackName;
             var version = req.Version;
-            downloader.Add(() => ResolveAndDownloadAsync(packName, version, client, log, forceLatest));
+            downloader.Add(() => ResolveAndDownloadAsync(
+                packName,
+                version,
+                client,
+                log,
+                forceLatest,
+                sourceOptions));
         }
         return downloader;
     }
@@ -194,7 +207,8 @@ public static class PlatformPackService
         string? version,
         HttpClient client,
         Action<string>? log,
-        bool forceLatest = false)
+        bool forceLatest,
+        NuGetSourceOptions? sourceOptions)
     {
         if (version == null)
         {
@@ -210,11 +224,20 @@ public static class PlatformPackService
             }
 
             // No cached pack (or @latest forced) — resolve from network
-            version = await GetLatestPackVersionAsync(packName, client, log).ConfigureAwait(false);
+            version = await GetLatestPackVersionAsync(
+                packName,
+                client,
+                log,
+                sourceOptions).ConfigureAwait(false);
         }
         if (version == null) return null;
 
-        var packDir = await EnsurePackAsync(packName, version, client, log).ConfigureAwait(false);
+        var packDir = await EnsurePackAsync(
+            packName,
+            version,
+            client,
+            log,
+            sourceOptions).ConfigureAwait(false);
         return packDir != null ? new PackResult(packName, version, packDir) : null;
     }
 
@@ -240,9 +263,12 @@ public static class PlatformPackService
     public static async Task<string?> GetLatestPackVersionAsync(
         string packName,
         HttpClient client,
-        Action<string>? log = null)
+        Action<string>? log = null,
+        NuGetSourceOptions? sourceOptions = null)
     {
-        var sources = NuGetSourceResolver.ResolveSources(null);
+        var sources = NuGetSourceResolver.ResolveSourcesForPackage(
+            sourceOptions,
+            packName);
         return await PackageExtractor.GetLatestVersionAsync(client, packName, sources, log).ConfigureAwait(false);
     }
 
@@ -255,7 +281,8 @@ public static class PlatformPackService
         string packName,
         string version,
         HttpClient client,
-        Action<string>? log = null)
+        Action<string>? log = null,
+        NuGetSourceOptions? sourceOptions = null)
     {
         var cachePath = GetPacksCachePath();
         if (cachePath == null)
@@ -277,7 +304,8 @@ public static class PlatformPackService
             client,
             $"{packName}@{version}",
             log,
-            tempDirPrefix: "inspect-pack").ConfigureAwait(false);
+            tempDirPrefix: "inspect-pack",
+            sourceOptions: sourceOptions).ConfigureAwait(false);
 
         if (!outcome.IsSuccess)
         {

--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -4,6 +4,7 @@ using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using CSharpText;
 using DotnetInspector.Core;
+using DotnetInspector.Packages;
 using ILInspector.Metadata;
 using NuGet.Versioning;
 
@@ -548,7 +549,8 @@ public static class PlatformResolver
         Action<string>? log = null,
         string? frameworkSpec = null,
         bool useRuntimeAssemblies = false,
-        string? platformVersion = null)
+        string? platformVersion = null,
+        NuGetSourceOptions? sourceOptions = null)
     {
         // Try resolving from already-installed packs first (SDK + app cache, no network)
         var local = ResolveAssembly(assemblyName, frameworkSpec, useRuntimeAssemblies: useRuntimeAssemblies, platformVersion: platformVersion);
@@ -569,7 +571,11 @@ public static class PlatformResolver
                 explicitVersion = frameworkSpec[(frameworkSpec.LastIndexOf('@') + 1)..];
 
             var requests = PlatformPackService.BuildPackRequests(assemblyName, explicitVersion);
-            await foreach (var _ in PlatformPackService.EnsurePacksAsync(requests, httpClient, log).ConfigureAwait(false))
+            await foreach (var _ in PlatformPackService.EnsurePacksAsync(
+                requests,
+                httpClient,
+                log,
+                sourceOptions: sourceOptions).ConfigureAwait(false))
             {
             }
 

--- a/src/NuGetFetch.Tests/SourceResolverTests.cs
+++ b/src/NuGetFetch.Tests/SourceResolverTests.cs
@@ -530,6 +530,181 @@ public class SourceResolverTests : IDisposable
         Assert.Equal("https://additional.example.com/v3/index.json", source.Url);
     }
 
+    [Fact]
+    public void ResolvePackageSourceMapping_Absent_IsDisabled()
+    {
+        PackageSourceMapping mapping = SourceResolver.ResolvePackageSourceMapping(
+            configPath: WriteConfig("""
+                <configuration>
+                  <packageSources>
+                    <add key="private" value="https://private.example/v3/index.json" />
+                  </packageSources>
+                </configuration>
+                """));
+
+        Assert.False(mapping.IsEnabled);
+        Assert.Empty(mapping.GetConfiguredPackageSources("Example.Package"));
+    }
+
+    [Fact]
+    public void ResolvePackageSourceMapping_UsesExactThenLongestPrefixThenDefault()
+    {
+        PackageSourceMapping mapping = SourceResolver.ResolvePackageSourceMapping(
+            configPath: WriteConfig("""
+                <configuration>
+                  <packageSourceMapping>
+                    <packageSource key="default">
+                      <package pattern="*" />
+                    </packageSource>
+                    <packageSource key="family">
+                      <package pattern="Contoso.*" />
+                    </packageSource>
+                    <packageSource key="specific">
+                      <package pattern="Contoso.Tools.*" />
+                    </packageSource>
+                    <packageSource key="exact">
+                      <package pattern="Contoso.Tools.Build" />
+                    </packageSource>
+                  </packageSourceMapping>
+                </configuration>
+                """));
+
+        Assert.Equal(
+            ["exact"],
+            mapping.GetConfiguredPackageSources("contoso.tools.build"));
+        Assert.Equal(
+            ["specific"],
+            mapping.GetConfiguredPackageSources("CONTOSO.Tools.Compiler"));
+        Assert.Equal(
+            ["family"],
+            mapping.GetConfiguredPackageSources("Contoso.Core"));
+        Assert.Equal(
+            ["default"],
+            mapping.GetConfiguredPackageSources("Other.Package"));
+    }
+
+    [Fact]
+    public void ResolvePackageSourceMapping_ReturnsEverySourceWithWinningPattern()
+    {
+        PackageSourceMapping mapping = SourceResolver.ResolvePackageSourceMapping(
+            configPath: WriteConfig("""
+                <configuration>
+                  <packageSourceMapping>
+                    <packageSource key="primary">
+                      <package pattern="Contoso.*" />
+                    </packageSource>
+                    <packageSource key="mirror">
+                      <package pattern="contoso.*" />
+                    </packageSource>
+                  </packageSourceMapping>
+                </configuration>
+                """));
+
+        Assert.Equal(
+            ["primary", "mirror"],
+            mapping.GetConfiguredPackageSources("Contoso.Core"));
+    }
+
+    [Fact]
+    public void MergePackageSourceMappings_NearestSourceKeyReplacesPatternListCaseInsensitively()
+    {
+        string parent = WriteConfig("""
+            <configuration>
+              <packageSourceMapping>
+                <packageSource key="Private">
+                  <package pattern="Parent.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+        string child = WriteConfig("""
+            <configuration>
+              <packageSourceMapping>
+                <packageSource key="private">
+                  <package pattern="Child.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        PackageSourceMapping mapping =
+            SourceResolver.MergePackageSourceMappings([child, parent]);
+
+        Assert.Empty(mapping.GetConfiguredPackageSources("Parent.Package"));
+        Assert.Equal(
+            ["private"],
+            mapping.GetConfiguredPackageSources("Child.Package"));
+    }
+
+    [Fact]
+    public void MergePackageSourceMappings_ClearRemovesInheritedMappings()
+    {
+        string parent = WriteConfig("""
+            <configuration>
+              <packageSourceMapping>
+                <packageSource key="parent">
+                  <package pattern="*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+        string child = WriteConfig("""
+            <configuration>
+              <packageSourceMapping>
+                <clear />
+                <packageSource key="child">
+                  <package pattern="Child.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        PackageSourceMapping mapping =
+            SourceResolver.MergePackageSourceMappings([child, parent]);
+
+        Assert.Empty(mapping.GetConfiguredPackageSources("Other.Package"));
+        Assert.Equal(
+            ["child"],
+            mapping.GetConfiguredPackageSources("Child.Package"));
+    }
+
+    [Fact]
+    public void ResolvePackageSourceMapping_SourceWithoutPatternsFails()
+    {
+        string config = WriteConfig("""
+            <configuration>
+              <packageSourceMapping>
+                <packageSource key="private" />
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => SourceResolver.ResolvePackageSourceMapping(configPath: config));
+
+        Assert.Contains("must contain at least one package pattern", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Contoso.*.Tools")]
+    [InlineData("Contoso**")]
+    public void ResolvePackageSourceMapping_InvalidPatternFails(string pattern)
+    {
+        string config = WriteConfig($"""
+            <configuration>
+              <packageSourceMapping>
+                <packageSource key="private">
+                  <package pattern="{pattern}" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        Assert.Throws<InvalidDataException>(
+            () => SourceResolver.ResolvePackageSourceMapping(configPath: config));
+    }
+
     private string WriteConfig(string xml)
     {
         var path = Path.Combine(_tempDir, $"nuget-{Guid.NewGuid():N}.config");

--- a/src/NuGetFetch/PackageSourceMapping.cs
+++ b/src/NuGetFetch/PackageSourceMapping.cs
@@ -1,0 +1,92 @@
+namespace NuGetFetch;
+
+/// <summary>
+/// Package-id patterns that authorize configured package-source names.
+/// </summary>
+public sealed class PackageSourceMapping
+{
+    private readonly IReadOnlyList<SourcePatterns> _sources;
+
+    internal PackageSourceMapping(IEnumerable<KeyValuePair<string, IReadOnlyList<string>>> sources)
+    {
+        _sources =
+        [
+            .. sources.Select(source => new SourcePatterns(source.Key, source.Value)),
+        ];
+    }
+
+    /// <summary>
+    /// Gets whether configuration declared at least one mapped source.
+    /// </summary>
+    public bool IsEnabled => _sources.Count > 0;
+
+    /// <summary>
+    /// Returns the configured source names authorized to serve <paramref name="packageId"/>.
+    /// </summary>
+    /// <remarks>
+    /// Exact package-id patterns win over prefix patterns. Otherwise, the longest matching
+    /// prefix ending in <c>*</c> wins, with <c>*</c> as the least-specific default. More than
+    /// one source may declare the winning pattern.
+    /// </remarks>
+    public IReadOnlyList<string> GetConfiguredPackageSources(string packageId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+
+        List<string> exact = [];
+        foreach (SourcePatterns source in _sources)
+        {
+            if (source.Patterns.Any(pattern =>
+                !pattern.EndsWith('*')
+                && string.Equals(pattern, packageId, StringComparison.OrdinalIgnoreCase)))
+            {
+                exact.Add(source.Name);
+            }
+        }
+
+        if (exact.Count > 0)
+        {
+            return exact;
+        }
+
+        List<string> prefixes = [];
+        int bestLength = -1;
+        foreach (SourcePatterns source in _sources)
+        {
+            int sourceBest = -1;
+            foreach (string pattern in source.Patterns)
+            {
+                if (!pattern.EndsWith('*'))
+                {
+                    continue;
+                }
+
+                string prefix = pattern[..^1];
+                if (prefix.Length >= sourceBest
+                    && packageId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    sourceBest = Math.Max(sourceBest, prefix.Length);
+                }
+            }
+
+            if (sourceBest < bestLength)
+            {
+                continue;
+            }
+
+            if (sourceBest > bestLength)
+            {
+                prefixes.Clear();
+                bestLength = sourceBest;
+            }
+
+            if (sourceBest >= 0)
+            {
+                prefixes.Add(source.Name);
+            }
+        }
+
+        return prefixes;
+    }
+
+    private sealed record SourcePatterns(string Name, IReadOnlyList<string> Patterns);
+}

--- a/src/NuGetFetch/SourceResolver.cs
+++ b/src/NuGetFetch/SourceResolver.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Xml;
 using System.Xml.Linq;
 using InertText;
 
@@ -194,23 +195,82 @@ public static class SourceResolver
         => Validated(BuildConfiguredSources(
             configPath,
             workingDirectory,
-            PackageSources.Empty));
+            PackageSources.Empty,
+            includeDisabled: false));
+
+    /// <summary>
+    /// Resolves every configured source alias, including aliases currently disabled for ambient
+    /// use.
+    /// </summary>
+    /// <remarks>
+    /// Explicit command-line source selection can reactivate a disabled endpoint. Callers use
+    /// this view only to retain its configured name and credentials; ordinary source resolution
+    /// continues to exclude disabled entries.
+    /// </remarks>
+    public static IReadOnlyList<PackageSource> ResolveConfiguredSourceAliases(
+        string? configPath = null,
+        string? workingDirectory = null)
+        => Validated(BuildConfiguredSources(
+            configPath,
+            workingDirectory,
+            configPath is null ? PackageSources.Default : PackageSources.Empty,
+            includeDisabled: true));
+
+    /// <summary>
+    /// Resolves package source mapping from the same configuration hierarchy as package sources.
+    /// </summary>
+    /// <remarks>
+    /// Mapping is independent of source replacement. Supplying <paramref name="configPath"/>
+    /// selects only that file; otherwise, configurations are merged most-distant first and a
+    /// nearer source key replaces the complete pattern list inherited for that key.
+    /// </remarks>
+    /// <exception cref="InvalidDataException">
+    /// A mapping source has no key or patterns, or a pattern is not an exact package id or a
+    /// prefix ending in <c>*</c>.
+    /// </exception>
+    public static PackageSourceMapping ResolvePackageSourceMapping(
+        string? configPath = null,
+        string? workingDirectory = null)
+    {
+        IReadOnlyList<string> configFiles = configPath is not null
+            ? [configPath]
+            : FindConfigFiles(workingDirectory);
+        return MergePackageSourceMappings(configFiles);
+    }
+
+    internal static PackageSourceMapping MergePackageSourceMappings(
+        IReadOnlyList<string> configFiles)
+    {
+        ArgumentNullException.ThrowIfNull(configFiles);
+
+        var mappings =
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+        for (int i = configFiles.Count - 1; i >= 0; i--)
+        {
+            MergePackageSourceMappingFile(configFiles[i], mappings);
+        }
+
+        return new PackageSourceMapping(mappings);
+    }
 
     private static IReadOnlyList<PackageSource> BuildConfiguredSources(
         string? configPath,
         string? workingDirectory,
-        IReadOnlyList<PackageSource> initialSources)
+        IReadOnlyList<PackageSource> initialSources,
+        bool includeDisabled = false)
     {
         IReadOnlyList<string> configFiles = configPath is not null
             ? [configPath]
             : FindConfigFiles(workingDirectory);
 
-        return MergeConfigFiles(configFiles, initialSources);
+        return MergeConfigFiles(configFiles, initialSources, includeDisabled);
     }
 
     internal static IReadOnlyList<PackageSource> MergeConfigFiles(
         IReadOnlyList<string> configFiles,
-        IReadOnlyList<PackageSource> initialSources)
+        IReadOnlyList<PackageSource> initialSources,
+        bool includeDisabled = false)
     {
         ArgumentNullException.ThrowIfNull(configFiles);
         ArgumentNullException.ThrowIfNull(initialSources);
@@ -255,7 +315,7 @@ public static class SourceResolver
         // Explicitly configured sources are consulted before surviving defaults.
         foreach (string name in configuredSources.Concat(inheritedSources))
         {
-            if (disabled.Contains(name))
+            if (!includeDisabled && disabled.Contains(name))
             {
                 continue;
             }
@@ -265,6 +325,94 @@ public static class SourceResolver
         }
 
         return sources.Count == 0 ? PackageSources.Empty : sources;
+    }
+
+    private static void MergePackageSourceMappingFile(
+        string configPath,
+        Dictionary<string, IReadOnlyList<string>> mappings)
+    {
+        if (!File.Exists(configPath))
+        {
+            return;
+        }
+
+        XDocument document;
+        try
+        {
+            document = XDocument.Load(configPath);
+        }
+        catch (Exception ex) when (ex is
+            XmlException
+            or IOException
+            or UnauthorizedAccessException
+            or NotSupportedException)
+        {
+            // Source parsing treats unreadable ambient configuration as absent.
+            return;
+        }
+
+        XElement? mapping = document.Root?.Element("packageSourceMapping");
+        if (mapping is null)
+        {
+            return;
+        }
+
+        foreach (XElement element in mapping.Elements())
+        {
+            if (element.Name == "clear")
+            {
+                mappings.Clear();
+                continue;
+            }
+
+            if (element.Name != "packageSource")
+            {
+                continue;
+            }
+
+            string? sourceName = element.Attribute("key")?.Value.Trim();
+            if (string.IsNullOrWhiteSpace(sourceName))
+            {
+                throw new InvalidDataException(
+                    $"Package source mapping in '{configPath}' contains a source without a key.");
+            }
+
+            List<string> patterns = [];
+            foreach (XElement package in element.Elements("package"))
+            {
+                string? pattern = package.Attribute("pattern")?.Value.Trim();
+                if (pattern is null)
+                {
+                    throw new InvalidDataException(
+                        $"Package source mapping for '{sourceName}' in '{configPath}' "
+                        + "contains a package without a pattern.");
+                }
+
+                patterns.Add(pattern);
+            }
+            if (patterns.Count == 0)
+            {
+                throw new InvalidDataException(
+                    $"Package source mapping for '{sourceName}' in '{configPath}' "
+                    + "must contain at least one package pattern.");
+            }
+
+            foreach (string pattern in patterns)
+            {
+                if (string.IsNullOrWhiteSpace(pattern)
+                    || (pattern.Contains('*')
+                        && (pattern[^1] != '*'
+                            || pattern[..^1].Contains('*'))))
+                {
+                    throw new InvalidDataException(
+                        $"Package source mapping pattern '{pattern}' for '{sourceName}' "
+                        + $"in '{configPath}' must be an exact package id or a prefix ending in '*'.");
+                }
+            }
+
+            mappings.Remove(sourceName);
+            mappings.Add(sourceName, patterns);
+        }
     }
 
     /// <summary>
@@ -316,7 +464,8 @@ public static class SourceResolver
         => Validated(BuildConfiguredSources(
             configPath,
             workingDirectory: null,
-            initialSources: PackageSources.Empty));
+            initialSources: PackageSources.Empty,
+            includeDisabled: false));
 
     /// <summary>
     /// Merges a single nuget.config file into the accumulated sources, disabled set, and credentials.

--- a/src/dotnet-inspect.Tests/NuGetSearchSourcesTests.cs
+++ b/src/dotnet-inspect.Tests/NuGetSearchSourcesTests.cs
@@ -722,6 +722,34 @@ public class NuGetSearchSourcesTests
     }
 
     [Fact]
+    public async Task SearchAsync_ConflictingEligibleAliasCredentialsFail()
+    {
+        const string index = "https://feed.example/v3/index.json";
+        const string search = "https://feed.example/v3/query";
+        using var config = new TempNuGetConfig(
+            [("anonymous", index), ("authenticated", index)],
+            credentialedSource: "authenticated",
+            mappings: [("anonymous", "Contoso.*"), ("authenticated", "Contoso.*")]);
+        var handler = new RouteHandler
+        {
+            [index] = $$"""{"resources":[{"@id":"{{search}}","@type":"SearchQueryService"}]}""",
+            [search] = """{"data":[{"id":"Contoso.Package","version":"1.0.0"}]}""",
+        };
+        using var client = new HttpClient(handler);
+
+        PackageSourceMappingException exception =
+            await Assert.ThrowsAsync<PackageSourceMappingException>(
+                () => NuGetSearchService.SearchAsync(
+                    client,
+                    "Contoso",
+                    sourceOptions: new NuGetSourceOptions { ConfigFile = config.Path }));
+
+        Assert.Equal(
+            PackageSourceMappingFailure.ConflictingCredentials,
+            exception.Failure);
+    }
+
+    [Fact]
     public async Task SearchByPrefixAsync_UsesSelectedSourcesAndFiltersTheirResults()
     {
         const string index = "https://private.example/v3/index.json";

--- a/src/dotnet-inspect.Tests/NuGetSearchSourcesTests.cs
+++ b/src/dotnet-inspect.Tests/NuGetSearchSourcesTests.cs
@@ -685,6 +685,43 @@ public class NuGetSearchSourcesTests
     }
 
     [Fact]
+    public async Task SearchAsync_PackageSourceMappingFiltersEachResultByReportingAlias()
+    {
+        const string indexA = "https://a.example/v3/index.json";
+        const string indexB = "https://b.example/v3/index.json";
+        const string searchA = "https://a.example/v3/query";
+        const string searchB = "https://b.example/v3/query";
+        const string results = """
+            {"data":[
+                {"id":"A.Package","version":"1.0.0"},
+                {"id":"B.Package","version":"1.0.0"},
+                {"id":"Unmapped.Package","version":"1.0.0"}
+            ]}
+            """;
+        using var config = new TempNuGetConfig(
+            [("a", indexA), ("b", indexB)],
+            mappings: [("a", "A.*"), ("b", "B.*")]);
+        var handler = new RouteHandler
+        {
+            [indexA] = $$"""{"resources":[{"@id":"{{searchA}}","@type":"SearchQueryService"}]}""",
+            [indexB] = $$"""{"resources":[{"@id":"{{searchB}}","@type":"SearchQueryService"}]}""",
+            [searchA] = results,
+            [searchB] = results,
+        };
+        using var client = new HttpClient(handler);
+
+        NuGetSearchOutcome outcome = await NuGetSearchService.SearchAsync(
+            client,
+            "Package",
+            sourceOptions: new NuGetSourceOptions { ConfigFile = config.Path });
+
+        Assert.Empty(outcome.Failures);
+        Assert.Equal(
+            ["A.Package", "B.Package"],
+            outcome.Results.Select(result => result.PackageId));
+    }
+
+    [Fact]
     public async Task SearchByPrefixAsync_UsesSelectedSourcesAndFiltersTheirResults()
     {
         const string index = "https://private.example/v3/index.json";
@@ -814,12 +851,12 @@ public class NuGetSearchSourcesTests
     }
 
     /// <summary>
-    /// Two configured entries differing only by a trailing slash are separate entries that may
-    /// carry separate credentials. Slash tolerance decides candidacy, never authorization, so an
-    /// exact spelling wins outright rather than the first slash-tolerant candidate.
+    /// Two configured entries differing only by a trailing slash are aliases for one producer,
+    /// but package source mapping names those aliases independently. Both must survive source
+    /// selection until a package id chooses between them.
     /// </summary>
     [Fact]
-    public void ResolveSources_TrailingSlashAmbiguity_PrefersExactSpelling()
+    public void ResolveSources_TrailingSlashAliases_AreAllRetained()
     {
         const string bare = "https://feed.example/v3/index.json";
         const string slashed = "https://feed.example/v3/index.json/";
@@ -830,20 +867,18 @@ public class NuGetSearchSourcesTests
         List<PackageSource> sources = NuGetSourceResolver.ResolveSources(
             new NuGetSourceOptions { Sources = [slashed], ConfigFile = config.Path });
 
-        PackageSource only = Assert.Single(sources);
-        Assert.Equal(slashed, only.Url);
-        Assert.Equal("slashed", only.Name);
-        Assert.Null(only.Credential);
-        Assert.Null(only.GetAuthHeader());
+        Assert.Equal(["bare", "slashed"], sources.Select(source => source.Name));
+        Assert.All(sources, source => Assert.Equal(slashed, source.Url));
+        Assert.NotNull(sources[0].Credential);
+        Assert.Null(sources[1].Credential);
     }
 
     /// <summary>
-    /// With no exact spelling to prefer, an ambiguous slash-tolerant match adopts no credential at
-    /// all. Picking either candidate would be a guess that could send one entry's secret to the
-    /// other's spelling.
+    /// Repeated trailing slashes are a different producer identity. An unmatched explicit URL
+    /// therefore retains its literal spelling as the alias mapping must name.
     /// </summary>
     [Fact]
-    public void ResolveSources_TrailingSlashAmbiguity_WithoutExactMatch_AdoptsNoCredential()
+    public void ResolveSources_RepeatedTrailingSlash_UsesLiteralAlias()
     {
         using var config = new TempNuGetConfig(
             [("bare", "https://feed.example/v3/index.json"),
@@ -858,9 +893,163 @@ public class NuGetSearchSourcesTests
             });
 
         PackageSource only = Assert.Single(sources);
-        Assert.Equal("explicit", only.Name);
+        Assert.Equal("https://feed.example/v3/index.json//", only.Name);
         Assert.Null(only.Credential);
         Assert.Null(only.GetAuthHeader());
+    }
+
+    [Fact]
+    public void ResolveSourcesForPackage_MappingAbsent_AllowsEveryProducer()
+    {
+        using var config = new TempNuGetConfig(
+            [("a", "https://a.example/v3/index.json"),
+             ("b", "https://b.example/v3/index.json")]);
+
+        List<PackageSource> sources = NuGetSourceResolver.ResolveSourcesForPackage(
+            new NuGetSourceOptions { ConfigFile = config.Path },
+            "Contoso.Package");
+
+        Assert.Equal(["a", "b"], sources.Select(source => source.Name));
+    }
+
+    [Fact]
+    public void ResolveSourcesForPackage_MappingSelectsConfiguredName()
+    {
+        using var config = new TempNuGetConfig(
+            [("a", "https://a.example/v3/index.json"),
+             ("b", "https://b.example/v3/index.json")],
+            mappings: [("a", "A.*"), ("B", "B.*")]);
+
+        PackageSource source = Assert.Single(
+            NuGetSourceResolver.ResolveSourcesForPackage(
+                new NuGetSourceOptions { ConfigFile = config.Path },
+                "B.Package"));
+
+        Assert.Equal("b", source.Name);
+    }
+
+    [Fact]
+    public void ResolveSourcesForPackage_UnmatchedPackageFails()
+    {
+        using var config = new TempNuGetConfig(
+            [("a", "https://a.example/v3/index.json")],
+            mappings: [("a", "A.*")]);
+
+        PackageSourceMappingException exception = Assert.Throws<PackageSourceMappingException>(
+            () => NuGetSourceResolver.ResolveSourcesForPackage(
+                new NuGetSourceOptions { ConfigFile = config.Path },
+                "B.Package"));
+
+        Assert.Equal(PackageSourceMappingFailure.NoPattern, exception.Failure);
+        Assert.Contains("no pattern", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResolveSourcesForPackage_InactiveMappedSourceFails()
+    {
+        using var config = new TempNuGetConfig(
+            [("active", "https://active.example/v3/index.json")],
+            mappings: [("inactive", "*")]);
+
+        PackageSourceMappingException exception = Assert.Throws<PackageSourceMappingException>(
+            () => NuGetSourceResolver.ResolveSourcesForPackage(
+                new NuGetSourceOptions { ConfigFile = config.Path },
+                "Any.Package"));
+
+        Assert.Equal(PackageSourceMappingFailure.InactiveSource, exception.Failure);
+        Assert.Contains("inactive", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("not active", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResolveSourcesForPackage_ExplicitUrlRetainsAliasesUntilMappingSelectsOne()
+    {
+        const string bare = "https://feed.example/v3/index.json";
+        const string slashed = "https://feed.example/v3/index.json/";
+        using var config = new TempNuGetConfig(
+            [("bare", bare), ("slashed", slashed)],
+            credentialedSource: "bare",
+            mappings: [("bare", "Contoso.*"), ("slashed", "Other.*")]);
+
+        PackageSource source = Assert.Single(
+            NuGetSourceResolver.ResolveSourcesForPackage(
+                new NuGetSourceOptions
+                {
+                    ConfigFile = config.Path,
+                    Sources = [slashed],
+                },
+                "Contoso.Package"));
+
+        Assert.Equal("bare", source.Name);
+        Assert.Equal(slashed, source.Url);
+        Assert.NotNull(source.Credential);
+    }
+
+    [Fact]
+    public void ResolveSourcesForPackage_EligibleAliasesWithConflictingCredentialsFail()
+    {
+        const string bare = "https://feed.example/v3/index.json";
+        const string slashed = "https://feed.example/v3/index.json/";
+        using var config = new TempNuGetConfig(
+            [("bare", bare), ("slashed", slashed)],
+            credentialedSource: "bare",
+            mappings: [("bare", "*"), ("slashed", "*")]);
+
+        PackageSourceMappingException exception = Assert.Throws<PackageSourceMappingException>(
+            () => NuGetSourceResolver.ResolveSourcesForPackage(
+                new NuGetSourceOptions
+                {
+                    ConfigFile = config.Path,
+                    Sources = [slashed],
+                },
+                "Contoso.Package"));
+
+        Assert.Equal(PackageSourceMappingFailure.ConflictingCredentials, exception.Failure);
+        Assert.Contains("conflicting credentials", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResolveSourcesForPackage_ExplicitUrlRetainsDisabledConfiguredAlias()
+    {
+        using var config = new TempNuGetConfig(
+            [("private", IndexUrl)],
+            credentialedSource: "private",
+            mappings: [("private", "Contoso.*")],
+            disabledSources: ["private"]);
+
+        PackageSource source = Assert.Single(
+            NuGetSourceResolver.ResolveSourcesForPackage(
+                new NuGetSourceOptions
+                {
+                    ConfigFile = config.Path,
+                    Sources = [IndexUrl],
+                },
+                "Contoso.Package"));
+
+        Assert.Equal("private", source.Name);
+        Assert.NotNull(source.Credential);
+    }
+
+    [Fact]
+    public void ReporterRestriction_IsAppliedAfterPackageSourceMapping()
+    {
+        const string sourceA = "https://a.example/v3/index.json";
+        const string sourceB = "https://b.example/v3/index.json";
+        using var config = new TempNuGetConfig(
+            [("a", sourceA), ("b", sourceB)],
+            mappings: [("a", "Contoso.*"), ("b", "Other.*")]);
+        NuGetSourceOptions? options = NuGetSourceResolver.RestrictToSources(
+            new NuGetSourceOptions { ConfigFile = config.Path },
+            [sourceB]);
+
+        List<PackageSource> mapped = NuGetSourceResolver.ResolveSourcesForPackage(
+            options,
+            "Contoso.Package");
+        IReadOnlyList<PackageSource> authorized =
+            NuGetSourceResolver.ResolveAuthorizedSources(options, mapped);
+
+        Assert.Equal(["a"], mapped.Select(source => source.Name));
+        Assert.Empty(authorized);
     }
 
     /// <summary>
@@ -905,7 +1094,9 @@ public class NuGetSearchSourcesTests
 
         public TempNuGetConfig(
             IReadOnlyList<(string Name, string Url)> sources,
-            string? credentialedSource = null)
+            string? credentialedSource = null,
+            IReadOnlyList<(string Source, string Pattern)>? mappings = null,
+            IReadOnlyList<string>? disabledSources = null)
         {
             string adds = string.Join(
                 Environment.NewLine,
@@ -919,6 +1110,29 @@ public class NuGetSearchSourcesTests
                     </{credentialedSource}>
                   </packageSourceCredentials>
                 """;
+            string mapping = mappings is null ? "" : $"""
+                  <packageSourceMapping>
+                {string.Join(
+                    Environment.NewLine,
+                    mappings
+                        .GroupBy(item => item.Source)
+                        .Select(group => $"""
+                    <packageSource key="{group.Key}">
+                {string.Join(
+                    Environment.NewLine,
+                    group.Select(item => $"""      <package pattern="{item.Pattern}" />"""))}
+                    </packageSource>
+                """))}
+                  </packageSourceMapping>
+                """;
+            string disabled = disabledSources is null ? "" : $"""
+                  <disabledPackageSources>
+                {string.Join(
+                    Environment.NewLine,
+                    disabledSources.Select(
+                        source => $"""    <add key="{source}" value="true" />"""))}
+                  </disabledPackageSources>
+                """;
 
             Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"nuget-{Guid.NewGuid():N}.config");
             File.WriteAllText(Path, $"""
@@ -929,6 +1143,8 @@ public class NuGetSearchSourcesTests
                 {adds}
                   </packageSources>
                 {credentials}
+                {mapping}
+                {disabled}
                 </configuration>
                 """);
         }

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -1550,6 +1550,53 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
     }
 
     [Fact]
+    public async Task ExtractPackageAsync_PackageSourceMappingSelectsEligibleSource()
+    {
+        const string PackageName = "gamma.mapped";
+        const string Version = "1.0.0";
+        string configPath = Path.Combine(
+            Path.GetTempPath(),
+            $"acquisition-mapping-{Guid.NewGuid():N}.config");
+        File.WriteAllText(configPath, """
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="refusing" value="https://refusing.example/v3/index.json" />
+                <add key="serving" value="https://serving.example/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="serving">
+                  <package pattern="gamma.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        var handler = new RefusesOnePackageHandler(
+            PackageName,
+            CreatePackageArchive(PackageName, Version));
+        using var client = new HttpClient(handler);
+
+        try
+        {
+            PackageExtractionOutcome outcome = await PackageExtractor.ExtractPackageAsync(
+                client,
+                PackageName,
+                sourceOptions: new NuGetSourceOptions { ConfigFile = configPath },
+                version: Version);
+
+            Assert.True(outcome.IsSuccess);
+            Assert.DoesNotContain(
+                handler.Requests,
+                url => url.Contains("refusing.example", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            File.Delete(configPath);
+        }
+    }
+
+    [Fact]
     public async Task ExtractPackageAsync_OneSourceRefusesAndAnotherAnswers_SucceedsWithoutBlamingTheRefusal()
     {
         const string PackageName = "gamma.available";
@@ -1624,10 +1671,13 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         string refusedPackageId,
         byte[] refusedPackageArchive) : HttpMessageHandler
     {
+        public List<string> Requests { get; } = [];
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Uri uri = request.RequestUri!;
+            Requests.Add(uri.AbsoluteUri);
             HttpResponseMessage response;
 
             if (uri.AbsolutePath.Equals("/v3/index.json", StringComparison.OrdinalIgnoreCase))

--- a/src/dotnet-inspect.Tests/RidPackageVerifierTests.cs
+++ b/src/dotnet-inspect.Tests/RidPackageVerifierTests.cs
@@ -50,6 +50,58 @@ public class RidPackageVerifierTests
             request.Host.Equals("api.nuget.org", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task VerifyAsync_UnmappedRidPackagePropagatesMappingFailure()
+    {
+        string configPath = Path.Combine(
+            Path.GetTempPath(),
+            $"rid-mapping-{Guid.NewGuid():N}.config");
+        File.WriteAllText(configPath, """
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="private" value="https://private.example/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="private">
+                  <package pattern="Parent.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+        var result = new InspectionResult
+        {
+            RuntimeIdentifierPackages =
+            [
+                new RidPackageReference
+                {
+                    RuntimeIdentifier = "linux-x64",
+                    PackageId = "runtime.linux-x64.Unmapped"
+                }
+            ]
+        };
+
+        try
+        {
+            PackageSourceMappingException exception =
+                await Assert.ThrowsAsync<PackageSourceMappingException>(
+                    () => RidPackageVerifier.VerifyAsync(
+                        new HttpClient(),
+                        result,
+                        "1.0.0",
+                        localDir: null,
+                        logger: new VerboseLogger(enabled: false),
+                        sourceOptions: new NuGetSourceOptions { ConfigFile = configPath }));
+
+            Assert.Equal(PackageSourceMappingFailure.NoPattern, exception.Failure);
+            Assert.Null(Assert.Single(result.RuntimeIdentifierPackages).Exists);
+        }
+        finally
+        {
+            File.Delete(configPath);
+        }
+    }
+
     sealed class StubHandler : HttpMessageHandler
     {
         readonly List<(string Match, string Body)> _routes = [];

--- a/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
+++ b/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
@@ -4,6 +4,7 @@ using System.Net;
 using DotnetInspector.CommandLine;
 using DotnetInspector.Commands;
 using DotnetInspector.Core;
+using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
@@ -556,6 +557,35 @@ public sealed class SourceScopedRoutingTests : IDisposable
             new CommandContext(verbose: false));
 
         Assert.False(exists);
+    }
+
+    [Fact]
+    public void SourceEnrichment_TreatsUnmappedCacheCandidateAsAMiss()
+    {
+        string configPath = Path.Combine(_testRoot, "enrichment-mapping.nuget.config");
+        Directory.CreateDirectory(_testRoot);
+        File.WriteAllText(configPath, $"""
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="excluded" value="{ExcludedSource}" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="excluded">
+                  <package pattern="Other.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        string? version = SourceEnricher.FindCachedPackageVersion(
+            $"Unmapped{Guid.NewGuid():N}",
+            new ApiOptions
+            {
+                SourceOptions = new NuGetSourceOptions { ConfigFile = configPath },
+            });
+
+        Assert.Null(version);
     }
 
     private static void SeedLatestCandidate(

--- a/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
+++ b/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
@@ -528,6 +528,36 @@ public sealed class SourceScopedRoutingTests : IDisposable
         Assert.True(exists);
     }
 
+    [Fact]
+    public async Task TypePrefixProbe_TreatsUnmappedPackageAsAMiss()
+    {
+        string configPath = Path.Combine(_testRoot, "type-probe-mapping.nuget.config");
+        Directory.CreateDirectory(_testRoot);
+        File.WriteAllText(configPath, $"""
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="excluded" value="{ExcludedSource}" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="excluded">
+                  <package pattern="Other.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        bool exists = await TypeCommand.PackageExistsAsync(
+            $"Unmapped{Guid.NewGuid():N}",
+            new TypeOptions
+            {
+                SourceOptions = new NuGetSourceOptions { ConfigFile = configPath },
+            },
+            new CommandContext(verbose: false));
+
+        Assert.False(exists);
+    }
+
     private static void SeedLatestCandidate(
         string packageName,
         string sourceUrl,

--- a/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
+++ b/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
@@ -138,6 +138,39 @@ public sealed class SourceScopedRoutingTests : IDisposable
     }
 
     [Fact]
+    public async Task UnmappedPackage_ReportsMappingFailureWithoutNetworkLookup()
+    {
+        string packageName = $"Unmapped{Guid.NewGuid():N}";
+        string configPath = Path.Combine(_testRoot, "unmapped.nuget.config");
+        Directory.CreateDirectory(_testRoot);
+        File.WriteAllText(configPath, $"""
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="excluded" value="{ExcludedSource}" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="excluded">
+                  <package pattern="Other.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+
+        var (exit, output, error) = await RunCommandAsync(
+            ["package", packageName, "--version", "--nugetconfig", configPath]);
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains(
+            $"Package source mapping has no pattern for package '{packageName.ToLowerInvariant()}'.",
+            error,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("PackageSourceMappingException", error);
+        Assert.DoesNotContain(" at DotnetInspector.", error);
+    }
+
+    [Fact]
     public async Task Router_MissingSourceValue_ReportsCleanParseError()
     {
         var (exit, output, error) = await RunCommandAsync(
@@ -203,6 +236,81 @@ public sealed class SourceScopedRoutingTests : IDisposable
             qualifiedName,
             [NuGetCache.GetSourceKey(ExcludedSource)],
             allowPlatformPrefixFallback: false));
+    }
+
+    [Fact]
+    public void QualifiedName_PackageSourceMappingSelectsCandidateCachePerPackageId()
+    {
+        string packageName = $"RouteMapped{Guid.NewGuid():N}.Package";
+        string qualifiedName = $"{packageName}.Widget";
+        string configPath = Path.Combine(_testRoot, "mapping.nuget.config");
+        Directory.CreateDirectory(_testRoot);
+        File.WriteAllText(configPath, $"""
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="excluded" value="{ExcludedSource}" />
+                <add key="second" value="{SecondSource}" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="second">
+                  <package pattern="{packageName}" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+        var sourceOptions = new NuGetSourceOptions { ConfigFile = configPath };
+
+        SeedLatestCandidate(packageName, ExcludedSource, "1.0.0");
+        Assert.Null(SourceResolver.TryResolveQualifiedTypeName(
+            qualifiedName,
+            sourceOptions,
+            allowPlatformPrefixFallback: false));
+
+        SeedLatestCandidate(packageName, SecondSource, "1.0.0");
+        Assert.NotNull(SourceResolver.TryResolveQualifiedTypeName(
+            qualifiedName,
+            sourceOptions,
+            allowPlatformPrefixFallback: false));
+    }
+
+    [Fact]
+    public void PackageContentCache_PackageSourceMappingSelectsEligibleProducer()
+    {
+        string packageName = $"PayloadMapped{Guid.NewGuid():N}";
+        string configPath = Path.Combine(_testRoot, "payload-mapping.nuget.config");
+        Directory.CreateDirectory(_testRoot);
+        File.WriteAllText(configPath, $"""
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="excluded" value="{ExcludedSource}" />
+                <add key="second" value="{SecondSource}" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="second">
+                  <package pattern="{packageName}" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+        var sourceOptions = new NuGetSourceOptions { ConfigFile = configPath };
+
+        SeedPackage(packageName, ExcludedSource);
+        IReadOnlyList<string> eligibleKeys =
+            NuGetSourceResolver.ResolveSourceKeysForPackage(
+                sourceOptions,
+                packageName);
+        Assert.Null(NuGetCache.TryGetCachedPackage(
+            packageName,
+            "1.0.0",
+            eligibleKeys));
+
+        SeedPackage(packageName, SecondSource);
+        Assert.NotNull(NuGetCache.TryGetCachedPackage(
+            packageName,
+            "1.0.0",
+            eligibleKeys));
     }
 
     [Theory]
@@ -437,7 +545,7 @@ public sealed class SourceScopedRoutingTests : IDisposable
             extension: "txt");
     }
 
-    private void SeedPackage(string packageName)
+    private void SeedPackage(string packageName, string? sourceUrl = null)
     {
         string staged = Path.Combine(_testRoot, $"stage-{Guid.NewGuid():N}");
         Directory.CreateDirectory(staged);
@@ -451,7 +559,9 @@ public sealed class SourceScopedRoutingTests : IDisposable
             nupkgPath: null,
             packageName,
             version: "1.0.0",
-            _ambientSourceKeys[0]);
+            sourceUrl is null
+                ? _ambientSourceKeys[0]
+                : NuGetCache.GetSourceKey(sourceUrl));
     }
 
     private static async Task<IReadOnlyList<BreadcrumbObservation>> RunAppAsync(string[] args)

--- a/src/dotnet-inspect.Tests/SymbolPackageDownloaderTests.cs
+++ b/src/dotnet-inspect.Tests/SymbolPackageDownloaderTests.cs
@@ -122,6 +122,55 @@ public class SymbolPackageDownloaderTests : IDisposable
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => download);
     }
 
+    [Fact]
+    public async Task DownloadPdbAsync_PrivateMappingDoesNotProbeNuGetOrgSnupkg()
+    {
+        string configPath = Path.Combine(
+            Path.GetTempPath(),
+            $"symbol-mapping-{Guid.NewGuid():N}.config");
+        File.WriteAllText(configPath, """
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="private" value="https://private.example/v3/index.json" />
+              </packageSources>
+              <packageSourceMapping>
+                <packageSource key="private">
+                  <package pattern="Private.*" />
+                </packageSource>
+              </packageSourceMapping>
+            </configuration>
+            """);
+        var handler = new CountingHandler(_ => new HttpResponseMessage(HttpStatusCode.NotFound));
+        using var client = new HttpClient(handler);
+        var downloader = new SymbolPackageDownloader(client);
+
+        try
+        {
+            await downloader.DownloadPdbAsync(
+                Guid.Parse("00112233-4455-6677-8899-aabbccddeeff"),
+                pdbAge: 1,
+                pdbFileName: "Symbols.pdb",
+                isPortable: true,
+                assemblyPath: "/tmp/Private.Package.dll",
+                packageName: "Private.Package",
+                packageVersion: "1.0.0",
+                sourceOptions: new NuGetSourceOptions { ConfigFile = configPath },
+                cancellationToken: TestContext.Current.CancellationToken);
+
+            Assert.DoesNotContain(
+                handler.RequestUris,
+                uri => uri.Contains(".snupkg", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(
+                handler.RequestUris,
+                uri => uri.Contains("private.package", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            File.Delete(configPath);
+        }
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_cacheDir))

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Packages;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using ILInspector.Metadata;
@@ -348,6 +349,7 @@ public static class InspectionCommandDefinitions
             string? platformAssembly = explicitPlatform;
             var requestedFramework = parseResult.GetValue(asmFrameworkOption);
             var requestedPlatformVersion = parseResult.GetValue(asmVersionOption);
+            NuGetSourceOptions? sourceOptions = opts.ParseNuGetSourceOptions(parseResult);
 
             if (!string.IsNullOrEmpty(source) && string.IsNullOrEmpty(explicitPlatform) && string.IsNullOrEmpty(explicitPackage))
             {
@@ -372,7 +374,8 @@ public static class InspectionCommandDefinitions
                         source, HttpClientFactory.Shared, log,
                         requestedFramework,
                         platformVersion: requestedPlatformVersion,
-                        useRuntimeAssemblies: true);
+                        useRuntimeAssemblies: true,
+                        sourceOptions: sourceOptions);
                     if (error == null && asmPath != null)
                         platformAssembly = source;
                     else if (!string.IsNullOrEmpty(requestedFramework) || !string.IsNullOrEmpty(requestedPlatformVersion))

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -207,14 +207,14 @@ public static class RouterCommandDefinition
             if (hasVersionQuery || target.Contains('@'))
                 return ["package", .. tokens];
 
-            var sourceKeys = NuGetSourceResolver.ResolveSourceKeys(sourceOptions);
             var context = new CommandContext(verbose: false);
             if (PlatformResolver.IsPlatformCandidate(target))
             {
                 var (resolvedPath, _, _, resolvedError) = await PlatformResolver.ResolveAssemblyAsync(
                     target,
                     context.HttpClient,
-                    context.Logger.Log);
+                    context.Logger.Log,
+                    sourceOptions: sourceOptions);
                 if (resolvedPath != null && resolvedError == null)
                 {
                     AssemblySurfaceClassificationOutcome classification =
@@ -241,7 +241,7 @@ public static class RouterCommandDefinition
             string? platformLookupFailure = null;
             var memberSplit = SharedParsers.TrySplitQualifiedTypeMember(
                 target,
-                sourceKeys,
+                sourceOptions,
                 allowPlatformPrefixFallback,
                 message => platformLookupFailure = message);
             if (platformLookupFailure is not null)
@@ -285,7 +285,7 @@ public static class RouterCommandDefinition
 
             var typeProbe = SourceResolver.TryResolveQualifiedTypeName(
                 target,
-                sourceKeys,
+                sourceOptions,
                 allowPlatformPrefixFallback,
                 message => platformLookupFailure = message);
             if (platformLookupFailure is not null)
@@ -348,8 +348,9 @@ public static class RouterCommandDefinition
         {
             if (PackageExtractor.HasCachedCandidateVersion(
                     packageName,
-                    NuGetSourceResolver.ResolveSourceKeys(
-                        sourceOptions)))
+                    NuGetSourceResolver.ResolveSourceKeysForPackage(
+                        sourceOptions,
+                        packageName)))
             {
                 return true;
             }

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -348,7 +348,7 @@ public static class RouterCommandDefinition
         {
             if (PackageExtractor.HasCachedCandidateVersion(
                     packageName,
-                    NuGetSourceResolver.ResolveSourceKeysForPackage(
+                    SourceResolver.ResolveSourceKeysForProbe(
                         sourceOptions,
                         packageName)))
             {

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -103,10 +103,6 @@ public static class MemberOptionsParser
             return new ShowHelp();
         }
 
-        IReadOnlyList<string> sourceKeys = projectSourcePath is not null
-            ? []
-            : NuGetSourceResolver.ResolveSourceKeys(sourceOptions);
-
         // Extract positional members
         List<string> positionalMembers = [];
         if (projectSourcePath is not null && sourceInputs.Args.Length >= 2)
@@ -139,7 +135,10 @@ public static class MemberOptionsParser
         else
         {
             sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
-                sourceInputs, sourceKeys, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: false);
+                sourceInputs,
+                sourceOptions,
+                parseResult.GetValue(opts.Verbose),
+                tryQualifiedTypeName: false);
             source = sourceSelection.Source;
         }
 
@@ -164,7 +163,7 @@ public static class MemberOptionsParser
             string? platformLookupFailure = null;
             var split = SharedParsers.TrySplitQualifiedTypeMember(
                 source.PackagePath,
-                sourceKeys,
+                sourceOptions,
                 allowPlatformPrefixFallback: true,
                 message => platformLookupFailure = message);
             if (platformLookupFailure is not null)
@@ -192,7 +191,7 @@ public static class MemberOptionsParser
             string? platformLookupFailure = null;
             var probe = SourceResolver.TryResolveQualifiedTypeName(
                 source.PackagePath,
-                sourceKeys,
+                sourceOptions,
                 allowPlatformPrefixFallback: true,
                 message => platformLookupFailure = message);
             if (platformLookupFailure is not null)

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -56,13 +56,13 @@ public static class SharedParsers
 
     public static async Task<SourceSelection> ResolveSourceSelectionAsync(
         SourceSelectionInputs inputs,
-        IReadOnlyList<string> sourceKeys,
+        NuGetSourceOptions? sourceOptions,
         bool verbose,
         bool tryQualifiedTypeName)
     {
         var source = await SourceResolver.ResolveAsync(
             inputs.Args, inputs.ExplicitPackage, inputs.ExplicitAssembly, inputs.ExplicitPlatform,
-            sourceKeys, verbose, tryQualifiedTypeName).ConfigureAwait(false);
+            sourceOptions, verbose, tryQualifiedTypeName).ConfigureAwait(false);
 
         return new SourceSelection(
             inputs.Args,
@@ -99,6 +99,36 @@ public static class SharedParsers
         IReadOnlyList<string> sourceKeys,
         bool allowPlatformPrefixFallback,
         Action<string>? reportPlatformLookupFailure = null)
+        => TrySplitQualifiedTypeMember(
+            value,
+            (candidate, fallback, report) => SourceResolver.TryResolveQualifiedTypeName(
+                candidate,
+                sourceKeys,
+                fallback,
+                report),
+            allowPlatformPrefixFallback,
+            reportPlatformLookupFailure);
+
+    internal static (SourceResolver.LocalProbeResult Probe, string MemberName)? TrySplitQualifiedTypeMember(
+        string value,
+        NuGetSourceOptions? sourceOptions,
+        bool allowPlatformPrefixFallback,
+        Action<string>? reportPlatformLookupFailure = null)
+        => TrySplitQualifiedTypeMember(
+            value,
+            (candidate, fallback, report) => SourceResolver.TryResolveQualifiedTypeName(
+                candidate,
+                sourceOptions,
+                fallback,
+                report),
+            allowPlatformPrefixFallback,
+            reportPlatformLookupFailure);
+
+    private static (SourceResolver.LocalProbeResult Probe, string MemberName)? TrySplitQualifiedTypeMember(
+        string value,
+        Func<string, bool, Action<string>?, SourceResolver.LocalProbeResult?> resolve,
+        bool allowPlatformPrefixFallback,
+        Action<string>? reportPlatformLookupFailure)
     {
         for (var i = value.Length - 1; i > 0; i--)
         {
@@ -111,9 +141,8 @@ public static class SharedParsers
                 continue;
 
             string? platformLookupFailure = null;
-            var probe = SourceResolver.TryResolveQualifiedTypeName(
+            var probe = resolve(
                 typeCandidate,
-                sourceKeys,
                 allowPlatformPrefixFallback,
                 message => platformLookupFailure = message);
             if (platformLookupFailure is not null)

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -102,10 +102,6 @@ public static class TypeOptionsParser
         if (hasProjectSource && hasNonProjectSource)
             return new VersionError("--project cannot be combined with --package, --library, or --platform.");
 
-        IReadOnlyList<string> sourceKeys = hasProjectSource
-            ? []
-            : NuGetSourceResolver.ResolveSourceKeys(sourceOptions);
-
         // Check for unrecognized options in positional args
         var badOption = sourceInputs.Args.FirstOrDefault(a => a.StartsWith('-'));
         if (badOption != null)
@@ -134,7 +130,10 @@ public static class TypeOptionsParser
         else
         {
             sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
-                sourceInputs, sourceKeys, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: true);
+                sourceInputs,
+                sourceOptions,
+                parseResult.GetValue(opts.Verbose),
+                tryQualifiedTypeName: true);
             source = sourceSelection.Source;
         }
 

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -107,6 +107,11 @@ public static class CommandLineBuilder
             CommandError.Write(ex);
             return 1;
         }
+        catch (PackageSourceMappingException ex)
+        {
+            CommandError.Write(ex);
+            return 1;
+        }
         catch (OperationCanceledException)
         {
             return 1;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -673,7 +673,8 @@ public class ApiCommand
                     ? PackageExtractor.ParsePackageReference(options.PackagePath)
                     : (null, null);
                 await SourceEnricher.AcquirePdbAsync(context, httpClient, pkgName, pkgVersion,
-                    isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
+                    isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log,
+                    sourceOptions: options.SourceOptions);
             }
             return context.PortablePdbPath;
         }
@@ -940,7 +941,8 @@ public class ApiCommand
 
                 await SourceEnricher.AcquirePdbAsync(context, httpClient,
                     pkgName, pkgVersion,
-                    isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
+                    isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log,
+                    sourceOptions: options.SourceOptions);
             }
 
             // Capture the acquired portable PDB path now so the decompiler can reuse it for local

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -965,7 +965,8 @@ public class DiffCommand
                         packageName,
                         packageVersion,
                         isPlatformAssembly: options.PlatformVersionRange is not null,
-                        logger.Log);
+                        logger.Log,
+                        sourceOptions: options.SourceOptions);
                 }
 
                 foreach (var target in targets)

--- a/src/dotnet-inspect/Commands/ILOffsetQuery.cs
+++ b/src/dotnet-inspect/Commands/ILOffsetQuery.cs
@@ -84,7 +84,8 @@ internal static class ILOffsetQuery
                 packageName,
                 packageVersion,
                 isPlatformAssembly,
-                logger.Log);
+                logger.Log,
+                sourceOptions: options.SourceOptions);
 
             if (service.HasPdb && !service.HasSourceLink)
                 logger.LogWarning("No SourceLink information found. URLs will not be available.");

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -525,7 +525,8 @@ public class LibraryCommand
                     logger.Log,
                     options.PlatformFramework,
                     useRuntimeAssemblies: true,
-                    platformVersion: options.PlatformVersion);
+                    platformVersion: options.PlatformVersion,
+                    sourceOptions: options.SourceOptions);
 
                 if (error != null)
                 {

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -543,7 +543,12 @@ public class LibraryCommand
                 // family in -D and keys the effective cache so a warmed/cleared PDB busts a
                 // stale catalog. Skipped (false) outside discovery.
                 bool sourceLinkAvailable = fullEffectiveDiscovery && !HasILOffsetCoordinate(options)
-                    && await LibraryMetadataService.ProbeLocalSourceLinkAsync(resolvedPath!, context.HttpClient, logger, isPlatformAssembly: true);
+                    && await LibraryMetadataService.ProbeLocalSourceLinkAsync(
+                        resolvedPath!,
+                        context.HttpClient,
+                        logger,
+                        isPlatformAssembly: true,
+                        sourceOptions: options.SourceOptions);
 
                 // Identity of the bytes about to be inspected. Computed once and reused for the
                 // lookup, the pre-inspection snapshot, and (via CacheEffective) the write, so a
@@ -637,8 +642,14 @@ public class LibraryCommand
 
                 // Network-free SourceLink availability probe (see platform branch).
                 bool sourceLinkAvailable = fullEffectiveDiscovery && assemblyPaths.Count > 0 && !HasILOffsetCoordinate(options)
-                    && await LibraryMetadataService.ProbeLocalSourceLinkAsync(assemblyPaths[0], context.HttpClient, logger, isPlatformAssembly: false,
-                        packageName: packageName, packageVersion: packageVersion);
+                    && await LibraryMetadataService.ProbeLocalSourceLinkAsync(
+                        assemblyPaths[0],
+                        context.HttpClient,
+                        logger,
+                        isPlatformAssembly: false,
+                        packageName: packageName,
+                        packageVersion: packageVersion,
+                        sourceOptions: options.SourceOptions);
 
                 // Identity of the bytes about to be inspected; see the platform path above.
                 string? inspectedContentHash = fullEffectiveDiscovery && assemblyPaths.Count > 0
@@ -747,7 +758,12 @@ public class LibraryCommand
 
                 // Network-free SourceLink availability probe (see platform branch).
                 bool sourceLinkAvailable = fullEffectiveDiscovery && !HasILOffsetCoordinate(options)
-                    && await LibraryMetadataService.ProbeLocalSourceLinkAsync(assemblyPath!, context.HttpClient, logger, isPlatformAssembly: false);
+                    && await LibraryMetadataService.ProbeLocalSourceLinkAsync(
+                        assemblyPath!,
+                        context.HttpClient,
+                        logger,
+                        isPlatformAssembly: false,
+                        sourceOptions: options.SourceOptions);
 
                 // Identity of the bytes about to be inspected; see the platform path above.
                 string? inspectedContentHash = fullEffectiveDiscovery ? TryGetContentHash(assemblyPath!) : null;

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -303,7 +303,9 @@ public class PackageCommand
                     && NuGetCache.TryGetCachedPackage(
                         normalizedName,
                         versionQueryPinned,
-                        NuGetSourceResolver.ResolveSourceKeys(options.SourceOptions)) != null)
+                        NuGetSourceResolver.ResolveSourceKeysForPackage(
+                            options.SourceOptions,
+                            normalizedName)) != null)
                 {
                     if (LensProjection.TryProject(options, "--versions", 1, out var cachedPinnedExit))
                         return cachedPinnedExit;
@@ -348,7 +350,9 @@ public class PackageCommand
 
             if (options.Limit == 1 && options.ForceLatest)
             {
-                var sources = NuGetSourceResolver.ResolveSources(options.SourceOptions);
+                var sources = NuGetSourceResolver.ResolveSourcesForPackage(
+                    options.SourceOptions,
+                    normalizedName);
                 var latest = await PackageExtractor.GetLatestVersionAsync(
                     context.HttpClient,
                     normalizedName,

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -693,7 +693,8 @@ public class PackageCommand
             if (wantsSignals)
             {
                 result.BinarySignals = await PackageInspector.ScanBinarySignalsAsync(
-                    extractPath, packageName, version, client, logger, acquirePdb: true);
+                    extractPath, packageName, version, client, logger,
+                    acquirePdb: true, options.SourceOptions);
             }
 
             if (wantsSignals)
@@ -1607,7 +1608,8 @@ public class PackageCommand
             if (wantsSignals)
             {
                 result.BinarySignals = await PackageInspector.ScanBinarySignalsAsync(
-                    extractPath, target.PackageName, version, context.HttpClient, logger, acquirePdb: true);
+                    extractPath, target.PackageName, version, context.HttpClient, logger,
+                    acquirePdb: true, options.SourceOptions);
                 await AuditSignalBuilder.PopulatePackageAuditAsync(
                     result, context.HttpClient, logger, options.SourceOptions);
             }
@@ -1743,7 +1745,8 @@ public class PackageCommand
                     version,
                     isPlatformAssembly: false,
                     CoreSourceLinkQueryCache.Instance,
-                    logger.Log);
+                    logger.Log,
+                    options.SourceOptions);
 
                 InspectionQueryResults? queryResults = null;
                 if (requestedQueries.Count > 0)
@@ -1760,7 +1763,8 @@ public class PackageCommand
                         packageName,
                         version,
                         isPlatformAssembly: false,
-                        logger.Log).ConfigureAwait(false);
+                        logger.Log,
+                        sourceOptions: options.SourceOptions).ConfigureAwait(false);
                 }
 
                 if (collectSourceFiles)

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -564,8 +564,9 @@ public static class TypeCommand
     {
         if (PackageExtractor.HasCachedCandidateVersion(
                 packageName,
-                NuGetSourceResolver.ResolveSourceKeys(
-                    options.SourceOptions)))
+                NuGetSourceResolver.ResolveSourceKeysForPackage(
+                    options.SourceOptions,
+                    packageName)))
         {
             return true;
         }
@@ -634,7 +635,8 @@ public static class TypeCommand
                 assembly,
                 context.HttpClient,
                 logger.Log,
-                framework);
+                framework,
+                sourceOptions: options.SourceOptions);
             if (assemblyPath == null || error != null)
             {
                 logger.LogWarning($"Could not resolve platform library '{assembly}' in {framework}: {error}");

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -564,7 +564,7 @@ public static class TypeCommand
     {
         if (PackageExtractor.HasCachedCandidateVersion(
                 packageName,
-                NuGetSourceResolver.ResolveSourceKeysForPackage(
+                SourceResolver.ResolveSourceKeysForProbe(
                     options.SourceOptions,
                     packageName)))
         {

--- a/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
+++ b/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
@@ -214,7 +214,8 @@ internal static class ApiSourceResolver
                 options.PlatformAssembly,
                 context.HttpClient,
                 logger.Log,
-                options.PlatformFramework);
+                options.PlatformFramework,
+                sourceOptions: options.SourceOptions);
 
             if (error != null)
             {
@@ -226,7 +227,8 @@ internal static class ApiSourceResolver
                         typeName,
                         [frameworkShortName],
                         context.HttpClient,
-                        logger);
+                        logger,
+                        options.SourceOptions);
 
                     if (lookupResult != null)
                     {
@@ -257,7 +259,8 @@ internal static class ApiSourceResolver
                             typeName,
                             otherFrameworks,
                             context.HttpClient,
-                            logger);
+                            logger,
+                            options.SourceOptions);
 
                         if (foundElsewhere != null)
                         {

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -84,7 +84,8 @@ internal static class LibraryMetadataService
                 packageVersion,
                 isPlatformAssembly,
                 CoreSourceLinkQueryCache.Instance,
-                logger.Log);
+                logger.Log,
+                options.SourceOptions);
 
             if (!pdbContext.HasMetadata)
             {
@@ -346,7 +347,8 @@ internal static class LibraryMetadataService
                 isPlatformAssembly,
                 allowPdbDownload: sourcePlan.AllowPdbDownload && !sourceQueryCheckedPdb,
                 pdbAcquisitionAttempted: sourceQueryCheckedPdb,
-                readCachedPdb: sourcePlan.ReadCachedPdb);
+                readCachedPdb: sourcePlan.ReadCachedPdb,
+                sourceOptions: options.SourceOptions);
 
             var sourceSubject = FindingSubjectFor(path);
             inspection.SourceDocumentInspection ??= SourceLinkFindings.InspectSourceDocuments(
@@ -427,7 +429,8 @@ internal static class LibraryMetadataService
         bool isPlatformAssembly = false,
         bool allowPdbDownload = false,
         bool pdbAcquisitionAttempted = false,
-        bool readCachedPdb = false)
+        bool readCachedPdb = false,
+        NuGetSourceOptions? sourceOptions = null)
     {
         var pdbContext = service.Context;
 
@@ -450,7 +453,14 @@ internal static class LibraryMetadataService
         // If no local PDB, try downloading (only when a selected section authorizes remote acquisition)
         if (!pdbContext.HasPdb && !pdbContext.WindowsPdbDetected && allowPdbDownload)
         {
-            await SourceEnricher.AcquirePdbAsync(pdbContext, httpClient, packageName, packageVersion, isPlatformAssembly, logger.Log);
+            await SourceEnricher.AcquirePdbAsync(
+                pdbContext,
+                httpClient,
+                packageName,
+                packageVersion,
+                isPlatformAssembly,
+                logger.Log,
+                sourceOptions: sourceOptions);
 
             if (pdbContext.HasPdb)
             {
@@ -474,7 +484,8 @@ internal static class LibraryMetadataService
         {
             await SourceEnricher.AcquirePdbAsync(
                 pdbContext, httpClient, packageName, packageVersion,
-                isPlatformAssembly, logger.Log, cacheOnly: true);
+                isPlatformAssembly, logger.Log, cacheOnly: true,
+                sourceOptions: sourceOptions);
 
             if (pdbContext.HasPdb)
             {

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -550,7 +550,8 @@ internal static class LibraryMetadataService
         VerboseLogger logger,
         bool isPlatformAssembly = false,
         string? packageName = null,
-        string? packageVersion = null)
+        string? packageVersion = null,
+        NuGetSourceOptions? sourceOptions = null)
     {
         try
         {
@@ -561,7 +562,8 @@ internal static class LibraryMetadataService
             {
                 await SourceEnricher.AcquirePdbAsync(
                     context, httpClient, packageName, packageVersion,
-                    isPlatformAssembly, logger.Log, cacheOnly: true);
+                    isPlatformAssembly, logger.Log, cacheOnly: true,
+                    sourceOptions: sourceOptions);
             }
 
             return context.HasPdb && service.HasSourceLink;

--- a/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
+++ b/src/dotnet-inspect/Inspectors/MemberSourceLocationCollector.cs
@@ -28,7 +28,8 @@ internal static class MemberSourceLocationCollector
             {
                 await SourceEnricher.AcquirePdbAsync(context, httpClient,
                     packageName, packageVersion,
-                    isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
+                    isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log,
+                    sourceOptions: options.SourceOptions);
             }
 
             var pdbPath = context.PortablePdbPath;

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -117,7 +117,8 @@ internal static class PackageInspector
         result.AssemblyCount = ToolsAnalyzer.CountAssemblies(extractPath);
         PopulateLibraryFiles(extractPath, result);
         result.BinarySignals = await ScanBinarySignalsAsync(
-            extractPath, packageName, version, httpClient, logger, acquirePdb: false);
+            extractPath, packageName, version, httpClient, logger,
+            acquirePdb: false, sourceOptions);
 
         // Parse deps.json files (present in tool packages, typically in tools/{tfm}/{rid}/)
         if (hasToolsDir)
@@ -180,7 +181,8 @@ internal static class PackageInspector
         string? packageVersion,
         HttpClient httpClient,
         VerboseLogger logger,
-        bool acquirePdb)
+        bool acquirePdb,
+        NuGetSourceOptions? sourceOptions = null)
     {
         var dlls = TfmSelector.GetPackageAssemblies(extractPath);
         if (dlls.Count == 0)
@@ -207,7 +209,8 @@ internal static class PackageInspector
                 {
                     await SourceEnricher.AcquirePdbAsync(
                         service.Context, httpClient, packageName, packageVersion,
-                        isPlatformAssembly: false, logger.Log).ConfigureAwait(false);
+                        isPlatformAssembly: false, logger.Log,
+                        sourceOptions: sourceOptions).ConfigureAwait(false);
                 }
 
                 if (service.HasPdb)

--- a/src/dotnet-inspect/Inspectors/RidPackageVerifier.cs
+++ b/src/dotnet-inspect/Inspectors/RidPackageVerifier.cs
@@ -47,6 +47,10 @@ public static class RidPackageVerifier
                     string status = ridPkg.Exists == true ? "available" : "NOT FOUND";
                     logger.Log($"  {ridPkg.RuntimeIdentifier}: {status} ({ridPkg.PackageId} {version})");
                 }
+                catch (PackageSourceMappingException)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     ridPkg.Exists = false;

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -383,7 +383,9 @@ internal static class SourceEnricher
     private static string? FindCachedPackageVersion(string packageName, ApiOptions options)
         => PackageExtractor.TryGetLatestCachedCandidateVersion(
             packageName,
-            NuGetSourceResolver.ResolveSourceKeys(options.SourceOptions));
+            NuGetSourceResolver.ResolveSourceKeysForPackage(
+                options.SourceOptions,
+                packageName));
 
     /// <summary>
     /// Enriches multiple types from a single XML doc file (loaded once).

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -380,10 +380,10 @@ internal static class SourceEnricher
     /// <summary>
     /// Finds the latest cached version candidate reported by an active source.
     /// </summary>
-    private static string? FindCachedPackageVersion(string packageName, ApiOptions options)
+    internal static string? FindCachedPackageVersion(string packageName, ApiOptions options)
         => PackageExtractor.TryGetLatestCachedCandidateVersion(
             packageName,
-            NuGetSourceResolver.ResolveSourceKeysForPackage(
+            SourceResolver.ResolveSourceKeysForProbe(
                 options.SourceOptions,
                 packageName));
 

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -23,7 +23,8 @@ internal static class SourceEnricher
         PdbContext context, HttpClient httpClient,
         string? packageName, string? packageVersion,
         bool isPlatformAssembly, Action<string>? log,
-        bool cacheOnly = false)
+        bool cacheOnly = false,
+        NuGetSourceOptions? sourceOptions = null)
         => await PdbAcquisitionService.AcquireAsync(
             context,
             httpClient,
@@ -31,7 +32,8 @@ internal static class SourceEnricher
             packageVersion,
             isPlatformAssembly,
             log,
-            cacheOnly).ConfigureAwait(false);
+            cacheOnly,
+            sourceOptions).ConfigureAwait(false);
 
     /// <summary>
     /// Acquires symbols using the provenance of the descriptor that supplied the
@@ -42,13 +44,15 @@ internal static class SourceEnricher
         ResolvedAssemblyReference assembly,
         HttpClient httpClient,
         Action<string>? log,
-        bool cacheOnly = false)
+        bool cacheOnly = false,
+        NuGetSourceOptions? sourceOptions = null)
         => PdbAcquisitionService.AcquireAsync(
             context,
             assembly,
             httpClient,
             log,
-            cacheOnly);
+            cacheOnly,
+            sourceOptions);
 
     // ===== Verbosity-Aware Enrichment Gateways =====
 
@@ -119,7 +123,8 @@ internal static class SourceEnricher
             var (packageName, packageVersion) = ResolvePackageInfo(options, dllPath);
 
             await AcquirePdbAsync(context, httpClient, packageName, packageVersion,
-                isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
+                isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log,
+                sourceOptions: options.SourceOptions);
 
             if (!context.HasPdb)
             {
@@ -206,7 +211,8 @@ internal static class SourceEnricher
         }
 
         await AcquirePdbAsync(context, httpClient, packageName, packageVersion,
-            isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
+            isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log,
+            sourceOptions: options.SourceOptions);
 
         if (!context.HasPdb)
         {
@@ -339,7 +345,8 @@ internal static class SourceEnricher
             var (packageName, packageVersion) = ResolvePackageInfo(options, dllPath);
 
             await AcquirePdbAsync(context, httpClient, packageName, packageVersion,
-                isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log);
+                isPlatformAssembly: !string.IsNullOrEmpty(options.PlatformAssembly), logger.Log,
+                sourceOptions: options.SourceOptions);
 
             return service.RepositoryUrl;
         }
@@ -687,7 +694,8 @@ internal static class SourceEnricher
             service.Context,
             implementation,
             httpClient,
-            logger.Log);
+            logger.Log,
+            sourceOptions: options.SourceOptions);
         if (!service.HasPdb || !service.HasSourceLink)
             return false;
 

--- a/src/dotnet-inspect/Inspectors/SourceFileCollector.cs
+++ b/src/dotnet-inspect/Inspectors/SourceFileCollector.cs
@@ -1,6 +1,7 @@
 using DotnetInspector.Core;
 using DotnetInspector.Models;
 using DotnetInspector.Output;
+using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using ILInspector.Metadata;
 
@@ -67,7 +68,8 @@ internal static class SourceFileCollector
         HttpClient httpClient,
         bool includeAll = false,
         bool browsableUrls = false,
-        string? typeFilter = null)
+        string? typeFilter = null,
+        NuGetSourceOptions? sourceOptions = null)
     {
         using var service = SourceLinkService.Open(assemblyPath, logger.Log);
         await SourceEnricher.AcquirePdbAsync(
@@ -76,7 +78,8 @@ internal static class SourceFileCollector
             packageName,
             packageVersion,
             isPlatformAssembly,
-            logger.Log);
+            logger.Log,
+            sourceOptions: sourceOptions);
         return await CollectAsync(
             service,
             assemblyPath,

--- a/src/dotnet-inspect/Inspectors/TypeLookupService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeLookupService.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Commands;
+using DotnetInspector.Packages;
 using ILInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
@@ -59,13 +60,15 @@ public static class TypeLookupService
         string typeName,
         string[] platformFrameworks,
         HttpClient httpClient,
-        VerboseLogger logger)
+        VerboseLogger logger,
+        NuGetSourceOptions? sourceOptions = null)
     {
         // Search for the type across all framework assemblies
         var options = new FindOptions
         {
             Pattern = typeName,
             PlatformFrameworks = platformFrameworks,
+            SourceOptions = sourceOptions,
             Limit = 1 // We only need the first match
         };
 
@@ -77,7 +80,11 @@ public static class TypeLookupService
         var match = results[0];
 
         // Resolve the assembly path
-        var assemblyPath = await ResolveAssemblyPathAsync(match, httpClient, logger);
+        var assemblyPath = await ResolveAssemblyPathAsync(
+            match,
+            httpClient,
+            logger,
+            sourceOptions);
         if (assemblyPath == null)
             return null;
 
@@ -97,10 +104,16 @@ public static class TypeLookupService
         string typeName,
         string[] platformFrameworks,
         HttpClient httpClient,
-        VerboseLogger logger)
+        VerboseLogger logger,
+        NuGetSourceOptions? sourceOptions = null)
     {
         // First try exact match
-        var match = await FindTypeAsync(typeName, platformFrameworks, httpClient, logger);
+        var match = await FindTypeAsync(
+            typeName,
+            platformFrameworks,
+            httpClient,
+            logger,
+            sourceOptions);
         if (match != null)
             return (match, []);
 
@@ -108,7 +121,8 @@ public static class TypeLookupService
         var options = new FindOptions
         {
             Pattern = "*", // Get all types
-            PlatformFrameworks = platformFrameworks
+            PlatformFrameworks = platformFrameworks,
+            SourceOptions = sourceOptions,
         };
 
         var allTypes = await TypeSearchService.CollectTypesAsync(options, null, logger, httpClient);
@@ -135,7 +149,8 @@ public static class TypeLookupService
     private static async Task<string?> ResolveAssemblyPathAsync(
         TypeSearchResult result,
         HttpClient httpClient,
-        VerboseLogger logger)
+        VerboseLogger logger,
+        NuGetSourceOptions? sourceOptions)
     {
         if (result.Assembly == null || result.Source == null)
             return null;
@@ -148,7 +163,8 @@ public static class TypeLookupService
             result.Assembly,
             httpClient,
             logger.Log,
-            framework);
+            framework,
+            sourceOptions: sourceOptions);
 
         if (error != null)
         {

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -322,6 +322,11 @@ try
 
     return exitCode;
 }
+catch (PackageSourceMappingException ex)
+{
+    CommandError.Write(ex.Message);
+    return 1;
+}
 catch (NuGetFetch.UnsupportedSourceException ex)
 {
     // Sources arrive from nuget.config as well as from options, so only resolution sees all of

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -59,6 +59,24 @@ public static class SourceResolver
         string name,
         IReadOnlyList<string> sourceKeys,
         Action<string>? reportPlatformLookupFailure = null)
+        => TryProbeLocalQualifiedName(
+            name,
+            _ => sourceKeys,
+            reportPlatformLookupFailure);
+
+    internal static LocalProbeResult? TryProbeLocalQualifiedName(
+        string name,
+        NuGetSourceOptions? sourceOptions,
+        Action<string>? reportPlatformLookupFailure = null)
+        => TryProbeLocalQualifiedName(
+            name,
+            candidate => ResolveSourceKeysForProbe(sourceOptions, candidate),
+            reportPlatformLookupFailure);
+
+    private static LocalProbeResult? TryProbeLocalQualifiedName(
+        string name,
+        Func<string, IReadOnlyList<string>> sourceKeysForPackage,
+        Action<string>? reportPlatformLookupFailure)
     {
         // Require at least 2 dots (e.g., System.Text.Json.JsonSerializer).
         // Single-dot names like "System.CommandLine" are ambiguous: could be
@@ -101,7 +119,7 @@ public static class SourceResolver
             // name without letting package-content directories invent versions.
             if (PackageExtractor.HasCachedCandidateVersion(
                     candidate,
-                    sourceKeys))
+                    sourceKeysForPackage(candidate)))
             {
                 RequestTelemetry.Breadcrumb(
                     "qualified-type-split",
@@ -159,11 +177,33 @@ public static class SourceResolver
         IReadOnlyList<string> sourceKeys,
         bool allowPlatformPrefixFallback,
         Action<string>? reportPlatformLookupFailure = null)
+        => TryResolveQualifiedTypeName(
+            name,
+            _ => sourceKeys,
+            allowPlatformPrefixFallback,
+            reportPlatformLookupFailure);
+
+    internal static LocalProbeResult? TryResolveQualifiedTypeName(
+        string name,
+        NuGetSourceOptions? sourceOptions,
+        bool allowPlatformPrefixFallback,
+        Action<string>? reportPlatformLookupFailure = null)
+        => TryResolveQualifiedTypeName(
+            name,
+            candidate => ResolveSourceKeysForProbe(sourceOptions, candidate),
+            allowPlatformPrefixFallback,
+            reportPlatformLookupFailure);
+
+    private static LocalProbeResult? TryResolveQualifiedTypeName(
+        string name,
+        Func<string, IReadOnlyList<string>> sourceKeysForPackage,
+        bool allowPlatformPrefixFallback,
+        Action<string>? reportPlatformLookupFailure)
     {
         bool platformLookupFailed = false;
         var probe = TryProbeLocalQualifiedName(
             name,
-            sourceKeys,
+            sourceKeysForPackage,
             message =>
             {
                 platformLookupFailed = true;
@@ -269,6 +309,62 @@ public static class SourceResolver
         IReadOnlyList<string> sourceKeys,
         bool verbose,
         bool tryQualifiedTypeName = false)
+        => await ResolveAsync(
+            args,
+            explicitPackage,
+            explicitAssembly,
+            explicitPlatform,
+            _ => sourceKeys,
+            sourceOptions: null,
+            verbose,
+            tryQualifiedTypeName).ConfigureAwait(false);
+
+    public static async Task<ResolvedSource> ResolveAsync(
+        string[] args,
+        string? explicitPackage,
+        string? explicitAssembly,
+        string? explicitPlatform,
+        NuGetSourceOptions? sourceOptions,
+        bool verbose,
+        bool tryQualifiedTypeName = false)
+        => await ResolveAsync(
+            args,
+            explicitPackage,
+            explicitAssembly,
+            explicitPlatform,
+            candidate => ResolveSourceKeysForProbe(sourceOptions, candidate),
+            sourceOptions,
+            verbose,
+            tryQualifiedTypeName).ConfigureAwait(false);
+
+    private static IReadOnlyList<string> ResolveSourceKeysForProbe(
+        NuGetSourceOptions? sourceOptions,
+        string packageId)
+    {
+        try
+        {
+            return NuGetSourceResolver.ResolveSourceKeysForPackage(
+                sourceOptions,
+                packageId);
+        }
+        catch (PackageSourceMappingException ex)
+            when (ex.Failure is
+                PackageSourceMappingFailure.NoPattern
+                or PackageSourceMappingFailure.InactiveSource)
+        {
+            return [];
+        }
+    }
+
+    private static async Task<ResolvedSource> ResolveAsync(
+        string[] args,
+        string? explicitPackage,
+        string? explicitAssembly,
+        string? explicitPlatform,
+        Func<string, IReadOnlyList<string>> sourceKeysForPackage,
+        NuGetSourceOptions? sourceOptions,
+        bool verbose,
+        bool tryQualifiedTypeName)
     {
         bool isLibrarySelector = IsLibrarySelector(explicitAssembly, explicitPackage);
         bool hasExplicitSource = HasExplicitSource(explicitPackage, explicitAssembly, explicitPlatform, isLibrarySelector);
@@ -409,7 +505,11 @@ public static class SourceResolver
 
                     // Resolve assembly (local-first, then network if needed)
                     var (resolvedPath, _, _, resolvedError) = await PlatformResolver.ResolveAssemblyAsync(
-                        bareName, client, log, frameworkSpec);
+                        bareName,
+                        client,
+                        log,
+                        frameworkSpec,
+                        sourceOptions: sourceOptions);
 
                     if (resolvedPath != null && resolvedError == null)
                     {
@@ -426,7 +526,7 @@ public static class SourceResolver
                     string? platformLookupFailure = null;
                     var probe = TryResolveQualifiedTypeName(
                         bareName,
-                        sourceKeys,
+                        sourceKeysForPackage,
                         allowPlatformPrefixFallback: true,
                         message => platformLookupFailure = message);
                     if (platformLookupFailure is not null)

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -337,7 +337,7 @@ public static class SourceResolver
             verbose,
             tryQualifiedTypeName).ConfigureAwait(false);
 
-    private static IReadOnlyList<string> ResolveSourceKeysForProbe(
+    internal static IReadOnlyList<string> ResolveSourceKeysForProbe(
         NuGetSourceOptions? sourceOptions,
         string packageId)
     {

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -51,7 +51,8 @@
   active eligible feed.
 - Honors layered NuGet `<packageSourceMapping>` configuration for package
   acquisition, dependencies, version discovery, search results, routing,
-  redirects, metadata enrichment, RID companions, and platform packs.
+  redirects, metadata and symbol-package enrichment, RID companions, and
+  platform packs.
   Configured-name aliases remain distinct through mapping and collapse to one
   producer only after the package-specific names are selected.
 - Uses unambiguous, atomically published `versions-v5` candidate entries and

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -49,6 +49,11 @@
   identifies an authorized producer. Discovered coordinates are restricted to
   feeds that reported the selected version; pinned coordinates may use any
   active eligible feed.
+- Honors layered NuGet `<packageSourceMapping>` configuration for package
+  acquisition, dependencies, version discovery, search results, routing,
+  redirects, metadata enrichment, RID companions, and platform packs.
+  Configured-name aliases remain distinct through mapping and collapse to one
+  producer only after the package-specific names are selected.
 - Uses unambiguous, atomically published `versions-v5` candidate entries and
   rejects malformed latest entries and incomplete listing snapshots. Reporter
   restrictions apply to the selected coordinate only; pinned tool-wrapper


### PR DESCRIPTION
Closes #3722.

## Why

`dotnet-inspect` resolved package sources but ignored NuGet
`<packageSourceMapping>`. A configuration that assigned a package family to a
private feed could therefore still query, cache, enrich, or acquire that package
through another active source.

Package source mapping is authorization by package ID, not source ordering. This
change makes that authorization part of every package-specific resolution
boundary.

## Design

- Parse mapping from the same layered NuGet configuration hierarchy as package
  sources. Nearer configuration replaces an inherited pattern list for the same
  source key; `<clear/>` removes inherited mappings.
- Match source keys and package IDs case-insensitively. Exact IDs win over the
  longest matching prefix, with `*` as the least-specific default. Multiple
  sources may carry the winning pattern.
- Keep configured aliases distinct until mapping selects eligible names, then
  collapse aliases to canonical producer endpoints. Eligible aliases for one
  endpoint must agree on credentials.
- Preserve explicit CLI source selection, including explicit reactivation of a
  disabled configured alias, without letting a literal URL bypass mapping.
- Treat no match, inactive mapped names, and conflicting credentials as typed,
  cleanly reported configuration failures. Speculative routing and cache probes
  treat only no-match/inactive candidates as misses.

## Coverage

Mapping is enforced for:

- exact package acquisition and source-scoped content caches;
- version discovery, wildcard/range resolution, and source listings;
- transitive nuspecs and dependencies;
- search results, evaluated against the alias that reported each result;
- routing and qualified package/type/member candidate probes;
- tool-wrapper redirects and RID companion packages;
- platform/reference packs;
- NuGet.org metadata enrichment; and
- NuGet.org `.snupkg` enrichment, without changing the separate symbol-server
  capability.

Reporter restrictions remain orthogonal: mapping selects package-eligible
producers first, then a discovered coordinate is restricted to the producers
that reported it. Redirect targets recalculate mapping independently.

## Validation

The new coverage includes layered configuration, precedence, aliases,
credentials, disabled sources, search filtering, exact acquisition, dependency
manifests, routing/cache probes, metadata, RID packages, platform packs,
diagnostics, and symbol-package privacy. Mutation checks proved the
package-specific seams are load-bearing.
