### PR TITLE
Adopt assembly-context Integrations query in CLI

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -59,17 +59,18 @@ content-shaped registry over a host-owned `AssemblyInspectionSession`. The
 scanner key, and the CLI and package convenience route lower section selection
 into that same registry. Library and package SourceLink sections execute a
 shared document prerequisite plus availability or integrity query over a
-host-owned `SourceLinkService`. Separately, the first workspace query executes
-Integrations inspection across every participant in one binding-consistent
-assembly context group, reusing retained immutable content and returning
-per-participant evidence or failure. No command uses that group-scoped query
-yet.
+host-owned `SourceLinkService`. The library CLI and package `--all-libraries`
+route focused Integrations demand through the first workspace query across every
+participant in one binding-consistent assembly context group. The command
+projects per-participant evidence or failure into compatibility models and
+continues each library inspection over the same retained immutable image.
 
 This is an incremental boundary, not the completed split. The remaining
 library scanners still use the transitional string-keyed `ScannerRegistry`,
 `LibraryMetadataService` still projects query results into the mutable
 `LibraryInspection` compatibility aggregate, and transitive reference resolution
-remains host-owned. The SourceLink document query delegates PDB acquisition to
+remains host-owned. Integration opportunities also remain a host composition
+scanner over query-produced evidence. The SourceLink document query delegates PDB acquisition to
 shared Services while the host supplies trusted symbol and SSRF-hardened source
 clients. The registry supports deterministic synchronous and asynchronous
 execution and passes each query's maximum transitive cost into the host execution

--- a/docs/design/integrations.md
+++ b/docs/design/integrations.md
@@ -141,9 +141,25 @@ gate participant ordering, snapshot reuse, and general partial acquisition.
 `AssemblyContextIntegrationsQueryTests.Execute_ReportsBudgetExhaustionAsIncompleteEntry`
 gates the budget-limited case.
 
-This query does not yet drive `@Integrations` sections. Command migration,
-integration-opportunity composition, cancellation-aware execution, and optional
-concurrent execution remain later slices.
+The library CLI and package `--all-libraries` host now execute this query when a
+focused `Integration:` section or `@Integrations` is selected. The section
+catalog binds every member of the family to the same query definition by object
+identity and owns a separate group-query registry because the query consumes an
+`AssemblyContextGroup`, not a single-library scanner context.
+
+The command creates one group for the selected assembly set, projects each typed
+entry into the corresponding `LibraryInspection`, and retains the workspace's
+authoritative immutable image for the rest of that library inspection. A path
+retarget after query execution therefore cannot mix one assembly's integration
+evidence with another assembly's metadata or opportunity scan.
+`AssemblyContextIntegrationsRunner_LendsTheQueriedSnapshotToLibraryInspection`
+gates that shared-image boundary.
+
+`Integration: Opportunities` remains a CLI composition scanner. It consumes the
+query-produced existing-integration evidence before scanning for missing
+registration surfaces; opportunity production has not moved into the L1 group
+query. Cancellation-aware group execution and optional concurrency remain later
+slices.
 
 ## Relationship to sections and categories
 

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -14,17 +14,15 @@ shared contracts, not dynamically loaded plugins.
 ## Status
 
 This document describes the target core architecture and the principles that
-govern its migration. No command runs through a workspace today. Library
-metadata and direct-reference inspection are the first typed-query canaries:
-the section catalog plans typed demand and executes it through a
-prerequisite-aware registry, while the command still owns orchestration.
-`DotnetInspector.Queries` also contains the first workspace foundation: an
-ephemeral workspace can own binding-consistent assembly context groups, and a
-group retains lazily acquired immutable assembly snapshots behind
-callback-scoped and stack-only access. The first group-scoped query scans
-Integrations evidence across every participant sequentially while preserving
-per-assembly identity, provenance, and failures. Existing commands have not
-migrated to that workspace owner yet. Other foundations include shared image
+govern its migration. Library metadata and direct-reference inspection are the
+first typed-query canaries: the section catalog plans typed demand and executes
+it through a prerequisite-aware registry, while the command still owns
+orchestration. The library CLI and package `--all-libraries` now use an
+ephemeral workspace for focused Integrations demand. One binding-consistent
+assembly context group scans every selected participant sequentially, preserves
+per-assembly identity, provenance, and failures, and retains each available
+immutable snapshot for the rest of that library inspection without reopening
+the source path. Other foundations include shared image
 and inspection session ownership, catalog generations, `CoreCache`, typed
 provenance and resolution currencies, and `InertString`; the remaining
 workspace model describes how those pieces will be composed.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,13 +9,12 @@ It is built for both humans and agents. Markdown is the default output because h
 The target [inspection space architecture](inspection-space.md) defines the
 core: workspace contexts, typed query planning, acquisition and caching, shared
 identity and provenance, owner-issued correspondence, and safe presentation
-boundaries. The first typed query-planning slices are implemented for library
-metadata-image and direct-reference inspection. `DotnetInspector.Queries` also
-contains the first workspace context foundation and a sequential group-scoped
-Integrations query, but commands have not migrated to that owner and the
-remaining query families remain future work. The components below are the
-current hosts, shared substrates, and inspection producers that will extend
-that space.
+boundaries. Typed query-planning slices are implemented for library
+metadata-image, direct-reference, SourceLink, and Integrations inspection. The
+library CLI and package `--all-libraries` use the first workspace-backed,
+group-scoped query for focused Integrations demand while remaining query
+families are future work. The components below are the current hosts, shared
+substrates, and inspection producers that will extend that space.
 
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
 - `src/DotnetInspector.Queries/` contains host-neutral typed query definitions,

--- a/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
@@ -106,6 +106,7 @@ public sealed class InspectionWorkspaceTests
 
         Assert.Same(source.Assembly.Registration, retained.Registration);
         Assert.Same(source.Assembly.Provenance, retained.Provenance);
+        Assert.Equal(source.Assembly.LastWriteTimeUtc, retained.LastWriteTimeUtc);
         using Stream stream = retained.OpenRead();
         Assert.Equal(first, stream.ReadByte());
         Assert.Equal(1, source.OpenCount);

--- a/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
@@ -87,6 +87,31 @@ public sealed class InspectionWorkspaceTests
     }
 
     [Fact]
+    public void RetainedReference_RemainsSnapshotBackedAfterWorkspaceDisposal()
+    {
+        TestAssembly source = TestAssembly.Create();
+        var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [source.Participant]);
+
+        var retained = Assert.IsType<
+            AssemblyImageAccessResult<
+                ResolvedAssemblyReference>.Available>(
+                    group.RetainAssemblyReference(source.Assembly)).Value;
+        byte first = source.Bytes[0];
+
+        source.Bytes[0] ^= 0xff;
+        workspace.Dispose();
+
+        Assert.Same(source.Assembly.Registration, retained.Registration);
+        Assert.Same(source.Assembly.Provenance, retained.Provenance);
+        using Stream stream = retained.OpenRead();
+        Assert.Equal(first, stream.ReadByte());
+        Assert.Equal(1, source.OpenCount);
+    }
+
+    [Fact]
     public void DisposalInsideCallback_DoesNotRevokeActiveView()
     {
         TestAssembly source = TestAssembly.Create();

--- a/src/DotnetInspector.Queries/InspectionWorkspace.cs
+++ b/src/DotnetInspector.Queries/InspectionWorkspace.cs
@@ -241,6 +241,27 @@ public sealed class AssemblyContextGroup : IDisposable
                     snapshot.Content.AsSpan())));
     }
 
+    /// <summary>
+    /// Retains the participant's authoritative immutable image behind a fresh stream factory
+    /// while preserving its acquisition registration, identity, path hint, and provenance.
+    /// </summary>
+    /// <remarks>
+    /// The returned descriptor remains valid after the group is disposed because its stream
+    /// factory retains the immutable, non-pooled snapshot. The source path is not reopened.
+    /// Gated by
+    /// <c>RetainedReference_RemainsSnapshotBackedAfterWorkspaceDisposal</c>.
+    /// </remarks>
+    public AssemblyImageAccessResult<ResolvedAssemblyReference>
+        RetainAssemblyReference(
+            ResolvedAssemblyReference assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        return UseSnapshot(
+            assembly,
+            snapshot => snapshot.RetainAssemblyReference(assembly));
+    }
+
     internal AssemblyImageAccessResult<TResult> UseAssemblySession<TResult>(
         ResolvedAssemblyReference assembly,
         Func<AssemblyInspectionSession, TResult> callback)

--- a/src/ILInspector.Metadata/AssemblyAcquisition.cs
+++ b/src/ILInspector.Metadata/AssemblyAcquisition.cs
@@ -218,6 +218,18 @@ public sealed class ResolvedAssemblyReference
     /// </remarks>
     public Func<Stream> OpenRead { get; }
     public AssemblyResolutionProvenance Provenance { get; }
+
+    internal ResolvedAssemblyReference WithOpenRead(
+        Func<Stream> openRead)
+    {
+        ArgumentNullException.ThrowIfNull(openRead);
+        return new ResolvedAssemblyReference(
+            Registration,
+            Identity,
+            Path,
+            openRead,
+            Provenance);
+    }
 }
 
 /// <summary>Identifies one acquisition catalog's candidate key space.</summary>

--- a/src/ILInspector.Metadata/AssemblyAcquisition.cs
+++ b/src/ILInspector.Metadata/AssemblyAcquisition.cs
@@ -130,20 +130,23 @@ public sealed class ResolvedAssemblyReference
         AssemblyReferenceIdentity identity,
         string? path,
         Func<Stream> openRead,
