### PR TITLE
Serialize package cache service tests

### DIFF
--- a/src/DotnetInspector.Services.Tests/PackageCacheServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageCacheServiceTests.cs
@@ -2,6 +2,7 @@ using DotnetInspector.Packages;
 
 namespace DotnetInspector.Services.Tests;
 
+[Collection(CoreCacheCollection.Name)]
 public class PackageCacheServiceTests
 {
     [Fact]


### PR DESCRIPTION
## Summary

Prevents `PackageCacheServiceTests` from racing process-wide `NuGetCache` / `CoreCache` mutations by joining the existing non-parallel `CoreCache` test collection.

This addresses two observed Ubuntu CI failures where `GetCacheInfo_EmptyCache_ReturnsZeroStats` saw `pkg-index-v12` and `versions-v5` categories created by concurrent tests.

## Evidence

- `dotnet build src/DotnetInspector.Services.Tests -c Release`
- 25 consecutive `dotnet run --project src/DotnetInspector.Services.Tests -c Release --no-build --no-restore` runs

## Compatibility

Test-isolation only; product behavior is unchanged.
