### PR TITLE
Isolate HTTP client snapshot test from concurrent callers

### DIFF
--- a/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
+++ b/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
@@ -78,6 +78,7 @@ public class HttpClientFactoryTests : IDisposable
     public async Task CreateClient_CapturesOneOptionsSnapshot()
     {
         const string ClosedPort = "http://127.0.0.1:1/";
+        var observeCreation = new AsyncLocal<bool>();
         using var decoratorEntered = new ManualResetEventSlim();
         using var continueCreation = new ManualResetEventSlim();
 
@@ -88,6 +89,9 @@ public class HttpClientFactoryTests : IDisposable
         });
         DotnetInspector.Core.HttpClientFactory.SetAuthenticationDecorator(handler =>
         {
+            if (!observeCreation.Value)
+                return handler;
+
             decoratorEntered.Set();
             if (!continueCreation.Wait(
                 TimeSpan.FromSeconds(10),
@@ -96,8 +100,17 @@ public class HttpClientFactoryTests : IDisposable
             return handler;
         });
 
-        Task<HttpClient> creation = Task.Run(
+        using HttpClient unrelated = await Task.Run(
             DotnetInspector.Core.HttpClientFactory.CreateClient,
+            TestContext.Current.CancellationToken);
+        Assert.False(decoratorEntered.IsSet);
+
+        Task<HttpClient> creation = Task.Run(
+            () =>
+            {
+                observeCreation.Value = true;
+                return DotnetInspector.Core.HttpClientFactory.CreateClient();
+            },
             TestContext.Current.CancellationToken);
         try
         {


### PR DESCRIPTION
## Summary

- scope the `CreateClient_CapturesOneOptionsSnapshot` decorator gate to the intended task with `AsyncLocal`
- add a deterministic unrelated client creation that proves other concurrent callers cannot release the gate

## Why

The factory decorator is process-wide. The test previously treated the first decorator invocation as its own `CreateClient` task, but any parallel caller could enter it first. That released the test to install the second option set before the intended task captured the first, producing the observed `45s` versus `9s` failure in both #3950 and #3951.

## Verification

- `HttpClientFactoryTests`: 20 consecutive passes, 380/380 tests
- CI-equivalent fast lane: 2,315 total, 0 failed