### PR TITLE
Adopt typed Analysis Diff query

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -51,14 +51,18 @@ the ownership boundaries below, not the project count.
 
 ## Implementation status
 
-`DotnetInspector.Queries` now implements metadata-image, direct-reference,
-extension-method, custom-attribute, SourceLink audit, API-comparison,
-assembly-context Integrations, and progressive member call-graph slices. The
-API-comparison seam retains Metadata-owned Finding correspondence and
-compatibility classification over two host-resolved surfaces. The call-graph
-seam composes Analysis indexes and one catalog generation over workspace-owned
-immutable snapshots; both return typed results without choosing a renderer or
-output format.
+`DotnetInspector.Queries` and the optional
+`DotnetInspector.ResearchQueries` companion now implement metadata-image,
+direct-reference, extension-method, custom-attribute, SourceLink audit,
+API-comparison, Analysis body-signal comparison, assembly-context Integrations,
+and progressive member call-graph slices. The API-comparison seam retains
+Metadata-owned Finding correspondence and compatibility classification over
+two host-resolved surfaces. The body-signal seam consumes already-acquired
+Analysis indexes and retains `ResearchComparison`; keeping that query in the
+companion assembly avoids imposing Research and Decompiler dependencies on
+core query consumers. The call-graph seam composes Analysis indexes and one
+catalog generation over workspace-owned immutable snapshots. These queries
+return typed results without choosing a renderer or output format.
 The library CLI executes metadata-image, direct assembly-reference, and
 extension-method and custom-attribute queries through a typed, content-shaped
 registry over a host-owned `AssemblyInspectionSession`. The `References`,
@@ -73,6 +77,11 @@ query across every participant in one binding-consistent assembly context
 group. The command projects per-participant evidence or failure into
 compatibility models and continues each library inspection over the same
 retained immutable image.
+The diff CLI binds Changes and Analysis Diff to their concrete query
+definitions. Its transitional Analysis adapter resolves member targets and
+opens `LibraryBodyIndex` values lazily inside selected query execution; the L1
+query itself receives content-derived indexes rather than paths, and the CLI
+continues to own ranking and rendering.
 
 This is an incremental boundary, not the completed split. The remaining
 library scanners still use the transitional string-keyed `ScannerRegistry`,
@@ -233,7 +242,8 @@ consumer's convenience.
 ## Current migration state
 
 Metadata-image, direct-reference, extension-method, custom-attribute,
-SourceLink, and API-comparison inspection are the first vertical L1 canaries:
+SourceLink, API-comparison, and Analysis body-signal comparison inspection are
+the first vertical L1 canaries:
 
 - `DotnetInspector.Queries` owns typed query definitions, typed result retrieval,
   prerequisite expansion, and query cost.
@@ -258,13 +268,17 @@ SourceLink, and API-comparison inspection are the first vertical L1 canaries:
   both their Finding correspondence and Metadata-owned compatibility
   classification. The `diff` command keeps endpoint acquisition and member
   filtering host-owned.
+- `BodySignalComparisonQuery` consumes old/new `LibraryBodyIndex` collections
+  and returns the Research-owned `ResearchComparison`. The diff adapter builds
+  those indexes only under selected Analysis query demand; path acquisition
+  remains an explicit host-owned migration boundary.
 - Library and package sections bind to the same SourceLink query definitions.
   Package owns compatible/highest-TFM asset selection and aggregation, not a
   parallel audit implementation.
 - Metadata sections, `References`, `Library Info`, `Extension Methods`,
-  `Custom Attributes`, and diff `Changes` bind to query definitions by object
-  identity. A section may bind multiple definitions; diagnostic names are
-  never lookup keys.
+  `Custom Attributes`, and the diff `Changes` and `Analysis Diff` sections bind
+  to query definitions by object identity. A section may bind multiple
+  definitions; diagnostic names are never lookup keys.
 - An executor can read only its declared transitive prerequisite results. A
   hidden dependency therefore fails whether or not another requested query
   happened to populate the shared run, and cannot understate cost.

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -457,11 +457,14 @@ own acquisition cost or producer dependencies.
 
 The existing `ScannerRegistry` remains an assembly-local predecessor: its
 explicit prerequisites, once-per-run resources, deterministic ordering, and
