### PR TITLE
Trim terminal void returns before trailing local declarations

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TerminalReturnPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TerminalReturnPrinterTests.cs
@@ -49,8 +49,10 @@ public class TerminalReturnPrinterTests
         Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
     }
 
-    [Fact]
-    public void LabeledTerminalReturnBeforeLocalFunction_IsPreserved()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void LabeledTerminalReturnBeforeLocalFunction_IsPreserved(bool targetStatementOffset)
     {
         var localBody = new BlockContainer();
         localBody.Add(new Block());
@@ -67,8 +69,11 @@ public class TerminalReturnPrinterTests
 
         var entry = new Block();
         entry.Add(new Branch(0x10));
-        var target = new Block(0x10);
-        target.Add(new Return(null));
+        var target = new Block(targetStatementOffset ? 0x08 : 0x10);
+        var terminalReturn = new Return(null);
+        if (targetStatementOffset)
+            terminalReturn.SetSourceOffset(0x10);
+        target.Add(terminalReturn);
         target.Add(localFunction);
         var body = new BlockContainer();
         body.Add(entry);

--- a/src/ILInspector.Decompiler.Tests/TerminalReturnPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TerminalReturnPrinterTests.cs
@@ -1,0 +1,106 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Area", "Printer")]
+public class TerminalReturnPrinterTests
+{
+    static readonly TypeRef s_void = TypeRef.CoreLib("System", "Void");
+
+    [Fact]
+    public void TerminalReturnBeforeLocalFunction_IsTrimmed()
+    {
+        string output = Raise(nameof(TerminalReturnSamples.BeforeLocalFunction));
+
+        Assert.Equal(
+            """
+            F();
+            static void F()
+            {
+            }
+            """.ReplaceLineEndings("\n"),
+            output);
+    }
+
+    [Fact]
+    public void EarlyReturnBeforeLocalFunction_IsPreserved()
+    {
+        string output = Raise(nameof(TerminalReturnSamples.EarlyReturnBeforeLocalFunction));
+
+        Assert.Equal(1, CountOccurrences(output, "return;"));
+        Assert.Contains("static void F()", output);
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void TerminalReturnBeforeLocalFunction_RecompilesOpcodeExact()
+    {
+        string assembly = typeof(TerminalReturnSamples).Assembly.Location;
+        var result = Assert.Single(FidelityCheck.EvaluateTargets(
+            [assembly],
+            [new FidelityCheck.CompileBackTarget(
+                assembly,
+                typeof(TerminalReturnSamples).FullName!,
+                nameof(TerminalReturnSamples.BeforeLocalFunction),
+                Overload: 0,
+                Signature: "() -> corelib:System.Void")]));
+
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+    }
+
+    [Fact]
+    public void LabeledTerminalReturnBeforeLocalFunction_IsPreserved()
+    {
+        var localBody = new BlockContainer();
+        localBody.Add(new Block());
+        var localFunction = new LocalFunctionStatement(
+            "F",
+            s_void,
+            [],
+            isStatic: true,
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            localBody);
+
+        var entry = new Block();
+        entry.Add(new Branch(0x10));
+        var target = new Block(0x10);
+        target.Add(new Return(null));
+        target.Add(localFunction);
+        var body = new BlockContainer();
+        body.Add(entry);
+        body.Add(target);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("synthetic", "", "Holder"),
+            new MethodSignature(s_void, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        function.CheckInvariant();
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").Trim();
+
+        Assert.Contains("IL_0010:", output);
+        Assert.Contains("return;", output);
+        Assert.Contains("static void F()", output);
+    }
+
+    static string Raise(string methodName)
+    {
+        var type = typeof(TerminalReturnSamples);
+        using var source = MetadataSource.Open(type.Assembly.Location);
+        var function = IrImporter.Import(source, type.FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.NotNull(result.Output);
+        return result.Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    static int CountOccurrences(string text, string value)
+        => text.Split(value, StringSplitOptions.None).Length - 1;
+}

--- a/src/ILInspector.Decompiler.Tests/TerminalReturnSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/TerminalReturnSamples.cs
@@ -1,0 +1,19 @@
+namespace ILInspector.Decompiler.Tests;
+
+public static class TerminalReturnSamples
+{
+    public static void BeforeLocalFunction()
+    {
+        F();
+        static void F() { }
+    }
+
+    public static void EarlyReturnBeforeLocalFunction(bool skip)
+    {
+        if (skip)
+            return;
+
+        F();
+        static void F() { }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/UnraisedLocalFunctionCallTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnraisedLocalFunctionCallTests.cs
@@ -121,7 +121,6 @@ public class UnraisedLocalFunctionCallTests
         Assert.Equal(
             """
             F();
-            return;
             static void F()
             {
             }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -659,6 +659,21 @@ public sealed partial class CSharpPrinter
     {
         string pad = new(' ', indent * 4);
         var blocks = container.Blocks;
+        IrNode? lastStatementBeforeTrailingLocalFunctions = null;
+        if (topLevel && blocks.Count > 0)
+        {
+            // Local-function declarations execute nothing and may legally follow
+            // the host's terminal return, so they do not make that return non-terminal.
+            var statements = blocks[^1].Children;
+            for (int i = statements.Count - 1; i >= 0; i--)
+            {
+                if (statements[i] is LocalFunctionStatement)
+                    continue;
+                lastStatementBeforeTrailingLocalFunctions = statements[i];
+                break;
+            }
+        }
+
         // A label binds to the next statement, even one in a following block, so
         // an empty labeled block is fine mid-container. It only strands when the
         // container ends with no statement after the label; track that and emit a
@@ -679,15 +694,16 @@ public sealed partial class CSharpPrinter
             // The trailing 'return;' trims, current-style — unless it is a
             // labeled block's only statement, where trimming would strand
             // the label as invalid C#.
-            bool labeledReturnOnly = _labelTargets.Contains(block.StartOffset) && block.Children.Count == 1;
+            bool labeledReturnOnly = _labelTargets.Contains(block.StartOffset)
+                && block.Children.Count(statement => statement is not LocalFunctionStatement) == 1;
             var emit = new List<IrNode>();
             foreach (var statement in block.Children)
             {
                 if (ReferenceEquals(statement, _chainStatement) || _fieldInitStores.Contains(statement))
                     continue;   // lifted to the signature initializer / field declarations
-                bool isLast = topLevel && i == blocks.Count - 1 && ReferenceEquals(statement, block.Children[^1]);
-                if (isLast && !labeledReturnOnly && statement is Return { Value: null })
-                    break;
+                bool isLastStatement = ReferenceEquals(statement, lastStatementBeforeTrailingLocalFunctions);
+                if (isLastStatement && !labeledReturnOnly && statement is Return { Value: null })
+                    continue;
                 emit.Add(statement);
             }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -702,7 +702,10 @@ public sealed partial class CSharpPrinter
                 if (ReferenceEquals(statement, _chainStatement) || _fieldInitStores.Contains(statement))
                     continue;   // lifted to the signature initializer / field declarations
                 bool isLastStatement = ReferenceEquals(statement, lastStatementBeforeTrailingLocalFunctions);
-                if (isLastStatement && !labeledReturnOnly && statement is Return { Value: null })
+                bool statementOwnsLabel = statement.SourceOffset >= 0
+                    && _labelTargets.Contains(statement.SourceOffset);
+                if (isLastStatement && !labeledReturnOnly && !statementOwnsLabel
+                    && statement is Return { Value: null })
                     continue;
                 emit.Add(statement);
             }


### PR DESCRIPTION
- Fixes #3914
- Trims a null-valued terminal return when only local-function declarations follow it
- Card revision: `9299810b9f00997275ae1bf4e08c595b0204f21c`

## Change

**Conclusion: PASS** — local-function declarations execute nothing, so they no longer hide the host method's terminal `return;` from the printer's existing canonicalization. Early returns and a return that is the sole executable target of a label remain intact.

The implementation stays in `CSharpPrinter.AppendContainer`: it finds the last top-level statement before trailing `LocalFunctionStatement` nodes and applies the existing null-return trim there. It does not mutate IR or introduce a taste option.

### Original source

```csharp
public static void CallsEmpty()
{
    F();
    static void F() { }
}
```

### Before

```csharp
public static void CallsEmpty()
{
    F();
    return;
    static void F()
    {
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: True
- Taste applied: None
- Commit: `1d47eb9443d6bf00d8546a5da90277001441467a`

### After

```csharp
public static void CallsEmpty()
{
    F();
    static void F()
    {
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: True (`Exact`, compile-back contract v3)
- Taste applied: None
- Commit: `9299810b9f00997275ae1bf4e08c595b0204f21c`

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused printer fixture | Pre-fix witness retained 2 terminal returns | 5/5 passed; required early, block-start-labeled, and statement-offset-labeled returns retained |
| Empty-local-function regression class | Expected explicit terminal return | 32/32 passed with return omitted |
| Decompiler fast suite | Not rerun | 4,619 total; 0 failed; 8 Windows privilege skips |
| Full decompiler suite | Not rerun | 4,879 total; 0 failed; 15 environment/tool skips |
| Compile-back | Explicit/implicit terminal return are opcode-equivalent | `TerminalReturnSamples.BeforeLocalFunction`: `Exact` |
| CoreLib render A/B | Exact-base snapshot | 43,157 methods; 1 structural `invalid→valid`; 0 added or removed |

The render A/B sensor has no cross-method import seam, so the compiler-produced fixture and targeted compile-back gate own the positive local-function claim. Its one structural movement repairs a tightly coupled pre-existing invalid output: `System.Reflection.InvokeUtils.PrimitiveWiden` now preserves the statement-offset target as `IL_02F2: return;` instead of emitting a `goto IL_02F2;` with no matching label.

## Adversarial review

Round-one GPT review of `b4bcc7c6` found that the initial guard protected only block-start labels, while `AppendStatementLabel` can also emit a label for a statement `SourceOffset`. The missing guard was reproduced as invalid output, fixed in `9299810b`, and gated by a non-vacuous theory covering both label sources. Fixed-head GPT re-review of `9299810b` was clean with no blocking or non-blocking correctness findings.
## Decompiler quality

**Conclusion: PASS** — the exact-base PR-quick card matched tolerances with no pass bugs.

| Metric | Exact base | Head |
| --- | ---: | ---: |
| Detected lowering residue | 240 (16.00%) | 239 (15.93%) |
| Conditional-branch residue | 44 (2.93%) | 43 (2.87%) |
| Forward-merge stops | 28 (1.87%) | 27 (1.80%) |
| Pass bugs | 0 | 0 |

Corpus: 15 assemblies, hash-stable 100-method sample per assembly, 1,500 methods. The population differs only in four added/removed self-assembly sample rows caused by generated/hash identity churn; there are no changed common-method rows, so the apparent one-row improvements are not claimed as product wins. The checked-in PR baseline currently contains unrelated `main` drift; the card above was generated from the exact merge base.

## Style oracle

This is a class-3, byte-neutral canonicalization.

- **Declared facet:** [`dotnet/runtime` `.editorconfig`](https://github.com/dotnet/runtime/blob/9904b9343c89c898fea3a9dfa68a6aba7fa8f3c1/.editorconfig) is silent: no `dotnet_style_*` / `csharp_style_*` key or enabled analyzer addresses unnecessary terminal `return;` statements.
- **Revealed facet:** runtime's [`TensorPrimitives.InvokeSpanIntoSpan`](https://github.com/dotnet/runtime/blob/9904b9343c89c898fea3a9dfa68a6aba7fa8f3c1/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IBooleanUnaryOperator.cs#L181-L209) ends its executable dispatch and then declares trailing local functions without inserting `return;`. Conversely, [`ValueTask`](https://github.com/dotnet/runtime/blob/9904b9343c89c898fea3a9dfa68a6aba7fa8f3c1/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs#L241-L259) retains a genuine early `return;` immediately before a local-function declaration. The change follows both forms.

## Non-action boundary

- No configurable “explicit terminal return” taste option is added.
- Returns with values, early returns, nested-container returns, and labeled sole-executable returns are unchanged.
- Broader compiler-fixture partitioning remains #3913.


