### PR TITLE
Port Implementation Diff to typed query

### DIFF
--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -207,6 +207,11 @@ unified line with `Member`, `Mechanism`, `Difference`, `Change`, and `Evidence`
 columns. `Difference` contains the IL body outcome for IL rows and is empty for
 C# rows, keeping mechanism, result, edit kind, and evidence as separate
 dimensions.
+The section binds `ImplementationComparisonQuery`, whose input carries retained
+assembly descriptors, reference resolvers, and body indexes. The query opens
+those descriptors for the offline C# and IL producers and returns
+`ImplementationDiffResult`; the CLI adapter's current path-backed descriptors
+are an acquisition boundary, not part of the query contract.
 With `--authored-source`, it acquires each changed implementation member's
 endpoint PDB and
 SourceLink body, verifies the document checksum, and adds a separately labeled

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -54,8 +54,9 @@ the ownership boundaries below, not the project count.
 `DotnetInspector.Queries` and the optional
 `DotnetInspector.ResearchQueries` companion now implement metadata-image,
 direct-reference, extension-method, custom-attribute, SourceLink audit,
-API-comparison, Analysis body-signal comparison, assembly-context Integrations,
-and progressive member call-graph slices. The API-comparison seam retains
+API-comparison, Analysis body-signal comparison, Implementation comparison,
+assembly-context Integrations, and progressive member call-graph slices. The
+API-comparison seam retains
 Metadata-owned Finding correspondence and compatibility classification over
 two host-resolved surfaces. The body-signal seam consumes already-acquired
 Analysis indexes and retains `ResearchComparison`; keeping that query in the
@@ -77,11 +78,16 @@ query across every participant in one binding-consistent assembly context
 group. The command projects per-participant evidence or failure into
 compatibility models and continues each library inspection over the same
 retained immutable image.
-The diff CLI binds Changes and Analysis Diff to their concrete query
-definitions. Its transitional Analysis adapter resolves member targets and
-opens `LibraryBodyIndex` values lazily inside selected query execution; the L1
-query itself receives content-derived indexes rather than paths, and the CLI
-continues to own ranking and rendering.
+The diff CLI binds Changes, Analysis Diff, and Implementation Diff to their
+concrete query definitions. Its transitional adapters resolve member targets
+and acquire body indexes and retained assembly descriptors lazily inside
+selected query execution. The L1 queries receive content-derived inputs rather
+than paths, and the CLI continues to own ranking and rendering. Implementation
+comparison opens descriptor-backed metadata sources once for the offline C#
+and IL producers; authored-source acquisition remains a separate explicit
+enrichment. `ImplementationComparisonQueryTests.
+Execute_UsesSuppliedAssemblyContentForCSharpAndIlEvidence` gates the
+stream-backed target-content path.
 
 This is an incremental boundary, not the completed split. The remaining
 library scanners still use the transitional string-keyed `ScannerRegistry`,
@@ -272,12 +278,18 @@ the first vertical L1 canaries:
   and returns the Research-owned `ResearchComparison`. The diff adapter builds
   those indexes only under selected Analysis query demand; path acquisition
   remains an explicit host-owned migration boundary.
+- `ImplementationComparisonQuery` consumes old/new retained assembly
+  descriptors, reference resolvers, and `LibraryBodyIndex` values and returns
+  `ImplementationDiffResult`. The diff adapter creates path-backed descriptors
+  only under selected Implementation query demand; non-filesystem consumers
+  can supply stream-backed descriptors.
 - Library and package sections bind to the same SourceLink query definitions.
   Package owns compatible/highest-TFM asset selection and aggregation, not a
   parallel audit implementation.
 - Metadata sections, `References`, `Library Info`, `Extension Methods`,
-  `Custom Attributes`, and the diff `Changes` and `Analysis Diff` sections bind
-  to query definitions by object identity. A section may bind multiple
+  `Custom Attributes`, and the diff `Changes`, `Analysis Diff`, and
+  `Implementation Diff` sections bind to query definitions by object identity.
+  A section may bind multiple
   definitions; diagnostic names are never lookup keys.
 - An executor can read only its declared transitive prerequisite results. A
   hidden dependency therefore fails whether or not another requested query

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -85,9 +85,9 @@ selected query execution. The L1 queries receive content-derived inputs rather
 than paths, and the CLI continues to own ranking and rendering. Implementation
 comparison opens descriptor-backed metadata sources once for the offline C#
 and IL producers; authored-source acquisition remains a separate explicit
-enrichment. `ImplementationComparisonQueryTests.
-Execute_UsesSuppliedAssemblyContentForCSharpAndIlEvidence` gates the
-stream-backed target-content path.
+enrichment.
+`ImplementationComparisonQueryTests.Execute_UsesSuppliedAssemblyContentForCSharpAndIlEvidence`
+gates the stream-backed target-content path.
 
 This is an incremental boundary, not the completed split. The remaining
 library scanners still use the transitional string-keyed `ScannerRegistry`,

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,9 +11,10 @@ core: workspace contexts, typed query planning, acquisition and caching, shared
 identity and provenance, owner-issued correspondence, and safe presentation
 boundaries. Typed query-planning slices are implemented for library
 metadata-image, direct-reference, extension-method, custom-attribute,
-SourceLink, Integrations, API-comparison, and Analysis body-signal comparison
-inspection. The `diff` Changes and Analysis Diff sections consume
-producer-owned comparison results over host-resolved surfaces and body indexes.
+SourceLink, Integrations, API-comparison, Analysis body-signal comparison, and
+Implementation comparison inspection. The `diff` Changes, Analysis Diff, and
+Implementation Diff sections consume producer-owned comparison results over
+host-resolved surfaces, body indexes, and retained assembly content.
 The library CLI and package `--all-libraries` use the first
 workspace-backed, group-scoped query for focused Integrations demand while
 remaining query families are future work. The components below are the current
@@ -26,9 +27,10 @@ hosts, shared substrates, and inspection producers that will extend that space.
   SourceLink, API-comparison, and progressive call-graph queries. It has no
   Markout, console, or filesystem-path dependency.
 - `src/DotnetInspector.ResearchQueries/` contains the optional Research-backed
