### PR TITLE
Adopt typed API comparison query for diff Changes

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -52,11 +52,13 @@ the ownership boundaries below, not the project count.
 ## Implementation status
 
 `DotnetInspector.Queries` now implements metadata-image, direct-reference,
-extension-method, custom-attribute, SourceLink audit, assembly-context
-Integrations, and progressive member call-graph slices. The call-graph seam
-composes Analysis indexes and one catalog generation over workspace-owned
-immutable snapshots; it returns typed roots and diagnostics without choosing a
-renderer or graph format.
+extension-method, custom-attribute, SourceLink audit, API-comparison,
+assembly-context Integrations, and progressive member call-graph slices. The
+API-comparison seam retains Metadata-owned Finding correspondence and
+compatibility classification over two host-resolved surfaces. The call-graph
+seam composes Analysis indexes and one catalog generation over workspace-owned
+immutable snapshots; both return typed results without choosing a renderer or
+output format.
 The library CLI executes metadata-image, direct assembly-reference, and
 extension-method and custom-attribute queries through a typed, content-shaped
 registry over a host-owned `AssemblyInspectionSession`. The `References`,
@@ -230,8 +232,8 @@ consumer's convenience.
 
 ## Current migration state
 
-Metadata-image, direct-reference, extension-method, custom-attribute, and
-SourceLink inspection are the first vertical L1 canaries:
+Metadata-image, direct-reference, extension-method, custom-attribute,
+SourceLink, and API-comparison inspection are the first vertical L1 canaries:
 
 - `DotnetInspector.Queries` owns typed query definitions, typed result retrieval,
   prerequisite expansion, and query cost.
@@ -252,12 +254,17 @@ SourceLink inspection are the first vertical L1 canaries:
 - `SourceAvailabilityQuery` and `SourceIntegrityQuery` consume that prerequisite
   and return explicit `Available`, `Absent`, or `Failed` outcomes. Availability
   and Missing Files share one query result.
+- `ApiComparisonQuery` consumes two already-resolved API surfaces and retains
+  both their Finding correspondence and Metadata-owned compatibility
+  classification. The `diff` command keeps endpoint acquisition and member
+  filtering host-owned.
 - Library and package sections bind to the same SourceLink query definitions.
   Package owns compatible/highest-TFM asset selection and aggregation, not a
   parallel audit implementation.
-- Metadata sections, `References`, `Library Info`, `Extension Methods`, and
-  `Custom Attributes` bind to query definitions by object identity. A section
-  may bind multiple definitions; diagnostic names are never lookup keys.
+- Metadata sections, `References`, `Library Info`, `Extension Methods`,
+  `Custom Attributes`, and diff `Changes` bind to query definitions by object
+  identity. A section may bind multiple definitions; diagnostic names are
+  never lookup keys.
 - An executor can read only its declared transitive prerequisite results. A
   hidden dependency therefore fails whether or not another requested query
   happened to populate the shared run, and cannot understate cost.
@@ -282,7 +289,10 @@ These are canaries, not the completed split. The remaining boundaries are
 intentional and visible:
 
 - Other library facets still use `ScannerRegistry`, string keys, and shared
-  `LibraryInspection` mutation.
+  `LibraryInspection` mutation. Diff Analysis, Implementation, and Finding
+  Transition production still runs directly from the command while their
+  presentation-shaped residual result contracts are separated from reusable
+  query results.
 - L2 currently registers assembly queries through a `ScannerContext` adapter so
   typed queries and legacy scanners can borrow one metadata session. SourceLink
   queries instead receive their narrower host-neutral context.
@@ -313,8 +323,8 @@ still neither typed nor demand-driven:
   queries without materializing `LibraryInspection`.
 - The binding to residual collection is a **nullable string key** for the
   remaining scanner-backed sections. Metadata, `References`, `Library Info`,
