### PR TITLE
Bind call graph row projections to edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ of post-processing. `--top` limits the ranked data before rendering; `-n N`
 remains a renderer cap and is applied afterward if both are supplied. Drill
 candidates with `Call Graph` (a bounded bidirectional graph: inbound callers up
 to entry points and outbound calls in one view), and project per-node cost with
-`--fields`.
+`--fields`. Its row unit is a call edge, so `--count` reports relationships and
+`--rows` selects the same ordered relationships in tree and table output.
 Ranking rows carry a copyable `Stable` selector, `Visibility`, and `Selector`;
 add `--all` to drill non-public members.
 

--- a/docs/design/call-graph-projection.md
+++ b/docs/design/call-graph-projection.md
@@ -96,6 +96,10 @@ The projection owns everything a host must not re-invent in JavaScript:
   offset. Requesting an otherwise noncontributing catalog scope therefore does
   not change sibling order, revisit placement, or which nodes fit in a bounded
   traversal.
+- **Stable rows.** A call graph answers "what calls what", so its row unit is a
+  directed edge. `Rows` numbers those edges from one in deterministic edge order
+  and retains those numbers when a host filters them. Counts and row windows
+  therefore bind to the projection rather than to a rendered tree's node lines.
 - **Cycles and duplicates.** The bounded tree marks re-encountered members
   `AlreadyShown`; the projection collapses them onto the existing node and still
   records the edge, so a cycle `A → B → A` is two edges between two nodes.
@@ -238,6 +242,10 @@ picks the lowering the sink can express: a tree in Markdown and plain text, an
 edge table under `--table`/`--tsv`/`--jsonl`, and a flowchart in Mermaid. The
 adapter is the only place that knows call-graph vocabulary; the section is a
 graph, not a pre-rendered tree, which is what lets one model serve every sink.
+`--count` reports the projection's edge-row count. `--rows` selects those same
+stable edge rows before tree/diagram lowering and at the table writer boundary
+for tabular output, so changing the final rendering does not change the
+addressed relationships.
 
 The browser engine consumes the same projection and generates its own Mermaid; it
 reconstructs no graph identity, direction, truncation, cycles, or labels. The CLI

--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -38,6 +38,10 @@ descend to a Scalar by selecting a section, then columns, then collapsing.
 Most sections are Tables, but a section can also be a key-value field set, a
 list, a code/text blob, or a tree (for example a call graph). Those are still
 "one section" — the Table rung — and they collapse to Scalars the same way.
+For a call graph, the declared row unit is a directed edge: `--count` counts
+relationships, and `--rows` selects the same ordered relationships whether the
+section is rendered as a tree or an edge table. Tree nodes are presentation
+context, not additional rows.
 
 ## Flag families
 

--- a/src/ILInspector.Analysis.Tests/CallGraphProjectionTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphProjectionTests.cs
@@ -171,6 +171,20 @@ public class CallGraphProjectionTests
     }
 
     [Fact]