-  L1 query family. Its first query compares already-acquired Analysis body
-  indexes and returns `ResearchComparison` without pulling Research or
-  Decompiler dependencies into the core query assembly.
+  L1 query family. It compares already-acquired Analysis body indexes and
+  retained implementation assembly content, returning Research-owned results
+  without pulling Research or Decompiler dependencies into the core query
+  assembly.
 - `src/ILInspector.Metadata/` reads PE metadata and portable-PDB structure: named documents, checksums, sequence-point relationships/ranges, raw custom-debug-information blobs, API surfaces, method classification, and assembly details. `MetadataFindings` projects API and portable-PDB build-context observations onto the shared Finding spine while retaining compatibility classification through `ApiDiff`.
 - `src/ILInspector.SourceLink/` sits above Metadata and SourceLinkFetch. It owns SourceLink map extraction, canonical document paths, URL decoration, provenance, high-level type/member/IL-offset resolution, source-document/member-source Findings, and SourceLink-aware debug audits.
 - `src/SourceLinkFetch/` owns the dependency-free SourceLink map matcher and provenance grammar.

--- a/src/DotnetInspector.Queries.Tests/ImplementationComparisonQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ImplementationComparisonQueryTests.cs
@@ -1,0 +1,75 @@
+using DotnetInspector.Fixtures;
+using ILInspector.Analysis;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+using ILInspector.Research;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class ImplementationComparisonQueryTests
+{
+    [Fact]
+    public void Execute_UsesSuppliedAssemblyContentForCSharpAndIlEvidence()
+    {
+        string oldPath = FixtureCatalog.DiffPair.OldAssemblyPath();
+        string newPath = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        ImplementationDiffResult result =
+            ImplementationComparisonQuery.Execute(
+                new ImplementationComparisonInput(
+                    [StreamBackedInput(oldPath, "old.dll")],
+                    [StreamBackedInput(newPath, "new.dll")],
+                    TypeFilters: new HashSet<string>(
+                        StringComparer.OrdinalIgnoreCase)
+                    {
+                        "DiffSample",
+                    }));
+
+        ImplementationDiffMember member = Assert.Single(
+            result.Members,
+            member => member.Subject.Display.Contains(
+                "ConstantValue",
+                StringComparison.Ordinal));
+        Assert.Contains(
+            member.Changes,
+            change => change.Mechanism
+                == ResearchChangeMechanism.CSharp);
+        Assert.Contains(
+            member.Changes,
+            change => change.Mechanism
+                == ResearchChangeMechanism.IlBody);
+    }
+
+    [Fact]
+    public void Definition_IsUnbounded()
+        => Assert.Equal(
+            InspectionCost.Unbounded,
+            ImplementationComparisonQuery.Definition.Cost);
+
+    static ImplementationAssemblyInput StreamBackedInput(
+        string path,
+        string displayName)
+    {
+        byte[] content = File.ReadAllBytes(path);
+        ResolvedAssemblyReference pathReference =
+            ResolvedAssemblyReference.CreateFromPath(
+                path,
+                AssemblyResolutionProvenance.Local(
+                    "implementation query test identity"));
+        string missingPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-missing-{Guid.NewGuid():N}",
+            displayName);
+        ResolvedAssemblyReference contentReference =
+            ResolvedAssemblyReference.Create(
+                pathReference.Identity,
+                missingPath,
+                () => new MemoryStream(content, writable: false),
+                AssemblyResolutionProvenance.Local(
+                    "implementation query test content"));
+        return new ImplementationAssemblyInput(
+            contentReference,
+            MetadataSource.DefaultAssemblyReferenceResolver(path),
+            LibraryBodyIndex.Open(path));
+    }
+}

--- a/src/DotnetInspector.Queries.Tests/ImplementationComparisonQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ImplementationComparisonQueryTests.cs
@@ -1,6 +1,9 @@
 using DotnetInspector.Fixtures;
 using ILInspector.Analysis;
+using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
+using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.Research;
 
@@ -38,6 +41,43 @@ public sealed class ImplementationComparisonQueryTests
             member.Changes,
             change => change.Mechanism
                 == ResearchChangeMechanism.IlBody);
+        Assert.False(Assert.Single(
+            result.Research.RetainedComparisons
+                .Get<CSharpCanonicalLine>(
+                    CSharpFindings.LineDescriptor),
+            comparison => comparison.Subject.MemberName
+                == "ConstantValue").IsExact);
+        Assert.False(Assert.Single(
+            result.Research.RetainedComparisons
+                .Get<CanonicalIlOperation>(
+                    IlFindings.OperationDescriptor),
+            comparison => comparison.Subject.MemberName
+                == "ConstantValue").IsExact);
+    }
+
+    [Fact]
+    public void Execute_RejectsBodyIndexFromDifferentAssemblyImage()
+    {
+        string oldPath = FixtureCatalog.DiffPair.OldAssemblyPath();
+        string newPath = FixtureCatalog.DiffPair.NewAssemblyPath();
+        ImplementationAssemblyInput oldContent =
+            StreamBackedInput(oldPath, "old.dll");
+
+        var error = Assert.Throws<ArgumentException>(() =>
+            ImplementationComparisonQuery.Execute(
+                new ImplementationComparisonInput(
+                    [
+                        oldContent with
+                        {
+                            BodyIndex = LibraryBodyIndex.Open(newPath),
+                        },
+                    ],
+                    [StreamBackedInput(newPath, "new.dll")])));
+
+        Assert.Contains(
+            "does not match assembly content",
+            error.Message,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/DotnetInspector.ResearchQueries/ImplementationComparisonQuery.cs
+++ b/src/DotnetInspector.ResearchQueries/ImplementationComparisonQuery.cs
@@ -1,0 +1,38 @@
+using ILInspector.Research;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// Content-shaped inputs for comparing C# and IL implementation evidence
+/// across two already-acquired assembly versions.
+/// </summary>
+public sealed record ImplementationComparisonInput(
+    IReadOnlyList<ImplementationAssemblyInput> OldAssemblies,
+    IReadOnlyList<ImplementationAssemblyInput> NewAssemblies,
+    IReadOnlySet<string>? TypeFilters = null,
+    IReadOnlySet<string>? MemberTargetIdentities = null);
+
+/// <summary>
+/// Compares implementation evidence while retaining the Research-owned result
+/// and Finding correspondence.
+/// </summary>
+public static class ImplementationComparisonQuery
+{
+    public static InspectionQuery<ImplementationDiffResult> Definition { get; } =
+        new("Implementation comparison", InspectionCost.Unbounded);
+
+    public static ImplementationDiffResult Execute(
+        ImplementationComparisonInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(input.OldAssemblies);
+        ArgumentNullException.ThrowIfNull(input.NewAssemblies);
+
+        return ImplementationDiff.Compare(
+            input.OldAssemblies,
+            input.NewAssemblies,
+            new ImplementationDiffOptions(
+                TypeFilters: input.TypeFilters,
+                MemberTargetIdentities: input.MemberTargetIdentities));
+    }
+}

--- a/src/ILInspector.Decompiler/CSharpBodyDiff.cs
+++ b/src/ILInspector.Decompiler/CSharpBodyDiff.cs
@@ -359,6 +359,43 @@ public static class CSharpBodyDiff
             includeNonPublic,
             typeFilters,
             "new");
+        return CompareMethodIndexes(
+            oldIndex,
+            newIndex,
+            memberTargetIdentities);
+    }
+
+    public static CSharpBodyDiffResult CompareAssemblies(
+        IReadOnlyList<MetadataSource> oldSources,
+        IReadOnlyList<MetadataSource> newSources,
+        bool includeNonPublic = false,
+        IReadOnlySet<string>? typeFilters = null,
+        IReadOnlySet<string>? memberTargetIdentities = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldSources);
+        ArgumentNullException.ThrowIfNull(newSources);
+
+        var oldIndex = BuildMethodIndexWithFailures(
+            oldSources,
+            includeNonPublic,
+            typeFilters,
+            "old");
+        var newIndex = BuildMethodIndexWithFailures(
+            newSources,
+            includeNonPublic,
+            typeFilters,
+            "new");
+        return CompareMethodIndexes(
+            oldIndex,
+            newIndex,
+            memberTargetIdentities);
+    }
+
+    static CSharpBodyDiffResult CompareMethodIndexes(
+        CSharpMethodIndex oldIndex,
+        CSharpMethodIndex newIndex,
+        IReadOnlySet<string>? memberTargetIdentities)
+    {
         var oldMethods = oldIndex.Methods;
         var newMethods = newIndex.Methods;
         var rows = ImmutableArray.CreateBuilder<CSharpDiffRow>();
@@ -448,6 +485,46 @@ public static class CSharpBodyDiff
                 failures));
         }
 
