### PR TITLE
Extract with and anonymous wrapping compiler fixtures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.WithAndAnonymousWrappingSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.WithAndAnonymousWrappingSamples.cs
@@ -1,0 +1,38 @@
+namespace ILInspector.Decompiler.Tests;
+
+// The CfgSampleClass. filename keeps this file immediately after CfgSampleClass.cs
+// in compiler item order; exact-base render A/B guards the anonymous-type ordinals.
+// #3371 follow-up witnesses: a record `with` expression and an anonymous object
+// wide enough that the printer's brace-body width wrapper breaks them Allman-style
+// (one entry per line). These related top-level types stay together as one
+// compiler-fixture group.
+public sealed record MeasuredRecord(
+    int FirstMeasuredValue,
+    int SecondMeasuredValue,
+    int ThirdMeasuredValue,
+    int FourthMeasuredValue);
+
+public static class BraceBodyWrappingSamples
+{
+    // `source with { A = .., B = .., C = .., D = .. }` — flat form exceeds 120 cols.
+    public static MeasuredRecord WidenMeasuredRecord(MeasuredRecord source, int first, int second, int third, int fourth)
+        => source with
+        {
+            FirstMeasuredValue = first,
+            SecondMeasuredValue = second,
+            ThirdMeasuredValue = third,
+            FourthMeasuredValue = fourth,
+        };
+
+    // Anonymous types are reference types, so returning one as `object` needs no
+    // box/cast; the anonymous object stays the bare return value. Explicit
+    // `Name = value` form (value names differ from property names), flat > 120 cols.
+    public static object ProjectMeasuredValues(int first, int second, int third, int fourth)
+        => new
+        {
+            FirstMeasuredProjection = first,
+            SecondMeasuredProjection = second,
+            ThirdMeasuredProjection = third,
+            FourthMeasuredProjection = fourth,
+        };
+}

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -6177,38 +6177,3 @@ public static class FlagsEnumAccumulatorSamples
         return (int)caps;
     }
 }
-
-// #3371 follow-up witnesses: a record `with` expression and an anonymous object
-// wide enough that the printer's brace-body width wrapper breaks them Allman-style
-// (one entry per line). New top-level types appended at end of file so they cannot
-// shift any existing CfgSampleClass generated-code ordinals.
-public sealed record MeasuredRecord(
-    int FirstMeasuredValue,
-    int SecondMeasuredValue,
-    int ThirdMeasuredValue,
-    int FourthMeasuredValue);
-
-public static class BraceBodyWrappingSamples
-{
-    // `source with { A = .., B = .., C = .., D = .. }` — flat form exceeds 120 cols.
-    public static MeasuredRecord WidenMeasuredRecord(MeasuredRecord source, int first, int second, int third, int fourth)
-        => source with
-        {
-            FirstMeasuredValue = first,
-            SecondMeasuredValue = second,
-            ThirdMeasuredValue = third,
-            FourthMeasuredValue = fourth,
-        };
-
-    // Anonymous types are reference types, so returning one as `object` needs no
-    // box/cast; the anonymous object stays the bare return value. Explicit
-    // `Name = value` form (value names differ from property names), flat > 120 cols.
-    public static object ProjectMeasuredValues(int first, int second, int third, int fourth)
-        => new
-        {
-            FirstMeasuredProjection = first,
-            SecondMeasuredProjection = second,
-            ThirdMeasuredProjection = third,
-            FourthMeasuredProjection = fourth,
-        };
-}


### PR DESCRIPTION
## Summary

Extracts `MeasuredRecord` and `BraceBodyWrappingSamples` from the oversized `CfgSampleClass.cs` into the focused `CfgSampleClass.WithAndAnonymousWrappingSamples.cs` beside their sole owner, `WithAndAnonymousWrappingTests`.

The `CfgSampleClass.` prefix is intentional: SDK compiler item order places the new file immediately after `CfgSampleClass.cs`, preserving the anonymous fixture and every later anonymous type ordinal. A plain `WithAndAnonymousWrappingSamples.cs` placement was tested and rejected because it rekeyed 49 generated methods in each direction and changed one test body through synthesized type names. The compile-adjacent name removes all of that avoidable churn while retaining feature ownership.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`
- `WithAndAnonymousWrappingTests` and `WithAndAnonymousWrappingFixtureTests`: 8 passed
- Decompiler fast lane: 4,670 total, 0 failed, 8 privilege-dependent skips
- Exact-base whole-test-assembly render A/B against `383df6e0`: 19,185 methods; 0 changed, added, or removed

## Compatibility

Product behavior, symbols, method bodies, generated anonymous-type identities, and artifact-local metadata ordering are unchanged. The compiler fixtures move to a new PDB source document as intended.

Related to #3913. Leaves #3913 open for the remaining fixture groups.