-        AssemblyResolutionProvenance provenance)
+        AssemblyResolutionProvenance provenance,
+        DateTime? lastWriteTimeUtc)
     {
         Registration = registration;
         Identity = identity;
         Path = path;
         OpenRead = openRead;
         Provenance = provenance;
+        LastWriteTimeUtc = lastWriteTimeUtc;
     }
 
     public static ResolvedAssemblyReference Create(
         AssemblyReferenceIdentity selectedIdentity,
         string? path,
         Func<Stream> openRead,
-        AssemblyResolutionProvenance provenance)
+        AssemblyResolutionProvenance provenance,
+        DateTime? lastWriteTimeUtc = null)
     {
         ArgumentNullException.ThrowIfNull(selectedIdentity);
         ArgumentException.ThrowIfNullOrWhiteSpace(selectedIdentity.Name);
@@ -155,10 +158,23 @@ public sealed class ResolvedAssemblyReference
             selectedIdentity,
             path,
             openRead,
-            provenance);
+            provenance,
+            lastWriteTimeUtc);
     }
 
     public static ResolvedAssemblyReference CreateFromPath(
+        string path,
+        AssemblyResolutionProvenance provenance)
+        => CreateFromPathIfManaged(path, provenance)
+            ?? throw new BadImageFormatException(
+                "The selected image has no managed metadata.");
+
+    /// <summary>
+    /// Creates a descriptor for a managed assembly path, or returns
+    /// <see langword="null"/> when the PE image has no managed metadata.
+    /// Malformed managed metadata remains a visible failure.
+    /// </summary>
+    public static ResolvedAssemblyReference? CreateFromPathIfManaged(
         string path,
         AssemblyResolutionProvenance provenance)
     {
@@ -166,12 +182,11 @@ public sealed class ResolvedAssemblyReference
         ArgumentNullException.ThrowIfNull(provenance);
 
         string fullPath = System.IO.Path.GetFullPath(path);
-        using var stream = File.OpenRead(fullPath);
+        using FileStream stream = File.OpenRead(fullPath);
         using var peReader =
             new System.Reflection.PortableExecutable.PEReader(stream);
         if (!peReader.HasMetadata)
-            throw new BadImageFormatException(
-                "The selected image has no managed metadata.");
+            return null;
 
         AssemblyReferenceIdentity identity =
             AssemblyReferenceIdentity.FromAssemblyDefinition(
@@ -180,7 +195,8 @@ public sealed class ResolvedAssemblyReference
             identity,
             fullPath,
             () => File.OpenRead(fullPath),
-            provenance);
+            provenance,
+            File.GetLastWriteTimeUtc(stream.SafeFileHandle));
     }
 
     public static bool TryCreateFromPath(
@@ -218,9 +234,15 @@ public sealed class ResolvedAssemblyReference
     /// </remarks>
     public Func<Stream> OpenRead { get; }
     public AssemblyResolutionProvenance Provenance { get; }
+    /// <summary>
+    /// Last write time captured by the acquisition owner for the content
+    /// returned by <see cref="OpenRead"/>, when available.
+    /// </summary>
+    public DateTime? LastWriteTimeUtc { get; }
 
     internal ResolvedAssemblyReference WithOpenRead(
-        Func<Stream> openRead)
+        Func<Stream> openRead,
+        DateTime? lastWriteTimeUtc)
     {
         ArgumentNullException.ThrowIfNull(openRead);
         return new ResolvedAssemblyReference(
@@ -228,7 +250,8 @@ public sealed class ResolvedAssemblyReference
             Identity,
             Path,
             openRead,
-            Provenance);
+            Provenance,
+            lastWriteTimeUtc);
     }
 }
 

--- a/src/ILInspector.Metadata/AssemblyAcquisition.cs
+++ b/src/ILInspector.Metadata/AssemblyAcquisition.cs
@@ -183,20 +183,35 @@ public sealed class ResolvedAssemblyReference
 
         string fullPath = System.IO.Path.GetFullPath(path);
         using FileStream stream = File.OpenRead(fullPath);
-        using var peReader =
-            new System.Reflection.PortableExecutable.PEReader(stream);
-        if (!peReader.HasMetadata)
+        System.Reflection.PortableExecutable.PEReader? peReader = null;
+        try
+        {
+            peReader =
+                new System.Reflection.PortableExecutable.PEReader(stream);
+            if (!peReader.HasMetadata)
+            {
+                peReader.Dispose();
+                return null;
+            }
+        }
+        catch (BadImageFormatException)
+        {
+            peReader?.Dispose();
             return null;
+        }
 
-        AssemblyReferenceIdentity identity =
-            AssemblyReferenceIdentity.FromAssemblyDefinition(
-                peReader.GetMetadataReader());
-        return Create(
-            identity,
-            fullPath,
-            () => File.OpenRead(fullPath),
-            provenance,
-            File.GetLastWriteTimeUtc(stream.SafeFileHandle));
+        using (peReader)
+        {
+            AssemblyReferenceIdentity identity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            return Create(
+                identity,
+                fullPath,
+                () => File.OpenRead(fullPath),
+                provenance,
+                File.GetLastWriteTimeUtc(stream.SafeFileHandle));
+        }
     }
 
     public static bool TryCreateFromPath(

--- a/src/ILInspector.Metadata/AssemblyImageSnapshot.cs
+++ b/src/ILInspector.Metadata/AssemblyImageSnapshot.cs
@@ -47,18 +47,25 @@ public sealed class AssemblyImageSnapshot
         ImmutableArray<byte> content,
         AssemblyReferenceIdentity identity,
         Guid moduleVersionId,
-        AssemblyAcquisitionRegistration registration)
+        AssemblyAcquisitionRegistration registration,
+        DateTime? lastWriteTimeUtc)
     {
         Content = content;
         Identity = identity;
         ModuleVersionId = moduleVersionId;
         Registration = registration;
+        LastWriteTimeUtc = lastWriteTimeUtc;
     }
 
     public ImmutableArray<byte> Content { get; }
     public AssemblyReferenceIdentity Identity { get; }
     public Guid ModuleVersionId { get; }
     public AssemblyAcquisitionRegistration Registration { get; }
+    /// <summary>
+    /// Last write time captured from the source that supplied
+    /// <see cref="Content"/>, when available.
+    /// </summary>
+    public DateTime? LastWriteTimeUtc { get; }
     public long Length => Content.Length;
 
     /// <summary>
@@ -79,7 +86,8 @@ public sealed class AssemblyImageSnapshot
 
         byte[] bytes = ImmutableCollectionsMarshal.AsArray(Content)!;
         return assembly.WithOpenRead(
-            () => new MemoryStream(bytes, writable: false));
+            () => new MemoryStream(bytes, writable: false),
+            LastWriteTimeUtc);
     }
 
     /// <summary>
@@ -105,6 +113,9 @@ public sealed class AssemblyImageSnapshot
             AssemblyImageSnapshot snapshot;
             using (Stream stream = OpenSource(assembly))
             {
+                DateTime? lastWriteTimeUtc = stream is FileStream fileStream
+                    ? File.GetLastWriteTimeUtc(fileStream.SafeFileHandle)
+                    : assembly.LastWriteTimeUtc;
                 long length = ReadRemainingLength(stream);
 
                 if (length > int.MaxValue
@@ -146,7 +157,8 @@ public sealed class AssemblyImageSnapshot
                     identity,
                     reader.GetGuid(
                         reader.GetModuleDefinition().Mvid),
-                    assembly.Registration);
+                    assembly.Registration,
+                    lastWriteTimeUtc);
             }
 
             var result = new AssemblyImageSnapshotResult.Ready(

--- a/src/ILInspector.Metadata/AssemblyImageSnapshot.cs
+++ b/src/ILInspector.Metadata/AssemblyImageSnapshot.cs
@@ -46,17 +46,41 @@ public sealed class AssemblyImageSnapshot
     AssemblyImageSnapshot(
         ImmutableArray<byte> content,
         AssemblyReferenceIdentity identity,
-        Guid moduleVersionId)
+        Guid moduleVersionId,
+        AssemblyAcquisitionRegistration registration)
     {
         Content = content;
         Identity = identity;
         ModuleVersionId = moduleVersionId;
+        Registration = registration;
     }
 
     public ImmutableArray<byte> Content { get; }
     public AssemblyReferenceIdentity Identity { get; }
     public Guid ModuleVersionId { get; }
+    public AssemblyAcquisitionRegistration Registration { get; }
     public long Length => Content.Length;
+
+    /// <summary>
+    /// Returns the same acquisition descriptor backed by this immutable snapshot instead of its
+    /// original content source.
+    /// </summary>
+    public ResolvedAssemblyReference RetainAssemblyReference(
+        ResolvedAssemblyReference assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        if (!ReferenceEquals(assembly.Registration, Registration)
+            || assembly.Identity != Identity)
+        {
+            throw new ArgumentException(
+                "The assembly descriptor does not own this snapshot.",
+                nameof(assembly));
+        }
+
+        byte[] bytes = ImmutableCollectionsMarshal.AsArray(Content)!;
+        return assembly.WithOpenRead(
+            () => new MemoryStream(bytes, writable: false));
+    }
 
     /// <summary>
     /// Opens, bounds, copies, and validates an assembly image.
@@ -121,7 +145,8 @@ public sealed class AssemblyImageSnapshot
                     content,
                     identity,
                     reader.GetGuid(
-                        reader.GetModuleDefinition().Mvid));
+                        reader.GetModuleDefinition().Mvid),
+                    assembly.Registration);
             }
 
             var result = new AssemblyImageSnapshotResult.Ready(

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -185,7 +185,8 @@ public class PdbContext : IDisposable
     public long FileSize { get; }
 
     /// <summary>
-    /// Last write time captured at open time (avoids repeated lstat syscalls).
+    /// Last write time retained from the authoritative acquisition or captured
+    /// from the open file handle.
     /// </summary>
     public DateTime LastWriteTimeUtc { get; }
 
@@ -219,7 +220,8 @@ public class PdbContext : IDisposable
         string? assemblyPath,
         string assemblyDisplayName,
         Action<string>? log,
-        bool entireImagePrefetched)
+        bool entireImagePrefetched,
+        DateTime? lastWriteTimeUtc)
     {
         _peStream = peStream;
         _peReader = peReader;
@@ -230,9 +232,7 @@ public class PdbContext : IDisposable
         FileSize = peStream.Length;
         LastWriteTimeUtc = peStream is FileStream fileStream
             ? File.GetLastWriteTimeUtc(fileStream.SafeFileHandle)
-            : assemblyPath is not null && File.Exists(assemblyPath)
-                ? File.GetLastWriteTimeUtc(assemblyPath)
-                : default;
+            : lastWriteTimeUtc ?? default;
     }
 
     /// <summary>
@@ -251,7 +251,7 @@ public class PdbContext : IDisposable
 
     /// <summary>
     /// Opens an acquisition descriptor through its authoritative stream factory.
-    /// The optional path is used only for adjacent PDB discovery and file metadata.
+    /// The optional path is used only for adjacent PDB discovery.
     /// </summary>
     public static PdbContext Open(
         ResolvedAssemblyReference assembly,
@@ -263,7 +263,8 @@ public class PdbContext : IDisposable
             assembly.Path,
             assembly.Identity.Name,
             log,
-            PEStreamOptions.Default);
+            PEStreamOptions.Default,
+            assembly.LastWriteTimeUtc);
     }
 
     /// <summary>
@@ -314,7 +315,8 @@ public class PdbContext : IDisposable
             assembly.Path,
             assembly.Identity.Name,
             log,
-            PEStreamOptions.PrefetchEntireImage | PEStreamOptions.LeaveOpen);
+            PEStreamOptions.PrefetchEntireImage | PEStreamOptions.LeaveOpen,
+            assembly.LastWriteTimeUtc);
     }
 
     static PdbContext Open(
@@ -328,6 +330,7 @@ public class PdbContext : IDisposable
             Path.GetFileName(assemblyPath),
             log,
             streamOptions,
+            lastWriteTimeUtc: null,
             loadLocalPdb);
 
     static PdbContext Open(
@@ -336,6 +339,7 @@ public class PdbContext : IDisposable
         string assemblyDisplayName,
         Action<string>? log,
         PEStreamOptions streamOptions,
+        DateTime? lastWriteTimeUtc,
         bool loadLocalPdb = true)
     {
         PEReader peReader;
@@ -355,7 +359,8 @@ public class PdbContext : IDisposable
             assemblyPath,
             assemblyDisplayName,
             log,
-            (streamOptions & PEStreamOptions.PrefetchEntireImage) != 0);
+            (streamOptions & PEStreamOptions.PrefetchEntireImage) != 0,
+            lastWriteTimeUtc);
 
         if (!peReader.HasMetadata)
             return context;

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -230,7 +230,9 @@ public class PdbContext : IDisposable
         FileSize = peStream.Length;
         LastWriteTimeUtc = peStream is FileStream fileStream
             ? File.GetLastWriteTimeUtc(fileStream.SafeFileHandle)
