### PR TITLE
Format generic constraints on continuation lines

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -608,6 +608,24 @@ exceed that width:
       JsonDocumentOptions options = default) => JsonDocument.ParseValue(utf8Json, options).RootElement;
   ```
 
+Generic method constraints use a continuation layout independently of width:
+each top-level `where` clause occupies its own line, indented four spaces from
+the declaration. The declared oracle is silent: `dotnet/runtime` has no
+`dotnet_style_*` or `csharp_style_*` key for constraint placement, and
+`eng/CodeAnalysis.src.globalconfig:1312` explicitly disables SA1127. The revealed
+facet favors the multiline form; examples at runtime commit `795badfa03d`
+include
+`src/libraries/System.Text.Json/src/System/Text/Json/Nodes/JsonValueOfJsonPrimitive.cs:66`
+and
+`src/libraries/Microsoft.Bcl.AsyncInterfaces/src/System/Runtime/CompilerServices/AsyncIteratorMethodBuilder.cs:40`.
+That form is therefore the shipped default:
+
+```csharp
+public override T? Pick<T, U>(T? value)
+    where T : U
+    where U : class => value;
+```
+
 - **Short-circuit `&&` / `||` chains — opt-in.** The boolean analog breaks each
   operand onto its own line with the operator trailing each broken line. It
   carries the same whitespace-only guarantee — it re-renders each flattened
@@ -638,13 +656,14 @@ signature wrappers reproduce the corpus and stay on.
 
 **General one-liner opt-out.** A single knob,
 `PrinterOptions.DisableOneLinerWrapping` (catalog id `disable-one-liner-wrapping`,
-off by default), suppresses *all* always-on width wrapping — both the fluent-chain
-and the member-signature wrappers — so a caller who wants wide constructs to stay
-on one physical line gets true one-liners. It deliberately does **not** touch the
-opt-in `WrapSplittableExpressions` wrappers, which are already off unless
-explicitly enabled. Keeping a wide construct inline diverges from the corpus
-(which wraps), so this knob is a user compactness preference endorsed by neither
-the oracle nor the corpus — classified like the branchless-boolean lens.
+off by default), suppresses all always-on layout wrapping — the fluent-chain and
+member-signature width wrappers plus generic-constraint continuation lines — so
+a caller who wants constructs to stay on one physical line gets true one-liners.
+It deliberately does **not** touch the opt-in `WrapSplittableExpressions`
+wrappers, which are already off unless explicitly enabled. Keeping either a wide
+construct or generic constraints inline diverges from the revealed corpus, while
+the declared facet is silent, so this knob remains a user compactness preference
+endorsed by neither facet — classified like the branchless-boolean lens.
 
 ### Range indexer
 
@@ -1052,8 +1071,9 @@ runtime code wraps long boolean chains in line with its 120-column practice. The
 other formatting/synthesis knobs are left un-endorsed on both axes: wrapping the
 expression-body arrow actually *diverges* from the corpus (the runtime keeps `=>`
 on the same line, which the shipped default already does), suppressing the
-always-on width wrappers (`disable-one-liner-wrapping`) diverges too (the runtime
-wraps wide constructs, which the shipped default also does), and a synthesized
+always-on layout wrappers (`disable-one-liner-wrapping`) diverges too (the
+runtime wraps wide constructs and normally places generic constraints on
+continuation lines, which the shipped default also does), and a synthesized
 local name is our own invention, not a corpus spelling. The catalog exposes the
 revealed subset as `CorpusEndorsedOptions`; a future "house style" aggregate would
 fold declared ∪ revealed while "full taste" stays declared-only

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -626,6 +626,11 @@ public override T? Pick<T, U>(T? value)
     where U : class => value;
 ```
 
+Constraint layout is comment-aware. Text that resembles a `where` clause inside
+a block comment is ignored while locating real clauses. A declaration head that
+contains a line comment stays unchanged because inserting a line break after
+`//` can promote commented text into live C#.
+
 - **Short-circuit `&&` / `||` chains — opt-in.** The boolean analog breaks each
   operand onto its own line with the operator trailing each broken line. It
   carries the same whitespace-only guarantee — it re-renders each flattened

--- a/src/CSharpText/CSharpMemberLayout.cs
+++ b/src/CSharpText/CSharpMemberLayout.cs
@@ -273,10 +273,18 @@ public static class CSharpMemberLayout
             i++;
 
         int identifierStart = i;
-        while (i < head.Length && (char.IsLetterOrDigit(head[i]) || head[i] == '_'))
+        while (i < head.Length
+            && !char.IsWhiteSpace(head[i])
+            && head[i] != ':')
+        {
             i++;
-        if (i == identifierStart)
+        }
+        if (i == identifierStart
+            || !CSharpIdentifierCore.IsIdentifierLike(
+                head[identifierStart..i]))
+        {
             return false;
+        }
 
         while (i < head.Length && char.IsWhiteSpace(head[i]))
             i++;

--- a/src/CSharpText/CSharpMemberLayout.cs
+++ b/src/CSharpText/CSharpMemberLayout.cs
@@ -82,6 +82,24 @@ public static class CSharpMemberLayout
     }
 
     /// <summary>
+    /// Applies this layout's generic-constraint wrapping to a declaration head
+    /// without adding a body, terminator, or indentation. A head without
+    /// constraints remains unchanged, including an over-width signature.
+    /// </summary>
+    public static string LayOutDeclarationHead(string head, bool disableSignatureWrapping = false)
+    {
+        ArgumentNullException.ThrowIfNull(head);
+        var parts = SplitConstraintClauses(head);
+        if (disableSignatureWrapping || parts.Count == 1)
+            return head;
+
+        var sb = new StringBuilder(parts[0]);
+        for (int i = 1; i < parts.Count; i++)
+            sb.Append('\n').Append("    ").Append(parts[i]);
+        return sb.ToString();
+    }
+
+    /// <summary>
     /// Renders a multi-line single-<c>return</c> expression body (a raised switch
     /// expression, a wrapped fluent chain, or any other wrapped single
     /// expression). The value/arrow line sits after the arrow — on
@@ -217,9 +235,18 @@ public static class CSharpMemberLayout
         if (indexes.Count == 0)
             return [head];
 
+        int firstConstraint = indexes[0];
+        if (!TryLocateParameterList(head, firstConstraint, out int parameterOpen, out _)
+            || parameterOpen == 0
+            || head[parameterOpen - 1] != '>'
+            || indexes.Any(index => !IsConstraintClauseStart(head, index + 1)))
+        {
+            return [head];
+        }
+
         var parts = new List<string>(indexes.Count + 1)
         {
-            head[..indexes[0]].TrimEnd()
+            head[..firstConstraint].TrimEnd()
         };
         for (int i = 0; i < indexes.Count; i++)
         {
@@ -228,6 +255,26 @@ public static class CSharpMemberLayout
             parts.Add(head[start..end].Trim());
         }
         return parts;
+    }
+
+    static bool IsConstraintClauseStart(string head, int start)
+    {
+        int i = start + "where".Length;
+        while (i < head.Length && char.IsWhiteSpace(head[i]))
+            i++;
+
+        if (i < head.Length && head[i] == '@')
+            i++;
+
+        int identifierStart = i;
+        while (i < head.Length && (char.IsLetterOrDigit(head[i]) || head[i] == '_'))
+            i++;
+        if (i == identifierStart)
+            return false;
+
+        while (i < head.Length && char.IsWhiteSpace(head[i]))
+            i++;
+        return i < head.Length && head[i] == ':';
     }
 
     static bool ContainsLineComment(string head)
@@ -287,12 +334,16 @@ public static class CSharpMemberLayout
     /// the signature inline rather than risk mangling it.
     /// </summary>
     static bool TryLocateParameterList(string head, out int open, out int close)