-tracing are useful foundations. `DotnetInspector.Queries` now owns typed
-metadata, direct-reference, extension-method, custom-attribute, and SourceLink
-plans. String keys, mutable CLI models, path-shaped residual inputs, and
-library-command ownership remain migration boundaries rather than workspace
-contracts.
+tracing are useful foundations. `DotnetInspector.Queries` and its optional
+Research-backed companion now own typed metadata, direct-reference,
+extension-method, custom-attribute, SourceLink, API-comparison, and Analysis
+body-signal comparison plans. The Analysis query consumes old/new
+`LibraryBodyIndex` collections and returns `ResearchComparison`; the diff CLI
+still owns lazy path-to-index acquisition as a transitional adapter. String
+keys, mutable CLI models, path-shaped residual inputs, and command-owned
+acquisition remain migration boundaries rather than workspace contracts.
 
 The registry executes synchronous and asynchronous queries in deterministic
 prerequisite order. It passes each query's maximum transitive cost into the host

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,9 +11,10 @@ core: workspace contexts, typed query planning, acquisition and caching, shared
 identity and provenance, owner-issued correspondence, and safe presentation
 boundaries. Typed query-planning slices are implemented for library
 metadata-image, direct-reference, extension-method, custom-attribute,
-SourceLink, Integrations, and API-comparison inspection. The `diff` Changes
-section consumes the API-comparison result over host-resolved surfaces. The
-library CLI and package `--all-libraries` use the first
+SourceLink, Integrations, API-comparison, and Analysis body-signal comparison
+inspection. The `diff` Changes and Analysis Diff sections consume
+producer-owned comparison results over host-resolved surfaces and body indexes.
+The library CLI and package `--all-libraries` use the first
 workspace-backed, group-scoped query for focused Integrations demand while
 remaining query families are future work. The components below are the current
 hosts, shared substrates, and inspection producers that will extend that space.
@@ -24,6 +25,10 @@ hosts, shared substrates, and inspection producers that will extend that space.
   and content-shaped metadata, reference, extension-method, custom-attribute,
   SourceLink, API-comparison, and progressive call-graph queries. It has no
   Markout, console, or filesystem-path dependency.
+- `src/DotnetInspector.ResearchQueries/` contains the optional Research-backed
+  L1 query family. Its first query compares already-acquired Analysis body
+  indexes and returns `ResearchComparison` without pulling Research or
+  Decompiler dependencies into the core query assembly.
 - `src/ILInspector.Metadata/` reads PE metadata and portable-PDB structure: named documents, checksums, sequence-point relationships/ranges, raw custom-debug-information blobs, API surfaces, method classification, and assembly details. `MetadataFindings` projects API and portable-PDB build-context observations onto the shared Finding spine while retaining compatibility classification through `ApiDiff`.
 - `src/ILInspector.SourceLink/` sits above Metadata and SourceLinkFetch. It owns SourceLink map extraction, canonical document paths, URL decoration, provenance, high-level type/member/IL-offset resolution, source-document/member-source Findings, and SourceLink-aware debug audits.
 - `src/SourceLinkFetch/` owns the dependency-free SourceLink map matcher and provenance grammar.

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -15,6 +15,7 @@
     <Project Path="src/DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
     <Project Path="src/DotnetInspector.Queries.Tests/DotnetInspector.Queries.Tests.csproj" />
     <Project Path="src/DotnetInspector.Queries/DotnetInspector.Queries.csproj" />
+    <Project Path="src/DotnetInspector.ResearchQueries/DotnetInspector.ResearchQueries.csproj" />
     <Project Path="src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj" />
     <Project Path="src/DotnetInspector.Services/DotnetInspector.Services.csproj" />
     <Project Path="src/ILInspector.Analysis.App/ILInspector.Analysis.App.csproj" />