-            : default;
+            : assemblyPath is not null && File.Exists(assemblyPath)
+                ? File.GetLastWriteTimeUtc(assemblyPath)
+                : default;
     }
 
     /// <summary>
@@ -298,6 +300,22 @@ public class PdbContext : IDisposable
             log,
             PEStreamOptions.PrefetchEntireImage | PEStreamOptions.LeaveOpen,
             loadLocalPdb: true);
+
+    /// <summary>
+    /// Opens an acquisition descriptor with its complete authoritative image prefetched.
+    /// </summary>
+    public static PdbContext OpenPrefetched(
+        ResolvedAssemblyReference assembly,
+        Action<string>? log = null)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        return Open(
+            assembly.OpenRead(),
+            assembly.Path,
+            assembly.Identity.Name,
+            log,
+            PEStreamOptions.PrefetchEntireImage | PEStreamOptions.LeaveOpen);
+    }
 
     static PdbContext Open(
         string assemblyPath,

--- a/src/ILInspector.SourceLink/SourceLinkService.cs
+++ b/src/ILInspector.SourceLink/SourceLinkService.cs
@@ -84,6 +84,15 @@ public sealed class SourceLinkService : IDisposable
         Action<string>? log = null)
         => new(PdbContext.OpenPrefetched(assemblyPath, log), DefaultCache, log);
 
+    public static SourceLinkService OpenPrefetched(
+        ResolvedAssemblyReference assembly,
+        Action<string>? log = null,
+        ISourceLinkIndexCache? cache = null)
+        => new(
+            PdbContext.OpenPrefetched(assembly, log),
+            cache ?? DefaultCache,
+            log);
+
     public PdbContext Context => _context;
     public bool HasPdb => _context.HasPdb;
     public bool NeedsPdb => _context.NeedsPdb;

--- a/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
@@ -288,7 +288,6 @@ public class LibraryFindingConsumerTests
         string path = Path.GetTempFileName();
         try
         {
-            File.WriteAllBytes(path, new byte[64]);
             HashSet<InspectionQueryDefinition> queries =
                 [AssemblyContextIntegrationsQuery.Definition];
 
@@ -311,6 +310,45 @@ public class LibraryFindingConsumerTests
         finally
         {
             File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void AssemblyContextIntegrationsRunner_SkipsInvalidFileBesideManagedInput()
+    {
+        string invalidPath = Path.GetTempFileName();
+        string managedPath =
+            typeof(LibraryFindingConsumerTests).Assembly.Location;
+        try
+        {
+            HashSet<InspectionQueryDefinition> queries =
+                [AssemblyContextIntegrationsQuery.Definition];
+
+            AssemblyContextIntegrationsBatch batch =
+                Assert.IsType<AssemblyContextIntegrationsBatch>(
+                    AssemblyContextIntegrationsRunner.RunIfRequested(
+                        queries,
+                        LibrarySections.CreateGroupQueryRegistry(),
+                        [
+                            new AssemblyContextIntegrationsInput(
+                                invalidPath,
+                                AssemblyResolutionProvenance.Local(
+                                    "invalid compatibility test")),
+                            new AssemblyContextIntegrationsInput(
+                                managedPath,
+                                AssemblyResolutionProvenance.Local(
+                                    "managed compatibility test")),
+                        ]));
+
+            Assert.Null(batch.EntryFor(invalidPath));
+            Assert.Null(batch.AssemblyForInspection(invalidPath));
+            Assert.IsType<AssemblyIntegrationsEntry.Available>(
+                batch.EntryFor(managedPath));
+            Assert.NotNull(batch.AssemblyForInspection(managedPath));
+        }
+        finally
+        {
+            File.Delete(invalidPath);
         }
     }
 

--- a/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection.PortableExecutable;
+using System.Text;
 using System.Text.Json;
 using DotnetInspector.Commands;
 using DotnetInspector.Core;
@@ -353,6 +355,87 @@ public class LibraryFindingConsumerTests
     }
 
     [Fact]
+    public void AssemblyContextIntegrationsRunner_SkipsMissingFileBesideManagedInput()
+    {
+        string missingPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-missing-{Guid.NewGuid():N}.dll");
+        string managedPath =
+            typeof(LibraryFindingConsumerTests).Assembly.Location;
+        HashSet<InspectionQueryDefinition> queries =
+            [AssemblyContextIntegrationsQuery.Definition];
+
+        AssemblyContextIntegrationsBatch batch =
+            Assert.IsType<AssemblyContextIntegrationsBatch>(
+                AssemblyContextIntegrationsRunner.RunIfRequested(
+                    queries,
+                    LibrarySections.CreateGroupQueryRegistry(),
+                    [
+                        new AssemblyContextIntegrationsInput(
+                            missingPath,
+                            AssemblyResolutionProvenance.Local(
+                                "missing compatibility test")),
+                        new AssemblyContextIntegrationsInput(
+                            managedPath,
+                            AssemblyResolutionProvenance.Local(
+                                "managed compatibility test")),
+                    ]));
+
+        Assert.Null(batch.EntryFor(missingPath));
+        Assert.Null(batch.AssemblyForInspection(missingPath));
+        Assert.IsType<AssemblyIntegrationsEntry.Available>(
+            batch.EntryFor(managedPath));
+        Assert.NotNull(batch.AssemblyForInspection(managedPath));
+    }
+
+    [Fact]
+    public void AssemblyContextIntegrationsRunner_SkipsMalformedManagedFileBesideManagedInput()
+    {
+        string malformedPath = Path.GetTempFileName();
+        string managedPath =
+            typeof(LibraryFindingConsumerTests).Assembly.Location;
+        try
+        {
+            File.WriteAllBytes(
+                malformedPath,
+                CorruptTableStream(File.ReadAllBytes(managedPath)));
+            Assert.Throws<BadImageFormatException>(
+                () => ResolvedAssemblyReference.CreateFromPathIfManaged(
+                    malformedPath,
+                    AssemblyResolutionProvenance.Local(
+                        "malformed compatibility test")));
+            HashSet<InspectionQueryDefinition> queries =
+                [AssemblyContextIntegrationsQuery.Definition];
+
+            AssemblyContextIntegrationsBatch batch =
+                Assert.IsType<AssemblyContextIntegrationsBatch>(
+                    AssemblyContextIntegrationsRunner.RunIfRequested(
+                        queries,
+                        LibrarySections.CreateGroupQueryRegistry(),
+                        [
+                            new AssemblyContextIntegrationsInput(
+                                malformedPath,
+                                AssemblyResolutionProvenance.Local(
+                                    "malformed compatibility test")),
+                            new AssemblyContextIntegrationsInput(
+                                managedPath,
+                                AssemblyResolutionProvenance.Local(
+                                    "managed compatibility test")),
+                        ]));
+
+            Assert.Null(batch.EntryFor(malformedPath));
+            Assert.Null(batch.AssemblyForInspection(malformedPath));
+            Assert.IsType<AssemblyIntegrationsEntry.Available>(
+                batch.EntryFor(managedPath));
+            Assert.NotNull(batch.AssemblyForInspection(managedPath));
+        }
+        finally
+        {
+            File.Delete(malformedPath);
+        }
+    }
+
+    [Fact]
     public async Task AssemblyContextIntegrationsRunner_LendsTheQueriedSnapshotToLibraryInspection()
     {
         string tempDir = Path.Combine(
@@ -562,4 +645,45 @@ public class LibraryFindingConsumerTests
         Assert.Same(expectedDescriptor, failure.Error.Descriptor);
         Assert.False(string.IsNullOrWhiteSpace(failure.Error.Reason));
     }
+
+    static byte[] CorruptTableStream(byte[] bytes)
+    {
+        int metadataStart;
+        using (var peReader =
+               new PEReader(new MemoryStream(bytes, writable: false)))
+        {
+            metadataStart = peReader.PEHeaders.MetadataStartOffset;
+        }
+
+        int versionLength = BitConverter.ToInt32(
+            bytes,
+            metadataStart + 12);
+        int cursor = metadataStart + 16 + AlignTo4(versionLength);
+        int streamCount = BitConverter.ToUInt16(bytes, cursor + 2);
+        cursor += 4;
+
+        for (int i = 0; i < streamCount; i++)
+        {
+            int sizeOffset = cursor + 4;
+            int nameStart = cursor + 8;
+            int nameEnd = Array.IndexOf(bytes, (byte)0, nameStart);
+            string name = Encoding.ASCII.GetString(
+                bytes,
+                nameStart,
+                nameEnd - nameStart);
+            if (name is "#~" or "#-")
+            {
+                BitConverter.GetBytes(4).CopyTo(bytes, sizeOffset);
+                return bytes;
+            }
+
+            cursor = nameStart + AlignTo4(nameEnd - nameStart + 1);
+        }
+
+        throw new InvalidOperationException(
+            "The test assembly has no metadata table stream.");
+    }
+
+    static int AlignTo4(int value)
+        => (value + 3) & ~3;
 }

--- a/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using DotnetInspector.Commands;
+using DotnetInspector.Core;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
 using DotnetInspector.Output;
@@ -282,6 +283,38 @@ public class LibraryFindingConsumerTests
     }
 
     [Fact]
