### PR TITLE
Migrate custom attributes to typed query

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -52,13 +52,14 @@ the ownership boundaries below, not the project count.
 ## Implementation status
 
 `DotnetInspector.Queries` now implements metadata-image, direct-reference,
-extension-method, SourceLink audit, and assembly-context Integrations slices.
-The library CLI executes metadata-image, direct assembly-reference, and
-extension-method queries through a typed, content-shaped registry over a
-host-owned `AssemblyInspectionSession`. The `References`, `Extension Methods`,
-and `Library Info` sections bind to concrete query definitions rather than
-string scanner keys, and the CLI and package convenience route lower section
-selection into that same registry. Library and package SourceLink sections
+extension-method, custom-attribute, SourceLink audit, and assembly-context
+Integrations slices. The library CLI executes metadata-image, direct
+assembly-reference, extension-method, and custom-attribute queries through a
+typed, content-shaped registry over a host-owned `AssemblyInspectionSession`.
+The `References`, `Extension Methods`, `Custom Attributes`, and `Library Info`
+sections bind to concrete query definitions rather than string scanner keys,
+and the CLI and package convenience route lower section selection into that
+same registry. Library and package SourceLink sections
 execute a shared document prerequisite plus availability or integrity query
 over a host-owned `SourceLinkService`. The library CLI and package
 `--all-libraries` route focused Integrations demand through the first workspace
@@ -225,8 +226,8 @@ consumer's convenience.
 
 ## Current migration state
 
-Metadata-image, direct-reference, extension-method, and SourceLink inspection
-are the first vertical L1 canaries:
+Metadata-image, direct-reference, extension-method, custom-attribute, and
+SourceLink inspection are the first vertical L1 canaries:
 
 - `DotnetInspector.Queries` owns typed query definitions, typed result retrieval,
   prerequisite expansion, and query cost.
@@ -239,6 +240,9 @@ are the first vertical L1 canaries:
 - `ExtensionMethodsQuery` returns one immutable result shared by `Library Info`
   and `Extension Methods`. The CLI adds path-based Finding provenance and
   compatibility projections after query execution.
+- `CustomAttributesQuery` returns metadata-ordered immutable attributes shared
+  by `Library Info` and `Custom Attributes`. The CLI adds path-based Finding
+  provenance and preserves the compatibility JSON order after query execution.
 - `SourceLinkDocumentsQuery` may acquire one matching portable PDB and returns
   the typed source-document Finding inspection.
 - `SourceAvailabilityQuery` and `SourceIntegrityQuery` consume that prerequisite
@@ -247,9 +251,9 @@ are the first vertical L1 canaries:
 - Library and package sections bind to the same SourceLink query definitions.
   Package owns compatible/highest-TFM asset selection and aggregation, not a
   parallel audit implementation.
-- Metadata sections, `References`, `Library Info`, and `Extension Methods` bind
-  to query definitions by object identity. Diagnostic names are never lookup
-  keys.
+- Metadata sections, `References`, `Library Info`, `Extension Methods`, and
+  `Custom Attributes` bind to query definitions by object identity. A section
+  may bind multiple definitions; diagnostic names are never lookup keys.
 - An executor can read only its declared transitive prerequisite results. A
   hidden dependency therefore fails whether or not another requested query
   happened to populate the shared run, and cannot understate cost.
@@ -297,16 +301,16 @@ establishes the L1 project and structural pattern, but the remaining facets and
 the L2 project split still need migration.
 
 The structural fix is completing L1. Outside the metadata, direct-reference,
-extension-method, and SourceLink canaries, collection is still neither typed
-nor demand-driven:
+extension-method, custom-attribute, and SourceLink canaries, collection is
+still neither typed nor demand-driven:
 
 - Data collection **mutates a shared aggregate** rather than returning typed
   results for most scanner families, so a consumer cannot yet take those
   queries without materializing `LibraryInspection`.
 - The binding to residual collection is a **nullable string key** for the
   remaining scanner-backed sections. Metadata, `References`, `Library Info`,
-  `Extension Methods`, and SourceLink sections use checked query-definition
-  bindings.
+  `Extension Methods`, `Custom Attributes`, and SourceLink sections use checked
+  query-definition bindings.
 - The collection context is **path-shaped**, so a consumer without a filesystem
   cannot call the residual `LibraryMetadataService` orchestration. The
   implemented queries themselves take a borrowed content owner, not a path.

--- a/docs/design/section-pipeline.md
+++ b/docs/design/section-pipeline.md
@@ -180,10 +180,13 @@ and trace machinery still owns execution.
 The planner enables direct or tree collection from the candidate set instead
 of creating synonymous sections.
 
-Extension-method inspection is also typed query work. `Library Info` and
-`Extension Methods` bind to the same `ExtensionMethodsQuery`, so one immutable
-result supplies both the summary count and detailed rows without a string
-scanner key or duplicate metadata pass.
+Extension-method and custom-attribute inspection are also typed query work.
+`Library Info` binds both query definitions, while `Extension Methods` and
+`Custom Attributes` each bind the definition for their detailed rows. One
+immutable result per facet therefore supplies the summary count and detailed
+rows without string scanner keys or duplicate metadata passes. A section may
+bind multiple typed queries; its effective cost is the maximum over every
+query's prerequisite closure.
 
 ## Effectiveness
 

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -14,10 +14,11 @@ shared contracts, not dynamically loaded plugins.
 ## Status
 
 This document describes the target core architecture and the principles that