+    public void RowsAreNumberedEdgesInDeterministicOrder()
+    {
+        var target = Member("Widget", "Build");
+        var callers = Node(target, CallTreeStatus.Expanded, [Leaf(Member("Program", "Main"))]);
+        var callees = Node(target, CallTreeStatus.Expanded, [Leaf(Member("Store", "Save"))]);
+
+        var projection = CallGraphProjection.Create(callers, callees);
+
+        Assert.Equal(2, projection.RowCount);
+        Assert.Equal([1, 2], projection.Rows.Select(row => row.Number));
+        Assert.Equal(projection.Edges, projection.Rows.Select(row => row.Edge));
+    }
+
+    [Fact]
     public void NodesAreOrderedFocusThenCallersThenCallees()
     {
         var target = Member("Widget", "Build");

--- a/src/ILInspector.CallGraph/CallGraphProjection.cs
+++ b/src/ILInspector.CallGraph/CallGraphProjection.cs
@@ -72,6 +72,19 @@ public sealed record CallGraphNode(
 public readonly record struct CallGraphEdge(int From, int To, string? LoopLabel);
 
 /// <summary>
+/// One stable row of a <see cref="CallGraphProjection"/>.
+/// </summary>
+/// <param name="Number">
+/// The one-based row number in the projection's deterministic edge order. The number is
+/// retained when rows are filtered, so a window never renumbers the surviving rows.
+/// </param>
+/// <param name="Edge">
+/// The call edge denoted by this row. Call graphs answer "what calls what", so edges are
+/// their row unit.
+/// </param>
+public readonly record struct CallGraphRow(int Number, CallGraphEdge Edge);
+
+/// <summary>
 /// A format-neutral projection of the typed call-graph facts that
 /// <c>ILInspector.Analysis</c> produces (<see cref="CallTreeNode"/> caller and callee roots
 /// built by <c>LibraryBodyIndex.BuildCallerTree</c> / <c>BuildCallTree</c>) into a single
@@ -105,6 +118,11 @@ public sealed class CallGraphProjection
     {
         Nodes = nodes;
         Edges = edges;
+
+        var rows = ImmutableArray.CreateBuilder<CallGraphRow>(edges.Length);
+        for (var i = 0; i < edges.Length; i++)
+            rows.Add(new CallGraphRow(i + 1, edges[i]));
+        Rows = rows.MoveToImmutable();
     }
 
     /// <summary>Nodes in deterministic order. The focus node is always first.</summary>
@@ -112,6 +130,15 @@ public sealed class CallGraphProjection
 
     /// <summary>Edges in deterministic first-seen order, always oriented caller → callee.</summary>
     public ImmutableArray<CallGraphEdge> Edges { get; }
+
+    /// <summary>
+    /// Rows in deterministic order, one per <see cref="Edges"/> entry. Row numbers are
+    /// one-based and stable across filtering.
+    /// </summary>
+    public ImmutableArray<CallGraphRow> Rows { get; }
+
+    /// <summary>The number of edge rows in this projection.</summary>
+    public int RowCount => Rows.Length;
 
     /// <summary>The selected overload the graph is centered on.</summary>
     public CallGraphNode Focus => Nodes[0];

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -149,8 +149,10 @@ public class MemberCallGraphSectionTests
         }));
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("No inbound callers or outbound calls found for this method.", result.Output);
-        Assert.DoesNotContain(nameof(MemberCallGraphFixture.RootCall), result.Output);
+        Assert.Contains("## Call Graph", result.Output);
+        var section = result.Output[result.Output.IndexOf("## Call Graph", StringComparison.Ordinal)..];
+        Assert.Contains("No inbound callers or outbound calls found for this method.", section);
+        Assert.DoesNotContain(nameof(MemberCallGraphFixture.RootCall), section);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 using DotnetInspector.Sections;
 
 namespace DotnetInspector.Tests;
@@ -47,6 +48,109 @@ public class MemberCallGraphSectionTests
         Assert.Contains("\tExternal", result.Output);
         Assert.Contains($"{nameof(MemberCallGraphFixture.RootCall)}", result.Output);
         Assert.Contains($"{nameof(MemberCallGraphFixture.Mid)}", result.Output);