+        => TryLocateParameterList(
+            head,
+            FindTopLevelWhere(head) is { } where and >= 0 ? where : head.Length,
+            out open,
+            out close);
+
+    static bool TryLocateParameterList(string head, int limit, out int open, out int close)
     {
         open = -1;
         close = -1;
-        int limit = FindTopLevelWhere(head);
-        if (limit < 0)
-            limit = head.Length;
 
         int angle = 0, bracket = 0, brace = 0;
         for (int i = 0; i < limit; i++)

--- a/src/CSharpText/CSharpMemberLayout.cs
+++ b/src/CSharpText/CSharpMemberLayout.cs
@@ -84,13 +84,19 @@ public static class CSharpMemberLayout
     /// <summary>
     /// Applies this layout's generic-constraint wrapping to a declaration head
     /// without adding a body, terminator, or indentation. A head without
-    /// constraints remains unchanged, including an over-width signature.
+    /// constraints remains unchanged, including an over-width signature. A
+    /// line comment disables splitting so commented text cannot become live;
+    /// <c>LayOutDeclarationHead_WhereInsideLineComment_DoesNotBecomeLiveConstraint</c>
+    /// gates that token-preservation boundary.
     /// </summary>
     public static string LayOutDeclarationHead(string head, bool disableSignatureWrapping = false)
     {
         ArgumentNullException.ThrowIfNull(head);
+        if (disableSignatureWrapping || ContainsLineComment(head))
+            return head;
+
         var parts = SplitConstraintClauses(head);
-        if (disableSignatureWrapping || parts.Count == 1)
+        if (parts.Count == 1)
             return head;
 
         var sb = new StringBuilder(parts[0]);

--- a/src/CSharpText/CSharpMemberLayout.cs
+++ b/src/CSharpText/CSharpMemberLayout.cs
@@ -39,11 +39,17 @@ public static class CSharpMemberLayout
     /// single-line bodies stay on the
     /// <see cref="CSharpExpressionBody.FromSingleStatement"/> path.
     /// </param>
-    public static void Append(StringBuilder sb, string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleExpressionBody = false, bool disableOneLinerWrapping = false)
+    /// <param name="disableSignatureWrapping">
+    /// When <see langword="true"/>, suppresses the layout's one-line wrapping
+    /// decisions. The public parameter name is retained for source
+    /// compatibility with existing callers using the named argument.
+    /// </param>
+    public static void Append(StringBuilder sb, string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleExpressionBody = false, bool disableSignatureWrapping = false)
     {
         ArgumentNullException.ThrowIfNull(sb);
         ArgumentNullException.ThrowIfNull(head);
 
+        bool disableOneLinerWrapping = disableSignatureWrapping;
         string pad = new(' ', indent);
         if (body is null)
         {
@@ -177,17 +183,10 @@ public static class CSharpMemberLayout
         int angle = 0, paren = 0, bracket = 0, brace = 0;
         for (int i = 0; i + 7 <= head.Length; i++)
         {
+            if (TrySkipConventionalLiteralOrBlockComment(head, ref i))
+                continue;
+
             char c = head[i];
-            if (c is '"' or '\'')
-            {
-                i = SkipLiteral(head, i);
-                continue;
-            }
-            if (c == '/' && i + 1 < head.Length && head[i + 1] == '*')
-            {
-                i = SkipBlockComment(head, i);
-                continue;
-            }
             switch (c)
             {
                 case '<':
@@ -235,18 +234,14 @@ public static class CSharpMemberLayout
     {
         for (int i = 0; i + 1 < head.Length; i++)
         {
-            char c = head[i];
-            if (c is '"' or '\'')
-            {
-                i = SkipLiteral(head, i);
+            if (TrySkipConventionalLiteralOrBlockComment(head, ref i))
                 continue;
-            }
+
+            char c = head[i];
             if (c != '/')
                 continue;
             if (head[i + 1] == '/')
                 return true;
-            if (head[i + 1] == '*')
-                i = SkipBlockComment(head, i);
         }
         return false;
     }
@@ -302,12 +297,10 @@ public static class CSharpMemberLayout
         int angle = 0, bracket = 0, brace = 0;
         for (int i = 0; i < limit; i++)
         {
-            char c = head[i];
-            if (c is '"' or '\'')
-            {
-                i = SkipLiteral(head, i);
+            if (TrySkipConventionalLiteralOrBlockComment(head, ref i))
                 continue;
-            }
+
+            char c = head[i];
             switch (c)
             {
                 case '<': angle++; break;
@@ -356,12 +349,10 @@ public static class CSharpMemberLayout
         int segmentStart = start;
         for (int i = start; i < end; i++)
         {
-            char c = head[i];
-            if (c is '"' or '\'')
-            {
-                i = SkipLiteral(head, i);
+            if (TrySkipConventionalLiteralOrBlockComment(head, ref i))
                 continue;
-            }
+
+            char c = head[i];
             switch (c)
             {
                 case '<': angle++; break;
@@ -393,12 +384,10 @@ public static class CSharpMemberLayout
         int depth = 0;
         for (int i = open; i < head.Length; i++)
         {
-            char c = head[i];
-            if (c is '"' or '\'')
-            {
-                i = SkipLiteral(head, i);
+            if (TrySkipConventionalLiteralOrBlockComment(head, ref i))
                 continue;
-            }
+
+            char c = head[i];
             if (c == '(')
                 depth++;
             else if (c == ')' && --depth == 0)
@@ -413,12 +402,10 @@ public static class CSharpMemberLayout
         int angle = 0, paren = 0, bracket = 0, brace = 0;
         for (int i = 0; i + 7 <= head.Length; i++)
         {
-            char c = head[i];
-            if (c is '"' or '\'')
-            {
-                i = SkipLiteral(head, i);
+            if (TrySkipConventionalLiteralOrBlockComment(head, ref i))
                 continue;
-            }
+
+            char c = head[i];
             switch (c)
             {
                 case '<': angle++; break;
@@ -449,13 +436,17 @@ public static class CSharpMemberLayout
     /// these forms could be misread as a top-level separator. When any is present
     /// the caller declines to wrap and keeps the signature on one line — the safe
     /// fallback — rather than risk splitting inside a literal. Conventional
-    /// literals are skipped correctly during the scan so their contents never
-    /// trigger a false positive.
+    /// literals and block comments are skipped correctly during the scan so
+    /// their contents never trigger a false positive or hide a later unsupported
+    /// literal opener.
     /// </summary>
     static bool ContainsUnsupportedLiteral(string head)
     {
         for (int i = 0; i < head.Length; i++)
         {
+            if (TrySkipBlockComment(head, ref i))
+                continue;
+
             char c = head[i];
             if (c == '\'')
             {
@@ -464,14 +455,42 @@ public static class CSharpMemberLayout
             }
             if (c == '"')
             {
-                char prev = i > 0 ? head[i - 1] : '\0';
-                if (prev is '@' or '$')
-                    return true; // verbatim / interpolated (incl. $@" and @$")
-                if (i + 2 < head.Length && head[i + 1] == '"' && head[i + 2] == '"')
-                    return true; // raw string literal ("""…""")
+                if (IsUnsupportedLiteralStart(head, i))
+                    return true;
                 i = SkipLiteral(head, i);
             }
         }
+        return false;
+    }
+
+    static bool TrySkipConventionalLiteralOrBlockComment(string head, ref int i)
+    {
+        if (TrySkipBlockComment(head, ref i))
+            return true;
+
+        if (head[i] != '"' && head[i] != '\'')
+            return false;
+
+        i = SkipLiteral(head, i);
+        return true;
+    }
+
+    static bool TrySkipBlockComment(string head, ref int i)
+    {
+        if (head[i] != '/' || i + 1 >= head.Length || head[i + 1] != '*')
+            return false;
+
+        i = SkipBlockComment(head, i);
+        return true;
+    }
+
+    static bool IsUnsupportedLiteralStart(string head, int i)
+    {
+        char prev = i > 0 ? head[i - 1] : '\0';
+        if (prev is '@' or '$')
+            return true; // verbatim / interpolated (incl. $@" and @$")
+        if (i + 2 < head.Length && head[i + 1] == '"' && head[i + 2] == '"')
+            return true; // raw string literal ("""…""")
         return false;
     }
 

--- a/src/CSharpText/CSharpMemberLayout.cs
+++ b/src/CSharpText/CSharpMemberLayout.cs
@@ -132,7 +132,8 @@ public static class CSharpMemberLayout
             sb.Append(LayOutHead(pad, head, $" => {valueLine}", " =>", disableOneLinerWrapping)).Append('\n');
         }
 
-        string continuationPad = new(' ', wrapExpressionBodyArrow ? indent + 4 : indent);
+        bool arrowIsOnFollowingLine = wrapExpressionBodyArrow || ContainsLineComment(head);
+        string continuationPad = new(' ', arrowIsOnFollowingLine ? indent + 4 : indent);
         for (int i = 1; i < expressionLines.Count; i++)
         {
             string line = expressionLines[i];
@@ -165,14 +166,25 @@ public static class CSharpMemberLayout
     /// over-width parameter list wraps one parameter per continuation line when it
     /// can be located unambiguously. <paramref name="renderTail"/> is the member
     /// terminator, expression body, or empty block tail; with constraints it follows
-    /// the final clause. Falls back to the inline single line when one-liner wrapping
-    /// is disabled or a line comment makes line breaks semantically significant.
-    /// Block-comment contents are ignored while locating clauses. Whitespace only:
-    /// every transformed form is token-identical.
+    /// the final clause. A line comment prevents reshaping the head, but any live
+    /// <paramref name="renderTail"/> moves to an indented following line rather than
+    /// becoming comment text; an empty block tail leaves existing block layout
+    /// unchanged. Block-comment contents are ignored while locating clauses.
+    /// Whitespace only: every transformed form is token-identical;
+    /// <c>Append_LineCommentTails_CompileAndPreserveTokens</c> gates the
+    /// line-comment boundary.
     /// </summary>
     static string LayOutHead(string pad, string head, string renderTail, string decisionSuffix, bool disableOneLinerWrapping)
     {
-        if (disableOneLinerWrapping || ContainsLineComment(head))
+        if (ContainsLineComment(head))
+        {
+            string renderedHead = pad + head;
+            return renderTail.Length == 0
+                ? renderedHead
+                : renderedHead + '\n' + pad + "    " + renderTail.TrimStart();
+        }
+
+        if (disableOneLinerWrapping)
             return pad + head + renderTail;
 
         if (SplitConstraintClauses(head) is { Count: > 1 } parts)

--- a/src/CSharpText/CSharpMemberLayout.cs
+++ b/src/CSharpText/CSharpMemberLayout.cs
@@ -136,11 +136,13 @@ public static class CSharpMemberLayout
     /// can be located unambiguously. <paramref name="renderTail"/> is the member
     /// terminator, expression body, or empty block tail; with constraints it follows
     /// the final clause. Falls back to the inline single line when one-liner wrapping
-    /// is disabled. Whitespace only: every form is token-identical.
+    /// is disabled or a line comment makes line breaks semantically significant.
+    /// Block-comment contents are ignored while locating clauses. Whitespace only:
+    /// every transformed form is token-identical.
     /// </summary>
     static string LayOutHead(string pad, string head, string renderTail, string decisionSuffix, bool disableOneLinerWrapping)
     {
-        if (disableOneLinerWrapping)
+        if (disableOneLinerWrapping || ContainsLineComment(head))
             return pad + head + renderTail;
 
         if (SplitConstraintClauses(head) is { Count: > 1 } parts)
@@ -179,6 +181,11 @@ public static class CSharpMemberLayout
             if (c is '"' or '\'')
             {
                 i = SkipLiteral(head, i);
+                continue;
+            }
+            if (c == '/' && i + 1 < head.Length && head[i + 1] == '*')
+            {
+                i = SkipBlockComment(head, i);
                 continue;
             }
             switch (c)
@@ -222,6 +229,32 @@ public static class CSharpMemberLayout
             parts.Add(head[start..end].Trim());
         }
         return parts;
+    }
+
+    static bool ContainsLineComment(string head)
+    {
+        for (int i = 0; i + 1 < head.Length; i++)
+        {
+            char c = head[i];
+            if (c is '"' or '\'')
+            {
+                i = SkipLiteral(head, i);
+                continue;
+            }
+            if (c != '/')
+                continue;
+            if (head[i + 1] == '/')
+                return true;
+            if (head[i + 1] == '*')
+                i = SkipBlockComment(head, i);
+        }
+        return false;
+    }
+
+    static int SkipBlockComment(string head, int start)
+    {
+        int end = head.IndexOf("*/", start + 2, StringComparison.Ordinal);
+        return end < 0 ? head.Length - 1 : end + 1;
     }
 
     static string? WrapParameterList(string pad, string head, string renderTail)

--- a/src/CSharpText/CSharpMemberLayout.cs
+++ b/src/CSharpText/CSharpMemberLayout.cs
@@ -39,7 +39,7 @@ public static class CSharpMemberLayout
     /// single-line bodies stay on the
     /// <see cref="CSharpExpressionBody.FromSingleStatement"/> path.
     /// </param>
-    public static void Append(StringBuilder sb, string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleExpressionBody = false, bool disableSignatureWrapping = false)
+    public static void Append(StringBuilder sb, string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleExpressionBody = false, bool disableOneLinerWrapping = false)
     {
         ArgumentNullException.ThrowIfNull(sb);
         ArgumentNullException.ThrowIfNull(head);
@@ -47,29 +47,29 @@ public static class CSharpMemberLayout
         string pad = new(' ', indent);
         if (body is null)
         {
-            sb.Append(LayOutHead(pad, head, ";", ";", disableSignatureWrapping)).Append('\n');
+            sb.Append(LayOutHead(pad, head, ";", ";", disableOneLinerWrapping)).Append('\n');
             return;
         }
         if (bodyIsSingleExpressionBody
             && CSharpExpressionBody.MultilineExpressionBodyLines(body) is { } expressionLines)
         {
-            AppendMultilineExpressionBody(sb, head, expressionLines, indent, wrapExpressionBodyArrow, disableSignatureWrapping);
+            AppendMultilineExpressionBody(sb, head, expressionLines, indent, wrapExpressionBodyArrow, disableOneLinerWrapping);
             return;
         }
         if (CSharpExpressionBody.FromSingleStatement(body) is { } expression)
         {
             if (wrapExpressionBodyArrow)
             {
-                sb.Append(LayOutHead(pad, head, "", " =>", disableSignatureWrapping)).Append('\n');
+                sb.Append(LayOutHead(pad, head, "", " =>", disableOneLinerWrapping)).Append('\n');
                 sb.Append($"{pad}    => {expression};").Append('\n');
             }
             else
             {
-                sb.Append(LayOutHead(pad, head, $" => {expression};", " =>", disableSignatureWrapping)).Append('\n');
+                sb.Append(LayOutHead(pad, head, $" => {expression};", " =>", disableOneLinerWrapping)).Append('\n');
             }
             return;
         }
-        sb.Append(LayOutHead(pad, head, "", " {", disableSignatureWrapping)).Append('\n');
+        sb.Append(LayOutHead(pad, head, "", " {", disableOneLinerWrapping)).Append('\n');
         sb.Append($"{pad}{{").Append('\n');
         AppendIndentedBody(sb, body, indent + 4);
         sb.Append($"{pad}}}").Append('\n');
@@ -88,18 +88,18 @@ public static class CSharpMemberLayout
     /// terminator (<c>;</c>). Blank lines are preserved.
     /// </summary>
     static void AppendMultilineExpressionBody(
-        StringBuilder sb, string head, IReadOnlyList<string> expressionLines, int indent, bool wrapExpressionBodyArrow, bool disableSignatureWrapping)
+        StringBuilder sb, string head, IReadOnlyList<string> expressionLines, int indent, bool wrapExpressionBodyArrow, bool disableOneLinerWrapping)
     {
         string pad = new(' ', indent);
         string valueLine = expressionLines[0];
         if (wrapExpressionBodyArrow)
         {
-            sb.Append(LayOutHead(pad, head, "", " =>", disableSignatureWrapping)).Append('\n');
+            sb.Append(LayOutHead(pad, head, "", " =>", disableOneLinerWrapping)).Append('\n');
             sb.Append($"{pad}    => {valueLine}").Append('\n');
         }
         else
         {
-            sb.Append(LayOutHead(pad, head, $" => {valueLine}", " =>", disableSignatureWrapping)).Append('\n');
+            sb.Append(LayOutHead(pad, head, $" => {valueLine}", " =>", disableOneLinerWrapping)).Append('\n');
         }
 
         string continuationPad = new(' ', wrapExpressionBodyArrow ? indent + 4 : indent);
@@ -129,26 +129,99 @@ public static class CSharpMemberLayout
     internal const int SignatureWrapWidth = 120;
 
     /// <summary>
-    /// Renders the declaration <paramref name="head"/> at <paramref name="pad"/>,
-    /// wrapping its parameter list one parameter per line (each under a four-space
-    /// continuation indent, the closing <c>)</c> and everything after it kept on the
-    /// last parameter's line) when the single physical line
-    /// <c>pad + head + decisionSuffix</c> would exceed
-    /// <see cref="SignatureWrapWidth"/> and the parameter list can be unambiguously
-    /// located. <paramref name="renderTail"/> is whatever follows the head's closing
-    /// <c>)</c> on its final line (<c>" =&gt; expr;"</c>, <c>";"</c>, or <c>""</c>).
-    /// Falls back to the inline single line when wrapping is disabled, the signature
-    /// fits, or the parameter list cannot be located — so an unrecognized shape
-    /// degrades to today's output rather than a mangled signature. Whitespace only:
-    /// the wrapped form is token-identical to the inline form.
+    /// Renders the declaration <paramref name="head"/> at <paramref name="pad"/>.
+    /// Top-level generic-constraint clauses each occupy an indented continuation
+    /// line, matching the dominant dotnet/runtime source form. Independently, an
+    /// over-width parameter list wraps one parameter per continuation line when it
+    /// can be located unambiguously. <paramref name="renderTail"/> is the member
+    /// terminator, expression body, or empty block tail; with constraints it follows
+    /// the final clause. Falls back to the inline single line when one-liner wrapping
+    /// is disabled. Whitespace only: every form is token-identical.
     /// </summary>
-    static string LayOutHead(string pad, string head, string renderTail, string decisionSuffix, bool disableSignatureWrapping)
+    static string LayOutHead(string pad, string head, string renderTail, string decisionSuffix, bool disableOneLinerWrapping)
     {
-        if (!disableSignatureWrapping
-            && pad.Length + head.Length + decisionSuffix.Length > SignatureWrapWidth
-            && WrapParameterList(pad, head, renderTail) is { } wrapped)
-            return wrapped;
+        if (disableOneLinerWrapping)
+            return pad + head + renderTail;
+
+        if (SplitConstraintClauses(head) is { Count: > 1 } parts)
+        {
+            string declaration = parts[0];
+            string laidOutDeclaration =
+                pad.Length + declaration.Length > SignatureWrapWidth
+                    && WrapParameterList(pad, declaration, renderTail: "") is { } wrapped
+                    ? wrapped
+                    : pad + declaration;
+
+            var sb = new StringBuilder(laidOutDeclaration);
+            string continuation = pad + "    ";
+            for (int i = 1; i < parts.Count; i++)
+                sb.Append('\n').Append(continuation).Append(parts[i]);
+            sb.Append(renderTail);
+            return sb.ToString();
+        }
+
+        if (pad.Length + head.Length + decisionSuffix.Length > SignatureWrapWidth
+            && WrapParameterList(pad, head, renderTail) is { } widthWrapped)
+            return widthWrapped;
         return pad + head + renderTail;
+    }
+
+    static List<string> SplitConstraintClauses(string head)
+    {
+        if (ContainsUnsupportedLiteral(head))
+            return [head];
+
+        var indexes = new List<int>();
+        int angle = 0, paren = 0, bracket = 0, brace = 0;
+        for (int i = 0; i + 7 <= head.Length; i++)
+        {
+            char c = head[i];
+            if (c is '"' or '\'')
+            {
+                i = SkipLiteral(head, i);
+                continue;
+            }
+            switch (c)
+            {
+                case '<':
+                    if (paren == 0 && bracket == 0 && brace == 0)
+                        angle++;
+                    break;
+                case '>':
+                    if (paren == 0 && bracket == 0 && brace == 0 && angle > 0)
+                        angle--;
+                    break;
+                case '(': paren++; break;
+                case ')': if (paren > 0) paren--; break;
+                case '[': bracket++; break;
+                case ']': if (bracket > 0) bracket--; break;
+                case '{': brace++; break;
+                case '}': if (brace > 0) brace--; break;
+                case ' ':
+                    if (angle == 0 && paren == 0 && bracket == 0 && brace == 0
+                        && string.CompareOrdinal(head, i, " where ", 0, 7) == 0)
+                    {
+                        indexes.Add(i);
+                        i += 6;
+                    }
+                    break;
+            }
+        }
+
+        if (indexes.Count == 0)
+            return [head];
+
+        var parts = new List<string>(indexes.Count + 1)
+        {
+            head[..indexes[0]].TrimEnd()
+        };
+        for (int i = 0; i < indexes.Count; i++)
+        {
+            int start = indexes[i] + 1;
+            int end = i + 1 < indexes.Count ? indexes[i + 1] : head.Length;
+            parts.Add(head[start..end].Trim());
+        }
+        return parts;
     }
 
     static string? WrapParameterList(string pad, string head, string renderTail)

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -555,10 +555,11 @@ public class StyleOptionCatalogTests
     [Fact]
     public void DisableOneLinerWrapping_IsEndorsedByNeitherFacet()
     {
-        // Suppressing the always-on width wrappers is a user compactness preference,
-        // not the corpus's practice: the runtime wraps wide constructs (the shipped
-        // default keeps wrapping), so keeping a one-liner on one line diverges from
-        // the corpus, and no .editorconfig rule declares it. Neither facet endorses it.
+        // Suppressing the always-on layout wrappers is a user compactness preference,
+        // not the corpus's practice: the runtime wraps wide constructs and normally
+        // places generic constraints on continuation lines, so keeping a one-liner
+        // on one line diverges from the corpus. No .editorconfig rule declares it.
+        // Neither facet endorses it.
         var disable = Options.Single(o => o.Id == "disable-one-liner-wrapping");
         Assert.False(disable.OracleEndorsed);
         Assert.False(disable.CorpusEndorsed);

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -71,10 +71,11 @@ public sealed record DecompilerOptions
     public bool WrapSplittableExpressions { get; init; }
 
     /// <summary>
-    /// The always-on width-based wrappers (long fluent chains, long member
-    /// signatures) may be suppressed so a wide construct stays on one physical
-    /// line. Off by default; wrapping is the shipped house style. A whitespace-only
-    /// user compactness preference that leaves the tokens and IL unchanged.
+    /// The always-on layout wrappers (long fluent chains, long member signatures,
+    /// and generic <c>where</c> clauses) may be suppressed so the declaration stays
+    /// on one physical line. Off by default; wrapping is the shipped house style. A
+    /// whitespace-only user compactness preference that leaves the tokens and IL
+    /// unchanged.
     /// </summary>
     public bool DisableOneLinerWrapping { get; init; }
 

--- a/src/ILInspector.Decompiler/MemberBodyProducer.cs
+++ b/src/ILInspector.Decompiler/MemberBodyProducer.cs
@@ -1247,7 +1247,7 @@ public static class MemberBodyProducer
                         }
                         else if (bodyIsSingleExpressionBody || CSharpExpressionBody.FromSingleStatement(body) is not null)
                         {
-                            CSharpMemberLayout.Append(sb, head, body, 4, WrapExpressionBodyArrow(printerOptions), bodyIsSingleExpressionBody, DisableSignatureWrapping(printerOptions));
+                            CSharpMemberLayout.Append(sb, head, body, 4, WrapExpressionBodyArrow(printerOptions), bodyIsSingleExpressionBody, DisableOneLinerWrapping(printerOptions));
                         }
                         else
                         {
@@ -1279,7 +1279,7 @@ public static class MemberBodyProducer
                     var declaration = bodyShape is null
                         ? declarationFormatter.FormatMember(type, member)
                         : declarationFormatter.FormatMemberWithBody(type, member, bodyShape);
-                    AppendMember(sb, declaration, body, WrapExpressionBodyArrow(printerOptions), constructorChain, bodyIsSingleExpressionBody, DisableSignatureWrapping(printerOptions));
+                    AppendMember(sb, declaration, body, WrapExpressionBodyArrow(printerOptions), constructorChain, bodyIsSingleExpressionBody, DisableOneLinerWrapping(printerOptions));
                     break;
                 }
 
@@ -1531,12 +1531,12 @@ public static class MemberBodyProducer
         return null;
     }
 
-    static void AppendMember(StringBuilder sb, string signature, string? body, bool wrapExpressionBodyArrow, string? constructorChain = null, bool bodyIsSingleExpressionBody = false, bool disableSignatureWrapping = false)
+    static void AppendMember(StringBuilder sb, string signature, string? body, bool wrapExpressionBodyArrow, string? constructorChain = null, bool bodyIsSingleExpressionBody = false, bool disableOneLinerWrapping = false)
     {
         // An explicit base(...)/this(...) chain renders as a signature
         // initializer (the printer lifted it out of the body).
         string head = constructorChain is null ? signature : $"{signature} : {constructorChain}";
-        CSharpMemberLayout.Append(sb, head, body, 4, wrapExpressionBodyArrow, bodyIsSingleExpressionBody, disableSignatureWrapping);
+        CSharpMemberLayout.Append(sb, head, body, 4, wrapExpressionBodyArrow, bodyIsSingleExpressionBody, disableOneLinerWrapping);
     }
 
     static string TypeParameterDisplayName(TypeParameter typeParameter)
@@ -1970,7 +1970,7 @@ public static class MemberBodyProducer
         if (accessors is [("get", "get", { } loneGet, _, _, var loneGetSingleReturn)]
             && (loneGetSingleReturn || CSharpExpressionBody.FromSingleStatement(loneGet) is not null))
         {
-            CSharpMemberLayout.Append(sb, head, loneGet, 4, WrapExpressionBodyArrow(printerOptions), loneGetSingleReturn, DisableSignatureWrapping(printerOptions));
+            CSharpMemberLayout.Append(sb, head, loneGet, 4, WrapExpressionBodyArrow(printerOptions), loneGetSingleReturn, DisableOneLinerWrapping(printerOptions));
             return;
         }
 
@@ -2095,7 +2095,7 @@ public static class MemberBodyProducer
     static bool WrapExpressionBodyArrow(Pipeline.PrinterOptions? printerOptions)
         => (printerOptions ?? Pipeline.PrinterOptions.Default).WrapExpressionBodyArrow;
 
-    static bool DisableSignatureWrapping(Pipeline.PrinterOptions? printerOptions)
+    static bool DisableOneLinerWrapping(Pipeline.PrinterOptions? printerOptions)
         => (printerOptions ?? Pipeline.PrinterOptions.Default).DisableOneLinerWrapping;
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -47,21 +47,20 @@ public sealed record PrinterOptions
     public bool WrapSplittableExpressions { get; init; }
 
     /// <summary>
-    /// When set, the always-on <b>width-based</b> wrappers are suppressed, so a
-    /// construct that would otherwise break across continuation lines because its
-    /// single-line form exceeds the wrap width stays on one physical line no matter
-    /// how wide. This covers the long fluent-call chain wrapper and the long
-    /// member-signature (parameter-list) wrapper — the "one-liner pretty printing"
-    /// the renderer applies by default. Off by default (wrapping is the shipped
-    /// house style, matching the runtime corpus, which wraps long lines).
+    /// When set, the always-on member-layout wrappers are suppressed, so a
+    /// construct that would otherwise break across continuation lines stays on one
+    /// physical line. This covers long fluent-call chains, long member signatures,
+    /// and generic <c>where</c> clauses — the "one-liner pretty printing" the
+    /// renderer applies by default. Off by default (wrapping is the shipped house
+    /// style, matching the runtime corpus).
     ///
-    /// This is a user compactness preference: keeping a wide construct inline
-    /// <b>diverges</b> from the corpus, so it is neither declared- nor
-    /// revealed-endorsed. It governs only the <em>always-on</em> width wrappers; the
-    /// opt-in <see cref="WrapSplittableExpressions"/> boolean/bitwise chain wrapping
-    /// is independent (a user who opts into that has explicitly asked for it).
-    /// Whitespace-only: it never changes which tokens are emitted, so the IL is
-    /// unchanged.
+    /// This is a user compactness preference: keeping a wide construct or generic
+    /// constraints inline <b>diverges</b> from the corpus, so it is neither
+    /// declared- nor revealed-endorsed. It governs only the <em>always-on</em>
+    /// wrappers; the opt-in <see cref="WrapSplittableExpressions"/>
+    /// boolean/bitwise chain wrapping is independent (a user who opts into that
+    /// has explicitly asked for it). Whitespace-only: it never changes which
+    /// tokens are emitted, so the IL is unchanged.
     /// </summary>
     public bool DisableOneLinerWrapping { get; init; }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -492,7 +492,7 @@ public static class StyleOptionCatalog
         Boolean(
             id: "disable-one-liner-wrapping",
             title: "Keep one-liners on one line",
-            summary: "Suppress the always-on width wrappers (long fluent chains and long member signatures) so a wide construct stays on a single physical line instead of wrapping (whitespace only).",
+            summary: "Suppress the always-on layout wrappers (long fluent chains, long member signatures, and generic where clauses) so the construct stays on a single physical line instead of wrapping (whitespace only).",
             tier: StyleOptionTier.Formatting,
             byteDivergent: false,
             oracleEndorsed: false,

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -941,19 +941,57 @@ public class ApiOutputFormatterTests
                 UnsafeOperations: false)));
         var sections = new MemberCodeView();
 
-        // The selected-member projection retains its compact declaration. The whole-type
-        // projection applies the runtime-style constraint layout owned by CSharpText.
-        string selectedMemberSignature = memberName is nameof(RestatementRowFixture.Transitive)
+        // Selected-member and whole-type projections share the runtime-style
+        // constraint layout owned by CSharpText.
+        string compactSignature = memberName is nameof(RestatementRowFixture.Transitive)
             or nameof(RestatementRowFixture.OpenChain)
             ? $"{memberName}<T, U>(T? value) where T : {expected} where U : {expected}"
             : $"{memberName}<T>(T? value) where T : {expected}";
+        string selectedMemberSignature = memberName is nameof(RestatementRowFixture.Transitive)
+            or nameof(RestatementRowFixture.OpenChain)
+            ? $"{memberName}<T, U>(T? value)\n    where T : {expected}\n    where U : {expected}"
+            : $"{memberName}<T>(T? value)\n    where T : {expected}";
         string wholeTypeSignature = memberName is nameof(RestatementRowFixture.Transitive)
             or nameof(RestatementRowFixture.OpenChain)
             ? $"{memberName}<T, U>(T? value)\n        where T : {expected}\n        where U : {expected}"
             : $"{memberName}<T>(T? value)\n        where T : {expected}";
 
         Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, collected.Code));
-        Assert.Contains(selectedMemberSignature, sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+        Assert.Contains(
+            selectedMemberSignature,
+            sections.DecompiledSourceCode.Content,
+            StringComparison.Ordinal);
+
+        var compactCollected = Assert.Single(MemberCodeProvider.Collect(
+            type,
+            [member],
+            path,
+            overloadIndex: 0,
+            new MemberCodeProvider.Request(
+                DecompiledSource: true,
+                AnnotatedSource: false,
+                CostOverlay: false,
+                SemanticsOverlay: false,
+                IL: false,
+                Attributes: false,
+                Calls: false,
+                Callers: false,
+                CallGraph: false,
+                UnsafeOperations: false),
+            renderOptions: ILInspector.Decompiler.Pipeline.PrinterOptions.Default with
+            {
+                DisableOneLinerWrapping = true
+            }));
+        var compactSections = new MemberCodeView();
+        Assert.True(ApiOutputFormatter.PopulateCSharpSections(
+            compactSections,
+            type,
+            member,
+            compactCollected.Code));
+        Assert.Contains(
+            compactSignature,
+            compactSections.DecompiledSourceCode.Content,
+            StringComparison.Ordinal);
 
         var typeSource = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
         Assert.NotNull(typeSource);
@@ -968,7 +1006,7 @@ public class ApiOutputFormatterTests
                 DisableOneLinerWrapping = true
             }).Output;
         Assert.NotNull(compactTypeSource);
-        Assert.Contains(selectedMemberSignature, compactTypeSource, StringComparison.Ordinal);
+        Assert.Contains(compactSignature, compactTypeSource, StringComparison.Ordinal);
 
         static string WithoutWhitespace(string value)
             => string.Concat(value.Where(c => !char.IsWhiteSpace(c)));

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -941,18 +941,39 @@ public class ApiOutputFormatterTests
                 UnsafeOperations: false)));
         var sections = new MemberCodeView();
 
-        // A second type parameter exists only on the rows that need one to constrain T.
-        string signature = memberName is nameof(RestatementRowFixture.Transitive)
+        // The selected-member projection retains its compact declaration. The whole-type
+        // projection applies the runtime-style constraint layout owned by CSharpText.
+        string selectedMemberSignature = memberName is nameof(RestatementRowFixture.Transitive)
             or nameof(RestatementRowFixture.OpenChain)
             ? $"{memberName}<T, U>(T? value) where T : {expected} where U : {expected}"
             : $"{memberName}<T>(T? value) where T : {expected}";
+        string wholeTypeSignature = memberName is nameof(RestatementRowFixture.Transitive)
+            or nameof(RestatementRowFixture.OpenChain)
+            ? $"{memberName}<T, U>(T? value)\n        where T : {expected}\n        where U : {expected}"
+            : $"{memberName}<T>(T? value)\n        where T : {expected}";
 
         Assert.True(ApiOutputFormatter.PopulateCSharpSections(sections, type, member, collected.Code));
-        Assert.Contains(signature, sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
+        Assert.Contains(selectedMemberSignature, sections.DecompiledSourceCode.Content, StringComparison.Ordinal);
 
         var typeSource = MemberBodyProducer.Project(type, path, pdbPath: null).Output;
         Assert.NotNull(typeSource);
-        Assert.Contains(signature, typeSource, StringComparison.Ordinal);
+        Assert.Contains(wholeTypeSignature, typeSource, StringComparison.Ordinal);
+
+        var compactTypeSource = MemberBodyProducer.Project(
+            type,
+            path,
+            pdbPath: null,
+            printerOptions: ILInspector.Decompiler.Pipeline.PrinterOptions.Default with
+            {
+                DisableOneLinerWrapping = true
+            }).Output;
+        Assert.NotNull(compactTypeSource);
+        Assert.Contains(selectedMemberSignature, compactTypeSource, StringComparison.Ordinal);
+
+        static string WithoutWhitespace(string value)
+            => string.Concat(value.Where(c => !char.IsWhiteSpace(c)));
+
+        Assert.Equal(WithoutWhitespace(compactTypeSource), WithoutWhitespace(typeSource));
     }
 
     [Theory]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3025,22 +3025,22 @@ public partial class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains(
-            "ClassConstraint<T>(T? value) where T : class",
+            "ClassConstraint<T>(T? value)\n        where T : class",
             output);
         Assert.Contains(
-            "DelegateConstraint<T>(T? value) where T : class",
+            "DelegateConstraint<T>(T? value)\n        where T : class",
             output);
         Assert.Contains(
-            "InterfaceConstraint<T>(T? value) where T : default",
+            "InterfaceConstraint<T>(T? value)\n        where T : default",
             output);
         Assert.Contains(
-            "EnumConstraint<T>(T? value) where T : default",
+            "EnumConstraint<T>(T? value)\n        where T : default",
             output);
         Assert.Contains(
-            "TransitiveConstraint<T, U>(T? value) where T : class where U : class",
+            "TransitiveConstraint<T, U>(T? value)\n        where T : class\n        where U : class",
             output);
         Assert.Contains(
-            "GenericBaseConstraint<T>(T? value) where T : class",
+            "GenericBaseConstraint<T>(T? value)\n        where T : class",
             output);
     }
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2925,6 +2925,9 @@ public static class ApiOutputFormatter
         {
             declaration = $"{declaration} : {constructorChain}";
         }
+        declaration = CSharpText.CSharpMemberLayout.LayOutDeclarationHead(
+            declaration,
+            result.Metadata.EffectiveOptions.DisableOneLinerWrapping);
         var body = lowered.TrimEnd();
 
         // The trailing side comment rides the signature line, so it has to be

--- a/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
+++ b/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
@@ -219,6 +219,22 @@ public sealed class CSharpMemberLayoutTests
             Render(LongParseHead, "return JsonDocument.ParseValue(utf8Json, options).RootElement;", indent: 4, disableOneLinerWrapping: true));
 
     [Fact]
+    public void Append_DisableSignatureWrappingNamedArgument_RemainsAccepted()
+    {
+        var sb = new StringBuilder();
+        CSharpMemberLayout.Append(
+            sb,
+            LongParseHead,
+            "return JsonDocument.ParseValue(utf8Json, options).RootElement;",
+            4,
+            disableSignatureWrapping: true);
+
+        Assert.Equal(
+            "    " + LongParseHead + " => JsonDocument.ParseValue(utf8Json, options).RootElement;\n",
+            sb.ToString().Replace("\r\n", "\n"));
+    }
+
+    [Fact]
     public void Append_ShortSignature_StaysInline()
         => Assert.Equal(
             "    public int Add(int a, int b) => a + b;\n",
@@ -313,6 +329,25 @@ public sealed class CSharpMemberLayoutTests
                 "public void Log<T>() /* // mentions where U : class */ where T : class",
                 body: null,
                 indent: 4));
+
+    [Fact]
+    public void Append_QuoteInsideBlockComment_DoesNotHideInterpolatedStringDefault()
+    {
+        const string head =
+            """public void Log<T>(string text = /* " */ $"{Format(" where U : class")}") where T : class""";
+        Assert.Equal("    " + head + ";\n", Render(head, body: null, indent: 4));
+    }
+
+    [Fact]
+    public void Append_QuoteInsideBlockComment_DoesNotForceBroadConstraintFallback()
+    {
+        const string head =
+            """public void Log<T>(string text = /* " */ " where U : class") where T : class""";
+        Assert.Equal(
+            "    public void Log<T>(string text = /* \" */ \" where U : class\")\n"
+            + "        where T : class;\n",
+            Render(head, body: null, indent: 4));
+    }
 
     [Fact]
     public void Append_GenericConstraints_DisableOneLinerWrapping_StayInline()
@@ -419,6 +454,18 @@ public sealed class CSharpMemberLayoutTests
         string head = OverBudgetPrefix + "(string s = \"\"\"a,b\"\"\", int x = 0)";
         Assert.Equal("    " + head + ";\n", Render(head, body: null, indent: 4));
     }
+
+    [Fact]
+    public void Append_LongSignature_BlockCommentPunctuation_DoesNotBreakParameterWrapping()
+        => Assert.Equal(
+            "    " + OverBudgetPrefix + "(\n"
+            + "        int first /* ) , hidden separator */,\n"
+            + "        int second,\n"
+            + "        int third);\n",
+            Render(
+                OverBudgetPrefix + "(int first /* ) , hidden separator */, int second, int third)",
+                body: null,
+                indent: 4));
 
     [Fact]
     public void Append_LongSignature_ConventionalStringWithComma_WrapsWithoutSplittingLiteral()

--- a/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
+++ b/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
@@ -298,6 +298,15 @@ public sealed class CSharpMemberLayoutTests
                 indent: 4));
 
     [Fact]
