### PR TITLE
Bind Deep Inspect notifier to its repository

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -574,11 +574,15 @@ jobs:
         run: |
           set -euo pipefail
           title="Deep Inspect scheduled run failed"
-          num=$(gh issue list --state open --search "$title in:title" \
+          num=$(gh issue list --repo "${{ github.repository }}" \
+            --state open --search "$title in:title" \
             --json number,title \
             --jq "map(select(.title == \"$title\")) | .[0].number // empty")
           if [ -n "$num" ]; then
-            gh issue comment "$num" --body "Another scheduled Deep Inspect run failed: $RUN_URL"
+            gh issue comment --repo "${{ github.repository }}" "$num" \
+              --body "Another scheduled Deep Inspect run failed: $RUN_URL"
           else
-            gh issue create --title "$title" --body $'The weekly Deep Inspect scheduled run failed.\n\nRun: '"$RUN_URL"$'\n\nThe failed lane(s) are visible on the run. This issue was opened automatically; it will not auto-close, so close it once the failure is triaged.'
+            gh issue create --repo "${{ github.repository }}" \
+              --title "$title" \
+              --body $'The weekly Deep Inspect scheduled run failed.\n\nRun: '"$RUN_URL"$'\n\nThe failed lane(s) are visible on the run. This issue was opened automatically; it will not auto-close, so close it once the failure is triaged.'
           fi


### PR DESCRIPTION
## Summary

Makes the scheduled Deep Inspect failure notifier work without a repository checkout by passing `--repo` to every `gh issue` command.

The notifier failed in scheduled run 30813830103 with `fatal: not a git repository`, so the underlying slow-lane failure was never reported.

## Evidence

- Parsed the rendered notifier block with `bash -n`
- Ran the exact-repository `gh issue list` lookup successfully from `/tmp`

## Compatibility

Workflow-only; manual Deep Inspect lanes and product behavior are unchanged.