--- a/src/DotnetInspector.Queries.Tests/BodySignalComparisonQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/BodySignalComparisonQueryTests.cs
@@ -1,0 +1,42 @@
+using DotnetInspector.Fixtures;
+using ILInspector.Analysis;
+using ILInspector.Research;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class BodySignalComparisonQueryTests
+{
+    [Fact]
+    public void Execute_ReturnsResearchOwnedAnalysisEvidenceFromSuppliedIndexes()
+    {
+        var oldIndex = LibraryBodyIndex.Open(
+            FixtureCatalog.DiffPair.OldAssemblyPath());
+        var newIndex = LibraryBodyIndex.Open(
+            FixtureCatalog.DiffPair.NewAssemblyPath());
+
+        ResearchComparison comparison = BodySignalComparisonQuery.Execute(
+            new BodySignalComparisonInput([oldIndex], [newIndex]));
+
+        ResearchChange regression = Assert.Single(
+            comparison.Changes,
+            change => change.Descriptor.Id == AnalysisFindings.AllocationDescriptor.Id
+                && change.Subject.Display.Contains(
+                    "RegressesAllocInLoop",
+                    StringComparison.Ordinal));
+        Assert.Equal("1", regression.OldValue);
+        Assert.Equal("2", regression.NewValue);
+        Assert.Equal("in-loop", regression.Shape);
+        Assert.Equal(1, regression.DirectionScore);
+    }
+
+    [Fact]
+    public void Definition_IsUnboundedAndPresentationIndependent()
+    {
+        Assert.Equal(
+            InspectionCost.Unbounded,
+            BodySignalComparisonQuery.Definition.Cost);
+        Assert.DoesNotContain(
+            typeof(BodySignalComparisonQuery).Assembly.GetReferencedAssemblies(),
+            reference => reference.Name is "Markout" or "dotnet-inspect");
+    }
+}

--- a/src/DotnetInspector.Queries.Tests/BodySignalComparisonQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/BodySignalComparisonQueryTests.cs
@@ -30,13 +30,8 @@ public sealed class BodySignalComparisonQueryTests
     }
 
     [Fact]
-    public void Definition_IsUnboundedAndPresentationIndependent()
-    {
-        Assert.Equal(
+    public void Definition_IsUnbounded()
+        => Assert.Equal(
             InspectionCost.Unbounded,
             BodySignalComparisonQuery.Definition.Cost);
-        Assert.DoesNotContain(
-            typeof(BodySignalComparisonQuery).Assembly.GetReferencedAssemblies(),
-            reference => reference.Name is "Markout" or "dotnet-inspect");
-    }
 }

--- a/src/DotnetInspector.Queries.Tests/DotnetInspector.Queries.Tests.csproj
+++ b/src/DotnetInspector.Queries.Tests/DotnetInspector.Queries.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DotnetInspector.Queries\DotnetInspector.Queries.csproj" />
+    <ProjectReference Include="..\DotnetInspector.ResearchQueries\DotnetInspector.ResearchQueries.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCaller\ILInspector.Analysis.CallerGraphCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphTarget\ILInspector.Analysis.CallerGraphTarget.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphTargetV2\ILInspector.Analysis.CallerGraphTargetV2.csproj" ReferenceOutputAssembly="false" />

--- a/src/DotnetInspector.ResearchQueries/BodySignalComparisonQuery.cs
+++ b/src/DotnetInspector.ResearchQueries/BodySignalComparisonQuery.cs
@@ -1,0 +1,39 @@
+using ILInspector.Analysis;
+using ILInspector.Research;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// Content-shaped inputs for comparing Analysis body signals across two
+/// already-acquired assembly versions.
+/// </summary>
+public sealed record BodySignalComparisonInput(
+    IReadOnlyList<LibraryBodyIndex> OldIndexes,
+    IReadOnlyList<LibraryBodyIndex> NewIndexes,
+    IReadOnlySet<string>? TypeFilters = null,
+    IReadOnlySet<string>? MemberTargetIdentities = null);
+
+/// <summary>
+/// Compares two sets of Analysis body indexes while retaining the
+/// Research-owned evidence and Finding correspondence.
+/// </summary>
+public static class BodySignalComparisonQuery
+{
+    public static InspectionQuery<ResearchComparison> Definition { get; } =
+        new("Body signal comparison", InspectionCost.Unbounded);
+
+    public static ResearchComparison Execute(BodySignalComparisonInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(input.OldIndexes);
+        ArgumentNullException.ThrowIfNull(input.NewIndexes);
+
+        return ResearchDiff.Compare(
+            new ResearchDiffInput([], BodyIndexes: input.OldIndexes),
+            new ResearchDiffInput([], BodyIndexes: input.NewIndexes),
+            new ResearchDiffOptions(
+                ResearchChangeMechanism.BodySignals,
+                TypeFilters: input.TypeFilters,
+                MemberTargetIdentities: input.MemberTargetIdentities));
+    }
+}