+    }
+
+    [Fact]
+    public async Task CallGraphSection_CountsEdgeRowsAcrossRenderModes()
+    {
+        var baseOptions = new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            IncludeSections = [SectionNames.CallGraph],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Normal,
+        };
+
+        var edgeTable = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            baseOptions with
+            {
+                Count = false,
+                Tabular = true,
+                Tsv = true,
+                TabularExplicitlySet = true,
+                FormatExplicitlySet = true,
+            }));
+        var markdown = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(baseOptions));
+        var table = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            baseOptions with
+            {
+                Tabular = true,
+                TabularExplicitlySet = true,
+                FormatExplicitlySet = true,
+            }));
+
+        Assert.Equal(0, edgeTable.ExitCode);
+        Assert.Equal(0, markdown.ExitCode);
+        Assert.Equal(0, table.ExitCode);
+        Assert.Equal(markdown.Output, table.Output);
+        var edgeRows = edgeTable.Output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Skip(1)
+            .Count();
+        Assert.True(edgeRows > 0, "fixture must produce a non-empty graph");
+        Assert.Equal(
+            edgeRows,
+            int.Parse(markdown.Output.Trim(), System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task CallGraphSection_AbsoluteWindowSelectsTheSameEdgeInTreeAndTable()
+    {
+        var baseOptions = new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            IncludeSections = [SectionNames.CallGraph],
+            Rows = RowWindow.Range(2, 2),
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Normal,
+        };
+
+        var tree = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(baseOptions));
+        var table = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            baseOptions with
+            {
+                Tabular = true,
+                Tsv = true,
+                TabularExplicitlySet = true,
+                FormatExplicitlySet = true,
+            }));
+        var count = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            baseOptions with { Count = true }));
+
+        Assert.Equal(0, tree.ExitCode);
+        Assert.Equal(0, table.ExitCode);
+        Assert.Equal(0, count.ExitCode);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), tree.Output);
+        Assert.Contains(nameof(MemberCallGraphFixture.Mid), tree.Output);
+        Assert.DoesNotContain(nameof(MemberCallGraphFixture.LoopHeavyCall), tree.Output);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), table.Output);
+        Assert.Contains(nameof(MemberCallGraphFixture.Mid), table.Output);
+        Assert.DoesNotContain(nameof(MemberCallGraphFixture.LoopHeavyCall), table.Output);
+        Assert.Equal("1", count.Output.Trim());
+    }
+
+    [Fact]
+    public async Task CallGraphSection_EmptyWindowDoesNotRenderFocusAsARow()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            IncludeSections = [SectionNames.CallGraph],
+            Rows = RowWindow.Range(100, 100),
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Normal,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("No inbound callers or outbound calls found for this method.", result.Output);
+        Assert.DoesNotContain(nameof(MemberCallGraphFixture.RootCall), result.Output);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1308,6 +1308,18 @@ public class ApiCommand
 
         if (options.Count)
         {
+            // A call graph declares edge rows in its projection. Count those rows directly
+            // rather than scanning the rendered tree, which has a different node-shaped
+            // lowering and therefore cannot answer the row question.
+            if (options.IncludeSections is { Count: 1 } sections
+                && sections.Contains(SectionNames.CallGraph)
+                && view.MemberCode?.CallGraphRowCount is { } graphRows)
+            {
+                CountOutput.WriteCount(graphRows);
+                ApiOutputFormatter.WriteCallGraphWarning(view);
+                return 0;
+            }
+
             var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, options);
             writerOptions.RowWindow = RowWindow.ToMarkout(options.Rows);
             var sw = new StringWriter { NewLine = "\n" };

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1595,16 +1595,29 @@ public static class ApiOutputFormatter
             var projection = ILInspector.CallGraph.CallGraphProjection.Create(
                 callerTree,
                 analysisInspection.BuildCallTree(graphToken));
+            var selectedRows = RowWindow.Apply(options?.Rows, projection.Rows);
+            memberCode.CallGraphRowCount = selectedRows.Count;
+            bool treeWindowIsEmpty =
+                options is { Tabular: false, Rows: not null }
+                && selectedRows.Count == 0;
             // A lone focus node with no edges is the empty state, not a graph.
-            if (projection.Edges.Length > 0)
+            if (projection.Edges.Length > 0 && !treeWindowIsEmpty)
             {
+                // Markout's graph formatters lower the same graph to a tree or an edge table.
+                // Table output already windows the rendered edge rows at its writer boundary;
+                // tree formats have no rows of their own, so give them the selected projection
+                // rows and let every lowering describe the same edge set.
+                IReadOnlyList<ILInspector.CallGraph.CallGraphRow>? renderedRows =
+                    options is { Tabular: false, Rows: not null } ? selectedRows : null;
                 memberCode.CallGraph = CallGraphSectionAdapter.ToGraph(
                     projection,
                     FormatCallee,
-                    GetRequestedCallGraphFields(options));
+                    GetRequestedCallGraphFields(options),
+                    renderedRows);
                 hasCode = true;
             }