+        return CreateMethodIndex(entries, failures);
+    }
+
+    internal static CSharpMethodIndex BuildMethodIndexWithFailures(
+        IReadOnlyList<MetadataSource> sources,
+        bool includeNonPublic,
+        IReadOnlySet<string>? typeFilters,
+        string side)
+    {
+        var entries = new List<CSharpMethodEntry>();
+        var failures = ImmutableArray.CreateBuilder<CSharpIdentityResolutionFailure>();
+        var assemblyOccurrences = new Dictionary<string, int>(StringComparer.Ordinal);
+        var seen = new HashSet<MetadataSource>(
+            ReferenceEqualityComparer.Instance);
+        foreach (var source in sources)
+        {
+            if (!seen.Add(source))
+                continue;
+
+            string assemblyKey = StableAssemblyKey(source);
+            int occurrence = assemblyOccurrences.GetValueOrDefault(assemblyKey);
+            assemblyOccurrences[assemblyKey] = occurrence + 1;
+            string occurrenceKey = $"{assemblyKey}#{occurrence}";
+            entries.AddRange(EnumerateMethods(
+                source,
+                source.Path,
+                occurrenceKey,
+                includeNonPublic,
+                typeFilters,
+                side,
+                failures).Select(entry => entry with { Source = source }));
+        }
+
+        return CreateMethodIndex(entries, failures);
+    }
+
+    static CSharpMethodIndex CreateMethodIndex(
+        List<CSharpMethodEntry> entries,
+        ImmutableArray<CSharpIdentityResolutionFailure>.Builder failures)
+    {
         var methods = entries
             .GroupBy(entry => $"{entry.StableAssemblyKey}|{entry.RawKey}", StringComparer.Ordinal)
             .SelectMany(group => group
@@ -469,7 +546,7 @@ public static class CSharpBodyDiff
 
     static CSharpMethodRender Decompile(CSharpMethodEntry entry, SourceCache sources)
     {
-        var source = sources.Open(entry.Path);
+        var source = sources.Open(entry);
         return Decompile(entry, source);
     }
 
@@ -2177,13 +2254,17 @@ public static class CSharpBodyDiff
         MethodDefinitionHandle MethodHandle,
         int OverloadIndex,
         bool HasBody,
-        string? BodyFingerprint);
+        string? BodyFingerprint,
+        MetadataSource? Source = null);
 
     sealed record CSharpMethodRender(CSharpRenderState State, IReadOnlyList<SourceLine> Lines, DecompilationFidelity Fidelity);
 
     internal sealed class SourceCache : IDisposable
     {
         readonly Dictionary<string, MetadataSource> _sources = new(StringComparer.Ordinal);
+
+        public MetadataSource Open(CSharpMethodEntry entry)
+            => entry.Source ?? Open(entry.Path);
 
         public MetadataSource Open(string path)
         {

--- a/src/ILInspector.Decompiler/CSharpFindings.cs
+++ b/src/ILInspector.Decompiler/CSharpFindings.cs
@@ -99,6 +99,47 @@ public static class CSharpFindings
             includeNonPublic,
             typeFilters,
             "new");
+        return CompareMethodIndexes(
+            oldIndex,
+            newIndex,
+            memberTargetIdentities,
+            acceptanceThreshold);
+    }
+
+    public static CSharpAssemblyFindingComparisonResult CompareAssemblies(
+        IReadOnlyList<MetadataSource> oldSources,
+        IReadOnlyList<MetadataSource> newSources,
+        bool includeNonPublic = false,
+        IReadOnlySet<string>? typeFilters = null,
+        IReadOnlySet<string>? memberTargetIdentities = null,
+        int acceptanceThreshold = 100)
+    {
+        ArgumentNullException.ThrowIfNull(oldSources);
+        ArgumentNullException.ThrowIfNull(newSources);
+
+        var oldIndex = CSharpBodyDiff.BuildMethodIndexWithFailures(
+            oldSources,
+            includeNonPublic,
+            typeFilters,
+            "old");
+        var newIndex = CSharpBodyDiff.BuildMethodIndexWithFailures(
+            newSources,
+            includeNonPublic,
+            typeFilters,
+            "new");
+        return CompareMethodIndexes(
+            oldIndex,
+            newIndex,
+            memberTargetIdentities,
+            acceptanceThreshold);
+    }
+
+    static CSharpAssemblyFindingComparisonResult CompareMethodIndexes(
+        CSharpBodyDiff.CSharpMethodIndex oldIndex,
+        CSharpBodyDiff.CSharpMethodIndex newIndex,
+        IReadOnlySet<string>? memberTargetIdentities,
+        int acceptanceThreshold)
+    {
         var oldMethods = oldIndex.Methods;
         var newMethods = newIndex.Methods;
         var comparisons = ImmutableArray.CreateBuilder<CSharpMemberFindingComparison>();
@@ -120,10 +161,10 @@ public static class CSharpFindings
                 representative.Display);
             var oldInspection = oldMethod is null
                 ? new FindingInspection<CSharpCanonicalLine>.Absent("Member is absent.")