--- a/src/DotnetInspector.ResearchQueries/DotnetInspector.ResearchQueries.csproj
+++ b/src/DotnetInspector.ResearchQueries/DotnetInspector.ResearchQueries.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Richard Lander</Authors>
+    <Description>Typed Research-backed inspection queries for dotnet-inspect consumers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotnetInspector.Queries\DotnetInspector.Queries.csproj" />
+    <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
+    <ProjectReference Include="..\ILInspector.Research\ILInspector.Research.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/dotnet-inspect.Tests/CommandErrorOwnershipTests.cs
+++ b/src/dotnet-inspect.Tests/CommandErrorOwnershipTests.cs
@@ -708,7 +708,7 @@ public class CommandErrorOwnershipTests
     /// a reference added by an imported build file appears in the second and in
     /// no project XML -- and the union is the safe answer.
     /// </remarks>
-    private static HashSet<string> ProjectClosure(string projectPath)
+    internal static HashSet<string> ProjectClosure(string projectPath)
     {
         return Closures.GetOrAdd(Path.GetFullPath(projectPath), Walk);
 
@@ -970,7 +970,7 @@ public class CommandErrorOwnershipTests
             StringComparer.Ordinal);
     }
 
-    private static string RepositoryRoot()
+    internal static string RepositoryRoot()
     {
         for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
         {

--- a/src/dotnet-inspect.Tests/LayeringTests.cs
+++ b/src/dotnet-inspect.Tests/LayeringTests.cs
@@ -4,6 +4,7 @@ using System.Reflection.PortableExecutable;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
 using DotnetInspector.Models;
+using DotnetInspector.Queries;
 
 namespace DotnetInspector.Tests;
 
@@ -18,6 +19,25 @@ public sealed class LayeringTests
         Assert.DoesNotContain(
             typeof(InstructionProducer).Assembly.GetReferencedAssemblies(),
             reference => reference.Name == "ILInspector.Metadata");
+    }
+
+    [Fact]
+    public void CoreQueries_DoNotAcquireResearchOrDecompilerProjects()
+    {
+        string project = Path.Combine(
+            CommandErrorOwnershipTests.RepositoryRoot(),
+            "src",
+            "DotnetInspector.Queries",
+            "DotnetInspector.Queries.csproj");
+        string[] closure = CommandErrorOwnershipTests.ProjectClosure(project)
+            .Select(path => Path.GetFileNameWithoutExtension(path)!)
+            .ToArray();
+
+        Assert.DoesNotContain("ILInspector.Research", closure);
+        Assert.DoesNotContain("ILInspector.Decompiler", closure);
+        Assert.Equal(
+            "DotnetInspector.Queries",
+            typeof(ApiComparisonQuery).Assembly.GetName().Name);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1809,10 +1809,25 @@ public class SectionPipelineTests
                         DiffSections.AnalysisDiff.Name,
                     },
                 });
+        HashSet<InspectionQueryDefinition> implementationSelection =
+            DiffCommand.GetRequestedQueries(
+                catalog.Pipeline,
+                new DiffOptions
+                {
+                    AllocRegressionsOnly = true,
+                    IncludeSections = new HashSet<string>(
+                        StringComparer.OrdinalIgnoreCase)
+                    {
+                        DiffSections.ImplementationDiff.Name,
+                    },
+                });
 
         Assert.Equal(
             [BodySignalComparisonQuery.Definition],
             singleSection);
