### PR TITLE
Allow harmless encoded dots in SourceLink provenance

### DIFF
--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -340,8 +340,16 @@ one that was here, and it had gone stale by two.
 - `System.Uri` preserves percent-encoded separators verbatim: `..%2f` and
   `..%5c` survive canonicalization, so a "canonicalize, then prefix-check" step
   passes while a server that percent-decodes before resolving dot segments still
-  traverses out. Encoded separators and encoded dot segments are rejected rather
-  than assumed resolved.
+  traverses out. Encoded separators are rejected rather than assumed resolved.
+  Encoded dots are different: `System.Uri` decodes them, removes encoded parent
+  segments from the path before the origin is read, and sends that canonical
+  path. Provenance therefore follows the final origin exactly as it does for
+  literal `..`; an encoded dot in a file name is not treated as traversal.
+  Measured against `dotnet/runtime` commit `9904b934...`, GitHub serves
+  `README%2Emd` as the same 4800 bytes and SHA-256 as `README.md`. Gated by
+  `SourceLinkProvenanceTests.AnEncodedDotOutsideAParentSegment_RemainsAttributable`,
+  `...AnEncodedParentSegment_ReportsWhereContentIsReallyServedFrom`, and
+  `...AnEncodedDotInAnAzureContentPath_RemainsAttributable`.
 - `https://raw.githubusercontent.com@evil.example/...` parses with host
   `evil.example` and user info `raw.githubusercontent.com`. The host allow list
   rejects it, since `Uri` takes the authority after the last `@`; user info is

--- a/src/SourceLinkFetch/SourceLinkProvenance.cs
+++ b/src/SourceLinkFetch/SourceLinkProvenance.cs
@@ -966,7 +966,7 @@ public static class SourceLinkProvenance
             return false;
         }
 
-        if (ContainsEncodedSeparatorOrDotSegment(url, out string encoded))
+        if (ContainsEncodedSeparator(url, out string encoded))
         {
             // Uri preserves these verbatim through canonicalization, so a canonicalize-then-check
             // step passes while a server that percent-decodes before resolving dot segments still
@@ -1637,10 +1637,9 @@ public static class SourceLinkProvenance
     }
 
     /// <summary>
-    /// Detects percent-encoded path separators and percent-encoded dot segments, which survive
-    /// <see cref="Uri"/> canonicalization unchanged.
+    /// Detects percent-encoded path separators, which survive <see cref="Uri"/> canonicalization.
     /// </summary>
