### PR TITLE
Route search commands through inspection workspaces

### DIFF
--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -136,11 +136,13 @@ public sealed record InspectionTarget(
     MemberSelector? Selector = null);   // optional: which member / IL coordinate inside it
 ```
 
-The current metadata canary implements the inner, facet-level contract as
+The current metadata canaries implement the inner, facet-level contract as
 `InspectionQuery<TResult>` plus an `InspectionQueryDefinition` identity. That
-generic definition says what one facet returns and costs; it is not the
-non-generic aggregate request above, which will carry the target, selected
-facets, and options when the acquisition seam migrates.
+generic definition says what one facet returns and costs. Assembly-context
+queries apply the same contract to ordered participant outcomes for extension
+members and reachability, implementation relationships, and type/member
+search. They are not the non-generic aggregate request above, which will carry
+the target, selected facets, and options when the acquisition seam migrates.
 
 Each facet executor receives a result view restricted to its declared
 transitive prerequisite closure. Reading an undeclared result throws even when

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -55,15 +55,16 @@ the ownership boundaries below, not the project count.
 `DotnetInspector.ResearchQueries` companion now implement metadata-image,
 direct-reference, extension-method, custom-attribute, SourceLink audit,
 API-comparison, Analysis body-signal comparison, Implementation comparison,
-assembly-context Integrations, and progressive member call-graph slices. The
-API-comparison seam retains
+assembly-context Integrations,
+implementation relationships, type/member search, extension reachability, and
+progressive member call-graph slices. The API-comparison seam retains
 Metadata-owned Finding correspondence and compatibility classification over
 two host-resolved surfaces. The body-signal seam consumes already-acquired
 Analysis indexes and retains `ResearchComparison`; keeping that query in the
 companion assembly avoids imposing Research and Decompiler dependencies on
-core query consumers. The call-graph seam composes Analysis indexes and one
-catalog generation over workspace-owned immutable snapshots. These queries
-return typed results without choosing a renderer or output format.
+core query consumers. The call-graph and extension-reachability seams compose
+evidence over workspace-owned immutable snapshots. These queries return typed
+results without choosing a renderer or output format.
 The library CLI executes metadata-image, direct assembly-reference, and
 extension-method and custom-attribute queries through a typed, content-shaped
 registry over a host-owned `AssemblyInspectionSession`. The `References`,
@@ -78,6 +79,15 @@ query across every participant in one binding-consistent assembly context
 group. The command projects per-participant evidence or failure into
 compatibility models and continues each library inspection over the same
 retained immutable image.
+The `extensions`, `implements`, and `find` CLIs resolve their assembly sets in
+the host, then execute content-shaped L1 queries through an ephemeral
+workspace. Ordinary independent scans use sequential one-participant groups so
+the workspace does not retain the entire search set; this is gated by
+`RunPerAssembly_RetainsOnlyCurrentParticipant`. The explicit
+`extensions --reachable` traversal uses one binding-consistent group and lazily
+decodes edges only for reached types. CLI adapters retain output naming,
+source/version projection, Findings projection, fuzzy matching, and format
+selection.
 The diff CLI binds Changes, Analysis Diff, and Implementation Diff to their
 concrete query definitions. Its transitional adapters resolve member targets
 and acquire body indexes and retained assembly descriptors lazily inside

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -85,9 +85,10 @@ workspace. Ordinary independent scans use sequential one-participant groups so
 the workspace does not retain the entire search set; this is gated by
 `RunPerAssembly_RetainsOnlyCurrentParticipant`. The explicit
 `extensions --reachable` traversal uses one binding-consistent group and lazily
-decodes edges only for reached types. CLI adapters retain output naming,
-source/version projection, Findings projection, fuzzy matching, and format
-selection.
+decodes edges only for reached types. The retained-image budget remains active,
+and both census and reachability participant rejections are visible. CLI
+adapters retain output naming, source/version projection, Findings projection,
+fuzzy matching, and format selection.
 The diff CLI binds Changes, Analysis Diff, and Implementation Diff to their
 concrete query definitions. Its transitional adapters resolve member targets
 and acquire body indexes and retained assembly descriptors lazily inside

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -15,13 +15,13 @@ shared contracts, not dynamically loaded plugins.
 
 This document describes the target core architecture and the principles that
 govern its migration. Library metadata, direct-reference, extension-method,
-custom-attribute, SourceLink, and API-comparison inspection are the first
-typed-query canaries: section catalogs plan typed demand and execute it through
-prerequisite-aware registries, while commands still own orchestration. The
-`diff` Changes section consumes one API-comparison result over host-resolved
-surfaces, retaining Metadata-owned Finding correspondence and compatibility
-classification without coupling the query to endpoint acquisition or output.
-The library CLI and package
+custom-attribute, SourceLink, API-comparison, implementation-relationship, and
+type/member search inspection are the first typed-query canaries: commands and
+section catalogs plan typed demand while queries remain independent of
+acquisition and output. The `diff` Changes section consumes one API-comparison
+result over host-resolved surfaces, retaining Metadata-owned Finding
+correspondence and compatibility classification without coupling the query to
+endpoint acquisition or output. The library CLI and package
 `--all-libraries` now use an ephemeral workspace for focused Integrations
 demand. One binding-consistent assembly context group scans every selected
 participant sequentially, preserves per-assembly identity, provenance, and
@@ -29,9 +29,14 @@ failures, and retains each available immutable snapshot for the rest of that
 library inspection without reopening the source path. Progressive member call
 graphs now run over the same group: they build Analysis indexes from retained
 snapshots, keep one cross-assembly catalog generation for both traversal
-directions, and remain independent of rendering. Other foundations include
-shared image and inspection session ownership, catalog generations, `CoreCache`,
-typed provenance and resolution currencies, and `InertString`; the remaining
+directions, and remain independent of rendering. The `extensions`,
+`implements`, and `find` commands also execute typed queries through ephemeral
+workspaces. Ordinary search fan-out creates and disposes one-participant groups
+sequentially; explicit extension reachability uses one binding-consistent group
+so its name index, lazy member-edge traversal, and extension census observe the
+same retained participant images. Other foundations include shared image and
+inspection session ownership, catalog generations, `CoreCache`, typed
+provenance and resolution currencies, and `InertString`; the remaining
 workspace model describes how those pieces will be composed.
 
 Mechanism-specific documents remain authoritative for the current behavior,

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -34,10 +34,13 @@ directions, and remain independent of rendering. The `extensions`,
 workspaces. Ordinary search fan-out creates and disposes one-participant groups
 sequentially; explicit extension reachability uses one binding-consistent group
 so its name index, lazy member-edge traversal, and extension census observe the
-same retained participant images. Other foundations include shared image and
-inspection session ownership, catalog generations, `CoreCache`, typed
-provenance and resolution currencies, and `InertString`; the remaining
-workspace model describes how those pieces will be composed.
+same retained participant images. That group retains the workspace's bounded
+image budget; participants rejected by acquisition or the budget remain visible
+as extension and reachability warnings rather than silently shortening the
+search. Other foundations include shared image and inspection session ownership,
+catalog generations, `CoreCache`, typed provenance and resolution currencies,
+and `InertString`; the remaining workspace model describes how those pieces
+will be composed.
 
 Mechanism-specific documents remain authoritative for the current behavior,
 target design, and verification they own. In particular:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,21 +11,26 @@ core: workspace contexts, typed query planning, acquisition and caching, shared
 identity and provenance, owner-issued correspondence, and safe presentation
 boundaries. Typed query-planning slices are implemented for library
 metadata-image, direct-reference, extension-method, custom-attribute,
-SourceLink, Integrations, API-comparison, Analysis body-signal comparison, and
-Implementation comparison inspection. The `diff` Changes, Analysis Diff, and
-Implementation Diff sections consume producer-owned comparison results over
-host-resolved surfaces, body indexes, and retained assembly content.
-The library CLI and package `--all-libraries` use the first
-workspace-backed, group-scoped query for focused Integrations demand while
-remaining query families are future work. The components below are the current
-hosts, shared substrates, and inspection producers that will extend that space.
+SourceLink, Integrations, implementation relationships, type/member search,
+extension reachability, API-comparison, and Analysis body-signal comparison
+inspection, plus Implementation comparison inspection. The `diff` Changes,
+Analysis Diff, and Implementation Diff sections consume producer-owned
+comparison results over host-resolved surfaces, body indexes, and retained
+assembly content.
+The library CLI, package `--all-libraries`, `extensions`, `implements`, and
+`find` now host workspace-backed queries. Independent search fan-out remains
+sequential and bounded to one retained participant at a time; group-scoped
+Integrations and extension reachability retain compatible participants for
+cross-assembly composition. The components below are the current hosts, shared
+substrates, and inspection producers that will extend that space.
 
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
 - `src/DotnetInspector.Queries/` contains host-neutral typed query definitions,
   deterministic synchronous/asynchronous execution, prerequisite-aware cost,
   and content-shaped metadata, reference, extension-method, custom-attribute,
-  SourceLink, API-comparison, and progressive call-graph queries. It has no
-  Markout, console, or filesystem-path dependency.
+  SourceLink, implementation-relationship, type/member search,
+  extension-reachability, API-comparison, and progressive call-graph queries.
+  It has no Markout, console, or filesystem-path dependency.
 - `src/DotnetInspector.ResearchQueries/` contains the optional Research-backed
   L1 query family. It compares already-acquired Analysis body indexes and
   retained implementation assembly content, returning Research-owned results

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextSearchQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextSearchQueryTests.cs
@@ -1,0 +1,234 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class AssemblyContextSearchQueryTests
+{
+    [Fact]
+    public void RegistryRun_ProducesAllSearchFacetsFromOneParticipant()
+    {
+        string path = typeof(WorkspaceQueryImplementation).Assembly.Location;
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            CreateGroup(workspace, path);
+        var registry =
+            new InspectionQueryRegistry<AssemblyContextGroup>()
+                .Add(
+                    AssemblyContextExtensionMethodsQuery.Definition,
+                    context =>
+                        AssemblyContextExtensionMethodsQuery.Execute(
+                            context,
+                            includeAll: true))
+                .Add(
+                    AssemblyContextImplementersQuery.Definition,
+                    context =>
+                        AssemblyContextImplementersQuery.Execute(
+                            context,
+                            typeof(IWorkspaceQueryMarker).FullName!,
+                            includeAll: true))
+                .Add(
+                    AssemblyContextTypeInventoryQuery.Definition,
+                    context =>
+                        AssemblyContextTypeInventoryQuery.Execute(
+                            context,
+                            includeAll: true))
+                .Add(
+                    AssemblyContextMemberMatchesQuery.Definition,
+                    context =>
+                        AssemblyContextMemberMatchesQuery.Execute(
+                            context,
+                            [nameof(WorkspaceQueryImplementation.WorkspaceQueryMember)],
+                            includeAll: true));
+
+        InspectionQueryResults results = registry.Run(
+            [
+                AssemblyContextExtensionMethodsQuery.Definition,
+                AssemblyContextImplementersQuery.Definition,
+                AssemblyContextTypeInventoryQuery.Definition,
+                AssemblyContextMemberMatchesQuery.Definition,
+            ],
+            group);
+
+        ImmutableArray<ExtensionMethodInfo> extensions =
+            Available(
+                results.Get(
+                    AssemblyContextExtensionMethodsQuery.Definition));
+        Assert.Contains(
+            extensions,
+            method =>
+                method.MethodName
+                == nameof(WorkspaceQueryExtensions.WorkspaceQueryExtension));
+
+        ImmutableArray<TypeRelationship> implementers =
+            Available(
+                results.Get(
+                    AssemblyContextImplementersQuery.Definition));
+        Assert.Contains(
+            implementers,
+            relationship =>
+                relationship.TypeName.Contains(
+                    nameof(WorkspaceQueryImplementation),
+                    StringComparison.Ordinal));
+
+        ImmutableArray<AssemblyTypeInventoryEntry> types =
+            Available(
+                results.Get(
+                    AssemblyContextTypeInventoryQuery.Definition));
+        Assert.Contains(
+            types,
+            type =>
+                type.FullName
+                == typeof(WorkspaceQueryImplementation).FullName);
+
+        ImmutableArray<MemberSearchResult> members =
+            Available(
+                results.Get(
+                    AssemblyContextMemberMatchesQuery.Definition));
+        Assert.Contains(
+            members,
+            member =>
+                member.MemberName
+                == nameof(
+                    WorkspaceQueryImplementation.WorkspaceQueryMember));
+
+        Assert.True(group.RetainedImageBytes > 0);
+    }
+
+    [Fact]
+    public void TypeInventory_CarriesRejectedParticipantBesideAvailableResult()
+    {
+        string path = typeof(WorkspaceQueryImplementation).Assembly.Location;
+        byte[] bytes = File.ReadAllBytes(path);
+        AssemblyReferenceIdentity actualIdentity;
+        using (var reader = new PEReader(
+                   new MemoryStream(bytes, writable: false)))
+        {
+            actualIdentity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    reader.GetMetadataReader());
+        }
+
+        var policy = new TestBindingPolicy();
+        ResolvedAssemblyReference rejected =
+            ResolvedAssemblyReference.Create(
+                actualIdentity with { Name = "WrongIdentity" },
+                path: null,
+                () => new MemoryStream(bytes, writable: false),
+                AssemblyResolutionProvenance.Local("rejected"));
+        ResolvedAssemblyReference available =
+            ResolvedAssemblyReference.CreateFromPath(
+                path,
+                AssemblyResolutionProvenance.Local("available"));
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(rejected, policy),
+                    new AssemblyContextParticipant(available, policy),
+                ]);
+
+        AssemblyContextResult<
+            ImmutableArray<AssemblyTypeInventoryEntry>> result =
+            AssemblyContextTypeInventoryQuery.Execute(
+                group,
+                includeAll: true);
+
+        var rejectedEntry = Assert.IsType<
+            AssemblyContextEntry<
+                ImmutableArray<AssemblyTypeInventoryEntry>>.Rejected>(
+                    result.Assemblies[0]);
+        Assert.Equal(
+            CandidateOpenFailureKind.InvalidImage,
+            rejectedEntry.Failure.Kind);
+        Assert.IsType<
+            AssemblyContextEntry<
+                ImmutableArray<AssemblyTypeInventoryEntry>>.Available>(
+                    result.Assemblies[1]);
+    }
+
+    [Fact]
+    public void ExtensionReachability_MatchesPathBasedTraversal()
+    {
+        string path = typeof(WorkspaceReachabilityRoot).Assembly.Location;
+        string target = typeof(WorkspaceReachabilityRoot).FullName!;
+        List<(string Type, string Path)> expected =
+            ExtensionMethodScanner.FindReachableTypes(
+                target,
+                [path],
+                maxDepth: 2);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            CreateGroup(workspace, path);
+
+        AssemblyContextExtensionReachabilityResult actual =
+            AssemblyContextExtensionReachabilityQuery.Execute(
+                group,
+                target,
+                maxDepth: 2);
+
+        Assert.Equal(
+            expected,
+            actual.ReachableTypes.Select(
+                row => (row.Type, row.Path)));
+        Assert.True(actual.TypeInventories.IsComplete);
+    }
+
+    private static ImmutableArray<TValue> Available<TValue>(
+        AssemblyContextResult<ImmutableArray<TValue>> result)
+        => Assert.IsType<
+                AssemblyContextEntry<
+                    ImmutableArray<TValue>>.Available>(
+                    Assert.Single(result.Assemblies))
+            .Value;
+
+    private static AssemblyContextGroup CreateGroup(
+        InspectionWorkspace workspace,
+        string path)
+    {
+        ResolvedAssemblyReference assembly =
+            ResolvedAssemblyReference.CreateFromPath(
+                path,
+                AssemblyResolutionProvenance.Local("query tests"));
+        var policy = new TestBindingPolicy();
+        return workspace.CreateAssemblyContextGroup(
+            [new AssemblyContextParticipant(assembly, policy)]);
+    }
+
+    private sealed class TestBindingPolicy : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+
+        public AssemblyBindingSelection Select(
+            AssemblyBindingRequest request) =>
+            AssemblyBindingSelection.CannotSelect(
+                new AssemblyBindingFailure(
+                    AssemblyBindingFailureKind.CandidateUnavailable));
+    }
+}
+
+public interface IWorkspaceQueryMarker;
+
+public sealed class WorkspaceQueryImplementation :
+    IWorkspaceQueryMarker
+{
+    public WorkspaceReachableType WorkspaceQueryMember() => new();
+}
+
+public sealed class WorkspaceReachabilityRoot
+{
+    public WorkspaceReachableType Reachable { get; } = new();
+}
+
+public sealed class WorkspaceReachableType;
+
+public static class WorkspaceQueryExtensions
+{
+    public static string WorkspaceQueryExtension(
+        this WorkspaceReachableType value)
+        => value.ToString()!;
+}

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextSearchQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextSearchQueryTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
+using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 using DotnetInspector.Services;
@@ -75,26 +77,28 @@ public sealed class AssemblyContextSearchQueryTests
                     nameof(WorkspaceQueryImplementation),
                     StringComparison.Ordinal));
 
-        ImmutableArray<AssemblyTypeInventoryEntry> types =
+        AssemblyTypeInventory typeInventory =
             Available(
                 results.Get(
                     AssemblyContextTypeInventoryQuery.Definition));
         Assert.Contains(
-            types,
+            typeInventory.Types,
             type =>
                 type.FullName
                 == typeof(WorkspaceQueryImplementation).FullName);
+        Assert.Empty(typeInventory.InspectionFailures);
 
-        ImmutableArray<MemberSearchResult> members =
+        AssemblyMemberMatches memberMatches =
             Available(
                 results.Get(
                     AssemblyContextMemberMatchesQuery.Definition));
         Assert.Contains(
-            members,
+            memberMatches.Members,
             member =>
                 member.MemberName
                 == nameof(
                     WorkspaceQueryImplementation.WorkspaceQueryMember));
+        Assert.Empty(memberMatches.InspectionFailures);
 
         Assert.True(group.RetainedImageBytes > 0);
     }
@@ -132,23 +136,58 @@ public sealed class AssemblyContextSearchQueryTests
                     new AssemblyContextParticipant(available, policy),
                 ]);
 
-        AssemblyContextResult<
-            ImmutableArray<AssemblyTypeInventoryEntry>> result =
+        AssemblyContextResult<AssemblyTypeInventory> result =
             AssemblyContextTypeInventoryQuery.Execute(
                 group,
                 includeAll: true);
 
         var rejectedEntry = Assert.IsType<
             AssemblyContextEntry<
-                ImmutableArray<AssemblyTypeInventoryEntry>>.Rejected>(
+                AssemblyTypeInventory>.Rejected>(
                     result.Assemblies[0]);
         Assert.Equal(
             CandidateOpenFailureKind.InvalidImage,
             rejectedEntry.Failure.Kind);
         Assert.IsType<
             AssemblyContextEntry<
-                ImmutableArray<AssemblyTypeInventoryEntry>>.Available>(
+                AssemblyTypeInventory>.Available>(
                     result.Assemblies[1]);
+    }
+
+    [Fact]
+    public void SurfaceQueries_PreserveHealthyRowsAndInspectionFailures()
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"workspace-query-partial-{Guid.NewGuid():N}.dll");
+        File.WriteAllBytes(path, BuildPartialSurfaceImage());
+        try
+        {
+            using var workspace = new InspectionWorkspace();
+            using AssemblyContextGroup group =
+                CreateGroup(workspace, path);
+
+            AssemblyTypeInventory types = Available(
+                AssemblyContextTypeInventoryQuery.Execute(
+                    group,
+                    includeAll: true));
+            Assert.Contains(
+                types.Types,
+                type => type.TypeName == "Sibling");
+            Assert.Single(types.InspectionFailures);
+
+            AssemblyMemberMatches members = Available(
+                AssemblyContextMemberMatchesQuery.Execute(
+                    group,
+                    ["*"],
+                    includeAll: true));
+            Assert.Empty(members.Members);
+            Assert.Single(members.InspectionFailures);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     [Fact]
@@ -178,11 +217,10 @@ public sealed class AssemblyContextSearchQueryTests
         Assert.True(actual.TypeInventories.IsComplete);
     }
 
-    private static ImmutableArray<TValue> Available<TValue>(
-        AssemblyContextResult<ImmutableArray<TValue>> result)
+    private static TValue Available<TValue>(
+        AssemblyContextResult<TValue> result)
         => Assert.IsType<
-                AssemblyContextEntry<
-                    ImmutableArray<TValue>>.Available>(
+                AssemblyContextEntry<TValue>.Available>(
                     Assert.Single(result.Assemblies))
             .Value;
 
@@ -197,6 +235,55 @@ public sealed class AssemblyContextSearchQueryTests
         var policy = new TestBindingPolicy();
         return workspace.CreateAssemblyContextGroup(
             [new AssemblyContextParticipant(assembly, policy)]);
+    }
+
+    private static byte[] BuildPartialSurfaceImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle cyclic = metadata.AddTypeDefinition(
+            TypeAttributes.NestedPublic,
+            default,
+            metadata.GetOrAddString("Rejected"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddNestedType(cyclic, cyclic);
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("Sibling"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
     }
 
     private sealed class TestBindingPolicy : IAssemblyBindingPolicy

--- a/src/DotnetInspector.Queries/AssemblyContextSearchQueries.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextSearchQueries.cs
@@ -1,0 +1,369 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>One participant's typed outcome from an assembly-context query.</summary>
+public abstract record AssemblyContextEntry<TValue>(
+    AssemblyContextSubject Subject)
+{
+    public sealed record Available(
+        AssemblyContextSubject Subject,
+        TValue Value)
+        : AssemblyContextEntry<TValue>(Subject);
+
+    public sealed record Rejected(
+        AssemblyContextSubject Subject,
+        CandidateOpenFailure Failure)
+        : AssemblyContextEntry<TValue>(Subject);
+
+    public sealed record Failed(
+        AssemblyContextSubject Subject,
+        Exception Error)
+        : AssemblyContextEntry<TValue>(Subject);
+}
+
+/// <summary>Ordered outcomes for every participant in an assembly context.</summary>
+public sealed record AssemblyContextResult<TValue>(
+    ImmutableArray<AssemblyContextEntry<TValue>> Assemblies)
+{
+    public bool IsComplete =>
+        Assemblies.All(
+            static entry =>
+                entry is AssemblyContextEntry<TValue>.Available);
+}
+
+/// <summary>A presentation-independent type row from an assembly API surface.</summary>
+public sealed record AssemblyTypeInventoryEntry(
+    string TypeName,
+    string? Namespace,
+    string FullName,
+    string Kind);
+
+/// <summary>One type reached through public members of the requested root type.</summary>
+public sealed record ExtensionReachableTypePath(
+    string Type,
+    string Path);
+
+/// <summary>
+/// Reachability rows plus the per-participant type-index outcomes that bounded
+/// the traversal.
+/// </summary>
+public sealed record AssemblyContextExtensionReachabilityResult(
+    ImmutableArray<ExtensionReachableTypePath> ReachableTypes,
+    AssemblyContextResult<
+        ImmutableArray<ExtensionReachabilityType>> TypeInventories);
+
+/// <summary>Reads extension members from every participant in deterministic order.</summary>
+public static class AssemblyContextExtensionMethodsQuery
+{
+    public static InspectionQuery<
+        AssemblyContextResult<ImmutableArray<ExtensionMethodInfo>>>
+        Definition { get; } =
+        new("Assembly context extension methods", InspectionCost.Unbounded);
+
+    public static AssemblyContextResult<ImmutableArray<ExtensionMethodInfo>>
+        Execute(
+            AssemblyContextGroup group,
+            bool includeAll = false)
+        => AssemblyContextQueryExecutor.Execute(
+            group,
+            session => ExtensionMethodsQuery.Read(session, includeAll));
+}
+
+/// <summary>Reads direct implementation relationships from every participant.</summary>
+public static class AssemblyContextImplementersQuery
+{
+    public static InspectionQuery<
+        AssemblyContextResult<ImmutableArray<TypeRelationship>>>
+        Definition { get; } =
+        new("Assembly context implementers", InspectionCost.Unbounded);
+
+    public static AssemblyContextResult<ImmutableArray<TypeRelationship>>
+        Execute(
+            AssemblyContextGroup group,
+            string targetType,
+            bool includeAll = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+        return AssemblyContextQueryExecutor.Execute(
+            group,
+            session =>
+                session.Implementers(targetType, includeAll)
+                    .ToImmutableArray());
+    }
+}
+
+/// <summary>
+/// Traverses public-member return types across one binding-consistent assembly
+/// context while decoding member signatures only for visited types.
+/// </summary>
+public static class AssemblyContextExtensionReachabilityQuery
+{
+    public static InspectionQuery<
+        AssemblyContextExtensionReachabilityResult> Definition { get; } =
+        new("Assembly context extension reachability", InspectionCost.Unbounded);
+
+    public static AssemblyContextExtensionReachabilityResult Execute(
+        AssemblyContextGroup group,
+        string targetType,
+        int maxDepth)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetType);
+
+        AssemblyContextResult<
+            ImmutableArray<ExtensionReachabilityType>> inventories =
+            AssemblyContextQueryExecutor.Execute(
+                group,
+                session =>
+                    session.ExtensionReachabilityTypes()
+                        .ToImmutableArray());
+        var byFullName =
+            new Dictionary<string, ReachabilityAddress>(
+                StringComparer.OrdinalIgnoreCase);
+        var bySimpleName =
+            new Dictionary<string, ReachabilityAddress>(
+                StringComparer.OrdinalIgnoreCase);
+
+        for (int index = 0;
+            index < inventories.Assemblies.Length;
+            index++)
+        {
+            if (inventories.Assemblies[index]
+                is not AssemblyContextEntry<
+                    ImmutableArray<ExtensionReachabilityType>>.Available
+                    available)
+            {
+                continue;
+            }
+
+            AssemblyContextParticipant participant =
+                group.Participants[index];
+            foreach (ExtensionReachabilityType type in available.Value)
+            {
+                var address = new ReachabilityAddress(
+                    participant,
+                    type.MetadataToken);
+                byFullName.TryAdd(type.FullName, address);
+                bySimpleName.TryAdd(type.SimpleName, address);
+            }
+        }
+
+        var results =
+            ImmutableArray.CreateBuilder<ExtensionReachableTypePath>();
+        var visited = new HashSet<string>(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            targetType,
+        };
+        var pending = new Queue<(string Type, string Path, int Depth)>();
+        pending.Enqueue((targetType, "", maxDepth));
+
+        while (pending.TryDequeue(out var current))
+        {
+            if (current.Depth <= 0)
+                continue;
+
+            if (!TryResolve(
+                    current.Type,
+                    byFullName,
+                    bySimpleName,
+                    out ReachabilityAddress address))
+            {
+                continue;
+            }
+
+            AssemblyImageAccessResult<
+                IReadOnlyList<ExtensionReachabilityEdge>> access =
+                group.UseAssemblySession(
+                    address.Participant.Assembly,
+                    session =>
+                        session.ExtensionReachabilityEdges(
+                            address.MetadataToken));
+            if (access
+                is not AssemblyImageAccessResult<
+                    IReadOnlyList<ExtensionReachabilityEdge>>.Available
+                    availableEdges)
+            {
+                throw new InspectionQueryException(
+                    $"Reachability participant '{address.Participant.Assembly.Identity.Name}' became unavailable after its type inventory was produced.");
+            }
+
+            foreach (ExtensionReachabilityEdge edge
+                in availableEdges.Value)
+            {
+                if (!visited.Add(edge.Type))
+                    continue;
+
+                string path = current.Path + edge.PathSegment;
+                results.Add(
+                    new ExtensionReachableTypePath(
+                        edge.Type,
+                        path));
+                pending.Enqueue(
+                    (edge.Type, path, current.Depth - 1));
+            }
+        }
+
+        return new AssemblyContextExtensionReachabilityResult(
+            results.ToImmutable(),
+            inventories);
+    }
+
+    private static bool TryResolve(
+        string type,
+        IReadOnlyDictionary<string, ReachabilityAddress> byFullName,
+        IReadOnlyDictionary<string, ReachabilityAddress> bySimpleName,
+        out ReachabilityAddress address)
+    {
+        if (byFullName.TryGetValue(type, out ReachabilityAddress? candidate)
+            || bySimpleName.TryGetValue(type, out candidate)
+            || bySimpleName.TryGetValue(
+                type.Split('.').Last(),
+                out candidate))
+        {
+            address = candidate;
+            return true;
+        }
+
+        address = null!;
+        return false;
+    }
+
+    private sealed record ReachabilityAddress(
+        AssemblyContextParticipant Participant,
+        int MetadataToken);
+}
+
+/// <summary>Reads a type inventory from every participant.</summary>
+public static class AssemblyContextTypeInventoryQuery
+{
+    public static InspectionQuery<
+        AssemblyContextResult<ImmutableArray<AssemblyTypeInventoryEntry>>>
+        Definition { get; } =
+        new("Assembly context type inventory", InspectionCost.Unbounded);
+
+    public static AssemblyContextResult<
+        ImmutableArray<AssemblyTypeInventoryEntry>> Execute(
+            AssemblyContextGroup group,
+            bool includeAll = false)
+        => AssemblyContextQueryExecutor.Execute(
+            group,
+            session =>
+                session.ApiSurface(includeAll, typesOnly: true)
+                    .Types
+                    .Select(
+                        static type =>
+                            new AssemblyTypeInventoryEntry(
+                                type.Name,
+                                type.Namespace,
+                                type.FullName,
+                                type.Kind))
+                    .ToImmutableArray());
+}
+
+/// <summary>Searches member names in every participant.</summary>
+public static class AssemblyContextMemberMatchesQuery
+{
+    public static InspectionQuery<
+        AssemblyContextResult<ImmutableArray<MemberSearchResult>>>
+        Definition { get; } =
+        new("Assembly context member matches", InspectionCost.Unbounded);
+
+    public static AssemblyContextResult<ImmutableArray<MemberSearchResult>>
+        Execute(
+            AssemblyContextGroup group,
+            IReadOnlyList<string> patterns,
+            bool includeAll = false,
+            int? limit = null)
+    {
+        ArgumentNullException.ThrowIfNull(patterns);
+        return AssemblyContextQueryExecutor.Execute(
+            group,
+            (subject, session) =>
+                MemberSearch.Search(
+                        session.ApiSurface(includeAll),
+                        subject.Identity.Name,
+                        patterns,
+                        limit)
+                    .ToImmutableArray());
+    }
+}
+
+internal static class AssemblyContextQueryExecutor
+{
+    internal static AssemblyContextResult<TValue> Execute<TValue>(
+        AssemblyContextGroup group,
+        Func<AssemblyInspectionSession, TValue> inspect)
+        => Execute(group, (_, session) => inspect(session));
+
+    internal static AssemblyContextResult<TValue> Execute<TValue>(
+        AssemblyContextGroup group,
+        Func<AssemblyContextSubject, AssemblyInspectionSession, TValue> inspect)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentNullException.ThrowIfNull(inspect);
+
+        var entries =
+            ImmutableArray.CreateBuilder<AssemblyContextEntry<TValue>>(
+                group.Participants.Length);
+        foreach (AssemblyContextParticipant participant
+            in group.Participants)
+        {
+            var subject = new AssemblyContextSubject(
+                participant.Assembly);
+            AssemblyImageAccessResult<AssemblyContextEntry<TValue>> access =
+                group.UseAssemblySession(
+                    participant.Assembly,
+                    session => Inspect(subject, session, inspect));
+            entries.Add(
+                access switch
+                {
+                    AssemblyImageAccessResult<
+                        AssemblyContextEntry<TValue>>.Available available =>
+                        available.Value,
+                    AssemblyImageAccessResult<
+                        AssemblyContextEntry<TValue>>.Rejected rejected =>
+                        new AssemblyContextEntry<TValue>.Rejected(
+                            subject,
+                            rejected.Failure),
+                    _ => throw new InvalidOperationException(
+                        "Unknown assembly image access result."),
+                });
+        }
+
+        return new AssemblyContextResult<TValue>(
+            entries.MoveToImmutable());
+    }
+
+    private static AssemblyContextEntry<TValue> Inspect<TValue>(
+        AssemblyContextSubject subject,
+        AssemblyInspectionSession session,
+        Func<AssemblyContextSubject, AssemblyInspectionSession, TValue> inspect)
+    {
+        try
+        {
+            return new AssemblyContextEntry<TValue>.Available(
+                subject,
+                inspect(subject, session));
+        }
+        catch (Exception ex) when (IsArtifactFailure(ex))
+        {
+            return new AssemblyContextEntry<TValue>.Failed(
+                subject,
+                ex);
+        }
+    }
+
+    private static bool IsArtifactFailure(Exception exception)
+        => exception is IOException
+            or UnauthorizedAccessException
+            or BadImageFormatException
+            or InvalidOperationException
+            or ArgumentException
+            or NotSupportedException
+            or OverflowException
+            or IndexOutOfRangeException;
+}

--- a/src/DotnetInspector.Queries/AssemblyContextSearchQueries.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextSearchQueries.cs
@@ -41,6 +41,20 @@ public sealed record AssemblyTypeInventoryEntry(
     string FullName,
     string Kind);
 
+/// <summary>
+/// Healthy type rows and metadata rows rejected while producing them.
+/// </summary>
+public sealed record AssemblyTypeInventory(
+    ImmutableArray<AssemblyTypeInventoryEntry> Types,
+    ImmutableArray<ApiSurfaceInspectionFailure> InspectionFailures);
+
+/// <summary>
+/// Healthy member matches and metadata rows rejected while producing them.
+/// </summary>
+public sealed record AssemblyMemberMatches(
+    ImmutableArray<MemberSearchResult> Members,
+    ImmutableArray<ApiSurfaceInspectionFailure> InspectionFailures);
+
 /// <summary>One type reached through public members of the requested root type.</summary>
 public sealed record ExtensionReachableTypePath(
     string Type,
@@ -241,19 +255,21 @@ public static class AssemblyContextExtensionReachabilityQuery
 public static class AssemblyContextTypeInventoryQuery
 {
     public static InspectionQuery<
-        AssemblyContextResult<ImmutableArray<AssemblyTypeInventoryEntry>>>
+        AssemblyContextResult<AssemblyTypeInventory>>
         Definition { get; } =
         new("Assembly context type inventory", InspectionCost.Unbounded);
 
-    public static AssemblyContextResult<
-        ImmutableArray<AssemblyTypeInventoryEntry>> Execute(
+    public static AssemblyContextResult<AssemblyTypeInventory> Execute(
             AssemblyContextGroup group,
             bool includeAll = false)
         => AssemblyContextQueryExecutor.Execute(
             group,
             session =>
-                session.ApiSurface(includeAll, typesOnly: true)
-                    .Types
+            {
+                ApiSurface surface =
+                    session.ApiSurface(includeAll, typesOnly: true);
+                return new AssemblyTypeInventory(
+                    surface.Types
                     .Select(
                         static type =>
                             new AssemblyTypeInventoryEntry(
@@ -261,18 +277,20 @@ public static class AssemblyContextTypeInventoryQuery
                                 type.Namespace,
                                 type.FullName,
                                 type.Kind))
-                    .ToImmutableArray());
+                    .ToImmutableArray(),
+                    surface.InspectionFailures.ToImmutableArray());
+            });
 }
 
 /// <summary>Searches member names in every participant.</summary>
 public static class AssemblyContextMemberMatchesQuery
 {
     public static InspectionQuery<
-        AssemblyContextResult<ImmutableArray<MemberSearchResult>>>
+        AssemblyContextResult<AssemblyMemberMatches>>
         Definition { get; } =
         new("Assembly context member matches", InspectionCost.Unbounded);
 
-    public static AssemblyContextResult<ImmutableArray<MemberSearchResult>>
+    public static AssemblyContextResult<AssemblyMemberMatches>
         Execute(
             AssemblyContextGroup group,
             IReadOnlyList<string> patterns,
@@ -283,12 +301,17 @@ public static class AssemblyContextMemberMatchesQuery
         return AssemblyContextQueryExecutor.Execute(
             group,
             (subject, session) =>
-                MemberSearch.Search(
-                        session.ApiSurface(includeAll),
+            {
+                ApiSurface surface = session.ApiSurface(includeAll);
+                return new AssemblyMemberMatches(
+                    MemberSearch.Search(
+                        surface,
                         subject.Identity.Name,
                         patterns,
                         limit)
-                    .ToImmutableArray());
+                    .ToImmutableArray(),
+                    surface.InspectionFailures.ToImmutableArray());
+            });
     }
 }
 

--- a/src/DotnetInspector.Queries/ExtensionMethodsQuery.cs
+++ b/src/DotnetInspector.Queries/ExtensionMethodsQuery.cs
@@ -24,18 +24,32 @@ public static class ExtensionMethodsQuery
     public static InspectionQuery<ExtensionMethodsResult> Definition { get; } =
         new("Extension methods", InspectionCost.NetworkFree);
 
-    public static ExtensionMethodsResult Execute(AssemblyInspectionSession session)
+    public static ExtensionMethodsResult Execute(
+        AssemblyInspectionSession session)
+        => Execute(session, includeAll: false);
+
+    public static ExtensionMethodsResult Execute(
+        AssemblyInspectionSession session,
+        bool includeAll)
     {
         ArgumentNullException.ThrowIfNull(session);
 
         try
         {
             return new ExtensionMethodsResult.Available(
-                session.ExtensionMethods().ToImmutableArray());
+                Read(session, includeAll));
         }
         catch (Exception ex)
         {
             return new ExtensionMethodsResult.Failed(ex);
         }
+    }
+
+    internal static ImmutableArray<ExtensionMethodInfo> Read(
+        AssemblyInspectionSession session,
+        bool includeAll)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        return session.ExtensionMethods(includeAll).ToImmutableArray();
     }
 }

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -138,6 +138,26 @@ public sealed class AssemblyInspectionSession : IDisposable
     public IEnumerable<ExtensionMethodInfo> ExtensionMethods(bool includeAll = false)
         => ExtensionMethodScanner.FindAllExtensions(_image.PEReader, includeAll);
 
+    /// <summary>Image-local type addresses for lazy extension reachability.</summary>
+    public IReadOnlyList<ExtensionReachabilityType> ExtensionReachabilityTypes()
+        => ExtensionMethodScanner.IndexReachableTypes(_image.PEReader);
+
+    /// <summary>Reachable public-member edges for one image-local type address.</summary>
+    public IReadOnlyList<ExtensionReachabilityEdge> ExtensionReachabilityEdges(
+        int metadataToken)
+        => ExtensionMethodScanner.FindReachableEdges(
+            _image.PEReader,
+            metadataToken);
+
+    /// <summary>Types that directly implement or extend the requested type.</summary>
+    public IEnumerable<TypeRelationship> Implementers(
+        string targetType,
+        bool includeHidden = false)
+        => TypeHierarchyScanner.FindImplementers(
+            _image.PEReader,
+            targetType,
+            includeHidden);
+
     /// <summary>Assembly-level custom attributes.</summary>
     public List<AssemblyAttributeInfo> CustomAttributes()
         => AssemblyDetailScanner.ScanCustomAttributes(_image.PEReader);

--- a/src/ILInspector.Metadata/ExtensionMethodScanner.cs
+++ b/src/ILInspector.Metadata/ExtensionMethodScanner.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using CSharpText;
 using ILInspector.MetadataPrimitives;
@@ -50,6 +51,19 @@ public record ExtensionMethodInfo(
         return hash.ToHashCode();
     }
 }
+
+/// <summary>
+/// Image-local address used to resolve one type during extension reachability.
+/// </summary>
+public sealed record ExtensionReachabilityType(
+    string FullName,
+    string SimpleName,
+    int MetadataToken);
+
+/// <summary>One public-member edge used by extension reachability.</summary>
+public sealed record ExtensionReachabilityEdge(
+    string Type,
+    string PathSegment);
 
 /// <summary>
 /// Scans assemblies for extension methods targeting a specific type.
@@ -266,6 +280,55 @@ public static class ExtensionMethodScanner
     }
 
     /// <summary>
+    /// Indexes type names without decoding their member signatures.
+    /// </summary>
+    public static List<ExtensionReachabilityType> IndexReachableTypes(
+        PEReader peReader)
+    {
+        if (!peReader.HasMetadata)
+            return [];
+
+        MetadataReader reader = peReader.GetMetadataReader();
+        var types = new List<ExtensionReachabilityType>(
+            reader.TypeDefinitions.Count);
+        foreach (TypeDefinitionHandle handle in reader.TypeDefinitions)
+        {
+            TypeDefinition type = reader.GetTypeDefinition(handle);
+            types.Add(
+                new ExtensionReachabilityType(
+                    reader.GetFullTypeName(type),
+                    reader.GetString(type.Name),
+                    MetadataTokens.GetToken(handle)));
+        }
+
+        return types;
+    }
+
+    /// <summary>
+    /// Decodes the reachable public-member edges of one image-local type.
+    /// </summary>
+    public static List<ExtensionReachabilityEdge> FindReachableEdges(
+        PEReader peReader,
+        int metadataToken)
+    {
+        if (!peReader.HasMetadata)
+            return [];
+
+        EntityHandle entity = MetadataTokens.EntityHandle(metadataToken);
+        if (entity.Kind != HandleKind.TypeDefinition)
+        {
+            throw new ArgumentException(
+                "Extension reachability requires a TypeDef token.",
+                nameof(metadataToken));
+        }
+
+        MetadataReader reader = peReader.GetMetadataReader();
+        return FindReachableEdges(
+            reader,
+            (TypeDefinitionHandle)entity);
+    }
+
+    /// <summary>
     /// Finds types reachable from a target type by traversing public members.
     /// Used for the --reachable flag to discover transitive extension methods.
     /// </summary>
@@ -329,61 +392,16 @@ public static class ExtensionMethodScanner
                     continue;
 
                 var (reader, typeDefHandle) = found;
-                var typeDef = reader.GetTypeDefinition(typeDefHandle);
-                var context = GenericContext.ForType(reader, typeDef);
-
-                // Properties
-                foreach (var propHandle in typeDef.GetProperties())
+                foreach (ExtensionReachabilityEdge edge
+                    in FindReachableEdges(reader, typeDefHandle))
                 {
-                    var prop = reader.GetPropertyDefinition(propHandle);
-                    var propName = reader.GetString(prop.Name);
-
-                    try
-                    {
-                        var sig = GuardedSignatureText.PropertyText(reader, prop, context)
-                            .GetValueOrThrow();
-                        var propType = UnwrapAsyncType(sig.ReturnType);
-
-                        if (!string.IsNullOrEmpty(propType) && !IsPrimitiveType(propType) && visited.Add(propType))
-                        {
-                            var path = $"{currentPath}.{propName}";
-                            results.Add((propType, path));
-                            toProcess.Enqueue((propType, path, remainingDepth - 1));
-                        }
-                    }
-                    // Skip properties with undecodable signatures
-                    catch { }
-                }
-
-                // Methods (return types)
-                foreach (var methodHandle in typeDef.GetMethods())
-                {
-                    var method = reader.GetMethodDefinition(methodHandle);
-                    if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public) continue;
-
-                    string methodName = reader.GetString(method.Name);
-                    if (methodName.StartsWith("get_") || methodName.StartsWith("set_") ||
-                        methodName.StartsWith("add_") || methodName.StartsWith("remove_") ||
-                        methodName.StartsWith("."))
+                    if (!visited.Add(edge.Type))
                         continue;
 
-                    try
-                    {
-                        var methodContext = GenericContext.ForMethod(reader, typeDef, method);
-                        var sig = GuardedSignatureText.MethodText(reader, method, methodContext)
-                            .GetValueOrThrow();
-                        var retType = UnwrapAsyncType(sig.ReturnType);
-
-                        if (!string.IsNullOrEmpty(retType) && retType != "void" &&
-                            !IsPrimitiveType(retType) && visited.Add(retType))
-                        {
-                            var path = $"{currentPath}.{methodName}()";
-                            results.Add((retType, path));
-                            toProcess.Enqueue((retType, path, remainingDepth - 1));
-                        }
-                    }
-                    // Skip methods with undecodable signatures
-                    catch { }
+                    var path = currentPath + edge.PathSegment;
+                    results.Add((edge.Type, path));
+                    toProcess.Enqueue(
+                        (edge.Type, path, remainingDepth - 1));
                 }
             }
         }
@@ -395,6 +413,111 @@ public static class ExtensionMethodScanner
 
         return results;
     }
+
+    private static List<ExtensionReachabilityEdge> FindReachableEdges(
+        MetadataReader reader,
+        TypeDefinitionHandle typeDefHandle)
+    {
+        var results = new List<ExtensionReachabilityEdge>();
+        TypeDefinition typeDef =
+            reader.GetTypeDefinition(typeDefHandle);
+        GenericContext context =
+            GenericContext.ForType(reader, typeDef);
+
+        foreach (PropertyDefinitionHandle propHandle
+            in typeDef.GetProperties())
+        {
+            PropertyDefinition prop =
+                reader.GetPropertyDefinition(propHandle);
+            string propName = reader.GetString(prop.Name);
+
+            try
+            {
+                var signature =
+                    GuardedSignatureText.PropertyText(
+                            reader,
+                            prop,
+                            context)
+                        .GetValueOrThrow();
+                string propType =
+                    UnwrapAsyncType(signature.ReturnType);
+
+                if (!string.IsNullOrEmpty(propType)
+                    && !IsPrimitiveType(propType))
+                {
+                    results.Add(
+                        new ExtensionReachabilityEdge(
+                            propType,
+                            $".{propName}"));
+                }
+            }
+            catch (Exception ex) when (IsUndecodableSignature(ex))
+            {
+            }
+        }
+
+        foreach (MethodDefinitionHandle methodHandle
+            in typeDef.GetMethods())
+        {
+            MethodDefinition method =
+                reader.GetMethodDefinition(methodHandle);
+            if ((method.Attributes & MethodAttributes.MemberAccessMask)
+                != MethodAttributes.Public)
+            {
+                continue;
+            }
+
+            string methodName = reader.GetString(method.Name);
+            if (methodName.StartsWith("get_", StringComparison.Ordinal)
+                || methodName.StartsWith("set_", StringComparison.Ordinal)
+                || methodName.StartsWith("add_", StringComparison.Ordinal)
+                || methodName.StartsWith("remove_", StringComparison.Ordinal)
+                || methodName.StartsWith(".", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            try
+            {
+                GenericContext methodContext =
+                    GenericContext.ForMethod(
+                        reader,
+                        typeDef,
+                        method);
+                var signature =
+                    GuardedSignatureText.MethodText(
+                            reader,
+                            method,
+                            methodContext)
+                        .GetValueOrThrow();
+                string returnType =
+                    UnwrapAsyncType(signature.ReturnType);
+
+                if (!string.IsNullOrEmpty(returnType)
+                    && returnType != "void"
+                    && !IsPrimitiveType(returnType))
+                {
+                    results.Add(
+                        new ExtensionReachabilityEdge(
+                            returnType,
+                            $".{methodName}()"));
+                }
+            }
+            catch (Exception ex) when (IsUndecodableSignature(ex))
+            {
+            }
+        }
+
+        return results;
+    }
+
+    private static bool IsUndecodableSignature(Exception exception)
+        => exception is BadImageFormatException
+            or InvalidOperationException
+            or ArgumentException
+            or NotSupportedException
+            or OverflowException
+            or IndexOutOfRangeException;
 
     private static string UnwrapAsyncType(string type)
     {

--- a/src/ILInspector.Metadata/MemberSearch.cs
+++ b/src/ILInspector.Metadata/MemberSearch.cs
@@ -33,7 +33,11 @@ public sealed record MemberSearchResult
     /// <summary>Durable 10-char overload digest, when the surface projected member identity.</summary>
     public string? Digest { get; init; }
 
-    /// <summary>The assembly file name without extension that declared the member.</summary>
+    /// <summary>
+    /// The declaring assembly name supplied by the caller. Path-based searches
+    /// use the file name without extension; content-backed callers may use the
+    /// assembly identity.
+    /// </summary>
     public required string Assembly { get; init; }
 
     /// <summary>True when <see cref="Pattern"/> was a glob (contained <c>*</c> or <c>?</c>).</summary>
@@ -96,7 +100,12 @@ public static class MemberSearch
                 continue;
             }
 
-            CollectFromSurface(surface, path, patterns, limit, results);
+            CollectFromSurface(
+                surface,
+                Path.GetFileNameWithoutExtension(path),
+                patterns,
+                limit,
+                results);
         }
 
         return new MemberSearchOutcome(results, skipped);
@@ -121,20 +130,41 @@ public static class MemberSearch
 
         var surface = AssemblyReader.ExtractApiSurface(assemblyPath, includeAll, typesOnly: false);
         if (surface is not null)
-            CollectFromSurface(surface, assemblyPath, patterns, limit: null, results);
+            CollectFromSurface(
+                surface,
+                Path.GetFileNameWithoutExtension(assemblyPath),
+                patterns,
+                limit: null,
+                results);
 
+        return results;
+    }
+
+    /// <summary>
+    /// Searches an already-produced API surface without reopening its assembly.
+    /// </summary>
+    public static IReadOnlyList<MemberSearchResult> Search(
+        ApiSurface surface,
+        string assemblyName,
+        IReadOnlyList<string> patterns,
+        int? limit = null)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyName);
+        ArgumentNullException.ThrowIfNull(patterns);
+
+        var results = new List<MemberSearchResult>();
+        CollectFromSurface(surface, assemblyName, patterns, limit, results);
         return results;
     }
 
     private static void CollectFromSurface(
         ApiSurface surface,
-        string assemblyPath,
+        string assemblyName,
         IReadOnlyList<string> patterns,
         int? limit,
         List<MemberSearchResult> results)
     {
-        var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-
         foreach (var type in surface.Types)
         {
             foreach (var member in type.Members)

--- a/src/dotnet-inspect.Tests/AssemblySetInspectionWorkspaceTests.cs
+++ b/src/dotnet-inspect.Tests/AssemblySetInspectionWorkspaceTests.cs
@@ -32,8 +32,7 @@ public sealed class AssemblySetInspectionWorkspaceTests
             {
                 Assert.IsType<
                     AssemblyContextEntry<
-                        System.Collections.Immutable.ImmutableArray<
-                            AssemblyTypeInventoryEntry>>.Available>(entry);
+                        AssemblyTypeInventory>.Available>(entry);
                 availableCount++;
             },
             (_, failure) => Assert.Fail(failure));

--- a/src/dotnet-inspect.Tests/AssemblySetInspectionWorkspaceTests.cs
+++ b/src/dotnet-inspect.Tests/AssemblySetInspectionWorkspaceTests.cs
@@ -1,0 +1,47 @@
+using DotnetInspector.Inspectors;
+using DotnetInspector.Queries;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Tests;
+
+public sealed class AssemblySetInspectionWorkspaceTests
+{
+    [Fact]
+    public async Task RunPerAssembly_RetainsOnlyCurrentParticipant()
+    {
+        string path =
+            typeof(AssemblySetInspectionWorkspaceTests).Assembly.Location;
+        using var httpClient = new HttpClient();
+        using AssemblySet assemblySet =
+            await AssemblySetResolver.CollectAsync(
+                httpClient,
+                new AssemblySetRequest
+                {
+                    Assemblies = [path, path],
+                });
+        using var workspace = new AssemblySetInspectionWorkspace();
+        int availableCount = 0;
+
+        workspace.RunPerAssembly(
+            assemblySet,
+            AssemblyContextTypeInventoryQuery.Definition,
+            group => AssemblyContextTypeInventoryQuery.Execute(
+                group,
+                includeAll: true),
+            (_, entry) =>
+            {
+                Assert.IsType<
+                    AssemblyContextEntry<
+                        System.Collections.Immutable.ImmutableArray<
+                            AssemblyTypeInventoryEntry>>.Available>(entry);
+                availableCount++;
+            },
+            (_, failure) => Assert.Fail(failure));
+
+        Assert.Equal(2, availableCount);
+        Assert.InRange(
+            workspace.PeakRetainedImageBytes,
+            1,
+            new FileInfo(path).Length);
+    }
+}

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -2,6 +2,7 @@ using System.Reflection.PortableExecutable;
 using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
+using DotnetInspector.Queries;
 using ILInspector.Findings;
 using ILInspector.Metadata;
 using DotnetInspector.Options;
@@ -231,6 +232,67 @@ public class ExtensionsCommandTests
             nameof(ExtensionWorkspaceMethods.WorkspaceExtension),
             output);
         Assert.Contains("\"reachable_path\": \".Reachable\"", output);
+    }
+
+    [Fact]
+    public async Task ReachabilityBudgetRejectionIsVisible()
+    {
+        string path = typeof(ExtensionsCommandTests).Assembly.Location;
+        ResolvedAssemblyReference first =
+            ResolvedAssemblyReference.CreateFromPath(
+                path,
+                AssemblyResolutionProvenance.Local("first"));
+        ResolvedAssemblyReference second =
+            ResolvedAssemblyReference.CreateFromPath(
+                path,
+                AssemblyResolutionProvenance.Local("second"));
+        var policy = new AssemblyDependencyResolver(
+            new AssemblyDependencyResolutionOptions(path));
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(first, policy),
+                    new AssemblyContextParticipant(second, policy),
+                ],
+                new AssemblyContextGroupOptions
+                {
+                    MaxRetainedImageBytes = new FileInfo(path).Length,
+                });
+        AssemblyContextExtensionReachabilityResult reachability =
+            AssemblyContextExtensionReachabilityQuery.Execute(
+                group,
+                typeof(ExtensionWorkspaceRoot).FullName!,
+                maxDepth: 1);
+        var entries = new AssemblyContextEntryMap(
+            [
+                (
+                    first.Registration,
+                    new AssemblySetEntry(
+                        path,
+                        "first",
+                        null,
+                        AssemblySetSourceKind.Assembly)),
+                (
+                    second.Registration,
+                    new AssemblySetEntry(
+                        path,
+                        "second",
+                        null,
+                        AssemblySetSourceKind.Assembly)),
+            ]);
+
+        var (_, error) = await ConsoleCapture.RunAsync(
+            () => ExtensionsCommand.WriteReachabilityFailures(
+                reachability,
+                entries));
+
+        Assert.Contains(
+            "Extension reachability inspection failed",
+            error);
+        Assert.Contains(
+            "retained-image budget was exhausted",
+            error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -15,6 +15,7 @@ namespace DotnetInspector.Tests;
 /// <summary>
 /// Tests for extension method discovery.
 /// </summary>
+[Collection("Console")]
 public class ExtensionsCommandTests
 {
     [Fact]
@@ -205,6 +206,31 @@ public class ExtensionsCommandTests
 
         Assert.Same(MetadataFindings.ExtensionMemberDescriptor, failure.Error.Descriptor);
         Assert.Contains("Finding inspection failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReachableSearchUsesWorkspaceQueries()
+    {
+        var options = new ExtensionsOptions
+        {
+            TargetType = typeof(ExtensionWorkspaceRoot).FullName!,
+            Assemblies = [typeof(ExtensionsCommandTests).Assembly.Location],
+            IncludeAll = true,
+            Reachable = true,
+            Depth = 1,
+            JsonOutput = true,
+        };
+
+        var (exitCode, output, error) =
+            await ConsoleCapture.RunAsync(
+                () => ExtensionsCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.Contains(
+            nameof(ExtensionWorkspaceMethods.WorkspaceExtension),
+            output);
+        Assert.Contains("\"reachable_path\": \".Reachable\"", output);
     }
 
     [Fact]
@@ -541,4 +567,18 @@ public static class SampleExtensions
 public class SampleTargetType
 {
     public string Name { get; set; } = "";
+}
+
+public sealed class ExtensionWorkspaceRoot
+{
+    public ExtensionWorkspaceTarget Reachable { get; } = new();
+}
+
+public sealed class ExtensionWorkspaceTarget;
+
+public static class ExtensionWorkspaceMethods
+{
+    public static string WorkspaceExtension(
+        this ExtensionWorkspaceTarget target)
+        => target.ToString()!;
 }

--- a/src/dotnet-inspect.Tests/ImplementsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ImplementsCommandTests.cs
@@ -1,0 +1,38 @@
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public sealed class ImplementsCommandTests
+{
+    [Fact]
+    public async Task ExecuteAsync_UsesWorkspaceQueryAndPreservesProvenance()
+    {
+        var options = new ImplementsOptions
+        {
+            TargetType = typeof(IWorkspaceImplementationMarker).FullName!,
+            Assemblies = [typeof(ImplementsCommandTests).Assembly.Location],
+            IncludeAll = true,
+            JsonOutput = true,
+        };
+
+        var (exitCode, output, error) =
+            await ConsoleCapture.RunAsync(
+                () => ImplementsCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.Contains(
+            typeof(WorkspaceImplementation).FullName!,
+            output);
+        Assert.Contains(
+            "\"source\": \"dotnet-inspect.Tests.dll\"",
+            output);
+    }
+}
+
+public interface IWorkspaceImplementationMarker;
+
+public sealed class WorkspaceImplementation :
+    IWorkspaceImplementationMarker;

--- a/src/dotnet-inspect.Tests/ImplementsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ImplementsCommandTests.cs
@@ -30,6 +30,37 @@ public sealed class ImplementsCommandTests
             "\"source\": \"dotnet-inspect.Tests.dll\"",
             output);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidAssemblyWarnsWithoutVerbose()
+    {
+        string path = Path.GetTempFileName();
+        await File.WriteAllTextAsync(
+            path,
+            "not a managed assembly",
+            TestContext.Current.CancellationToken);
+        try
+        {
+            var options = new ImplementsOptions
+            {
+                TargetType = typeof(IDisposable).FullName!,
+                Assemblies = [path],
+                JsonOutput = true,
+            };
+
+            var (exitCode, output, error) =
+                await ConsoleCapture.RunAsync(
+                    () => ImplementsCommand.ExecuteAsync(options));
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("[]", output.Trim());
+            Assert.Contains($"Error scanning {path}", error);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }
 
 public interface IWorkspaceImplementationMarker;

--- a/src/dotnet-inspect.Tests/MemberSearchServiceTests.cs
+++ b/src/dotnet-inspect.Tests/MemberSearchServiceTests.cs
@@ -81,6 +81,42 @@ public class MemberSearchServiceTests
     }
 
     [Fact]
+    public async Task FindMembersAsync_InvalidAssemblyWarnsWithoutVerbose()
+    {
+        string path = Path.GetTempFileName();
+        await File.WriteAllTextAsync(
+            path,
+            "not a managed assembly",
+            TestContext.Current.CancellationToken);
+        using var httpClient = new HttpClient();
+        try
+        {
+            var capture = await ConsoleCapture.RunAsync(async () =>
+            {
+                List<MemberFindResult> results =
+                    await MemberSearchService.FindMembersAsync(
+                        new FindOptions
+                        {
+                            Pattern = ".NoSuchMember",
+                            Assemblies = [path],
+                            Members = true,
+                        },
+                        ["NoSuchMember"],
+                        new VerboseLogger(enabled: false),
+                        httpClient);
+                Assert.Empty(results);
+                return 0;
+            });
+
+            Assert.Contains($"Could not read {path}", capture.Error);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task FindMembersAsync_WithLimitDoesNotResolveLaterSources()
     {
         using var httpClient = new HttpClient();

--- a/src/dotnet-inspect.Tests/TypeSearchServiceTests.cs
+++ b/src/dotnet-inspect.Tests/TypeSearchServiceTests.cs
@@ -42,6 +42,84 @@ public class TypeSearchServiceTests
     }
 
     [Fact]
+    public async Task CollectTypesAsync_TrailingDirectorySeparatorDoesNotAbort()
+    {
+        string directory =
+            Directory.CreateTempSubdirectory(
+                "type-search-trailing-bin-test").FullName;
+        string copiedAssembly =
+            Path.Combine(directory, "CopiedSearchAssembly.dll");
+        File.Copy(
+            typeof(TypeSearchServiceTests).Assembly.Location,
+            copiedAssembly);
+
+        try
+        {
+            using var httpClient = new HttpClient();
+            List<TypeSearchResult> results =
+                await TypeSearchService.CollectTypesAsync(
+                    new FindOptions
+                    {
+                        Pattern = nameof(TypeSearchServiceTests),
+                        BinPaths =
+                        [
+                            directory + Path.DirectorySeparatorChar,
+                        ],
+                        IncludeAll = true,
+                    },
+                    nameof(TypeSearchServiceTests),
+                    new VerboseLogger(enabled: false),
+                    httpClient);
+
+            TypeSearchResult result = Assert.Single(
+                results,
+                candidate =>
+                    candidate.FullName
+                    == typeof(TypeSearchServiceTests).FullName);
+            Assert.Equal("", result.Source);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CollectTypesAsync_InvalidAssemblyWarnsWithoutVerbose()
+    {
+        string path = Path.GetTempFileName();
+        await File.WriteAllTextAsync(
+            path,
+            "not a managed assembly",
+            TestContext.Current.CancellationToken);
+        using var httpClient = new HttpClient();
+        try
+        {
+            var capture = await ConsoleCapture.RunAsync(async () =>
+            {
+                List<TypeSearchResult> results =
+                    await TypeSearchService.CollectTypesAsync(
+                        new FindOptions
+                        {
+                            Pattern = "NoSuchType",
+                            Assemblies = [path],
+                        },
+                        "NoSuchType",
+                        new VerboseLogger(enabled: false),
+                        httpClient);
+                Assert.Empty(results);
+                return 0;
+            });
+
+            Assert.Contains($"Could not read {path}", capture.Error);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task CollectTypesAsync_PackageFallbackKeepsRuntimeAssembliesForFind()
     {
         var packageDir = Directory.CreateTempSubdirectory("type-search-runtime-package-test").FullName;

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using DotnetInspector.Packages;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
@@ -5,6 +6,7 @@ using ILInspector.Findings;
 using ILInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Queries;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using Markout;
@@ -91,9 +93,78 @@ public class ExtensionsCommand
         AssemblySetDiagnosticWriter.Write(assemblySet);
 
         List<ExtensionMethodResult> results = [];
-        var censuses = assemblySet.Assemblies
-            .Select(assembly => InspectExtensionAssembly(assembly, options.IncludeAll))
-            .ToList();
+        var censuses = new List<ExtensionAssemblyCensus>(
+            assemblySet.Assemblies.Count);
+        ImmutableArray<ExtensionReachableTypePath> reachableTypes = [];
+        using var workspace = new AssemblySetInspectionWorkspace();
+        if (options.Reachable)
+        {
+            workspace.RunGroup(
+                assemblySet,
+                (group, entries) =>
+                {
+                    var registry =
+                        new InspectionQueryRegistry<AssemblyContextGroup>()
+                            .Add(
+                                AssemblyContextExtensionMethodsQuery.Definition,
+                                contextGroup =>
+                                    AssemblyContextExtensionMethodsQuery.Execute(
+                                        contextGroup,
+                                        options.IncludeAll))
+                            .Add(
+                                AssemblyContextExtensionReachabilityQuery.Definition,
+                                contextGroup =>
+                                    AssemblyContextExtensionReachabilityQuery.Execute(
+                                        contextGroup,
+                                        targetType,
+                                        options.Depth));
+                    InspectionQueryResults queryResults = registry.Run(
+                        [
+                            AssemblyContextExtensionMethodsQuery.Definition,
+                            AssemblyContextExtensionReachabilityQuery.Definition,
+                        ],
+                        group);
+                    AssemblyContextResult<
+                        ImmutableArray<ExtensionMethodInfo>> extensionMethods =
+                        queryResults.Get(
+                            AssemblyContextExtensionMethodsQuery.Definition);
+                    foreach (AssemblyContextEntry<
+                        ImmutableArray<ExtensionMethodInfo>> entry
+                        in extensionMethods.Assemblies)
+                    {
+                        censuses.Add(
+                            CreateExtensionCensus(
+                                entries.EntryFor(entry.Subject),
+                                entry));
+                    }
+
+                    reachableTypes = queryResults.Get(
+                            AssemblyContextExtensionReachabilityQuery.Definition)
+                        .ReachableTypes;
+                },
+                (assembly, failure) =>
+                    censuses.Add(
+                        FailedExtensionCensus(
+                            assembly,
+                            failure)));
+        }
+        else
+        {
+            workspace.RunPerAssembly(
+                assemblySet,
+                AssemblyContextExtensionMethodsQuery.Definition,
+                group => AssemblyContextExtensionMethodsQuery.Execute(
+                    group,
+                    options.IncludeAll),
+                (assembly, entry) =>
+                    censuses.Add(CreateExtensionCensus(assembly, entry)),
+                (assembly, failure) =>
+                    censuses.Add(
+                        FailedExtensionCensus(
+                            assembly,
+                            failure)));
+        }
+
         var availableCensuses = new List<ExtensionAssemblyCensus>(censuses.Count);
 
         foreach (var census in censuses)
@@ -109,27 +180,70 @@ public class ExtensionsCommand
             results.AddRange(ProjectExtensions(census, targetType));
         }
 
-        if (!options.Reachable)
-            return results;
-
-        var assemblyPaths = assemblySet.Assemblies.Select(a => a.Path).ToList();
-        var reachableTypes = ExtensionMethodScanner.FindReachableTypes(targetType, assemblyPaths, options.Depth);
-        foreach (var (reachableType, path) in reachableTypes)
+        foreach (ExtensionReachableTypePath reachable
+            in reachableTypes)
         {
-            if (reachableType == targetType) continue;
-
             foreach (var census in availableCensuses)
             {
                 results.AddRange(ProjectExtensions(
                     census,
-                    reachableType,
-                    reachablePath: path,
-                    reachableFromType: reachableType));
+                    reachable.Type,
+                    reachablePath: reachable.Path,
+                    reachableFromType: reachable.Type));
             }
         }
 
         return results;
     }
+
+    private static ExtensionAssemblyCensus CreateExtensionCensus(
+        AssemblySetEntry assembly,
+        AssemblyContextEntry<ImmutableArray<ExtensionMethodInfo>> entry)
+        => entry switch
+        {
+            AssemblyContextEntry<
+                ImmutableArray<ExtensionMethodInfo>>.Available available =>
+                AvailableExtensionCensus(assembly, available.Value),
+            AssemblyContextEntry<
+                ImmutableArray<ExtensionMethodInfo>>.Rejected rejected =>
+                FailedExtensionCensus(
+                    assembly,
+                    rejected.Failure.Detail),
+            AssemblyContextEntry<
+                ImmutableArray<ExtensionMethodInfo>>.Failed failed =>
+                FailedExtensionCensus(
+                    assembly,
+                    failed.Error.Message),
+            _ => throw new InvalidOperationException(
+                "Unknown assembly-context extension result."),
+        };
+
+    private static ExtensionAssemblyCensus AvailableExtensionCensus(
+        AssemblySetEntry assembly,
+        IReadOnlyList<ExtensionMethodInfo> members)
+        => new(
+            assembly,
+            members,
+            MetadataFindings.InspectExtensionMembers(
+                members,
+                ExtensionSubject(assembly.Path)));
+
+    private static ExtensionAssemblyCensus FailedExtensionCensus(
+        AssemblySetEntry assembly,
+        string reason)
+        => new(
+            assembly,
+            [],
+            new FindingInspection<ExtensionMemberObservation>.Failed(
+                new InspectionError(
+                    ExtensionSubject(assembly.Path),
+                    MetadataFindings.ExtensionMemberDescriptor,
+                    reason)));
+
+    private static FindingSubject ExtensionSubject(string path)
+        => new(
+            Path.GetFullPath(path),
+            Path.GetFileName(path));
 
     internal sealed record ExtensionAssemblyCensus(
         AssemblySetEntry Assembly,
@@ -144,23 +258,11 @@ public class ExtensionsCommand
         {
             using var session = AssemblyInspectionSession.Open(assembly.Path);
             var members = session.ExtensionMethods(includeAll).ToList();
-            var inspection = MetadataFindings.InspectExtensionMembers(
-                members,
-                new FindingSubject(Path.GetFullPath(assembly.Path), Path.GetFileName(assembly.Path)));
-            return new ExtensionAssemblyCensus(assembly, members, inspection);
+            return AvailableExtensionCensus(assembly, members);
         }
         catch (Exception ex)
         {
-            return new ExtensionAssemblyCensus(
-                assembly,
-                [],
-                new FindingInspection<ExtensionMemberObservation>.Failed(
-                    new InspectionError(
-                        new FindingSubject(
-                            Path.GetFullPath(assembly.Path),
-                            Path.GetFileName(assembly.Path)),
-                        MetadataFindings.ExtensionMemberDescriptor,
-                        ex.Message)));
+            return FailedExtensionCensus(assembly, ex.Message);
         }
     }
 

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -138,9 +138,11 @@ public class ExtensionsCommand
                                 entry));
                     }
 
-                    reachableTypes = queryResults.Get(
-                            AssemblyContextExtensionReachabilityQuery.Definition)
-                        .ReachableTypes;
+                    AssemblyContextExtensionReachabilityResult reachability =
+                        queryResults.Get(
+                            AssemblyContextExtensionReachabilityQuery.Definition);
+                    WriteReachabilityFailures(reachability, entries);
+                    reachableTypes = reachability.ReachableTypes;
                 },
                 (assembly, failure) =>
                     censuses.Add(
@@ -194,6 +196,36 @@ public class ExtensionsCommand
         }
 
         return results;
+    }
+
+    internal static void WriteReachabilityFailures(
+        AssemblyContextExtensionReachabilityResult reachability,
+        AssemblyContextEntryMap entries)
+    {
+        foreach (AssemblyContextEntry<
+            ImmutableArray<ExtensionReachabilityType>> entry
+            in reachability.TypeInventories.Assemblies)
+        {
+            switch (entry)
+            {
+                case AssemblyContextEntry<
+                    ImmutableArray<
+                        ExtensionReachabilityType>>.Rejected rejected:
+                    CommandError.WriteWarning(
+                        $"Extension reachability inspection failed for "
+                        + $"{entries.EntryFor(entry.Subject).Path}: "
+                        + rejected.Failure.Detail);
+                    break;
+                case AssemblyContextEntry<
+                    ImmutableArray<
+                        ExtensionReachabilityType>>.Failed failed:
+                    CommandError.WriteWarning(
+                        $"Extension reachability inspection failed for "
+                        + $"{entries.EntryFor(entry.Subject).Path}: "
+                        + failed.Error.Message);
+                    break;
+            }
+        }
     }
 
     private static ExtensionAssemblyCensus CreateExtensionCensus(

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -1,9 +1,11 @@
+using System.Collections.Immutable;
 using DotnetInspector.Packages;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
 using ILInspector.Metadata;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Queries;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using Markout;
@@ -51,15 +53,19 @@ public class ImplementsCommand
             logger.Log($"Scanning {assemblySet.Assemblies.Count} libraries for types implementing {targetType}");
 
             var results = new List<ImplementerResult>();
-            foreach (var assemblyInfo in assemblySet.Assemblies)
-            {
-                foreach (var result in ScanForImplementers(assemblyInfo.Path, targetType, options.IncludeAll, logger))
-                {
-                    result.Source = assemblyInfo.Source;
-                    result.SourceVersion = assemblyInfo.Version;
-                    results.Add(result);
-                }
-            }
+            using var workspace = new AssemblySetInspectionWorkspace();
+            workspace.RunPerAssembly(
+                assemblySet,
+                AssemblyContextImplementersQuery.Definition,
+                group => AssemblyContextImplementersQuery.Execute(
+                    group,
+                    targetType,
+                    options.IncludeAll),
+                (assembly, entry) =>
+                    AddImplementers(results, assembly, entry, logger),
+                (assembly, failure) =>
+                    logger.LogWarning(
+                        $"Error scanning {assembly.Path}: {failure}"));
 
             // Deduplicate by type name + source (same type from multiple TFM folders)
             results = results
@@ -102,37 +108,46 @@ public class ImplementsCommand
         }
     }
 
-    private static List<ImplementerResult> ScanForImplementers(
-        string assemblyPath,
-        string targetType,
-        bool includeAll,
+    private static void AddImplementers(
+        List<ImplementerResult> results,
+        AssemblySetEntry assembly,
+        AssemblyContextEntry<ImmutableArray<TypeRelationship>> entry,
         VerboseLogger logger)
     {
-        List<ImplementerResult> results = [];
-
-        try
+        switch (entry)
         {
-            var assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-
-            foreach (var relationship in AssemblyReader.FindImplementers(assemblyPath, targetType, includeAll))
-            {
-                results.Add(new ImplementerResult
+            case AssemblyContextEntry<
+                ImmutableArray<TypeRelationship>>.Available available:
+                string assemblyName =
+                    Path.GetFileNameWithoutExtension(assembly.Path);
+                foreach (TypeRelationship relationship
+                    in available.Value)
                 {
-                    TypeName = relationship.TypeName,
-                    Namespace = relationship.Namespace,
-                    Kind = relationship.Kind,
-                    Relationship = relationship.RelationshipKind.ToString().ToLowerInvariant(),
-                    Assembly = assemblyName
-                });
-            }
-
+                    results.Add(new ImplementerResult
+                    {
+                        TypeName = relationship.TypeName,
+                        Namespace = relationship.Namespace,
+                        Kind = relationship.Kind,
+                        Relationship = relationship.RelationshipKind
+                            .ToString()
+                            .ToLowerInvariant(),
+                        Assembly = assemblyName,
+                        Source = assembly.Source,
+                        SourceVersion = assembly.Version,
+                    });
+                }
+                break;
+            case AssemblyContextEntry<
+                ImmutableArray<TypeRelationship>>.Rejected rejected:
+                logger.LogWarning(
+                    $"Error scanning {assembly.Path}: {rejected.Failure.Detail}");
+                break;
+            case AssemblyContextEntry<
+                ImmutableArray<TypeRelationship>>.Failed failed:
+                logger.LogWarning(
+                    $"Error scanning {assembly.Path}: {failed.Error.Message}");
+                break;
         }
-        catch (Exception ex)
-        {
-            logger.LogWarning($"Error scanning {assemblyPath}: {ex.Message}");
-        }
-
-        return results;
     }
 
     private static void WriteJsonOutput(List<ImplementerResult> results, bool compact)

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -62,9 +62,9 @@ public class ImplementsCommand
                     targetType,
                     options.IncludeAll),
                 (assembly, entry) =>
-                    AddImplementers(results, assembly, entry, logger),
+                    AddImplementers(results, assembly, entry),
                 (assembly, failure) =>
-                    logger.LogWarning(
+                    CommandError.WriteWarning(
                         $"Error scanning {assembly.Path}: {failure}"));
 
             // Deduplicate by type name + source (same type from multiple TFM folders)
@@ -111,8 +111,7 @@ public class ImplementsCommand
     private static void AddImplementers(
         List<ImplementerResult> results,
         AssemblySetEntry assembly,
-        AssemblyContextEntry<ImmutableArray<TypeRelationship>> entry,
-        VerboseLogger logger)
+        AssemblyContextEntry<ImmutableArray<TypeRelationship>> entry)
     {
         switch (entry)
         {
@@ -139,12 +138,12 @@ public class ImplementsCommand
                 break;
             case AssemblyContextEntry<
                 ImmutableArray<TypeRelationship>>.Rejected rejected:
-                logger.LogWarning(
+                CommandError.WriteWarning(
                     $"Error scanning {assembly.Path}: {rejected.Failure.Detail}");
                 break;
             case AssemblyContextEntry<
                 ImmutableArray<TypeRelationship>>.Failed failed:
-                logger.LogWarning(
+                CommandError.WriteWarning(
                     $"Error scanning {assembly.Path}: {failed.Error.Message}");
                 break;
         }

--- a/src/dotnet-inspect/Inspectors/AssemblySetInspectionWorkspace.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblySetInspectionWorkspace.cs
@@ -1,0 +1,199 @@
+using DotnetInspector.Queries;
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Inspectors;
+
+/// <summary>
+/// CLI host for sequential typed-query execution over resolved assembly sets.
+/// Ordinary scans use one-participant groups so retained image memory is bounded
+/// by the largest current participant rather than the entire search set.
+/// </summary>
+internal sealed class AssemblySetInspectionWorkspace : IDisposable
+{
+    private readonly InspectionWorkspace _workspace = new();
+
+    internal long PeakRetainedImageBytes { get; private set; }
+
+    internal void RunGroup(
+        AssemblySet assemblySet,
+        Action<AssemblyContextGroup, AssemblyContextEntryMap> execute,
+        Action<AssemblySetEntry, string> unavailable)
+    {
+        ArgumentNullException.ThrowIfNull(assemblySet);
+        ArgumentNullException.ThrowIfNull(execute);
+        ArgumentNullException.ThrowIfNull(unavailable);
+
+        var resolved =
+            new List<(AssemblySetEntry Entry, ResolvedAssemblyReference Assembly)>();
+        foreach (AssemblySetEntry entry in assemblySet.Assemblies)
+        {
+            ResolvedAssemblyReference? assembly =
+                TryCreateManagedAssembly(entry, out string? failure);
+            if (assembly is null)
+            {
+                unavailable(entry, failure!);
+                continue;
+            }
+
+            resolved.Add((entry, assembly));
+        }
+
+        if (resolved.Count == 0)
+            return;
+
+        var sourcePolicies = resolved
+            .Select(candidate => (
+                candidate.Assembly,
+                Policy: (IAssemblyBindingPolicy)new AssemblyDependencyResolver(
+                    new AssemblyDependencyResolutionOptions(
+                        candidate.Entry.Path))))
+            .ToArray();
+        var groupPolicy =
+            new SourceRelativeAssemblyGroupBindingPolicy(sourcePolicies);
+        var participants = resolved
+            .Select(candidate =>
+                new AssemblyContextParticipant(
+                    candidate.Assembly,
+                    groupPolicy))
+            .ToArray();
+        using AssemblyContextGroup group =
+            _workspace.CreateAssemblyContextGroup(participants);
+        execute(
+            group,
+            new AssemblyContextEntryMap(
+                resolved.Select(candidate => (
+                    candidate.Assembly.Registration,
+                    candidate.Entry))));
+    }
+
+    internal void RunPerAssembly<TValue>(
+        AssemblySet assemblySet,
+        InspectionQuery<AssemblyContextResult<TValue>> query,
+        Func<AssemblyContextGroup, AssemblyContextResult<TValue>> execute,
+        Action<AssemblySetEntry, AssemblyContextEntry<TValue>> consume,
+        Action<AssemblySetEntry, string> unavailable,
+        Func<bool>? stop = null)
+    {
+        ArgumentNullException.ThrowIfNull(assemblySet);
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(execute);
+        ArgumentNullException.ThrowIfNull(consume);
+        ArgumentNullException.ThrowIfNull(unavailable);
+
+        var registry =
+            new InspectionQueryRegistry<AssemblyContextGroup>()
+                .Add(query, execute);
+        foreach (AssemblySetEntry entry in assemblySet.Assemblies)
+        {
+            if (stop?.Invoke() == true)
+                break;
+
+            ResolvedAssemblyReference? assembly =
+                TryCreateManagedAssembly(entry, out string? failure);
+            if (assembly is null)
+            {
+                unavailable(entry, failure!);
+                continue;
+            }
+
+            var policy = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(entry.Path));
+            using AssemblyContextGroup group =
+                _workspace.CreateAssemblyContextGroup(
+                    [new AssemblyContextParticipant(assembly, policy)]);
+            AssemblyContextResult<TValue> result =
+                registry.Run([query], group).Get(query);
+            PeakRetainedImageBytes = Math.Max(
+                PeakRetainedImageBytes,
+                group.RetainedImageBytes);
+            if (result.Assemblies.Length != 1)
+            {
+                throw new InspectionQueryException(
+                    $"Query '{query.Name}' produced {result.Assemblies.Length} results for a one-participant group.");
+            }
+
+            consume(entry, result.Assemblies[0]);
+        }
+    }
+
+    private static ResolvedAssemblyReference? TryCreateManagedAssembly(
+        AssemblySetEntry entry,
+        out string? failure)
+    {
+        try
+        {
+            ResolvedAssemblyReference? assembly =
+                ResolvedAssemblyReference.CreateFromPathIfManaged(
+                    entry.Path,
+                    ProvenanceFor(entry));
+            failure = assembly is null
+                ? "The selected file does not contain managed metadata."
+                : null;
+            return assembly;
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException)
+        {
+            failure = ex.Message;
+            return null;
+        }
+    }
+
+    private static AssemblyResolutionProvenance ProvenanceFor(
+        AssemblySetEntry entry)
+        => entry.SourceKind switch
+        {
+            AssemblySetSourceKind.Package
+                when !string.IsNullOrWhiteSpace(entry.Version) =>
+                AssemblyResolutionProvenance.Package(
+                    entry.Source,
+                    entry.Version,
+                    entry.Tfm,
+                    rid: null),
+            AssemblySetSourceKind.PlatformAssembly
+                or AssemblySetSourceKind.PlatformFramework =>
+                AssemblyResolutionProvenance.Platform(
+                    entry.Source,
+                    entry.Version,
+                    "assembly-set search"),
+            AssemblySetSourceKind.Project =>
+                AssemblyResolutionProvenance.Local(
+                    "restored project asset"),
+            _ => AssemblyResolutionProvenance.Local(
+                entry.Source),
+        };
+
+    public void Dispose() => _workspace.Dispose();
+}
+
+internal sealed class AssemblyContextEntryMap
+{
+    private readonly Dictionary<
+        AssemblyAcquisitionRegistration,
+        AssemblySetEntry> _entries;
+
+    internal AssemblyContextEntryMap(
+        IEnumerable<(
+            AssemblyAcquisitionRegistration Registration,
+            AssemblySetEntry Entry)> entries)
+    {
+        _entries = new Dictionary<
+            AssemblyAcquisitionRegistration,
+            AssemblySetEntry>(
+                ReferenceEqualityComparer.Instance);
+        foreach (var (registration, entry) in entries)
+            _entries.Add(registration, entry);
+    }
+
+    internal AssemblySetEntry EntryFor(
+        AssemblyContextSubject subject)
+        => _entries.TryGetValue(
+                subject.Registration,
+                out AssemblySetEntry? entry)
+            ? entry
+            : throw new InspectionQueryException(
+                $"No assembly-set entry corresponds to '{subject.Identity.Name}'.");
+}

--- a/src/dotnet-inspect/Inspectors/AssemblySetInspectionWorkspace.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblySetInspectionWorkspace.cs
@@ -135,7 +135,12 @@ internal sealed class AssemblySetInspectionWorkspace : IDisposable
         catch (Exception ex) when (
             ex is IOException
                 or UnauthorizedAccessException
-                or BadImageFormatException)
+                or BadImageFormatException
+                or InvalidOperationException
+                or ArgumentException
+                or NotSupportedException
+                or OverflowException
+                or IndexOutOfRangeException)
         {
             failure = ex.Message;
             return null;
@@ -163,7 +168,9 @@ internal sealed class AssemblySetInspectionWorkspace : IDisposable
                 AssemblyResolutionProvenance.Local(
                     "restored project asset"),
             _ => AssemblyResolutionProvenance.Local(
-                entry.Source),
+                string.IsNullOrWhiteSpace(entry.Source)
+                    ? "assembly-set search"
+                    : entry.Source),
         };
 
     public void Dispose() => _workspace.Dispose();

--- a/src/dotnet-inspect/Inspectors/MemberSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/MemberSearchService.cs
@@ -73,10 +73,9 @@ internal static class MemberSearchService
                     switch (entry)
                     {
                         case AssemblyContextEntry<
-                            ImmutableArray<
-                                MemberSearchResult>>.Available available:
+                            AssemblyMemberMatches>.Available available:
                             foreach (MemberSearchResult member
-                                in available.Value)
+                                in available.Value.Members)
                             {
                                 results.Add(new MemberFindResult
                                 {
@@ -98,23 +97,25 @@ internal static class MemberSearchService
                                     SourceVersion = assembly.Version,
                                 });
                             }
+                            WriteInspectionFailures(
+                                assembly,
+                                available.Value.InspectionFailures,
+                                logger);
                             break;
                         case AssemblyContextEntry<
-                            ImmutableArray<
-                                MemberSearchResult>>.Rejected rejected:
-                            logger.LogWarning(
+                            AssemblyMemberMatches>.Rejected rejected:
+                            CommandError.WriteWarning(
                                 $"Could not read {assembly.Path}: {rejected.Failure.Detail}");
                             break;
                         case AssemblyContextEntry<
-                            ImmutableArray<
-                                MemberSearchResult>>.Failed failed:
-                            logger.LogWarning(
+                            AssemblyMemberMatches>.Failed failed:
+                            CommandError.WriteWarning(
                                 $"Could not read {assembly.Path}: {failed.Error.Message}");
                             break;
                     }
                 },
                 (assembly, failure) =>
-                    logger.LogWarning(
+                    CommandError.WriteWarning(
                         $"Could not read {assembly.Path}: {failure}"),
                 ReachedLimit);
         }
@@ -127,5 +128,23 @@ internal static class MemberSearchService
 
         await CollectAndScanAsync(FindSourceCollector.BuildFindRequest(options));
         return results;
+    }
+
+    private static void WriteInspectionFailures(
+        AssemblySetEntry assembly,
+        ImmutableArray<ApiSurfaceInspectionFailure> failures,
+        VerboseLogger logger)
+    {
+        if (failures.IsEmpty)
+            return;
+
+        CommandError.WriteWarning(
+            $"Member search in {assembly.Path} skipped {failures.Length} metadata row(s).");
+        foreach (ApiSurfaceInspectionFailure failure in failures)
+        {
+            logger.LogWarning(
+                $"Member search rejected {failure.Operation} at 0x{failure.SubjectToken:X8}: "
+                + $"{failure.Kind}: {failure.Detail}");
+        }
     }
 }

--- a/src/dotnet-inspect/Inspectors/MemberSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/MemberSearchService.cs
@@ -1,17 +1,18 @@
+using System.Collections.Immutable;
 using ILInspector.Metadata;
 using DotnetInspector.Models;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Queries;
 using DotnetInspector.Services;
 
 namespace DotnetInspector.Inspectors;
 
 /// <summary>
-/// Searches member names across the same six ordered sources as type search (packages, libraries,
-/// platform assemblies/frameworks, projects, and bin directories), routed through the closed-set
-/// <see cref="Corpus.SearchMembers"/>. Member search is exact/glob only — there is no fuzzy or
-/// namespace-prefix fallback — so the collected matches are the final results. Resolution and the
-/// streaming early-exit for a result limit are shared with type search via
+/// Searches member names across the same ordered sources as type search through
+/// workspace-backed typed queries. Member search is exact/glob only — there is
+/// no fuzzy or namespace-prefix fallback — so the collected matches are the
+/// final results. Resolution and streaming early-exit for a result limit are shared via
 /// <see cref="FindSourceCollector"/>.
 /// </summary>
 internal static class MemberSearchService
@@ -27,19 +28,26 @@ internal static class MemberSearchService
         VerboseLogger logger,
         HttpClient httpClient)
     {
-        return await CollectMembersAsync(options, patterns, logger, httpClient);
+        using var workspace = new AssemblySetInspectionWorkspace();
+        return await CollectMembersAsync(
+            options,
+            patterns,
+            logger,
+            httpClient,
+            workspace);
     }
 
     /// <summary>
-    /// Resolves the configured sources and searches their members through the corpus. When a result
-    /// limit is active the sources are streamed one at a time (later sources are never resolved once
-    /// the limit is met); otherwise the whole set is resolved once and scanned together.
+    /// Resolves configured sources and searches their members through typed
+    /// participant queries. With a result limit, sources stream one at a time
+    /// and later sources are not resolved after the limit is met.
     /// </summary>
     private static async Task<List<MemberFindResult>> CollectMembersAsync(
         FindOptions options,
         IReadOnlyList<string> patterns,
         VerboseLogger logger,
-        HttpClient httpClient)
+        HttpClient httpClient,
+        AssemblySetInspectionWorkspace workspace)
     {
         List<MemberFindResult> results = [];
 
@@ -50,36 +58,65 @@ internal static class MemberSearchService
             using var assemblySet = await AssemblySetResolver.CollectAsync(httpClient, request, logger.Log);
             AssemblySetDiagnosticWriter.Write(assemblySet);
 
-            // Streaming caps each source at the remaining budget so later sources are never resolved
-            // once the limit is met; the unbounded path passes null so the corpus scans the whole set.
-            int? remaining = options.Limit.HasValue
-                ? options.Limit.Value - results.Count
-                : null;
-
-            var corpus = CorpusProducer.ToCorpus(assemblySet);
-            var outcome = corpus.SearchMembers(patterns, options.IncludeAll, remaining);
-
-            foreach (var skippedPath in outcome.SkippedAssemblies)
-                logger.LogWarning($"Could not read {skippedPath}");
-
-            foreach (var match in outcome.Results)
-            {
-                var member = match.Member;
-                results.Add(new MemberFindResult
+            workspace.RunPerAssembly(
+                assemblySet,
+                AssemblyContextMemberMatchesQuery.Definition,
+                group => AssemblyContextMemberMatchesQuery.Execute(
+                    group,
+                    patterns,
+                    options.IncludeAll,
+                    options.Limit.HasValue
+                        ? options.Limit.Value - results.Count
+                        : null),
+                (assembly, entry) =>
                 {
-                    Pattern = member.Pattern,
-                    Match = member.IsGlob ? MatchKind.Glob : MatchKind.Exact,
-                    Member = member.MemberName,
-                    Kind = member.Kind,
-                    DeclaringType = member.DeclaringType,
-                    Namespace = member.DeclaringNamespace ?? "",
-                    Signature = member.Signature,
-                    ReturnType = member.ReturnType,
-                    Library = member.Assembly,
-                    Source = match.Source ?? "",
-                    SourceVersion = match.Version,
-                });
-            }
+                    switch (entry)
+                    {
+                        case AssemblyContextEntry<
+                            ImmutableArray<
+                                MemberSearchResult>>.Available available:
+                            foreach (MemberSearchResult member
+                                in available.Value)
+                            {
+                                results.Add(new MemberFindResult
+                                {
+                                    Pattern = member.Pattern,
+                                    Match = member.IsGlob
+                                        ? MatchKind.Glob
+                                        : MatchKind.Exact,
+                                    Member = member.MemberName,
+                                    Kind = member.Kind,
+                                    DeclaringType = member.DeclaringType,
+                                    Namespace =
+                                        member.DeclaringNamespace ?? "",
+                                    Signature = member.Signature,
+                                    ReturnType = member.ReturnType,
+                                    Library =
+                                        Path.GetFileNameWithoutExtension(
+                                            assembly.Path),
+                                    Source = assembly.Source,
+                                    SourceVersion = assembly.Version,
+                                });
+                            }
+                            break;
+                        case AssemblyContextEntry<
+                            ImmutableArray<
+                                MemberSearchResult>>.Rejected rejected:
+                            logger.LogWarning(
+                                $"Could not read {assembly.Path}: {rejected.Failure.Detail}");
+                            break;
+                        case AssemblyContextEntry<
+                            ImmutableArray<
+                                MemberSearchResult>>.Failed failed:
+                            logger.LogWarning(
+                                $"Could not read {assembly.Path}: {failed.Error.Message}");
+                            break;
+                    }
+                },
+                (assembly, failure) =>
+                    logger.LogWarning(
+                        $"Could not read {assembly.Path}: {failure}"),
+                ReachedLimit);
         }
 
         if (options.Limit.HasValue)

--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -333,10 +333,9 @@ internal static class TypeSearchService
                     switch (entry)
                     {
                         case AssemblyContextEntry<
-                            ImmutableArray<
-                                AssemblyTypeInventoryEntry>>.Available available:
+                            AssemblyTypeInventory>.Available available:
                             foreach (AssemblyTypeInventoryEntry type
-                                in available.Value)
+                                in available.Value.Types)
                             {
                                 if (!searchPatterns.Any(searchPattern =>
                                         TypeMatcher.MatchesTypeFilter(
@@ -360,23 +359,25 @@ internal static class TypeSearchService
                                 if (ReachedLimit())
                                     break;
                             }
+                            WriteInspectionFailures(
+                                assembly,
+                                available.Value.InspectionFailures,
+                                logger);
                             break;
                         case AssemblyContextEntry<
-                            ImmutableArray<
-                                AssemblyTypeInventoryEntry>>.Rejected rejected:
-                            logger.LogWarning(
+                            AssemblyTypeInventory>.Rejected rejected:
+                            CommandError.WriteWarning(
                                 $"Could not read {assembly.Path}: {rejected.Failure.Detail}");
                             break;
                         case AssemblyContextEntry<
-                            ImmutableArray<
-                                AssemblyTypeInventoryEntry>>.Failed failed:
-                            logger.LogWarning(
+                            AssemblyTypeInventory>.Failed failed:
+                            CommandError.WriteWarning(
                                 $"Could not read {assembly.Path}: {failed.Error.Message}");
                             break;
                     }
                 },
                 (assembly, failure) =>
-                    logger.LogWarning(
+                    CommandError.WriteWarning(
                         $"Could not read {assembly.Path}: {failure}"),
                 ReachedLimit);
         }
@@ -389,5 +390,23 @@ internal static class TypeSearchService
 
         await CollectAndScanAsync(FindSourceCollector.BuildFindRequest(options));
         return results;
+    }
+
+    private static void WriteInspectionFailures(
+        AssemblySetEntry assembly,
+        ImmutableArray<ApiSurfaceInspectionFailure> failures,
+        VerboseLogger logger)
+    {
+        if (failures.IsEmpty)
+            return;
+
+        CommandError.WriteWarning(
+            $"Type search in {assembly.Path} skipped {failures.Length} metadata row(s).");
+        foreach (ApiSurfaceInspectionFailure failure in failures)
+        {
+            logger.LogWarning(
+                $"Type search rejected {failure.Operation} at 0x{failure.SubjectToken:X8}: "
+                + $"{failure.Kind}: {failure.Detail}");
+        }
     }
 }

--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -1,15 +1,17 @@
+using System.Collections.Immutable;
 using DotnetInspector.Commands;
 using ILInspector.Metadata;
 using DotnetInspector.Models;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Queries;
 using DotnetInspector.Services;
 
 namespace DotnetInspector.Inspectors;
 
 /// <summary>
-/// Collects types from multiple sources: packages, assemblies, platform frameworks,
-/// projects, and bin directories. Handles the 6-source iteration pattern.
+/// Collects types from multiple sources and executes typed inventory queries
+/// through an invocation-owned inspection workspace.
 /// </summary>
 internal static class TypeSearchService
 {
@@ -23,23 +25,41 @@ internal static class TypeSearchService
         VerboseLogger logger,
         HttpClient httpClient)
     {
+        using var workspace = new AssemblySetInspectionWorkspace();
+
         // Optimized single-pattern path: collect with filtering, then partial match if empty
         if (patterns.Length == 1 && !options.Tabular)
         {
-            return await FindSinglePatternAsync(patterns[0], options, logger, httpClient);
+            return await FindSinglePatternAsync(
+                patterns[0],
+                options,
+                logger,
+                httpClient,
+                workspace);
         }
 
         // Multi-pattern or tabular output: collect all types, then match each pattern
-        return await FindMultiPatternAsync(patterns, options, logger, httpClient);
+        return await FindMultiPatternAsync(
+            patterns,
+            options,
+            logger,
+            httpClient,
+            workspace);
     }
 
     private static async Task<List<TypeFindResult>> FindMultiPatternAsync(
         string[] patterns,
         FindOptions options,
         VerboseLogger logger,
-        HttpClient httpClient)
+        HttpClient httpClient,
+        AssemblySetInspectionWorkspace workspace)
     {
-        var allTypes = await CollectTypesAsync(options, null, logger, httpClient);
+        var allTypes = await CollectTypesAsync(
+            options,
+            null,
+            logger,
+            httpClient,
+            workspace);
         var typeNames = allTypes.Select(t => t.FullName).Distinct().ToList();
 
         Dictionary<string, List<TypeSearchResult>> resultsByPattern = [];
@@ -131,15 +151,26 @@ internal static class TypeSearchService
         string pattern,
         FindOptions options,
         VerboseLogger logger,
-        HttpClient httpClient)
+        HttpClient httpClient,
+        AssemblySetInspectionWorkspace workspace)
     {
-        var results = await CollectTypesAsync(options, pattern, logger, httpClient);
+        var results = await CollectTypesAsync(
+            options,
+            pattern,
+            logger,
+            httpClient,
+            workspace);
 
         List<TypeSearchResult>? partialMatches = null;
         Dictionary<string, double>? partialSimilarities = null;
         if (results.Count == 0 && !pattern.Contains('*') && !pattern.Contains('?'))
         {
-            var allTypes = await CollectTypesAsync(options, null, logger, httpClient);
+            var allTypes = await CollectTypesAsync(
+                options,
+                null,
+                logger,
+                httpClient,
+                workspace);
             var typeNames = allTypes.Select(t => t.FullName).Distinct().ToList();
 
             if (TryGetNamespacePrefixMatches(pattern, allTypes, options, out var prefixPattern, out var prefixResults))
@@ -262,11 +293,26 @@ internal static class TypeSearchService
         VerboseLogger logger,
         HttpClient httpClient)
     {
+        using var workspace = new AssemblySetInspectionWorkspace();
+        return await CollectTypesAsync(
+            options,
+            pattern,
+            logger,
+            httpClient,
+            workspace);
+    }
+
+    private static async Task<List<TypeSearchResult>> CollectTypesAsync(
+        FindOptions options,
+        string? pattern,
+        VerboseLogger logger,
+        HttpClient httpClient,
+        AssemblySetInspectionWorkspace workspace)
+    {
         List<TypeSearchResult> results = [];
 
-        // Search the resolved closed set through the corpus. A specific pattern filters during the
-        // scan; a null pattern enumerates every type ("*" matches all) for the callers that collect
-        // first and match later (the multi-pattern and fuzzy-fallback paths).
+        // A specific pattern filters each typed inventory during collection; a
+        // null pattern enumerates every type for callers that match later.
         IReadOnlyList<string> searchPatterns = pattern is null ? ["*"] : [pattern];
 
         bool ReachedLimit() => pattern != null && options.Limit.HasValue && results.Count >= options.Limit.Value;
@@ -276,32 +322,63 @@ internal static class TypeSearchService
             using var assemblySet = await AssemblySetResolver.CollectAsync(httpClient, request, logger.Log);
             AssemblySetDiagnosticWriter.Write(assemblySet);
 
-            // Streaming (pattern + limit) caps each source at the remaining budget so later sources are
-            // never resolved once the limit is met; the unbounded path passes null so the corpus scans
-            // the whole set in parallel.
-            int? remaining = pattern != null && options.Limit.HasValue
-                ? options.Limit.Value - results.Count
-                : null;
-
-            var corpus = CorpusProducer.ToCorpus(assemblySet);
-            var outcome = corpus.SearchTypes(searchPatterns, options.IncludeAll, remaining);
-
-            foreach (var skippedPath in outcome.SkippedAssemblies)
-                logger.LogWarning($"Could not read {skippedPath}");
-
-            foreach (var match in outcome.Results)
-            {
-                results.Add(new TypeSearchResult
+            workspace.RunPerAssembly(
+                assemblySet,
+                AssemblyContextTypeInventoryQuery.Definition,
+                group => AssemblyContextTypeInventoryQuery.Execute(
+                    group,
+                    options.IncludeAll),
+                (assembly, entry) =>
                 {
-                    TypeName = match.TypeName,
-                    Namespace = match.Namespace,
-                    FullName = match.FullName,
-                    Kind = match.Kind,
-                    Assembly = match.Assembly,
-                    Source = match.Source,
-                    SourceVersion = match.Version,
-                });
-            }
+                    switch (entry)
+                    {
+                        case AssemblyContextEntry<
+                            ImmutableArray<
+                                AssemblyTypeInventoryEntry>>.Available available:
+                            foreach (AssemblyTypeInventoryEntry type
+                                in available.Value)
+                            {
+                                if (!searchPatterns.Any(searchPattern =>
+                                        TypeMatcher.MatchesTypeFilter(
+                                            type.FullName,
+                                            searchPattern)))
+                                {
+                                    continue;
+                                }
+
+                                results.Add(new TypeSearchResult
+                                {
+                                    TypeName = type.TypeName,
+                                    Namespace = type.Namespace,
+                                    FullName = type.FullName,
+                                    Kind = type.Kind,
+                                    Assembly = Path.GetFileNameWithoutExtension(
+                                        assembly.Path),
+                                    Source = assembly.Source,
+                                    SourceVersion = assembly.Version,
+                                });
+                                if (ReachedLimit())
+                                    break;
+                            }
+                            break;
+                        case AssemblyContextEntry<
+                            ImmutableArray<
+                                AssemblyTypeInventoryEntry>>.Rejected rejected:
+                            logger.LogWarning(
+                                $"Could not read {assembly.Path}: {rejected.Failure.Detail}");
+                            break;
+                        case AssemblyContextEntry<
+                            ImmutableArray<
+                                AssemblyTypeInventoryEntry>>.Failed failed:
+                            logger.LogWarning(
+                                $"Could not read {assembly.Path}: {failed.Error.Message}");
+                            break;
+                    }
+                },
+                (assembly, failure) =>
+                    logger.LogWarning(
+                        $"Could not read {assembly.Path}: {failure}"),
+                ReachedLimit);
         }
 
         if (pattern != null && options.Limit.HasValue)


### PR DESCRIPTION
## Change

**Conclusion:** Route `extensions`, `implements`, and `find` through invocation-owned inspection workspaces and typed L1 queries, matching the architecture established by `library`.

- preserves source ordering, early result-limit backpressure, provenance, Findings, and healthy partial results
- preserves partial metadata failures as typed query data and emits participant failures without requiring verbose mode
- bounds ordinary fan-out to one retained participant at a time
- keeps `extensions --reachable` in one binding-consistent, retained-image-bounded group and lazily decodes only reached type edges
- leaves acquisition, matching policy, and presentation in the CLI while removing path-shaped inspection from these command paths

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release --no-restore -v:q`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build` — 51 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -maxThreads 1` — 3301 total, 0 failed, 4 environment skips
- focused review regressions — 35 passed
- `npx markdownlint-cli docs/design/assembly-inspection-query.md docs/design/inspection-layers.md docs/inspection-space.md docs/overview.md`

## Compatibility boundary

No command syntax, default disclosure, output shape, source order, or network behavior changes. Failed participants and partial metadata rejection now produce visible warnings instead of reading as empty success. Ordinary search groups are intentionally per-participant. Explicit extension reachability retains a full binding-consistent group and its 512 MiB retained-image safety budget; participant rejection is surfaced for both the extension census and reachability inventory rather than silently shortening traversal.