### PR TITLE
Render multi-assembly reference trees

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -12477,6 +12477,44 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_TfmAll_ReferenceTree_RendersPerAssembly()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"references-multitfm-{Guid.NewGuid():N}");
+        try
+        {
+            var content = Path.Combine(tempDir, "content");
+            foreach (var tfm in new[] { "net8.0", "net10.0" })
+            {
+                var dir = Path.Combine(content, "lib", tfm);
+                Directory.CreateDirectory(dir);
+                File.Copy(TestAssemblyPath, Path.Combine(dir, "Lib.dll"));
+            }
+            var packagePath = Path.Combine(tempDir, "References.MultiTfm.1.0.0.nupkg");
+            ZipFile.CreateFromDirectory(content, packagePath);
+
+            var (exit, output, error) = await RunAppAsync(
+                "library", "Lib.dll", "--package", packagePath, "--tfm", "all",
+                "-S", "References", "--tree", "--depth", "1", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.StartsWith("# Lib\n\n## Libraries", output);
+            Assert.Contains("### Lib.dll (net10.0)", output);
+            Assert.Contains("### Lib.dll (net8.0)", output);
+            Assert.Equal(
+                2,
+                output.Split("#### References", StringSplitOptions.None).Length - 1);
+            Assert.True(
+                output.Split("System.Runtime", StringSplitOptions.None).Length - 1 >= 2,
+                output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task LibraryCommand_TfmAll_ExactSectionRendersRowsFromLaterAssembly()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"section-multitfm-{Guid.NewGuid():N}");

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -441,13 +441,26 @@ public static class OutputFormatter
 
     private static void WriteReferenceTree(LibraryInspection inspection)
     {
+        var writer = MarkoutWriter.Create(Console.Out, new MarkdownFormatter());
+        WriteReferenceTree(
+            writer,
+            inspection,
+            1,
+            LibraryViewText.Contain(inspection.FileName) ?? string.Empty);
+        writer.Flush();
+    }
+
+    private static void WriteReferenceTree(
+        MarkoutWriter writer,
+        LibraryInspection inspection,
+        int headingLevel,
+        string title)
+    {
         var references = inspection.AssemblyInfo?.TransitiveReferences ?? [];
         var tree = LibraryInspectionView.BuildNestedReferenceTree(references);
-        var writer = MarkoutWriter.Create(Console.Out, new MarkdownFormatter());
-        writer.WriteHeading(1, LibraryViewText.Contain(inspection.FileName) ?? string.Empty);
-        writer.WriteHeading(2, SectionNames.References);
+        writer.WriteHeading(headingLevel, title);
+        writer.WriteHeading(headingLevel + 1, SectionNames.References);
         writer.WriteTree([.. tree]);
-        writer.Flush();
     }
 
     /// <summary>
@@ -575,6 +588,12 @@ public static class OutputFormatter
             return;
         }
 
+        if (options.Tree && options.Discover == null)
+        {
+            WriteReferenceTrees(inspections);
+            return;
+        }
+
         if (options.JsonOutput)
         {
             Console.WriteLine(JsonSerializer.Serialize(inspections.ToArray(), JsonContext.Default.LibraryInspectionArray));
@@ -645,6 +664,21 @@ public static class OutputFormatter
         writer.WriteHeading(level, title);
         writer.Flush();
         return output.ToString().TrimEnd();
+    }
+
+    private static void WriteReferenceTrees(IReadOnlyList<LibraryInspection> inspections)
+    {
+        var output = new StringWriter { NewLine = "\n" };
+        var writer = MarkoutWriter.Create(output, new MarkdownFormatter());
+        writer.WriteHeading(
+            1,
+            LibraryViewText.Contain(
+                Path.GetFileNameWithoutExtension(inspections[0].FileName)) ?? string.Empty);
+        writer.WriteHeading(2, "Libraries");
+        foreach (var inspection in inspections)
+            WriteReferenceTree(writer, inspection, 3, LibraryViewText.DocumentTitle(inspection));
+        writer.Flush();
+        WriteLfLine(Console.Out, output.ToString().TrimEnd());
     }
 
     private static string RemoveMarkdownDocumentTitle(string markdown)


### PR DESCRIPTION
## Summary

- render one `References` tree per selected TFM inspection instead of returning a title-only document
- compose those trees under the standard `Libraries` hierarchy with TFM-qualified child headings
- share the existing tree-writing primitive while preserving single-library output

Fixes #3885.

## Compatibility boundary

Single-library trees, flat `References` tables, depth limiting, discovery trees, and non-Markdown validation are unchanged. Multi-library tree output now follows the same package/library hierarchy introduced by #3931; each child tree retains its own resolved reference graph.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- seven focused library tree and parser tests pass on the exact head
- full CLI/output suite: 3,209 passed, 0 failed, 4 skipped