-                : Inspect(sources.Open(oldMethod.Path), oldMethod.MethodHandle, subject);
+                : Inspect(sources.Open(oldMethod), oldMethod.MethodHandle, subject);
             var newInspection = newMethod is null
                 ? new FindingInspection<CSharpCanonicalLine>.Absent("Member is absent.")
-                : Inspect(sources.Open(newMethod.Path), newMethod.MethodHandle, subject);
+                : Inspect(sources.Open(newMethod), newMethod.MethodHandle, subject);
             comparisons.Add(new CSharpMemberFindingComparison(
                 key,
                 representative.Anchor,

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -283,10 +283,17 @@ public static class ImplementationDiff
         ArgumentNullException.ThrowIfNull(newInput);
 
         options ??= new ImplementationDiffOptions();
-        var research = ResearchDiff.Compare(oldInput, newInput, new ResearchDiffOptions(
-            ToResearchMechanisms(options.Mechanisms),
-            TypeFilters: options.TypeFilters,
-            MemberTargetIdentities: options.MemberTargetIdentities));
+        var research = ResearchDiff.Compare(
+            oldInput,
+            newInput,
+            new ResearchDiffOptions(
+                ToResearchMechanisms(options.Mechanisms),
+                TypeFilters: options.TypeFilters,
+                MemberTargetIdentities: options.MemberTargetIdentities)
+            {
+                RetainedComparisonDescriptorIds =
+                    RetainedComparisonDescriptorIds(options.Mechanisms),
+            });
         return FromResearchComparison(research, options);
     }
 
@@ -385,11 +392,21 @@ public static class ImplementationDiff
                 ArgumentNullException.ThrowIfNull(assembly.Assembly);
                 ArgumentNullException.ThrowIfNull(assembly.Resolver);
                 ArgumentNullException.ThrowIfNull(assembly.BodyIndex);
-                contents.Add(new ResearchAssemblyContent(
-                    MetadataSource.OpenWithoutSymbols(
-                        assembly.Assembly,
-                        assembly.Resolver),
-                    assembly.BodyIndex));
+                var source = MetadataSource.OpenWithoutSymbols(
+                    assembly.Assembly,
+                    assembly.Resolver);
+                try
+                {
+                    ValidateBodyIndex(source, assembly.BodyIndex);
+                    contents.Add(new ResearchAssemblyContent(
+                        source,
+                        assembly.BodyIndex));
+                }
+                catch
+                {
+                    source.Dispose();
+                    throw;
+                }
             }
 
             return contents;
@@ -406,6 +423,44 @@ public static class ImplementationDiff
     {
         foreach (var content in contents)
             content.Source.Dispose();
+    }
+
+    static void ValidateBodyIndex(
+        MetadataSource source,
+        LibraryBodyIndex bodyIndex)
+    {
+        MethodIdentity? indexedMethod =
+            bodyIndex.DeclaredMethods.FirstOrDefault()
+            ?? bodyIndex.Methods.FirstOrDefault();
+        if (indexedMethod is null)
+            return;
+
+        Guid sourceMvid = source.Reader.GetGuid(
+            source.Reader.GetModuleDefinition().Mvid);
+        if (StringComparer.OrdinalIgnoreCase.Equals(
+                source.AssemblyName,
+                indexedMethod.AssemblyName)
+            && sourceMvid == indexedMethod.ModuleVersionId)
+        {
+            return;
+        }
+
+        throw new ArgumentException(
+            $"The body index for '{indexedMethod.AssemblyName}' does not match "
+            + $"assembly content '{source.AssemblyName}'.",
+            nameof(bodyIndex));
+    }
+
+    static ImmutableHashSet<string> RetainedComparisonDescriptorIds(
+        ImplementationDiffMechanism mechanisms)
+    {
+        var descriptors = ImmutableHashSet.CreateBuilder<string>(
+            StringComparer.Ordinal);
+        if (mechanisms.HasFlag(ImplementationDiffMechanism.CSharp))
+            descriptors.Add(CSharpFindings.LineDescriptor.Id);
+        if (mechanisms.HasFlag(ImplementationDiffMechanism.IlBody))
+            descriptors.Add(IlFindings.OperationDescriptor.Id);
+        return descriptors.ToImmutable();
     }
 
     public static ImplementationDiffResult WithAuthoredSourceComparisons(

--- a/src/ILInspector.Research/ImplementationDiff.cs
+++ b/src/ILInspector.Research/ImplementationDiff.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
+using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Findings;
@@ -26,6 +27,11 @@ public sealed record ImplementationDiffOptions(
     ImplementationDiffMechanism Mechanisms = ImplementationDiffMechanism.All,
     IReadOnlySet<string>? TypeFilters = null,
     IReadOnlySet<string>? MemberTargetIdentities = null);
+
+public sealed record ImplementationAssemblyInput(
+    ResolvedAssemblyReference Assembly,
+    IAssemblyReferenceResolver Resolver,
+    LibraryBodyIndex BodyIndex);
 
 public sealed record ImplementationDiffResult(
     IReadOnlyList<ImplementationDiffMember> Members,
@@ -284,6 +290,42 @@ public static class ImplementationDiff
         return FromResearchComparison(research, options);
     }
 
+    public static ImplementationDiffResult Compare(
+        IReadOnlyList<ImplementationAssemblyInput> oldAssemblies,
+        IReadOnlyList<ImplementationAssemblyInput> newAssemblies,
+        ImplementationDiffOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldAssemblies);
+        ArgumentNullException.ThrowIfNull(newAssemblies);
+
+        var oldContents = OpenAssemblyContents(oldAssemblies);
+        try
+        {
+            var newContents = OpenAssemblyContents(newAssemblies);
+            try
+            {
+                return Compare(
+                    new ResearchDiffInput([])
+                    {
+                        AssemblyContents = oldContents,
+                    },
+                    new ResearchDiffInput([])
+                    {
+                        AssemblyContents = newContents,
+                    },
+                    options);
+            }
+            finally
+            {
+                DisposeAssemblyContents(newContents);
+            }
+        }
+        finally
+        {
+            DisposeAssemblyContents(oldContents);
+        }
+    }
+
     public static ImplementationDiffResult FromResearchComparison(
         ResearchComparison research,
         ImplementationDiffOptions? options = null)
@@ -329,6 +371,41 @@ public static class ImplementationDiff
             .ToArray();
 
         return new ImplementationDiffResult(members, research);