-govern its migration. Library metadata, direct-reference, extension-method, and
-SourceLink inspection are the first typed-query canaries: the section catalog
-plans typed demand and executes it through a prerequisite-aware registry, while
-the command still owns orchestration. The library CLI and package
+govern its migration. Library metadata, direct-reference, extension-method,
+custom-attribute, and SourceLink inspection are the first typed-query canaries:
+the section catalog plans typed demand and executes it through a
+prerequisite-aware registry, while the command still owns orchestration. The
+library CLI and package
 `--all-libraries` now use an ephemeral workspace for focused Integrations
 demand. One binding-consistent assembly context group scans every selected
 participant sequentially, preserves per-assembly identity, provenance, and
@@ -426,9 +427,10 @@ own acquisition cost or producer dependencies.
 The existing `ScannerRegistry` remains an assembly-local predecessor: its
 explicit prerequisites, once-per-run resources, deterministic ordering, and
 tracing are useful foundations. `DotnetInspector.Queries` now owns typed
-metadata, direct-reference, extension-method, and SourceLink plans. String keys,
-mutable CLI models, path-shaped residual inputs, and library-command ownership
-remain migration boundaries rather than workspace contracts.
+metadata, direct-reference, extension-method, custom-attribute, and SourceLink
+plans. String keys, mutable CLI models, path-shaped residual inputs, and
+library-command ownership remain migration boundaries rather than workspace
+contracts.
 
 The registry executes synchronous and asynchronous queries in deterministic
 prerequisite order. It passes each query's maximum transitive cost into the host

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,8 +10,9 @@ The target [inspection space architecture](inspection-space.md) defines the
 core: workspace contexts, typed query planning, acquisition and caching, shared
 identity and provenance, owner-issued correspondence, and safe presentation
 boundaries. Typed query-planning slices are implemented for library
-metadata-image, direct-reference, extension-method, SourceLink, and Integrations
-inspection. The library CLI and package `--all-libraries` use the first
+metadata-image, direct-reference, extension-method, custom-attribute,
+SourceLink, and Integrations inspection. The library CLI and package
+`--all-libraries` use the first
 workspace-backed, group-scoped query for focused Integrations demand while
 remaining query families are future work. The components below are the current
 hosts, shared substrates, and inspection producers that will extend that space.
@@ -19,8 +20,9 @@ hosts, shared substrates, and inspection producers that will extend that space.
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
 - `src/DotnetInspector.Queries/` contains host-neutral typed query definitions,
   deterministic synchronous/asynchronous execution, prerequisite-aware cost,
-  and content-shaped metadata, reference, extension-method, and SourceLink
-  queries. It has no Markout, console, or filesystem-path dependency.
+  and content-shaped metadata, reference, extension-method, custom-attribute,
+  and SourceLink queries. It has no Markout, console, or filesystem-path
+  dependency.
 - `src/ILInspector.Metadata/` reads PE metadata and portable-PDB structure: named documents, checksums, sequence-point relationships/ranges, raw custom-debug-information blobs, API surfaces, method classification, and assembly details. `MetadataFindings` projects API and portable-PDB build-context observations onto the shared Finding spine while retaining compatibility classification through `ApiDiff`.
 - `src/ILInspector.SourceLink/` sits above Metadata and SourceLinkFetch. It owns SourceLink map extraction, canonical document paths, URL decoration, provenance, high-level type/member/IL-offset resolution, source-document/member-source Findings, and SourceLink-aware debug audits.
 - `src/SourceLinkFetch/` owns the dependency-free SourceLink map matcher and provenance grammar.

--- a/src/DotnetInspector.Queries/CustomAttributesQuery.cs
+++ b/src/DotnetInspector.Queries/CustomAttributesQuery.cs
@@ -1,0 +1,41 @@
+using System.Collections.Immutable;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>Typed result of reading assembly-level and module-level custom attributes.</summary>
+public abstract record CustomAttributesResult
+{
+    private CustomAttributesResult()
+    {
+    }
+
+    /// <summary>The custom attributes, in metadata order, which may be empty.</summary>
+    public sealed record Available(
+        ImmutableArray<AssemblyAttributeInfo> Attributes) : CustomAttributesResult;
+
+    /// <summary>The query failed while reading custom attributes.</summary>
+    public sealed record Failed(Exception Error) : CustomAttributesResult;
+}
+
+/// <summary>Reads custom attributes from an already-open assembly session.</summary>
+public static class CustomAttributesQuery
+{
+    public static InspectionQuery<CustomAttributesResult> Definition { get; } =
+        new("Custom attributes", InspectionCost.NetworkFree);
+
+    public static CustomAttributesResult Execute(AssemblyInspectionSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        try
+        {
+            return new CustomAttributesResult.Available(
+                session.CustomAttributes().ToImmutableArray());
+        }
+        catch (Exception ex)
+        {
+            return new CustomAttributesResult.Failed(ex);
+        }
+    }
+}

--- a/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
@@ -74,6 +74,34 @@ public class LibraryFindingConsumerTests
     }
 
     [Fact]
