### PR TITLE
Scope Azure plugin credentials by organization

### DIFF
--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -428,6 +428,13 @@ second reason NuGet put the loop in a handler: no call site can forget to partic
 a fix for the `nuget.config` path, which still depends on the caller threading a credential
 through.
 
+Acquired credentials are normally cached by origin so the service index and discovered package
+endpoints share one challenge response. Azure Artifacts needs a narrower identity: every
+organization uses `pkgs.dev.azure.com`. For that host the cache key includes the first path
+segment, which is the organization. Organizations therefore acquire independently, while one
+organization's configured service-index URL and Azure's project/feed-GUID endpoint aliases reuse
+the same credential.
+
 ## Tests
 
 Two tiers, in `src/NuGetFetch.Tests`:
@@ -439,7 +446,8 @@ Two tiers, in `src/NuGetFetch.Tests`:
   - `PluginDiscoveryTests` pins all three discovery routes and their precedence, over a temporary
     directory tree and `PATH`.
   - `PluginAuthenticationHandlerTests` pins the 401 loop: retry bound, `IsRetry` progression,
-    per-authority scoping, 403 opt-in, and that an existing credential is not overwritten.
+    origin scoping for ordinary hosts, organization scoping and GUID-alias reuse for Azure
+    Artifacts, 403 opt-in, and that an existing credential is not overwritten.
   - `PluginProtocolTests` runs a **real plugin process** — a shell script that genuinely speaks
     the line protocol — so framing, the symmetric handshake, `Progress`-driven timeout extension,
     and shutdown are exercised end to end rather than mocked.

--- a/src/NuGetFetch.Tests/PluginAuthenticationHandlerTests.cs
+++ b/src/NuGetFetch.Tests/PluginAuthenticationHandlerTests.cs
@@ -279,17 +279,13 @@ public sealed class PluginAuthenticationHandlerTests
     }
 
     [Fact]
-    public async Task TwoFeedsSharingAHostRecoverFromTheAuthorityKeyedCacheRatherThanFailing()
+    public async Task AzureOrganizationsHaveIndependentCredentialSlots()
     {
-        // Every Azure DevOps organization lives on pkgs.dev.azure.com and differs only by path,
-        // so two orgs collide in a cache keyed by scheme/host/port. This pins what that collision
-        // actually costs: the stale token is offered, refused, and replaced, so the request still
-        // succeeds. It is wasted work, not a failure, and it never approaches the retry budget.
         var orgA = new Uri("https://pkgs.dev.azure.com/org-a/_packaging/feed/nuget/v3/index.json");
         var orgB = new Uri("https://pkgs.dev.azure.com/org-b/_packaging/feed/nuget/v3/index.json");
 
-        var source = new PerOrgCredentialSource();
-        var transport = new PerOrgTransport();
+        var source = new PerAzureOrganizationCredentialSource();
+        var transport = new PerAzureOrganizationTransport();
         using HttpClient client = Client(source, transport);
 
         var attemptsPerRequest = new List<int>();
@@ -301,20 +297,11 @@ public sealed class PluginAuthenticationHandlerTests
             attemptsPerRequest.Add(transport.Attempts - before);
         }
 
-        // The first request pays one 401 to learn its token. Each later request pays one more,
-        // because the previous org overwrote the shared slot: 4 requests, 4 challenges answered.
-        Assert.Equal(4, source.Calls);
-        Assert.Equal(8, transport.Attempts);
+        Assert.Equal(2, source.Calls);
+        Assert.Equal(6, transport.Attempts);
+        Assert.Equal([2, 2, 1, 1], attemptsPerRequest);
+        Assert.Null(transport.Log[2].Authorization);
 
-        // Crucially, every request settles in exactly two attempts -- one refusal, one success --
-        // so no request approaches MaxAuthRetries and none of them fails.
-        Assert.All(attemptsPerRequest, n => Assert.Equal(2, n));
-
-        // Control: without contention the cache does its job, so a repeat of the org that just
-        // ran costs one attempt and no acquisition. This is what makes the counts above evidence
-        // of a *collision* rather than of a handler that simply never caches -- one that
-        // reacquired unconditionally would also spend two attempts per request, but it would
-        // spend two here as well.
         int beforeRepeat = transport.Attempts;
         int callsBeforeRepeat = source.Calls;
 
