### PR TITLE
Reconstruct enum switch pre-guards

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedGuardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SwitchRaisingSharedGuardTests.cs
@@ -231,11 +231,15 @@ public class SwitchRaisingSharedGuardTests
 
         Assert.Single(function.Descendants.OfType<Switch>());
         Assert.Empty(function.Descendants.OfType<SwitchBranch>());
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
         string output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("switch (algorithm)", output);
+        Assert.Contains("case SharedGuardAlgorithm.Low6:", output);
+        Assert.Contains("case SharedGuardAlgorithm.Low7:", output);
         Assert.Contains("case SharedGuardAlgorithm.Dense24:", output);
         Assert.Contains("case SharedGuardAlgorithm.Dense41:", output);
         Assert.DoesNotContain("Dense24Alias", output);
+        Assert.DoesNotContain("case (SharedGuardAlgorithm)", output);
         Assert.DoesNotContain("algorithm - 24", output);
         Assert.DoesNotContain("__switchValue", output);
         Assert.DoesNotContain("goto", output);
@@ -572,6 +576,143 @@ public class SwitchRaisingSharedGuardTests
         Assert.DoesNotContain("__switchValue", output);
         Assert.DoesNotContain("goto", output);
         Assert.DoesNotContain("IL_", output);
+    }
+
+    [Fact]
+    public void EnumRangeGuardSharingContinuation_IsAbsorbedIntoSwitch()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "", "GuardedAlgorithm");
+        var function = BuildSharedGuardSwitch(enumType, useEnumRangeGuard: true);
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum };
+        function.EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [enumType] = s_int };
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Empty(function.Descendants.OfType<ConditionalBranch>());
+        Assert.Equal(
+            [6, 7, 24, 25],
+            node.Sections.SelectMany(section => section.Labels).Select(label => label.Value).Order());
+    }
+
+    [Fact]
+    public void OverlappingEnumRangeGuard_RemainsSeparateFromSwitch()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "", "GuardedAlgorithm");
+        var function = BuildSharedGuardSwitch(
+            enumType,
+            switchOffset: 6,
+            useEnumRangeGuard: true);
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum };
+        function.EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [enumType] = s_int };
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<ConditionalBranch>());
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Equal([6, 7, 8, 9], node.Sections.SelectMany(section => section.Labels).Select(label => label.Value));
+    }
+
+    [Fact]
+    public void SignedEnumRangeGuard_RemainsSeparateFromSwitch()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "", "GuardedAlgorithm");
+        var function = BuildSharedGuardSwitch(
+            enumType,
+            useEnumRangeGuard: true,
+            guardIsUnsigned: false);
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum };
+        function.EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [enumType] = s_int };
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<ConditionalBranch>());
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Equal([24, 25, 26, 27], node.Sections.SelectMany(section => section.Labels).Select(label => label.Value));
+    }
+
+    [Fact]
+    public void EnumRangeGuardWithInterveningMutation_RemainsSeparateFromSwitch()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "", "GuardedAlgorithm");
+        var function = BuildSharedGuardSwitch(
+            enumType,
+            useEnumRangeGuard: true,
+            mutateBeforeSwitch: true);
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum };
+        function.EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [enumType] = s_int };
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<ConditionalBranch>());
+        Assert.Single(function.Descendants.OfType<StoreArgument>());
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Equal([24, 25, 26, 27], node.Sections.SelectMany(section => section.Labels).Select(label => label.Value));
+    }
+
+    [Fact]
+    public void EnumRangeGuardOverDifferentVariable_RemainsSeparateFromSwitch()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "", "GuardedAlgorithm");
+        var function = BuildSharedGuardSwitch(
+            enumType,
+            useEnumRangeGuard: true,
+            guardUsesOtherArgument: true);
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum };
+        function.EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [enumType] = s_int };
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<ConditionalBranch>());
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Equal([24, 25, 26, 27], node.Sections.SelectMany(section => section.Labels).Select(label => label.Value));
+    }
+
+    [Fact]
+    public void OutOfRangeNarrowEnumGuard_RemainsSeparateFromSwitch()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "", "ByteGuardedAlgorithm");
+        var function = BuildSharedGuardSwitch(
+            enumType,
+            switchOffset: 252,
+            useEnumRangeGuard: true,
+            guardOffset: 300);
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum };
+        function.EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef>
+        {
+            [enumType] = TypeRef.CoreLib("System", "Byte"),
+        };
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<ConditionalBranch>());
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Equal([252, 253, 254, 255], node.Sections.SelectMany(section => section.Labels).Select(label => label.Value));
+    }
+
+    [Fact]
+    public void EnumRangeGuardWithExternalDispatchEntry_RemainsSeparateFromSwitch()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "", "GuardedAlgorithm");
+        var function = BuildSharedGuardSwitch(
+            enumType,
+            useEnumRangeGuard: true,
+            externalDispatchEntry: true);
+        function.TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum };
+        function.EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [enumType] = s_int };
+
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<ConditionalBranch>());
+        var node = Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Equal([24, 25, 26, 27], node.Sections.SelectMany(section => section.Labels).Select(label => label.Value));
     }
 
     [Fact]