+        Assert.Equal(
+            [BodySignalComparisonQuery.Definition],
+            implementationSelection);
         Assert.Equal(
             [
                 ApiComparisonQuery.Definition,

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1663,12 +1663,15 @@ public class SectionPipelineTests
                 query => query.Name,
                 StringComparer.Ordinal));
         Assert.Equal(
-            [ApiComparisonQuery.Definition],
+            [
+                ApiComparisonQuery.Definition,
+                BodySignalComparisonQuery.Definition,
+            ],
             catalog.Pipeline.DeclaredQueries);
     }
 
     [Fact]
-    public void DiffChangesSection_DemandsOnlyApiComparisonQuery()
+    public void DiffComparisonSections_DemandTheirProducerQueriesAndCosts()
     {
         DiffSectionCatalog catalog = DiffSections.CreateCatalog();
         var changes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -1686,32 +1689,54 @@ public class SectionPipelineTests
         Assert.Equal(
             [ApiComparisonQuery.Definition],
             catalog.Pipeline.GetRequiredQueries(Verbosity.Minimal));
-        Assert.Empty(
+        Assert.Equal(
+            [BodySignalComparisonQuery.Definition],
             catalog.Pipeline.GetRequiredQueries(Verbosity.Minimal, analysis));
         Assert.Equal(
             SectionCost.NetworkFree,
             Assert.Single(
                 catalog.Pipeline.SectionCosts,
                 section => section.Name == DiffSections.Changes.Name).Cost);
+        Assert.Equal(
+            SectionCost.Unbounded,
+            Assert.Single(
+                catalog.Pipeline.SectionCosts,
+                section => section.Name == DiffSections.AnalysisDiff.Name).Cost);
     }
 
     [Fact]
     public void DiffQueryRegistry_RunsOnlySelectedSectionDemand()
     {
         DiffSectionCatalog catalog = DiffSections.CreateCatalog();
-        var context = new DiffQueryContext(new ApiSurface(), new ApiSurface());
-        List<InspectionQueryDefinition> executed = [];
         var analysis = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             DiffSections.AnalysisDiff.Name,
         };
+        int analysisInputsCreated = 0;
+        var analysisContext = new DiffQueryContext(
+            new ApiSurface(),
+            new ApiSurface(),
+            () =>
+            {
+                analysisInputsCreated++;
+                return new BodySignalComparisonInput([], []);
+            });
+        List<InspectionQueryDefinition> analysisExecuted = [];
 
         catalog.QueryRegistry.Run(
             catalog.Pipeline.GetRequiredQueries(Verbosity.Minimal, analysis),
-            context,
-            (query, _) => executed.Add(query));
-        Assert.Empty(executed);
+            analysisContext,
+            (query, _) => analysisExecuted.Add(query));
 
+        Assert.Equal([BodySignalComparisonQuery.Definition], analysisExecuted);
+        Assert.Equal(1, analysisInputsCreated);
+
+        var changesContext = new DiffQueryContext(
+            new ApiSurface(),
+            new ApiSurface(),
+            () => throw new InvalidOperationException(
+                "Changes-only demand must not acquire Analysis indexes."));
+        List<InspectionQueryDefinition> changesExecuted = [];
         catalog.QueryRegistry.Run(
             catalog.Pipeline.GetRequiredQueries(
                 Verbosity.Minimal,
@@ -1719,14 +1744,43 @@ public class SectionPipelineTests
                 {
                     DiffSections.Changes.Name,
                 }),
-            context,
-            (query, _) => executed.Add(query));
+            changesContext,
+            (query, _) => changesExecuted.Add(query));
 