-            else if (ExplicitlySelected(SectionNames.CallGraph))
+            else if (ExplicitlySelected(SectionNames.CallGraph)
+                || treeWindowIsEmpty)
             {
                 memberCode.CallGraph = new Markout.Graph([], []);
                 hasCode = true;

--- a/src/dotnet-inspect/Output/CallGraphSectionAdapter.cs
+++ b/src/dotnet-inspect/Output/CallGraphSectionAdapter.cs
@@ -40,14 +40,31 @@ internal static class CallGraphSectionAdapter
     public static Markout.Graph ToGraph(
         CallGraphProjection projection,
         Func<MemberRef, string> spellMember,
-        IReadOnlyList<string>? requestedFields = null)
+        IReadOnlyList<string>? requestedFields = null,
+        IReadOnlyList<CallGraphRow>? rows = null)
     {
         ArgumentNullException.ThrowIfNull(projection);
         ArgumentNullException.ThrowIfNull(spellMember);
 
-        var nodes = new List<Markout.GraphNode>(projection.Nodes.Length);
+        var selectedRows = rows ?? projection.Rows;
+        HashSet<int>? selectedNodeIds = null;
+        if (rows is not null)
+        {
+            selectedNodeIds = [projection.Focus.Id];
+            foreach (var row in selectedRows)
+            {
+                selectedNodeIds.Add(row.Edge.From);
+                selectedNodeIds.Add(row.Edge.To);
+            }
+        }
+
+        var nodes = new List<Markout.GraphNode>(
+            selectedNodeIds?.Count ?? projection.Nodes.Length);
         foreach (var node in projection.Nodes)
         {
+            if (selectedNodeIds is not null && !selectedNodeIds.Contains(node.Id))
+                continue;
+
             nodes.Add(new Markout.GraphNode(Key(node.Id), Label(node, spellMember, requestedFields))
             {
                 Group = Group(node),
@@ -57,9 +74,12 @@ internal static class CallGraphSectionAdapter
             });
         }
 
-        var edges = new List<Markout.GraphEdge>(projection.Edges.Length);
-        foreach (var edge in projection.Edges)
+        var edges = new List<Markout.GraphEdge>(selectedRows.Count);
+        foreach (var row in selectedRows)
+        {
+            var edge = row.Edge;
             edges.Add(new Markout.GraphEdge(Key(edge.From), Key(edge.To)) { Label = edge.LoopLabel });
+        }
 
         return new Markout.Graph(nodes, edges, focusKey: Key(projection.Focus.Id));
     }

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -919,7 +919,10 @@ public class MemberCodeView
 
     [MarkoutSection(Name = SectionNames.CallGraph, EmptyText = "No inbound callers or outbound calls found for this method.")]
     public Markout.Graph? CallGraph { get; set; }
- 
+
+    [MarkoutIgnore]
+    public int? CallGraphRowCount { get; set; }
+
     [MarkoutSection(Name = "Unsafe Operations", EmptyText = "No unsafe operations found in this method body.")]
     public List<UnsafeOperationRow>? UnsafeOperationRows { get; set; }
 


### PR DESCRIPTION
## Summary

- declare one stable, one-based row per directed call edge in `CallGraphProjection`
- bind `Call Graph --count` and `--rows` to those model rows instead of rendered tree lines
- preserve the same selected edge set across tree, table, TSV, and JSONL lowerings, including empty windows

This is the call-graph slice of #3427. Dependency-graph projection and any shared graph-row abstraction remain out of scope until there is a second model consumer.

## Behavioral claim

A `Call Graph` row denotes one directed call relationship. `--count` reports edge rows, and a row window selects the same ordered edges regardless of the final renderer; rendering never re-walks or re-acquires the graph.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -class '*CallGraphProjectionTests*'` (34 passed)
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -class '*MemberCallGraphSectionTests*'` (22 passed)
- full Analysis suite (569 passed)

## Compatibility / non-action

Default unwindowed graph rendering and acquisition are unchanged. This PR does not add depth or scope flags, move the graph out of `member`, change dependency graphs, or make graph rows printable payloads.