@@ -326,11 +313,6 @@ public sealed class PluginAuthenticationHandlerTests
         Assert.Equal(1, transport.Attempts - beforeRepeat);
         Assert.Equal(callsBeforeRepeat, source.Calls);
 
-        // Second control, on the property the cache key is actually named for. A single global
-        // credential slot would satisfy every assertion above, so reach a *different* authority
-        // and require that nothing is offered to it on the first attempt: the token just cached
-        // for pkgs.dev.azure.com must not travel to another host. This is the same-origin
-        // guarantee, observed from the handler's side.
         var otherHost = new Uri("https://nuget.pkg.github.com/org-b/index.json");
         transport.Log.Clear();
 
@@ -343,8 +325,31 @@ public sealed class PluginAuthenticationHandlerTests
         Assert.NotNull(transport.Log[1].Authorization);
     }
 
-    /// <summary>Hands back a distinct credential per Azure DevOps organization, keyed on the URL path.</summary>
-    private sealed class PerOrgCredentialSource : ICredentialSource
+    [Fact]
+    public async Task AzureNameAndGuidEndpointAliasesReuseTheCredential()
+    {
+        var index = new Uri(
+            "https://pkgs.dev.azure.com/org/project-name/_packaging/feed-name/nuget/v3/index.json");
+        var package = new Uri(
+            "https://pkgs.dev.azure.com/org/11111111-1111-1111-1111-111111111111"
+            + "/_packaging/22222222-2222-2222-2222-222222222222/nuget/v3/flat2/markout/index.json");
+
+        var source = new PerAzureOrganizationCredentialSource();
+        var transport = new PerAzureOrganizationTransport();
+        using HttpClient client = Client(source, transport);
+
+        using (HttpResponseMessage first = await client.GetAsync(index, TestContext.Current.CancellationToken))
+            Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        using (HttpResponseMessage second = await client.GetAsync(package, TestContext.Current.CancellationToken))
+            Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+
+        Assert.Equal(1, source.Calls);
+        Assert.Equal(3, transport.Attempts);
+        Assert.NotNull(transport.Log[2].Authorization);
+    }
+
+    /// <summary>Hands back a distinct credential per Azure DevOps organization.</summary>
+    private sealed class PerAzureOrganizationCredentialSource : ICredentialSource
     {
         private int _calls;
 
@@ -355,13 +360,15 @@ public sealed class PluginAuthenticationHandlerTests
         public Task<PackageSourceCredential?> GetCredentialsAsync(Uri uri, bool isRetry, CancellationToken cancellationToken)
         {
             Interlocked.Increment(ref _calls);
-            string org = uri.Segments[1].Trim('/');
-            return Task.FromResult<PackageSourceCredential?>(new PackageSourceCredential("user", $"token-{org}"));
+            return Task.FromResult<PackageSourceCredential?>(
+                new PackageSourceCredential(
+                    "user",
+                    $"token-{AzureOrganization(uri)}"));
         }
     }
 
-    /// <summary>Accepts a request only when its credential matches the organization it addresses.</summary>
-    private sealed class PerOrgTransport : HttpMessageHandler
+    /// <summary>Accepts a request only when its credential matches the Azure organization it addresses.</summary>
+    private sealed class PerAzureOrganizationTransport : HttpMessageHandler
     {
         private int _attempts;
 
@@ -382,13 +389,20 @@ public sealed class PluginAuthenticationHandlerTests
                 Log.Add((uri, offered));
             }
 
-            string org = uri.Segments[1].Trim('/');
-            string expected = Convert.ToBase64String(Encoding.UTF8.GetBytes($"user:token-{org}"));
+            string expected = Convert.ToBase64String(
+                Encoding.UTF8.GetBytes(
+                    $"user:token-{AzureOrganization(uri)}"));
             bool ok = string.Equals(offered, expected, StringComparison.Ordinal);
 
             return Task.FromResult(new HttpResponseMessage(ok ? HttpStatusCode.OK : HttpStatusCode.Unauthorized));
         }
     }
+
+    private static string AzureOrganization(Uri uri)
+        => uri.Segments
+            .Select(segment => segment.Trim('/'))
+            .FirstOrDefault(segment => segment.Length > 0)
+            ?? "";
 
     private static HttpClient Client(ICredentialSource source, HttpMessageHandler transport) =>
         new(new PluginAuthenticationHandler(source, transport));

