### PR TITLE
Stabilize package concurrency tests on Windows

### DIFF
--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -66,7 +66,7 @@ internal sealed record PackageVersionResolution(
 public static class PackageExtractor
 {
     private const int MaxToolWrapperRedirectHops = 8;
-    private static readonly TimeSpan CachedVersionResolutionTimeout =
+    internal static TimeSpan CachedVersionResolutionTimeout { get; } =
         TimeSpan.FromSeconds(1);
 
     private static readonly AsyncCache<PackageAcquisitionRequest, PackageExtractionOutcome>

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -399,6 +399,8 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
     {
         using var ready = new CountdownEvent(2);
         using var start = new ManualResetEventSlim();
+        using var workersWaiting = new CountdownEvent(2);
+        using var releaseWorkers = new ManualResetEventSlim();
         using var cancellation = new CancellationTokenSource();
         int completedWorkers = 0;
 
@@ -406,21 +408,44 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             StartDedicatedWorker(
                 ready,
                 start,
-                () => Interlocked.Increment(ref completedWorkers));
+                () =>
+                {
+                    workersWaiting.Signal();
+                    releaseWorkers.Wait();
+                    return Interlocked.Increment(ref completedWorkers);
+                });
 
         Task<int> first = StartWorker();
         Task<int> second = StartWorker();
         cancellation.Cancel();
 
+        Task<(bool Ready, int[] Results)> completion =
+            WaitForAndJoinWorkersAsync(
+                ready,
+                start,
+                cancellation.Token,
+                first,
+                second);
+
+        bool bothWorkersWaiting;
+        bool completedBeforeRelease;
+        try
+        {
+            bothWorkersWaiting =
+                workersWaiting.WaitHandle.WaitOne(TimeSpan.FromSeconds(5));
+            completedBeforeRelease = completion.IsCompleted;
+        }
+        finally
+        {
+            releaseWorkers.Set();
+        }
+
         OperationCanceledException exception =
             await Assert.ThrowsAsync<OperationCanceledException>(
-                () => WaitForAndJoinWorkersAsync(
-                    ready,
-                    start,
-                    cancellation.Token,
-                    first,
-                    second));
+                () => completion);
 
+        Assert.True(bothWorkersWaiting);
+        Assert.False(completedBeforeRelease);
         Assert.Equal(cancellation.Token, exception.CancellationToken);
         Assert.True(first.IsCompletedSuccessfully);
         Assert.True(second.IsCompletedSuccessfully);

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -372,19 +372,13 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
                 Version,
                 TestSourceKey));
 
-        bool publishersReady = false;
-        try
-        {
-            publishersReady = ready.Wait(
-                TimeSpan.FromSeconds(5),
-                TestContext.Current.CancellationToken);
-        }
-        finally
-        {
-            start.Set();
-        }
-
-        CommittedPackage[] committed = await Task.WhenAll(publishA, publishB);
+        (bool publishersReady, CommittedPackage[] committed) =
+            await WaitForAndJoinWorkersAsync(
+                ready,
+                start,
+                TestContext.Current.CancellationToken,
+                publishA,
+                publishB);
         Assert.True(publishersReady);
 
         Assert.Equal(committed[0].ExtractPath, committed[1].ExtractPath);
@@ -398,6 +392,39 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             payloads,
             payload => Assert.Equal(winner, File.ReadAllText(payload)));
         AssertNoStagingDirectories(packageName);
+    }
+
+    [Fact]
+    public async Task WaitForAndJoinWorkersAsync_CancellationJoinsWorkersBeforeRethrowing()
+    {
+        using var ready = new CountdownEvent(2);
+        using var start = new ManualResetEventSlim();
+        using var cancellation = new CancellationTokenSource();
+        int completedWorkers = 0;
+
+        Task<int> StartWorker() =>
+            StartDedicatedWorker(
+                ready,
+                start,
+                () => Interlocked.Increment(ref completedWorkers));
+
+        Task<int> first = StartWorker();
+        Task<int> second = StartWorker();
+        cancellation.Cancel();
+
+        OperationCanceledException exception =
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => WaitForAndJoinWorkersAsync(
+                    ready,
+                    start,
+                    cancellation.Token,
+                    first,
+                    second));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.True(first.IsCompletedSuccessfully);
+        Assert.True(second.IsCompletedSuccessfully);
+        Assert.Equal(2, completedWorkers);
     }
 
     [Fact]
@@ -932,6 +959,10 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         var handler = new NeverAnsweringHandler();
         using var client = new HttpClient(handler);
 
