### PR TITLE
Build package aggregate sections with MarkoutTable

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -10834,6 +10834,40 @@ public partial class CommandExecutionTests
         Assert.DoesNotContain("Tip:", error);
     }
 
+    /// <summary>
+    /// The aggregate <c>--all-libraries</c> sections pool rows across libraries and pick their
+    /// columns from the pooled data, so they are declared as a runtime-column
+    /// <c>MarkoutTable</c> rather than appended as Markdown text. This is the gate for that
+    /// routing on the real command path: <c>--rows</c> must window the aggregate table even
+    /// though nothing post-processes the rendered document any more.
+    ///
+    /// The separator assertion is the observable signature of the routing. markout sizes a
+    /// separator to its header text; the hand-built table this replaced always emitted a fixed
+    /// <c>---</c>, so a revert to string building would restore <c>| --- | --- | --- |</c> and
+    /// fail here.
+    /// </summary>
+    [Fact]
+    public async Task PackageCommand_AllLibraries_AggregatedSection_WindowsRowsAtTheWriterSeam()
+    {
+        var (exit, all, _) = await RunAppAsync(
+            "package", "System.Text.Json", "--all-libraries", "-S", "Switches");
+        var (windowedExit, windowed, _) = await RunAppAsync(
+            "package", "System.Text.Json", "--all-libraries", "-S", "Switches", "--rows", "2");
+
+        Assert.Equal(0, exit);
+        Assert.Equal(0, windowedExit);
+        Assert.Contains("## Switches", all, StringComparison.Ordinal);
+        Assert.Contains("| Kind | Switch | API |", all, StringComparison.Ordinal);
+        Assert.Contains("| ---- | ------ | --- |", all, StringComparison.Ordinal);
+
+        static int DataRows(string output) =>
+            output.Split('\n').Count(line => line.StartsWith("| ", StringComparison.Ordinal))
+            - 2; // header and separator
+
+        Assert.True(DataRows(all) > 2, $"expected an unwindowed table wider than the window, got {DataRows(all)} rows");
+        Assert.Equal(2, DataRows(windowed));
+    }
+
     [Fact]
     public async Task LibraryCommand_DiscoverSwitchesCategory_ListsSwitchesSection()
     {

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -2731,4 +2731,72 @@ public class OutputFormatterTests
         var (_, error) = await ConsoleCapture.RunAsync(action);
         return error;
     }