+    public void Append_ContextualWhereMethodName_DoesNotStartConstraintClause()
+        => Assert.Equal(
+            "    public (int, int) where(int value) => (value, value);\n",
+            Render(
+                "public (int, int) where(int value)",
+                "return (value, value);",
+                indent: 4));
+
+    [Fact]
     public void Append_WhereInsideLineComment_DoesNotBecomeLiveConstraint()
         => Assert.Equal(
             "    public void Log<T>() // mentions where U : class\n"

--- a/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
+++ b/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
@@ -320,6 +320,17 @@ public sealed class CSharpMemberLayoutTests
                 indent: 4));
 
     [Fact]
+    public void LayOutDeclarationHead_WhereInsideLineComment_DoesNotBecomeLiveConstraint()
+    {
+        const string head =
+            "public void Log<T>() // mentions where U : class";
+
+        Assert.Equal(
+            head,
+            CSharpMemberLayout.LayOutDeclarationHead(head));
+    }
+
+    [Fact]
     public void Append_WhereInsideBlockComment_IsIgnoredWhileRealConstraintWraps()
         => Assert.Equal(
             "    public void Log<T>() /* mentions where U : class */\n"

--- a/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
+++ b/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
@@ -274,6 +274,32 @@ public sealed class CSharpMemberLayoutTests
                 indent: 4));
 
     [Fact]