+    }
+
+    static IReadOnlyList<ResearchAssemblyContent> OpenAssemblyContents(
+        IReadOnlyList<ImplementationAssemblyInput> assemblies)
+    {
+        var contents = new List<ResearchAssemblyContent>(assemblies.Count);
+        try
+        {
+            foreach (var assembly in assemblies)
+            {
+                ArgumentNullException.ThrowIfNull(assembly);
+                ArgumentNullException.ThrowIfNull(assembly.Assembly);
+                ArgumentNullException.ThrowIfNull(assembly.Resolver);
+                ArgumentNullException.ThrowIfNull(assembly.BodyIndex);
+                contents.Add(new ResearchAssemblyContent(
+                    MetadataSource.OpenWithoutSymbols(
+                        assembly.Assembly,
+                        assembly.Resolver),
+                    assembly.BodyIndex));
+            }
+
+            return contents;
+        }
+        catch
+        {
+            DisposeAssemblyContents(contents);
+            throw;
+        }
+    }
+
+    static void DisposeAssemblyContents(
+        IReadOnlyList<ResearchAssemblyContent> contents)
+    {
+        foreach (var content in contents)
+            content.Source.Dispose();
     }
 
     public static ImplementationDiffResult WithAuthoredSourceComparisons(

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -9,6 +9,7 @@ using ILInspector.Findings;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
+using MetadataSource = ILInspector.Decompiler.Pipeline.MetadataSource;
 
 namespace ILInspector.Research;
 
@@ -28,6 +29,8 @@ public sealed record ResearchDiffInput(
     ApiSurface? ApiSurface = null,
     IReadOnlyList<LibraryBodyIndex>? BodyIndexes = null)
 {
+    internal IReadOnlyList<ResearchAssemblyContent>? AssemblyContents { get; init; }
+
     public static ResearchDiffInput FromAssembly(string assemblyPath, ApiSurface? apiSurface = null, LibraryBodyIndex? bodyIndex = null)
         => new([assemblyPath], apiSurface, bodyIndex is null ? null : [bodyIndex]);
 
@@ -37,6 +40,10 @@ public sealed record ResearchDiffInput(
     public static ResearchDiffInput FromApiSurface(ApiSurface apiSurface)
         => new([], apiSurface);
 }
+
+internal sealed record ResearchAssemblyContent(
+    MetadataSource Source,
+    LibraryBodyIndex BodyIndex);
 
 public static class ResearchDiff
 {
@@ -820,8 +827,8 @@ public static class ResearchDiff
             var oldMethods = MethodLookup(pair.Old.Index);
             var newMethods = MethodLookup(pair.New.Index);
             var keys = oldMethods.Keys.Intersect(newMethods.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
-            using var oldBodies = new MethodBodyLookup(pair.Old.Path);
-            using var newBodies = new MethodBodyLookup(pair.New.Path);
+            using var oldBodies = new MethodBodyLookup(pair.Old);
+            using var newBodies = new MethodBodyLookup(pair.New);
 
             foreach (var key in keys)
             {
@@ -944,10 +951,10 @@ public static class ResearchDiff
                 : IlRetentionMethodLookup(pair.New);
             using var oldBodies = pair.Old is null
                 ? null
-                : new MethodBodyLookup(pair.Old.Path);
+                : new MethodBodyLookup(pair.Old);
             using var newBodies = pair.New is null
                 ? null
-                : new MethodBodyLookup(pair.New.Path);
+                : new MethodBodyLookup(pair.New);
 
             foreach (string key in oldMethods.Keys
                 .Union(newMethods.Keys, StringComparer.Ordinal)
@@ -1079,14 +1086,28 @@ public static class ResearchDiff
         IReadOnlySet<string>? memberTargetIdentities,
         IReadOnlySet<string> retainedComparisonDescriptorIds)
     {
-        if (oldInput.AssemblyPaths.Count == 0 || newInput.AssemblyPaths.Count == 0)
+        var oldContents = oldInput.AssemblyContents;
+        var newContents = newInput.AssemblyContents;
+        bool hasContent = oldContents is { Count: > 0 }
+            && newContents is { Count: > 0 };
+        if (!hasContent
+            && (oldInput.AssemblyPaths.Count == 0
+                || newInput.AssemblyPaths.Count == 0))
+        {
             return;
+        }
 
-        var diff = CSharpBodyDiff.CompareAssemblies(
-            oldInput.AssemblyPaths,
-            newInput.AssemblyPaths,
-            typeFilters: typeFilters,
-            memberTargetIdentities: memberTargetIdentities);
+        var diff = hasContent
+            ? CSharpBodyDiff.CompareAssemblies(
+                oldContents!.Select(content => content.Source).ToArray(),
+                newContents!.Select(content => content.Source).ToArray(),
+                typeFilters: typeFilters,
+                memberTargetIdentities: memberTargetIdentities)
+            : CSharpBodyDiff.CompareAssemblies(
+                oldInput.AssemblyPaths,
+                newInput.AssemblyPaths,
+                typeFilters: typeFilters,
+                memberTargetIdentities: memberTargetIdentities);
         foreach (var failure in diff.IdentityFailures.IsDefault
             ? []
             : diff.IdentityFailures)
@@ -1151,11 +1172,17 @@ public static class ResearchDiff
         if (!retainedComparisonDescriptorIds.Contains(CSharpFindings.LineDescriptor.Id))
             return;
 
-        var findingComparisons = CSharpFindings.CompareAssemblies(
-            oldInput.AssemblyPaths,
-            newInput.AssemblyPaths,
-            typeFilters: typeFilters,
-            memberTargetIdentities: memberTargetIdentities);
+        var findingComparisons = hasContent
+            ? CSharpFindings.CompareAssemblies(
+                oldContents!.Select(content => content.Source).ToArray(),
+                newContents!.Select(content => content.Source).ToArray(),
+                typeFilters: typeFilters,
+                memberTargetIdentities: memberTargetIdentities)
+            : CSharpFindings.CompareAssemblies(
+                oldInput.AssemblyPaths,
+                newInput.AssemblyPaths,
+                typeFilters: typeFilters,
+                memberTargetIdentities: memberTargetIdentities);
         foreach (var failure in findingComparisons.IdentityFailures)
         {
             string token = $"0x{failure.SubjectToken:X8}";
@@ -1331,6 +1358,19 @@ public static class ResearchDiff
 
     static IEnumerable<BodyIndexEntry> BodyIndexEntries(ResearchDiffInput input)
     {
+        if (input.AssemblyContents is { Count: > 0 } contents)
+        {
+            foreach (var content in contents)
+            {
+                yield return new BodyIndexEntry(
+                    AssemblyKey(content.BodyIndex),
+                    content.Source.Path,
+                    content.BodyIndex,
+                    content.Source);
+            }
+            yield break;
+        }
+
         if (input.BodyIndexes is { Count: > 0 } bodyIndexes)
         {
             foreach (var index in bodyIndexes)
@@ -1599,7 +1639,11 @@ public static class ResearchDiff
             _ => ToKebabCase(kind.ToString()),
         };
 
-    sealed record BodyIndexEntry(string Key, string Path, LibraryBodyIndex Index);
+    sealed record BodyIndexEntry(
+        string Key,
+        string Path,
+        LibraryBodyIndex Index,
+        MetadataSource? Source = null);
     sealed record UnionBodyIndexEntry(
         string Key,
         BodyIndexEntry? Old,
@@ -1657,15 +1701,34 @@ public static class ResearchDiff
 
     sealed class MethodBodyLookup : IDisposable
     {
-        readonly FileStream _stream;
+        readonly Stream? _stream;
         readonly PEReader _peReader;
         readonly MetadataReader _metadataReader;
+        readonly bool _ownsReaders;
 
         public MethodBodyLookup(string path)
         {
             _stream = File.OpenRead(path);
             _peReader = new PEReader(_stream, PEStreamOptions.PrefetchEntireImage);
             _metadataReader = _peReader.GetMetadataReader();
+            _ownsReaders = true;
+        }
+
+        public MethodBodyLookup(BodyIndexEntry entry)
+        {
+            if (entry.Source is null)
+            {
+                _stream = File.OpenRead(entry.Path);
+                _peReader = new PEReader(
+                    _stream,
+                    PEStreamOptions.PrefetchEntireImage);
+                _metadataReader = _peReader.GetMetadataReader();
+                _ownsReaders = true;
+                return;
+            }
+
+            _peReader = entry.Source.Pe;
+            _metadataReader = entry.Source.Reader;
         }
 
         public MetadataReader MetadataReader => _metadataReader;
@@ -1695,8 +1758,11 @@ public static class ResearchDiff
 
         public void Dispose()
         {
+            if (!_ownsReaders)
+                return;
+
             _peReader.Dispose();
-            _stream.Dispose();
+            _stream!.Dispose();
         }
     }
 }

--- a/src/dotnet-inspect.Tests/LayeringTests.cs
+++ b/src/dotnet-inspect.Tests/LayeringTests.cs
@@ -3,6 +3,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
+using ILInspector.Research;
 using DotnetInspector.Models;
 using DotnetInspector.Queries;
 
@@ -38,6 +39,18 @@ public sealed class LayeringTests
         Assert.Equal(
             "DotnetInspector.Queries",
             typeof(ApiComparisonQuery).Assembly.GetName().Name);
+    }
+
+    [Fact]
+    public void ImplementationQuery_ReturnsResearchOwnedPresentationNeutralResult()
+    {
+        Assert.Equal(
+            "ILInspector.Research",
+            typeof(ImplementationDiffResult).Assembly.GetName().Name);
+        Assert.DoesNotContain(
+            typeof(ImplementationDiffResult).Assembly
+                .GetReferencedAssemblies(),
+            reference => reference.Name == "Markout");
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1666,6 +1666,7 @@ public class SectionPipelineTests
             [
                 ApiComparisonQuery.Definition,
                 BodySignalComparisonQuery.Definition,
+                ImplementationComparisonQuery.Definition,
             ],
             catalog.Pipeline.DeclaredQueries);
     }
@@ -1682,6 +1683,11 @@ public class SectionPipelineTests
         {
             DiffSections.AnalysisDiff.Name,
         };
+        var implementation = new HashSet<string>(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            DiffSections.ImplementationDiff.Name,
+        };
 
         Assert.Equal(
             [ApiComparisonQuery.Definition],
@@ -1693,6 +1699,11 @@ public class SectionPipelineTests
             [BodySignalComparisonQuery.Definition],
             catalog.Pipeline.GetRequiredQueries(Verbosity.Minimal, analysis));
         Assert.Equal(
+            [ImplementationComparisonQuery.Definition],
+            catalog.Pipeline.GetRequiredQueries(
+                Verbosity.Minimal,
+                implementation));
+        Assert.Equal(
             SectionCost.NetworkFree,
             Assert.Single(
                 catalog.Pipeline.SectionCosts,
@@ -1702,6 +1713,12 @@ public class SectionPipelineTests
             Assert.Single(
                 catalog.Pipeline.SectionCosts,
                 section => section.Name == DiffSections.AnalysisDiff.Name).Cost);
+        Assert.Equal(
+            SectionCost.Unbounded,
+            Assert.Single(
+                catalog.Pipeline.SectionCosts,
+                section => section.Name
+                    == DiffSections.ImplementationDiff.Name).Cost);
     }
 
     [Fact]
@@ -1735,7 +1752,9 @@ public class SectionPipelineTests
             new ApiSurface(),
             new ApiSurface(),
             () => throw new InvalidOperationException(
-                "Changes-only demand must not acquire Analysis indexes."));
+                "Changes-only demand must not acquire Analysis indexes."),
+            () => throw new InvalidOperationException(
+                "Changes-only demand must not acquire Implementation inputs."));
         List<InspectionQueryDefinition> changesExecuted = [];
         catalog.QueryRegistry.Run(
             catalog.Pipeline.GetRequiredQueries(
@@ -1749,14 +1768,45 @@ public class SectionPipelineTests
 
         Assert.Equal([ApiComparisonQuery.Definition], changesExecuted);
 
-        int composedInputsCreated = 0;
+        int implementationInputsCreated = 0;
+        var implementationContext = new DiffQueryContext(
+            new ApiSurface(),
+            new ApiSurface(),
+            createImplementationComparisonInput: () =>
+            {
+                implementationInputsCreated++;
+                return new ImplementationComparisonInput([], []);
+            });
+        List<InspectionQueryDefinition> implementationExecuted = [];
+        catalog.QueryRegistry.Run(
+            catalog.Pipeline.GetRequiredQueries(
+                Verbosity.Minimal,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    DiffSections.ImplementationDiff.Name,
+                }),
+            implementationContext,
+            (query, _) => implementationExecuted.Add(query));
+
+        Assert.Equal(
+            [ImplementationComparisonQuery.Definition],
+            implementationExecuted);
+        Assert.Equal(1, implementationInputsCreated);
+
+        int analysisComposedInputsCreated = 0;
+        int implementationComposedInputsCreated = 0;
         var composedContext = new DiffQueryContext(
             new ApiSurface(),
             new ApiSurface(),
             () =>
             {
-                composedInputsCreated++;
+                analysisComposedInputsCreated++;
                 return new BodySignalComparisonInput([], []);
+            },
+            () =>
+            {
+                implementationComposedInputsCreated++;
+                return new ImplementationComparisonInput([], []);
             });
         List<InspectionQueryDefinition> composedExecuted = [];
         catalog.QueryRegistry.Run(
@@ -1766,6 +1816,7 @@ public class SectionPipelineTests
                 {
                     DiffSections.Changes.Name,
                     DiffSections.AnalysisDiff.Name,
+                    DiffSections.ImplementationDiff.Name,
                 }),
             composedContext,
             (query, _) => composedExecuted.Add(query));
@@ -1774,9 +1825,11 @@ public class SectionPipelineTests
             [
                 ApiComparisonQuery.Definition,
                 BodySignalComparisonQuery.Definition,
+                ImplementationComparisonQuery.Definition,
             ],
             composedExecuted);
-        Assert.Equal(1, composedInputsCreated);
+        Assert.Equal(1, analysisComposedInputsCreated);
+        Assert.Equal(1, implementationComposedInputsCreated);
     }
 
     [Fact]
@@ -1821,6 +1874,17 @@ public class SectionPipelineTests
                         DiffSections.ImplementationDiff.Name,
                     },
                 });