+    public void AssemblyContextIntegrationsRunner_PreservesNonManagedInputBehavior()
+    {
+        string path = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllBytes(path, new byte[64]);
+            HashSet<InspectionQueryDefinition> queries =
+                [AssemblyContextIntegrationsQuery.Definition];
+
+            AssemblyContextIntegrationsBatch batch =
+                Assert.IsType<AssemblyContextIntegrationsBatch>(
+                    AssemblyContextIntegrationsRunner.RunIfRequested(
+                        queries,
+                        LibrarySections.CreateGroupQueryRegistry(),
+                        [
+                            new AssemblyContextIntegrationsInput(
+                                path,
+                                AssemblyResolutionProvenance.Local(
+                                    "non-managed compatibility test")),
+                        ]));
+
+            Assert.Null(batch.EntryFor(path));
+            Assert.Null(batch.AssemblyForInspection(path));
+            Assert.Empty(queries);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task AssemblyContextIntegrationsRunner_LendsTheQueriedSnapshotToLibraryInspection()
     {
         string tempDir = Path.Combine(
@@ -292,6 +325,11 @@ public class LibraryFindingConsumerTests
         string originalPath = typeof(LibraryFindingConsumerTests).Assembly.Location;
         string replacementPath = typeof(LibraryInspection).Assembly.Location;
         File.Copy(originalPath, targetPath);
+        DateTime originalTimestamp =
+            new(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        DateTime replacementTimestamp =
+            new(2025, 6, 7, 8, 9, 10, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(targetPath, originalTimestamp);
 
         try
         {
@@ -308,10 +346,14 @@ public class LibraryFindingConsumerTests
                                 AssemblyResolutionProvenance.Local(
                                     "snapshot reuse test")),
                         ]));
-            AssemblyIntegrationsEntry entry = batch.EntryFor(targetPath);
+            AssemblyIntegrationsEntry entry =
+                Assert.IsAssignableFrom<AssemblyIntegrationsEntry>(
+                    batch.EntryFor(targetPath));
 
             File.Copy(replacementPath, targetPath, overwrite: true);
+            File.SetLastWriteTimeUtc(targetPath, replacementTimestamp);
 
+            CoreCache.Initialize("dotnet-inspect-test");
             using var httpClient = new HttpClient();
             LibraryInspection inspection = Assert.IsType<LibraryInspection>(
                 await LibraryMetadataService.InspectAsync(
@@ -331,6 +373,7 @@ public class LibraryFindingConsumerTests
             Assert.NotEqual(
                 Path.GetFileNameWithoutExtension(replacementPath),
                 inspection.AssemblyInfo.AssemblyName);
+            Assert.Equal(originalTimestamp, inspection.LastModified);
             Assert.Same(entry, inspection.AssemblyIntegrationsEntry);
         }
         finally

--- a/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
@@ -3,6 +3,8 @@ using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
 using DotnetInspector.Output;
+using DotnetInspector.Queries;
+using DotnetInspector.Sections;
 using ILInspector.Findings;
 using ILInspector.Metadata;
 
@@ -172,7 +174,10 @@ public class LibraryFindingConsumerTests
         inspection.Apply(LibraryMetadataService.ScanExtensionMembers(missingPath, logger));
         inspection.Apply(LibraryMetadataService.ScanCustomAttributes(missingPath, logger));
         inspection.TypeForwarderInspection = LibraryMetadataService.ScanTypeForwarders(missingPath, logger);
-        LibraryMetadataService.ScanIntegrations(missingPath, inspection, logger);
+        LibraryMetadataService.ScanIntegrationOpportunities(
+            missingPath,
+            inspection,
+            logger);
 
         AssertFailure(inspection.ClassifiedMethodInspection, MetadataFindings.ClassifiedMethodDescriptor);
         AssertFailure(inspection.ExtensionMemberInspection, MetadataFindings.ExtensionMemberDescriptor);
@@ -184,6 +189,154 @@ public class LibraryFindingConsumerTests
         AssertFailure(inspection.EcosystemIntegrationInspection, MetadataFindings.EcosystemIntegrationDescriptor);
         AssertFailure(inspection.OpenTelemetryInspection, MetadataFindings.OpenTelemetrySignalDescriptor);
         Assert.Equal(9, inspection.InspectionFailures!.Count);
+    }
+
+    [Fact]
+    public void AssemblyContextIntegrationsRunner_ExecutesOneGroupAndRetainsProvenance()
+    {
+        string firstPath = typeof(LibraryFindingConsumerTests).Assembly.Location;
+        string secondPath = typeof(LibraryInspection).Assembly.Location;
+        HashSet<InspectionQueryDefinition> queries =
+            [AssemblyContextIntegrationsQuery.Definition];
+        var trace = new DotnetInspector.Sections.InspectionTrace();
+
+        AssemblyContextIntegrationsBatch batch =
+            Assert.IsType<AssemblyContextIntegrationsBatch>(
+                AssemblyContextIntegrationsRunner.RunIfRequested(
+                    queries,
+                    LibrarySections.CreateGroupQueryRegistry(),
+                    [
+                        new AssemblyContextIntegrationsInput(
+                            firstPath,
+                            AssemblyResolutionProvenance.Local("first test input")),
+                        new AssemblyContextIntegrationsInput(
+                            secondPath,
+                            AssemblyResolutionProvenance.Local("second test input")),
+                    ],
+                    trace));
+
+        var first = Assert.IsType<AssemblyIntegrationsEntry.Available>(
+            batch.EntryFor(firstPath));
+        var second = Assert.IsType<AssemblyIntegrationsEntry.Available>(
+            batch.EntryFor(secondPath));
+        Assert.Equal(
+            "first test input",
+            Assert.IsType<AssemblyResolutionProvenance.LocalAsset>(
+                first.Subject.Provenance).ResolverSource);
+        Assert.Equal(
+            "second test input",
+            Assert.IsType<AssemblyResolutionProvenance.LocalAsset>(
+                second.Subject.Provenance).ResolverSource);
+        Assert.Empty(queries);
+        Assert.Same(
+            AssemblyContextIntegrationsQuery.Definition,
+            Assert.Single(trace.QueryExecutions).Query);
+    }
+
+    [Fact]
+    public void AssemblyContextIntegrationsRunner_ProjectsBudgetFailureBesideAvailableEntry()
+    {
+        string firstPath = typeof(LibraryFindingConsumerTests).Assembly.Location;
+        string secondPath = typeof(LibraryInspection).Assembly.Location;
+        HashSet<InspectionQueryDefinition> queries =
+            [AssemblyContextIntegrationsQuery.Definition];
+
+        AssemblyContextIntegrationsBatch batch =
+            Assert.IsType<AssemblyContextIntegrationsBatch>(
+                AssemblyContextIntegrationsRunner.RunIfRequested(
+                    queries,
+                    LibrarySections.CreateGroupQueryRegistry(),
+                    [
+                        new AssemblyContextIntegrationsInput(
+                            firstPath,
+                            AssemblyResolutionProvenance.Local("available test input")),
+                        new AssemblyContextIntegrationsInput(
+                            secondPath,
+                            AssemblyResolutionProvenance.Local("rejected test input")),
+                    ],
+                    groupOptions: new AssemblyContextGroupOptions
+                    {
+                        MaxRetainedImageBytes = new FileInfo(firstPath).Length,
+                    }));
+
+        Assert.IsType<AssemblyIntegrationsEntry.Available>(
+            batch.EntryFor(firstPath));
+        var rejected = Assert.IsType<AssemblyIntegrationsEntry.Rejected>(
+            batch.EntryFor(secondPath));
+        Assert.Equal(CandidateOpenFailureKind.ResourceBudget, rejected.Failure.Kind);
+
+        var inspection = new LibraryInspection();
+        LibraryMetadataService.ApplyAssemblyIntegrationsEntry(
+            secondPath,
+            inspection,
+            new VerboseLogger(enabled: false),
+            rejected);
+
+        Assert.Same(rejected, inspection.AssemblyIntegrationsEntry);
+        Assert.Equal(
+            [
+                LibraryIntegrationCatalog.RollupName,
+                EcosystemIntegrationNames.OpenTelemetry,
+            ],
+            inspection.InspectionFailures!.Select(failure => failure.Section));
+    }
+
+    [Fact]
+    public async Task AssemblyContextIntegrationsRunner_LendsTheQueriedSnapshotToLibraryInspection()
+    {
+        string tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-integrations-snapshot-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        string targetPath = Path.Combine(tempDir, "Target.dll");
+        string originalPath = typeof(LibraryFindingConsumerTests).Assembly.Location;
+        string replacementPath = typeof(LibraryInspection).Assembly.Location;
+        File.Copy(originalPath, targetPath);
+
+        try
+        {
+            HashSet<InspectionQueryDefinition> queries =
+                [AssemblyContextIntegrationsQuery.Definition];
+            AssemblyContextIntegrationsBatch batch =
+                Assert.IsType<AssemblyContextIntegrationsBatch>(
+                    AssemblyContextIntegrationsRunner.RunIfRequested(
+                        queries,
+                        LibrarySections.CreateGroupQueryRegistry(),
+                        [
+                            new AssemblyContextIntegrationsInput(
+                                targetPath,
+                                AssemblyResolutionProvenance.Local(
+                                    "snapshot reuse test")),
+                        ]));
+            AssemblyIntegrationsEntry entry = batch.EntryFor(targetPath);
+
+            File.Copy(replacementPath, targetPath, overwrite: true);
+
+            using var httpClient = new HttpClient();
+            LibraryInspection inspection = Assert.IsType<LibraryInspection>(
+                await LibraryMetadataService.InspectAsync(
+                    targetPath,
+                    new DotnetInspector.Options.LibraryOptions(),
+                    new VerboseLogger(enabled: false),
+                    packageName: null,
+                    packageVersion: null,
+                    httpClient,
+                    assemblyReference: Assert.IsType<ResolvedAssemblyReference>(
+                        batch.AssemblyForInspection(targetPath)),
+                    integrationsEntry: entry));
+
+            Assert.Equal(
+                entry.Subject.Identity.Name,
+                inspection.AssemblyInfo!.AssemblyName);
+            Assert.NotEqual(
+                Path.GetFileNameWithoutExtension(replacementPath),
+                inspection.AssemblyInfo.AssemblyName);
+            Assert.Same(entry, inspection.AssemblyIntegrationsEntry);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -478,7 +478,9 @@ public class SectionPipelineTests
         var detailedQueries = pipeline.GetRequiredQueries(Verbosity.Detailed);
 
         Assert.DoesNotContain(MetadataImageQuery.Definition, detailedQueries);
-        Assert.DoesNotContain(LibrarySections.ScannerIntegrations, detailedScanners);
+        Assert.DoesNotContain(
+            AssemblyContextIntegrationsQuery.Definition,
+            detailedQueries);
         Assert.DoesNotContain(LibrarySections.ScannerIntegrationOpportunities, detailedScanners);
         Assert.DoesNotContain(LibrarySections.ScannerOptimizationOpportunities, detailedScanners);
         Assert.DoesNotContain(LibrarySections.ScannerResourceTriage, detailedScanners);
@@ -1528,16 +1530,44 @@ public class SectionPipelineTests
     [Fact]
     public void LibraryQueryRegistry_RegistrationMatchesDeclaration()
     {
-        var registry = LibrarySections.CreateQueryRegistry();
-        var pipeline = LibrarySections.CreatePipeline();
+        LibrarySectionCatalog catalog = LibrarySections.CreateCatalog();
+        var pipeline = catalog.Pipeline;
+        HashSet<InspectionQueryDefinition> scannerContextQueries =
+        [
+            .. pipeline.DeclaredQueries.Where(
+                catalog.QueryRegistry.RegisteredQueries.Contains),
+        ];
+        HashSet<InspectionQueryDefinition> groupQueries =
+        [
+            .. pipeline.DeclaredQueries.Where(
+                catalog.GroupQueryRegistry.RegisteredQueries.Contains),
+        ];
         HashSet<InspectionQueryDefinition> closure =
-            registry.ExpandRequired(pipeline.DeclaredQueries);
+            catalog.QueryRegistry.ExpandRequired(scannerContextQueries);
+        closure.UnionWith(
+            catalog.GroupQueryRegistry.ExpandRequired(groupQueries));
+        HashSet<InspectionQueryDefinition> registered =
+        [
+            .. catalog.QueryRegistry.RegisteredQueries,
+            .. catalog.GroupQueryRegistry.RegisteredQueries,
+        ];
 
+        Assert.Empty(
+            catalog.QueryRegistry.RegisteredQueries.Intersect(
+                catalog.GroupQueryRegistry.RegisteredQueries));
         Assert.Equal(
             closure.OrderBy(q => q.Name, StringComparer.Ordinal),
-            registry.RegisteredQueries.OrderBy(q => q.Name, StringComparer.Ordinal));
+            registered.OrderBy(q => q.Name, StringComparer.Ordinal));
+        Assert.Equal(
+            pipeline.DeclaredQueries.OrderBy(
+                query => query.Name,
+                StringComparer.Ordinal),
+            scannerContextQueries.Union(groupQueries).OrderBy(
+                query => query.Name,
+                StringComparer.Ordinal));
         Assert.Equal(
             [
+                AssemblyContextIntegrationsQuery.Definition,
                 AssemblyReferencesQuery.Definition,
                 MetadataImageQuery.Definition,
                 SourceAvailabilityQuery.Definition,
@@ -2540,7 +2570,7 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void LibrarySections_AboveNetworkFree_AreExactlyTheBodyIndexFamily()
+    public void LibrarySections_AboveNetworkFree_AreExplicitlyPinned()
     {
         // GPT review of #3626 caught Switches silently leaving -v:n: its scanner had been declared
         // Moderated, and Moderated means "auto-runs only at -v:d". Nothing failed. The regression
@@ -2589,12 +2619,14 @@ public class SectionPipelineTests
             scannerAboveCheap);
 
         // The effective axis: everything the ladder will refuse to auto-render, whichever
-        // declaration made it so. The Metadata table sections and the SourceLink family were
-        // already Unbounded by their own descriptors before this change — they are here because
-        // this list is the honest full set, not because this PR moved them.
+        // declaration made it so. Metadata and SourceLink declare their own cost; Integrations
+        // inherits the group query's Unbounded cost. This is the honest full set, so either kind
+        // of cost declaration crossing the boundary requires an explicit review update.
         string[] expectedAboveCheap =
         [
             .. expectedBodyIndexFamily,
+            .. LibraryIntegrationCatalog.CategorySections,
+            IntegrationSectionNames.Opportunities,
             "Metadata: #Blob",
             "Metadata: #GUID",
             "Metadata: #Strings",
@@ -2809,28 +2841,41 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void IntegrationOpportunities_DeclaresIntegrationsPrerequisite()
+    public void IntegrationSections_BindToTheAssemblyContextQueryByIdentity()
     {
-        // This pins the declaration, not the behavior, and that is a deliberate weakening.
-        // LibrarySections_RenderIdenticallyAloneAndTogether covers every other prerequisite
-        // behaviorally, but it cannot cover this one.
-        //
-        // Not because the section never renders offline — it does; System.Data.Common yields two
-        // rows (DbDataSource under Aspire and Health Checks). It is because the failure mode is
-        // EXTRA rows rather than missing ones: without Integrations the existing-integration set
-        // is empty, so already-integrated categories stop being suppressed. Distinguishing the
-        // two therefore needs an assembly that both renders opportunities AND carries an existing
-        // integration in one of those same categories, so that dropping the prerequisite makes a
-        // suppressed row reappear. No assembly available offline does both.
-        //
-        // Closing the gap properly needs a purpose-built fixture with that combination. Until
-        // then this catches the realistic failure — someone deleting the declaration — and
-        // nothing more.
-        var registry = LibrarySections.CreateScannerRegistry();
-
+        LibrarySectionCatalog catalog = LibrarySections.CreateCatalog();
+        SectionPipeline<LibraryInspection> pipeline = catalog.Pipeline;
         Assert.Contains(
-            LibrarySections.ScannerIntegrations,
-            registry.RequirementsOf(LibrarySections.ScannerIntegrationOpportunities));
+            AssemblyContextIntegrationsQuery.Definition,
+            catalog.GroupQueryRegistry.RegisteredQueries);
+        Assert.DoesNotContain(
+            AssemblyContextIntegrationsQuery.Definition,
+            catalog.QueryRegistry.RegisteredQueries);
+
+        foreach (string section in LibraryIntegrationCatalog.CategorySections
+                     .Append(IntegrationSectionNames.Opportunities))
+        {
+            var include = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                section,
+            };
+            HashSet<InspectionQueryDefinition> queries =
+                pipeline.GetRequiredQueries(Verbosity.Minimal, include);
+
+            Assert.Contains(
+                AssemblyContextIntegrationsQuery.Definition,
+                queries);
+        }
+
+        var opportunities = new HashSet<string>(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            IntegrationSectionNames.Opportunities,
+        };
+        Assert.Contains(
+            LibrarySections.ScannerIntegrationOpportunities,
+            pipeline.GetRequiredScanners(Verbosity.Minimal, opportunities));
     }
 
     [Fact]
@@ -2862,8 +2907,6 @@ public class SectionPipelineTests
             LibrarySections.ScannerResources,
             LibrarySections.ScannerCustomAttributes,
             LibrarySections.ScannerTypeForwarders,
-            // was ScanIntegrationOpportunities re-running ScanIntegrations
-            LibrarySections.ScannerIntegrations,
             LibrarySections.ScannerIntegrationOpportunities,
             // was PopulateLibraryAudit running ScanClassifiedMethods on its own session
             LibrarySections.ScannerAuditSignals,
@@ -3195,16 +3238,6 @@ public class SectionPipelineTests
                 m => Xunit.Assert.IsType<FindingInspection<TypeForwarderInfo>.Failed>(
                     m.TypeForwarderInspection!.Value)),
 
-            ("Integrations",
-                m => LibraryMetadataService.ScanIntegrations(session, Path, m, logger),
-                m =>
-                {
-                    Xunit.Assert.IsType<FindingInspection<OpenTelemetrySignalInfo>.Failed>(
-                        m.OpenTelemetryInspection!.Value);
-                    Xunit.Assert.IsType<FindingInspection<EcosystemIntegrationSignalInfo>.Failed>(
-                        m.EcosystemIntegrationInspection!.Value);
-                }),
-
             ("IntegrationOpportunities",
                 m => LibraryMetadataService.ScanIntegrationOpportunities(session, Path, m, logger),
                 m =>
@@ -3503,7 +3536,6 @@ public class SectionPipelineTests
         LibrarySections.ScannerResources,
         LibrarySections.ScannerCustomAttributes,
         LibrarySections.ScannerTypeForwarders,
-        LibrarySections.ScannerIntegrations,
         LibrarySections.ScannerIntegrationOpportunities,
         LibrarySections.ScannerAuditSignals,
     ];

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -88,6 +88,7 @@ public class LibraryCommand
         var pipeline = catalog.Pipeline;
         var scannerRegistry = catalog.ScannerRegistry;
         var queryRegistry = catalog.QueryRegistry;
+        var groupQueryRegistry = catalog.GroupQueryRegistry;
 
         var schemaMap = MetadataSectionNames.AugmentSchema(
             InspectionContext.Default.GetSchemaInfo<LibraryInspectionView>()!.ToDocumentSchema());
@@ -554,10 +555,25 @@ public class LibraryCommand
                     }
                 }
 
+                AssemblyContextIntegrationsBatch? integrations =
+                    AssemblyContextIntegrationsRunner.RunIfRequested(
+                        queries,
+                        groupQueryRegistry,
+                        [
+                            new AssemblyContextIntegrationsInput(
+                                resolvedPath!,
+                                AssemblyResolutionProvenance.Platform(
+                                    framework!,
+                                    version,
+                                    "library --platform")),
+                        ],
+                        trace);
                 var inspection = await LibraryMetadataService.InspectAsync(
                     resolvedPath!, inspectionOptions, logger, null, null, context.HttpClient,
                     isPlatformAssembly: true, scanners: scanners, scannerRegistry: scannerRegistry,
                     queries: queries, queryRegistry: queryRegistry,
+                    assemblyReference: integrations?.AssemblyForInspection(resolvedPath!),
+                    integrationsEntry: integrations?.EntryFor(resolvedPath!),
                     discoveryOnly: discoveryInspection && !fullEffectiveDiscovery, trace: trace);
                 if (inspection == null)
                 {
@@ -647,10 +663,23 @@ public class LibraryCommand
                 var inspectionPaths = discoveryInspection && assemblyPaths.Count > 0
                     ? [assemblyPaths[0]]
                     : assemblyPaths;
+                AssemblyContextIntegrationsBatch? integrations =
+                    AssemblyContextIntegrationsRunner.RunIfRequested(
+                        queries,
+                        groupQueryRegistry,
+                        inspectionPaths.Select(path =>
+                            new AssemblyContextIntegrationsInput(
+                                path,
+                                PackageIntegrationProvenance(
+                                    path,
+                                    extractPath,
+                                    packageName,
+                                    packageVersion))),
+                        trace);
                 var inspections = await CollectPackageInspectionsAsync(
                     inspectionPaths, inspectionOptions, logger, packageName, packageVersion,
                     extractPath, context.HttpClient, signatureResult, scanners, scannerRegistry,
-                    queries, queryRegistry,
+                    queries, queryRegistry, integrations,
                     discoveryInspection && !fullEffectiveDiscovery, trace);
 
                 if (inspections.Count == 0)
@@ -729,10 +758,23 @@ public class LibraryCommand
                     }
                 }
 
+                AssemblyContextIntegrationsBatch? integrations =
+                    AssemblyContextIntegrationsRunner.RunIfRequested(
+                        queries,
+                        groupQueryRegistry,
+                        [
+                            new AssemblyContextIntegrationsInput(
+                                assemblyPath!,
+                                AssemblyResolutionProvenance.Local(
+                                    "library path")),
+                        ],
+                        trace);
                 var inspection = await LibraryMetadataService.InspectAsync(
                     assemblyPath!, inspectionOptions, logger, null, null, context.HttpClient,
                     scanners: scanners, scannerRegistry: scannerRegistry,
                     queries: queries, queryRegistry: queryRegistry,
+                    assemblyReference: integrations?.AssemblyForInspection(assemblyPath!),
+                    integrationsEntry: integrations?.EntryFor(assemblyPath!),
                     discoveryOnly: discoveryInspection && !fullEffectiveDiscovery, trace: trace);
                 if (inspection == null)
                 {
@@ -2254,6 +2296,7 @@ public class LibraryCommand
         HashSet<string>? scanners = null, ScannerRegistry? scannerRegistry = null,
         HashSet<InspectionQueryDefinition>? queries = null,
         InspectionQueryRegistry<ScannerContext>? queryRegistry = null,
+        AssemblyContextIntegrationsBatch? integrations = null,
         bool discoveryOnly = false, InspectionTrace? trace = null)
     {
         List<LibraryInspection> inspections = [];
@@ -2262,7 +2305,21 @@ public class LibraryCommand
         {
             var version = packageVersion ?? (packageName != null ? PackageExtractor.ExtractVersionFromPath(targetPath, packageName) : null);
 
-            var inspection = await LibraryMetadataService.InspectAsync(targetPath, options, logger, packageName, version, httpClient, scanners: scanners, scannerRegistry: scannerRegistry, queries: queries, queryRegistry: queryRegistry, discoveryOnly: discoveryOnly, trace: trace);
+            var inspection = await LibraryMetadataService.InspectAsync(
+                targetPath,
+                options,
+                logger,
+                packageName,
+                version,
+                httpClient,
+                scanners: scanners,
+                scannerRegistry: scannerRegistry,
+                queries: queries,
+                queryRegistry: queryRegistry,
+                assemblyReference: integrations?.AssemblyForInspection(targetPath),
+                integrationsEntry: integrations?.EntryFor(targetPath),
+                discoveryOnly: discoveryOnly,
+                trace: trace);
             if (inspection == null)
             {
                 logger.LogWarning($"Could not read library: {Path.GetFileName(targetPath)}");
@@ -2285,6 +2342,29 @@ public class LibraryCommand
         }
 
         return inspections;
+    }
+
+    private static AssemblyResolutionProvenance PackageIntegrationProvenance(
+        string assemblyPath,
+        string extractPath,
+        string? packageName,
+        string? packageVersion)
+    {
+        if (string.IsNullOrWhiteSpace(packageName)
+            || string.IsNullOrWhiteSpace(packageVersion))
+        {
+            return AssemblyResolutionProvenance.Local(
+                "library package extraction");
+        }
+
+        string relativePath = Path.GetRelativePath(
+            extractPath,
+            assemblyPath).Replace('\\', '/');
+        return AssemblyResolutionProvenance.Package(
+            packageName,
+            packageVersion,
+            TfmResolver.ExtractTfmFromPath(relativePath),
+            rid: null);
     }
 
     private static async Task<(List<string> assemblyPaths, string extractPath, string? tempDir, string? nupkgPath, string? packageName, string? packageVersion)?> ExtractFromPackageAsync(

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -583,7 +583,6 @@ public class LibraryCommand
 
                 inspection.Source = SourceKind.Platform;
                 inspection.PlatformVersion = version;
-                inspection.LastModified = File.GetLastWriteTimeUtc(resolvedPath!);
 
                 var ilOffsetExitCode = await PopulateILOffsetIfRequestedAsync(
                     inspection, resolvedPath!, null, null, isPlatformAssembly: true, options, context.HttpClient, logger);

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -2490,6 +2490,7 @@ public class PackageCommand
         var pipeline = catalog.Pipeline;
         var scannerRegistry = catalog.ScannerRegistry;
         var queryRegistry = catalog.QueryRegistry;
+        var groupQueryRegistry = catalog.GroupQueryRegistry;
         var libraryOptions = CreateLibraryOptions(assemblyName: null, packageReference, options);
 
         var selectResult = SelectResolver.ResolveSelectAsSections(
@@ -2518,6 +2519,23 @@ public class PackageCommand
             commandDemand: commandQueryDemand);
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
+        AssemblyContextIntegrationsBatch? integrations =
+            AssemblyContextIntegrationsRunner.RunIfRequested(
+                queries,
+                groupQueryRegistry,
+                selected.Select(selection =>
+                {
+                    string relativePath = Path.GetRelativePath(
+                        extractPath,
+                        selection.Path).Replace('\\', '/');
+                    return new AssemblyContextIntegrationsInput(
+                        selection.Path,
+                        AssemblyResolutionProvenance.Package(
+                            packageName,
+                            version,
+                            TfmResolver.ExtractTfmFromPath(relativePath),
+                            rid: null));
+                }));
         List<LibraryInspection> inspections = [];
         foreach (var selection in selected)
         {
@@ -2531,7 +2549,9 @@ public class PackageCommand
                 scanners: scanners,
                 scannerRegistry: scannerRegistry,
                 queries: queries,
-                queryRegistry: queryRegistry);
+                queryRegistry: queryRegistry,
+                assemblyReference: integrations?.AssemblyForInspection(selection.Path),
+                integrationsEntry: integrations?.EntryFor(selection.Path));
             if (inspection == null)
             {
                 logger.LogWarning($"Could not read library: {Path.GetFileName(selection.Path)}");

--- a/src/dotnet-inspect/Inspectors/AssemblyContextIntegrationsRunner.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyContextIntegrationsRunner.cs
@@ -17,7 +17,7 @@ internal sealed class AssemblyContextIntegrationsBatch
         IEnumerable<(
             string Path,
             ResolvedAssemblyReference? Assembly,
-            AssemblyIntegrationsEntry Entry)> entries)
+            AssemblyIntegrationsEntry? Entry)> entries)
     {
         _resultByPath = entries.ToDictionary(
             entry => System.IO.Path.GetFullPath(entry.Path),
@@ -25,7 +25,7 @@ internal sealed class AssemblyContextIntegrationsBatch
             StringComparer.OrdinalIgnoreCase);
     }
 