-        Assert.Equal([ApiComparisonQuery.Definition], executed);
+        Assert.Equal([ApiComparisonQuery.Definition], changesExecuted);
+
+        int composedInputsCreated = 0;
+        var composedContext = new DiffQueryContext(
+            new ApiSurface(),
+            new ApiSurface(),
+            () =>
+            {
+                composedInputsCreated++;
+                return new BodySignalComparisonInput([], []);
+            });
+        List<InspectionQueryDefinition> composedExecuted = [];
+        catalog.QueryRegistry.Run(
+            catalog.Pipeline.GetRequiredQueries(
+                Verbosity.Minimal,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    DiffSections.Changes.Name,
+                    DiffSections.AnalysisDiff.Name,
+                }),
+            composedContext,
+            (query, _) => composedExecuted.Add(query));
+
+        Assert.Equal(
+            [
+                ApiComparisonQuery.Definition,
+                BodySignalComparisonQuery.Definition,
+            ],
+            composedExecuted);
+        Assert.Equal(1, composedInputsCreated);
     }
 
     [Fact]
-    public void DiffCommand_AllocRegressionsDoesNotRequestUnusedChangesQuery()
+    public void DiffCommand_AllocRegressionsRequestsAnalysisWithoutUnusedChanges()
     {
         DiffSectionCatalog catalog = DiffSections.CreateCatalog();
 
@@ -1756,9 +1810,14 @@ public class SectionPipelineTests
                     },
                 });
 
-        Assert.Empty(singleSection);
         Assert.Equal(
-            [ApiComparisonQuery.Definition],
+            [BodySignalComparisonQuery.Definition],
+            singleSection);
+        Assert.Equal(
+            [
+                ApiComparisonQuery.Definition,
+                BodySignalComparisonQuery.Definition,
+            ],
             composedDocument);
     }
 

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -196,7 +196,10 @@ public class DiffCommand
                     GetRequestedQueries(pipeline, options);
                 InspectionQueryResults queryResults = catalog.QueryRegistry.Run(
                     requestedQueries,
-                    new DiffQueryContext(inputs.FromSurface, inputs.ToSurface));
+                    new DiffQueryContext(
+                        inputs.FromSurface,
+                        inputs.ToSurface,
+                        () => CreateBodySignalComparisonInput(inputs, options)));
 
                 if (options.JsonOutput || options.IncludeSections is { Count: > 1 })
                 {
@@ -268,7 +271,9 @@ public class DiffCommand
 
                 if (SelectsAnalysisDiff(options))
                 {
-                    var analysis = BuildAnalysisDiff(inputs.FromPaths, inputs.ToPaths, options, inputs.FromSurface, inputs.ToSurface);
+                    var analysis = BuildAnalysisDiff(
+                        queryResults.Get(BodySignalComparisonQuery.Definition),
+                        options);
                     var view = DiffOutputFormatter.BuildAnalysisDiffView(
                         inputs.Name,
                         analysis.Rows,
@@ -726,10 +731,16 @@ public class DiffCommand
             }
         }
         else if (SelectsFindingTransitions(options)
-            || SelectsImplementationDiff(options)
-            || SelectsAnalysisDiff(options))
+            || SelectsImplementationDiff(options))
         {
             return [];
+        }
+        else if (SelectsAnalysisDiff(options))
+        {
+            querySections = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                DiffSections.AnalysisDiff.Name,
+            };
         }
 
         return pipeline.GetRequiredQueries(Verbosity.Minimal, querySections);
