### PR TITLE
Preserve function-pointer call-graph cache identity

### DIFF
--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -2679,6 +2679,10 @@ frozen generation. `CatalogMemberCorrespondencePlanTests`,
 `CatalogCallGraphScopeTests`, and `MemberCallGraphSessionTests` gate
 forwarded declaring/parameter/return types, duplicate and unavailable evidence,
 physical participant deduplication, generation release, and product reuse.
+`CatalogCallGraphScopeTests.FunctionPointerPayloadKeepsOverloadsAndTheirCallersSeparate`
+and `PlanCacheIdentityPreservesRecursiveFunctionPointerPayload` gate the
+catalog plan cache against collapsing function-pointer calling conventions,
+return and parameter types, or custom modifiers (#3911).
 `TypeResolutionContextTests.NestedForwarder_ResolvesFullDeclarationChain`
 gates the nested-forwarder composition from declaration chain through final
 definition.

--- a/src/ILInspector.Analysis.CallerGraphCaller/ILInspector.Analysis.CallerGraphCaller.csproj
+++ b/src/ILInspector.Analysis.CallerGraphCaller/ILInspector.Analysis.CallerGraphCaller.csproj
@@ -10,6 +10,7 @@
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>

--- a/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
+++ b/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
@@ -51,6 +51,14 @@ namespace Shared
         public static void UseGenericStore() =>
             Target.ArityApi.Store<string>(1);
 
+        public static unsafe void UseCdeclStore(
+            delegate* unmanaged[Cdecl]<int, int> value) =>
+            Target.FunctionPointerApi.Store(value);
+
+        public static unsafe void UseStdcallStore(
+            delegate* unmanaged[Stdcall]<int, int> value) =>
+            Target.FunctionPointerApi.Store(value);
+
         public static void CallBodiless(Target.IBodilessApi target) =>
             target.Invoke();
 

--- a/src/ILInspector.Analysis.CallerGraphTarget/ILInspector.Analysis.CallerGraphTarget.csproj
+++ b/src/ILInspector.Analysis.CallerGraphTarget/ILInspector.Analysis.CallerGraphTarget.csproj
@@ -10,6 +10,7 @@
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>

--- a/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
+++ b/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
@@ -69,6 +69,19 @@ namespace Target
         }
     }
 