+        Assert.Equal(
+            TimeSpan.FromSeconds(1),
+            PackageExtractor.CachedVersionResolutionTimeout);
+
         Task<PackageExtractionOutcome> extraction = PackageExtractor.ExtractPackageAsync(
             client,
             packageName,
@@ -1387,19 +1418,13 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         Task<CommittedPackage> publishA = Publish(sourceA, keyA);
         Task<CommittedPackage> publishB = Publish(sourceB, keyB);
 
-        bool publishersReady = false;
-        try
-        {
-            publishersReady = ready.Wait(
-                TimeSpan.FromSeconds(5),
-                TestContext.Current.CancellationToken);
-        }
-        finally
-        {
-            start.Set();
-        }
-
-        CommittedPackage[] committed = await Task.WhenAll(publishA, publishB);
+        (bool publishersReady, CommittedPackage[] committed) =
+            await WaitForAndJoinWorkersAsync(
+                ready,
+                start,
+                TestContext.Current.CancellationToken,
+                publishA,
+                publishB);
         Assert.True(publishersReady);
 
         Assert.NotEqual(committed[0].ExtractPath, committed[1].ExtractPath);
@@ -1557,6 +1582,43 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
             CancellationToken.None,
             TaskCreationOptions.LongRunning,
             TaskScheduler.Default);
+    }
+
+    private static async Task<(bool Ready, T[] Results)> WaitForAndJoinWorkersAsync<T>(
+        CountdownEvent ready,
+        ManualResetEventSlim start,
+        CancellationToken cancellationToken,
+        params Task<T>[] workers)
+    {
+        bool workersReady = false;
+        System.Runtime.ExceptionServices.ExceptionDispatchInfo? cancellation = null;
+        try
+        {
+            workersReady = ready.Wait(
+                TimeSpan.FromSeconds(5),
+                cancellationToken);
+        }
+        catch (OperationCanceledException exception)
+        {
+            cancellation =
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(exception);
+        }
+        finally
+        {
+            start.Set();
+        }
+
+        T[] results;
+        try
+        {
+            results = await Task.WhenAll(workers);
+        }
+        finally
+        {
+            cancellation?.Throw();
+        }
+
+        return (workersReady, results);
     }
 
     private static void AssertNoTemporaryDirectories(string prefix)

--- a/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
+++ b/src/dotnet-inspect.Tests/PackageAcquisitionConcurrencyTests.cs
@@ -353,35 +353,39 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         using var ready = new CountdownEvent(2);
         using var start = new ManualResetEventSlim();
 
-        Task<CommittedPackage> publishA = Task.Run(() =>
-        {
-            ready.Signal();
-            start.Wait();
-            return NuGetCache.CommitPackage(
+        Task<CommittedPackage> publishA = StartDedicatedWorker(
+            ready,
+            start,
+            () => NuGetCache.CommitPackage(
                 sourceA,
                 nupkgPath: null,
                 packageName,
                 Version,
-                TestSourceKey);
-        });
-        Task<CommittedPackage> publishB = Task.Run(() =>
-        {
-            ready.Signal();
-            start.Wait();
-            return NuGetCache.CommitPackage(
+                TestSourceKey));
+        Task<CommittedPackage> publishB = StartDedicatedWorker(
+            ready,
+            start,
+            () => NuGetCache.CommitPackage(
                 sourceB,
                 nupkgPath: null,
                 packageName,
                 Version,
-                TestSourceKey);
-        });
+                TestSourceKey));
 
-        Assert.True(
-            ready.Wait(
+        bool publishersReady = false;
+        try
+        {
+            publishersReady = ready.Wait(
                 TimeSpan.FromSeconds(5),
-                TestContext.Current.CancellationToken));
-        start.Set();
+                TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            start.Set();
+        }
+
         CommittedPackage[] committed = await Task.WhenAll(publishA, publishB);
+        Assert.True(publishersReady);
 
         Assert.Equal(committed[0].ExtractPath, committed[1].ExtractPath);
         string[] payloads = Directory.GetFiles(
@@ -925,22 +929,29 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
                 TestSourceKey);
         }
 
-        using var client = new HttpClient(new NeverAnsweringHandler());
-        var stopwatch = Stopwatch.StartNew();
+        var handler = new NeverAnsweringHandler();
+        using var client = new HttpClient(handler);
 