@@ -769,11 +780,8 @@ public class DiffCommand
         if (selected.Contains(DiffSections.AnalysisDiff.Name))
         {
             var analysis = BuildAnalysisDiff(
-                inputs.FromPaths,
-                inputs.ToPaths,
-                options,
-                inputs.FromSurface,
-                inputs.ToSurface);
+                queryResults.Get(BodySignalComparisonQuery.Definition),
+                options);
             analysisView = DiffOutputFormatter.BuildAnalysisDiffView(
                 inputs.Name,
                 analysis.Rows,
@@ -846,21 +854,24 @@ public class DiffCommand
         ApiSurface? fromSurface = null,
         ApiSurface? toSurface = null)
     {
-        var memberTargetIdentities = options.MemberFilter.Count == 0
-            ? null
-            : ResolveMemberTargetIdentities(
-                fromSurface ?? AssemblySetSurfaceBuilder.Build(fromPaths, includeAll: options.IncludeAll) ?? new ApiSurface(),
-                toSurface ?? AssemblySetSurfaceBuilder.Build(toPaths, includeAll: options.IncludeAll) ?? new ApiSurface(),
-                options.MemberFilter,
-                options.TypeFilter,
-                requireBodyTargets: true).MemberIdentities;
-        var research = ResearchDiff.Compare(
-            ResearchDiffInput.FromAssemblies(fromPaths),
-            ResearchDiffInput.FromAssemblies(toPaths),
-            new ResearchDiffOptions(
-                ResearchChangeMechanism.BodySignals,
-                TypeFilters: options.TypeFilter,
-                MemberTargetIdentities: memberTargetIdentities));
+        var comparisonInput = CreateBodySignalComparisonInput(
+            fromPaths,
+            toPaths,
+            options,
+            fromSurface,
+            toSurface);
+        return BuildAnalysisDiff(
+            BodySignalComparisonQuery.Execute(comparisonInput),
+            options);
+    }
+
+    internal static AnalysisDiffResult BuildAnalysisDiff(
+        ResearchComparison research,
+        DiffOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(research);
+        ArgumentNullException.ThrowIfNull(options);
+
         var ranked = research.Changes
             .Where(change => change.Category == ResearchChangeCategory.BodySignal
                 && change.Descriptor.Id.StartsWith("analysis.", StringComparison.Ordinal)
@@ -881,6 +892,38 @@ public class DiffCommand
             .ToList();
 
         return RankAnalysisRows(ranked, options.ChangedOnly, options.AllocRegressionsOnly);
+    }
+
+    private static BodySignalComparisonInput CreateBodySignalComparisonInput(
+        DiffInputs inputs,
+        DiffOptions options)
+        => CreateBodySignalComparisonInput(
+            inputs.FromPaths,
+            inputs.ToPaths,
+            options,
+            inputs.FromSurface,
+            inputs.ToSurface);
+
+    internal static BodySignalComparisonInput CreateBodySignalComparisonInput(
+        IReadOnlyList<string> fromPaths,
+        IReadOnlyList<string> toPaths,
+        DiffOptions options,
+        ApiSurface? fromSurface = null,
+        ApiSurface? toSurface = null)
+    {
+        var memberTargetIdentities = options.MemberFilter.Count == 0
+            ? null
+            : ResolveMemberTargetIdentities(
+                fromSurface ?? AssemblySetSurfaceBuilder.Build(fromPaths, includeAll: options.IncludeAll) ?? new ApiSurface(),
+                toSurface ?? AssemblySetSurfaceBuilder.Build(toPaths, includeAll: options.IncludeAll) ?? new ApiSurface(),
+                options.MemberFilter,
+                options.TypeFilter,
+                requireBodyTargets: true).MemberIdentities;
+        return new BodySignalComparisonInput(
+            fromPaths.Select(LibraryBodyIndex.Open).ToArray(),
+            toPaths.Select(LibraryBodyIndex.Open).ToArray(),
+            options.TypeFilter,
+            memberTargetIdentities);
     }
 
     internal static ImplementationDiffResult BuildImplementationDiff(

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -731,7 +731,8 @@ public class DiffCommand
             }
         }
         else if (SelectsFindingTransitions(options)
-            || SelectsImplementationDiff(options))
+            || (SelectsImplementationDiff(options)
+                && !SelectsAnalysisDiff(options)))
         {
             return [];
         }

--- a/src/dotnet-inspect/Sections/DiffSections.cs
+++ b/src/dotnet-inspect/Sections/DiffSections.cs
@@ -6,9 +6,30 @@ namespace DotnetInspector.Sections;
 
 public sealed record DiffDiscoveryModel;
 