--- a/src/NuGetFetch/Plugins/PluginAuthenticationHandler.cs
+++ b/src/NuGetFetch/Plugins/PluginAuthenticationHandler.cs
@@ -35,6 +35,8 @@ namespace NuGetFetch.Plugins;
 /// </remarks>
 public sealed class PluginAuthenticationHandler : DelegatingHandler
 {
+    private const string AzureArtifactsHost = "pkgs.dev.azure.com";
+
     /// <summary>
     /// Maximum credential attempts for a single request, matching
     /// <c>AmbientAuthenticationState.MaxAuthRetries</c> in NuGet. Bounding this is what stops a
@@ -43,7 +45,8 @@ public sealed class PluginAuthenticationHandler : DelegatingHandler
     public const int MaxAuthRetries = 4;
 
     private readonly ICredentialSource _provider;
-    private readonly ConcurrentDictionary<string, AuthorityState> _authorities = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, CredentialScopeState> _credentialScopes =
+        new(StringComparer.Ordinal);
 
     /// <summary>Creates the handler.</summary>
     /// <param name="provider">Supplies credentials for challenged sources.</param>
@@ -83,7 +86,9 @@ public sealed class PluginAuthenticationHandler : DelegatingHandler
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
-        AuthorityState authority = _authorities.GetOrAdd(GetAuthority(request.RequestUri), static _ => new AuthorityState());
+        CredentialScopeState credentialScope = _credentialScopes.GetOrAdd(
+            GetCredentialScope(request.RequestUri),
+            static _ => new CredentialScopeState());
 
         HttpResponseMessage? response = null;
         bool acquiredCredentials = false;
@@ -95,7 +100,7 @@ public sealed class PluginAuthenticationHandler : DelegatingHandler
 
             // Snapshot before sending, so that if a concurrent request refreshes the credential
             // while this one is in flight we can tell and simply retry rather than acquire again.
-            (PackageSourceCredential? credential, long version) = authority.Read();
+            (PackageSourceCredential? credential, long version) = credentialScope.Read();
 
             using (HttpRequestMessage attempt = CloneRequest(request))
             {
@@ -113,7 +118,7 @@ public sealed class PluginAuthenticationHandler : DelegatingHandler
             }
 
             PackageSourceCredential? acquired = await AcquireAsync(
-                authority,
+                credentialScope,
                 request.RequestUri,
                 version,
                 isRetry: acquiredCredentials,
@@ -131,19 +136,19 @@ public sealed class PluginAuthenticationHandler : DelegatingHandler
     }
 
     private async Task<PackageSourceCredential?> AcquireAsync(
-        AuthorityState authority,
+        CredentialScopeState credentialScope,
         Uri uri,
         long observedVersion,
         bool isRetry,
         CancellationToken cancellationToken)
     {
-        // One acquisition at a time per authority: concurrent requests to the same feed should
+        // One acquisition at a time per credential scope: concurrent requests to the same feed should
         // trigger a single plugin round trip, not one each.
-        await authority.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await credentialScope.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
-            (PackageSourceCredential? current, long version) = authority.Read();
+            (PackageSourceCredential? current, long version) = credentialScope.Read();
 
             // Someone else refreshed while we waited. Their credential is untried by us, so
             // retry with it before asking for another.
@@ -158,14 +163,14 @@ public sealed class PluginAuthenticationHandler : DelegatingHandler
 
             if (credential is not null)
             {
-                authority.Set(credential);
+                credentialScope.Set(credential);
             }
 
             return credential;
         }
         finally
         {
-            authority.Gate.Release();
+            credentialScope.Gate.Release();
         }
     }
 
@@ -179,8 +184,42 @@ public sealed class PluginAuthenticationHandler : DelegatingHandler
         return new AuthenticationHeaderValue("Basic", encoded);
     }
 
