### PR TITLE
Add annotated source highlighter prototype

### DIFF
--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -527,6 +527,13 @@ contained surrogate and therefore reversible. That containment is what makes the
 document's own rule — `Text` is well-formed UTF-16, and an unpaired surrogate is
 rejected rather than repaired — one a producer already satisfies: the malformed
 value is visible ASCII by the time a document is built.
+
+The first independent consumer is
+`prototypes/annotated-source-viewer/`. It derives lines from `Text`, uses the
+absolute spans directly as JavaScript UTF-16 indexes, follows
+`fact → target → node → spans → text`, highlights separated runs without
+selecting interleaved IL, and keeps targetless facts visible. Its model tests
+pin those consumer-side assumptions without importing the decompiler.
 Production is opt-in and uses
 an isolated import: printing and style lenses mutate IR, so sharing that graph
 would let selecting the payload alter sibling projections.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -42,6 +42,10 @@ hosts, shared substrates, and inspection producers that will extend that space.
   and nuspec parsing.
 - `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and structural annotated IL from method bodies.
 - `src/ILInspector.Research/` owns the offset-keyed fact overlay above Analysis and Decompiler: its registry orders fact producers, joins R1 analysis occurrences with R2 decompiler projections, and projects facts into the Annotated Source, annotated IL, and Facts views used by `member`.
+- `prototypes/annotated-source-viewer/` is the dependency-free browser consumer
+  for `AnnotatedSourceDocument`: it derives lines from the canonical text buffer,
+  resolves facts through targets to multi-span nodes, and keeps unanchored facts
+  visible without inventing coordinates.
 - `tools/DecompilerHarness/` owns ReturnToSender closure discovery and type-cluster planning. RTS specifies the required Metadata/CSharp request shape; `ILInspector.CSharp` owns rendering it.
 
 ## Engineering guidance

--- a/prototypes/annotated-source-viewer/README.md
+++ b/prototypes/annotated-source-viewer/README.md
@@ -1,0 +1,38 @@
+# Annotated source viewer
+
+This dependency-free browser prototype consumes the exact
+`AnnotatedSourceDocument` JSON emitted by `dotnet-inspect`. It demonstrates the
+portable contract without re-running the decompiler:
+
+- lines and line numbers are derived from the canonical `text` buffer;
+- JavaScript string indexes consume the document's UTF-16 span coordinates
+  directly;
+- clicking a fact follows `fact → target → node → spans → text`;
+- clicking source text chooses the tightest structural node at that offset;
+- one node can highlight several separated spans without selecting interleaved
+  IL;
+- C# and IL lines can be hidden independently without rebasing coordinates;
+- facts with no targets remain visible as explicitly unanchored observations.
+
+## Run
+
+```bash
+cd prototypes/annotated-source-viewer
+npm test
+npm run dev
+```
+
+Open <http://127.0.0.1:5199>. The built-in sample includes a multi-span C#
+`ForLoop`, two IL instructions, a cross-medium allocation fact, and an
+unanchored member-header fact.
+
+Load a real document produced by the CLI:
+
+```bash
+dotnet-inspect member MyType --library MyLibrary.dll MyMethod:1 \
+  -S "Annotated Source Document" --json > document.json
+```
+
+Use **load JSON** in the viewer and select `document.json`. Input strings are
+HTML-escaped before rendering, and the viewer validates IDs, targets, spans,
+bounds, and UTF-16 before accepting a payload.

--- a/prototypes/annotated-source-viewer/index.html
+++ b/prototypes/annotated-source-viewer/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Interactive highlighter for dotnet-inspect AnnotatedSourceDocument JSON."
+    />
+    <title>Annotated source viewer</title>
+    <link rel="stylesheet" href="./src/styles.css" />
+  </head>
+  <body>
+    <main id="app"></main>
+    <script type="module" src="./src/app.js"></script>
+  </body>
+</html>

--- a/prototypes/annotated-source-viewer/package.json
+++ b/prototypes/annotated-source-viewer/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dotnet-inspect-annotated-source-viewer",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "node server.js",
+    "test": "node --test"
+  }
+}

--- a/prototypes/annotated-source-viewer/server.js
+++ b/prototypes/annotated-source-viewer/server.js
@@ -1,0 +1,54 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { dirname, extname, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const port = Number.parseInt(process.env.PORT ?? "5199", 10);
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".json", "application/json; charset=utf-8"],
+]);
+
+export function createViewerServer(directory = root) {
+  return createServer(async (request, response) => {
+    let relativePath;
+    try {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      relativePath = url.pathname === "/" ? "index.html" : decodeURIComponent(url.pathname.slice(1));
+    } catch {
+      response.writeHead(400).end("Malformed request path");
+      return;
+    }
+    const path = resolve(directory, relativePath);
+
+    if (path !== directory && !path.startsWith(directory + sep)) {
+      response.writeHead(403).end("Forbidden");
+      return;
+    }
+
+    try {
+      const content = await readFile(path);
+      response.writeHead(200, {
+        "Content-Type": contentTypes.get(extname(path)) ?? "application/octet-stream",
+        "Cache-Control": "no-store",
+      });
+      response.end(content);
+    } catch (error) {
+      if (error?.code === "ENOENT" || error?.code === "EISDIR") {
+        response.writeHead(404).end("Not found");
+        return;
+      }
+      response.writeHead(500).end("Failed to read the requested file");
+      console.error(error);
+    }
+  });
+}
+
+if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  createViewerServer().listen(port, "127.0.0.1", () => {
+    console.log(`Annotated source viewer: http://127.0.0.1:${port}`);
+  });
+}