-    internal AssemblyIntegrationsEntry EntryFor(string path)
+    internal AssemblyIntegrationsEntry? EntryFor(string path)
         => ResultFor(path).Entry;
 
     internal ResolvedAssemblyReference? AssemblyForInspection(string path)
@@ -41,7 +41,7 @@ internal sealed class AssemblyContextIntegrationsBatch
 
     sealed record ParticipantResult(
         ResolvedAssemblyReference? Assembly,
-        AssemblyIntegrationsEntry Entry);
+        AssemblyIntegrationsEntry? Entry);
 }
 
 internal static class AssemblyContextIntegrationsRunner
@@ -67,11 +67,26 @@ internal static class AssemblyContextIntegrationsRunner
                 "Assembly context integrations requires at least one assembly.");
         }
 
-        var roots = inputArray
-            .Select(input => ResolvedAssemblyReference.CreateFromPath(
-                input.Path,
-                input.Provenance))
+        var candidates = inputArray
+            .Select(input => (
+                Input: input,
+                Assembly: ResolvedAssemblyReference.CreateFromPathIfManaged(
+                    input.Path,
+                    input.Provenance)))
             .ToArray();
+        var roots = candidates
+            .Where(candidate => candidate.Assembly is not null)
+            .Select(candidate => candidate.Assembly!)
+            .ToArray();
+        if (roots.Length == 0)
+        {
+            return new AssemblyContextIntegrationsBatch(
+                inputArray.Select(input => (
+                    input.Path,
+                    Assembly: (ResolvedAssemblyReference?)null,
+                    Entry: (AssemblyIntegrationsEntry?)null)));
+        }
+
         var sourcePolicies = roots
             .Select(root => (
                 Assembly: root,
@@ -109,17 +124,26 @@ internal static class AssemblyContextIntegrationsRunner
                         : RetainAcquiredAssembly(group, root))
             .ToArray();
 
+        int managedIndex = 0;
         return new AssemblyContextIntegrationsBatch(
-            inputArray
-                .Zip(
-                    retainedAssemblies,
-                    static (input, assembly) => (input, assembly))
-                .Zip(
-                    result.Assemblies,
-                    static (participant, entry) => (
-                        participant.input.Path,
-                        participant.assembly,
-                        entry)));
+            candidates.Select(candidate =>
+            {
+                if (candidate.Assembly is null)
+                {
+                    return (
+                        Path: candidate.Input.Path,
+                        Assembly: (ResolvedAssemblyReference?)null,
+                        Entry: (AssemblyIntegrationsEntry?)null);
+                }
+
+                int index = managedIndex++;
+                return (
+                    Path: candidate.Input.Path,
+                    Assembly: (ResolvedAssemblyReference?)
+                        retainedAssemblies[index],
+                    Entry: (AssemblyIntegrationsEntry?)
+                        result.Assemblies[index]);
+            }));
     }
 
     static ResolvedAssemblyReference RetainAcquiredAssembly(

--- a/src/dotnet-inspect/Inspectors/AssemblyContextIntegrationsRunner.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyContextIntegrationsRunner.cs
@@ -70,9 +70,7 @@ internal static class AssemblyContextIntegrationsRunner
         var candidates = inputArray
             .Select(input => (
                 Input: input,
-                Assembly: ResolvedAssemblyReference.CreateFromPathIfManaged(
-                    input.Path,
-                    input.Provenance)))
+                Assembly: TryCreateManagedParticipant(input)))
             .ToArray();
         var roots = candidates
             .Where(candidate => candidate.Assembly is not null)