+
+    /// <summary>
+    /// The aggregate <c>--all-libraries</c> sections declare a <see cref="MarkoutTable"/> rather
+    /// than appending Markdown, so their rows reach the writer and <c>--rows</c> applies at the
+    /// writer seam. This is the gate for that routing: a window set on the writer options must
+    /// drop rows from a runtime-column table it never saw at compile time.
+    /// </summary>
+    [Fact]
+    public void AggregatedSection_RowWindow_AppliesAtTheWriterSeam()
+    {
+        var document = new AggregatedSectionDocument
+        {
+            Sections =
+            [
+                new AggregatedSectionView
+                {
+                    Name = "Switches",
+                    Body = new MarkoutTable(
+                        ["Kind", "Switch"],
+                        [["AppContext", "A"], ["AppContext", "B"], ["Feature Switch", "C"]])
+                }
+            ]
+        };
+
+        var all = MarkoutSerializer.Serialize(document, InspectionContext.Default);
+        var windowed = MarkoutSerializer.Serialize(
+            document, InspectionContext.Default, OutputFormatter.CreateWindowedOptions(RowWindow.Head(2)));
+
+        Assert.Contains("## Switches", all, StringComparison.Ordinal);
+        Assert.Contains("| Feature Switch | C |", all, StringComparison.Ordinal);
+        Assert.DoesNotContain("| Feature Switch | C |", windowed, StringComparison.Ordinal);
+        Assert.Contains("| AppContext | B |", windowed, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Routing aggregate cells through markout's semantic code tag rather than literal backticks
+    /// corrects two escapes that a hand-written code span gets wrong, neither of which the
+    /// differential corpus exercises. This is the gate that keeps them fixed.
+    ///
+    /// A pipe must not become <c>&amp;#124;</c> inside a code span, where it would render as that
+    /// literal text; GFM unescapes <c>\|</c> while splitting table rows, before code spans are
+    /// parsed. A backtick must not be backslash-escaped, because backslash escapes do not apply
+    /// inside a code span; the delimiter has to be doubled instead.
+    /// </summary>
+    [Theory]
+    [InlineData("Foo.Bar(a|b)", "\\|")]
+    [InlineData("IEnumerable`1", "``")]
+    public void AggregatedSection_CodeCell_EscapesForACodeSpanRatherThanForPlainText(
+        string value, string expectedSpelling)
+    {
+        var document = new AggregatedSectionDocument
+        {
+            Sections =
+            [
+                new AggregatedSectionView
+                {
+                    Name = "Switches",
+                    Body = new MarkoutTable(["API"], [[MarkoutInline.Code(value)]])
+                }
+            ]
+        };
+
+        var rendered = MarkoutSerializer.Serialize(document, InspectionContext.Default);
+
+        Assert.Contains(expectedSpelling, rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("&#124;", rendered, StringComparison.Ordinal);
+        Assert.DoesNotContain("\\`", rendered, StringComparison.Ordinal);
+    }
 }

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.CommandLine.Parsing;
 using DotnetInspector.CommandLine;
 using DotnetInspector.Options;
+using DotnetInspector.Packages;
 using DotnetInspector.Services;
 
 namespace DotnetInspector.Tests.Parsers;
@@ -13,6 +14,9 @@ namespace DotnetInspector.Tests.Parsers;
 [Collection("Console")]
 public class MemberOptionsParserTests
 {
+    public MemberOptionsParserTests()
+        => NuGetCache.Initialize("dotnet-inspect");
+
     /// <summary>
     /// Creates the member command with shared options and args for testing.
     /// Mirrors ApiCommandDefinitions.CreateMemberCommand but exposes the args.

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -2943,15 +2943,33 @@ public class PackageCommand
         foreach (var section in sections)
         {
             if (IsAggregatedAllLibrariesSection(section))
-                AppendAggregatedSection(sb, section, inspections);
+                AppendAggregatedSection(sb, section, inspections, options.Rows);
             else
                 AppendPerLibrarySections(sb, section, inspections, options, pipeline);
         }
 
-        var markdown = sb.ToString().TrimEnd();
-        // Windowed as text rather than at the writer seam because AppendAggregatedSection
-        // hand-builds its tables into `sb`; the writer never sees those rows. See #3624.
-        return MarkdownTableRowLimiter.Apply(markdown, options.Rows);
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Renders one runtime-named, runtime-column section through the serializer so its rows reach
+    /// the writer, which is what applies <c>--rows</c>.
+    /// </summary>
+    private static void AppendAggregatedTable(StringBuilder sb, string section, MarkoutTable table, RowWindow? rows)
+    {
+        var document = new AggregatedSectionDocument
+        {
+            Sections = [new AggregatedSectionView { Name = section, Body = table }]
+        };
+        var rendered = MarkoutSerializer.Serialize(
+            document, InspectionContext.Default, OutputFormatter.CreateWindowedOptions(rows)).Trim();
+        if (rendered.Length == 0)
+            return;
+
+        if (sb.Length > 0 && !sb.ToString().EndsWith("\n\n", StringComparison.Ordinal))
+            sb.AppendLine();
+        sb.AppendLine(rendered);
+        sb.AppendLine();
     }
 
     private static bool IsAggregatedAllLibrariesSection(string section)
@@ -2959,7 +2977,7 @@ public class PackageCommand
            || section.Equals("Switches", StringComparison.OrdinalIgnoreCase)
            || LibraryIntegrationCatalog.All.Any(descriptor => descriptor.SectionName.Equals(section, StringComparison.OrdinalIgnoreCase));
 
-    private static void AppendAggregatedSection(StringBuilder sb, string section, List<LibraryInspection> inspections)
+    private static void AppendAggregatedSection(StringBuilder sb, string section, List<LibraryInspection> inspections, RowWindow? rows)
     {
         if (section.Equals(IntegrationSectionNames.Opportunities, StringComparison.OrdinalIgnoreCase))
         {
@@ -2979,13 +2997,12 @@ public class PackageCommand
             if (opportunityRows.Count == 0)
                 return;
 
-            AppendHeading(sb, section);
             var includeLibrary = opportunityRows.Select(row => row.Library).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1;
-            AppendTable(sb,
+            AppendAggregatedTable(sb, section, new MarkoutTable(
                 includeLibrary ? ["Library", "Integration", "API", "Integration Type", "Look For"] : ["Integration", "API", "Integration Type", "Look For"],
                 opportunityRows.Select(row => includeLibrary
                     ? new[] { CodeCell(row.Library), row.Integration, row.Api, row.IntegrationType, row.LookFor }
-                    : [row.Integration, row.Api, row.IntegrationType, row.LookFor]));
+                    : [row.Integration, row.Api, row.IntegrationType, row.LookFor]).ToList()), rows);
             return;
         }
 
@@ -3006,13 +3023,12 @@ public class PackageCommand
             if (switchRows.Count == 0)
                 return;
 
-            AppendHeading(sb, section);
             var includeLibrary = switchRows.Select(row => row.Library).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1;
-            AppendTable(sb,
+            AppendAggregatedTable(sb, section, new MarkoutTable(
                 includeLibrary ? ["Library", "Kind", "Switch", "API"] : ["Kind", "Switch", "API"],
                 switchRows.Select(row => includeLibrary
                     ? new[] { CodeCell(row.Library), row.Kind, row.Switch, row.Api }
-                    : [row.Kind, row.Switch, row.Api]));
+                    : [row.Kind, row.Switch, row.Api]).ToList()), rows);
             return;
         }
 
@@ -3038,7 +3054,6 @@ public class PackageCommand
         if (focusedRows.Count == 0)
             return;
 
-        AppendHeading(sb, section);
         var includeLibraryColumn = focusedRows.Select(row => row.Library).Distinct(StringComparer.OrdinalIgnoreCase).Count() > 1;
         var includeKindColumn = focusedRows.Select(row => row.Signal.Kind).Distinct(StringComparer.Ordinal).Count() > 1;
         var valueColumn = hasApis ? "API" : "Type";
@@ -3048,14 +3063,14 @@ public class PackageCommand
         if (includeKindColumn) headers.Add("Kind");
         headers.Add(valueColumn);
 
-        AppendTable(sb, headers, focusedRows.Select(row =>
+        AppendAggregatedTable(sb, section, new MarkoutTable(headers, focusedRows.Select(row =>
         {
             List<string> values = [];
             if (includeLibraryColumn) values.Add(CodeCell(row.Library));
             if (includeKindColumn) values.Add(row.Signal.Kind);
             values.Add(CodeCell(row.Signal.Name));
             return values.ToArray();
-        }));
+        }).ToList()), rows);
     }
 
     private static void AppendPerLibrarySections(
@@ -3087,7 +3102,10 @@ public class PackageCommand
         var writerOptions = new MarkoutWriterOptions
         {
             IncludeSections = [section],
-            Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields)
+            Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields),
+            // Windowed here rather than over the assembled document: the heading rewrite below is
+            // the only text this path edits, and it does not touch rows.
+            RowWindow = RowWindow.ToMarkout(options.Rows)
         };
         var markdown = MarkoutSerializer.Serialize(view, InspectionContext.Default, writerOptions).Trim();
         if (markdown.Length == 0)