+    public void Append_UnicodeGenericConstraints_UseContinuationLines()
+        => Assert.Equal(
+            "    public void Pick<T\u0301, T\u203FValue, T\u200CValue, \U00010400>()\n"
+            + "        where T\u0301 : class\n"
+            + "        where T\u203FValue : class\n"
+            + "        where T\u200CValue : class\n"
+            + "        where \U00010400 : class;\n",
+            Render(
+                "public void Pick<T\u0301, T\u203FValue, T\u200CValue, \U00010400>()"
+                + " where T\u0301 : class"
+                + " where T\u203FValue : class"
+                + " where T\u200CValue : class"
+                + " where \U00010400 : class",
+                body: null,
+                indent: 4));
+
+    [Fact]
+    public void Append_InvalidConstraintIdentifier_DoesNotWrap()
+        => Assert.Equal(
+            "    public void Pick<T>() where T-Value : class;\n",
+            Render(
+                "public void Pick<T>() where T-Value : class",
+                body: null,
+                indent: 4));
+
+    [Fact]
     public void Append_GenericConstraint_BlockBraceFollowsConstraintLine()
         => Assert.Equal(
             "    public T Pick<T>(T value)\n"

--- a/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
+++ b/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
@@ -282,6 +282,39 @@ public sealed class CSharpMemberLayoutTests
                 indent: 4));
 
     [Fact]