@@ -158,5 +156,26 @@ internal static class AssemblyContextIntegrationsRunner
                     ? available.Value
                     : throw new InspectionQueryException(
                         $"Integrations participant '{assembly.Identity.Name}' could not retain its acquired image.");
+    }
+
+    static ResolvedAssemblyReference? TryCreateManagedParticipant(
+        AssemblyContextIntegrationsInput input)
+    {
+        try
+        {
+            return ResolvedAssemblyReference.CreateFromPathIfManaged(
+                input.Path,
+                input.Provenance);
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException)
+        {
+            // The owning per-library inspection path reports the artifact
+            // failure; it must not prevent valid group participants from
+            // producing evidence.
+            return null;
+        }
     }
 }

--- a/src/dotnet-inspect/Inspectors/AssemblyContextIntegrationsRunner.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyContextIntegrationsRunner.cs
@@ -1,0 +1,138 @@
+using DotnetInspector.Queries;
+using DotnetInspector.Sections;
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Inspectors;
+
+internal sealed record AssemblyContextIntegrationsInput(
+    string Path,
+    AssemblyResolutionProvenance Provenance);
+
+internal sealed class AssemblyContextIntegrationsBatch
+{
+    readonly Dictionary<string, ParticipantResult> _resultByPath;
+
+    internal AssemblyContextIntegrationsBatch(
+        IEnumerable<(
+            string Path,
+            ResolvedAssemblyReference? Assembly,
+            AssemblyIntegrationsEntry Entry)> entries)
+    {
+        _resultByPath = entries.ToDictionary(
+            entry => System.IO.Path.GetFullPath(entry.Path),
+            entry => new ParticipantResult(entry.Assembly, entry.Entry),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal AssemblyIntegrationsEntry EntryFor(string path)
+        => ResultFor(path).Entry;
+
+    internal ResolvedAssemblyReference? AssemblyForInspection(string path)
+        => ResultFor(path).Assembly;
+
+    ParticipantResult ResultFor(string path)
+        => _resultByPath.TryGetValue(
+            System.IO.Path.GetFullPath(path),
+            out ParticipantResult? result)
+                ? result
+                : throw new InspectionQueryException(
+                    $"Assembly context integrations did not produce a result for '{path}'.");
+
+    sealed record ParticipantResult(
+        ResolvedAssemblyReference? Assembly,
+        AssemblyIntegrationsEntry Entry);
+}
+
+internal static class AssemblyContextIntegrationsRunner
+{
+    internal static AssemblyContextIntegrationsBatch? RunIfRequested(
+        HashSet<InspectionQueryDefinition>? requestedQueries,
+        InspectionQueryRegistry<AssemblyContextGroup> queryRegistry,
+        IEnumerable<AssemblyContextIntegrationsInput> inputs,
+        InspectionTrace? trace = null,
+        AssemblyContextGroupOptions? groupOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(queryRegistry);
+        if (requestedQueries?.Remove(
+                AssemblyContextIntegrationsQuery.Definition) != true)
+        {
+            return null;
+        }
+
+        AssemblyContextIntegrationsInput[] inputArray = [.. inputs];
+        if (inputArray.Length == 0)
+        {
+            throw new InspectionQueryException(
+                "Assembly context integrations requires at least one assembly.");
+        }
+
+        var roots = inputArray
+            .Select(input => ResolvedAssemblyReference.CreateFromPath(
+                input.Path,
+                input.Provenance))
+            .ToArray();
+        var sourcePolicies = roots
+            .Select(root => (
+                Assembly: root,
+                Policy: (IAssemblyBindingPolicy)new AssemblyDependencyResolver(
+                    new AssemblyDependencyResolutionOptions(root.Path!))))
+            .ToArray();
+        var groupPolicy =
+            new SourceRelativeAssemblyGroupBindingPolicy(sourcePolicies);
+        var participants = roots
+            .Select(root => new AssemblyContextParticipant(root, groupPolicy))
+            .ToArray();
+
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(participants, groupOptions);
+        HashSet<InspectionQueryDefinition> requested =
+            [AssemblyContextIntegrationsQuery.Definition];
+        HashSet<InspectionQueryDefinition> closure =
+            queryRegistry.ExpandRequired(requested);
+        trace?.RecordQueryClosure(closure);
+        Action<InspectionQueryDefinition, TimeSpan>? recordExecution =
+            trace is null ? null : trace.RecordQueryExecution;
+        InspectionQueryResults queryResults = queryRegistry.Run(
+            requested,
+            group,
+            recordExecution);
+        AssemblyContextIntegrationsResult result = queryResults.Get(
+            AssemblyContextIntegrationsQuery.Definition);
+        ResolvedAssemblyReference?[] retainedAssemblies = roots
+            .Zip(
+                result.Assemblies,
+                (root, entry) => entry
+                    is AssemblyIntegrationsEntry.Rejected
+                        ? null
+                        : RetainAcquiredAssembly(group, root))
+            .ToArray();
+
+        return new AssemblyContextIntegrationsBatch(
+            inputArray
+                .Zip(
+                    retainedAssemblies,
+                    static (input, assembly) => (input, assembly))
+                .Zip(
+                    result.Assemblies,
+                    static (participant, entry) => (
+                        participant.input.Path,
+                        participant.assembly,
+                        entry)));
+    }
+
+    static ResolvedAssemblyReference RetainAcquiredAssembly(
+        AssemblyContextGroup group,
+        ResolvedAssemblyReference assembly)
+    {
+        AssemblyImageAccessResult<ResolvedAssemblyReference> retained =
+            group.RetainAssemblyReference(assembly);
+        return retained
+            is AssemblyImageAccessResult<
+                ResolvedAssemblyReference>.Available available
+                    ? available.Value
+                    : throw new InspectionQueryException(
+                        $"Integrations participant '{assembly.Identity.Name}' could not retain its acquired image.");
+    }
+}

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -39,6 +39,8 @@ internal static class LibraryMetadataService
         ScannerRegistry? scannerRegistry = null,
         HashSet<InspectionQueryDefinition>? queries = null,
         InspectionQueryRegistry<ScannerContext>? queryRegistry = null,
+        ResolvedAssemblyReference? assemblyReference = null,
+        AssemblyIntegrationsEntry? integrationsEntry = null,
         bool discoveryOnly = false,
         Sections.InspectionTrace? trace = null)
     {
@@ -61,11 +63,17 @@ internal static class LibraryMetadataService
             var bodyAnalysisFeatures = requiredScanners is null
                 ? Analysis.LibraryBodyAnalysisFeatures.None
                 : SelectBodyAnalysisFeatures(requiredScanners);
-            using var service = discoveryOnly
-                ? SourceLinkService.OpenMetadataOnly(path, logger.Log)
-                : bodyAnalysisFeatures == Analysis.LibraryBodyAnalysisFeatures.None
-                    ? SourceLinkService.Open(path, logger.Log)
-                    : SourceLinkService.OpenPrefetched(path, logger.Log);
+            using var service = assemblyReference is not null
+                ? bodyAnalysisFeatures == Analysis.LibraryBodyAnalysisFeatures.None
+                    ? SourceLinkService.Open(assemblyReference, logger.Log)
+                    : SourceLinkService.OpenPrefetched(
+                        assemblyReference,
+                        logger.Log)
+                : discoveryOnly
+                    ? SourceLinkService.OpenMetadataOnly(path, logger.Log)
+                    : bodyAnalysisFeatures == Analysis.LibraryBodyAnalysisFeatures.None
+                        ? SourceLinkService.Open(path, logger.Log)
+                        : SourceLinkService.OpenPrefetched(path, logger.Log);
             var pdbContext = service.Context;
             var sourceLinkQueryContext = new SourceLinkQueryContext(
                 service,
@@ -178,6 +186,15 @@ internal static class LibraryMetadataService
                 AppContextSwitchProjectionProducer.Produce(pdbContext.MethodBodies));
             inspection.SwitchCount = presenceFlags.SwitchCount + appContextSwitches.Count;
             inspection.HasSwitches = inspection.SwitchCount > 0;
+
+            if (integrationsEntry is not null)
+            {
+                ApplyAssemblyIntegrationsEntry(
+                    path,
+                    inspection,
+                    logger,
+                    integrationsEntry);
+            }
 
             // PE debug directory fields
             inspection.HasReproducibleFlag = pdbContext.HasReproducibleFlag;
@@ -1524,43 +1541,6 @@ internal static class LibraryMetadataService
         }
     }
 