@@ -3113,31 +3131,25 @@ public class PackageCommand
         return string.Join('\n', lines).Trim();
     }
 
-    private static void AppendHeading(StringBuilder sb, string section)
-    {
-        if (sb.Length > 0 && !sb.ToString().EndsWith("\n\n", StringComparison.Ordinal))
-            sb.AppendLine();
-        sb.AppendLine($"## {section}");
-        sb.AppendLine();
-    }
-
-    private static void AppendTable(StringBuilder sb, IReadOnlyList<string> headers, IEnumerable<string[]> rows)
-    {
-        sb.AppendLine($"| {string.Join(" | ", headers.Select(EscapeMarkdownCell))} |");
-        sb.AppendLine($"| {string.Join(" | ", headers.Select(_ => "---"))} |");
-        foreach (var row in rows)
-            sb.AppendLine($"| {string.Join(" | ", row.Select(EscapeMarkdownCell))} |");
-        sb.AppendLine();
-    }
-
-    private static string EscapeMarkdownCell(string value)
-        => value
-            .Replace("\r", " ", StringComparison.Ordinal)
-            .Replace("\n", " ", StringComparison.Ordinal)
-            .Replace("|", "&#124;", StringComparison.Ordinal);
-
-    private static string CodeCell(string value)
-        => $"`{value.Replace("`", "\\`", StringComparison.Ordinal)}`";
+    /// <summary>
+    /// Marks a cell as code using markout's semantic inline tag rather than literal backticks, so
+    /// the formatter owns the spelling.
+    /// </summary>
+    /// <remarks>
+    /// This also changes two escapes that hand-written backticks got wrong. A pipe was written as
+    /// <c>&amp;#124;</c>, which renders literally inside a code span; markout emits <c>\|</c>,
+    /// which GFM unescapes while splitting rows, before code spans are parsed. A backtick was
+    /// written as <c>\`</c>, but backslash escapes do not apply inside a code span; markout uses
+    /// the doubled-delimiter form instead.
+    ///
+    /// Both corrections are unverified against real data: no package in the differential corpus
+    /// produced a pipe or a backtick in these cells. They are reachable in principle — the
+    /// integration scanner takes raw metadata names, which carry arity backticks such as
+    /// <c>IEnumerable`1</c>, without the display-name normalization other scanners apply — but
+    /// that path is not exercised by a test, so treat this as a latent fix rather than an
+    /// observed one.
+    /// </remarks>
+    private static string CodeCell(string value) => MarkoutInline.Code(value);
 
     private static void WritePackageLibraryCandidates(
         string extractPath,

--- a/src/dotnet-inspect/Views/AggregatedSectionView.cs
+++ b/src/dotnet-inspect/Views/AggregatedSectionView.cs
@@ -1,0 +1,53 @@
+using Markout;
+
+namespace DotnetInspector.Views;
+
+/// <summary>
+/// One <c>--all-libraries</c> section whose heading and columns are both runtime values.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The aggregate sections (<c>Opportunities</c>, <c>Switches</c>, and the
+/// <c>LibraryIntegrationCatalog</c> descriptor sections) pool rows from every library in the
+/// package, and decide their columns from the pooled data: a <c>Library</c> column appears only
+/// when more than one library contributed, a <c>Kind</c> column only when the rows disagree on
+/// kind, and the value column is headed <c>API</c> or <c>Type</c> depending on the signal shape.
+/// A generated table cannot describe that, because the source generator derives columns from an
+/// element type's properties at compile time.
+/// </para>
+/// <para>
+/// <see cref="MarkoutTable"/> is the model shape for exactly this case, so these sections are
+/// declared rather than appended as text. That is what lets <c>--rows</c> apply at the writer
+/// seam: the writer sees the rows, so the window no longer has to be re-derived by parsing the
+/// rendered document back into tables.
+/// </para>
+/// </remarks>
+[MarkoutSerializable(TitleProperty = nameof(Name))]
+public class AggregatedSectionView
+{
+    /// <summary>
+    /// The section heading. Ignored as a field so it drives only the heading rather than also
+    /// appearing as a row.
+    /// </summary>
+    [MarkoutIgnore]
+    public string Name { get; set; } = "";
+
+    /// <summary>The pooled rows. Ignored in table context because a shape cannot be a cell.</summary>
+    [MarkoutIgnoreInTable]
+    public MarkoutTable? Body { get; set; }
+}
+
+/// <summary>
+/// Carries a single <see cref="AggregatedSectionView"/> so it is emitted as a level-2 section.
+/// </summary>
+/// <remarks>
+/// Sections are rendered one at a time rather than as a batch because the all-libraries document
+/// interleaves aggregate sections with per-library ones in the caller's requested order.
+/// </remarks>
+[MarkoutSerializable]
+public class AggregatedSectionDocument
+{
+    /// <summary>The section to emit.</summary>
+    [MarkoutUnwrap]
+    public List<AggregatedSectionView> Sections { get; set; } = [];
+}

--- a/src/dotnet-inspect/Views/AggregatedSectionView.cs
+++ b/src/dotnet-inspect/Views/AggregatedSectionView.cs
@@ -25,12 +25,18 @@ namespace DotnetInspector.Views;
 [MarkoutSerializable(TitleProperty = nameof(Name))]
 public class AggregatedSectionView
 {
+    private string _name = "";
+
     /// <summary>
     /// The section heading. Ignored as a field so it drives only the heading rather than also
     /// appearing as a row.
     /// </summary>
     [MarkoutIgnore]
-    public string Name { get; set; } = "";
+    public string Name
+    {
+        get => LibraryViewText.Contain(_name);
+        set => _name = value;
+    }
 
     /// <summary>The pooled rows. Ignored in table context because a shape cannot be a cell.</summary>
     [MarkoutIgnoreInTable]

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -747,6 +747,7 @@ public sealed record PackageSourceIntegritySection(
 [MarkoutContext(typeof(ManifestRow))]
 [MarkoutContext(typeof(RidPackageReferenceView))]
 [MarkoutContext(typeof(EmptyDepsView))]
+[MarkoutContext(typeof(AggregatedSectionDocument))]
 public partial class InspectionContext : MarkoutSerializerContext
 {
 }


### PR DESCRIPTION
## Summary

- replace hand-built package aggregate Markdown with runtime-column `MarkoutTable` sections
- route aggregate row windows through the same writer seam as generated tables
- preserve projection, count, TSV, JSONL, multi-assembly, and plain-text behavior
- contain runtime section titles and make parser tests initialize their NuGet cache explicitly

## Design

Package `--all-libraries` output pools rows across libraries, so its headers and columns are runtime data rather than a compile-time attributed shape. `AggregatedSectionView` models that directly with `MarkoutTable`; the serializer now owns escaping, separator sizing, row windows, projection, and structured decomposition instead of receiving pre-rendered Markdown.

Parent #3950 established writer-level row windows, section ordering, and Markout 0.35.0. After that PR squash-merged, both child commits were replayed onto `main`; `range-diff` proved them patch-identical to the reviewed stacked commits.

## Adversarial review

Final adversarial review of exact `main`-based head `c8afad86b` found no actionable issues. It verified format routing, single-application row windows, hostile header/cell containment, runtime table invariants, duplicate-row preservation, empty-section behavior, structured keys, output framing, and integration with the squash-merged parent.

## Verification

- complete Release CLI suite before the patch-identical restack: 3,229 total, 3,215 passed, 14 skipped, 0 failed
- post-restack solution build and four focused aggregate-window tests pass
- Markdown differences from the previous aggregate renderer are separator-padding only
- count, TSV, and JSONL output remain byte-identical
- CI run 31338006265 is green at exact head `c8afad86b`

Part of #3624.