+    public static unsafe class FunctionPointerApi
+    {
+        public static void Store(
+            delegate* unmanaged[Cdecl]<int, int> value)
+        {
+        }
+
+        public static void Store(
+            delegate* unmanaged[Stdcall]<int, int> value)
+        {
+        }
+    }
+
     public sealed class InstanceRecursionApi
     {
         public bool Recurse(int depth) =>

--- a/src/ILInspector.Analysis.CallerGraphTargetV2/ILInspector.Analysis.CallerGraphTargetV2.csproj
+++ b/src/ILInspector.Analysis.CallerGraphTargetV2/ILInspector.Analysis.CallerGraphTargetV2.csproj
@@ -7,6 +7,7 @@
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>

--- a/src/ILInspector.Analysis.Tests/CatalogCallGraphScopeTests.cs
+++ b/src/ILInspector.Analysis.Tests/CatalogCallGraphScopeTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Reflection.Metadata;
 
 using DotnetInspector.Fixtures;
 using DotnetInspector.Services;
@@ -211,6 +212,141 @@ public class CatalogCallGraphScopeTests
         Assert.Equal(
             "UseGenericStore",
             Assert.Single(generic.Children).Member.Name);
+    }
+
+    [Fact]
+    public void FunctionPointerPayloadKeepsOverloadsAndTheirCallersSeparate()
+    {
+        LibraryBodyIndex target = LibraryBodyIndex.Open(
+            FixtureCatalog.AnalysisCallerGraphTarget.AssemblyPath());
+        LibraryBodyIndex caller = LibraryBodyIndex.Open(
+            FixtureCatalog.AnalysisCallerGraphCaller.AssemblyPath());
+        using CatalogCallGraphScope scope =
+            CatalogCallGraphTestExtensions.CreateScope(
+                target,
+                [caller]);
+        MethodIdentity[] overloads = target.DeclaredMethods
+            .Where(method =>
+                method.DeclaringType.Name == "FunctionPointerApi"
+                && method.Name == "Store")
+            .ToArray();
+
+        Assert.Equal(2, overloads.Length);
+        MethodIdentity cdecl = Assert.Single(overloads, method =>
+            method.ParameterTypes[0]
+                .FunctionPointerSignature?.Header.CallingConvention
+                == SignatureCallingConvention.CDecl);
+        MethodIdentity stdcall = Assert.Single(overloads, method =>
+            method.ParameterTypes[0]
+                .FunctionPointerSignature?.Header.CallingConvention
+                == SignatureCallingConvention.StdCall);
+
+        CallTreeNode cdeclCallers = scope.BuildCallerTree(
+            target,
+            cdecl.MetadataToken);
+        CallTreeNode stdcallCallers = scope.BuildCallerTree(
+            target,
+            stdcall.MetadataToken);
+
+        Assert.Equal(
+            "UseCdeclStore",
+            Assert.Single(cdeclCallers.Children).Member.Name);
+        Assert.Equal(
+            "UseStdcallStore",
+            Assert.Single(stdcallCallers.Children).Member.Name);
+        Assert.NotEqual(
+            cdeclCallers.GraphEvidence?.Identity,
+            stdcallCallers.GraphEvidence?.Identity);
+    }
+
+    [Fact]
+    public void PlanCacheIdentityPreservesRecursiveFunctionPointerPayload()
+    {
+        TypeRef owner = TypeRef.Definition("Owner", "", "Api");
+        TypeRef modifier = TypeRef.Definition(
+            "System.Runtime",
+            "System.Runtime.CompilerServices",
+            "CallConvCdecl");
+        TypeRef integer = TypeRef.CoreLib("System", "Int32");
+        TypeRef text = TypeRef.CoreLib("System", "String");
+        TypeRef voidType = TypeRef.CoreLib("System", "Void");
+
+        GraphNodeIdentity Identity(
+            SignatureCallingConvention convention,
+            TypeRef returnType,
+            TypeRef parameter) =>
+            GraphNodeIdentity.FromMember(
+                new MemberRef(
+                    owner,
+                    "Store",
+                    [
+                        TypeRef.UnsupportedFunctionPointer(
+                            new MethodSignature<TypeRef>(
+                                new SignatureHeader(
+                                    SignatureKind.Method,
+                                    convention,
+                                    SignatureAttributes.None),
+                                returnType,
+                                requiredParameterCount: 1,
+                                genericParameterCount: 0,
+                                [parameter])),
+                    ],
+                    voidType,
+                    MemberKind.Method));
+
+        GraphNodeIdentity baseline = Identity(
+            SignatureCallingConvention.CDecl,
+            integer,
+            integer);
+
+        Assert.NotEqual(
+            baseline,
+            Identity(
+                SignatureCallingConvention.StdCall,
+                integer,
+                integer));
+        Assert.NotEqual(
+            baseline,
+            Identity(
+                SignatureCallingConvention.CDecl,
+                text,
+                integer));
+        Assert.NotEqual(
+            baseline,
+            Identity(
+                SignatureCallingConvention.CDecl,
+                integer,
+                text));
+        Assert.NotEqual(
+            Identity(
+                SignatureCallingConvention.Unmanaged,
+                TypeRef.UnsupportedModified(
+                    modifier,
+                    integer,
+                    isRequired: true),
+                integer),
+            Identity(
+                SignatureCallingConvention.Unmanaged,
+                TypeRef.UnsupportedModified(
+                    modifier,
+                    integer,
+                    isRequired: false),
+                integer));
+        Assert.NotEqual(
+            Identity(
+                SignatureCallingConvention.Unmanaged,
+                TypeRef.UnsupportedModified(
+                    modifier,
+                    integer,
+                    isRequired: true),
+                integer),
+            Identity(
+                SignatureCallingConvention.Unmanaged,
+                TypeRef.UnsupportedModified(
+                    modifier,
+                    text,
+                    isRequired: true),
+                integer));
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/GraphIdentity.cs
+++ b/src/ILInspector.Analysis/GraphIdentity.cs
@@ -326,6 +326,8 @@ sealed class GraphStructuralMemberKey : IEquatable<GraphStructuralMemberKey>
 sealed class GraphStructuralTypeShape : IEquatable<GraphStructuralTypeShape>
 {
     const int MaxDepth = 256;
+    const byte CallingConventionMask = 0x0F;
+    const byte VarargCallingConvention = 0x05;
 
     GraphStructuralTypeShape(
         TypeRefKind kind,
@@ -335,6 +337,10 @@ sealed class GraphStructuralTypeShape : IEquatable<GraphStructuralTypeShape>
         int rank,
         int genericParameterIndex,
         string unsupportedReason,
+        byte signatureHeader,
+        int genericArity,
+        int requiredParameterCount,
+        bool isRequiredModifier,
         GraphStructuralTypeShape? elementType,
         ImmutableArray<GraphStructuralTypeShape> components)
     {
@@ -345,6 +351,10 @@ sealed class GraphStructuralTypeShape : IEquatable<GraphStructuralTypeShape>
         Rank = rank;
         GenericParameterIndex = genericParameterIndex;
         UnsupportedReason = unsupportedReason;
+        SignatureHeader = signatureHeader;
+        GenericArity = genericArity;
+        RequiredParameterCount = requiredParameterCount;
+        IsRequiredModifier = isRequiredModifier;
         ElementType = elementType;
         Components = components;
     }
@@ -356,6 +366,10 @@ sealed class GraphStructuralTypeShape : IEquatable<GraphStructuralTypeShape>
     int Rank { get; }
     int GenericParameterIndex { get; }
     string UnsupportedReason { get; }
+    byte SignatureHeader { get; }
+    int GenericArity { get; }
+    int RequiredParameterCount { get; }
+    bool IsRequiredModifier { get; }
     GraphStructuralTypeShape? ElementType { get; }
     ImmutableArray<GraphStructuralTypeShape> Components { get; }
 
@@ -374,13 +388,51 @@ sealed class GraphStructuralTypeShape : IEquatable<GraphStructuralTypeShape>
                 0,
                 -1,
                 "shape depth exceeded",
+                0,
+                0,
+                0,
+                false,
                 null,
                 []);
         }
 
