### PR TITLE
Start feature-focused decompiler fixtures

### DIFF
--- a/docs/fixture-governance.md
+++ b/docs/fixture-governance.md
@@ -56,6 +56,21 @@ metadata just because consumers observe them from another assembly.
 - Add or update contract tests when introducing a new boundary so the semantic
   axis cannot be erased by later cleanup.
 
+## Compiler-produced test sources
+
+Compiler-produced source in a test project should live in a feature-focused
+`*Samples.cs` file next to its owning tests. Name the file for the behavior it
+exercises, keep related sample types together, and preserve the source shape
+whose emitted IL is the evidence.
+
+Do not add unrelated fixtures to `CfgSampleClass.cs`. Migrate its existing
+standalone sample types incrementally when their owning feature changes,
+without renaming symbols or combining the move with behavior changes. Validate
+each extraction in Release with the focused tests and any affected source
+inventory, fidelity, or corpus gates; a source-file move can change PDB
+documents, metadata ordering, and corpus identities even when method bodies are
+unchanged.
+
 ## Expectation ownership
 
 Fixtures are test assets, not product. Reserve adversarial rigor for the

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -6903,32 +6903,3 @@ public static class GenericContextLambdaSamples
         return f();
     }
 }
-
-// A reference-type field initializer `field = arg ?? new()` evaluates the
-// receiver `this` first, then the `??` branch; both must survive the branch
-// join, so the importer spills them to stack slots
-// (S_0 = this; S_1 = arg ?? new(); S_0.field = S_1). Reference-type receiver
-// purity lets ExpressionInliningPass collapse both temporaries back into
-// `this.field = arg ?? new()`. In a primary constructor the implicit base
-// object..ctor is emitted AFTER the field inits, so leaving the temps spilled
-// also left that base call an unrepresentable `/* Unsupported ... call .ctor */`
-// residual (the prologue was no longer all instance-field stores); collapsing
-// the temps restores the clean prologue that elides the base call.
-public sealed class SpilledCoalesceOptions;
-
-public sealed class SpilledCoalesceField
-{
-    private readonly SpilledCoalesceOptions _options;
-
-    public SpilledCoalesceField(SpilledCoalesceOptions? options)
-    {
-        _options = options ?? new SpilledCoalesceOptions();
-    }
-}
-
-public sealed class SpilledCoalescePrimaryField(SpilledCoalesceOptions? options = null)
-{
-    private readonly SpilledCoalesceOptions _options = options ?? new SpilledCoalesceOptions();
-
-    public SpilledCoalesceOptions Options => _options;
-}

--- a/src/ILInspector.Decompiler.Tests/SpilledReceiverCoalesceSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/SpilledReceiverCoalesceSamples.cs
@@ -1,0 +1,30 @@
+namespace ILInspector.Decompiler.Tests;
+
+// A reference-type field initializer `field = arg ?? new()` evaluates the
+// receiver `this` first, then the `??` branch; both must survive the branch
+// join, so the importer spills them to stack slots
+// (S_0 = this; S_1 = arg ?? new(); S_0.field = S_1). Reference-type receiver
+// purity lets ExpressionInliningPass collapse both temporaries back into
+// `this.field = arg ?? new()`. In a primary constructor the implicit base
+// object..ctor is emitted AFTER the field inits, so leaving the temps spilled
+// also left that base call an unrepresentable `/* Unsupported ... call .ctor */`
+// residual (the prologue was no longer all instance-field stores); collapsing
+// the temps restores the clean prologue that elides the base call.
+public sealed class SpilledCoalesceOptions;
+
+public sealed class SpilledCoalesceField
+{
+    private readonly SpilledCoalesceOptions _options;
+
+    public SpilledCoalesceField(SpilledCoalesceOptions? options)
+    {
+        _options = options ?? new SpilledCoalesceOptions();
+    }
+}
+
+public sealed class SpilledCoalescePrimaryField(SpilledCoalesceOptions? options = null)
+{
+    private readonly SpilledCoalesceOptions _options = options ?? new SpilledCoalesceOptions();
+
+    public SpilledCoalesceOptions Options => _options;
+}


### PR DESCRIPTION
Related to #3913

## Conclusion

**Behavior-neutral first extraction** — establishes the feature-focused compiler-fixture convention and moves one coherent standalone group out of `CfgSampleClass.cs` without renaming symbols or changing its source declarations.

## Change

- Documents `*Samples.cs` placement and incremental-migration rules in `docs/fixture-governance.md`.
- Moves `SpilledCoalesceOptions`, `SpilledCoalesceField`, and `SpilledCoalescePrimaryField` verbatim into `SpilledReceiverCoalesceSamples.cs`, next to their owning tests.
- Leaves the wider `CfgSampleClass.cs` partitioning for later reviewable slices.

## Evidence

| Check | Result |
| --- | --- |
| Release solution build | Pass |
| `SpilledReceiverCoalesceInliningTests` | 14/14 passed |
| Decompiler fast lane | 4,620 total; 0 failed; 8 Windows privilege skips |
| Exact-base render A/B | 19,013 methods; 0 changed, added, or removed |
| Diff hygiene | `git diff --check` pass |

The source-document move is intentional; exact-base rendering confirms that symbol relocation and any resulting metadata/PDB ordering changes do not alter decompiler output across the compiled test assembly.

CI `markdownlint` passed. Local `markdownlint` could not start because this host has no Node installation and its TLS path to both npm registries fails during package acquisition; no TLS verification was weakened and no repository dependency was added.

## Non-action boundary

- Leaves #3913 open for the remaining fixture groups.
- Does not rename fixture types, alter test behavior, or bulk-move other fixture groups.
- Does not split the main `CfgSampleClass` type itself.