+        HashSet<InspectionQueryDefinition> implementationOnly =
+            DiffCommand.GetRequestedQueries(
+                catalog.Pipeline,
+                new DiffOptions
+                {
+                    IncludeSections = new HashSet<string>(
+                        StringComparer.OrdinalIgnoreCase)
+                    {
+                        DiffSections.ImplementationDiff.Name,
+                    },
+                });
 
         Assert.Equal(
             [BodySignalComparisonQuery.Definition],
@@ -1828,6 +1892,9 @@ public class SectionPipelineTests
         Assert.Equal(
             [BodySignalComparisonQuery.Definition],
             implementationSelection);
+        Assert.Equal(
+            [ImplementationComparisonQuery.Definition],
+            implementationOnly);
         Assert.Equal(
             [
                 ApiComparisonQuery.Definition,

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -9,6 +9,7 @@ using DotnetInspector.Services;
 using DotnetInspector.Views;
 using ILInspector.Analysis;
 using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
 using ILInspector.Findings;
 using ILInspector.Instructions;
 using ILInspector.Research;
@@ -199,7 +200,10 @@ public class DiffCommand
                     new DiffQueryContext(
                         inputs.FromSurface,
                         inputs.ToSurface,
-                        () => CreateBodySignalComparisonInput(inputs, options)));
+                        () => CreateBodySignalComparisonInput(inputs, options),
+                        () => CreateImplementationComparisonInput(
+                            inputs,
+                            options)));
 
                 if (options.JsonOutput || options.IncludeSections is { Count: > 1 })
                 {
@@ -240,13 +244,13 @@ public class DiffCommand
                 if (SelectsImplementationDiff(options) && !SelectsAnalysisDiff(options))
                 {
                     var implementation = await BuildImplementationDiffWithSourceAsync(
+                        queryResults.Get(
+                            ImplementationComparisonQuery.Definition),
                         inputs.FromPaths,
                         inputs.ToPaths,
                         options,
                         context.HttpClient,
-                        logger,
-                        inputs.FromSurface,
-                        inputs.ToSurface);
+                        logger);
                     var view = DiffOutputFormatter.BuildImplementationDiffView(
                         inputs.Name,
                         implementation,
@@ -730,11 +734,18 @@ public class DiffCommand
                 };
             }
         }
