### PR TITLE
Emit LF-only all-libraries package output

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -11132,6 +11132,8 @@ public partial class CommandExecutionTests
         Assert.Contains("## Switches", all, StringComparison.Ordinal);
         Assert.Contains("| Kind | Switch | API |", all, StringComparison.Ordinal);
         Assert.Contains("| ---- | ------ | --- |", all, StringComparison.Ordinal);
+        Assert.DoesNotContain('\r', all);
+        Assert.DoesNotContain('\r', windowed);
 
         static int DataRows(string output) =>
             output.Split('\n').Count(line => line.StartsWith("| ", StringComparison.Ordinal))
@@ -11139,6 +11141,32 @@ public partial class CommandExecutionTests
 
         Assert.True(DataRows(all) > 2, $"expected an unwindowed table wider than the window, got {DataRows(all)} rows");
         Assert.Equal(2, DataRows(windowed));
+    }
+
+    [Fact]
+    public async Task PackageCommand_AllLibraries_MarkdownUsesLfThroughout()
+    {
+        var (packagePath, tempDir) = CreateLocalLibPackage();
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package", packagePath, "--all-libraries", "-S", "Library Info");
+            var (windowedExit, windowed, windowedError) = await RunAppAsync(
+                "package", packagePath, "--all-libraries", "-S", "Library Info", "--rows", "20");
+
+            Assert.Equal(0, exit);
+            Assert.Equal(0, windowedExit);
+            Assert.DoesNotContain("Tip:", error);
+            Assert.DoesNotContain("Tip:", windowedError);
+            Assert.Contains('\n', output);
+            Assert.Contains('\n', windowed);
+            Assert.DoesNotContain('\r', output);
+            Assert.DoesNotContain('\r', windowed);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -2607,7 +2607,7 @@ public class PackageCommand
         if (libraryOptions.Count)
             CountOutput.WriteCountFromMarkdown(markdown, options.OutputPath);
         else
-            Console.WriteLine(markdown);
+            OutputFormatter.WriteLfLine(Console.Out, markdown);
         return 0;
     }
 
@@ -2945,8 +2945,7 @@ public class PackageCommand
     {
         var sb = new StringBuilder();
         var title = string.IsNullOrWhiteSpace(version) ? packageName : $"{packageName} {version}";
-        sb.AppendLine($"# {title}");
-        sb.AppendLine();
+        sb.Append("# ").Append(title).Append('\n').Append('\n');
 
         foreach (var section in sections)
         {
@@ -2969,15 +2968,16 @@ public class PackageCommand
         {
             Sections = [new AggregatedSectionView { Name = section, Body = table }]
         };
-        var rendered = MarkoutSerializer.Serialize(
-            document, InspectionContext.Default, OutputFormatter.CreateWindowedOptions(rows)).Trim();
+        var output = new StringWriter { NewLine = "\n" };
+        MarkoutSerializer.Serialize(
+            document, output, InspectionContext.Default, OutputFormatter.CreateWindowedOptions(rows));
+        var rendered = output.ToString().Trim();
         if (rendered.Length == 0)
             return;
 
         if (sb.Length > 0 && !sb.ToString().EndsWith("\n\n", StringComparison.Ordinal))
-            sb.AppendLine();
-        sb.AppendLine(rendered);
-        sb.AppendLine();
+            sb.Append('\n');
+        sb.Append(rendered).Append('\n').Append('\n');
     }
 
     private static bool IsAggregatedAllLibrariesSection(string section)
@@ -3098,9 +3098,8 @@ public class PackageCommand
                 continue;
 
             if (sb.Length > 0 && !sb.ToString().EndsWith("\n\n", StringComparison.Ordinal))
-                sb.AppendLine();
-            sb.AppendLine(rendered);
-            sb.AppendLine();
+                sb.Append('\n');
+            sb.Append(rendered).Append('\n').Append('\n');
         }
     }
 
@@ -3115,7 +3114,9 @@ public class PackageCommand
             // the only text this path edits, and it does not touch rows.
             RowWindow = RowWindow.ToMarkout(options.Rows)
         };
-        var markdown = MarkoutSerializer.Serialize(view, InspectionContext.Default, writerOptions).Trim();
+        var output = new StringWriter { NewLine = "\n" };
+        MarkoutSerializer.Serialize(view, output, InspectionContext.Default, writerOptions);
+        var markdown = output.ToString().Trim();
         if (markdown.Length == 0)
             return "";
 


### PR DESCRIPTION
`package --all-libraries` now emits LF-only Markdown on every platform, including Windows, with and without `--rows`.

The command now owns LF at every composition seam: Markout serializes through LF-configured writers, the assembled document uses explicit LF separators, and the console terminator is LF. This removes the mixed CRLF/LF heading output without restoring post-hoc row-limiter normalization or changing table/window semantics.

Coverage asserts LF-only output for both aggregate and per-library sections, including the windowed path.

Validation:
- Release build of `src/dotnet-inspect.Tests`
- All 10 `PackageCommand_AllLibraries_*` command tests
- New focused tests repeated five times on Windows

Fixes #3963