### PR TITLE
Adopt Markout row windows and section ordering

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Markout" Version="0.33.0" />
+    <PackageVersion Include="Markout" Version="0.35.0" />
     <PackageVersion Include="Markout.Templates" Version="0.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />

--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -128,8 +128,10 @@ dotnet-inspect member JsonSerializer --package System.Text.Json \
   -m Serialize -S Methods --columns "Name;Signature;Obsolete"
 ```
 
-Projection is validated against the selected section schema. Unknown names
-produce diagnostics; valid-but-empty names are reported as no data.
+Projection is validated against the selected section schema. Across multiple
+sections, a name may resolve in any selected section; tables that do not expose
+it contribute nothing. Unknown names produce diagnostics only when they resolve
+nowhere, and valid-but-empty names are reported as no data.
 
 Future filtering and ordering should extend the shared row-query path rather
 than add one flag per column. See

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1819,6 +1819,18 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_Listing_MarkdownUsesLfThroughout()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "--platform", "System.Text.Json", "-v:n", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains('\n', output);
+        Assert.DoesNotContain('\r', output);
+    }
+
+    [Fact]
     public async Task Type_SingleType_QuietVerbosity_RequiresMarkdown()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -12116,28 +12116,28 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Package_MultiSectionPartialMatchReportsCleanRenderError()
+    public async Task Package_MultiSectionProjectionMatchesAcrossTheDocument()
     {
         var (packagePath, tempDir) = CreateLocalLayoutPackage();
         try
         {
-            // Markout applies the projection to each table independently, so a column that
-            // matches one section can still abort on an earlier heterogeneous section.
+            // A projection is a document-wide allow list. Tables that do not expose a requested
+            // column contribute nothing; the request succeeds when another selected table does.
             var (normalExit, normalOutput, normalError) = await RunAppAsync(
                 "package", packagePath, "-v:n", "--columns", "TFM", "--tips", "q");
 
-            Assert.Equal(1, normalExit);
-            Assert.Empty(normalOutput);
-            Assert.Contains("No columns matched projection: TFM", normalError);
-            Assert.DoesNotContain("System.InvalidOperationException", normalError);
+            Assert.Equal(0, normalExit);
+            Assert.Empty(normalError);
+            Assert.Contains("| TFM |", normalOutput);
+            Assert.Contains("net8.0", normalOutput);
 
             var (overviewExit, overviewOutput, overviewError) = await RunAppAsync(
                 "package", packagePath, "-S", "--columns", "Path", "--tips", "q");
 
-            Assert.Equal(1, overviewExit);
-            Assert.Empty(overviewOutput);
-            Assert.Contains("No columns matched projection: Path", overviewError);
-            Assert.DoesNotContain("System.InvalidOperationException", overviewError);
+            Assert.Equal(0, overviewExit);
+            Assert.Empty(overviewError);
+            Assert.Contains("| Path |", overviewOutput);
+            Assert.Contains("README.md", overviewOutput);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/MetadataLensTests.cs
+++ b/src/dotnet-inspect.Tests/MetadataLensTests.cs
@@ -470,6 +470,21 @@ public partial class CommandExecutionTests
         Assert.Equal(2, rows.Length - 1);
     }
 
+    [Fact]
+    public async Task MetadataLens_PlainTextHonorsRowWindow()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "-S", "Metadata: AssemblyRef",
+            "--plaintext", "--rows", "1..2", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Metadata: AssemblyRef", output, StringComparison.Ordinal);
+        int dataRows = output.Split('\n')
+            .Count(line => line.TrimStart().StartsWith("| ", StringComparison.Ordinal)) - 2;
+        Assert.Equal(2, dataRows);
+    }
+
     /// <summary>
     /// A column name absent from the schema is rejected rather than silently ignored, and the
     /// remedy the error names resolves to a real column list.

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -794,10 +794,13 @@ public class ApiCommand
             else
             {
                 writerOptions.RowWindow = RowWindow.ToMarkout(options.Rows);
-                var markdown = MarkoutSerializer.Serialize(view, ApiViewContext.Default, writerOptions);
+                var markdownWriter = new StringWriter { NewLine = "\n" };
+                MarkoutSerializer.Serialize(
+                    view, markdownWriter, new MarkdownFormatter(), ApiViewContext.Default, writerOptions);
+                var markdown = markdownWriter.ToString().TrimEnd();
                 if (!TryReportEmptyProjection(markdown, options))
                     return 1;
-                OutputFormatter.WriteLfLine(Console.Out, markdown.TrimEnd());
+                OutputFormatter.WriteLfLine(Console.Out, markdown);
             }
         }
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -739,10 +739,10 @@ public class ApiCommand
         if (options.Count)
         {
             var writerOptions = ApiOutputFormatter.BuildWriterOptions(api, options);
+            writerOptions.RowWindow = RowWindow.ToMarkout(options.Rows);
             var markdown = MarkoutSerializer.Serialize(view, ApiViewContext.Default, writerOptions);
             if (!TryReportEmptyProjection(markdown, options))
                 return 1;
-            markdown = OutputFormatter.ApplyRowLimit(markdown, options.Rows);
             CountOutput.WriteCountFromMarkdown(markdown);
         }
         else if (options.Tabular)
@@ -793,10 +793,11 @@ public class ApiCommand
             }
             else
             {
+                writerOptions.RowWindow = RowWindow.ToMarkout(options.Rows);
                 var markdown = MarkoutSerializer.Serialize(view, ApiViewContext.Default, writerOptions);
                 if (!TryReportEmptyProjection(markdown, options))
                     return 1;
-                OutputFormatter.WriteLimitedMarkdown(Console.Out, markdown, options.Rows);
+                OutputFormatter.WriteLfLine(Console.Out, markdown.TrimEnd());
             }
         }
 
@@ -1279,13 +1280,14 @@ public class ApiCommand
         if (options.Count)
         {
             var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, options);
+            writerOptions.RowWindow = RowWindow.ToMarkout(options.Rows);
             var sw = new StringWriter { NewLine = "\n" };
             var writer = new Markout.MarkoutWriter(sw, new MarkdownFormatter(), writerOptions);
             ApiOutputFormatter.SerializeTypeDocument(
                 view, eventsView, methodGroupsView, methodsView, memberIndexView, operatorsView,
                 explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
             writer.Flush();
-            CountOutput.WriteCountFromMarkdown(OutputFormatter.ApplyRowLimit(sw.ToString(), options.Rows));
+            CountOutput.WriteCountFromMarkdown(sw.ToString().TrimEnd());
             ApiOutputFormatter.WriteCallGraphWarning(view);
             return 0;
         }
@@ -1344,6 +1346,18 @@ public class ApiCommand
             }
             else
             {
+                if (SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
+                {
+                    var pipeline = ApiMemberSectionPipelines.Create(options);
+                    writerOptions.SectionOrder = pipeline.GetAllSelectorSections(type);
+                }
+                else if (SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections))
+                {
+                    var pipeline = ApiMemberSectionPipelines.Create(options);
+                    writerOptions.SectionOrder = pipeline.InfoSectionNames;
+                }
+
+                writerOptions.RowWindow = RowWindow.ToMarkout(options.Rows);
                 var sw = new StringWriter { NewLine = "\n" };
                 var writer = new Markout.MarkoutWriter(sw, new MarkdownFormatter(), writerOptions);
                 ApiOutputFormatter.SerializeTypeDocument(
@@ -1351,17 +1365,7 @@ public class ApiCommand
                     explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
                 writer.Flush();
                 var markdown = sw.ToString().TrimEnd();
-                if (SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
-                {
-                    var pipeline = ApiMemberSectionPipelines.Create(options);
-                    markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.GetAllSelectorSections(type));
-                }
-                else if (SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections))
-                {
-                    var pipeline = ApiMemberSectionPipelines.Create(options);
-                    markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.InfoSectionNames);
-                }
-                OutputFormatter.WriteLfLine(sink, OutputFormatter.ApplyRowLimit(markdown, options.Rows));
+                OutputFormatter.WriteLfLine(sink, markdown);
             }
         }
         ApiOutputFormatter.WriteSignatureDecodeWarning(view);

--- a/src/dotnet-inspect/Commands/DependsCommand.cs
+++ b/src/dotnet-inspect/Commands/DependsCommand.cs
@@ -342,7 +342,7 @@ public class DependsCommand
 
     private static void WriteMarkdown(PackageDependenciesView view, RowWindow? rows)
     {
-        OutputFormatter.WriteLimitedMarkdown(Console.Out,
-            MarkoutSerializer.Serialize(view, PackageDependenciesContext.Default), rows);
+        OutputFormatter.WriteWindowedMarkdown(Console.Out, rows,
+            opts => MarkoutSerializer.Serialize(view, PackageDependenciesContext.Default, opts));
     }
 }

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -218,8 +218,9 @@ public class DiffCommand
                     }
                     else
                     {
-                        var output = DiffOutputFormatter.RenderFindingTransitionsView(view);
-                        Console.WriteLine(OutputFormatter.ApplyRowLimit(output, options.Rows));
+                        var output = DiffOutputFormatter.RenderFindingTransitionsView(
+                            view, OutputFormatter.CreateWindowedOptions(options.Rows));
+                        Console.WriteLine(output);
                     }
                     return 0;
                 }
@@ -249,8 +250,9 @@ public class DiffCommand
                     }
                     else
                     {
-                        var output = DiffOutputFormatter.RenderImplementationDiffView(view);
-                        Console.WriteLine(OutputFormatter.ApplyRowLimit(output, options.Rows));
+                        var output = DiffOutputFormatter.RenderImplementationDiffView(
+                            view, OutputFormatter.CreateWindowedOptions(options.Rows));
+                        Console.WriteLine(output);
                     }
                     return 0;
                 }
@@ -275,8 +277,9 @@ public class DiffCommand
                     }
                     else
                     {
-                        var output = DiffOutputFormatter.RenderAnalysisDiffView(view);
-                        Console.WriteLine(OutputFormatter.ApplyRowLimit(output, options.Rows));
+                        var output = DiffOutputFormatter.RenderAnalysisDiffView(
+                            view, OutputFormatter.CreateWindowedOptions(options.Rows));
+                        Console.WriteLine(output);
                     }
                     return 0;
                 }
@@ -777,9 +780,8 @@ public class DiffCommand
             return;
         }
 
-        Console.WriteLine(OutputFormatter.ApplyRowLimit(
-            DiffOutputFormatter.RenderDocumentView(view),
-            options.Rows));
+        Console.WriteLine(DiffOutputFormatter.RenderDocumentView(
+            view, OutputFormatter.CreateWindowedOptions(options.Rows)));
     }
 
     internal sealed record AnalysisDiffResult(List<AnalysisDiffRow> Rows, string Summary);
@@ -1162,8 +1164,8 @@ public class DiffCommand
             });
         }
 
-        var markdown = DiffOutputFormatter.RenderFullMarkdown(name, typeDiffs, fromVersion, toVersion);
-        return OutputFormatter.ApplyRowLimit(markdown, options.Rows);
+        return DiffOutputFormatter.RenderFullMarkdown(name, typeDiffs, fromVersion, toVersion,
+            OutputFormatter.CreateWindowedOptions(options.Rows));
     }
 
     internal static ApiDiff BuildApiDiff(ApiSurface fromSurface, ApiSurface toSurface, DiffOptions options)

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -244,8 +244,8 @@ public class ExtensionsCommand
     private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity, RowWindow? rows)
     {
         var view = ExtensionsOutputFormatter.BuildView(targetType, results, verbosity);
-        OutputFormatter.WriteLimitedMarkdown(Console.Out,
-            MarkoutSerializer.Serialize(view, SearchViewContext.Default), rows);
+        OutputFormatter.WriteWindowedMarkdown(Console.Out, rows,
+            opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts));
     }
 
     private static void WriteTableOutput(string targetType, List<ExtensionMethodResult> results, ExtensionsOptions options)

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -163,8 +163,8 @@ public class FindCommand
         }
         else
         {
-            OutputFormatter.WriteLimitedMarkdown(Console.Out,
-                MarkoutSerializer.Serialize(view, SearchViewContext.Default), options.Rows);
+            OutputFormatter.WriteWindowedMarkdown(Console.Out, options.Rows,
+                opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts));
         }
     }
 
@@ -194,8 +194,8 @@ public class FindCommand
         }
         else
         {
-            OutputFormatter.WriteLimitedMarkdown(Console.Out,
-                MarkoutSerializer.Serialize(view, SearchViewContext.Default), options.Rows);
+            OutputFormatter.WriteWindowedMarkdown(Console.Out, options.Rows,
+                opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts));
         }
     }
 

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -166,8 +166,8 @@ public class ImplementsCommand
         }
         else
         {
-            OutputFormatter.WriteLimitedMarkdown(Console.Out,
-                MarkoutSerializer.Serialize(view, SearchViewContext.Default), rows);
+            OutputFormatter.WriteWindowedMarkdown(Console.Out, rows,
+                opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts));
         }
     }
 }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -2949,6 +2949,8 @@ public class PackageCommand
         }
 
         var markdown = sb.ToString().TrimEnd();
+        // Windowed as text rather than at the writer seam because AppendAggregatedSection
+        // hand-builds its tables into `sb`; the writer never sees those rows. See #3624.
         return MarkdownTableRowLimiter.Apply(markdown, options.Rows);
     }
 

--- a/src/dotnet-inspect/Commands/TimelineCommand.cs
+++ b/src/dotnet-inspect/Commands/TimelineCommand.cs
@@ -1279,9 +1279,9 @@ public static class TimelineCommand
             return;
         }
 
-        var writer = new MarkoutWriter(new MarkdownFormatter());
+        var writer = new MarkoutWriter(new MarkdownFormatter(), OutputFormatter.CreateWindowedOptions(options.Rows));
         TimelineViewContext.Default.Serialize(view, writer);
-        Console.WriteLine(OutputFormatter.ApplyRowLimit(writer.ToString(), options.Rows));
+        Console.WriteLine(writer.ToString().TrimEnd());
     }
 
     internal sealed record TimelineEvaluation(

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -128,9 +128,9 @@ public static class DiffOutputFormatter
             FindingTransitions = findingTransitions?.Rows
         };
 
-    public static string RenderDocumentView(DiffDocumentView view)
+    public static string RenderDocumentView(DiffDocumentView view, MarkoutWriterOptions? options = null)
     {
-        var writer = new MarkoutWriter(new MarkdownFormatter());
+        var writer = new MarkoutWriter(new MarkdownFormatter(), options);
         writer.WriteHeading(1, view.Title);
         writer.WriteParagraph($"**Versions:** {view.Versions}");
 
@@ -242,9 +242,9 @@ public static class DiffOutputFormatter
             Rows = rows.Count > 0 ? rows.ToList() : null
         };
 
-    public static string RenderFindingTransitionsView(FindingTransitionsView view)
+    public static string RenderFindingTransitionsView(FindingTransitionsView view, MarkoutWriterOptions? options = null)
     {
-        var writer = new MarkoutWriter(new MarkdownFormatter());
+        var writer = new MarkoutWriter(new MarkdownFormatter(), options);
         DiffViewContext.Default.Serialize(view, writer);
         return writer.ToString().TrimEnd();
     }
@@ -280,10 +280,10 @@ public static class DiffOutputFormatter
         return view;
     }
 
-    public static string RenderFullMarkdown(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion)
+    public static string RenderFullMarkdown(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion, MarkoutWriterOptions? options = null)
     {
         var view = BuildFullView(name, typeDiffs, fromVersion, toVersion);
-        var writer = new MarkoutWriter(new MarkdownFormatter());
+        var writer = new MarkoutWriter(new MarkdownFormatter(), options);
         DiffViewContext.Default.Serialize(view, writer);
         return writer.ToString().TrimEnd();
     }
@@ -316,9 +316,9 @@ public static class DiffOutputFormatter
     /// <summary>
     /// Renders an Analysis Diff view to markdown.
     /// </summary>
-    public static string RenderAnalysisDiffView(AnalysisDiffView view)
+    public static string RenderAnalysisDiffView(AnalysisDiffView view, MarkoutWriterOptions? options = null)
     {
-        var writer = new MarkoutWriter(new MarkdownFormatter());
+        var writer = new MarkoutWriter(new MarkdownFormatter(), options);
         DiffViewContext.Default.Serialize(view, writer);
         return writer.ToString().TrimEnd();
     }
@@ -443,9 +443,9 @@ public static class DiffOutputFormatter
         return $"old: {oldState}; new: {newState}";
     }
 
-    public static string RenderImplementationDiffView(ImplementationDiffView view)
+    public static string RenderImplementationDiffView(ImplementationDiffView view, MarkoutWriterOptions? options = null)
     {
-        var writer = new MarkoutWriter(new MarkdownFormatter());
+        var writer = new MarkoutWriter(new MarkdownFormatter(), options);
         DiffViewContext.Default.Serialize(view, writer);
         return writer.ToString().TrimEnd();
     }

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -134,11 +134,27 @@ public static class OutputFormatter
         RowWindow? maxRows = null) =>
         output.Write(LimitRenderedTableRows(RenderProjectedTable(showHeader, tsv, jsonl, columns, fields, serialize), maxRows, showHeader));
 
-    public static string ApplyRowLimit(string markdown, RowWindow? rows) =>
-        MarkdownTableRowLimiter.Apply(markdown.TrimEnd(), rows);
+    /// <summary>
+    /// Serializes a view with <c>--rows</c> applied at the writer seam and writes the result.
+    /// </summary>
+    /// <remarks>
+    /// markout windows rows as it emits them, so the window is applied to table rows the writer
+    /// knows about rather than re-derived by parsing rendered Markdown back into tables. That
+    /// removes the need to tell a table row from a prose line or a fenced code line after the
+    /// fact. The two remaining rendered-text windowing sites are the ones whose content the
+    /// writer never sees: the <c>@Metadata</c> lens (#3619) and the package all-libraries
+    /// aggregates (#3624).
+    /// </remarks>
+    public static void WriteWindowedMarkdown(TextWriter output, RowWindow? rows,
+        Func<MarkoutWriterOptions, string> serialize) =>
+        output.WriteLine(serialize(CreateWindowedOptions(rows)).TrimEnd());
 
-    public static void WriteLimitedMarkdown(TextWriter output, string markdown, RowWindow? rows) =>
-        output.WriteLine(ApplyRowLimit(markdown, rows));
+    /// <summary>
+    /// Creates writer options carrying only a <c>--rows</c> window, for callers that serialize
+    /// directly rather than through <see cref="WriteWindowedMarkdown"/>.
+    /// </summary>
+    public static MarkoutWriterOptions CreateWindowedOptions(RowWindow? rows) =>
+        new() { RowWindow = RowWindow.ToMarkout(rows) };
 
     /// <summary>
     /// Writes <paramref name="payload"/> followed by a single LF, for payloads whose interior is
@@ -150,11 +166,9 @@ public static class OutputFormatter
     /// yields a document that is LF throughout except for its last line, which is the mixed-ending
     /// shape this method exists to avoid.
     ///
-    /// This is deliberately *not* the terminator used by <see cref="WriteLimitedMarkdown"/>: those
-    /// callers still receive CRLF interiors from the string-returning <c>MarkoutSerializer</c>
-    /// overloads, so switching only their terminator would introduce the very mixing described
-    /// above. Interior and terminator have to move together; that coherent platform-native
-    /// terminal path is outside this artifact-framing helper's contract.
+    /// Callers pair this terminator with payloads serialized through an LF-configured writer.
+    /// Switching only the terminator for a platform-native payload would introduce the very
+    /// mixed-ending shape described above; interior and terminator have to move together.
     /// </remarks>
     public static void WriteLfLine(TextWriter output, string payload)
     {
@@ -360,8 +374,8 @@ public static class OutputFormatter
 
         if (options.Count)
         {
-            var markdown = SerializeLibraryMarkdown(auditView, inspection, writerOpts, pipeline);
-            markdown = MarkdownTableRowLimiter.Apply(markdown, options.Rows);
+            var markdown = SerializeLibraryMarkdown(
+                auditView, inspection, writerOpts, pipeline, options.Rows);
             var ordered = ResolveCountMapSections(pipeline, options.IncludeSections, options.FixedOverview);
             if (ordered != null)
             {
@@ -388,19 +402,22 @@ public static class OutputFormatter
 
         if (options.Format == OutputFormat.PlainText)
         {
+            ApplyLibraryRowWindow(writerOpts, options.Rows);
             WriteLfLine(Console.Out, SerializeLibraryPlainText(
                 auditView, inspection, writerOpts));
         }
         else if (options.VerbosityEnabled)
         {
-            var markdown = SerializeLibraryMarkdown(auditView, inspection, writerOpts, pipeline);
-            WriteLfLine(Console.Out, ApplyRowLimit(markdown, options.Rows));
+            var markdown = SerializeLibraryMarkdown(
+                auditView, inspection, writerOpts, pipeline, options.Rows);
+            WriteLfLine(Console.Out, markdown);
         }
         else if (writerOpts.IncludeSections is { Count: > 1 } && !options.TabularExplicitlySet)
         {
             // Auto-promote to markdown when multiple sections and tabular output wasn't explicitly requested
-            var markdown = SerializeLibraryMarkdown(auditView, inspection, writerOpts, pipeline);
-            WriteLfLine(Console.Out, ApplyRowLimit(markdown, options.Rows));
+            var markdown = SerializeLibraryMarkdown(
+                auditView, inspection, writerOpts, pipeline, options.Rows);
+            WriteLfLine(Console.Out, markdown);
         }
         else
         {
@@ -452,19 +469,35 @@ public static class OutputFormatter
 
     /// <summary>
     /// Serializes the library view and, when the <c>@Metadata</c> lens is selected, composes its
-    /// sections into the same Markdown document before ordering.
+    /// sections into the same Markdown document before ordering and row windowing.
     ///
-    /// Metadata sections cannot be attributed view properties (their columns differ per table), so
-    /// they are rendered separately and appended. Ordering runs *after* the append, which is what
-    /// places them among the other sections rather than in a block at the end; every downstream
-    /// step — <c>--rows</c> windowing, <c>--count</c> — then treats them as ordinary sections.
+    /// Metadata sections are rendered as Markdown text and appended, so ordering and row
+    /// windowing have to run *after* the append. Without metadata, both operations run directly
+    /// at the writer seam.
+    ///
+    /// This is the last caller of <see cref="MarkdownSectionOrderer"/> and the reason it and
+    /// <see cref="MarkdownTableRowLimiter"/> still exist. Every other section producer applies
+    /// ordering and row windowing at the writer seam via <see cref="MarkoutWriterOptions"/>.
+    /// The stated reason for hand-writing — metadata columns differ per table, so they cannot be
+    /// attributed view properties — no longer holds: markout's <c>MarkoutTable</c> models a table
+    /// whose columns are runtime data. What still blocks the migration is the lens's caveat
+    /// *prose*, which has no serializer-model expression. See #3619 (the migration) and #3620
+    /// (the prose gap, which blocks it).
     /// </summary>
     private static string SerializeLibraryMarkdown(
         LibraryInspectionView auditView,
         LibraryInspection inspection,
         MarkoutWriterOptions writerOpts,
-        SectionPipeline<LibraryInspection> pipeline)
+        SectionPipeline<LibraryInspection> pipeline,
+        RowWindow? rows)
     {
+        var includesMetadata = MetadataLensRenderer.IsSelected(writerOpts.IncludeSections);
+        if (!includesMetadata)
+        {
+            writerOpts.SectionOrder = pipeline.AlphabeticalSectionOrder;
+            writerOpts.RowWindow = RowWindow.ToMarkout(rows);
+        }
+
         // Serialize through an LF writer rather than the string-returning overload, which inherits
         // Environment.NewLine. The metadata half appended below is LF on every platform, and
         // MarkdownSectionOrderer rejoins on whichever ending it detects — so a CRLF shell here
@@ -483,7 +516,17 @@ public static class OutputFormatter
             markdown = body.Length == 0 ? metadata : body + "\n" + "\n" + metadata;
         }
 
-        return MarkdownSectionOrderer.Apply(markdown, pipeline.AlphabeticalSectionOrder);
+        if (!includesMetadata)
+            return markdown;
+
+        markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.AlphabeticalSectionOrder);
+        return MarkdownTableRowLimiter.Apply(markdown, rows);
+    }
+
+    private static void ApplyLibraryRowWindow(MarkoutWriterOptions writerOpts, RowWindow? rows)
+    {
+        if (!MetadataLensRenderer.IsSelected(writerOpts.IncludeSections))
+            writerOpts.RowWindow = RowWindow.ToMarkout(rows);
     }
 
     /// <summary>
@@ -552,8 +595,8 @@ public static class OutputFormatter
             {
                 var auditView = new LibraryInspectionView(inspection, topFieldsOnly);
                 var markdown = SerializeLibraryMarkdown(
-                    auditView, inspection, WriterOptions(inspection), pipeline);
-                return MarkdownTableRowLimiter.Apply(markdown, options.Rows);
+                    auditView, inspection, WriterOptions(inspection), pipeline, options.Rows);
+                return markdown;
             }).ToList();
             var ordered = ResolveCountMapSections(pipeline, options.IncludeSections, options.FixedOverview);
             if (ordered != null)
@@ -592,10 +635,12 @@ public static class OutputFormatter
             documents.AddRange(inspections.Select(inspection =>
             {
                 var auditView = new LibraryInspectionView(inspection, topFieldsOnly);
+                var writerOpts = WriterOptions(inspection);
+                ApplyLibraryRowWindow(writerOpts, options.Rows);
                 var title = LibraryViewText.DocumentTitle(inspection);
                 var body = RemovePlainTextDocumentTitle(
                     SerializeLibraryPlainText(
-                        auditView, inspection, WriterOptions(inspection)),
+                        auditView, inspection, writerOpts),
                     LibraryViewText.DocumentTitle(auditView));
                 return body.Length == 0 ? title : title + "\n\n" + body;
             }));
@@ -614,7 +659,7 @@ public static class OutputFormatter
                 var auditView = new LibraryInspectionView(inspection, topFieldsOnly);
                 var title = LibraryViewText.DocumentTitle(inspection);
                 var body = RemoveMarkdownDocumentTitle(SerializeLibraryMarkdown(
-                    auditView, inspection, WriterOptions(inspection), pipeline));
+                    auditView, inspection, WriterOptions(inspection), pipeline, options.Rows));
                 body = ShiftMarkdownHeadingLevels(body, 2);
                 var heading = RenderMarkdownHeading(3, title);
                 return body.Length == 0
@@ -622,9 +667,7 @@ public static class OutputFormatter
                     : heading + "\n\n" + body;
             }));
             var markdown = string.Join("\n\n", documents);
-            WriteLfLine(
-                Console.Out,
-                MarkdownTableRowLimiter.Apply(markdown, options.Rows));
+            WriteLfLine(Console.Out, markdown);
         }
         else
         {

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -276,12 +276,12 @@ public static class OutputFormatter
         bool selectInfo = SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections);
         var view = new InspectionResultView(result, includeTitleVersion: false);
         var writerOptions = BuildWriterOptions(result, options, pipeline);
-        var markdown = MarkoutSerializer.Serialize(view, InspectionContext.Default, writerOptions).TrimEnd();
         if (selectAll)
-            markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.GetAllSelectorSections(result));
+            writerOptions.SectionOrder = pipeline.GetAllSelectorSections(result);
         else if (selectInfo)
-            markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.InfoSectionNames);
-        markdown = MarkdownTableRowLimiter.Apply(markdown, options.Rows);
+            writerOptions.SectionOrder = pipeline.InfoSectionNames;
+        writerOptions.RowWindow = RowWindow.ToMarkout(options.Rows);
+        var markdown = MarkoutSerializer.Serialize(view, InspectionContext.Default, writerOptions).TrimEnd();
         if (!options.Count)
             return markdown;
 

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -402,9 +402,8 @@ public static class OutputFormatter
 
         if (options.Format == OutputFormat.PlainText)
         {
-            ApplyLibraryRowWindow(writerOpts, options.Rows);
             WriteLfLine(Console.Out, SerializeLibraryPlainText(
-                auditView, inspection, writerOpts));
+                auditView, inspection, writerOpts, options.Rows));
         }
         else if (options.VerbosityEnabled)
         {
@@ -429,8 +428,13 @@ public static class OutputFormatter
     private static string SerializeLibraryPlainText(
         LibraryInspectionView auditView,
         LibraryInspection inspection,
-        MarkoutWriterOptions writerOpts)
+        MarkoutWriterOptions writerOpts,
+        RowWindow? rows)
     {
+        var includesMetadata = MetadataLensRenderer.IsSelected(writerOpts.IncludeSections);
+        if (!includesMetadata)
+            writerOpts.RowWindow = RowWindow.ToMarkout(rows);
+
         // Serialize into an LF writer rather than straight to Console.Out, whose ambient CRLF
         // would otherwise terminate lines whose interiors this branch already emits as LF —
         // the appended metadata is LF on every platform. Buffering matches the Markdown
@@ -453,7 +457,9 @@ public static class OutputFormatter
                 : plainText + "\n" + trimmedMetadata;
         }
 
-        return plainText;
+        return includesMetadata
+            ? MarkdownTableRowLimiter.Apply(plainText, rows)
+            : plainText;
     }
 
     private static void WriteReferenceTree(LibraryInspection inspection)
@@ -521,12 +527,6 @@ public static class OutputFormatter
 
         markdown = MarkdownSectionOrderer.Apply(markdown, pipeline.AlphabeticalSectionOrder);
         return MarkdownTableRowLimiter.Apply(markdown, rows);
-    }
-
-    private static void ApplyLibraryRowWindow(MarkoutWriterOptions writerOpts, RowWindow? rows)
-    {
-        if (!MetadataLensRenderer.IsSelected(writerOpts.IncludeSections))
-            writerOpts.RowWindow = RowWindow.ToMarkout(rows);
     }
 
     /// <summary>
@@ -636,11 +636,10 @@ public static class OutputFormatter
             {
                 var auditView = new LibraryInspectionView(inspection, topFieldsOnly);
                 var writerOpts = WriterOptions(inspection);
-                ApplyLibraryRowWindow(writerOpts, options.Rows);
                 var title = LibraryViewText.DocumentTitle(inspection);
                 var body = RemovePlainTextDocumentTitle(
                     SerializeLibraryPlainText(
-                        auditView, inspection, writerOpts),
+                        auditView, inspection, writerOpts, options.Rows),
                     LibraryViewText.DocumentTitle(auditView));
                 return body.Length == 0 ? title : title + "\n\n" + body;
             }));

--- a/src/dotnet-inspect/Output/RowSelection.cs
+++ b/src/dotnet-inspect/Output/RowSelection.cs
@@ -1,3 +1,5 @@
+using Markout;
+
 namespace DotnetInspector.Output;
 
 /// <summary>
@@ -63,6 +65,27 @@ public readonly record struct RowWindow
             ArgumentOutOfRangeException.ThrowIfLessThan(e, start);
         return new(RowWindowKind.Range, 0, start, end);
     }
+
+    /// <summary>
+    /// Projects this window onto the Markout writer option that applies it during
+    /// rendering. An unlimited window becomes <c>null</c>, because Markout expresses
+    /// "every row" by leaving <see cref="MarkoutWriterOptions.RowWindow"/> unset
+    /// rather than by carrying a negative count.
+    /// </summary>
+    public MarkoutRowWindow? ToMarkout() => Kind switch
+    {
+        _ when IsUnlimited => null,
+        RowWindowKind.Head => MarkoutRowWindow.Head(_count),
+        RowWindowKind.Tail => MarkoutRowWindow.Tail(_count),
+        RowWindowKind.Range => MarkoutRowWindow.Range(_start, _end),
+        _ => null,
+    };
+
+    /// <summary>
+    /// Null-tolerant form of <see cref="ToMarkout()"/>, for the common case of a
+    /// <c>--rows</c> option that may be absent.
+    /// </summary>
+    public static MarkoutRowWindow? ToMarkout(RowWindow? window) => window?.ToMarkout();
 
     /// <summary>
     /// Resolves this window against a table that rendered


### PR DESCRIPTION
## Summary

- move row-window selection and section ordering to `MarkoutWriterOptions` at the serialization seam
- apply the shared writer behavior across command output while preserving metadata composition, projection diagnostics, call-graph warnings, multi-assembly rendering, and LF framing
- adopt Markout 0.35.0 and its document-wide multi-section projection contract

## Design

Writer-level windowing replaces command-specific post-render limiting wherever the output remains a Markout document. The metadata-lens path remains an explicit exception: it appends rendered Markdown after serialization, so it must order and window only after composition to avoid applying non-idempotent ranges twice. Plain-text metadata composition uses the same post-composition fallback.

The package handoff uses the released Markout 0.35.0 package rather than the absolute project references used during co-development. `MarkdownTable.Formatting` remains at 0.3.4, matching the package dependency floor.

## Adversarial review

The first fixed-head review found two issues:

- type-listing Markdown could mix CRLF interiors with an LF terminator on Windows
- metadata-lens plain text silently ignored `--rows`

Both are fixed with regression tests. Final adversarial re-review of `00af5e54c` found no actionable issues.

## Verification

- complete Release CLI suite: 3,225 total, 3,211 passed, 14 skipped, 0 failed
- project-closure analyzer gate runs and passes with package references restored
- CI run 31334592491 is green at exact head `00af5e54c`

Part of #3624.