-        else if (SelectsFindingTransitions(options)
-            || (SelectsImplementationDiff(options)
-                && !SelectsAnalysisDiff(options)))
+        else if (SelectsFindingTransitions(options))
         {
             return [];
+        }
+        else if (SelectsImplementationDiff(options)
+            && !SelectsAnalysisDiff(options))
+        {
+            querySections = new HashSet<string>(
+                StringComparer.OrdinalIgnoreCase)
+            {
+                DiffSections.ImplementationDiff.Name,
+            };
         }
         else if (SelectsAnalysisDiff(options))
         {
@@ -796,13 +807,12 @@ public class DiffCommand
         if (selected.Contains(DiffSections.ImplementationDiff.Name))
         {
             var implementation = await BuildImplementationDiffWithSourceAsync(
+                queryResults.Get(ImplementationComparisonQuery.Definition),
                 inputs.FromPaths,
                 inputs.ToPaths,
                 options,
                 httpClient,
-                logger,
-                inputs.FromSurface,
-                inputs.ToSurface);
+                logger);
             implementationView = DiffOutputFormatter.BuildImplementationDiffView(
                 inputs.Name,
                 implementation,
@@ -933,6 +943,32 @@ public class DiffCommand
         DiffOptions options,
         ApiSurface? fromSurface = null,
         ApiSurface? toSurface = null)
+        => ImplementationComparisonQuery.Execute(
+            CreateImplementationComparisonInput(
+                fromPaths,
+                toPaths,
+                options,
+                fromSurface,
+                toSurface));
+
+    private static ImplementationComparisonInput
+        CreateImplementationComparisonInput(
+            DiffInputs inputs,
+            DiffOptions options)
+        => CreateImplementationComparisonInput(
+            inputs.FromPaths,
+            inputs.ToPaths,
+            options,
+            inputs.FromSurface,
+            inputs.ToSurface);
+
+    internal static ImplementationComparisonInput
+        CreateImplementationComparisonInput(
+            IReadOnlyList<string> fromPaths,
+            IReadOnlyList<string> toPaths,
+            DiffOptions options,
+            ApiSurface? fromSurface = null,
+            ApiSurface? toSurface = null)
     {
         var memberTargetIdentities = options.MemberFilter.Count == 0
             ? null
@@ -944,13 +980,22 @@ public class DiffCommand
                 requireBodyTargets: true,
                 bodySectionName: "Implementation Diff").MemberIdentities;
 
-        return ImplementationDiff.Compare(
-            ResearchDiffInput.FromAssemblies(fromPaths),
-            ResearchDiffInput.FromAssemblies(toPaths),
-            new ImplementationDiffOptions(
-                TypeFilters: options.TypeFilter,
-                MemberTargetIdentities: memberTargetIdentities));
+        return new ImplementationComparisonInput(
+            fromPaths.Select(CreateImplementationAssemblyInput).ToArray(),
+            toPaths.Select(CreateImplementationAssemblyInput).ToArray(),
+            options.TypeFilter,
+            memberTargetIdentities);
     }