+    public void Append_WhereInsideLineComment_DoesNotBecomeLiveConstraint()
+        => Assert.Equal(
+            "    public void Log<T>() // mentions where U : class\n"
+            + "    {\n"
+            + "        Log();\n"
+            + "        Log();\n"
+            + "    }\n",
+            Render(
+                "public void Log<T>() // mentions where U : class",
+                "Log();\nLog();",
+                indent: 4));
+
+    [Fact]
+    public void Append_WhereInsideBlockComment_IsIgnoredWhileRealConstraintWraps()
+        => Assert.Equal(
+            "    public void Log<T>() /* mentions where U : class */\n"
+            + "        where T : class;\n",
+            Render(
+                "public void Log<T>() /* mentions where U : class */ where T : class",
+                body: null,
+                indent: 4));
+
+    [Fact]
+    public void Append_LineCommentMarkerInsideBlockComment_DoesNotDisableConstraintWrapping()
+        => Assert.Equal(
+            "    public void Log<T>() /* // mentions where U : class */\n"
+            + "        where T : class;\n",
+            Render(
+                "public void Log<T>() /* // mentions where U : class */ where T : class",
+                body: null,
+                indent: 4));
+
+    [Fact]
     public void Append_GenericConstraints_DisableOneLinerWrapping_StayInline()
         => Assert.Equal(
             "    public override T? Pick<T, U>(T? value) where T : U where U : class => value;\n",

--- a/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
+++ b/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
@@ -4,10 +4,10 @@ namespace CSharpText.Tests;
 
 public sealed class CSharpMemberLayoutTests
 {
-    static string Render(string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleExpressionBody = false, bool disableSignatureWrapping = false)
+    static string Render(string head, string? body, int indent, bool wrapExpressionBodyArrow = false, bool bodyIsSingleExpressionBody = false, bool disableOneLinerWrapping = false)
     {
         var sb = new StringBuilder();
-        CSharpMemberLayout.Append(sb, head, body, indent, wrapExpressionBodyArrow, bodyIsSingleExpressionBody, disableSignatureWrapping);
+        CSharpMemberLayout.Append(sb, head, body, indent, wrapExpressionBodyArrow, bodyIsSingleExpressionBody, disableOneLinerWrapping);
         return sb.ToString().Replace("\r\n", "\n");
     }
 
@@ -216,7 +216,7 @@ public sealed class CSharpMemberLayoutTests
     public void Append_LongSignature_DisableOptOut_KeepsSingleLine()
         => Assert.Equal(
             "    " + LongParseHead + " => JsonDocument.ParseValue(utf8Json, options).RootElement;\n",
-            Render(LongParseHead, "return JsonDocument.ParseValue(utf8Json, options).RootElement;", indent: 4, disableSignatureWrapping: true));
+            Render(LongParseHead, "return JsonDocument.ParseValue(utf8Json, options).RootElement;", indent: 4, disableOneLinerWrapping: true));
 
     [Fact]
     public void Append_ShortSignature_StaysInline()
@@ -229,11 +229,85 @@ public sealed class CSharpMemberLayoutTests
         => Assert.Equal(
             "    public static void RegisterLongDescriptiveFactoryMethod<TService, TImpl>(\n"
             + "        IServiceCollection services,\n"
-            + "        string longParameterName) where TImpl : TService, new();\n",
+            + "        string longParameterName)\n"
+            + "        where TImpl : TService, new();\n",
             Render(
                 "public static void RegisterLongDescriptiveFactoryMethod<TService, TImpl>(IServiceCollection services, string longParameterName) where TImpl : TService, new()",
                 body: null,
                 indent: 4));
+
+    [Fact]
+    public void Append_GenericConstraints_UseIndentedContinuationLines()
+        => Assert.Equal(
+            "    public override T? Pick<T>(T? value)\n"
+            + "        where T : class => value;\n",
+            Render(
+                "public override T? Pick<T>(T? value) where T : class",
+                "return value;",
+                indent: 4));
+
+    [Fact]
+    public void Append_MultipleGenericConstraints_UseOneLineEach()
+        => Assert.Equal(
+            "    public override T? Pick<T, U>(T? value)\n"
+            + "        where T : U\n"
+            + "        where U : class => value;\n",
+            Render(
+                "public override T? Pick<T, U>(T? value) where T : U where U : class",
+                "return value;",
+                indent: 4));
+
+    [Fact]
+    public void Append_GenericConstraint_BlockBraceFollowsConstraintLine()
+        => Assert.Equal(
+            "    public T Pick<T>(T value)\n"
+            + "        where T : class\n"
+            + "    {\n"
+            + "        Log(value);\n"
+            + "        return value;\n"
+            + "    }\n",
+            Render(
+                "public T Pick<T>(T value) where T : class",
+                "Log(value);\nreturn value;",
+                indent: 4));
+
+    [Fact]
+    public void Append_WhereInsideParameterLiteral_DoesNotStartConstraintClause()
+        => Assert.Equal(
+            "    public void Log<T>(string text = \" where U : class\")\n"
+            + "        where T : class;\n",
+            Render(
+                "public void Log<T>(string text = \" where U : class\") where T : class",
+                body: null,
+                indent: 4));
+
+    [Fact]
+    public void Append_GenericConstraints_DisableOneLinerWrapping_StayInline()
+        => Assert.Equal(
+            "    public override T? Pick<T, U>(T? value) where T : U where U : class => value;\n",
+            Render(
+                "public override T? Pick<T, U>(T? value) where T : U where U : class",
+                "return value;",
+                indent: 4,
+                disableOneLinerWrapping: true));
+
+    [Fact]
+    public void Append_GenericConstraints_AreWhitespaceVariantOfInline()
+    {
+        static string Collapse(string value)
+            => string.Concat(value.Where(c => !char.IsWhiteSpace(c)));
+
+        const string head =
+            "public override T? Pick<T, U>(T? value) where T : U where U : class";
+        string wrapped = Render(head, "return value;", indent: 4);
+        string inline = Render(
+            head,
+            "return value;",
+            indent: 4,
+            disableOneLinerWrapping: true);
+
+        Assert.Equal(Collapse(inline), Collapse(wrapped));
+    }
 
     [Fact]
     public void Append_LongGenericSignature_KeepsGenericArgCommasIntact()

--- a/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
+++ b/tests/CSharpText.Tests/CSharpMemberLayoutTests.cs
@@ -1,4 +1,7 @@
 using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace CSharpText.Tests;
 
@@ -344,6 +347,105 @@ public sealed class CSharpMemberLayoutTests
                 "public void Log<T>() // mentions where U : class",
                 "Log();\nLog();",
                 indent: 4));