-    internal static FindingInspection<OpenTelemetrySignalInfo> ScanOpenTelemetry(
-        string path,
-        VerboseLogger logger)
-    {
-        try
-        {
-            using var session = AssemblyInspectionSession.Open(path);
-            return ScanOpenTelemetry(session, path, logger);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning($"Error scanning OpenTelemetry support in {path}: {ex.Message}");
-            return FailedInspection<OpenTelemetrySignalInfo>(
-                path, MetadataFindings.OpenTelemetrySignalDescriptor, ex);
-        }
-    }
-
-    internal static void ScanIntegrations(string path, LibraryInspection inspection, VerboseLogger logger)
-    {
-        try
-        {
-            using var session = AssemblyInspectionSession.Open(path);
-            ScanIntegrations(session, path, inspection, logger);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning($"Error scanning ecosystem integrations in {path}: {ex.Message}");
-            MarkIntegrationFailuresIfMissing(path, inspection, ex);
-        }
-    }
-
-    internal static void ScanIntegrations(AssemblyInspectionSession session, string path, LibraryInspection inspection, VerboseLogger logger)
-    {
-        inspection.OpenTelemetryInspection = ScanOpenTelemetry(session, path, logger);
-        inspection.EcosystemIntegrationInspection = ScanEcosystemIntegrations(session, path, logger);
-    }
-
     internal static void ScanIntegrationOpportunities(string path, LibraryInspection inspection, VerboseLogger logger)
     {
         try
@@ -1591,44 +1571,6 @@ internal static class LibraryMetadataService
         {
             logger.LogWarning($"Error scanning integration opportunities in {path}: {ex.Message}");
             MarkIntegrationFailuresIfMissing(path, inspection, ex);
-        }
-    }
-
-    internal static FindingInspection<OpenTelemetrySignalInfo> ScanOpenTelemetry(
-        AssemblyInspectionSession session,
-        string path,
-        VerboseLogger logger)
-    {
-        try
-        {
-            return MetadataFindings.InspectOpenTelemetrySignals(
-                session.OpenTelemetrySignals(),
-                FindingSubjectFor(path));
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning($"Error scanning OpenTelemetry support in {path}: {ex.Message}");
-            return FailedInspection<OpenTelemetrySignalInfo>(
-                path, MetadataFindings.OpenTelemetrySignalDescriptor, ex);
-        }
-    }
-
-    static FindingInspection<EcosystemIntegrationSignalInfo> ScanEcosystemIntegrations(
-        AssemblyInspectionSession session,
-        string path,
-        VerboseLogger logger)
-    {
-        try
-        {
-            return MetadataFindings.InspectEcosystemIntegrations(
-                session.EcosystemIntegrations(),
-                FindingSubjectFor(path));
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning($"Error scanning ecosystem integrations in {path}: {ex.Message}");
-            return FailedInspection<EcosystemIntegrationSignalInfo>(
-                path, MetadataFindings.EcosystemIntegrationDescriptor, ex);
         }
     }
 
@@ -2035,6 +1977,66 @@ internal static class LibraryMetadataService
                 FindingSubjectFor(path),
                 descriptor,
                 exception.Message));
+
+    static FindingInspection<T> FailedInspection<T>(
+        string path,
+        FindingDescriptor descriptor,
+        string reason)
+        where T : notnull
+        => new FindingInspection<T>.Failed(
+            new InspectionError(
+                FindingSubjectFor(path),
+                descriptor,
+                reason));
+
+    internal static void ApplyAssemblyIntegrationsEntry(
+        string path,
+        LibraryInspection inspection,
+        VerboseLogger logger,
+        AssemblyIntegrationsEntry entry)
+    {
+        inspection.AssemblyIntegrationsEntry = entry;
+        switch (entry)
+        {
+            case AssemblyIntegrationsEntry.Available available:
+                inspection.EcosystemIntegrationInspection =
+                    MetadataFindings.InspectEcosystemIntegrations(
+                        available.EcosystemSignals,
+                        FindingSubjectFor(path));
+                inspection.OpenTelemetryInspection =
+                    MetadataFindings.InspectOpenTelemetrySignals(
+                        available.OpenTelemetrySignals,
+                        FindingSubjectFor(path));
+                break;
+
+            case AssemblyIntegrationsEntry.Rejected rejected:
+                string acquisitionReason =
+                    $"{rejected.Failure.Kind}: {rejected.Failure.Detail}";
+                logger.LogWarning(
+                    $"Error acquiring integration metadata for {path}: {acquisitionReason}");
+                inspection.EcosystemIntegrationInspection =
+                    FailedInspection<EcosystemIntegrationSignalInfo>(
+                        path,
+                        MetadataFindings.EcosystemIntegrationDescriptor,
+                        acquisitionReason);
+                inspection.OpenTelemetryInspection =
+                    FailedInspection<OpenTelemetrySignalInfo>(
+                        path,
+                        MetadataFindings.OpenTelemetrySignalDescriptor,
+                        acquisitionReason);
+                break;
+
+            case AssemblyIntegrationsEntry.Failed failed:
+                logger.LogWarning(
+                    $"Error reading integration metadata of {path}: {failed.Error.Message}");
+                MarkIntegrationFailuresIfMissing(path, inspection, failed.Error);
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown assembly integrations entry '{entry.GetType().Name}'.");
+        }
+    }
 
     static void MarkIntegrationFailuresIfMissing(
         string path,

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -48,6 +48,9 @@ internal static class LibraryInspectionDisplay
 public class LibraryInspection
 {
     [JsonIgnore]
+    public AssemblyIntegrationsEntry? AssemblyIntegrationsEntry { get; set; }
+
+    [JsonIgnore]
     public string? Tfm { get; set; }
 
     public string FileName { get; set; } = "";

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -7,7 +7,8 @@ namespace DotnetInspector.Sections;
 public sealed record LibrarySectionCatalog(
     SectionPipeline<LibraryInspection> Pipeline,
     ScannerRegistry ScannerRegistry,
-    InspectionQueryRegistry<ScannerContext> QueryRegistry);
+    InspectionQueryRegistry<ScannerContext> QueryRegistry,
+    InspectionQueryRegistry<AssemblyContextGroup> GroupQueryRegistry);
 
 /// <summary>
 /// Section descriptors for the library command.
@@ -27,7 +28,6 @@ public static class LibrarySections
     public const string ScannerTypeForwarders = "TypeForwarders";
     public const string ScannerInfoCounts = "InfoCounts";
     public const string ScannerAuditSignals = "AuditSignals";
-    public const string ScannerIntegrations = LibraryIntegrationCatalog.RollupName;
     public const string ScannerIntegrationOpportunities = "IntegrationOpportunities";
     public const string ScannerSwitches = "Switches";
     public const string ScannerUnsafeMembers = "UnsafeMembers";
@@ -43,10 +43,16 @@ public static class LibrarySections
     {
         var scannerRegistry = CreateScannerRegistry();
         var queryRegistry = CreateQueryRegistry();
+        var groupQueryRegistry = CreateGroupQueryRegistry();
         return new LibrarySectionCatalog(
-            CreatePipeline(scannerRegistry.CostOf, queryRegistry.CostOf),
+            CreatePipeline(
+                scannerRegistry.CostOf,
+                query => groupQueryRegistry.RegisteredQueries.Contains(query)
+                    ? groupQueryRegistry.CostOf(query)
+                    : queryRegistry.CostOf(query)),
             scannerRegistry,
-            queryRegistry);
+            queryRegistry,
+            groupQueryRegistry);
     }
 
     /// <summary>Builds the section pipeline with all library sections registered.</summary>