-  `Extension Methods`, `Custom Attributes`, and SourceLink sections use checked
-  query-definition bindings.
+  `Extension Methods`, `Custom Attributes`, SourceLink, and diff `Changes`
+  sections use checked query-definition bindings.
 - The collection context is **path-shaped**, so a consumer without a filesystem
   cannot call the residual `LibraryMetadataService` orchestration. The
   implemented queries themselves take a borrowed content owner, not a path.

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -15,10 +15,13 @@ shared contracts, not dynamically loaded plugins.
 
 This document describes the target core architecture and the principles that
 govern its migration. Library metadata, direct-reference, extension-method,
-custom-attribute, and SourceLink inspection are the first typed-query canaries:
-the section catalog plans typed demand and executes it through a
-prerequisite-aware registry, while the command still owns orchestration. The
-library CLI and package
+custom-attribute, SourceLink, and API-comparison inspection are the first
+typed-query canaries: section catalogs plan typed demand and execute it through
+prerequisite-aware registries, while commands still own orchestration. The
+`diff` Changes section consumes one API-comparison result over host-resolved
+surfaces, retaining Metadata-owned Finding correspondence and compatibility
+classification without coupling the query to endpoint acquisition or output.
+The library CLI and package
 `--all-libraries` now use an ephemeral workspace for focused Integrations
 demand. One binding-consistent assembly context group scans every selected
 participant sequentially, preserves per-assembly identity, provenance, and

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,8 +11,9 @@ core: workspace contexts, typed query planning, acquisition and caching, shared
 identity and provenance, owner-issued correspondence, and safe presentation
 boundaries. Typed query-planning slices are implemented for library
 metadata-image, direct-reference, extension-method, custom-attribute,
-SourceLink, and Integrations inspection. The library CLI and package
-`--all-libraries` use the first
+SourceLink, Integrations, and API-comparison inspection. The `diff` Changes
+section consumes the API-comparison result over host-resolved surfaces. The
+library CLI and package `--all-libraries` use the first
 workspace-backed, group-scoped query for focused Integrations demand while
 remaining query families are future work. The components below are the current
 hosts, shared substrates, and inspection producers that will extend that space.
@@ -21,8 +22,8 @@ hosts, shared substrates, and inspection producers that will extend that space.
 - `src/DotnetInspector.Queries/` contains host-neutral typed query definitions,
   deterministic synchronous/asynchronous execution, prerequisite-aware cost,
   and content-shaped metadata, reference, extension-method, custom-attribute,
-  and SourceLink queries. It has no Markout, console, or filesystem-path
-  dependency.
+  SourceLink, API-comparison, and progressive call-graph queries. It has no
+  Markout, console, or filesystem-path dependency.
 - `src/ILInspector.Metadata/` reads PE metadata and portable-PDB structure: named documents, checksums, sequence-point relationships/ranges, raw custom-debug-information blobs, API surfaces, method classification, and assembly details. `MetadataFindings` projects API and portable-PDB build-context observations onto the shared Finding spine while retaining compatibility classification through `ApiDiff`.
 - `src/ILInspector.SourceLink/` sits above Metadata and SourceLinkFetch. It owns SourceLink map extraction, canonical document paths, URL decoration, provenance, high-level type/member/IL-offset resolution, source-document/member-source Findings, and SourceLink-aware debug audits.
 - `src/SourceLinkFetch/` owns the dependency-free SourceLink map matcher and provenance grammar.