@@ -1090,27 +1231,54 @@ public class SwitchRaisingSharedGuardTests
         bool guardTargetsCaseBody = false,
         bool defaultExitsToContinuation = false,
         bool defaultContainsNestedLoopBreak = false,
-        IrExpression? switchValue = null)
+        IrExpression? switchValue = null,
+        bool useEnumRangeGuard = false,
+        bool guardIsUnsigned = true,
+        bool mutateBeforeSwitch = false,
+        bool guardUsesOtherArgument = false,
+        int guardOffset = 6,
+        bool externalDispatchEntry = false)
     {
         governingType ??= s_int;
         var body = new BlockContainer();
 
+        if (externalDispatchEntry)
+        {
+            var externalDispatch = new Block(-0x10);
+            externalDispatch.Add(new SwitchBranch(
+                new Constant(0, s_int),
+                [0x0D]));
+            body.Add(externalDispatch);
+        }
+
         var guard = new Block(0);
         guard.Add(new ConditionalBranch(
-            new Comparison(
-                ComparisonKind.LessThanOrEqual,
-                isUnsigned: true,
-                new Binary(
-                    BinaryKind.Subtract,
-                    isChecked: false,
-                    isUnsigned: false,
-                    new LoadArgument(0, "algorithm", governingType),
-                    new Constant(6, s_int)),
-                new Constant(1, s_int)),
+            useEnumRangeGuard
+                ? new Comparison(
+                    ComparisonKind.LessThanOrEqual,
+                    isUnsigned: guardIsUnsigned,
+                    new Binary(
+                        BinaryKind.Subtract,
+                        isChecked: false,
+                        isUnsigned: false,
+                        guardUsesOtherArgument
+                            ? new LoadArgument(2, "otherAlgorithm", governingType)
+                            : new LoadArgument(0, "algorithm", governingType),
+                        new Constant(guardOffset, s_int)),
+                    new Constant(1, s_int))
+                : new LoadArgument(1, "skip", s_bool),
             guardTargetsCaseBody ? 0x20 : 0x30));
         body.Add(guard);
 
         var dispatch = new Block(0x0D);
+        if (mutateBeforeSwitch)
+        {
+            dispatch.Add(new StoreArgument(
+                0,
+                "algorithm",
+                governingType,
+                new Constant(24, governingType)));
+        }
         dispatch.Add(new SwitchBranch(
             new Binary(
                 BinaryKind.Subtract,
@@ -1148,7 +1316,11 @@ public class SwitchRaisingSharedGuardTests
             TypeRef.Definition("Synthetic", "", "T"),
             new MethodSignature(
                 s_void,
-                [new Parameter("algorithm", governingType)],
+                [
+                    new Parameter("algorithm", governingType),
+                    new Parameter("skip", s_bool),
+                    new Parameter("otherAlgorithm", governingType),
+                ],
                 HasThis: false,
                 GenericParameterCount: 0),
             defaultExitsToContinuation ? [s_int] : [],

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -38,6 +38,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// same 32-bit wraparound. Checked arithmetic, non-enum arithmetic, and known
 /// 64-bit enum backing types retain the normalized selector.
 ///
+/// A sparse enum switch may place a small contiguous case range in an unsigned
+/// pre-guard that branches directly to the shared continuation, then dispatch
+/// the remaining cases through the jump table. When that guard and the table
+/// read the same enum variable, the pass absorbs the guarded values as labels on
+/// the empty continuation section, restoring the original single switch.
+///
 /// When that model leaves the switch flat, a second attempt
 /// (<see cref="RaiseCaseTargetJoin"/>) handles tables whose default routes into
 /// shared case bodies: one case target is the post-switch join, so cases reaching
@@ -332,8 +338,20 @@ public sealed class SwitchRaisingPass : IIrPass
         if (!OnlyReachedByTable(blocks, owned, s, leaveTargets))
             return false;
 
+        GuardRange? guardRange = TryGetPrecedingEnumGuardRange(
+            function,
+            blocks,
+            s,
+            sw,
+            preds,
+            leaveTargets,
+            joinOffset,
+            out var range)
+                ? range
+                : null;
+
         BuildCaseTargetJoin(function, container, s, sw, caseTargets, regions, defaultIndex,
-            defaultSharesTarget, join, fallThroughCase, regionEnd, stepper);
+            defaultSharesTarget, join, fallThroughCase, regionEnd, guardRange, stepper);
         return true;
     }
 
@@ -1983,7 +2001,7 @@ public sealed class SwitchRaisingPass : IIrPass
     static void BuildCaseTargetJoin(
         IrFunction function, BlockContainer container, int s, SwitchBranch sw, int[] caseTargets,
         Dictionary<int, List<int>> regions, int defaultIndex, bool defaultSharesTarget, int join,
-        int? fallThroughCase, int regionEnd, Stepper stepper)
+        int? fallThroughCase, int regionEnd, GuardRange? guardRange, Stepper stepper)
     {
         var all = container.Blocks.ToList();
         int joinOffset = all[join].StartOffset;
@@ -1991,7 +2009,16 @@ public sealed class SwitchRaisingPass : IIrPass
 
         var labelsByTarget = new Dictionary<int, List<int>>();
         for (int i = 0; i < caseTargets.Length; i++)
-            (labelsByTarget.TryGetValue(caseTargets[i], out var list) ? list : labelsByTarget[caseTargets[i]] = []).Add(i);
+            (labelsByTarget.TryGetValue(caseTargets[i], out var list) ? list : labelsByTarget[caseTargets[i]] = [])
+                .Add(unchecked(input.LabelBase + i));
+        if (guardRange is { } guard)
+        {
+            guard.Branch.Detach();
+            var labels = labelsByTarget.TryGetValue(join, out var list)
+                ? list
+                : labelsByTarget[join] = [];
+            labels.InsertRange(0, guard.Labels);
+        }
 
         // Clone the shared terminator before detaching: the default falls into a
         // single-block terminating case, which C# cannot do, so its body is
@@ -2006,11 +2033,16 @@ public sealed class SwitchRaisingPass : IIrPass
         var sections = new List<SwitchSection>();
         foreach (var (target, labels) in labelsByTarget.OrderBy(kv => kv.Value.Min()))
         {
+            var sectionLabels = guardRange is not null
+                && defaultSharesTarget
+                && target == defaultIndex
+                    ? ImmutableArray<Constant>.Empty
+                    : labels.Select(IntConst).ToImmutableArray();
             if (target == join)
-                sections.Add(new SwitchSection(TranslatedConstants(labels, input.LabelBase),
+                sections.Add(new SwitchSection(sectionLabels,
                     isDefault: defaultSharesTarget && target == defaultIndex, EmptyBreakBody()));
             else
-                sections.Add(new SwitchSection(TranslatedConstants(labels, input.LabelBase),
+                sections.Add(new SwitchSection(sectionLabels,
                     isDefault: defaultSharesTarget && target == defaultIndex,
                     SectionBody(regions[target].Select(i => all[i]).ToList(), joinOffset)));
         }
@@ -2027,11 +2059,102 @@ public sealed class SwitchRaisingPass : IIrPass
             rebuilt.Add(all[idx]);
         for (int idx = regionEnd; idx < all.Count; idx++)
             rebuilt.Add(all[idx]);
-        stepper.StepOver("raise IL jump table to switch (case target is continuation)", container);
+        stepper.StepOver(
+            guardRange is null
+                ? "raise IL jump table to switch (case target is continuation)"
+                : "raise IL jump table and enum range guard to switch",
+            container);
         container.ReplaceWith(rebuilt);
     }
 
+    readonly record struct GuardRange(ConditionalBranch Branch, ImmutableArray<int> Labels);
+
     readonly record struct SwitchInput(IrExpression Value, int LabelBase);
+
+    static bool TryGetPrecedingEnumGuardRange(
+        IrFunction function,
+        IReadOnlyList<Block> blocks,
+        int switchIndex,
+        SwitchBranch sw,
+        IReadOnlyDictionary<int, List<int>> predecessors,
+        HashSet<int> leaveTargets,
+        int joinOffset,
+        out GuardRange range)
+    {
+        range = default;
+        if (switchIndex == 0
+            || blocks[switchIndex].Children is not [SwitchBranch]
+            || !OnlyReachedFromPrecedingGuard(blocks, switchIndex, leaveTargets)
+            || !predecessors.TryGetValue(switchIndex, out var switchPredecessors)
+            || switchPredecessors.Count != 1
+            || switchPredecessors[0] != switchIndex - 1
+            || blocks[switchIndex - 1].Children is not [.., ConditionalBranch branch]
+            || branch.TargetOffset != joinOffset
+            || branch.Condition is not Comparison
+            {
+                Kind: ComparisonKind.LessThanOrEqual,
+                IsUnsigned: true,
+                Left: var normalizedGuardValue,
+                Right: Constant { Value: int lastIndex },
+            }
+            || lastIndex < 0
+            // Keep emitted source bounded by the jump table that justified the
+            // surrounding switch; hostile IL cannot expand a tiny table into a
+            // huge case list through its pre-guard.
+            || lastIndex >= sw.TargetOffsets.Length
+            || !TryRestoreEnumSwitchInput(
+                function,
+                sw.Value,
+                sw.TargetOffsets.Length,
+                out var switchValue,
+                out int switchLabelBase)
+            || !TryRestoreEnumSwitchInput(
+                function,
+                normalizedGuardValue,
+                lastIndex + 1,
+                out var guardValue,
+                out int guardLabelBase)
+            || switchValue.ResultType is not { } switchType
+            || guardValue.ResultType is not { } guardType
+            || !switchType.Equals(guardType)
+            || !PlaceIdentity.SameVariable(switchValue, guardValue))
+        {
+            return false;
+        }
+
+        var guardLabels = TranslatedLabels(Enumerable.Range(0, lastIndex + 1), guardLabelBase);
+        var tableLabels = TranslatedLabels(Enumerable.Range(0, sw.TargetOffsets.Length), switchLabelBase);
+        if (guardLabels.Any(tableLabels.Contains))
+            return false;
+
+        range = new GuardRange(branch, guardLabels);
+        return true;
+    }
+
+    static bool OnlyReachedFromPrecedingGuard(
+        IReadOnlyList<Block> blocks,
+        int switchIndex,
+        HashSet<int> leaveTargets)
+    {
+        int switchOffset = blocks[switchIndex].StartOffset;
+        if (leaveTargets.Contains(switchOffset))
+            return false;
+
+        for (int index = 0; index < blocks.Count; index++)
+        {
+            if (index == switchIndex)
+                continue;
+            foreach (var child in blocks[index].Children)
+            {
+                foreach (var node in child.Descendants.Prepend(child))
+                {
+                    if (Targets(node).Contains(switchOffset))
+                        return false;
+                }
+            }
+        }
+        return true;
+    }
 
     static SwitchInput TakeSwitchInput(IrFunction function, SwitchBranch sw)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -2124,7 +2124,8 @@ public sealed class SwitchRaisingPass : IIrPass
 
         var guardLabels = TranslatedLabels(Enumerable.Range(0, lastIndex + 1), guardLabelBase);
         var tableLabels = TranslatedLabels(Enumerable.Range(0, sw.TargetOffsets.Length), switchLabelBase);
-        if (guardLabels.Any(tableLabels.Contains))
+        var guardLabelSet = guardLabels.ToHashSet();
+        if (tableLabels.Any(guardLabelSet.Contains))
             return false;
 
         range = new GuardRange(branch, guardLabels);


### PR DESCRIPTION
# Summary

Fixes #3985.

Reconstructs Roslyn's split unsigned enum pre-guard and normalized jump table as
the original single enum switch.

Card revision: `ee44a7bb6c048381d34babc99feb70999224f40e`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the raise is limited to a proven same-variable enum
guard/switch shape, restores exact compile-back fidelity for the real witness,
and rejects overlapping, signed, mutated, narrow, and externally entered close
cases.

### Benchmark target

Benchmark target: `NLOptNet@1.4.3` (`netstandard2.0`)

dotnet-inspect command:

```bash
dnx dotnet-inspect -y -- member NLoptNet.NLoptSolver CheckInequalityConstraintAvailability NLOptNet@1.4.3 -S "Decompiled Source"
```

### Original source

```csharp
protected void CheckInequalityConstraintAvailability()
{
    NLoptAlgorithm algorithm = Algorithm;
    switch (algorithm)
    {
        case NLoptAlgorithm.LD_MMA:
        case NLoptAlgorithm.LD_CCSAQ:
        case NLoptAlgorithm.LD_SLSQP:
        case NLoptAlgorithm.LN_COBYLA:
        case NLoptAlgorithm.GN_ISRES:
        case NLoptAlgorithm.GN_ORIG_DIRECT:
        case NLoptAlgorithm.GN_ORIG_DIRECT_L:
        case NLoptAlgorithm.AUGLAG:
        case NLoptAlgorithm.AUGLAG_EQ:
        case NLoptAlgorithm.LN_AUGLAG:
        case NLoptAlgorithm.LN_AUGLAG_EQ:
        case NLoptAlgorithm.LD_AUGLAG:
        case NLoptAlgorithm.LD_AUGLAG_EQ:
            break;

        default:
            throw new ArgumentException("Algorithm " + algorithm.ToString() + " does not support inequality constraint.");
    }
}
```

Roslyn lowers the sparse cases into an unsigned guard for values 6 and 7,
followed by a jump table normalized by 24:

```il
ldloc.0
ldc.i4.6
sub
ldc.i4.1
ble.un continuation

ldloc.0
ldc.i4.s 24
sub
switch (...)
```

### Before

```csharp
protected void CheckInequalityConstraintAvailability()
{
    NLoptAlgorithm V_0 = Algorithm;
    if ((V_0 - 6) > NLoptAlgorithm.GN_DIRECT_L)
    {
        switch (V_0)
        {
            case NLoptAlgorithm.LD_MMA:
            case NLoptAlgorithm.LN_COBYLA:
            case NLoptAlgorithm.LN_AUGLAG:
            case NLoptAlgorithm.LD_AUGLAG:
            case NLoptAlgorithm.LN_AUGLAG_EQ:
            case NLoptAlgorithm.LD_AUGLAG_EQ:
            case NLoptAlgorithm.GN_ISRES:
            case NLoptAlgorithm.AUGLAG:
            case NLoptAlgorithm.AUGLAG_EQ:
            case NLoptAlgorithm.LD_SLSQP:
            case NLoptAlgorithm.LD_CCSAQ:
                break;
            case NLoptAlgorithm.LN_NEWUOA:
            case NLoptAlgorithm.LN_NEWUOA_BOUND:
            case NLoptAlgorithm.LN_NELDERMEAD:
            case NLoptAlgorithm.LN_SBPLX:
            case NLoptAlgorithm.LN_BOBYQA:
            case NLoptAlgorithm.G_MLSL:
            case NLoptAlgorithm.G_MLSL_LDS:
            default:
                throw new ArgumentException(string.Concat("Algorithm ", V_0.ToString(), " does not support inequality constraint."));
        }
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: False
- Taste applied: None
- Commit: `eb20768cbed49d907acee004b40922a6f876a082`

The unsigned pre-guard is behaviorally correct, but it exposes compiler
normalization and misleading enum names for jump-table holes.

### After

```csharp
protected void CheckInequalityConstraintAvailability()
{
    NLoptAlgorithm V_0 = Algorithm;
    switch (V_0)
    {
        case NLoptAlgorithm.GN_ORIG_DIRECT:
        case NLoptAlgorithm.GN_ORIG_DIRECT_L:
        case NLoptAlgorithm.LD_MMA:
        case NLoptAlgorithm.LN_COBYLA:
        case NLoptAlgorithm.LN_AUGLAG:
        case NLoptAlgorithm.LD_AUGLAG:
        case NLoptAlgorithm.LN_AUGLAG_EQ:
        case NLoptAlgorithm.LD_AUGLAG_EQ:
        case NLoptAlgorithm.GN_ISRES:
        case NLoptAlgorithm.AUGLAG:
        case NLoptAlgorithm.AUGLAG_EQ:
        case NLoptAlgorithm.LD_SLSQP:
        case NLoptAlgorithm.LD_CCSAQ:
            break;
        default:
            throw new ArgumentException(string.Concat("Algorithm ", V_0.ToString(), " does not support inequality constraint."));
    }
}
```

- Valid: True
- Correct: True
- IL fidelity: True
- Taste applied: None
- Commit: `ee44a7bb6c048381d34babc99feb70999224f40e`

The raise absorbs the proven guard values into the continuation section and
leaves jump-table holes to `default`, reproducing the authored shape and exact
compiler lowering.

### Fully raised

The After decompilation is in the fully raised state.

## Evidence

| Check | Baseline | Head |
| --- | --- | --- |
| Product build | Pass | Pass |
| Focused tests | `SwitchRaisingSharedGuardTests`: 32 passed | `SwitchRaisingSharedGuardTests`: 39 passed |
| Decompiler suite excluding corpus | 4,555 passed, 0 failed | 4,562 passed, 0 failed |
| Compiler fixture fidelity | Opcode-different | Exact |
| NLOptNet render A/B | 64 methods | One valid-to-valid structural change; no additions or removals |
| NLOptNet compile-back | 3 exact, 8 opcode-different | 4 exact, 7 opcode-different |
| Real witness | Guard and switch exposed separately | Single source-like switch; exact |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — the hash-stable pinned subset is unchanged; the
aggregate conditional-residue movement is an unrelated population-drift
advisory.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly.

| Metric (goal) | Baseline | PR | Rate delta |
| --- | ---: | ---: | ---: |
| Detected lowering residue (-) | 16.83% | 16.83% | 0 pp |
| Conditional-branch residue (-) | 3.00% | 3.00% | 0 pp |
| Pass bugs (-) | 0 | 0 | 0 |

> **Conclusion:** **PASS** — no pinned-subset rate or count regressed.

### Aggregate context

Corpus: 15 assemblies, 1,500 methods. Sampling population differs from the
baseline; the only behavioral delta is an unrelated
`System.IO.TextWriter::WriteAsync` improvement.

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Detected lowering residue (-) | 234 / 15.60% | 235 / 15.67% |
| Conditional-branch residue (-) | 40 / 2.67% | 43 / 2.87% |
| Forward-merge stops (-) | 27 / 1.80% | 27 / 1.80% |
| Pass bugs (-) | 0 | 0 |

> **Conclusion:** **ADVISORY** — conditional residue moved +0.20 pp in the
population-drift aggregate, while the pinned gate and changed-method evidence
remain clean.

## Validation

```bash
source eng/activate-iltools.sh --mdv
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/SwitchRaisingSharedGuardTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- "Area=Corpus"
```
