### PR TITLE
Extract finally-dispose compiler fixtures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5894,60 +5894,6 @@ public static class EnumCastSamples
         => new[] { (System.StringComparison)4, System.StringComparison.OrdinalIgnoreCase };
 }
 
-
-// Issue #1759: a reference-typed value produced by `as`/isinst and tested for
-// truthiness in a branch (here the `?.Dispose()` null-conditional inside a
-// finally) must render `is null`/`is not null`, not `!S` — `!IDisposable` is
-// CS0023. IDisposable is a cross-assembly interface (TypeShape.Unknown), so the
-// reference classification comes from the isinst provenance.
-public static class FinallyDisposeSamples
-{
-    public static void DisposeEnumeratorInFinally(System.Collections.IDictionary dictionary)
-    {
-        System.Collections.IDictionaryEnumerator enumerator = dictionary.GetEnumerator();
-        try
-        {
-            while (enumerator.MoveNext())
-            {
-            }
-        }
-        finally
-        {
-            (enumerator as System.IDisposable)?.Dispose();
-        }
-    }
-}
-
-// Issue #1759 (review): a nested local function reusing the same stack-slot
-// number must not disable the isinst provenance for the outer finally-dispose
-// slot. Provenance is scoped to the current function body, so this still renders
-// `is null`, not `!S`.
-public static class FinallyDisposeNestedSamples
-{
-    public static int DisposeWithNestedLocalFunction(System.Collections.IDictionary dictionary, int x)
-    {
-        int seed = SquarePlusOne(x);
-        System.Collections.IDictionaryEnumerator enumerator = dictionary.GetEnumerator();
-        try
-        {
-            while (enumerator.MoveNext())
-            {
-            }
-        }
-        finally
-        {
-            (enumerator as System.IDisposable)?.Dispose();
-        }
-        return seed;
-
-        static int SquarePlusOne(int v)
-        {
-            int y = v + 1;
-            return y * y;
-        }
-    }
-}
-
 // Issue #1767: a value produced at a stack slot (the object-merged `cond ? null
 // : value` ternary) and consumed at a control-flow merge where the slot is typed
 // `string` (a field store) must share ONE local name. Keying slot names on

--- a/src/ILInspector.Decompiler.Tests/FinallyDisposeSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/FinallyDisposeSamples.cs
@@ -1,0 +1,54 @@
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #1759: a reference-typed value produced by `as`/isinst and tested for
+// truthiness in a branch (here the `?.Dispose()` null-conditional inside a
+// finally) must render `is null`/`is not null`, not `!S` — `!IDisposable` is
+// CS0023. IDisposable is a cross-assembly interface (TypeShape.Unknown), so the
+// reference classification comes from the isinst provenance.
+public static class FinallyDisposeSamples
+{
+    public static void DisposeEnumeratorInFinally(System.Collections.IDictionary dictionary)
+    {
+        System.Collections.IDictionaryEnumerator enumerator = dictionary.GetEnumerator();
+        try
+        {
+            while (enumerator.MoveNext())
+            {
+            }
+        }
+        finally
+        {
+            (enumerator as System.IDisposable)?.Dispose();
+        }
+    }
+}
+
+// Issue #1759 (review): a nested local function reusing the same stack-slot
+// number must not disable the isinst provenance for the outer finally-dispose
+// slot. Provenance is scoped to the current function body, so this still renders
+// `is null`, not `!S`.
+public static class FinallyDisposeNestedSamples
+{
+    public static int DisposeWithNestedLocalFunction(System.Collections.IDictionary dictionary, int x)
+    {
+        int seed = SquarePlusOne(x);
+        System.Collections.IDictionaryEnumerator enumerator = dictionary.GetEnumerator();
+        try
+        {
+            while (enumerator.MoveNext())
+            {
+            }
+        }
+        finally
+        {
+            (enumerator as System.IDisposable)?.Dispose();
+        }
+        return seed;
+
+        static int SquarePlusOne(int v)
+        {
+            int y = v + 1;
+            return y * y;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracts `FinallyDisposeSamples` and `FinallyDisposeNestedSamples` from the oversized `CfgSampleClass.cs` into the feature-focused `FinallyDisposeSamples.cs` beside their sole owner, `FinallyDisposePrinterTests`.

The compiler-fixture source shape is unchanged; only its source document changes. This keeps the cross-assembly `IDisposable` truthiness and nested-local-function slot-reuse fixtures together while continuing the incremental partitioning required by #3913.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`
- `FinallyDisposePrinterTests`: 2 passed
- Decompiler fast lane: 4,670 total, 0 failed, 8 privilege-dependent skips
- Exact-base whole-test-assembly render A/B against `f77a127d`: 19,181 methods; 0 changed, added, or removed

## Compatibility

Product behavior, symbols, and method bodies are unchanged. Moving compiler-produced source intentionally changes PDB document identity and may change artifact-local metadata row ordering; raw metadata tokens are not stable cross-build identities and consumers pair them with the same assembly/PDB and MVID.

Related to #3913. Leaves #3913 open for the remaining fixture groups.