-        GraphStructuralTypeShape? element = type.ElementType is { } elementType
-            ? Create(elementType, depth + 1)
-            : null;
+        GraphStructuralTypeShape? element;
+        ImmutableArray<GraphStructuralTypeShape> components;
+        byte signatureHeader = 0;
+        int genericArity = 0;
+        int requiredParameterCount = 0;
+        bool isRequiredModifier = false;
+        if (type.FunctionPointerSignature is { } signature)
+        {
+            element = Create(signature.ReturnType, depth + 1);
+            components = signature.ParameterTypes.IsDefault
+                ? []
+                : [.. signature.ParameterTypes.Select(
+                    parameter => Create(parameter, depth + 1))];
+            signatureHeader = signature.Header.RawValue;
+            genericArity = signature.GenericParameterCount;
+            requiredParameterCount =
+                (signature.Header.RawValue & CallingConventionMask)
+                    == VarargCallingConvention
+                        ? signature.RequiredParameterCount
+                        : signature.ParameterTypes.Length;
+        }
+        else if (type.ModifierType is not null
+            && type.UnmodifiedType is not null)
+        {
+            element = Create(type.UnmodifiedType, depth + 1);
+            components = [Create(type.ModifierType, depth + 1)];
+            isRequiredModifier = type.IsRequiredModifier;
+        }
+        else
+        {
+            element = type.ElementType is { } elementType
+                ? Create(elementType, depth + 1)
+                : null;
+            components = [.. type.TypeArguments.Select(
+                argument => Create(argument, depth + 1))];
+        }
+
         return new(
             type.Kind,
             type.Assembly,
@@ -389,9 +441,12 @@ sealed class GraphStructuralTypeShape : IEquatable<GraphStructuralTypeShape>
             type.Rank,
             type.GenericParameterIndex,
             type.UnsupportedReason,
+            signatureHeader,
+            genericArity,
+            requiredParameterCount,
+            isRequiredModifier,
             element,
-            [.. type.TypeArguments.Select(
-                argument => Create(argument, depth + 1))]);
+            components);
     }
 
     public bool Equals(GraphStructuralTypeShape? other)
@@ -407,6 +462,10 @@ sealed class GraphStructuralTypeShape : IEquatable<GraphStructuralTypeShape>
                 UnsupportedReason,
                 other.UnsupportedReason,
                 StringComparison.Ordinal)
+            || SignatureHeader != other.SignatureHeader
+            || GenericArity != other.GenericArity
+            || RequiredParameterCount != other.RequiredParameterCount
+            || IsRequiredModifier != other.IsRequiredModifier
             || ElementType != other.ElementType
             || Components.Length != other.Components.Length)
         {
@@ -435,6 +494,10 @@ sealed class GraphStructuralTypeShape : IEquatable<GraphStructuralTypeShape>
         hash.Add(Rank);
         hash.Add(GenericParameterIndex);
         hash.Add(UnsupportedReason, StringComparer.Ordinal);
+        hash.Add(SignatureHeader);
+        hash.Add(GenericArity);
+        hash.Add(RequiredParameterCount);
+        hash.Add(IsRequiredModifier);
         hash.Add(ElementType);
         foreach (GraphStructuralTypeShape component in Components)
             hash.Add(component);


### PR DESCRIPTION
## Summary

Catalog call graphs now preserve complete function-pointer and custom-modifier payloads in the per-source correspondence-plan cache key, so overloads that differ by calling convention or nested signature shape cannot reuse the wrong plan.

- include function-pointer header, generic arity, vararg required count, return type, and parameters recursively
- include custom-modifier kind, modifier type, and unmodified type recursively
- gate real CDecl/StdCall overloads and callers through `CatalogCallGraphScope`

Closes #3911.

## Evidence

- real cross-assembly fixture keeps CDecl and StdCall overload callers separate
- focused structural negatives cover calling convention, return type, parameter type, modifier requiredness, and modified type
- mutation check: both new gates fail when the `GraphIdentity.cs` change is removed

## Compatibility boundary

This changes only Analysis's internal structural cache identity. Catalog-issued correspondence, physical storage identity, graph output, scope selection, and command defaults are unchanged.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build` (579/579)
- `npx markdownlint-cli docs/design/type-forwarding-resolution.md`
- `git diff --check`