-    private static bool ContainsEncodedSeparatorOrDotSegment(string url, out string encoded)
+    private static bool ContainsEncodedSeparator(string url, out string encoded)
     {
         for (int i = 0; i + 2 < url.Length; i++)
         {
@@ -1651,8 +1650,7 @@ public static class SourceLinkProvenance
 
             ReadOnlySpan<char> pair = url.AsSpan(i + 1, 2);
             if (pair.Equals("2f", StringComparison.OrdinalIgnoreCase) ||
-                pair.Equals("5c", StringComparison.OrdinalIgnoreCase) ||
-                pair.Equals("2e", StringComparison.OrdinalIgnoreCase))
+                pair.Equals("5c", StringComparison.OrdinalIgnoreCase))
             {
                 encoded = url.Substring(i, 3);
                 return true;

--- a/tests/ILInspector.Metadata.Tests/SourceLinkProvenanceTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SourceLinkProvenanceTests.cs
@@ -151,12 +151,11 @@ public class SourceLinkProvenanceTests
     /// The threat model's fourth case: <see cref="Uri"/> preserves percent-encoded separators
     /// verbatim, so <c>..%2f</c> and <c>..%5c</c> survive canonicalization. A canonicalize-then-
     /// check step passes while a server that percent-decodes before resolving dot segments still
-    /// traverses out, so encoded separators and encoded dot segments are rejected outright.
+    /// traverses out, so encoded separators are rejected outright.
     /// </summary>
     [Theory]
     [InlineData("..%2f..%2f..%2fattacker")]
     [InlineData("..%5c..%5c..%5cattacker")]
-    [InlineData("%2e%2e/%2e%2e/attacker")]
     [InlineData("..%2F..%2Fattacker")]
     public void TheThreatModelsCase_OfEncodedSeparators_ReportsNoRepository(string traversal)
     {
@@ -166,6 +165,100 @@ public class SourceLinkProvenanceTests
 
         Assert.False(result.IsEstablished);
         Assert.Contains("canonicalization does not resolve", result.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// <see cref="Uri"/> resolves an encoded parent segment before provenance reads the path, so
+    /// traversal that leaves no valid owner/repository/revision still reports no repository.
+    /// </summary>
+    [Theory]
+    [InlineData("%2e%2e/%2e%2e/attacker")]
+    [InlineData(".%2e/.%2e/attacker")]
+    [InlineData("%2e./%2e./attacker")]
+    public void AnEncodedParentSegmentLeavingNoOrigin_ReportsNoRepository(string traversal)
+    {
+        var result = Determine(
+            $$$"""{"documents":{"/_/*":"https://raw.githubusercontent.com/dotnet/runtime/{{{Sha}}}/{{{traversal}}}/*"}}""",
+            "/_/A.cs");
+
+        Assert.False(result.IsEstablished);
+        Assert.Contains("names no owner, repository, and revision", result.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Encoded parent segments follow the same final-URL invariant as literal <c>..</c>: when
+    /// they traverse to a complete origin in a different repository, report that origin rather
+    /// than the raw mapping prefix.
+    /// </summary>
+    [Theory]
+    [InlineData("%2e%2e/%2e%2e/%2e%2e")]
+    [InlineData(".%2e/.%2e/.%2e")]
+    [InlineData("%2e./%2e./%2e.")]
+    public void AnEncodedParentSegment_ReportsWhereContentIsReallyServedFrom(string traversal)
+    {
+        var result = Determine(
+            $$$"""{"documents":{"/_/A.cs":"https://raw.githubusercontent.com/dotnet/runtime/{{{Sha}}}/{{{traversal}}}/attacker/evil/{{{OtherSha}}}/A.cs"}}""",
+            "/_/A.cs");
+
+        Assert.True(result.IsEstablished, result.Reason);
+        Assert.Equal("attacker", result.Origin!.Value.Organization);
+        Assert.Equal("evil", result.Origin!.Value.Repository);
+        Assert.Equal(OtherSha, result.Origin!.Value.Revision);
+    }
+
+    /// <summary>
+    /// A percent-encoded dot is punctuation, not traversal, unless decoding makes its whole path
+    /// segment <c>..</c>. GitHub serves <c>README%2Emd</c> as the same file as
+    /// <c>README.md</c>, and <see cref="Uri"/> removes a <c>%2e</c> current-directory segment
+    /// without changing the established repository or revision.
+    /// </summary>
+    /// <remarks>
+    /// Measured against <c>dotnet/runtime</c> commit
+    /// <c>9904b9343c89c898fea3a9dfa68a6aba7fa8f3c1</c>: both README spellings return 200,
+    /// 4800 bytes, and SHA-256 <c>bcd0ca8841408b85528eb4f91a610c072eb46df2a0e89ba5ab38a60270286057</c>.
+    /// A raw request-line capture through <see cref="HttpClient"/> sends the encoded spelling as
+    /// <c>GET /src/README.md</c>, so this is the product transport path rather than a raw-curl
+    /// assumption.
+    /// </remarks>
+    [Theory]
+    [InlineData("README%2Emd")]
+    [InlineData("%2e/README.md")]
+    [InlineData("%2e%2e%2e/README.md")]
+    public void AnEncodedDotOutsideAParentSegment_RemainsAttributable(string path)
+    {
+        var result = Determine(
+            $$$"""{"documents":{"/_/A.cs":"https://raw.githubusercontent.com/dotnet/runtime/{{{Sha}}}/{{{path}}}"}}""",
+            "/_/A.cs");
+
+        Assert.True(result.IsEstablished, result.Reason);
+        Assert.Equal("dotnet", result.Origin!.Value.Organization);
+        Assert.Equal("runtime", result.Origin!.Value.Repository);
+        Assert.Equal(Sha, result.Origin!.Value.Revision);
+    }
+
+    /// <summary>
+    /// Azure's content-selecting query value does not establish the repository or revision.
+    /// Encoded dots there therefore remain attributable; malformed or missing paths fail visibly
+    /// at the host rather than becoming an attribution refusal.
+    /// </summary>
+    /// <remarks>
+    /// Measured against <c>dev.azure.com/dnceng-public/public</c>, repository
+    /// <c>dotnet-public-wiki</c> at commit <c>af56d96fdbd7c26e9fc94336b6f50dcc6ceff484</c>:
+    /// <c>/README%2Emd</c> returns the same 985-byte response as <c>/README.md</c>, while all
+    /// three parent-segment spellings below return 404.
+    /// </remarks>
+    [Theory]
+    [InlineData("/src/System%2EObject.cs")]
+    [InlineData("/src/%2e%2e/README.md")]
+    [InlineData("/src/.%2e/README.md")]
+    [InlineData("/src/%2e./README.md")]
+    public void AnEncodedDotInAnAzureContentPath_RemainsAttributable(string path)
+    {
+        var result = Determine(
+            $$$"""{"documents":{"/_/A.cs":"https://dev.azure.com/contoso/widgets/_apis/git/repositories/core/items?api-version=1.0&versionType=commit&version={{{Sha}}}&path={{{path}}}"}}""",
+            "/_/A.cs");
+
+        Assert.True(result.IsEstablished, result.Reason);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3926.

## What changed

SourceLink provenance no longer rejects every `%2e` sequence as traversal. `System.Uri` and `HttpClient` decode encoded dots and canonicalize path parent segments before the request is sent, so provenance can apply its existing rule: read the origin from the final canonical URL.

- `README%2Emd` attributes exactly like `README.md`.
- Encoded parent traversal that leaves no valid owner/repository/revision still reports no origin.
- Encoded parent traversal to a complete origin in a different repository and commit reports that final origin, just like literal `..`.
- Encoded dots in Azure's content-selecting `path` query remain attributable; malformed/missing paths fail visibly at the host.

The separate `%2f`/`%5c` refusal is unchanged. Encoded separators survive `System.Uri` canonicalization, so the client and server can disagree about segment boundaries and traversal.

## Allowed and disallowed examples

"Allowed" means provenance can be established from the canonical URL; it does not promise that the host returns HTTP 200.

| Decision | SourceLink URL | Canonical reading / reason |
| --- | --- | --- |
| Allowed | `https://raw.githubusercontent.com/dotnet/runtime/<sha>/README%2Emd` | Reads as `.../<sha>/README.md`; origin remains `dotnet/runtime@<sha>`. |
| Allowed | `https://raw.githubusercontent.com/dotnet/runtime/<sha>/%2e/README.md` | The encoded current-directory segment is removed; origin remains unchanged. |
| Allowed, attributed to the final origin | `https://raw.githubusercontent.com/dotnet/runtime/<sha>/%2e%2e/%2e%2e/%2e%2e/attacker/evil/<other-sha>/A.cs` | Canonicalizes to `https://raw.githubusercontent.com/attacker/evil/<other-sha>/A.cs`; provenance reports `attacker/evil@<other-sha>`, not `dotnet/runtime`. |
| Allowed | `https://dev.azure.com/org/project/_apis/git/repositories/repo/items?versionType=commit&version=<sha>&path=/src/System%2EObject.cs` | The encoded dot is only in the content path; the origin-bearing repository and revision are unchanged. |
| No provenance | `https://raw.githubusercontent.com/dotnet/runtime/<sha>/%2e%2e/%2e%2e/attacker/A.cs` | Canonicalizes to `/dotnet/attacker/A.cs`, which contains no complete owner/repository/revision tuple. |
| Refused | `https://raw.githubusercontent.com/dotnet/runtime/<sha>/src%2f..%2fREADME.md` | `%2f` is an encoded separator; client and server may disagree about traversal. |
| Refused | `https://dev.azure.com/org/project/_apis/git/repositories/parent%2Frepo/items?versionType=commit&version=<sha>&path=/A.cs` | `%2f` changes the origin-bearing repository segment boundary. |

## Evidence

- GitHub Raw, `dotnet/runtime` commit `9904b9343c89c898fea3a9dfa68a6aba7fa8f3c1`: `README.md` and `README%2Emd` both returned 200, 4800 bytes, and SHA-256 `bcd0ca8841408b85528eb4f91a610c072eb46df2a0e89ba5ab38a60270286057`.
- Raw `HttpClient` request capture: `/src/README%2Emd` was sent as `/src/README.md`; `/src/%2e%2e/README.md` was sent as `/README.md`.
- Azure DevOps, `dnceng-public/public` repository `dotnet-public-wiki` at `af56d96fdbd7c26e9fc94336b6f50dcc6ceff484`: `/README%2Emd` returned the same 985-byte response as `/README.md`; the three encoded-parent spellings returned 404, which remains visible rather than becoming an attribution refusal.

## Gates

- Restoring the old `%2e` token refusal fails 13 new cases covering harmless dots, canonical final-origin traversal, and Azure query paths.
- Removing `%2f` refusal fails the existing GitHub traversal and Azure repository-segment gates.
- MAI-Code quick read of the in-progress diff was clean; it was early signal, not a review round.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — 0 errors
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build` — 1340 passed, 0 failed
- `npx markdownlint-cli docs/design/untrusted-data-threat-model.md` — clean

## Boundary

This changes provenance attribution only. It does not relax encoded-separator handling, alter SourceLink resolution, fetch content, or add provider-specific URL guessing.