--- a/prototypes/annotated-source-viewer/src/app.js
+++ b/prototypes/annotated-source-viewer/src/app.js
@@ -1,0 +1,246 @@
+import {
+  buildLines,
+  lineMedium,
+  nodeIdsForFact,
+  nodesAtOffset,
+  parseDocument,
+  segmentsForLine,
+  unanchoredFacts,
+  validateDocument,
+} from "./document-model.js";
+import { sampleDocument } from "./sample-document.js";
+
+const app = document.querySelector("#app");
+let sourceDocument = validateDocument(structuredClone(sampleDocument));
+let sourceName = "Built-in multi-span sample";
+let selectedFactId = null;
+let selectedNodeIds = new Set();
+let showCSharp = true;
+let showIl = true;
+let error = "";
+
+function render() {
+  const lines = buildLines(sourceDocument.text);
+  const anchoredFacts = sourceDocument.facts.filter(fact => nodeIdsForFact(sourceDocument, fact.id).length > 0);
+  const looseFacts = unanchoredFacts(sourceDocument);
+  const selectedNodes = [...selectedNodeIds].map(id => sourceDocument.nodes[id]).filter(Boolean);
+
+  app.innerHTML = `
+    <header class="titlebar">
+      <div>
+        <p class="eyebrow">dotnet-inspect prototype</p>
+        <h1>Annotated source viewer</h1>
+      </div>
+      <div class="load-actions">
+        <span class="source-name">${escapeHtml(sourceName)}</span>
+        <label class="button" for="document-file">load JSON</label>
+        <input id="document-file" type="file" accept=".json,application/json" />
+        <button id="load-sample" type="button">sample</button>
+      </div>
+    </header>
+    ${error ? `<div class="error" role="alert">${escapeHtml(error)}</div>` : ""}
+    <section class="summarybar">
+      <span><strong>${sourceDocument.nodes.length}</strong> nodes</span>
+      <span><strong>${sourceDocument.facts.length}</strong> facts</span>
+      <span><strong>${sourceDocument.targets.length}</strong> targets</span>
+      <span><strong>${looseFacts.length}</strong> unanchored</span>
+      <div class="medium-toggles" aria-label="Visible source media">
+        ${mediumToggle("CSharp", "C#", showCSharp)}
+        ${mediumToggle("Il", "IL", showIl)}
+      </div>
+    </section>
+    <div class="workspace">
+      <section class="code-panel" aria-label="Annotated source text">
+        <div class="panel-heading">
+          <div>
+            <p class="eyebrow">Canonical text</p>
+            <h2>UTF-16 buffer</h2>
+          </div>
+          <p>Click text to select its tightest node. Line numbers are derived from newlines.</p>
+        </div>
+        <div class="code-scroll">
+          ${lines.map(line => renderLine(line)).join("")}
+        </div>
+      </section>
+      <aside class="inspector">
+        <section>
+          <div class="panel-heading compact">
+            <div><p class="eyebrow">Selection</p><h2>${selectionTitle(selectedNodes)}</h2></div>
+            ${selectedNodeIds.size ? `<button id="clear-selection" type="button">clear</button>` : ""}
+          </div>
+          ${renderSelection(selectedNodes)}
+        </section>
+        <section>
+          <div class="panel-heading compact">
+            <div><p class="eyebrow">Semantic plane</p><h2>Facts</h2></div>
+          </div>
+          <div class="fact-list">
+            ${anchoredFacts.map(renderFact).join("")}
+          </div>
+        </section>
+        <section>
+          <div class="panel-heading compact">
+            <div><p class="eyebrow">No invented coordinate</p><h2>Unanchored facts</h2></div>
+          </div>
+          <div class="fact-list">
+            ${looseFacts.length ? looseFacts.map(renderFact).join("") : `<p class="empty">None</p>`}
+          </div>
+        </section>
+        <section>
+          <div class="panel-heading compact">
+            <div><p class="eyebrow">Structural plane</p><h2>Nodes</h2></div>
+          </div>
+          <div class="node-list">
+            ${sourceDocument.nodes.map(renderNodeButton).join("")}
+          </div>
+        </section>
+      </aside>
+    </div>`;
+
+  bindEvents();
+}
+
+function renderLine(line) {
+  const medium = lineMedium(sourceDocument, line);
+  const segments = segmentsForLine(sourceDocument, line, selectedNodeIds);
+  const content = segments.length
+    ? segments.map(segment => {
+        const nodes = segment.nodeIds.map(id => sourceDocument.nodes[id]);
+        const title = nodes.map(node => `#${node.id} ${node.kind}`).join(" · ");
+        const segmentMedia = segment.media.length
+          ? segment.media
+          : medium === "Mixed" ? ["CSharp", "Il"] : [medium];
+        const visible = segmentMedia.some(value => value === "Il" ? showIl : showCSharp);
+        return `<span
+          class="code-segment${segment.selected ? " selected" : ""}${segment.nodeIds.length ? " addressable" : ""}${visible ? "" : " segment-hidden"}"
+          data-offset="${segment.start}"
+          title="${escapeHtml(title)}"
+        >${escapeHtml(segment.text)}</span>`;
+      }).join("")
+    : " ";
+
+  return `<div class="code-line medium-${medium.toLowerCase()}">
+    <span class="line-number">${line.number}</span>
+    <span class="medium-label">${medium === "Il" ? "IL" : medium === "Mixed" ? "C#/IL" : "C#"}</span>
+    <code>${content}</code>
+  </div>`;
+}
+
+function renderFact(fact) {
+  const nodeIds = nodeIdsForFact(sourceDocument, fact.id);
+  const active = selectedFactId === fact.id;
+  return `<button class="fact${active ? " active" : ""}" type="button" data-fact-id="${fact.id}">
+    <span class="fact-title"><strong>${escapeHtml(fact.descriptor)}</strong><small>${escapeHtml(fact.category)}</small></span>
+    ${fact.detail ? `<span>${escapeHtml(fact.detail)}</span>` : ""}
+    <span class="fact-meta">${escapeHtml(fact.origin)} · ${nodeIds.length ? `${nodeIds.length} target${nodeIds.length === 1 ? "" : "s"}` : "unanchored"}</span>
+  </button>`;
+}
+
+function renderNodeButton(node) {
+  const active = selectedNodeIds.has(node.id);
+  return `<button class="node-chip${active ? " active" : ""}" type="button" data-node-id="${node.id}">
+    <span>#${node.id}</span>
+    <strong>${escapeHtml(node.kind)}</strong>
+    <small>${node.medium} · ${node.spans.length} span${node.spans.length === 1 ? "" : "s"}</small>
+  </button>`;
+}
+
+function renderSelection(nodes) {
+  if (nodes.length === 0) {
+    return `<p class="empty">Select a fact, node, or source substring.</p>`;
+  }
+  return `<div class="selection-list">${nodes.map(node => `
+    <article>
+      <div><strong>#${node.id} ${escapeHtml(node.kind)}</strong><span class="badge">${node.medium}</span></div>
+      <p>${node.spans.map(span => `[${span.start}..${span.start + span.length})`).join(" · ")}</p>
+      ${node.il_offset == null ? "" : `<p>IL_${node.il_offset.toString(16).padStart(4, "0").toUpperCase()}</p>`}
+    </article>`).join("")}</div>`;
+}
+
+function selectionTitle(nodes) {
+  if (selectedFactId != null) return `Fact #${selectedFactId} targets`;
+  if (nodes.length === 1) return `Node #${nodes[0].id}`;
+  if (nodes.length > 1) return `${nodes.length} nodes`;
+  return "Nothing selected";
+}
+
+function mediumToggle(value, label, checked) {
+  return `<label><input type="checkbox" data-medium-toggle="${value}"${checked ? " checked" : ""} /> ${label}</label>`;
+}
+
+function bindEvents() {
+  document.querySelector("#document-file")?.addEventListener("change", loadFile);
+  document.querySelector("#load-sample")?.addEventListener("click", () => {
+    sourceDocument = validateDocument(structuredClone(sampleDocument));
+    sourceName = "Built-in multi-span sample";
+    resetSelection();
+    error = "";
+    render();
+  });
+  document.querySelector("#clear-selection")?.addEventListener("click", () => {
+    resetSelection();
+    render();
+  });
+  document.querySelectorAll("[data-medium-toggle]").forEach(input => {
+    input.addEventListener("change", event => {
+      if (event.currentTarget.dataset.mediumToggle === "Il") showIl = event.currentTarget.checked;
+      else showCSharp = event.currentTarget.checked;
+      render();
+    });
+  });
+  document.querySelectorAll("[data-fact-id]").forEach(button => {
+    button.addEventListener("click", event => selectFact(Number(event.currentTarget.dataset.factId)));
+  });
+  document.querySelectorAll("[data-node-id]").forEach(button => {
+    button.addEventListener("click", event => selectNode(Number(event.currentTarget.dataset.nodeId)));
+  });
+  document.querySelectorAll(".code-segment.addressable").forEach(segment => {
+    segment.addEventListener("click", event => {
+      const offset = Number(event.currentTarget.dataset.offset);
+      const node = nodesAtOffset(sourceDocument, offset)[0];
+      if (node) selectNode(node.id);
+    });
+  });
+}
+
+async function loadFile(event) {
+  const file = event.currentTarget.files?.[0];
+  if (!file) return;
+  try {
+    sourceDocument = parseDocument(await file.text());
+    sourceName = file.name;
+    resetSelection();
+    error = "";
+  } catch (loadError) {
+    error = loadError instanceof Error ? loadError.message : String(loadError);
+  }
+  render();
+}
+
+function selectFact(factId) {
+  selectedFactId = factId;
+  selectedNodeIds = new Set(nodeIdsForFact(sourceDocument, factId));
+  render();
+}
+
+function selectNode(nodeId) {
+  selectedFactId = null;
+  selectedNodeIds = new Set([nodeId]);
+  render();
+}
+
+function resetSelection() {
+  selectedFactId = null;
+  selectedNodeIds = new Set();
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+render();

--- a/prototypes/annotated-source-viewer/src/document-model.js
+++ b/prototypes/annotated-source-viewer/src/document-model.js
@@ -2,6 +2,7 @@ const media = new Set(["CSharp", "Il"]);
 const conditionalities = new Set(["Always", "CachedOnce", "PerIteration"]);
 const origins = new Set(["Body", "MemberHeader"]);
 const regionRoles = new Set(["Construct", "Header", "Body", "Else", "Catch", "Finally", "Case"]);
+const maxInt32 = 2_147_483_647;
 
 export function parseDocument(json) {
   const document = JSON.parse(json);
@@ -36,8 +37,11 @@ export function validateDocument(document) {
     validateSpans(node.spans, document.text.length, `nodes[${index}].spans`);
 
     const hasIlOffset = node.il_offset != null;
-    if (hasIlOffset && (!Number.isInteger(node.il_offset) || node.il_offset < 0)) {
-      throw new TypeError(`Node ${index} IL offset must be a non-negative integer or null.`);
+    if (
+      hasIlOffset
+      && (!Number.isInteger(node.il_offset) || node.il_offset < 0 || node.il_offset > maxInt32)
+    ) {
+      throw new TypeError(`Node ${index} IL offset must be a non-negative 32-bit integer or null.`);
     }
     const instruction = node.kind === "Instruction";
     if (instruction !== (node.medium === "Il" && hasIlOffset)) {
@@ -76,8 +80,14 @@ export function validateDocument(document) {
       }
       validateUtf16(fact.detail, `facts[${index}].detail`);
     }
-    if (!Number.isInteger(fact.source_offset) || fact.source_offset < -1) {
-      throw new TypeError(`Fact ${index} source offset must be -1 or a non-negative integer.`);
+    if (
+      !Number.isInteger(fact.source_offset)
+      || fact.source_offset < -1
+      || fact.source_offset > maxInt32
+    ) {
+      throw new TypeError(
+        `Fact ${index} source offset must be -1 or a non-negative 32-bit integer.`,
+      );
     }
     if (fact.origin === "MemberHeader" && fact.source_offset !== -1) {
       throw new TypeError(`Member-header fact ${index} must have source offset -1.`);

--- a/prototypes/annotated-source-viewer/src/document-model.js
+++ b/prototypes/annotated-source-viewer/src/document-model.js
@@ -1,0 +1,274 @@
+const media = new Set(["CSharp", "Il"]);
+const conditionalities = new Set(["Always", "CachedOnce", "PerIteration"]);
+const origins = new Set(["Body", "MemberHeader"]);
+const regionRoles = new Set(["Construct", "Header", "Body", "Else", "Catch", "Finally", "Case"]);
+
+export function parseDocument(json) {
+  const document = JSON.parse(json);
+  validateDocument(document);
+  return document;
+}
+
+export function validateDocument(document) {
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    throw new TypeError("The payload must be an AnnotatedSourceDocument object.");
+  }
+  if (typeof document.text !== "string") {
+    throw new TypeError("The document text must be a string.");
+  }
+  validateUtf16(document.text, "text");
+
+  for (const property of ["nodes", "regions", "facts", "targets"]) {
+    if (!Array.isArray(document[property])) {
+      throw new TypeError(`The document ${property} must be an array.`);
+    }
+  }
+
+  let previousIlOffset = -1;
+  document.nodes.forEach((node, index) => {
+    if (node?.id !== index) {
+      throw new TypeError(`Node ids must be contiguous; slot ${index} has id ${node?.id}.`);
+    }
+    if (typeof node.kind !== "string" || !media.has(node.medium)) {
+      throw new TypeError(`Node ${index} must have a string kind and a known medium.`);
+    }
+    validateUtf16(node.kind, `nodes[${index}].kind`);
+    validateSpans(node.spans, document.text.length, `nodes[${index}].spans`);
+
+    const hasIlOffset = node.il_offset != null;
+    if (hasIlOffset && (!Number.isInteger(node.il_offset) || node.il_offset < 0)) {
+      throw new TypeError(`Node ${index} IL offset must be a non-negative integer or null.`);
+    }
+    const instruction = node.kind === "Instruction";
+    if (instruction !== (node.medium === "Il" && hasIlOffset)) {
+      throw new TypeError(`Node ${index} kind, medium, and IL offset do not identify one instruction.`);
+    }
+    if (hasIlOffset && node.il_offset <= previousIlOffset) {
+      throw new TypeError("IL instruction offsets must be unique and strictly increasing in node order.");
+    }
+    if (hasIlOffset) previousIlOffset = node.il_offset;
+  });
+
+  document.regions.forEach((region, index) => {
+    if (!regionRoles.has(region?.role)) {
+      throw new TypeError(`Region ${index} must have a known role.`);
+    }
+    validateSpans(region.spans, document.text.length, `regions[${index}].spans`);
+  });
+
+  const factIdentities = new Set();
+  document.facts.forEach((fact, index) => {
+    if (fact?.id !== index) {
+      throw new TypeError(`Fact ids must be contiguous; slot ${index} has id ${fact?.id}.`);
+    }
+    for (const property of ["descriptor", "category", "conditionality", "origin"]) {
+      if (typeof fact[property] !== "string") {
+        throw new TypeError(`Fact ${index} must have a string ${property}.`);
+      }
+      validateUtf16(fact[property], `facts[${index}].${property}`);
+    }
+    if (!conditionalities.has(fact.conditionality) || !origins.has(fact.origin)) {
+      throw new TypeError(`Fact ${index} must have a known conditionality and origin.`);
+    }
+    if (fact.detail != null) {
+      if (typeof fact.detail !== "string") {
+        throw new TypeError(`Fact ${index} detail must be a string or null.`);
+      }
+      validateUtf16(fact.detail, `facts[${index}].detail`);
+    }
+    if (!Number.isInteger(fact.source_offset) || fact.source_offset < -1) {
+      throw new TypeError(`Fact ${index} source offset must be -1 or a non-negative integer.`);
+    }
+    if (fact.origin === "MemberHeader" && fact.source_offset !== -1) {
+      throw new TypeError(`Member-header fact ${index} must have source offset -1.`);
+    }
+
+    const identity = JSON.stringify([
+      fact.descriptor,
+      fact.category,
+      fact.conditionality,
+      fact.detail ?? null,
+      fact.source_offset,
+      fact.origin,
+    ]);
+    if (factIdentities.has(identity)) {
+      throw new TypeError(`Fact ${index} repeats an existing semantic identity.`);
+    }
+    factIdentities.add(identity);
+  });
+
+  const seenTargets = new Set();
+  document.targets.forEach((target, index) => {
+    if (!Number.isInteger(target?.fact_id) || !document.facts[target.fact_id]) {
+      throw new TypeError(`Target ${index} names a fact that does not exist.`);
+    }
+    if (!Number.isInteger(target.node_id) || !document.nodes[target.node_id]) {
+      throw new TypeError(`Target ${index} names a node that does not exist.`);
+    }
+    const key = `${target.fact_id}:${target.node_id}`;
+    if (seenTargets.has(key)) {
+      throw new TypeError(`Target ${index} repeats ${key}.`);
+    }
+    seenTargets.add(key);
+
+    const fact = document.facts[target.fact_id];
+    const node = document.nodes[target.node_id];
+    if (fact.origin !== "Body") {
+      throw new TypeError(`Target ${index} anchors a fact that is not about the member body.`);
+    }
+    if (node.medium === "Il" && node.il_offset !== fact.source_offset) {
+      throw new TypeError(`Target ${index} anchors an IL instruction at the wrong source offset.`);
+    }
+  });
+
+  return document;
+}
+
+export function buildLines(text) {
+  const lines = [];
+  let start = 0;
+
+  for (let index = 0; index < text.length; index++) {
+    if (text[index] !== "\n") continue;
+    lines.push({
+      number: lines.length + 1,
+      start,
+      end: index,
+      text: text.slice(start, index),
+    });
+    start = index + 1;
+  }
+
+  lines.push({
+    number: lines.length + 1,
+    start,
+    end: text.length,
+    text: text.slice(start),
+  });
+  return lines;
+}
+
+export function lineMedium(document, line) {
+  const lineMedia = new Set(
+    document.nodes
+      .filter(node => node.spans.some(span => intersectsLine(span, line)))
+      .map(node => node.medium),
+  );
+  if (lineMedia.size > 1) return "Mixed";
+  return lineMedia.has("Il") ? "Il" : "CSharp";
+}
+
+export function nodeIdsForFact(document, factId) {
+  return document.targets
+    .filter(target => target.fact_id === factId)
+    .map(target => target.node_id);
+}
+
+export function unanchoredFacts(document) {
+  const targeted = new Set(document.targets.map(target => target.fact_id));
+  return document.facts.filter(fact => !targeted.has(fact.id));
+}
+
+export function nodesAtOffset(document, offset, medium = null) {
+  return document.nodes
+    .filter(node => medium == null || node.medium === medium)
+    .map(node => ({
+      node,
+      containingLength: Math.min(
+        ...node.spans
+          .filter(span => span.start <= offset && offset < span.start + span.length)
+          .map(span => span.length),
+      ),
+    }))
+    .filter(candidate => Number.isFinite(candidate.containingLength))
+    .sort((left, right) =>
+      left.containingLength - right.containingLength
+      || nodeLength(left.node) - nodeLength(right.node)
+      || left.node.id - right.node.id)
+    .map(candidate => candidate.node);
+}
+
+export function segmentsForLine(document, line, selectedNodeIds = []) {
+  const boundaries = new Set([line.start, line.end]);
+  const intersections = new Map();
+
+  for (const node of document.nodes) {
+    for (const span of node.spans) {
+      const start = Math.max(line.start, span.start);
+      const end = Math.min(line.end, span.start + span.length);
+      if (start >= end) continue;
+      boundaries.add(start);
+      boundaries.add(end);
+      const spans = intersections.get(node.id) ?? [];
+      spans.push({ start, end });
+      intersections.set(node.id, spans);
+    }
+  }
+
+  const selected = new Set(selectedNodeIds);
+  const ordered = [...boundaries].sort((left, right) => left - right);
+  const segments = [];
+
+  for (let index = 0; index < ordered.length - 1; index++) {
+    const start = ordered[index];
+    const end = ordered[index + 1];
+    if (start === end) continue;
+    const nodes = document.nodes
+      .filter(node => intersections.get(node.id)?.some(span => span.start <= start && end <= span.end))
+      .sort((left, right) => nodeLength(left) - nodeLength(right) || left.id - right.id);
+    const nodeIds = nodes.map(node => node.id);
+    segments.push({
+      start,
+      end,
+      text: document.text.slice(start, end),
+      nodeIds,
+      media: [...new Set(nodes.map(node => node.medium))],
+      selected: nodeIds.some(id => selected.has(id)),
+    });
+  }
+
+  return segments;
+}
+
+function validateSpans(spans, textLength, name) {
+  if (!Array.isArray(spans) || spans.length === 0) {
+    throw new TypeError(`${name} must contain at least one span.`);
+  }
+  let previousEnd = -1;
+  spans.forEach((span, index) => {
+    if (!Number.isInteger(span?.start) || !Number.isInteger(span.length) || span.length <= 0) {
+      throw new TypeError(`${name}[${index}] must contain integer start and positive length.`);
+    }
+    const end = span.start + span.length;
+    if (span.start < 0 || end > textLength) {
+      throw new TypeError(`${name}[${index}] is outside the document text.`);
+    }
+    if (index > 0 && span.start <= previousEnd) {
+      throw new TypeError(`${name} must be ordered, separated, and non-overlapping.`);
+    }
+    previousEnd = end;
+  });
+}
+
+function validateUtf16(value, name) {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code < 0xd800 || code > 0xdfff) continue;
+    if (code <= 0xdbff && index + 1 < value.length) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        index++;
+        continue;
+      }
+    }
+    throw new TypeError(`${name} contains malformed UTF-16 at offset ${index}.`);
+  }
+}
+
+function intersectsLine(span, line) {
+  return span.start < line.end && line.start < span.start + span.length;
+}
+
+function nodeLength(node) {
+  return node.spans.reduce((sum, span) => sum + span.length, 0);
+}

--- a/prototypes/annotated-source-viewer/src/document-model.js
+++ b/prototypes/annotated-source-viewer/src/document-model.js
@@ -44,7 +44,10 @@ export function validateDocument(document) {
       throw new TypeError(`Node ${index} IL offset must be a non-negative 32-bit integer or null.`);
     }
     const instruction = node.kind === "Instruction";
-    if (instruction !== (node.medium === "Il" && hasIlOffset)) {
+    if (instruction && node.medium !== "Il") {
+      throw new TypeError(`Node ${index} kind identifies an instruction outside IL text.`);
+    }
+    if (instruction !== hasIlOffset) {
       throw new TypeError(`Node ${index} kind, medium, and IL offset do not identify one instruction.`);
     }
     if (hasIlOffset && node.il_offset <= previousIlOffset) {
@@ -139,13 +142,14 @@ export function buildLines(text) {
   let start = 0;
 
   for (let index = 0; index < text.length; index++) {
-    if (text[index] !== "\n") continue;
+    if (text[index] !== "\r" && text[index] !== "\n") continue;
     lines.push({
       number: lines.length + 1,
       start,
       end: index,
       text: text.slice(start, index),
     });
+    if (text[index] === "\r" && text[index + 1] === "\n") index++;
     start = index + 1;
   }
 

--- a/prototypes/annotated-source-viewer/src/sample-document.js
+++ b/prototypes/annotated-source-viewer/src/sample-document.js
@@ -1,0 +1,97 @@
+const header = "for (var i = 0; i < 2; i++)";
+const initialize = "IL_0000: ldc.i4.0";
+const open = "{";
+const body = "    return new object();";
+const allocate = "IL_0001: newobj instance void System.Object::.ctor()";
+const close = "}";
+const lines = [header, initialize, open, body, allocate, close];
+const starts = [];
+let cursor = 0;
+
+for (const line of lines) {
+  starts.push(cursor);
+  cursor += line.length + 1;
+}
+
+const text = lines.join("\n");
+const objectStart = starts[3] + body.indexOf("new object()");
+
+export const sampleDocument = {
+  text,
+  nodes: [
+    {
+      id: 0,
+      kind: "ForLoop",
+      medium: "CSharp",
+      spans: [
+        { start: starts[0], length: header.length + 1 },
+        { start: starts[2], length: open.length + 1 + body.length + 1 },
+        { start: starts[5], length: close.length },
+      ],
+    },
+    {
+      id: 1,
+      kind: "NewObject",
+      medium: "CSharp",
+      spans: [{ start: objectStart, length: "new object()".length }],
+    },
+    {
+      id: 2,
+      kind: "Instruction",
+      medium: "Il",
+      spans: [{ start: starts[1], length: initialize.length }],
+      il_offset: 0,
+    },
+    {
+      id: 3,
+      kind: "Instruction",
+      medium: "Il",
+      spans: [{ start: starts[4], length: allocate.length }],
+      il_offset: 1,
+    },
+  ],
+  regions: [
+    {
+      role: "Body",
+      spans: [
+        { start: starts[2], length: open.length + 1 + body.length + 1 },
+        { start: starts[5], length: close.length },
+      ],
+    },
+  ],
+  facts: [
+    {
+      id: 0,
+      descriptor: "alloc.new",
+      category: "Allocation",
+      conditionality: "Always",
+      detail: "object",
+      source_offset: 1,
+      origin: "Body",
+    },
+    {
+      id: 1,
+      descriptor: "cost.loop",
+      category: "Cost",
+      conditionality: "Always",
+      detail: "2 iterations",
+      source_offset: 0,
+      origin: "Body",
+    },
+    {
+      id: 2,
+      descriptor: "cost.method",
+      category: "Cost",
+      conditionality: "Always",
+      detail: "header-only observation",
+      source_offset: -1,
+      origin: "MemberHeader",
+    },
+  ],
+  targets: [
+    { fact_id: 0, node_id: 1 },
+    { fact_id: 0, node_id: 3 },
+    { fact_id: 1, node_id: 0 },
+    { fact_id: 1, node_id: 2 },
+  ],
+};

--- a/prototypes/annotated-source-viewer/src/styles.css
+++ b/prototypes/annotated-source-viewer/src/styles.css
@@ -1,0 +1,177 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  --bg: #0d0f0e;
+  --panel: #141715;
+  --raised: #1b1f1c;
+  --line: #303630;
+  --text: #ecf0eb;
+  --muted: #9ba59d;
+  --dim: #6f7871;
+  --accent: #f27a52;
+  --accent-soft: #4b281d;
+  --csharp: #72b7d7;
+  --il: #c39ce5;
+  --selected: #7b4b20;
+  --selected-line: #f2ad62;
+  --mono: "SFMono-Regular", "Cascadia Code", Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+html, body, #app { min-height: 100%; margin: 0; }
+body { background: var(--bg); color: var(--text); }
+button, input { font: inherit; color: inherit; }
+button { cursor: pointer; }
+
+.titlebar {
+  min-height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 14px 22px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+}
+
+h1, h2, p { margin: 0; }
+h1 { font-size: 20px; letter-spacing: -.03em; }
+h2 { font-size: 14px; }
+.eyebrow {
+  margin-bottom: 4px;
+  color: var(--accent);
+  font: 10px var(--mono);
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.load-actions { display: flex; align-items: center; gap: 8px; }
+.source-name {
+  max-width: 340px;
+  overflow: hidden;
+  color: var(--muted);
+  font: 11px var(--mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.button, button {
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--raised);
+  color: var(--muted);
+  font: 11px var(--mono);
+}
+.button:hover, button:hover { border-color: var(--accent); color: var(--text); }
+#document-file { position: absolute; width: 1px; height: 1px; opacity: 0; }
+
+.summarybar {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 0 22px;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font: 11px var(--mono);
+}
+.summarybar strong { color: var(--text); }
+.medium-toggles { display: flex; gap: 12px; margin-left: auto; }
+.medium-toggles label { cursor: pointer; }
+.medium-toggles input { accent-color: var(--accent); }
+.error { padding: 9px 22px; background: #4d1f20; color: #ffd8d8; font: 12px var(--mono); }
+
+.workspace {
+  height: calc(100vh - 119px);
+  display: grid;
+  grid-template-columns: minmax(480px, 1fr) minmax(300px, 380px);
+  overflow: hidden;
+}
+.code-panel, .inspector { min-height: 0; }
+.code-panel { display: grid; grid-template-rows: auto minmax(0, 1fr); }
+.inspector { overflow: auto; border-left: 1px solid var(--line); background: var(--panel); }
+.inspector > section { padding: 16px; border-bottom: 1px solid var(--line); }
+
+.panel-heading {
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+}
+.panel-heading > p { max-width: 520px; color: var(--muted); font-size: 12px; }
+.panel-heading.compact { min-height: 38px; padding: 0 0 10px; border: 0; }
+
+.code-scroll {
+  overflow: auto;
+  padding: 12px 0 40px;
+  background: linear-gradient(90deg, #111412 0 76px, transparent 76px), var(--bg);
+}
+.code-line {
+  min-height: 24px;
+  display: grid;
+  grid-template-columns: 44px 32px minmax(max-content, 1fr);
+  align-items: baseline;
+  padding-right: 24px;
+  font: 13px/24px var(--mono);
+}
+.code-line:hover { background: rgba(255, 255, 255, .025); }
+.line-number { padding-right: 10px; color: var(--dim); text-align: right; user-select: none; }
+.medium-label { font-size: 9px; user-select: none; }
+.medium-csharp .medium-label { color: var(--csharp); }
+.medium-il .medium-label { color: var(--il); }
+.medium-mixed .medium-label { color: var(--selected-line); }
+.code-line code { white-space: pre; }
+.segment-hidden { visibility: hidden; }
+
+.code-segment.addressable { cursor: pointer; }
+.code-segment.addressable:hover { background: rgba(242, 122, 82, .18); }
+.code-segment.selected {
+  border-bottom: 2px solid var(--selected-line);
+  background: var(--selected);
+  color: #fff7e9;
+}
+
+.fact-list, .node-list, .selection-list { display: grid; gap: 7px; }
+.fact {
+  display: grid;
+  gap: 4px;
+  width: 100%;
+  padding: 9px;
+  text-align: left;
+}
+.fact.active, .node-chip.active { border-color: var(--accent); background: var(--accent-soft); }
+.fact-title { display: flex; justify-content: space-between; gap: 10px; }
+.fact-title strong { color: var(--text); }
+.fact-title small, .fact-meta { color: var(--dim); }
+.fact-meta { font-size: 10px; }
+
+.node-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.node-chip { min-width: 0; display: grid; gap: 2px; text-align: left; }
+.node-chip span { color: var(--accent); }
+.node-chip strong { overflow: hidden; text-overflow: ellipsis; }
+.node-chip small { color: var(--dim); }
+
+.selection-list article {
+  padding: 9px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--raised);
+}
+.selection-list article > div { display: flex; align-items: center; justify-content: space-between; }
+.selection-list p { margin-top: 5px; color: var(--muted); font: 10px/1.5 var(--mono); }
+.badge { padding: 2px 5px; border-radius: 2px; background: #28302b; color: var(--muted); font: 9px var(--mono); }
+.empty { color: var(--dim); font-size: 12px; }
+
+@media (max-width: 820px) {
+  .titlebar { align-items: flex-start; flex-direction: column; }
+  .load-actions { width: 100%; flex-wrap: wrap; }
+  .source-name { flex: 1; }
+  .workspace { height: auto; grid-template-columns: 1fr; overflow: visible; }
+  .code-panel { min-height: 55vh; }
+  .code-scroll { max-height: 65vh; }
+  .inspector { overflow: visible; border-top: 1px solid var(--line); border-left: 0; }
+}

--- a/prototypes/annotated-source-viewer/test/document-model.test.js
+++ b/prototypes/annotated-source-viewer/test/document-model.test.js
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildLines,
+  lineMedium,
+  nodeIdsForFact,
+  nodesAtOffset,
+  parseDocument,
+  segmentsForLine,
+  unanchoredFacts,
+  validateDocument,
+} from "../src/document-model.js";
+import { sampleDocument } from "../src/sample-document.js";
+
+test("line coordinates use decoded UTF-16 code units", () => {
+  const lines = buildLines("a😀\nb");
+
+  assert.deepEqual(lines, [
+    { number: 1, start: 0, end: 3, text: "a😀" },
+    { number: 2, start: 4, end: 5, text: "b" },
+  ]);
+});
+
+test("one fact resolves through targets to C# and IL nodes", () => {
+  validateDocument(sampleDocument);
+
+  assert.deepEqual(nodeIdsForFact(sampleDocument, 0), [1, 3]);
+  assert.deepEqual(unanchoredFacts(sampleDocument).map(fact => fact.id), [2]);
+});
+
+test("multi-span nodes highlight each separated run without filling gaps", () => {
+  const lines = buildLines(sampleDocument.text);
+  const selected = [0];
+  const header = segmentsForLine(sampleDocument, lines[0], selected);
+  const instruction = segmentsForLine(sampleDocument, lines[1], selected);
+  const body = segmentsForLine(sampleDocument, lines[3], selected);
+
+  assert.ok(header.some(segment => segment.selected));
+  assert.ok(instruction.every(segment => !segment.selected));
+  assert.ok(body.some(segment => segment.selected));
+});
+
+test("offset lookup selects the tightest nested node first", () => {
+  const objectNode = sampleDocument.nodes[1];
+  const offset = objectNode.spans[0].start;
+
+  assert.deepEqual(nodesAtOffset(sampleDocument, offset, "CSharp").map(node => node.id), [1, 0]);
+});
+
+test("offset lookup ranks the containing run, not unrelated spans", () => {
+  const document = {
+    text: "0123456789----x--",
+    nodes: [
+      {
+        id: 0,
+        kind: "Discontinuous",
+        medium: "CSharp",
+        spans: [{ start: 0, length: 10 }, { start: 14, length: 1 }],
+      },
+      {
+        id: 1,
+        kind: "Enclosing",
+        medium: "CSharp",
+        spans: [{ start: 13, length: 3 }],
+      },
+    ],
+    regions: [],
+    facts: [],
+    targets: [],
+  };
+  validateDocument(document);
+
+  assert.deepEqual(nodesAtOffset(document, 14).map(node => node.id), [0, 1]);
+});
+
+test("loaded JSON rejects dangling targets and adjacent spans", () => {
+  const dangling = structuredClone(sampleDocument);
+  dangling.targets[0].node_id = 99;
+  assert.throws(() => parseDocument(JSON.stringify(dangling)), /node that does not exist/);
+
+  const adjacent = structuredClone(sampleDocument);
+  adjacent.nodes[0].spans = [
+    { start: 0, length: 2 },
+    { start: 2, length: 2 },
+  ];
+  assert.throws(() => validateDocument(adjacent), /ordered, separated, and non-overlapping/);
+});
+
+test("semantic target invariants reject impossible joins", () => {
+  const headerTarget = structuredClone(sampleDocument);
+  headerTarget.targets.push({ fact_id: 2, node_id: 1 });
+  assert.throws(() => validateDocument(headerTarget), /not about the member body/);
+
+  const wrongIlOffset = structuredClone(sampleDocument);
+  wrongIlOffset.facts[0].source_offset = 0;
+  assert.throws(() => validateDocument(wrongIlOffset), /wrong source offset/);
+
+  const unknownConditionality = structuredClone(sampleDocument);
+  unknownConditionality.facts[0].conditionality = "Sometimes";
+  assert.throws(() => validateDocument(unknownConditionality), /known conditionality and origin/);
+});
+
+test("mixed-medium lines classify and segment each substring independently", () => {
+  const mixed = {
+    text: "ab",
+    nodes: [
+      { id: 0, kind: "Name", medium: "CSharp", spans: [{ start: 0, length: 1 }] },
+      { id: 1, kind: "Instruction", medium: "Il", spans: [{ start: 1, length: 1 }], il_offset: 0 },
+    ],
+    regions: [],
+    facts: [],
+    targets: [],
+  };
+  validateDocument(mixed);
+  const line = buildLines(mixed.text)[0];
+  const segments = segmentsForLine(mixed, line);
+
+  assert.equal(lineMedium(mixed, line), "Mixed");
+  assert.deepEqual(segments.map(segment => segment.media), [["CSharp"], ["Il"]]);
+  assert.deepEqual(nodesAtOffset(mixed, 0).map(node => node.id), [0]);
+  assert.deepEqual(nodesAtOffset(mixed, 1).map(node => node.id), [1]);
+});

--- a/prototypes/annotated-source-viewer/test/document-model.test.js
+++ b/prototypes/annotated-source-viewer/test/document-model.test.js
@@ -100,6 +100,16 @@ test("semantic target invariants reject impossible joins", () => {
   assert.throws(() => validateDocument(unknownConditionality), /known conditionality and origin/);
 });
 
+test("instruction and fact offsets stay within the signed 32-bit contract", () => {
+  const oversizedInstruction = structuredClone(sampleDocument);
+  oversizedInstruction.nodes[3].il_offset = 2_147_483_648;
+  assert.throws(() => validateDocument(oversizedInstruction), /non-negative 32-bit integer/);
+
+  const oversizedFact = structuredClone(sampleDocument);
+  oversizedFact.facts[0].source_offset = 2_147_483_648;
+  assert.throws(() => validateDocument(oversizedFact), /non-negative 32-bit integer/);
+});
+
 test("mixed-medium lines classify and segment each substring independently", () => {
   const mixed = {
     text: "ab",

--- a/prototypes/annotated-source-viewer/test/document-model.test.js
+++ b/prototypes/annotated-source-viewer/test/document-model.test.js
@@ -13,11 +13,13 @@ import {
 import { sampleDocument } from "../src/sample-document.js";
 
 test("line coordinates use decoded UTF-16 code units", () => {
-  const lines = buildLines("a😀\nb");
+  const lines = buildLines("a😀\r\nb\rc\n");
 
   assert.deepEqual(lines, [
     { number: 1, start: 0, end: 3, text: "a😀" },
-    { number: 2, start: 4, end: 5, text: "b" },
+    { number: 2, start: 5, end: 6, text: "b" },
+    { number: 3, start: 7, end: 8, text: "c" },
+    { number: 4, start: 9, end: 9, text: "" },
   ]);
 });
 
@@ -108,6 +110,12 @@ test("instruction and fact offsets stay within the signed 32-bit contract", () =
   const oversizedFact = structuredClone(sampleDocument);
   oversizedFact.facts[0].source_offset = 2_147_483_648;
   assert.throws(() => validateDocument(oversizedFact), /non-negative 32-bit integer/);
+});
+
+test("only IL instruction nodes may carry an IL offset", () => {
+  const csharpWithOffset = structuredClone(sampleDocument);
+  csharpWithOffset.nodes[1].il_offset = 1;
+  assert.throws(() => validateDocument(csharpWithOffset), /do not identify one instruction/);
 });
 
 test("mixed-medium lines classify and segment each substring independently", () => {

--- a/prototypes/annotated-source-viewer/test/server.test.js
+++ b/prototypes/annotated-source-viewer/test/server.test.js
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import net from "node:net";
+import test from "node:test";
+import { createViewerServer } from "../server.js";
+
+test("server returns content and contains malformed paths", async () => {
+  const server = createViewerServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address();
+
+  try {
+    const index = await fetch(`http://127.0.0.1:${port}/`);
+    assert.equal(index.status, 200);
+    assert.match(await index.text(), /<title>Annotated source viewer<\/title>/);
+
+    const malformed = await rawRequest(
+      port,
+      "GET /%ZZ HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    );
+    assert.match(malformed, /^HTTP\/1\.1 400 Bad Request/);
+
+    const traversal = await rawRequest(
+      port,
+      "GET /..%2Fserver.js HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    );
+    assert.match(traversal, /^HTTP\/1\.1 403 Forbidden/);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
+function rawRequest(port, request) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(port, "127.0.0.1", () => socket.write(request));
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("data", chunk => response += chunk);
+    socket.on("end", () => resolve(response));
+    socket.on("error", reject);
+  });
+}


### PR DESCRIPTION
## Summary

- add a dependency-free browser consumer for `AnnotatedSourceDocument`
- derive line and substring highlights from canonical UTF-16 text and node spans
- resolve facts through targets to C# and IL nodes while preserving targetless facts
- validate the portable document contract independently from the decompiler

## Testing

- `npm test` (9 tests)
- JavaScript syntax checks
- changed Markdown lint
- replayed a real CLI-emitted document with 36 nodes, 2 facts, 4 targets, and 28 lines