@@ -54,7 +60,12 @@ public static class LibrarySections
     {
         var scannerRegistry = CreateScannerRegistry();
         var queryRegistry = CreateQueryRegistry();
-        return CreatePipeline(scannerRegistry.CostOf, queryRegistry.CostOf);
+        var groupQueryRegistry = CreateGroupQueryRegistry();
+        return CreatePipeline(
+            scannerRegistry.CostOf,
+            query => groupQueryRegistry.RegisteredQueries.Contains(query)
+                ? groupQueryRegistry.CostOf(query)
+                : queryRegistry.CostOf(query));
     }
 
     private static SectionPipeline<LibraryInspection> CreatePipeline(
@@ -90,20 +101,22 @@ public static class LibrarySections
             .Add<Symbols>()
             .Add<Signals>(HasAssemblyInfo)
             .Add<Switches>()
-            .Add<IntegrationOpportunities>()
-            .Add<AI>()
-            .Add<AspNetCore>()
-            .Add<Authentication>()
-            .Add<Aspire>()
-            .Add<Configuration>()
-            .Add<DependencyInjection>()
-            .Add<Logging>()
-            .Add<OpenTelemetry>()
-            .Add<OpenAPI>()
-            .Add<Options>()
-            .Add<Hosting>()
-            .Add<HealthChecks>()
-            .Add<HttpClient>()
+            .Add<IntegrationOpportunities>(
+                AssemblyContextIntegrationsQuery.Definition)
+            .Add<AI>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<AspNetCore>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<Authentication>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<Aspire>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<Configuration>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<DependencyInjection>(
+                AssemblyContextIntegrationsQuery.Definition)
+            .Add<Logging>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<OpenTelemetry>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<OpenAPI>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<Options>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<Hosting>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<HealthChecks>(AssemblyContextIntegrationsQuery.Definition)
+            .Add<HttpClient>(AssemblyContextIntegrationsQuery.Definition)
             .Add<References>(AssemblyReferencesQuery.Definition, HasReferenceData)
             .Add<ExtensionMethods>()
             .Add<UnsafeMembers>(UnsafeMembersDiscoverable)
@@ -223,15 +236,10 @@ public static class LibrarySections
                     ctx.DrillMap,
                     ctx.AssemblyPath,
                     ctx.Logger)))
-            .Add(ScannerIntegrations, SectionCost.NetworkFree, ctx =>
-                ctx.Scan(
-                    session => LibraryMetadataService.ScanIntegrations(session, ctx.AssemblyPath, ctx.Model, ctx.Logger),
-                    () => LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger)))
             .Add(ScannerIntegrationOpportunities, SectionCost.NetworkFree, ctx =>
                 ctx.Scan(
                     session => LibraryMetadataService.ScanIntegrationOpportunities(session, ctx.AssemblyPath, ctx.Model, ctx.Logger),
-                    () => LibraryMetadataService.ScanIntegrationOpportunities(ctx.AssemblyPath, ctx.Model, ctx.Logger)),
-                ScannerIntegrations)
+                    () => LibraryMetadataService.ScanIntegrationOpportunities(ctx.AssemblyPath, ctx.Model, ctx.Logger)))
             ;
     }
 
@@ -275,6 +283,14 @@ public static class LibrarySections
                     }))
             .AddSourceLinkQueries(RequireSourceLinkContext);
     }
+
+    /// <summary>Builds the typed query registry for assembly-context group sections.</summary>
+    public static InspectionQueryRegistry<AssemblyContextGroup>
+        CreateGroupQueryRegistry()
+        => new InspectionQueryRegistry<AssemblyContextGroup>()
+            .Add(
+                AssemblyContextIntegrationsQuery.Definition,
+                AssemblyContextIntegrationsQuery.Execute);
 
     private static SourceLinkQueryContext RequireSourceLinkContext(ScannerContext context)
         => context.SourceLinkContext
@@ -430,7 +446,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.OpenTelemetry.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model)
             => LibraryIntegrationCatalog.OpenTelemetry.CanRender(model);
     }
@@ -450,7 +466,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.AI.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.AI.CanRender(model);
     }
 
@@ -459,7 +475,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.AspNetCore.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.AspNetCore.CanRender(model);
     }
 
@@ -468,7 +484,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.Authentication.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.Authentication.CanRender(model);
     }
 
@@ -477,7 +493,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.Aspire.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.Aspire.CanRender(model);
     }
 
@@ -486,7 +502,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.Configuration.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.Configuration.CanRender(model);
     }
 
@@ -495,7 +511,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.DependencyInjection.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model)
             => LibraryIntegrationCatalog.DependencyInjection.CanRender(model);
     }
@@ -505,7 +521,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.Logging.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.Logging.CanRender(model);
     }
 
@@ -514,7 +530,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.Options.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.Options.CanRender(model);
     }
 
@@ -523,7 +539,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.OpenAPI.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.OpenAPI.CanRender(model);
     }
 
@@ -532,7 +548,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.Hosting.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.Hosting.CanRender(model);
     }
 
@@ -541,7 +557,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.HealthChecks.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.HealthChecks.CanRender(model);
     }
 
@@ -550,7 +566,7 @@ public static class LibrarySections
         public static string Name => LibraryIntegrationCatalog.HttpClient.SectionName;
         public static bool IsExpensive => false;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
-        public static string? ScannerKey => ScannerIntegrations;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => LibraryIntegrationCatalog.HttpClient.CanRender(model);
     }
 

--- a/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
+++ b/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
@@ -63,6 +63,9 @@ public class InspectionAcquisitionPlanTests
 
         Assert.Equal(ReadIdentity(SelfBytes()), descriptor.Identity);
         Assert.Equal(Path.GetFullPath(SelfPath), descriptor.Path);
+        Assert.Equal(
+            File.GetLastWriteTimeUtc(SelfPath),
+            descriptor.LastWriteTimeUtc);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
+++ b/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
@@ -93,6 +93,23 @@ public class InspectionAcquisitionPlanTests
     }
 
     [Fact]
+    public void CreateFromPathIfManaged_NonPeImage_ReturnsNull()
+    {
+        string invalid = Path.GetTempFileName();
+        try
+        {
+            Assert.Null(
+                ResolvedAssemblyReference.CreateFromPathIfManaged(
+                    invalid,
+                    AssemblyResolutionProvenance.Local("test")));
+        }
+        finally
+        {
+            File.Delete(invalid);
+        }
+    }
+
+    [Fact]
     public void Register_SameDescriptor_IsOneCandidateAndOneInventoryRead()
     {
         byte[] image = SelfBytes();

--- a/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
+++ b/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
@@ -15,18 +15,20 @@ public class PdbContextDescriptorTests
         string informationalPath = typeof(PdbContext).Assembly.Location;
         byte[] authoritativeImage = File.ReadAllBytes(authoritativePath);
         AssemblyReferenceIdentity identity = ReadIdentity(authoritativeImage);
+        DateTime authoritativeTimestamp = new(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc);
         var descriptor = ResolvedAssemblyReference.Create(
             identity,
             informationalPath,
             () => new MemoryStream(authoritativeImage, writable: false),
-            AssemblyResolutionProvenance.Local("test"));
+            AssemblyResolutionProvenance.Local("test"),
+            authoritativeTimestamp);
 
         using var context = PdbContext.Open(descriptor);
 
         Assert.Equal(identity.Name, context.ExtractAssemblyInfo().AssemblyName);
         Assert.Equal(informationalPath, context.AssemblyPathOrNull);
         Assert.Equal(
-            File.GetLastWriteTimeUtc(informationalPath),
+            authoritativeTimestamp,
             context.LastWriteTimeUtc);
     }
 

--- a/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
+++ b/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
@@ -25,6 +25,28 @@ public class PdbContextDescriptorTests
 
         Assert.Equal(identity.Name, context.ExtractAssemblyInfo().AssemblyName);
         Assert.Equal(informationalPath, context.AssemblyPathOrNull);
+        Assert.Equal(
+            File.GetLastWriteTimeUtc(informationalPath),
+            context.LastWriteTimeUtc);
+    }
+
+    [Fact]
+    public void OpenPrefetchedDescriptor_UsesAuthoritativeStreamInsteadOfPath()
+    {
+        string authoritativePath = typeof(PdbContextDescriptorTests).Assembly.Location;
+        string informationalPath = typeof(PdbContext).Assembly.Location;
+        byte[] authoritativeImage = File.ReadAllBytes(authoritativePath);
+        AssemblyReferenceIdentity identity = ReadIdentity(authoritativeImage);
+        var descriptor = ResolvedAssemblyReference.Create(
+            identity,
+            informationalPath,
+            () => new MemoryStream(authoritativeImage, writable: false),
+            AssemblyResolutionProvenance.Local("test"));
+
+        using var context = PdbContext.OpenPrefetched(descriptor);
+
+        Assert.Equal(identity.Name, context.ExtractAssemblyInfo().AssemblyName);
+        Assert.Equal(informationalPath, context.AssemblyPathOrNull);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

CLI Integrations sections now execute the shared
`AssemblyContextIntegrationsQuery` over one binding-consistent assembly group
instead of using the legacy per-library Integrations scanner.

- Bind every focused `Integration:` section to the group query by object
  identity through a catalog-owned group-query registry.
- Execute one group query for library file, platform, package-library, and
  package `--all-libraries` hosts while preserving participant order and typed
  local/platform/package/TFM provenance.
- Project available, rejected, and failed participant outcomes into the
  existing `LibraryInspection`/Finding surfaces.
- Retain the workspace's authoritative immutable image for the rest of each
  library inspection, preventing path retargeting from mixing query evidence
  with later metadata or opportunity scans.
- Keep `Integration: Opportunities` as a compatibility composition scanner
  over query-produced existing-integration evidence.

## Compatibility boundary

User-visible Integration rows and output shapes remain unchanged. `Library
Info` still uses its cheap presence flags and does not request the group query.
Moving opportunity production into L1, cancellation-aware group execution, and
optional concurrency remain deferred.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- CLI suite: 3,200 total, zero failures, 14 environment skips
- Query/workspace suite: 21 passed
- Metadata suite: 1,334 passed
- Shared services suite: 380 passed
- Markdown lint and `git diff --check`
- Real singleton OpenTelemetry, Opportunities composition, and package
  `--all-libraries` JSONL canaries

Advances #3229.
