### PR TITLE
Detect stale CRLF Windows checkouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,30 @@ with a temporary NuGet config that includes both the .NET 11 daily feed and
 nuget.org. Most projects target the nightly `net11.0` SDK, while a few fixture
 projects still target stable `net10.0` packs.
 
+### Refreshing an older Windows checkout
+
+`.gitattributes` pins tracked text files to LF, but Git may leave CRLF bytes in
+a Windows working tree created before that policy was added. The tree still
+appears clean because Git compares normalized content. Check the effective
+working-tree endings with:
+
+```powershell
+git ls-files --eol | Select-String 'w/(crlf|mixed).*eol=lf'
+```
+
+No output means the checkout follows the policy. If files are listed, run the
+following commands from the repository root. First commit or stash any work and
+confirm `git status --short` is empty, because the final command discards
+working-tree changes:
+
+```powershell
+git rm --cached -r .
+git reset --hard HEAD
+```
+
+`RepositoryLineEndingTests.TrackedLfFilesHaveLfWorkingTreeEndings` enforces the
+same check and prints this repair when a stale checkout reaches the test suite.
+
 ## What it inspects
 
 | Source | Examples | Notes |

--- a/src/dotnet-inspect.Tests/RepositoryLineEndingTests.cs
+++ b/src/dotnet-inspect.Tests/RepositoryLineEndingTests.cs
@@ -1,0 +1,154 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace DotnetInspector.Tests;
+
+public sealed class RepositoryLineEndingTests
+{
+    /// <summary>
+    /// Gate for the working-tree half of <c>.gitattributes</c>. Git normalizes
+    /// content before comparison, so <c>git status</c> cannot reveal a stale
+    /// Windows checkout whose tracked files remain CRLF after the LF policy was
+    /// added. Git's own EOL inventory supplies both the working-tree ending and
+    /// the effective attribute without guessing which files are text.
+    /// </summary>
+    [Fact]
+    public async Task TrackedLfFilesHaveLfWorkingTreeEndings()
+    {
+        string root = FindRepositoryRoot();
+        string inventory = await RunGitAsync(root, "ls-files", "--eol", "-z");
+        string[] records = inventory.Split('\0', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.NotEmpty(records);
+        Assert.Contains(
+            records,
+            static record =>
+                record.EndsWith(
+                    "\tsrc/dotnet-inspect.Tests/RepositoryLineEndingTests.cs",
+                    StringComparison.Ordinal)
+                && HasLfPolicy(record));
+
+        string[] offenders = FindUnexpectedWorkingTreeEndings(records);
+
+        Assert.True(
+            offenders.Length == 0,
+            $$"""
+            Tracked files declared eol=lf have CRLF or mixed working-tree endings:
+            {{string.Join(Environment.NewLine, offenders)}}
+
+            From the repository root on a clean working tree, refresh tracked files with:
+            git rm --cached -r .
+            git reset --hard HEAD
+            """);
+    }
+
+    [Fact]
+    public void LineEndingGateHonorsEffectiveGitAttributes()
+    {
+        string[] records =
+        [
+            "i/lf    w/lf    attr/text eol=lf\tgood.cs",
+            "i/lf    w/crlf  attr/text eol=lf\tstale.cs",
+            "i/lf    w/mixed attr/text eol=lf\tmixed.cs",
+            "i/-text w/-text attr/-text\tfixture.dll",
+            "i/lf    w/crlf  attr/text\tunconstrained.txt",
+        ];
+
+        Assert.Equal(
+            ["mixed.cs", "stale.cs"],
+            FindUnexpectedWorkingTreeEndings(records));
+    }
+
+    private static string[] FindUnexpectedWorkingTreeEndings(
+        IEnumerable<string> records)
+    {
+        var offenders = new List<string>();
+        foreach (string record in records)
+        {
+            int pathSeparator = record.IndexOf('\t');
+            if (pathSeparator < 0)
+                continue;
+
+            if (!HasLfPolicy(record)
+                || !WorkingTreeHasUnexpectedEnding(record[..pathSeparator]))
+            {
+                continue;
+            }
+
+            offenders.Add(record[(pathSeparator + 1)..]);
+        }
+
+        return [.. offenders.Order(StringComparer.Ordinal)];
+    }
+
+    private static bool HasLfPolicy(string record)
+    {
+        int pathSeparator = record.IndexOf('\t');
+        string metadata = pathSeparator < 0 ? record : record[..pathSeparator];
+        return metadata
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Contains("eol=lf", StringComparer.Ordinal);
+    }
+
+    private static bool WorkingTreeHasUnexpectedEnding(string metadata) =>
+        metadata
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Any(static field => field is "w/crlf" or "w/mixed");
+
+    private static async Task<string> RunGitAsync(
+        string workingDirectory,
+        params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo("git")
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+            UseShellExecute = false,
+        };
+        foreach (string argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        using Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start git.");
+        Task<string> stdout = process.StandardOutput.ReadToEndAsync();
+        Task<string> stderr = process.StandardError.ReadToEndAsync();
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(30));
+
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            throw;
+        }
+
+        string output = await stdout;
+        string error = await stderr;
+        Assert.True(
+            process.ExitCode == 0,
+            $"git {string.Join(' ', arguments)} failed with exit code {process.ExitCode}: {error}");
+        return output;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+            directory is not null;
+            directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+                return directory.FullName;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not find repository root containing dotnet-inspect.slnx.");
+    }
+}


### PR DESCRIPTION
## Summary

- gate tracked `eol=lf` files with Git's effective EOL inventory so an old Windows checkout cannot remain silently CRLF
- keep binary and unconstrained paths out of the gate by honoring effective Git attributes
- document a clean-tree refresh procedure beside contributor SDK setup

The gate reports the problem and remedy; it never rewrites a contributor's checkout automatically.

Closes #3611.

## Validation

- `dotnet build src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -class DotnetInspector.Tests.RepositoryLineEndingTests`
- real `i/lf w/crlf attr/eol=lf` canary failed with the tracked path, then passed after LF normalization
- `npx markdownlint-cli README.md`