+    public void CustomAttributesQueryProjection_RetainsFindingSemanticsAndJsonOrder()
+    {
+        var inspection = new LibraryInspection();
+        string path = typeof(AssemblyInspectionSession).Assembly.Location;
+        using var session = AssemblyInspectionSession.Open(path);
+        var result = Assert.IsType<CustomAttributesResult.Available>(
+            CustomAttributesQuery.Execute(session));
+
+        LibraryMetadataService.ApplyCustomAttributesResult(
+            path,
+            inspection,
+            new VerboseLogger(enabled: false),
+            result);
+
+        var findings = inspection.AssemblyAttributeInspection.Findings();
+        Assert.Contains(
+            findings,
+            finding => finding.Payload.Name == "InternalsVisibleTo");
+        var finding = findings.First(
+            finding => finding.Payload.Name == "InternalsVisibleTo");
+
+        Assert.Same(MetadataFindings.AssemblyAttributeDescriptor, finding.Descriptor);
+        Assert.Equal(
+            result.Attributes.Select(attribute => attribute.Name),
+            inspection.CustomAttributes!.Select(attribute => attribute.Name));
+    }
+
+    [Fact]
     public void LibraryJson_ProjectsFindingPayloadsWithExistingShape()
     {
         AssemblyAttributeInfo[] attributes =
@@ -184,7 +212,12 @@ public class LibraryFindingConsumerTests
             logger,
             new ExtensionMethodsResult.Failed(
                 new FileNotFoundException("Extension method input was not found.", missingPath)));