--- a/src/DotnetInspector.Queries.Tests/ApiComparisonQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ApiComparisonQueryTests.cs
@@ -1,0 +1,57 @@
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class ApiComparisonQueryTests
+{
+    [Fact]
+    public void Execute_RetainsFindingCorrespondenceAndCompatibilityClassification()
+    {
+        var oldSurface = new ApiSurface();
+        var newSurface = new ApiSurface
+        {
+            Types =
+            [
+                new ApiType
+                {
+                    Namespace = "Sample",
+                    Name = "Widget",
+                    Kind = "class",
+                },
+            ],
+        };
+
+        ApiFindingComparison comparison =
+            ApiComparisonQuery.Execute(oldSurface, newSurface);
+
+        var types = Assert.IsType<FindingComparison<ApiTypeHandle>.Complete>(
+            comparison.Types.Value);
+        Assert.Contains(types.Pairs, pair => pair is PairFinding<ApiTypeHandle>.Added);
+        TypeDiff typeDiff = Assert.Single(comparison.ApiDiff.TypeDiffs);
+        Assert.Equal("Sample.Widget", typeDiff.TypeFullName);
+        Assert.Equal(ChangeKind.TypeAdded, Assert.Single(typeDiff.Changes).Kind);
+    }
+
+    [Fact]
+    public void RegistryRun_UsesDefinitionIdentityAndNetworkFreeCost()
+    {
+        var registry = new InspectionQueryRegistry<(ApiSurface Old, ApiSurface New)>()
+            .Add(
+                ApiComparisonQuery.Definition,
+                static context => ApiComparisonQuery.Execute(
+                    context.Old,
+                    context.New));
+
+        InspectionQueryResults results = registry.Run(
+            [ApiComparisonQuery.Definition],
+            (new ApiSurface(), new ApiSurface()));
+
+        Assert.Same(
+            results.Get(ApiComparisonQuery.Definition),
+            results.Get(ApiComparisonQuery.Definition));
+        Assert.Equal(
+            InspectionCost.NetworkFree,
+            registry.CostOf(ApiComparisonQuery.Definition));
+    }
+}

--- a/src/DotnetInspector.Queries/ApiComparisonQuery.cs
+++ b/src/DotnetInspector.Queries/ApiComparisonQuery.cs
@@ -1,0 +1,27 @@
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// Compares two already-resolved API surfaces and retains both their Finding correspondence and
+/// Metadata-owned compatibility classification.
+/// </summary>
+public static class ApiComparisonQuery
+{
+    public static InspectionQuery<ApiFindingComparison> Definition { get; } =
+        new("API comparison", InspectionCost.NetworkFree);
+
+    public static ApiFindingComparison Execute(ApiSurface oldSurface, ApiSurface newSurface)
+    {
+        ArgumentNullException.ThrowIfNull(oldSurface);
+        ArgumentNullException.ThrowIfNull(newSurface);
+
+        return MetadataFindings.CompareApi(
+            oldSurface,
+            newSurface,
+            new FindingSubject("api", "API surface"),
+            new ApiDiffOptions(ApiDiffScope.Signature),
+            memberAcceptanceThreshold: MetadataFindings.ExtensionInstanceMatchTier.Confidence);
+    }
+}

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -168,6 +168,32 @@ public partial class CommandExecutionTests
         assemblyBuilder.Save(path);
     }
 
+    private static void WriteApiDiffQueryAssembly(string path, bool includeAddedMethod)
+    {
+        var assemblyName = new AssemblyName("ApiDiffQueryFixture");
+        var assemblyBuilder = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            assemblyName,
+            typeof(object).Assembly);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule(assemblyName.Name!);
+        var typeBuilder = moduleBuilder.DefineType(
+            "Sample.Widget",
+            TypeAttributes.Public | TypeAttributes.Class);
+        typeBuilder.DefineDefaultConstructor(MethodAttributes.Public);
+
+        if (includeAddedMethod)
+        {
+            var method = typeBuilder.DefineMethod(
+                "Added",
+                MethodAttributes.Public,
+                typeof(void),
+                Type.EmptyTypes);
+            method.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+        }
+
+        typeBuilder.CreateType();
+        assemblyBuilder.Save(path);
+    }
+
     private static void WriteResourceAssembly(
         string path,
         params (string Name, byte[] Content)[] resources)