-        PackageExtractionOutcome outcome = await PackageExtractor.ExtractPackageAsync(
+        Task<PackageExtractionOutcome> extraction = PackageExtractor.ExtractPackageAsync(
             client,
             packageName,
             sourceOptions: s_nugetOrgSource);
 
-        stopwatch.Stop();
+        PackageExtractionOutcome outcome = await extraction.WaitAsync(
+            TimeSpan.FromSeconds(15),
+            TestContext.Current.CancellationToken);
+
         Assert.False(outcome.IsSuccess);
-        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(3), stopwatch.Elapsed.ToString());
         Assert.Contains("online lookup timed out", outcome.ErrorMessage);
         Assert.Contains("Locally cached versions: 2.0.0, 1.0.0", outcome.ErrorMessage);
         Assert.Contains(
             $"dotnet-inspect package {packageName}@2.0.0",
             outcome.ErrorMessage);
+        Assert.True(handler.RequestStarted.IsCompletedSuccessfully);
+        Assert.True(handler.CancellationObserved.IsCompletedSuccessfully);
+        Assert.True(
+            handler.CancellationDelay < TimeSpan.FromSeconds(5),
+            handler.CancellationDelay.ToString());
     }
 
     [Theory]
@@ -1362,19 +1373,34 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         using var ready = new CountdownEvent(2);
         using var start = new ManualResetEventSlim();
 
-        Task<CommittedPackage> Publish(string dir, string key) => Task.Run(() =>
-        {
-            ready.Signal();
-            start.Wait();
-            return NuGetCache.CommitPackage(dir, nupkgPath: null, packageName, Version, key);
-        });
+        Task<CommittedPackage> Publish(string dir, string key) =>
+            StartDedicatedWorker(
+                ready,
+                start,
+                () => NuGetCache.CommitPackage(
+                    dir,
+                    nupkgPath: null,
+                    packageName,
+                    Version,
+                    key));
 
         Task<CommittedPackage> publishA = Publish(sourceA, keyA);
         Task<CommittedPackage> publishB = Publish(sourceB, keyB);
 
-        Assert.True(ready.Wait(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
-        start.Set();
+        bool publishersReady = false;
+        try
+        {
+            publishersReady = ready.Wait(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            start.Set();
+        }
+
         CommittedPackage[] committed = await Task.WhenAll(publishA, publishB);
+        Assert.True(publishersReady);
 
         Assert.NotEqual(committed[0].ExtractPath, committed[1].ExtractPath);
         AssertNoStagingDirectories(packageName);
@@ -1512,6 +1538,25 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
         }
 
         return path;
+    }
+
+    private static Task<T> StartDedicatedWorker<T>(
+        CountdownEvent ready,
+        ManualResetEventSlim start,
+        Func<T> action)
+    {
+        // These tests exercise filesystem concurrency, not ThreadPool scheduling.
+        // Dedicated workers keep a loaded suite from consuming the readiness budget.
+        return Task.Factory.StartNew(
+            () =>
+            {
+                ready.Signal();
+                start.Wait();
+                return action();
+            },
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
     }
 
     private static void AssertNoTemporaryDirectories(string prefix)
@@ -1672,12 +1717,40 @@ public sealed class PackageAcquisitionConcurrencyTests : IDisposable
 
     private sealed class NeverAnsweringHandler : HttpMessageHandler
     {
+        private readonly TaskCompletionSource _requestStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _cancellationObserved =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private long _requestStartedTimestamp;
+        private long _cancellationObservedTimestamp;
+
+        public Task RequestStarted => _requestStarted.Task;
+
+        public Task CancellationObserved => _cancellationObserved.Task;
+
+        public TimeSpan CancellationDelay => Stopwatch.GetElapsedTime(
+            Volatile.Read(ref _requestStartedTimestamp),
+            Volatile.Read(ref _cancellationObservedTimestamp));
+
         protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-            throw new InvalidOperationException("The request should have been canceled.");
+            Volatile.Write(ref _requestStartedTimestamp, Stopwatch.GetTimestamp());
+            _requestStarted.TrySetResult();
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                throw new InvalidOperationException("The request should have been canceled.");
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                Volatile.Write(
+                    ref _cancellationObservedTimestamp,
+                    Stopwatch.GetTimestamp());
+                _cancellationObserved.TrySetResult();
+                throw;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- run package-publication race participants on dedicated workers so loaded Windows runners do not consume the five-second readiness budget
- measure the one-second cached-version timeout from HTTP request start to observed cancellation, with scheduling margin and a bounded deadlock guard
- preserve the timeout diagnostic and cached-pin assertions while ensuring failure paths join publisher workers

This is test-harness stabilization only; package acquisition behavior and the production timeout are unchanged.

Closes #3521.
Closes #3957.

## Validation

- `dotnet build src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release`
- 10 consecutive Windows runs of both publisher races and the cached-version timeout test on .NET 11 preview