-        inspection.Apply(LibraryMetadataService.ScanCustomAttributes(missingPath, logger));
+        LibraryMetadataService.ApplyCustomAttributesResult(
+            missingPath,
+            inspection,
+            logger,
+            new CustomAttributesResult.Failed(
+                new FileNotFoundException("Custom attribute input was not found.", missingPath)));
         inspection.TypeForwarderInspection = LibraryMetadataService.ScanTypeForwarders(missingPath, logger);
         LibraryMetadataService.ScanIntegrationOpportunities(
             missingPath,

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1458,15 +1458,16 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void LibraryPipeline_TargetedSection_OnlyRequiredScanner()
+    public void LibraryPipeline_TargetedCustomAttributes_OnlyRequiresItsQuery()
     {
         var pipeline = LibrarySections.CreatePipeline();
         var include = new HashSet<string> { "Custom Attributes" };
 
         var scanners = pipeline.GetRequiredScanners(Verbosity.Minimal, include);
+        var queries = pipeline.GetRequiredQueries(Verbosity.Minimal, include);
 
-        Assert.Single(scanners);
-        Assert.Contains(LibrarySections.ScannerCustomAttributes, scanners);
+        Assert.Empty(scanners);
+        Assert.Equal([CustomAttributesQuery.Definition], queries);
     }
 
     // ===== Scanner registry tests =====
@@ -1569,6 +1570,7 @@ public class SectionPipelineTests
             [
                 AssemblyContextIntegrationsQuery.Definition,
                 AssemblyReferencesQuery.Definition,
+                CustomAttributesQuery.Definition,
                 ExtensionMethodsQuery.Definition,
                 MetadataImageQuery.Definition,
                 SourceAvailabilityQuery.Definition,
@@ -1749,6 +1751,13 @@ public class SectionPipelineTests
     public void LibraryInfoAndExtensionMethodsSections_ShareTypedExtensionMethodsQuery()
     {
         var pipeline = LibrarySections.CreatePipeline();
+        string[] boundSections = pipeline.QueryBoundSections
+            .Where(binding => ReferenceEquals(
+                binding.Query,
+                ExtensionMethodsQuery.Definition))
+            .Select(binding => binding.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
         HashSet<string> sections =
             new(StringComparer.OrdinalIgnoreCase)
             {
@@ -1760,7 +1769,130 @@ public class SectionPipelineTests
             Verbosity.Minimal,
             sections);
 
-        Assert.Equal([ExtensionMethodsQuery.Definition], required);
+        Assert.Equal(
+            [SectionNames.ExtensionMethods, SectionNames.LibraryInfo],
+            boundSections);
+        Assert.Equal(
+            [CustomAttributesQuery.Definition, ExtensionMethodsQuery.Definition],
+            required.OrderBy(query => query.Name, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void LibraryInfoAndCustomAttributesSections_ShareTypedCustomAttributesQuery()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        string[] boundSections = pipeline.QueryBoundSections
+            .Where(binding => ReferenceEquals(
+                binding.Query,
+                CustomAttributesQuery.Definition))
+            .Select(binding => binding.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+        HashSet<string> sections =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                SectionNames.LibraryInfo,
+                SectionNames.CustomAttributes,
+            };
+
+        HashSet<InspectionQueryDefinition> required = pipeline.GetRequiredQueries(
+            Verbosity.Minimal,
+            sections);
+
+        Assert.Equal(
+            [SectionNames.CustomAttributes, SectionNames.LibraryInfo],
+            boundSections);
+        Assert.Equal(
+            [CustomAttributesQuery.Definition, ExtensionMethodsQuery.Definition],
+            required.OrderBy(query => query.Name, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void CustomAttributesQuery_ReturnsMetadataOrderedAttributesFromBorrowedContent()
+    {
+        using var session = AssemblyInspectionSession.Open(
+            typeof(AssemblyInspectionSession).Assembly.Location);
+
+        var result = Assert.IsType<CustomAttributesResult.Available>(
+            CustomAttributesQuery.Execute(session));
+
+        Assert.Contains(
+            result.Attributes,
+            attribute => attribute.Name == "InternalsVisibleTo");
+        Assert.Equal(session.CustomAttributes(), result.Attributes);
+    }
+
+    [Fact]
+    public void CustomAttributesQuery_UsesTheCommandsOpenImage()
+    {
+        string missingPath = Path.Combine(
+            Path.GetTempPath(),
+            $"missing-{Guid.NewGuid():N}.dll");
+        using var metadataContext = PdbContext.Open(
+            typeof(AssemblyInspectionSession).Assembly.Location);
+        using var context = new ScannerContext
+        {
+            AssemblyPath = missingPath,
+            Model = new LibraryInspection(),
+            Logger = new Output.VerboseLogger(false),
+            MetadataContext = metadataContext,
+        };
+
+        InspectionQueryResults results = LibrarySections.CreateQueryRegistry().Run(
+            [CustomAttributesQuery.Definition],
+            context);
+        var customAttributes = Assert.IsType<CustomAttributesResult.Available>(
+            results.Get(CustomAttributesQuery.Definition));
+
+        Assert.Contains(
+            customAttributes.Attributes,
+            attribute => attribute.Name == "InternalsVisibleTo");
+        Assert.Equal(1, context.SharedScanCount);
+    }
+
+    [Fact]
+    public void CustomAttributesQuery_OpenFailureRemainsTyped()
+    {
+        string missingPath = Path.Combine(
+            Path.GetTempPath(),
+            $"missing-{Guid.NewGuid():N}.dll");
+        using var context = new ScannerContext
+        {
+            AssemblyPath = missingPath,
+            Model = new LibraryInspection(),
+            Logger = new Output.VerboseLogger(false),
+        };
+
+        InspectionQueryResults results = LibrarySections.CreateQueryRegistry().Run(
+            [CustomAttributesQuery.Definition],
+            context);
+        var failure = Assert.IsType<CustomAttributesResult.Failed>(
+            results.Get(CustomAttributesQuery.Definition));
+
+        Assert.IsType<FileNotFoundException>(failure.Error);
+        Assert.Equal(0, context.SharedScanCount);
+    }
+
+    [Fact]
+    public void CustomAttributesQuery_FailureRemainsTypedAndProjectsFindingFailure()
+    {
+        var session = AssemblyInspectionSession.Open(
+            typeof(SectionPipelineTests).Assembly.Location);
+        session.Dispose();
+        var model = new LibraryInspection();
+
+        var result = Assert.IsType<CustomAttributesResult.Failed>(
+            CustomAttributesQuery.Execute(session));
+        LibraryMetadataService.ApplyCustomAttributesResult(
+            "disposed.dll",
+            model,
+            new Output.VerboseLogger(false),
+            result);
+
+        Assert.IsType<FindingInspection<AssemblyAttributeInfo>.Failed>(
+            model.AssemblyAttributeInspection!.Value);
+        Assert.Null(model.CustomAttributes);
+        Assert.Equal("Custom Attributes", Assert.Single(model.InspectionFailures!).Section);
     }
 
     [Fact]
@@ -1893,6 +2025,38 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void QueryBackedSection_MultipleQueries_InheritsMaximumCostAndDemandsEach()
+    {
+        var networkFree = new InspectionQuery<int>(
+            "network-free",
+            InspectionCost.NetworkFree);
+        var moderated = new InspectionQuery<int>(
+            "moderated",
+            InspectionCost.Moderated);
+        var pipeline = new SectionPipeline<TestModel>()
+            .UseQueryCosts(query => query.Cost)
+            .Add<QueryBackedSection>([networkFree, moderated]);
+
+        var section = Assert.Single(pipeline.SectionCosts);
+        HashSet<InspectionQueryDefinition> required = pipeline.GetRequiredQueries(
+            Verbosity.Minimal);
+
+        Assert.Equal(SectionCost.Moderated, section.Cost);
+        Assert.Equal(
+            [moderated, networkFree],
+            required.OrderBy(query => query.Name, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void QueryBackedSection_MultipleQueries_RejectsDuplicateIdentity()
+    {
+        var query = new InspectionQuery<int>("query", InspectionCost.NetworkFree);
+
+        Assert.Throws<ArgumentException>(() =>
+            new SectionPipeline<TestModel>().Add<QueryBackedSection>([query, query]));
+    }
+
+    [Fact]
     public void GetRequiredQueries_ExcludeUnbounded_PreservesExplicitBoundedSelection()
     {
         var bounded = new InspectionQuery<int>("bounded", InspectionCost.NetworkFree);
@@ -1907,7 +2071,7 @@ public class SectionPipelineTests
                 SizeClass = SectionSizeClass.Terse,
                 Cost = SectionCost.NetworkFree,
                 ScannerKey = null,
-                Query = bounded,
+                Queries = [bounded],
                 IsApplicable = _ => true,
                 CanRender = _ => true,
             })
@@ -1918,7 +2082,7 @@ public class SectionPipelineTests
                 SizeClass = SectionSizeClass.Terse,
                 Cost = SectionCost.NetworkFree,
                 ScannerKey = null,
-                Query = unbounded,
+                Queries = [unbounded],
                 IsApplicable = _ => true,
                 CanRender = _ => true,
             });
@@ -3007,10 +3171,9 @@ public class SectionPipelineTests
         // observable that stands in for it.
         string[] sharedSessionScanners =
         [
-            // was ScanInfoCounts's four-way fan-out
+            // was ScanInfoCounts's fan-out
             LibrarySections.ScannerClassifiedMethods,
             LibrarySections.ScannerResources,
-            LibrarySections.ScannerCustomAttributes,
             LibrarySections.ScannerTypeForwarders,
             LibrarySections.ScannerIntegrationOpportunities,
             // was PopulateLibraryAudit running ScanClassifiedMethods on its own session
@@ -3058,7 +3221,7 @@ public class SectionPipelineTests
     [Fact]
     public void Trace_RecordsWhatRan_AndMarksBundlesAsDoingNoWorkOfTheirOwn()
     {
-        // InfoCounts is a bundle: it does no work itself and exists only to pull in five scanners.
+        // InfoCounts is a bundle: it does no work itself and exists only to pull in three scanners.
         // A trace that reported it as an ordinary scanner would attribute the bundle's dispatch
         // cost to a step that has none, and hide that the real work belongs to its prerequisites.
         var registry = LibrarySections.CreateScannerRegistry();
@@ -3181,6 +3344,7 @@ public class SectionPipelineTests
         Assert.Equal(
             [
                 AssemblyReferencesQuery.Definition,
+                CustomAttributesQuery.Definition,
                 ExtensionMethodsQuery.Definition,
                 MetadataImageQuery.Definition,
             ],
@@ -3332,11 +3496,6 @@ public class SectionPipelineTests
                 m => Xunit.Assert.IsType<FindingInspection<ManifestResourceInfo>.Failed>(
                     m.ResourceInspection!.Value)),
 
-            ("CustomAttributes",
-                m => m.Apply(LibraryMetadataService.ScanCustomAttributes(session, Path, logger)),
-                m => Xunit.Assert.IsType<FindingInspection<AssemblyAttributeInfo>.Failed>(
-                    m.AssemblyAttributeInspection!.Value)),
-
             ("TypeForwarders",
                 m => m.TypeForwarderInspection = LibraryMetadataService.ScanTypeForwarders(session, Path, logger),
                 m => Xunit.Assert.IsType<FindingInspection<TypeForwarderInfo>.Failed>(
@@ -3429,7 +3588,7 @@ public class SectionPipelineTests
             Assert.NotEqual(expectedA.Full, expectedB.Full);
 
             // The action-based scanners must distinguish the fixtures on their own. Found by
-            // review: asserting only the combined signature let the four value-returning census
+            // review: asserting only the combined signature let the three value-returning census
             // scanners carry the whole assertion, so a tamper confined to the void Scan overload
             // -- which is how Audit Signals, Integrations and Integration Opportunities run --
             // left this gate green while three scanners reopened the path.
@@ -3610,7 +3769,7 @@ public class SectionPipelineTests
     /// <summary>
     /// Runs the shared-session scanners over an untouched path and returns their signature, split
     /// so a caller can assert that the action-based scanners on their own distinguish the two
-    /// fixtures. Without that split, the four value-returning census scanners could carry the whole
+    /// fixtures. Without that split, the three value-returning census scanners could carry the whole
     /// signature and a tamper confined to the void <c>Scan</c> overload would stay invisible.
     /// </summary>
     private static (string Full, string Actions) CensusSignature(string assemblyPath)
@@ -3637,7 +3796,6 @@ public class SectionPipelineTests
     [
         LibrarySections.ScannerClassifiedMethods,
         LibrarySections.ScannerResources,
-        LibrarySections.ScannerCustomAttributes,
         LibrarySections.ScannerTypeForwarders,
         LibrarySections.ScannerIntegrationOpportunities,
         LibrarySections.ScannerAuditSignals,
@@ -3645,7 +3803,6 @@ public class SectionPipelineTests
 
     private static string SignatureOf(LibraryInspection model) => string.Join(
         "|",
-        $"attrs={model.CustomAttributes?.Count}",
         $"classified={PayloadCount(model.ClassifiedMethodInspection)}",
         $"resources={PayloadCount(model.ResourceInspection)}",
         $"forwarders={PayloadCount(model.TypeForwarderInspection)}",

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -258,9 +258,13 @@ internal static class LibraryMetadataService
                         inspection,
                         logger,
                         ExtensionMethodsQuery.Execute(session));
+                    ApplyCustomAttributesResult(
+                        path,
+                        inspection,
+                        logger,
+                        CustomAttributesQuery.Execute(session));
                     inspection.Apply(ScanClassifiedMethods(session, path, logger));
                     inspection.ResourceInspection = ScanResources(session, path, logger);
-                    inspection.Apply(ScanCustomAttributes(session, path, logger));
                     inspection.UnionTypeInspection = ScanUnionTypes(session, path, logger);
                     inspection.TypeForwarderInspection = ScanTypeForwarders(session, path, logger);
                 }
@@ -1620,47 +1624,6 @@ internal static class LibraryMetadataService
         }
     }
 
-    /// <summary>
-    /// Scans an assembly for custom attributes (assembly-level and module-level).
-    /// </summary>
-    internal static AssemblyAttributeScan ScanCustomAttributes(string path, VerboseLogger logger)
-    {
-        try
-        {
-            using var session = AssemblyInspectionSession.Open(path);
-            return ScanCustomAttributes(session, path, logger);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning($"Error scanning custom attributes in {path}: {ex.Message}");
-            return new AssemblyAttributeScan(
-                FailedInspection<AssemblyAttributeInfo>(
-                    path, MetadataFindings.AssemblyAttributeDescriptor, ex),
-                JsonOrder: null);
-        }
-    }
-
-    internal static AssemblyAttributeScan ScanCustomAttributes(AssemblyInspectionSession session, string path, VerboseLogger logger)
-    {
-        try
-        {
-            var attributes = session.CustomAttributes();
-            return new AssemblyAttributeScan(
-                MetadataFindings.InspectAssemblyAttributes(
-                    attributes,
-                    FindingSubjectFor(path)),
-                attributes);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning($"Error scanning custom attributes in {path}: {ex.Message}");
-            return new AssemblyAttributeScan(
-                FailedInspection<AssemblyAttributeInfo>(
-                    path, MetadataFindings.AssemblyAttributeDescriptor, ex),
-                JsonOrder: null);
-        }
-    }
-
     internal static FindingInspection<UnionTypeInfo> ScanUnionTypes(
         string path,
         VerboseLogger logger)
@@ -1762,6 +1725,13 @@ internal static class LibraryMetadataService
                 out ExtensionMethodsResult? extensionMethods))
         {
             ApplyExtensionMethodsResult(path, inspection, logger, extensionMethods);
+        }
+
+        if (results.TryGet(
+                CustomAttributesQuery.Definition,
+                out CustomAttributesResult? customAttributes))
+        {
+            ApplyCustomAttributesResult(path, inspection, logger, customAttributes);
         }
 
         if (results.TryGet(
@@ -1922,6 +1892,39 @@ internal static class LibraryMetadataService
             default:
                 throw new InvalidOperationException(
                     $"Unknown extension-method result '{result.GetType().Name}'.");
+        }
+    }
+
+    internal static void ApplyCustomAttributesResult(
+        string path,
+        LibraryInspection inspection,
+        VerboseLogger logger,
+        CustomAttributesResult result)
+    {
+        switch (result)
+        {
+            case CustomAttributesResult.Available available:
+                inspection.SetAssemblyAttributeInspection(
+                    MetadataFindings.InspectAssemblyAttributes(
+                        available.Attributes,
+                        FindingSubjectFor(path)),
+                    available.Attributes);
+                break;
+
+            case CustomAttributesResult.Failed failed:
+                logger.LogWarning(
+                    $"Error scanning custom attributes in {path}: {failed.Error.Message}");
+                inspection.SetAssemblyAttributeInspection(
+                    FailedInspection<AssemblyAttributeInfo>(
+                        path,
+                        MetadataFindings.AssemblyAttributeDescriptor,
+                        failed.Error),
+                    jsonOrder: null);
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown custom-attributes result '{result.GetType().Name}'.");
         }
     }
 

--- a/src/dotnet-inspect/Inspectors/LibraryScanResults.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryScanResults.cs
@@ -18,13 +18,6 @@ namespace DotnetInspector.Inspectors;
 // which is where it will be deleted once L1 owns the queries.
 
 /// <summary>
-/// Assembly attribute census, plus the order used for JSON serialization.
-/// </summary>
-internal readonly record struct AssemblyAttributeScan(
-    FindingInspection<AssemblyAttributeInfo> Inspection,
-    IReadOnlyList<AssemblyAttributeInfo>? JsonOrder);
-
-/// <summary>
 /// Method classification census, plus the three per-classification projections derived from it.
 /// All four come from one pass over the same classified-method list, so they are produced together;
 /// splitting them into separate scanners would re-walk the assembly three more times.
@@ -60,9 +53,6 @@ internal readonly record struct ResourceTriageScan(
 /// </summary>
 internal static class LibraryScanApply
 {
-    public static void Apply(this LibraryInspection inspection, AssemblyAttributeScan scan)
-        => inspection.SetAssemblyAttributeInspection(scan.Inspection, scan.JsonOrder);
-
     public static void Apply(this LibraryInspection inspection, ClassifiedMethodScan scan)
     {
         inspection.ClassifiedMethodInspection = scan.Inspection;

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -22,7 +22,6 @@ public static class LibrarySections
     // section. Gate: SectionPipelineTests.LibraryScannerRegistry_RegistrationMatchesDeclaration.
     public const string ScannerClassifiedMethods = "ClassifiedMethods";
     public const string ScannerResources = "Resources";
-    public const string ScannerCustomAttributes = "CustomAttributes";
     public const string ScannerUnionTypes = "UnionTypes";
     public const string ScannerTypeForwarders = "TypeForwarders";
     public const string ScannerInfoCounts = "InfoCounts";
@@ -76,7 +75,8 @@ public static class LibrarySections
             .UseScannerCosts(scannerCost)
             .UseQueryCosts(queryCost)
             .WithoutComputedPoles()
-            .Add<LibraryInfo>(ExtensionMethodsQuery.Definition)
+            .Add<LibraryInfo>(
+                [CustomAttributesQuery.Definition, ExtensionMethodsQuery.Definition])
             .Add<InspectionFailures>()
             .Add<ILOffset>()
             .Add<MemberContext>()
@@ -132,7 +132,7 @@ public static class LibrarySections
             .Add<PInvokeMethods>()
             .Add<AsyncMethods>()
             .Add<Resources>()
-            .Add<CustomAttributes>()
+            .Add<CustomAttributes>(CustomAttributesQuery.Definition)
             .Add<UnionTypes>()
             .Add<TypeForwarders>()
             .Add<NonNormalizedPaths>()
@@ -190,10 +190,6 @@ public static class LibrarySections
                 ctx.Model.ResourceInspection = ctx.Scan(
                     session => LibraryMetadataService.ScanResources(session, ctx.AssemblyPath, ctx.Logger),
                     () => LibraryMetadataService.ScanResources(ctx.AssemblyPath, ctx.Logger)))
-            .Add(ScannerCustomAttributes, SectionCost.NetworkFree, ctx =>
-                ctx.Model.Apply(ctx.Scan(
-                    session => LibraryMetadataService.ScanCustomAttributes(session, ctx.AssemblyPath, ctx.Logger),
-                    () => LibraryMetadataService.ScanCustomAttributes(ctx.AssemblyPath, ctx.Logger))))
             .Add(ScannerUnionTypes, SectionCost.NetworkFree, ctx =>
                 ctx.Model.UnionTypeInspection = LibraryMetadataService.ScanUnionTypes(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerTypeForwarders, SectionCost.NetworkFree, ctx =>
@@ -204,7 +200,6 @@ public static class LibrarySections
                 ScannerInfoCounts,
                 ScannerClassifiedMethods,
                 ScannerResources,
-                ScannerCustomAttributes,
                 ScannerTypeForwarders)
             .Add(ScannerAuditSignals, SectionCost.NetworkFree, ctx =>
                 ctx.Scan(
@@ -273,6 +268,22 @@ public static class LibrarySections
                         catch (Exception ex)
                         {
                             return new AssemblyReferencesResult.Failed(ex);
+                        }
+                    }))
+            .Add(CustomAttributesQuery.Definition, ctx =>
+                ctx.Scan(
+                    CustomAttributesQuery.Execute,
+                    () =>
+                    {
+                        try
+                        {
+                            using var session = ILInspector.Metadata.AssemblyInspectionSession.Open(
+                                ctx.AssemblyPath);
+                            return CustomAttributesQuery.Execute(session);
+                        }
+                        catch (Exception ex)
+                        {
+                            return new CustomAttributesResult.Failed(ex);
                         }
                     }))
             .Add(ExtensionMethodsQuery.Definition, ctx =>
@@ -811,7 +822,7 @@ public static class LibrarySections
     {
         public static string Name => SectionNames.CustomAttributes;
         public static bool IsExpensive => false;
-        public static string? ScannerKey => ScannerCustomAttributes;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model)
             => model.AssemblyAttributeInspection.CanRenderWithPresence(model.HasAssemblyAttributes);
     }

--- a/src/dotnet-inspect/Sections/MetadataSections.cs
+++ b/src/dotnet-inspect/Sections/MetadataSections.cs
@@ -55,7 +55,7 @@ public static class MetadataSections
             SizeClass = SectionSizeClass.Fixed,
             Cost = SectionCost.NetworkFree,
             ScannerKey = null,
-            Query = MetadataImageQuery.Definition,
+            Queries = [MetadataImageQuery.Definition],
             HasExplicitApplicability = true,
             IsApplicable = HasMetadata,
             CanRender = HasMetadata,
@@ -76,7 +76,7 @@ public static class MetadataSections
             SizeClass = SectionSizeClass.Fixed,
             Cost = SectionCost.NetworkFree,
             ScannerKey = null,
-            Query = MetadataImageQuery.Definition,
+            Queries = [MetadataImageQuery.Definition],
             HasExplicitApplicability = true,
             IsApplicable = static model => model.MetadataHeap is not null,
             CanRender = static model => model.MetadataHeap is not null,
@@ -98,7 +98,7 @@ public static class MetadataSections
                 // entries. Unbounded is the honest classification.
                 Cost = SectionCost.Unbounded,
                 ScannerKey = null,
-                Query = MetadataImageQuery.Definition,
+                Queries = [MetadataImageQuery.Definition],
                 // Effectiveness follows the heap's size from the cheap image scan. Probing by
                 // rendering would project every table during discovery, paying the section's whole
                 // cost just to decide whether to list it.
@@ -126,7 +126,7 @@ public static class MetadataSections
                 // this section is reachable only by exact name or the @Metadata door.
                 Cost = SectionCost.Unbounded,
                 ScannerKey = null,
-                Query = MetadataImageQuery.Definition,
+                Queries = [MetadataImageQuery.Definition],
                 // Effectiveness is decided by the query's row count, which is exact: a table with
                 // rows always renders rows. Probing by rendering would project the whole table
                 // during discovery, paying the lens's expensive half just to list it.

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using DotnetInspector.Options;
 using DotnetInspector.Queries;
 
@@ -23,7 +24,7 @@ public sealed record SectionEntry<TModel>
     public SectionSizeClass SizeClass { get; init; }
     public SectionCost Cost { get; init; }
     public required string? ScannerKey { get; init; }
-    public InspectionQueryDefinition? Query { get; init; }
+    public ImmutableArray<InspectionQueryDefinition> Queries { get; init; } = [];
     public bool HasExplicitApplicability { get; init; }
     public required Func<TModel, bool> IsApplicable { get; init; }
     public required Func<TModel, bool> CanRender { get; init; }
@@ -99,7 +100,8 @@ public sealed class SectionPipeline<TModel>
         return this;
     }
     /// <summary>
-    /// Binds this pipeline to the typed query registry's prerequisite-aware costs.
+    /// Binds this pipeline to the typed query registry's prerequisite-aware costs. A section
+    /// backed by multiple queries inherits the maximum cost among their prerequisite closures.
     /// </summary>
     public SectionPipeline<TModel> UseQueryCosts(
         Func<InspectionQueryDefinition, InspectionCost> costOf)
@@ -167,7 +169,7 @@ public sealed class SectionPipeline<TModel>
     /// </summary>
     public SectionPipeline<TModel> Add<TDescriptor>(
         Func<TModel, bool>? isApplicable = null) where TDescriptor : ISectionDescriptor<TModel>
-        => AddDescriptor<TDescriptor>(query: null, isApplicable);
+        => AddDescriptor<TDescriptor>(queries: [], isApplicable);
 
     /// <summary>
     /// Registers a section descriptor whose data is supplied by a typed query.
@@ -177,11 +179,25 @@ public sealed class SectionPipeline<TModel>
         Func<TModel, bool>? isApplicable = null) where TDescriptor : ISectionDescriptor<TModel>
     {
         ArgumentNullException.ThrowIfNull(query);
-        return AddDescriptor<TDescriptor>(query, isApplicable);
+        return AddDescriptor<TDescriptor>([query], isApplicable);
+    }
+
+    /// <summary>
+    /// Registers a section whose data is supplied by multiple typed queries.
+    /// </summary>
+    public SectionPipeline<TModel> Add<TDescriptor>(
+        IReadOnlyList<InspectionQueryDefinition> queries,
+        Func<TModel, bool>? isApplicable = null) where TDescriptor : ISectionDescriptor<TModel>
+    {
+        ArgumentNullException.ThrowIfNull(queries);
+        foreach (InspectionQueryDefinition query in queries)
+            ArgumentNullException.ThrowIfNull(query);
+
+        return AddDescriptor<TDescriptor>(queries, isApplicable);
     }
 
     private SectionPipeline<TModel> AddDescriptor<TDescriptor>(
-        InspectionQueryDefinition? query,
+        IReadOnlyList<InspectionQueryDefinition> queries,
         Func<TModel, bool>? isApplicable) where TDescriptor : ISectionDescriptor<TModel>
     {
         return Add(new SectionEntry<TModel>
@@ -197,7 +213,7 @@ public sealed class SectionPipeline<TModel>
             SizeClass = TDescriptor.SizeClass,
             Cost = TDescriptor.Cost,
             ScannerKey = TDescriptor.ScannerKey,
-            Query = query,
+            Queries = [.. queries],
             HasExplicitApplicability = isApplicable != null,
             IsApplicable = isApplicable ?? TDescriptor.CanRender,
             CanRender = TDescriptor.CanRender,
@@ -211,6 +227,17 @@ public sealed class SectionPipeline<TModel>
     /// </summary>
     public SectionPipeline<TModel> Add(SectionEntry<TModel> entry)
     {
+        if (entry.Queries.IsDefault)
+            throw new InvalidOperationException($"{entry.Name} has an uninitialized query set.");
+        if (entry.Queries.Any(query => query is null))
+            throw new ArgumentException(
+                $"{entry.Name} has a null typed query binding.",
+                nameof(entry));
+        if (entry.Queries.Length != entry.Queries.Distinct().Count())
+            throw new ArgumentException(
+                $"{entry.Name} binds the same typed query more than once.",
+                nameof(entry));
+
         if (!entry.ProbeEffectiveness && !entry.ExplicitOnly && !entry.HasExplicitApplicability)
             throw new InvalidOperationException(
                 $"{entry.Name} sets ProbeEffectiveness=false and must be explicit-only or " +
@@ -229,12 +256,14 @@ public sealed class SectionPipeline<TModel>
                 entry = entry with { Cost = scanner };
         }
 
-        if (_queryCost is { } queryCostOf && entry.Query is { } query)
+        if (_queryCost is { } queryCostOf)
         {
-            SectionCost queryCost = queryCostOf(query).ToSectionCost(query);
-
-            if (queryCost > entry.Cost)
-                entry = entry with { Cost = queryCost };
+            foreach (InspectionQueryDefinition query in entry.Queries)
+            {
+                SectionCost queryCost = queryCostOf(query).ToSectionCost(query);
+                if (queryCost > entry.Cost)
+                    entry = entry with { Cost = queryCost };
+            }
         }
 
         // @All renders every member, so an Unbounded section must not be able to join it. Curated
@@ -321,9 +350,7 @@ public sealed class SectionPipeline<TModel>
     /// Query identity is the instance, not its diagnostic name.
     /// </summary>
     public IReadOnlySet<InspectionQueryDefinition> DeclaredQueries => _entries
-        .Select(e => e.Query)
-        .Where(query => query is not null)
-        .Cast<InspectionQueryDefinition>()
+        .SelectMany(e => e.Queries)
         .ToHashSet();
 
     /// <summary>
@@ -340,8 +367,7 @@ public sealed class SectionPipeline<TModel>
     /// Section names paired with the typed query each declares, for sections that declare one.
     /// </summary>
     public IEnumerable<(string Name, InspectionQueryDefinition Query)> QueryBoundSections => _entries
-        .Where(e => e.Query is not null)
-        .Select(e => (e.Name, e.Query!));
+        .SelectMany(e => e.Queries.Select(query => (e.Name, Query: query)));
 
     /// <summary>
     /// Section names paired with the <b>effective</b> cost the verbosity ladder consults — after
@@ -878,14 +904,17 @@ public sealed class SectionPipeline<TModel>
         for (int i = 0; i < _entries.Count; i++)
         {
             SectionEntry<TModel> entry = _entries[i];
-            if (entry.Query is not { } query)
+            if (entry.Queries.IsDefaultOrEmpty)
                 continue;
             if (excludeUnbounded && entry.Cost == SectionCost.Unbounded)
                 continue;
             if (IsRequested(entry, i, verbosity, include, fixedOverview))
             {
-                queries.Add(query);
-                trace?.RecordQueryDemand(entry.Name, query);
+                foreach (InspectionQueryDefinition query in entry.Queries)
+                {
+                    queries.Add(query);
+                    trace?.RecordQueryDemand(entry.Name, query);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Add a host-neutral, immutable `CustomAttributesQuery` over an already-open
  assembly session.
- Bind `Library Info` and `Custom Attributes` to the same query result while
  preserving Findings, typed failures, and JSON metadata order.
- Allow one section to declare multiple typed queries, using the maximum
  prerequisite-closure cost.
- Remove the legacy custom-attribute scanner key and mutable scan adapter.

## Behavioral claim

Custom-attribute inspection is now first-class typed query work. Focused and
summary views share one network-free result from the command's retained image,
with unchanged rendering, provenance, failure visibility, and package routing.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release` (3,222 passed; 14
  environment skips)
- Focused query, demand, failure, projection, and multi-query cost gates
- Markdown lint for changed architecture documents
- CLI Markdown and JSON custom-attribute output probes

## Non-action boundary

Resources, type forwarders, classified methods, and the remaining
scanner-backed facets are unchanged.