@@ -2571,6 +2597,46 @@ public partial class CommandExecutionTests
         Assert.Contains("5 additive", output);
         Assert.Contains("JsonKnownReferenceHandler", output);
         Assert.DoesNotContain("JsonSerializer |", output);
+    }
+
+    [Fact]
+    public async Task Diff_Changes_LocalPair_RendersTypedApiComparisonInMarkdownAndJson()
+    {
+        var tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"diff-query-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var oldPath = Path.Combine(tempDir, "old.dll");
+            var newPath = Path.Combine(tempDir, "new.dll");
+            WriteApiDiffQueryAssembly(oldPath, includeAddedMethod: false);
+            WriteApiDiffQueryAssembly(newPath, includeAddedMethod: true);
+            var range = $"{oldPath}..{newPath}";
+
+            var markdown = await RunAppAsync(
+                "diff", "--library", range,
+                "-S", DiffSections.Changes.Name,
+                "--tips", "q");
+            var json = await RunAppAsync(
+                "diff", "--library", range,
+                "-S", DiffSections.Changes.Name,
+                "--json", "--tips", "q");
+
+            Assert.Equal(0, markdown.Exit);
+            Assert.Empty(markdown.Error);
+            Assert.Contains("### Widget", markdown.Output);
+            Assert.Contains("Added", markdown.Output);
+            Assert.Equal(0, json.Exit);
+            Assert.Empty(json.Error);
+            Assert.Contains("\"changes\"", json.Output);
+            Assert.Contains("\"type\": \"Widget\"", json.Output);
+            Assert.Contains("Added", json.Output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1650,6 +1650,82 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void DiffQueryRegistry_RegistrationMatchesDeclaration()
+    {
+        DiffSectionCatalog catalog = DiffSections.CreateCatalog();
+
+        HashSet<InspectionQueryDefinition> closure =
+            catalog.QueryRegistry.ExpandRequired(catalog.Pipeline.DeclaredQueries);
+
+        Assert.Equal(
+            closure.OrderBy(query => query.Name, StringComparer.Ordinal),
+            catalog.QueryRegistry.RegisteredQueries.OrderBy(
+                query => query.Name,
+                StringComparer.Ordinal));
+        Assert.Equal(
+            [ApiComparisonQuery.Definition],
+            catalog.Pipeline.DeclaredQueries);
+    }
+
+    [Fact]
+    public void DiffChangesSection_DemandsOnlyApiComparisonQuery()
+    {
+        DiffSectionCatalog catalog = DiffSections.CreateCatalog();
+        var changes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            DiffSections.Changes.Name,
+        };
+        var analysis = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            DiffSections.AnalysisDiff.Name,
+        };
+
+        Assert.Equal(
+            [ApiComparisonQuery.Definition],
+            catalog.Pipeline.GetRequiredQueries(Verbosity.Minimal, changes));
+        Assert.Equal(
+            [ApiComparisonQuery.Definition],
+            catalog.Pipeline.GetRequiredQueries(Verbosity.Minimal));
+        Assert.Empty(
+            catalog.Pipeline.GetRequiredQueries(Verbosity.Minimal, analysis));
+        Assert.Equal(
+            SectionCost.NetworkFree,
+            Assert.Single(
+                catalog.Pipeline.SectionCosts,
+                section => section.Name == DiffSections.Changes.Name).Cost);
+    }
+
+    [Fact]
+    public void DiffQueryRegistry_RunsOnlySelectedSectionDemand()
+    {
+        DiffSectionCatalog catalog = DiffSections.CreateCatalog();
+        var context = new DiffQueryContext(new ApiSurface(), new ApiSurface());
+        List<InspectionQueryDefinition> executed = [];
+        var analysis = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            DiffSections.AnalysisDiff.Name,
+        };
+
+        catalog.QueryRegistry.Run(
+            catalog.Pipeline.GetRequiredQueries(Verbosity.Minimal, analysis),
+            context,
+            (query, _) => executed.Add(query));
+        Assert.Empty(executed);
+
+        catalog.QueryRegistry.Run(
+            catalog.Pipeline.GetRequiredQueries(
+                Verbosity.Minimal,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    DiffSections.Changes.Name,
+                }),
+            context,
+            (query, _) => executed.Add(query));
+
+        Assert.Equal([ApiComparisonQuery.Definition], executed);
+    }
+
+    [Fact]
     public void PackageIntegrityExitCode_FailsOnlyForMismatches()
     {
         var clean = new InspectionResult

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1726,6 +1726,43 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void DiffCommand_AllocRegressionsDoesNotRequestUnusedChangesQuery()
+    {
+        DiffSectionCatalog catalog = DiffSections.CreateCatalog();
+
+        HashSet<InspectionQueryDefinition> singleSection =
+            DiffCommand.GetRequestedQueries(
+                catalog.Pipeline,
+                new DiffOptions
+                {
+                    AllocRegressionsOnly = true,
+                    IncludeSections = new HashSet<string>(
+                        StringComparer.OrdinalIgnoreCase)
+                    {
+                        DiffSections.Changes.Name,
+                    },
+                });
+        HashSet<InspectionQueryDefinition> composedDocument =
+            DiffCommand.GetRequestedQueries(
+                catalog.Pipeline,
+                new DiffOptions
+                {
+                    AllocRegressionsOnly = true,
+                    IncludeSections = new HashSet<string>(
+                        StringComparer.OrdinalIgnoreCase)
+                    {
+                        DiffSections.Changes.Name,
+                        DiffSections.AnalysisDiff.Name,
+                    },
+                });
+
+        Assert.Empty(singleSection);
+        Assert.Equal(
+            [ApiComparisonQuery.Definition],
+            composedDocument);
+    }
+
+    [Fact]
     public void PackageIntegrityExitCode_FailsOnlyForMismatches()
     {
         var clean = new InspectionResult

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -192,17 +192,8 @@ public class DiffCommand
 
             try
             {
-                HashSet<string>? querySections = options.IncludeSections;
-                if (querySections is null && options.AllocRegressionsOnly)
-                {
-                    querySections = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-                    {
-                        DiffSections.AnalysisDiff.Name,
-                    };
-                }
-
                 HashSet<InspectionQueryDefinition> requestedQueries =
-                    pipeline.GetRequiredQueries(Verbosity.Minimal, querySections);
+                    GetRequestedQueries(pipeline, options);
                 InspectionQueryResults queryResults = catalog.QueryRegistry.Run(
                     requestedQueries,
                     new DiffQueryContext(inputs.FromSurface, inputs.ToSurface));
@@ -711,6 +702,35 @@ public class DiffCommand
 
     private static bool SelectsDetailedChanges(DiffOptions options)
         => options.IncludeSections?.Contains(DiffSections.Changes.Name) == true;
+
+    internal static HashSet<InspectionQueryDefinition> GetRequestedQueries(
+        SectionPipeline<DiffDiscoveryModel> pipeline,
+        DiffOptions options)
+    {
+        bool writesDocument =
+            options.JsonOutput
+            || options.IncludeSections is { Count: > 1 };
+        HashSet<string>? querySections = options.IncludeSections;
+
+        if (writesDocument)
+        {
+            if (querySections is null && options.AllocRegressionsOnly)
+            {
+                querySections = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    DiffSections.AnalysisDiff.Name,
+                };
+            }
+        }
+        else if (SelectsFindingTransitions(options)
+            || SelectsImplementationDiff(options)
+            || SelectsAnalysisDiff(options))
+        {
+            return [];
+        }
+
+        return pipeline.GetRequiredQueries(Verbosity.Minimal, querySections);
+    }
 
     private static async Task WriteSelectedDocumentAsync(
         DiffInputs inputs,

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -3,6 +3,7 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Queries;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
@@ -25,7 +26,8 @@ public class DiffCommand
     public const string Name = "diff";
     public static async Task<int> ExecuteAsync(DiffOptions options)
     {
-        var pipeline = DiffSections.CreatePipeline();
+        DiffSectionCatalog catalog = DiffSections.CreateCatalog();
+        var pipeline = catalog.Pipeline;
         var selectResult = SelectResolver.ResolveSelectAsSections(
             options.Select, pipeline.SelectableSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap(),
             selectDefault: options.SelectDefault);
@@ -190,11 +192,27 @@ public class DiffCommand
 
             try
             {
+                HashSet<string>? querySections = options.IncludeSections;
+                if (querySections is null && options.AllocRegressionsOnly)
+                {
+                    querySections = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        DiffSections.AnalysisDiff.Name,
+                    };
+                }
+
+                HashSet<InspectionQueryDefinition> requestedQueries =
+                    pipeline.GetRequiredQueries(Verbosity.Minimal, querySections);
+                InspectionQueryResults queryResults = catalog.QueryRegistry.Run(
+                    requestedQueries,
+                    new DiffQueryContext(inputs.FromSurface, inputs.ToSurface));
+
                 if (options.JsonOutput || options.IncludeSections is { Count: > 1 })
                 {
                     await WriteSelectedDocumentAsync(
                         inputs,
                         options,
+                        queryResults,
                         context.HttpClient,
                         logger);
                     return 0;
@@ -281,7 +299,11 @@ public class DiffCommand
                     return 0;
                 }
 
-                var diff = BuildApiDiff(inputs.FromSurface, inputs.ToSurface, options);
+                var diff = BuildApiDiff(
+                    queryResults.Get(ApiComparisonQuery.Definition),
+                    inputs.FromSurface,
+                    inputs.ToSurface,
+                    options);
 
                 if (options.Tabular)
                 {
@@ -693,6 +715,7 @@ public class DiffCommand
     private static async Task WriteSelectedDocumentAsync(
         DiffInputs inputs,
         DiffOptions options,
+        InspectionQueryResults queryResults,
         HttpClient httpClient,
         VerboseLogger logger)
     {
@@ -707,7 +730,11 @@ public class DiffCommand
         DiffDetailedChangesView? changesView = null;
         if (selected.Contains(DiffSections.Changes.Name))
         {
-            var diff = BuildApiDiff(inputs.FromSurface, inputs.ToSurface, options);
+            var diff = BuildApiDiff(
+                queryResults.Get(ApiComparisonQuery.Definition),
+                inputs.FromSurface,
+                inputs.ToSurface,
+                options);
             changesView = DiffOutputFormatter.BuildDetailedChangesView(
                 inputs.Name,
                 ApplyFilters(diff, options),
@@ -1167,15 +1194,19 @@ public class DiffCommand
     }
 
     internal static ApiDiff BuildApiDiff(ApiSurface fromSurface, ApiSurface toSurface, DiffOptions options)
+        => BuildApiDiff(
+            ApiComparisonQuery.Execute(fromSurface, toSurface),
+            fromSurface,
+            toSurface,
+            options);
+
+    private static ApiDiff BuildApiDiff(
+        ApiFindingComparison comparison,
+        ApiSurface fromSurface,
+        ApiSurface toSurface,
+        DiffOptions options)
     {
-        var diff = ResearchDiff.Compare(
-                ResearchDiffInput.FromApiSurface(fromSurface),
-                ResearchDiffInput.FromApiSurface(toSurface),
-                new ResearchDiffOptions(
-                    ResearchChangeMechanism.Api,
-                    IncludeAllApi: options.IncludeAll,
-                    ApiScope: ApiDiffScope.Signature)).ApiDiff
-            ?? new ApiDiff();
+        var diff = comparison.ApiDiff;
 
         if (options.MemberFilter.Count == 0)
             return diff;

--- a/src/dotnet-inspect/Sections/DiffSections.cs
+++ b/src/dotnet-inspect/Sections/DiffSections.cs
@@ -1,19 +1,53 @@
+using DotnetInspector.Queries;
+using ILInspector.Metadata;
 using Markout;
 
 namespace DotnetInspector.Sections;
 
 public sealed record DiffDiscoveryModel;
 
+public sealed record DiffQueryContext(
+    ApiSurface FromSurface,
+    ApiSurface ToSurface);
+
+public sealed record DiffSectionCatalog(
+    SectionPipeline<DiffDiscoveryModel> Pipeline,
+    InspectionQueryRegistry<DiffQueryContext> QueryRegistry);
+
 public static class DiffSections
 {
+    public static DiffSectionCatalog CreateCatalog()
+    {
+        var queryRegistry = CreateQueryRegistry();
+        return new DiffSectionCatalog(
+            CreatePipeline(queryRegistry.CostOf),
+            queryRegistry);
+    }
+
     public static SectionPipeline<DiffDiscoveryModel> CreatePipeline()
     {
+        var queryRegistry = CreateQueryRegistry();
+        return CreatePipeline(queryRegistry.CostOf);
+    }
+
+    private static SectionPipeline<DiffDiscoveryModel> CreatePipeline(
+        Func<InspectionQueryDefinition, InspectionCost> queryCost)
+    {
         return new SectionPipeline<DiffDiscoveryModel>()
-            .Add<Changes>()
+            .UseQueryCosts(queryCost)
+            .Add<Changes>(ApiComparisonQuery.Definition)
             .Add<AnalysisDiff>()
             .Add<ImplementationDiff>()
             .Add<FindingTransitions>();
     }
+
+    public static InspectionQueryRegistry<DiffQueryContext> CreateQueryRegistry()
+        => new InspectionQueryRegistry<DiffQueryContext>()
+            .Add(
+                ApiComparisonQuery.Definition,
+                static context => ApiComparisonQuery.Execute(
+                    context.FromSurface,
+                    context.ToSurface));
 
     public static DocumentSchema CreateSchema()
     {


### PR DESCRIPTION
## What

The `diff` Changes section now plans and executes one typed API-comparison
query instead of invoking the comparison producer directly from command
rendering.

- Adds `ApiComparisonQuery`, returning Metadata-owned
  `ApiFindingComparison`.
- Binds `DiffSections.Changes` to that definition by object identity and
  derives its NetworkFree cost from the query registry.
- Plans query demand after package/platform/local endpoints are resolved.
- Preserves the existing extension static/instance correspondence tier,
  member filtering and diagnostics, and Markdown/tabular/JSON output.
- Keeps Analysis Diff, Implementation Diff, Finding Transitions, endpoint
  acquisition, and rendering host-owned for later slices.

This builds on the declared section/query model from #3229. It is the first
`diff` vertical canary rather than a scanner-style mutable aggregate.

## Demand boundary

Default and explicitly selected Changes views request the comparison. Composed
documents request it only when they contain Changes. Single Analysis,
Implementation, Finding Transitions, and allocation-analysis paths do not run
unused API comparison work.

## Evidence

- Release solution build succeeds.
- `DotnetInspector.Queries.Tests`: 42 passed.
- Fast `dotnet-inspect.Tests`: 2,308 passed, 12 expected environment skips.
- Focused section/diff tests: 344 passed.
- A compiled local old/new assembly gate proves the command renders the added
  API member in both Markdown and JSON.
- Changed Markdown passes `markdownlint`; `git diff --check` passes.

## Review

More than trivial, not high risk: one MAI-Code review required.

The first fixed-head review found an unused query under
`--alloc-regressions -S Changes`. Commit `65e46104` makes demand planning follow
the command's actual branch precedence and adds a non-vacuous regression gate.
MAI-Code re-reviewed exact head `65e46104` and reported no blocking findings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