+
+    [Fact]
+    public void Append_LineComment_NullBody_PutsSemicolonOnFollowingLine()
+        => Assert.Equal(
+            "    public void M<T>() // note\n"
+            + "        ;\n",
+            Render(
+                "public void M<T>() // note",
+                body: null,
+                indent: 4));
+
+    [Fact]
+    public void Append_BlockComment_NullBody_KeepsSemicolonInline()
+        => Assert.Equal(
+            "    public void M<T>() /* note */;\n",
+            Render(
+                "public void M<T>() /* note */",
+                body: null,
+                indent: 4));
+
+    [Fact]
+    public void Append_LineComment_ExpressionBody_PutsTailOnFollowingLine()
+        => Assert.Equal(
+            "    public int E<T>() // note\n"
+            + "        => 42;\n",
+            Render(
+                "public int E<T>() // note",
+                "return 42;",
+                indent: 4));
+
+    [Fact]
+    public void Append_LineComment_MultilineExpressionBody_UsesFollowingLineIndentation()
+        => Assert.Equal(
+            "    public int E<T>() // note\n"
+            + "        => shape switch\n"
+            + "        {\n"
+            + "            Dot d => d.Radius,\n"
+            + "            _ => -1,\n"
+            + "        };\n",
+            Render(
+                "public int E<T>() // note",
+                SwitchReturnBody,
+                indent: 4,
+                bodyIsSingleExpressionBody: true));
+
+    [Fact]
+    public void Append_BlockComment_ExpressionBody_KeepsTailInline()
+        => Assert.Equal(
+            "    public int E<T>() /* note */ => 42;\n",
+            Render(
+                "public int E<T>() /* note */",
+                "return 42;",
+                indent: 4));
+
+    [Fact]
+    public void Append_LineCommentTails_CompileAndPreserveTokens()
+    {
+        string semicolonMember = Render(
+            "public void M<T>() // note",
+            body: null,
+            indent: 4);
+        string expressionMember = Render(
+            "public int E<T>() // note",
+            "return 42;",
+            indent: 4);
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var tree = CSharpSyntaxTree.ParseText(
+            "public interface C\n{\n"
+            + semicolonMember
+            + expressionMember
+            + "}\n",
+            new CSharpParseOptions(LanguageVersion.Preview),
+            cancellationToken: cancellationToken);
+        var compilation = CSharpCompilation.Create(
+            "LineCommentTailLayout",
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        Assert.DoesNotContain(
+            compilation.GetDiagnostics(cancellationToken),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+
+        MethodDeclarationSyntax[] methods =
+            [.. tree.GetRoot(cancellationToken).DescendantNodes().OfType<MethodDeclarationSyntax>()];
+        Assert.Equal(2, methods.Length);
+        Assert.Equal(
+            ["public", "void", "M", "<", "T", ">", "(", ")", ";"],
+            methods[0].DescendantTokens().Select(token => token.Text));
+        Assert.Equal(
+            ["public", "int", "E", "<", "T", ">", "(", ")", "=>", "42", ";"],
+            methods[1].DescendantTokens().Select(token => token.Text));
+        Assert.All(
+            methods,
+            method => Assert.Contains(
+                method.DescendantTrivia(),
+                trivia => trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)
+                    && trivia.ToString() == "// note"));
+    }
 
     [Fact]
     public void LayOutDeclarationHead_WhereInsideLineComment_DoesNotBecomeLiveConstraint()


### PR DESCRIPTION
- Stack: slice 3/3, parent #3924 (`fix/3903-cross-assembly-compileback`)
- Residual: none; this completes the cross-assembly constraint presentation track

## Change

**Conclusion:** generic method constraints in whole-type Decompiled Source now use the dominant `dotnet/runtime` continuation layout by default, while `disable-one-liner-wrapping` preserves the compact single-line form.

```csharp
public override T? Pick<T, U>(T? value)
    where T : U
    where U : class => value;
```

`CSharpMemberLayout` splits only top-level `where` clauses, keeps one clause per indented continuation line, and leaves parameter wrapping independent. The transform is whitespace-only; product coverage compares the default and compact whole-type projections after removing whitespace.

## Oracle and scope

- **Declared facet:** silent on constraint placement. `dotnet/runtime` has no `dotnet_style_*` or `csharp_style_*` key for it, and `eng/CodeAnalysis.src.globalconfig:1312` disables SA1127.
- **Revealed facet:** favors multiline constraints. Witnesses at runtime commit `795badfa03d` are `JsonValueOfJsonPrimitive.cs:66` and `AsyncIteratorMethodBuilder.cs:40`.
- **Compact override:** inline constraints deliberately diverge from the revealed corpus, so `disable-one-liner-wrapping` remains endorsed by neither facet.
- **Boundary:** this changes whole-type member layout, the surface already owned by `CSharpMemberLayout`; selected-member declaration formatting remains unchanged.

## Evidence

| Check | Result |
| --- | --- |
| Solution build | passed; 0 errors |
| CSharpText suite | 559/559 |
| CLI/product suite | 3,289 passed, 14 platform/tool skips |
| Style catalog + byte-neutrality gates | 41/41 |
| Markdown lint | passed |
