### PR TITLE
Honor exact output line limits

### DIFF
--- a/src/dotnet-inspect.Tests/LineLimitingTextWriterTests.cs
+++ b/src/dotnet-inspect.Tests/LineLimitingTextWriterTests.cs
@@ -1,0 +1,30 @@
+using DotnetInspector.Output;
+
+namespace DotnetInspector.Tests;
+
+public class LineLimitingTextWriterTests
+{
+    [Fact]
+    public void Write_ReachingLimitWithinString_DiscardsLaterWrites()
+    {
+        var output = new StringWriter();
+        var writer = new LineLimitingTextWriter(output, maxLines: 4);
+
+        writer.Write("# Library\n\n## Library Info\n\n");
+        writer.WriteLine();
+
+        Assert.Equal("# Library\n\n## Library Info\n\n", output.ToString());
+    }
+
+    [Fact]
+    public void WriteLine_ReachingLimitWithinValue_DiscardsLaterWrites()
+    {
+        var output = new StringWriter();
+        var writer = new LineLimitingTextWriter(output, maxLines: 2);
+
+        writer.WriteLine("first\nsecond\nthird");
+        writer.WriteLine("fourth");
+
+        Assert.Equal("first\nsecond\n", output.ToString());
+    }
+}

--- a/src/dotnet-inspect/Output/LineLimitingTextWriter.cs
+++ b/src/dotnet-inspect/Output/LineLimitingTextWriter.cs
@@ -47,7 +47,10 @@ internal sealed class LineLimitingTextWriter : TextWriter
             {
                 _lineCount++;
                 if (_lineCount >= _maxLines)
+                {
+                    _limitReached = true;
                     return;
+                }
             }
         }
     }
@@ -67,7 +70,10 @@ internal sealed class LineLimitingTextWriter : TextWriter
                 {
                     _lineCount++;
                     if (_lineCount >= _maxLines)
+                    {
+                        _limitReached = true;
                         return;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #3920.

`-n N` now emits exactly N lines when a bulk string write reaches the limit. The line-limiting writer latches that state consistently for `Write(string)` and embedded-newline `WriteLine(string)`, preventing a later Markdown separator write from adding an extra blank line.

This is a trivial change under the review policy: it adds the same existing `_limitReached` assignment to the two omitted newline-count paths, with direct regressions for both. No adversarial review round is required.

Validation:
- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.LineLimitingTextWriterTests` (2 passed)
- `dotnet-inspect System.Text.Json -n 4 | wc -l` (4)
- Full CLI suite: 3,205 passed, 4 platform skips; the known load-sensitive constraint-restatement threshold failed under full-suite load and passed immediately in isolation.