### PR TITLE
Avoid blocking the HTTP snapshot rendezvous

### DIFF
--- a/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
+++ b/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
@@ -79,7 +79,8 @@ public class HttpClientFactoryTests : IDisposable
     {
         const string ClosedPort = "http://127.0.0.1:1/";
         var observeCreation = new AsyncLocal<bool>();
-        using var decoratorEntered = new ManualResetEventSlim();
+        var decoratorEntered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         using var continueCreation = new ManualResetEventSlim();
 
         DotnetInspector.Core.HttpClientFactory.Initialize(new HttpClientFactoryOptions
@@ -92,7 +93,7 @@ public class HttpClientFactoryTests : IDisposable
             if (!observeCreation.Value)
                 return handler;
 
-            decoratorEntered.Set();
+            decoratorEntered.SetResult();
             if (!continueCreation.Wait(
                 TimeSpan.FromSeconds(10),
                 TestContext.Current.CancellationToken))
@@ -103,7 +104,7 @@ public class HttpClientFactoryTests : IDisposable
         using HttpClient unrelated = await Task.Run(
             DotnetInspector.Core.HttpClientFactory.CreateClient,
             TestContext.Current.CancellationToken);
-        Assert.False(decoratorEntered.IsSet);
+        Assert.False(decoratorEntered.Task.IsCompleted);
 
         Task<HttpClient> creation = Task.Run(
             () =>
@@ -114,9 +115,9 @@ public class HttpClientFactoryTests : IDisposable
             TestContext.Current.CancellationToken);
         try
         {
-            Assert.True(decoratorEntered.Wait(
+            await decoratorEntered.Task.WaitAsync(
                 TimeSpan.FromSeconds(10),
-                TestContext.Current.CancellationToken));
+                TestContext.Current.CancellationToken);
 
             DotnetInspector.Core.HttpClientFactory.Initialize(new HttpClientFactoryOptions
             {


### PR DESCRIPTION
## Summary

Prevents `CreateClient_CapturesOneOptionsSnapshot` from synchronously occupying its xUnit runner thread while waiting for a `Task.Run` client-creation worker.

The test failed in Ubuntu CI for #3980 because the worker did not reach the decorator rendezvous within 10 seconds. A `TaskCompletionSource` preserves the same ordering proof while allowing the runner thread to return to the pool during the wait.

## Evidence

- 50 consecutive focused Release runs of `CreateClient_CapturesOneOptionsSnapshot`
- `dotnet build dotnet-inspect.slnx -c Release`

The full fast CLI suite reached this test successfully but remains independently red on the existing `ConstraintRestatement_ResolvesManyCyclicListsWithoutPerListWaste` elapsed-time threshold; this PR does not alter that test.

## Compatibility

Test-harness scheduling only; product behavior is unchanged.