+
+    static ImplementationAssemblyInput CreateImplementationAssemblyInput(
+        string path)
+        => new(
+            ResolvedAssemblyReference.CreateFromPath(
+                path,
+                AssemblyResolutionProvenance.Local(
+                    "diff implementation comparison")),
+            MetadataSource.DefaultAssemblyReferenceResolver(path),
+            LibraryBodyIndex.Open(path));
 
     internal static async Task<ImplementationDiffResult> BuildImplementationDiffWithSourceAsync(
         IReadOnlyList<string> fromPaths,
@@ -967,6 +1012,25 @@ public class DiffCommand
             options,
             fromSurface,
             toSurface);
+        return await BuildImplementationDiffWithSourceAsync(
+            result,
+            fromPaths,
+            toPaths,
+            options,
+            httpClient,
+            logger);
+    }
+
+    internal static async Task<ImplementationDiffResult>
+        BuildImplementationDiffWithSourceAsync(
+            ImplementationDiffResult result,
+            IReadOnlyList<string> fromPaths,
+            IReadOnlyList<string> toPaths,
+            DiffOptions options,
+            HttpClient httpClient,
+            VerboseLogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(result);
         if (!options.IncludeAuthoredSource || result.Members.Count == 0)
             return result;
 

--- a/src/dotnet-inspect/Sections/DiffSections.cs
+++ b/src/dotnet-inspect/Sections/DiffSections.cs
@@ -9,16 +9,23 @@ public sealed record DiffDiscoveryModel;
 public sealed class DiffQueryContext
 {
     readonly Func<BodySignalComparisonInput>? _createBodySignalComparisonInput;
+    readonly Func<ImplementationComparisonInput>?
+        _createImplementationComparisonInput;
     BodySignalComparisonInput? _bodySignalComparisonInput;
+    ImplementationComparisonInput? _implementationComparisonInput;
 
     public DiffQueryContext(
         ApiSurface fromSurface,
         ApiSurface toSurface,
-        Func<BodySignalComparisonInput>? createBodySignalComparisonInput = null)
+        Func<BodySignalComparisonInput>? createBodySignalComparisonInput = null,
+        Func<ImplementationComparisonInput>?
+            createImplementationComparisonInput = null)
     {
         FromSurface = fromSurface ?? throw new ArgumentNullException(nameof(fromSurface));
         ToSurface = toSurface ?? throw new ArgumentNullException(nameof(toSurface));
         _createBodySignalComparisonInput = createBodySignalComparisonInput;
+        _createImplementationComparisonInput =
+            createImplementationComparisonInput;
     }
 
     public ApiSurface FromSurface { get; }
@@ -29,6 +36,12 @@ public sealed class DiffQueryContext
             (_createBodySignalComparisonInput
                 ?? throw new InspectionQueryException(
                     "Body signal comparison input was not provided."))();
+
+    public ImplementationComparisonInput GetImplementationComparisonInput()
+        => _implementationComparisonInput ??=
+            (_createImplementationComparisonInput
+                ?? throw new InspectionQueryException(
+                    "Implementation comparison input was not provided."))();
 }
 
 public sealed record DiffSectionCatalog(
@@ -58,7 +71,7 @@ public static class DiffSections
             .UseQueryCosts(queryCost)
             .Add<Changes>(ApiComparisonQuery.Definition)
             .Add<AnalysisDiff>(BodySignalComparisonQuery.Definition)
-            .Add<ImplementationDiff>()
+            .Add<ImplementationDiff>(ImplementationComparisonQuery.Definition)
             .Add<FindingTransitions>();
     }
 
@@ -72,7 +85,11 @@ public static class DiffSections
             .Add(
                 BodySignalComparisonQuery.Definition,
                 static context => BodySignalComparisonQuery.Execute(
-                    context.GetBodySignalComparisonInput()));
+                    context.GetBodySignalComparisonInput()))
+            .Add(
+                ImplementationComparisonQuery.Definition,
+                static context => ImplementationComparisonQuery.Execute(
+                    context.GetImplementationComparisonInput()));
 
     public static DocumentSchema CreateSchema()
     {


### PR DESCRIPTION
## Summary

- Add `ImplementationComparisonQuery` to the optional
  `DotnetInspector.ResearchQueries` L1 companion.
- Bind `diff` Implementation Diff to the typed query definition with
  `InspectionCost.Unbounded`.
- Compare descriptor-backed assembly content through retained
  `MetadataSource` instances for both C# and IL producers without reopening
  target paths.
- Return producer-owned `ImplementationDiffResult`, including native C# and IL
  Finding comparisons.
- Keep authored-source/PDB/SourceLink acquisition as a separate explicit
  enrichment of the retained offline result.

## Behavior

- Implementation inputs are acquired lazily only when selected query demand
  requires Implementation Diff.
- Changes-only and Analysis-only demand do not acquire implementation inputs.
- Implementation-only and composed demand execute each exact query once.
- The L1 contract accepts retained assembly descriptors, reference resolvers,
  and body indexes rather than filesystem paths or CLI row types.
- Descriptor/body-index pairs are checked by assembly name and MVID before
  method tokens are decoded.
- Markdown, TSV/JSONL, JSON, member/type filters, authored-source behavior, and
  the existing `--alloc-regressions` precedence remain unchanged.

The CLI's path-backed descriptor creation is intentionally transitional and
host-owned. A stream-backed query gate uses nonexistent informational paths and
asserts semantic plus retained C#/IL evidence, so any target-path reopen fails.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `DotnetInspector.Queries.Tests`: 47 passed
- `ILInspector.Research.Tests`: 157 passed
- focused C# body-diff producer tests: 38 passed
- focused CLI/query/layering tests: 349 passed
- fixed-head full `dotnet-inspect.Tests`: 3,286 passed, 14 environment skips
- changed Markdown passes `markdownlint`

## Review

Two-model adversarial review was completed on fixed head `ba708e9bf`.

The first round identified an unexercised retained-Finding content branch and
an unguarded descriptor/body-index pairing. Commit `290deaeb6` makes
assembly-wide Implementation Diff request native C# and IL comparisons, extends
the stream-backed gate across all four producer branches, and rejects
same-name/different-MVID index mismatches.

A reported `--alloc-regressions` planner failure was dismissed after
reproduction: query planning and rendering intentionally choose Analysis Diff
together, and the existing close-negative test pins that precedence. Both
reviewers re-reviewed the merged fixed head cleanly.

Part of #3229.