-    /// <summary>Credentials are scoped to scheme, host and port, so one feed's token is never sent to another.</summary>
-    private static string GetAuthority(Uri uri) => uri.GetLeftPart(UriPartial.Authority);
+    /// <summary>
+    /// Returns the credential-sharing boundary for one request.
+    /// </summary>
+    /// <remarks>
+    /// Most feed hosts identify one credential realm, so their origin is the scope. Azure
+    /// Artifacts is different: every organization shares <c>pkgs.dev.azure.com</c>. Its first
+    /// path segment, the organization, therefore participates in identity while the remainder
+    /// does not. This also keeps one credential across Azure's name-to-GUID endpoint aliases:
+    /// configured indexes use project and feed names, while discovered endpoints use their GUIDs.
+    ///
+    /// An Azure URL without an organization path gets its own host-wide root slot. It cannot
+    /// collide with any organization slot.
+    /// </remarks>
+    private static string GetCredentialScope(Uri uri)
+    {
+        string origin =
+            $"{uri.Scheme.ToLowerInvariant()}://{uri.IdnHost.ToLowerInvariant()}:{uri.Port}";
+        if (!string.Equals(
+                uri.IdnHost,
+                AzureArtifactsHost,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return origin;
+        }
+
+        string[] segments =
+        [
+            .. uri.Segments
+                .Select(segment => segment.Trim('/'))
+                .Where(segment => segment.Length > 0),
+        ];
+        if (segments.Length == 0)
+            return origin;
+
+        return $"{origin}/{segments[0]}";
+    }
 
     /// <summary>
     /// Copies a request so it can be sent again. An <see cref="HttpRequestMessage"/> cannot be
@@ -213,22 +252,22 @@ public sealed class PluginAuthenticationHandler : DelegatingHandler
     {
         if (disposing)
         {
-            foreach (AuthorityState authority in _authorities.Values)
+            foreach (CredentialScopeState credentialScope in _credentialScopes.Values)
             {
-                authority.Gate.Dispose();
+                credentialScope.Gate.Dispose();
             }
 
-            _authorities.Clear();
+            _credentialScopes.Clear();
         }
 
         base.Dispose(disposing);
     }
 
     /// <summary>
-    /// The credential currently believed good for one authority, with a version stamp used to
+    /// The credential currently believed good for one scope, with a version stamp used to
     /// detect refreshes by concurrent requests.
     /// </summary>
-    private sealed class AuthorityState
+    private sealed class CredentialScopeState
     {
         private readonly Lock _sync = new();
         private PackageSourceCredential? _credential;


### PR DESCRIPTION
Closes #3540.

## The defect

`PluginAuthenticationHandler` cached acquired credentials by URI authority. That is
normally a useful boundary: a feed's service index and package endpoints share a
credential without sending it to another host.

Azure Artifacts puts every Azure DevOps organization under the same authority:
`https://pkgs.dev.azure.com`. A credential acquired for organization A was therefore
preemptively attached to organization B. B rejected it, the plugin acquired B's
credential, and the one shared slot oscillated between organizations.

The requests eventually succeeded, but every cross-organization request paid another
401 and provider invocation. More importantly, the handler offered one organization's
credential to another organization before being challenged.

## The boundary

Ordinary hosts remain scoped by normalized scheme, IDN host, and port.

For `pkgs.dev.azure.com`, the first path segment—the Azure DevOps organization—is
part of the credential-cache key. Organizations now have independent acquisition
gates and cached credentials.

The boundary deliberately stops at the organization rather than the configured feed
path. Azure service indexes use project and feed names, while their discovered
resources use project and feed GUIDs:

```text
/org/project-name/_packaging/feed-name/nuget/v3/index.json
/org/<project-guid>/_packaging/<feed-guid>/nuget/v3/flat2/...
```

Those are aliases inside one credential realm and must share the result of the first
challenge. Feed-path or exact-endpoint keys would lose that reuse and can break a
provider configured for the original source URL.

## Result

For alternating requests to two organizations:

- provider acquisitions fall from 4 to 2;
- transport attempts fall from 8 to 6;
- the first request to organization B carries no credential from A;
- repeats for either organization succeed in one attempt;
- another host still receives no Azure credential.

## Tests

- two organizations on `pkgs.dev.azure.com` use distinct credentials;
- name-based and GUID-based endpoints in one organization reuse one credential;
- the ordinary cross-host boundary remains intact;
- 333 NuGetFetch tests pass;
- 23 live Azure/provider cases pass with a fresh short-lived Entra token.

Mutating the implementation back to authority-only fails the cross-organization
case. Mutating it to exact endpoint paths fails the name-to-GUID alias case.