-public sealed record DiffQueryContext(
-    ApiSurface FromSurface,
-    ApiSurface ToSurface);
+public sealed class DiffQueryContext
+{
+    readonly Func<BodySignalComparisonInput>? _createBodySignalComparisonInput;
+    BodySignalComparisonInput? _bodySignalComparisonInput;
+
+    public DiffQueryContext(
+        ApiSurface fromSurface,
+        ApiSurface toSurface,
+        Func<BodySignalComparisonInput>? createBodySignalComparisonInput = null)
+    {
+        FromSurface = fromSurface ?? throw new ArgumentNullException(nameof(fromSurface));
+        ToSurface = toSurface ?? throw new ArgumentNullException(nameof(toSurface));
+        _createBodySignalComparisonInput = createBodySignalComparisonInput;
+    }
+
+    public ApiSurface FromSurface { get; }
+    public ApiSurface ToSurface { get; }
+
+    public BodySignalComparisonInput GetBodySignalComparisonInput()
+        => _bodySignalComparisonInput ??=
+            (_createBodySignalComparisonInput
+                ?? throw new InspectionQueryException(
+                    "Body signal comparison input was not provided."))();
+}
 
 public sealed record DiffSectionCatalog(
     SectionPipeline<DiffDiscoveryModel> Pipeline,
@@ -36,7 +57,7 @@ public static class DiffSections
         return new SectionPipeline<DiffDiscoveryModel>()
             .UseQueryCosts(queryCost)
             .Add<Changes>(ApiComparisonQuery.Definition)
-            .Add<AnalysisDiff>()
+            .Add<AnalysisDiff>(BodySignalComparisonQuery.Definition)
             .Add<ImplementationDiff>()
             .Add<FindingTransitions>();
     }
@@ -47,7 +68,11 @@ public static class DiffSections
                 ApiComparisonQuery.Definition,
                 static context => ApiComparisonQuery.Execute(
                     context.FromSurface,
-                    context.ToSurface));
+                    context.ToSurface))
+            .Add(
+                BodySignalComparisonQuery.Definition,
+                static context => BodySignalComparisonQuery.Execute(
+                    context.GetBodySignalComparisonInput()));
 
     public static DocumentSchema CreateSchema()
     {

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -92,6 +92,7 @@
     <ProjectReference Include="..\DotnetInspector.CSharpBodySlicer\DotnetInspector.CSharpBodySlicer.csproj" />
     <ProjectReference Include="..\DotnetInspector.Packages\DotnetInspector.Packages.csproj" />
     <ProjectReference Include="..\DotnetInspector.Queries\DotnetInspector.Queries.csproj" />
+    <ProjectReference Include="..\DotnetInspector.ResearchQueries\DotnetInspector.ResearchQueries.csproj" />
     <ProjectReference Include="..\DotnetInspector.MetadataRendering\DotnetInspector.MetadataRendering.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\InertText\InertText.csproj" />


### PR DESCRIPTION
## Summary

- Add the optional `DotnetInspector.ResearchQueries` L1 companion.
- Add `BodySignalComparisonQuery` over already-acquired old/new
  `LibraryBodyIndex` collections, returning Research-owned
  `ResearchComparison`.
- Bind `diff` Analysis Diff to the typed query definition and derive its
  Unbounded cost from the registry.
- Keep member-target resolution, path-to-index acquisition, ranking,
  filtering, and rendering in the CLI.

## Behavior

- Analysis body indexes are acquired lazily only when the selected output path
  demands Analysis Diff.
- Changes-only demand does not acquire Analysis indexes.
- Analysis-only demand does not execute API comparison.
- Composed Changes and Analysis Diff demand executes both queries once.
- Markdown, TSV/JSONL, JSON, filtering, ranking, and allocation-regression
  behavior remain unchanged.

The path-to-index adapter is intentionally transitional and host-owned. The L1
query takes content-derived indexes rather than filesystem paths. Keeping the
query in a companion assembly avoids adding Research and Decompiler
dependencies to core `DotnetInspector.Queries`.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `DotnetInspector.Queries.Tests`: 44 passed
- focused `SectionPipelineTests`, `DiffCommandTests`, and `LayeringTests`: 348
  passed
- fixed-head full `dotnet-inspect.Tests`: 3,269 passed, 14 environment skips
- changed Markdown passes `markdownlint`
- fixed-head reviewers compared 29 CLI combinations against the base with
  byte-identical output and exit codes

## Review

Two-model adversarial review was completed on fixed head `56b0ea804`.
The first review found one planner-precedence regression and one weak layering
gate. Commit `56b0ea804` fixes both; MAI-Code and Claude Opus re-reviewed the
fixed head cleanly.

Part of #3229.
