### PR TITLE
Compose annotated call graph overlays

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,10 +212,17 @@ separate axes; see [Finding Coordinates](design/finding-coordinates.md).
 
 `ResearchFactRegistry` is the dogfooded analyzer registry for the overlay.
 Producers implement `IResearchFactProducer` with a stable name, produced fact
-ids, dependency names, and a `Produce(ResearchFactContext)` method. The registry
-orders producers by dependencies, invokes them for an imported method, and merges
-their annotations by IL offset and descriptor id. The default registry currently
-includes:
+ids, dependency names, declared `ResearchFactRequirements`, and a
+`Produce(ResearchFactContext)` method. Requirements name the Analysis feature
+set and whether it is body-local or assembly-wide; the registry unions them
+before acquisition. A body-local index can satisfy one member without decoding
+every body, while a compatible full index can satisfy a later narrower request.
+Assembly projections on `ResearchAssemblyContext` remain lazy. A producer that
+declares no Analysis requirement receives no assembly context.
+
+The registry orders producers by dependencies, invokes them for an imported
+method, and merges their annotations by IL offset and descriptor id. The default
+registry currently includes:
 
 | Producer | Source | Facts |
 | -------- | ------ | ----- |
@@ -225,6 +232,12 @@ includes:
 | `CallSiteSemanticsFactProducer` | Analysis call-site Findings joined with callee semantics | `semantics.callee`, `safety.callee` |
 | `MethodHeaderLeverageFactProducer` | Analysis method-signal and leverage aggregates | `cost.method` |
 | `DecompilerLifetimeFactProducer` | existing decompiler lifetime classifier | `lifetime.*` |
+
+`ResearchFactRegistry.CallRelationships` is a separate, focused profile. Its
+`DirectCallFactProducer` turns already-acquired physical `DirectCall` values
+into `call.edge` facts; it declares no Analysis requirement and fails if the
+caller omits the supplied evidence. This lets a graph-owning query annotate
+source without opening a second body index.
 
 The important boundary is that Analysis remains SRM-only, NativeAOT-friendly,
 Roslyn-free, and free of `IrNode`/decompiler dependencies. New whole-assembly or

--- a/docs/design/call-graph-projection.md
+++ b/docs/design/call-graph-projection.md
@@ -246,11 +246,14 @@ projection and the supplied relationship facts; omission under a
 Caller-only views are rejected because they contain no outbound topology to
 which body-local call sites could map.
 
-The query declares no graph or Analysis acquisition. The
+The query declares no graph or Analysis acquisition.
 `AnnotatedMemberDocument_ReusesCalleeLayerAndMapsEveryPhysicalCallSite` test
-gates that claim by asserting unchanged session build/source-open counts and
-the two-occurrences/one-edge shape. Requirement tests pin the call-only Research
-profile to `ResearchFactRequirements.None`.
+gates graph-session reuse by asserting unchanged session build/source-open
+counts and the two-occurrences/one-edge shape.
+`Registry_UnionsProducerAnalysisRequirementsBeforeAcquisition` pins the
+call-only Research profile to `ResearchFactRequirements.None`, and
+`RequirementsNone_DoesNotResolveAnAssemblyContext` is the non-vacuity gate that
+proves such a profile bypasses Research's Analysis-context resolver.
 
 Drive it by pull (`Callees()` / `Callers()` / `CrossLibrary()`, or the lazy
 `Tiers()` stream) or by push (`RunAsync` raising `LayerReady` per layer then

--- a/docs/design/call-graph-projection.md
+++ b/docs/design/call-graph-projection.md
@@ -100,6 +100,10 @@ The projection owns everything a host must not re-invent in JavaScript:
   directed edge. `Rows` numbers those edges from one in deterministic edge order
   and retains those numbers when a host filters them. Counts and row windows
   therefore bind to the projection rather than to a rendered tree's node lines.
+  `FindFocusCalleeRow` maps a physical call occurrence from the selected member
+  to that stable logical edge row. Exact catalog call-site storage wins; the
+  assembly-local fallback uses the same typed structural identity as projection.
+  A missing and an ambiguous mapping are distinct outcomes.
 - **Cycles and duplicates.** The bounded tree marks re-encountered members
   `AlreadyShown`; the projection collapses them onto the existing node and still
   records the edge, so a cycle `A → B → A` is two edges between two nodes.
@@ -189,8 +193,11 @@ acquisition is a capability of that session, not a separate call-graph kind.
 The layer names name the tier that was unlocked, not a direction: at `depth > 1`
 the `CrossLibrary` layer lets a caller chain *and* a callee chain each cross a
 package boundary. The seam yields presentation-free `CallTreeNode` roots as a
-`MemberCallGraphView` (`Tier`, `CalleeRoot`, `CallerRoot`, `Diagnostics`), so a
-host renders them directly or projects them with
+`MemberCallGraphView` (`Tier`, focus MVID/token, `CalleeRoot`, `CallerRoot`,
+`FocusCallSites`, `Diagnostics`). `FocusCallSites` retains every physical
+outbound operand occurrence from the same scoped or full index that produced
+the roots; it is not reconstructed from logical graph edges. A host renders the
+roots directly or projects them with
 `CallGraphProjection.Create(CallerRoot, CalleeRoot)` — "with or without mermaid."
 `Diagnostics` is a stable count summary of incomplete correspondence and exact
 bindings to a different identity of the primary assembly, distilled before any
@@ -226,6 +233,24 @@ group-owned release, including disposal of the catalog scope.
 `CatalogCallGraphScopeTests` pins the single-generation,
 single-policy-evaluation, shared-storage, duplicate-artifact, and
 incomplete-evidence contracts.
+
+`DotnetInspector.ResearchQueries.AnnotatedMemberDocumentQuery` is the first
+non-rendering consumer of this progressive seam. It accepts an already-acquired
+view and an already-open `MetadataSource`, projects the graph once, and returns
+portable source plus an `AnnotatedCallGraphOverlay`. Each overlay occurrence
+names both its stable edge row and its `call.edge` fact id. Two calls at
+different IL offsets therefore remain two physical occurrences and two source
+facts even when they share one logical edge row. A node budget limits both the
+projection and the supplied relationship facts; omission under a
+`DepthLimited` or `Truncated` focus is not reported as a mapping failure.
+Caller-only views are rejected because they contain no outbound topology to
+which body-local call sites could map.
+
+The query declares no graph or Analysis acquisition. The
+`AnnotatedMemberDocument_ReusesCalleeLayerAndMapsEveryPhysicalCallSite` test
+gates that claim by asserting unchanged session build/source-open counts and
+the two-occurrences/one-edge shape. Requirement tests pin the call-only Research
+profile to `ResearchFactRequirements.None`.
 
 Drive it by pull (`Callees()` / `Callers()` / `CrossLibrary()`, or the lazy
 `Tiers()` stream) or by push (`RunAsync` raising `LayerReady` per layer then

--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -468,6 +468,22 @@ origin) *after* portable escaping, and the constructor enforces that uniqueness
 along with contiguous ids, resolvable and non-duplicated target pairs, and — for
 a target on an IL node — an `IlOffset` equal to the fact's own `SourceOffset`.
 
+A graph overlay does not add an edge-to-node join.
+`AnnotatedMemberDocument` pairs the unchanged document with an
+`AnnotatedCallGraphOverlay`; each physical call occurrence carries a stable
+graph edge row and the id of an ordinary `call.edge` fact. Placement therefore
+continues through the existing relation:
+
+```text
+graph edge row → physical occurrence → fact → target → node → spans → text
+```
+
+Several physical call sites may share one logical edge row, but each keeps its
+own IL offset, operand token, fact, and source targets. The
+`AnnotatedMemberDocument_ReusesCalleeLayerAndMapsEveryPhysicalCallSite` test
+gates this shape with two call sites that collapse onto one edge and still
+target distinct C# and IL structure.
+
 **A fact with no target is the explicit unanchored case.** It is not a missing
 row and not a third kind of placement: the observation is real, and nothing in
 the text was the right thing to point at. Dropping it would lose the

--- a/src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs
@@ -5,7 +5,10 @@ using System.Reflection.PortableExecutable;
 using DotnetInspector.Fixtures;
 using DotnetInspector.Services;
 using ILInspector.CallGraph;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
+using ILInspector.Research;
 using Analysis = ILInspector.Analysis;
 
 namespace DotnetInspector.Queries.Tests;
@@ -82,6 +85,153 @@ public sealed class MemberCallGraphSessionTests
         Assert.Equal(
             Analysis.CallTreeStatus.DepthLimited,
             Child(view.CalleeRoot!, "Run").Status);
+    }
+
+    [Fact]
+    public void AnnotatedMemberDocument_ReusesCalleeLayerAndMapsEveryPhysicalCallSite()
+    {
+        using GraphContext context =
+            GraphContext.Create(CallerPath, TargetPath);
+        int runTwice = MemberToken(
+            CallerPath,
+            "Entry",
+            "RunTwice");
+        using var graph = new MemberCallGraphSession(
+            context.Group,
+            context.Sources[0].Assembly,
+            runTwice,
+            new MemberCallGraphOptions
+            {
+                Features =
+                    Analysis.LibraryBodyAnalysisFeatures.MethodEvidence,
+            });
+        MemberCallGraphView view = graph.Callees();
+        Assert.Equal(2, view.FocusCallSites.Length);
+
+        using var source = MetadataSource.Open(CallerPath);
+        AnnotatedMemberDocumentResult result =
+            AnnotatedMemberDocumentQuery.Execute(
+                new AnnotatedMemberDocumentInput(
+                    source,
+                    view));
+
+        var complete =
+            Assert.IsType<AnnotatedMemberDocumentResult.Complete>(
+                result);
+        AnnotatedMemberDocument document = complete.Document;
+        Assert.Equal(CallGraphTier.Callees, document.CallGraph.Tier);
+        Assert.Single(document.CallGraph.Projection.Rows);
+        Assert.Equal(2, document.CallGraph.Occurrences.Length);
+        Assert.All(
+            document.CallGraph.Occurrences,
+            occurrence => Assert.Equal(1, occurrence.EdgeRow));
+        Assert.Equal(
+            2,
+            document.CallGraph.Occurrences
+                .Select(occurrence => occurrence.FactId)
+                .Distinct()
+                .Count());
+
+        foreach (AnnotatedCallGraphOccurrence occurrence
+            in document.CallGraph.Occurrences)
+        {
+            AnnotatedSourceFact fact =
+                document.Source.Facts[occurrence.FactId];
+            Assert.Equal(
+                ResearchFactRegistry.CallRelationshipDescriptorId,
+                fact.Descriptor);
+            Assert.Equal(occurrence.ILOffset, fact.SourceOffset);
+
+            AnnotatedSourceNode[] targets =
+            [
+                .. document.Source.Targets
+                    .Where(target =>
+                        target.FactId == occurrence.FactId)
+                    .Select(target =>
+                        document.Source.Nodes[target.NodeId]),
+            ];
+            Assert.Contains(
+                targets,
+                node => node.Medium == SourceLineKind.CSharp);
+            Assert.Contains(
+                targets,
+                node => node.Medium == SourceLineKind.Il
+                    && node.IlOffset == occurrence.ILOffset);
+        }
+
+        Assert.Equal(
+            new MemberCallGraphBuildCounts(1, 0, 0),
+            graph.BuildCounts);
+        Assert.Equal(1, context.Sources[0].OpenCount);
+        Assert.Equal(0, context.Sources[1].OpenCount);
+    }
+
+    [Fact]
+    public void AnnotatedMemberDocument_RejectsSourceFromAnotherModule()
+    {
+        using GraphContext context =
+            GraphContext.Create(CallerPath, TargetPath);
+        int runTwice = MemberToken(
+            CallerPath,
+            "Entry",
+            "RunTwice");
+        using var graph = new MemberCallGraphSession(
+            context.Group,
+            context.Sources[0].Assembly,
+            runTwice);
+        MemberCallGraphView view = graph.Callees();
+
+        using var source = MetadataSource.Open(TargetPath);
+        AnnotatedMemberDocumentResult result =
+            AnnotatedMemberDocumentQuery.Execute(
+                new AnnotatedMemberDocumentInput(
+                    source,
+                    view));
+
+        Assert.IsType<AnnotatedMemberDocumentResult.Failed>(result);
+        Assert.Equal(
+            new MemberCallGraphBuildCounts(1, 0, 0),
+            graph.BuildCounts);
+    }
+
+    [Fact]
+    public void AnnotatedMemberDocument_HonorsACalleeNodeBudget()
+    {
+        using GraphContext context =
+            GraphContext.Create(CallerPath, TargetPath);
+        int runTwice = MemberToken(
+            CallerPath,
+            "Entry",
+            "RunTwice");
+        using var graph = new MemberCallGraphSession(
+            context.Group,
+            context.Sources[0].Assembly,
+            runTwice,
+            new MemberCallGraphOptions
+            {
+                MaxNodes = 1,
+            });
+        MemberCallGraphView view = graph.Callees();
+        Assert.Equal(
+            Analysis.CallTreeStatus.Truncated,
+            view.CalleeRoot!.Status);
+
+        using var source = MetadataSource.Open(CallerPath);
+        var complete =
+            Assert.IsType<AnnotatedMemberDocumentResult.Complete>(
+                AnnotatedMemberDocumentQuery.Execute(
+                    new AnnotatedMemberDocumentInput(
+                        source,
+                        view)));
+
+        Assert.Empty(complete.Document.CallGraph.Occurrences);
+        Assert.DoesNotContain(
+            complete.Document.Source.Facts,
+            fact => fact.Descriptor
+                == ResearchFactRegistry.CallRelationshipDescriptorId);
+        Assert.Equal(
+            new MemberCallGraphBuildCounts(1, 0, 0),
+            graph.BuildCounts);
     }
 
     [Fact]

--- a/src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs
@@ -235,6 +235,43 @@ public sealed class MemberCallGraphSessionTests
     }
 
     [Fact]
+    public void BodilessFocus_ProducesEveryProgressiveTier()
+    {
+        using GraphContext context =
+            GraphContext.Create(TargetPath, CallerPath);
+        Analysis.MethodIdentity focus =
+            Analysis.LibraryBodyIndex.Open(TargetPath)
+                .DeclaredMethods
+                .First(method =>
+                    method.DeclaringType.Name == "IBodilessApi"
+                    && method.Name == "Invoke");
+        using var graph = new MemberCallGraphSession(
+            context.Group,
+            context.Sources[0].Assembly,
+            focus.MetadataToken);
+
+        MemberCallGraphView[] views =
+        [
+            graph.Callees(),
+            graph.Callers(),
+            graph.CrossLibrary(),
+        ];
+
+        Assert.All(
+            views,
+            view =>
+            {
+                Assert.Equal(
+                    focus.ModuleVersionId,
+                    view.FocusModuleVersionId);
+                Assert.Equal(
+                    focus.MetadataToken,
+                    view.FocusMethodToken);
+                Assert.Empty(view.FocusCallSites);
+            });
+    }
+
+    [Fact]
     public void DirectFullTier_SkipsScopedAndLaterCalleesReusesFull()
     {
         using GraphContext context =

--- a/src/DotnetInspector.Queries/MemberCallGraphSession.cs
+++ b/src/DotnetInspector.Queries/MemberCallGraphSession.cs
@@ -69,6 +69,20 @@ public sealed record MemberCallGraphView(
     Analysis.CallTreeNode? CalleeRoot,
     Analysis.CallTreeNode? CallerRoot)
 {
+    /// <summary>The selected member's module identity.</summary>
+    public Guid FocusModuleVersionId { get; init; }
+
+    /// <summary>The selected member's MethodDef token.</summary>
+    public int FocusMethodToken { get; init; }
+
+    /// <summary>
+    /// Every physical call site originating in the selected member, retained
+    /// from the same index that produced the graph roots. The annotated-member
+    /// integration test gates this reuse boundary.
+    /// </summary>
+    public ImmutableArray<Analysis.DirectCall> FocusCallSites { get; init; } =
+        [];
+
     public Analysis.CatalogCallGraphDiagnostics Diagnostics { get; init; } =
         Analysis.CatalogCallGraphDiagnostics.Empty;
 }
@@ -228,13 +242,14 @@ public sealed class MemberCallGraphSession : IDisposable
         if (_fullRoot is not null)
         {
             IndexBuildResult.Available full = Require(_fullRoot);
-            return new(
+            return View(
                 CallGraphTier.Callees,
+                full.Index,
                 full.Index.BuildCallTree(
                     _memberToken,
                     _options.Depth,
                     _options.MaxNodes),
-                CallerRoot: null);
+                callerRoot: null);
         }
 
         IndexBuildResult.Available scoped = Require(
@@ -247,10 +262,11 @@ public sealed class MemberCallGraphSession : IDisposable
             _memberToken,
             maxDepth: 1,
             maxNodes: _options.MaxNodes);
-        return new(
+        return View(
             CallGraphTier.Callees,
+            scoped.Index,
             MarkImmediateCalleesBounded(root),
-            CallerRoot: null);
+            callerRoot: null);
     }
 
     static Analysis.CallTreeNode MarkImmediateCalleesBounded(
@@ -274,8 +290,9 @@ public sealed class MemberCallGraphSession : IDisposable
     MemberCallGraphView CallersCore()
     {
         IndexBuildResult.Available root = Require(GetFullRoot());
-        return new(
+        return View(
             CallGraphTier.Callers,
+            root.Index,
             root.Index.BuildCallTree(
                 _memberToken,
                 _options.Depth,
@@ -291,8 +308,9 @@ public sealed class MemberCallGraphSession : IDisposable
         IndexBuildResult.Available root = Require(GetFullRoot());
         EnsureCrossLibraryScope();
         ThrowIfCrossLibraryFailed();
-        return new MemberCallGraphView(
+        return View(
             CallGraphTier.CrossLibrary,
+            root.Index,
             root.Index.BuildCallTree(
                 _memberToken,
                 _catalogScope!,
@@ -302,11 +320,33 @@ public sealed class MemberCallGraphSession : IDisposable
                 _memberToken,
                 _catalogScope!,
                 _options.Depth,
-                _options.MaxNodes))
-        {
-            Diagnostics = _catalogScope!.Diagnostics,
-        };
+                _options.MaxNodes),
+            _catalogScope!.Diagnostics);
     }
+
+    MemberCallGraphView View(
+        CallGraphTier tier,
+        Analysis.LibraryBodyIndex index,
+        Analysis.CallTreeNode? calleeRoot,
+        Analysis.CallTreeNode? callerRoot,
+        Analysis.CatalogCallGraphDiagnostics? diagnostics = null) =>
+        new(tier, calleeRoot, callerRoot)
+        {
+            FocusModuleVersionId = index.Methods.First(method =>
+                method.MetadataToken == _memberToken).ModuleVersionId,
+            FocusMethodToken = _memberToken,
+            FocusCallSites =
+            [
+                .. index.DirectCalls
+                    .Where(call =>
+                        call.Caller.MetadataToken == _memberToken)
+                    .OrderBy(call => call.ILOffset)
+                    .ThenBy(call => call.OperandToken),
+            ],
+            Diagnostics =
+                diagnostics
+                ?? Analysis.CatalogCallGraphDiagnostics.Empty,
+        };
 
     void EnsureCrossLibraryScope()
     {

--- a/src/DotnetInspector.Queries/MemberCallGraphSession.cs
+++ b/src/DotnetInspector.Queries/MemberCallGraphSession.cs
@@ -244,7 +244,7 @@ public sealed class MemberCallGraphSession : IDisposable
             IndexBuildResult.Available full = Require(_fullRoot);
             return View(
                 CallGraphTier.Callees,
-                full.Index,
+                full,
                 full.Index.BuildCallTree(
                     _memberToken,
                     _options.Depth,
@@ -264,7 +264,7 @@ public sealed class MemberCallGraphSession : IDisposable
             maxNodes: _options.MaxNodes);
         return View(
             CallGraphTier.Callees,
-            scoped.Index,
+            scoped,
             MarkImmediateCalleesBounded(root),
             callerRoot: null);
     }
@@ -292,7 +292,7 @@ public sealed class MemberCallGraphSession : IDisposable
         IndexBuildResult.Available root = Require(GetFullRoot());
         return View(
             CallGraphTier.Callers,
-            root.Index,
+            root,
             root.Index.BuildCallTree(
                 _memberToken,
                 _options.Depth,
@@ -310,7 +310,7 @@ public sealed class MemberCallGraphSession : IDisposable
         ThrowIfCrossLibraryFailed();
         return View(
             CallGraphTier.CrossLibrary,
-            root.Index,
+            root,
             root.Index.BuildCallTree(
                 _memberToken,
                 _catalogScope!,
@@ -326,14 +326,16 @@ public sealed class MemberCallGraphSession : IDisposable
 
     MemberCallGraphView View(
         CallGraphTier tier,
-        Analysis.LibraryBodyIndex index,
+        IndexBuildResult.Available source,
         Analysis.CallTreeNode? calleeRoot,
         Analysis.CallTreeNode? callerRoot,
-        Analysis.CatalogCallGraphDiagnostics? diagnostics = null) =>
-        new(tier, calleeRoot, callerRoot)
+        Analysis.CatalogCallGraphDiagnostics? diagnostics = null)
+    {
+        Analysis.LibraryBodyIndex index = source.Index;
+        return new(tier, calleeRoot, callerRoot)
         {
-            FocusModuleVersionId = index.Methods.First(method =>
-                method.MetadataToken == _memberToken).ModuleVersionId,
+            FocusModuleVersionId =
+                source.ImageIdentity.ModuleVersionId,
             FocusMethodToken = _memberToken,
             FocusCallSites =
             [
@@ -347,6 +349,7 @@ public sealed class MemberCallGraphSession : IDisposable
                 diagnostics
                 ?? Analysis.CatalogCallGraphDiagnostics.Empty,
         };
+    }
 
     void EnsureCrossLibraryScope()
     {

--- a/src/DotnetInspector.ResearchQueries/AnnotatedMemberDocumentQuery.cs
+++ b/src/DotnetInspector.ResearchQueries/AnnotatedMemberDocumentQuery.cs
@@ -69,7 +69,9 @@ public abstract record AnnotatedMemberDocumentResult
 /// </summary>
 /// <remarks>
 /// <c>AnnotatedMemberDocument_ReusesCalleeLayerAndMapsEveryPhysicalCallSite</c>
-/// gates the reuse claim, including the unchanged graph build counts.
+/// gates graph-session reuse and the unchanged graph build counts.
+/// <c>RequirementsNone_DoesNotResolveAnAssemblyContext</c> gates the Research
+/// acquisition boundary used by the call-only profile.
 /// </remarks>
 public static class AnnotatedMemberDocumentQuery
 {

--- a/src/DotnetInspector.ResearchQueries/AnnotatedMemberDocumentQuery.cs
+++ b/src/DotnetInspector.ResearchQueries/AnnotatedMemberDocumentQuery.cs
@@ -1,0 +1,209 @@
+using System.Collections.Immutable;
+
+using ILInspector.Analysis;
+using ILInspector.CallGraph;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Annotations;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Research;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// Inputs for composing one already-acquired graph layer with portable
+/// annotated source for the selected member.
+/// </summary>
+public sealed record AnnotatedMemberDocumentInput(
+    MetadataSource Source,
+    MemberCallGraphView CallGraph,
+    AnnotationStage Stage = AnnotationStage.Raised,
+    PrinterOptions? PrinterOptions = null);
+
+/// <summary>
+/// One physical call occurrence joined to both a stable graph edge row and a
+/// portable source fact. The fact reaches source through the document's sole
+/// fact-to-node target relation.
+/// </summary>
+public readonly record struct AnnotatedCallGraphOccurrence(
+    int EdgeRow,
+    int FactId,
+    Guid ModuleVersionId,
+    int CallerToken,
+    int ILOffset,
+    int OperandToken,
+    CallKind Kind,
+    bool InLoop);
+
+/// <summary>One bounded graph layer attached to an annotated source document.</summary>
+public sealed record AnnotatedCallGraphOverlay(
+    CallGraphTier Tier,
+    CallGraphProjection Projection,
+    ImmutableArray<AnnotatedCallGraphOccurrence> Occurrences,
+    CatalogCallGraphDiagnostics Diagnostics);
+
+/// <summary>
+/// Portable annotated source plus a bounded, format-neutral relationship
+/// overlay over that source.
+/// </summary>
+public sealed record AnnotatedMemberDocument(
+    AnnotatedSourceDocument Source,
+    AnnotatedCallGraphOverlay CallGraph);
+
+/// <summary>Result of composing source and graph evidence.</summary>
+public abstract record AnnotatedMemberDocumentResult
+{
+    private AnnotatedMemberDocumentResult()
+    {
+    }
+
+    public sealed record Complete(AnnotatedMemberDocument Document)
+        : AnnotatedMemberDocumentResult;
+
+    public sealed record Failed(DecompilerResult Failure)
+        : AnnotatedMemberDocumentResult;
+}
+
+/// <summary>
+/// Composes an already-acquired progressive graph layer with one portable
+/// source document. It performs no graph or Analysis acquisition.
+/// </summary>
+/// <remarks>
+/// <c>AnnotatedMemberDocument_ReusesCalleeLayerAndMapsEveryPhysicalCallSite</c>
+/// gates the reuse claim, including the unchanged graph build counts.
+/// </remarks>
+public static class AnnotatedMemberDocumentQuery
+{
+    public static InspectionQuery<AnnotatedMemberDocumentResult> Definition
+        { get; } =
+        new("Annotated member document", InspectionCost.NetworkFree);
+
+    public static AnnotatedMemberDocumentResult Execute(
+        AnnotatedMemberDocumentInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(input.Source);
+        ArgumentNullException.ThrowIfNull(input.CallGraph);
+
+        MemberCallGraphView graphView = input.CallGraph;
+        if (graphView.CalleeRoot is null)
+        {
+            return Failure(
+                "A call relationship overlay requires a callee topology.");
+        }
+        if (graphView.FocusModuleVersionId
+                != input.Source.ModuleVersionId)
+        {
+            return Failure(
+                "The annotated source module does not match the call-graph focus.");
+        }
+
+        CallGraphProjection projection = CallGraphProjection.Create(
+            graphView.CallerRoot,
+            graphView.CalleeRoot);
+        var mappedCalls =
+            ImmutableArray.CreateBuilder<(
+                DirectCall Call,
+                CallGraphRow Row)>();
+        bool focusIsBudgetLimited =
+            graphView.CalleeRoot.Status
+                is CallTreeStatus.DepthLimited
+                or CallTreeStatus.Truncated;
+        foreach (DirectCall call in graphView.FocusCallSites)
+        {
+            CallGraphRowMatch match =
+                projection.FindFocusCalleeRow(call, out CallGraphRow row);
+            if (match == CallGraphRowMatch.Found)
+            {
+                mappedCalls.Add((call, row));
+                continue;
+            }
+            if (match == CallGraphRowMatch.NotProjected
+                && focusIsBudgetLimited)
+            {
+                continue;
+            }
+
+            return Failure(
+                match == CallGraphRowMatch.Ambiguous
+                    ? $"Call site IL_{call.ILOffset:X4} maps to more than one stable graph edge."
+                    : $"Call site IL_{call.ILOffset:X4} could not be joined to one stable graph edge.");
+        }
+
+        var sourceProjection = ResearchViews.ProjectMember(
+            new ResearchViews.MemberProjectionRequest(
+                input.Source,
+                projection.Focus.Member.DeclaringType
+                    .ToQualifiedDisplayString(),
+                projection.Focus.Member.Name,
+                AnnotatedStage: input.Stage,
+                Registry: ResearchFactRegistry.CallRelationships,
+                MethodToken: graphView.FocusMethodToken,
+                PrinterOptions: input.PrinterOptions,
+                SourceDocument: true,
+                CallSites:
+                [
+                    .. mappedCalls.Select(mapped => mapped.Call),
+                ]));
+        if (sourceProjection.SourceDocument is not { } source)
+        {
+            return new AnnotatedMemberDocumentResult.Failed(
+                sourceProjection.SourceDocumentFailure
+                ?? DecompilerResult.Failure(
+                    DiagnosticIds.InternalError,
+                    "Annotated source production returned no document."));
+        }
+
+        if (graphView.FocusMethodToken
+                != sourceProjection.SelectedMethodToken)
+        {
+            return Failure(
+                "The annotated source member does not match the call-graph focus.");
+        }
+
+        var factsByOffset = source.Facts
+            .Where(fact =>
+                fact.Descriptor
+                    == ResearchFactRegistry.CallRelationshipDescriptorId)
+            .ToDictionary(fact => fact.SourceOffset);
+        var occurrences =
+            ImmutableArray.CreateBuilder<AnnotatedCallGraphOccurrence>(
+                mappedCalls.Count);
+        foreach ((DirectCall call, CallGraphRow row) in mappedCalls)
+        {
+            if (!factsByOffset.TryGetValue(
+                    call.ILOffset,
+                    out AnnotatedSourceFact fact))
+            {
+                return Failure(
+                    $"Call site IL_{call.ILOffset:X4} has no portable source fact.");
+            }
+
+            occurrences.Add(
+                new AnnotatedCallGraphOccurrence(
+                    row.Number,
+                    fact.Id,
+                    call.Caller.ModuleVersionId,
+                    call.Caller.MetadataToken,
+                    call.ILOffset,
+                    call.OperandToken,
+                    call.Kind,
+                    call.InLoop));
+        }
+
+        return new AnnotatedMemberDocumentResult.Complete(
+            new AnnotatedMemberDocument(
+                source,
+                new AnnotatedCallGraphOverlay(
+                    graphView.Tier,
+                    projection,
+                    occurrences.MoveToImmutable(),
+                    graphView.Diagnostics)));
+    }
+
+    static AnnotatedMemberDocumentResult.Failed Failure(
+        string message) =>
+        new(
+            DecompilerResult.Failure(
+                DiagnosticIds.InternalError,
+                message));
+}

--- a/src/DotnetInspector.ResearchQueries/DotnetInspector.ResearchQueries.csproj
+++ b/src/DotnetInspector.ResearchQueries/DotnetInspector.ResearchQueries.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DotnetInspector.Queries\DotnetInspector.Queries.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
+    <ProjectReference Include="..\ILInspector.CallGraph\ILInspector.CallGraph.csproj" />
     <ProjectReference Include="..\ILInspector.Research\ILInspector.Research.csproj" />
   </ItemGroup>
 </Project>

--- a/src/ILInspector.CallGraph/CallGraphProjection.cs
+++ b/src/ILInspector.CallGraph/CallGraphProjection.cs
@@ -84,6 +84,19 @@ public readonly record struct CallGraphEdge(int From, int To, string? LoopLabel)
 /// </param>
 public readonly record struct CallGraphRow(int Number, CallGraphEdge Edge);
 
+/// <summary>The outcome of locating one physical focus call in a projection.</summary>
+public enum CallGraphRowMatch
+{
+    /// <summary>The call maps to exactly one projected logical edge.</summary>
+    Found,
+
+    /// <summary>The bounded projection contains no edge for the call.</summary>
+    NotProjected,
+
+    /// <summary>More than one projected edge claims the call.</summary>
+    Ambiguous,
+}
+
 /// <summary>
 /// A format-neutral projection of the typed call-graph facts that
 /// <c>ILInspector.Analysis</c> produces (<see cref="CallTreeNode"/> caller and callee roots
@@ -142,6 +155,64 @@ public sealed class CallGraphProjection
 
     /// <summary>The selected overload the graph is centered on.</summary>
     public CallGraphNode Focus => Nodes[0];
+
+    /// <summary>
+    /// Resolves one physical call site in the selected member to its stable
+    /// logical edge row. Exact catalog storage evidence wins; a unique typed
+    /// structural match handles assembly-local projections.
+    /// </summary>
+    public CallGraphRowMatch FindFocusCalleeRow(
+        DirectCall call,
+        out CallGraphRow row)
+    {
+        ArgumentNullException.ThrowIfNull(call);
+
+        CallGraphRow[] exact =
+        [
+            .. Rows.Where(candidate =>
+                candidate.Edge.From == Focus.Id
+                && Nodes[candidate.Edge.To].GraphEvidence.Any(evidence =>
+                    evidence.Storage.Kind
+                        == GraphNodeStorageKind.CallSite
+                    && evidence.Storage.ModuleVersionId
+                        == call.Caller.ModuleVersionId
+                    && evidence.Storage.MethodToken
+                        == call.Caller.MetadataToken
+                    && evidence.Storage.ILOffset == call.ILOffset
+                    && evidence.Storage.OperandToken
+                        == call.OperandToken)),
+        ];
+        if (exact.Length == 1)
+        {
+            row = exact[0];
+            return CallGraphRowMatch.Found;
+        }
+        if (exact.Length > 1)
+        {
+            row = default;
+            return CallGraphRowMatch.Ambiguous;
+        }
+
+        GraphNodeIdentity callee =
+            GraphNodeIdentity.FromMember(call.Callee);
+        CallGraphRow[] structural =
+        [
+            .. Rows.Where(candidate =>
+                candidate.Edge.From == Focus.Id
+                && GraphNodeIdentity.FromMember(
+                    Nodes[candidate.Edge.To].Member) == callee),
+        ];
+        if (structural.Length == 1)
+        {
+            row = structural[0];
+            return CallGraphRowMatch.Found;
+        }
+
+        row = default;
+        return structural.Length > 1
+            ? CallGraphRowMatch.Ambiguous
+            : CallGraphRowMatch.NotProjected;
+    }
 
     /// <summary>
     /// Projects the combined caller/target/callee view. Both roots are the selected

--- a/src/ILInspector.Decompiler/Annotations/Annotations.cs
+++ b/src/ILInspector.Decompiler/Annotations/Annotations.cs
@@ -43,6 +43,9 @@ public enum AnnotationCategory
 
     /// <summary>Behavioral semantics and safety facts — exception paths and unsafe callee contracts.</summary>
     Semantics,
+
+    /// <summary>Relationships to other members, such as one physical call-site occurrence.</summary>
+    Relationship,
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -53,6 +53,10 @@ public sealed class MetadataSource : IDisposable
     /// <summary>Simple assembly name (no version/culture).</summary>
     public string AssemblyName { get; }
 
+    /// <summary>The opened module's stable metadata identity.</summary>
+    public Guid ModuleVersionId =>
+        Reader.GetGuid(Reader.GetModuleDefinition().Mvid);
+
     /// <summary>
     /// Optimistic ("simulate") rendering: when set, the importer treats the
     /// module as if it opted into the updated memory-safety rules even when it

--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -1,3 +1,4 @@
+using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
@@ -7,6 +8,108 @@ namespace ILInspector.Research.Tests;
 
 public class ResearchFactRegistryTests
 {
+    [Fact]
+    public void Registry_UnionsProducerAnalysisRequirementsBeforeAcquisition()
+    {
+        Assert.Equal(
+            ResearchFactRequirements.None,
+            new ResearchFactRegistry().Requirements);
+        Assert.Equal(
+            ResearchFactRequirements.None,
+            ResearchFactRegistry.CallRelationships.Requirements);
+
+        ResearchFactRequirements requirements =
+            ResearchFactRegistry.Default.Requirements;
+        Assert.Equal(ResearchAnalysisScope.Assembly, requirements.Scope);
+        Assert.True(
+            requirements.Features.HasFlag(
+                LibraryBodyAnalysisFeatures.MethodEvidence));
+        Assert.True(
+            requirements.Features.HasFlag(
+                LibraryBodyAnalysisFeatures.Allocations));
+    }
+
+    [Fact]
+    public void CallRelationshipRegistry_RequiresSuppliedCallSites()
+    {
+        using var source = MetadataSource.Open(
+            typeof(ResearchFixture).Assembly.Location);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ResearchViews.CollectFacts(
+                source,
+                typeof(ResearchFixture).FullName!,
+                nameof(ResearchFixture.BoxInt),
+                registry: ResearchFactRegistry.CallRelationships));
+    }
+
+    [Fact]
+    public void AnalysisIndexCache_UsesMemberScopeAndReusesCompatibleFullIndex()
+    {
+        string sourcePath =
+            typeof(ResearchFixture).Assembly.Location;
+        int token = LibraryBodyIndex.Open(
+                sourcePath,
+                LibraryBodyAnalysisFeatures.MethodEvidence)
+            .Methods.First(method =>
+                method.Name
+                    == nameof(
+                        ResearchFixture.CallsAllocInLoopCallee))
+            .MetadataToken;
+        string copyPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-research-{Guid.NewGuid():N}.dll");
+        string fullFirstPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-research-{Guid.NewGuid():N}.dll");
+        File.Copy(sourcePath, copyPath);
+        File.Copy(sourcePath, fullFirstPath);
+        try
+        {
+            ResearchFactRequirements member =
+                ResearchFactRequirements.ForMember(
+                    LibraryBodyAnalysisFeatures.MethodEvidence);
+            LibraryBodyIndex scoped =
+                AnalysisIndexCache.ForPath(copyPath, member, token);
+            Assert.NotEmpty(scoped.DirectCalls);
+            Assert.All(
+                scoped.DirectCalls,
+                call => Assert.Equal(
+                    token,
+                    call.Caller.MetadataToken));
+
+            ResearchFactRequirements assembly =
+                ResearchFactRequirements.ForAssembly(
+                    LibraryBodyAnalysisFeatures.MethodEvidence);
+            LibraryBodyIndex full =
+                AnalysisIndexCache.ForPath(copyPath, assembly, token);
+            Assert.NotSame(scoped, full);
+            Assert.True(
+                full.DirectCalls.Length
+                    > scoped.DirectCalls.Length);
+            Assert.Same(
+                scoped,
+                AnalysisIndexCache.ForPath(copyPath, member, token));
+
+            LibraryBodyIndex fullFirst =
+                AnalysisIndexCache.ForPath(
+                    fullFirstPath,
+                    assembly,
+                    token);
+            Assert.Same(
+                fullFirst,
+                AnalysisIndexCache.ForPath(
+                    fullFirstPath,
+                    member,
+                    token));
+        }
+        finally
+        {
+            File.Delete(copyPath);
+            File.Delete(fullFirstPath);
+        }
+    }
+
     [Fact]
     public void Registry_OrdersProducersAfterTheirDependencies()
     {
@@ -461,6 +564,9 @@ public class ResearchFactRegistryTests
         public string Name => "counting";
         public IReadOnlyList<string> Produces { get; } = ["cost.test", "semantics.test", "cost.header.test"];
         public IReadOnlyList<string> DependsOn => [];
+        public ResearchFactRequirements Requirements { get; } =
+            ResearchFactRequirements.ForAssembly(
+                LibraryBodyAnalysisFeatures.MethodEvidence);
 
         public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
         {

--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -44,6 +44,23 @@ public class ResearchFactRegistryTests
     }
 
     [Fact]
+    public void RequirementsNone_DoesNotResolveAnAssemblyContext()
+    {
+        using var source = MetadataSource.Open(
+            typeof(ResearchFixture).Assembly.Location);
+        var producer = new AssemblyContextCapturingProducer();
+
+        _ = ResearchViews.CollectFacts(
+            source,
+            typeof(ResearchFixture).FullName!,
+            nameof(ResearchFixture.BoxInt),
+            registry: new ResearchFactRegistry(producer));
+
+        Assert.True(producer.WasInvoked);
+        Assert.Null(producer.AssemblyContext);
+    }
+
+    [Fact]
     public void AnalysisIndexCache_UsesMemberScopeAndReusesCompatibleFullIndex()
     {
         string sourcePath =
@@ -595,6 +612,30 @@ public class ResearchFactRegistryTests
                     new AnnotationDescriptor("cost.header.test", AnnotationCategory.Cost, "test header"),
                     "shared")
             ];
+        }
+
+    }
+
+    sealed class AssemblyContextCapturingProducer
+        : IResearchFactProducer
+    {
+        public bool WasInvoked { get; private set; }
+        public ResearchAssemblyContext? AssemblyContext
+        {
+            get;
+            private set;
+        }
+
+        public string Name => "assembly-context-capturing";
+        public IReadOnlyList<string> Produces => [];
+        public IReadOnlyList<string> DependsOn => [];
+
+        public IReadOnlyList<IAnnotation> Produce(
+            ResearchFactContext context)
+        {
+            WasInvoked = true;
+            AssemblyContext = context.Assembly;
+            return [];
         }
     }
 }

--- a/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
@@ -17,6 +17,9 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
     public string Name => "allocation-occurrences";
     public IReadOnlyList<string> Produces { get; } = ["alloc.*"];
     public IReadOnlyList<string> DependsOn => [];
+    public ResearchFactRequirements Requirements { get; } =
+        ResearchFactRequirements.ForMember(
+            LibraryBodyAnalysisFeatures.Allocations);
 
     public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
     {

--- a/src/ILInspector.Research/AnalysisIndexCache.cs
+++ b/src/ILInspector.Research/AnalysisIndexCache.cs
@@ -6,19 +6,49 @@ static class AnalysisIndexCache
 {
     const int MaxCachedIndexes = 8;
     static readonly object s_indexLock = new();
-    static readonly Dictionary<string, LibraryBodyIndex> s_indexes = new(PathComparer());
+    static readonly List<CachedIndex> s_indexes = [];
 
     public static LibraryBodyIndex ForPath(string path)
+        => ForPath(
+            path,
+            ResearchFactRequirements.ForAssembly(
+                LibraryBodyAnalysisFeatures.Default),
+            methodToken: 0);
+
+    public static LibraryBodyIndex ForPath(
+        string path,
+        ResearchFactRequirements requirements,
+        int methodToken)
     {
         var fullPath = Path.GetFullPath(path);
         lock (s_indexLock)
         {
-            if (s_indexes.TryGetValue(fullPath, out var index))
-                return index;
+            CachedIndex? cached = s_indexes.FirstOrDefault(candidate =>
+                PathComparer().Equals(candidate.Path, fullPath)
+                && (candidate.Index.Features & requirements.Features)
+                    == requirements.Features
+                && (candidate.MethodToken is null
+                    || (requirements.Scope == ResearchAnalysisScope.Member
+                        && candidate.MethodToken == methodToken)));
+            if (cached is not null)
+                return cached.Index;
+
             if (s_indexes.Count >= MaxCachedIndexes)
                 s_indexes.Clear();
-            index = LibraryBodyIndex.Open(fullPath);
-            s_indexes[fullPath] = index;
+
+            int? scopedToken =
+                requirements.Scope == ResearchAnalysisScope.Member
+                && methodToken != 0
+                    ? methodToken
+                    : null;
+            IReadOnlySet<int>? bodyScope = scopedToken is { } token
+                ? new HashSet<int> { token }
+                : null;
+            LibraryBodyIndex index = LibraryBodyIndex.Open(
+                fullPath,
+                requirements.Features,
+                bodyScope: bodyScope);
+            s_indexes.Add(new CachedIndex(fullPath, scopedToken, index));
             return index;
         }
     }
@@ -27,4 +57,9 @@ static class AnalysisIndexCache
         => OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
+
+    sealed record CachedIndex(
+        string Path,
+        int? MethodToken,
+        LibraryBodyIndex Index);
 }

--- a/src/ILInspector.Research/CallSiteCostFactProducer.cs
+++ b/src/ILInspector.Research/CallSiteCostFactProducer.cs
@@ -15,6 +15,9 @@ sealed class CallSiteCostFactProducer : IResearchFactProducer
     public string Name => "call-site-cost";
     public IReadOnlyList<string> Produces { get; } = ["cost.callee"];
     public IReadOnlyList<string> DependsOn { get; } = [];
+    public ResearchFactRequirements Requirements { get; } =
+        ResearchFactRequirements.ForAssembly(
+            LibraryBodyAnalysisFeatures.Allocations);
 
     public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
     {

--- a/src/ILInspector.Research/CallSiteSemanticsFactProducer.cs
+++ b/src/ILInspector.Research/CallSiteSemanticsFactProducer.cs
@@ -13,6 +13,9 @@ sealed class CallSiteSemanticsFactProducer : IResearchFactProducer
     public string Name => "call-site-semantics";
     public IReadOnlyList<string> Produces { get; } = ["semantics.callee", "safety.callee"];
     public IReadOnlyList<string> DependsOn { get; } = [];
+    public ResearchFactRequirements Requirements { get; } =
+        ResearchFactRequirements.ForAssembly(
+            LibraryBodyAnalysisFeatures.MethodEvidence);
 
     public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
     {

--- a/src/ILInspector.Research/DirectCallFactProducer.cs
+++ b/src/ILInspector.Research/DirectCallFactProducer.cs
@@ -1,0 +1,39 @@
+using ILInspector.Analysis;
+using ILInspector.Decompiler.Annotations;
+
+namespace ILInspector.Research;
+
+sealed class DirectCallFactProducer : IResearchFactProducer
+{
+    static readonly AnnotationDescriptor CallEdge =
+        new(
+            ResearchFactRegistry.CallRelationshipDescriptorId,
+            AnnotationCategory.Relationship,
+            "calls another member");
+
+    public string Name => "direct-call-relationships";
+    public IReadOnlyList<string> Produces { get; } =
+        [ResearchFactRegistry.CallRelationshipDescriptorId];
+    public IReadOnlyList<string> DependsOn => [];
+
+    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
+    {
+        IReadOnlyList<DirectCall> calls = context.CallSites
+            ?? throw new InvalidOperationException(
+                "Direct call relationship facts require supplied call-site evidence.");
+        return calls.Count == 0
+            ? []
+            :
+            [
+                .. calls
+                    .OrderBy(call => call.ILOffset)
+                    .ThenBy(call => call.OperandToken)
+                    .Select(call => new Annotation<DirectCall>(
+                        CallEdge,
+                        call.ILOffset,
+                        call,
+                        Formatter: static occurrence =>
+                            occurrence.Callee.ToQualifiedDisplayString())),
+            ];
+    }
+}

--- a/src/ILInspector.Research/MethodHeaderLeverageFactProducer.cs
+++ b/src/ILInspector.Research/MethodHeaderLeverageFactProducer.cs
@@ -14,6 +14,9 @@ sealed class MethodHeaderLeverageFactProducer : IResearchFactProducer
     public string Name => "method-header-leverage";
     public IReadOnlyList<string> Produces { get; } = ["cost.method"];
     public IReadOnlyList<string> DependsOn { get; } = [];
+    public ResearchFactRequirements Requirements { get; } =
+        ResearchFactRequirements.ForAssembly(
+            ILInspector.Analysis.LibraryBodyAnalysisFeatures.MethodEvidence);
 
     public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context) => [];
 

--- a/src/ILInspector.Research/ResearchFactRegistry.cs
+++ b/src/ILInspector.Research/ResearchFactRegistry.cs
@@ -193,9 +193,9 @@ public sealed class ResearchFactRegistry
     /// The body-local relationship dimension. Its call evidence is supplied by
     /// the graph session, so producing the document opens no second Analysis
     /// index. <c>Registry_UnionsProducerAnalysisRequirementsBeforeAcquisition</c>
-    /// and
-    /// <c>AnnotatedMemberDocument_ReusesCalleeLayerAndMapsEveryPhysicalCallSite</c>
-    /// gate that acquisition boundary.
+    /// pins the profile's declaration, while
+    /// <c>RequirementsNone_DoesNotResolveAnAssemblyContext</c> gates the
+    /// declaration-to-acquisition wiring.
     /// </summary>
     public static ResearchFactRegistry CallRelationships { get; } = new(
         new DirectCallFactProducer());

--- a/src/ILInspector.Research/ResearchFactRegistry.cs
+++ b/src/ILInspector.Research/ResearchFactRegistry.cs
@@ -7,13 +7,37 @@ using ILInspector.Findings;
 
 namespace ILInspector.Research;
 
-public sealed record ResearchAssemblyContext(
-    LibraryBodyIndex Index,
-    IReadOnlyDictionary<int, MethodSignals> Signals,
-    IReadOnlyDictionary<int, MethodLeverage> LeverageByToken,
-    IReadOnlyDictionary<int, IReadOnlyList<DirectCall>> CallsByCaller,
-    IReadOnlyDictionary<int, IReadOnlyList<UnsafeEvidence>> UnsafeEvidenceByToken)
+public sealed class ResearchAssemblyContext
 {
+    readonly Lazy<IReadOnlyDictionary<int, MethodSignals>> _signals;
+    readonly Lazy<IReadOnlyDictionary<int, MethodLeverage>> _leverageByToken;
+    readonly Lazy<IReadOnlyDictionary<int, IReadOnlyList<DirectCall>>> _callsByCaller;
+    readonly Lazy<IReadOnlyDictionary<int, IReadOnlyList<UnsafeEvidence>>> _unsafeEvidenceByToken;
+
+    ResearchAssemblyContext(LibraryBodyIndex index)
+    {
+        Index = index;
+        _signals = new(() => index.GetMethodSignals());
+        _leverageByToken = new(() => index.TopLeverage(int.MaxValue)
+            .ToDictionary(entry => entry.Method.MetadataToken, entry => entry));
+        _callsByCaller = new(() => index.DirectCalls
+            .GroupBy(call => call.Caller.MetadataToken)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<DirectCall>)group.ToArray()));
+        _unsafeEvidenceByToken = new(() => index.UnsafeEvidence
+            .GroupBy(evidence => evidence.Member.MetadataToken)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<UnsafeEvidence>)group.ToArray()));
+    }
+
+    public LibraryBodyIndex Index { get; }
+    public IReadOnlyDictionary<int, MethodSignals> Signals => _signals.Value;
+    public IReadOnlyDictionary<int, MethodLeverage> LeverageByToken => _leverageByToken.Value;
+    public IReadOnlyDictionary<int, IReadOnlyList<DirectCall>> CallsByCaller => _callsByCaller.Value;
+    public IReadOnlyDictionary<int, IReadOnlyList<UnsafeEvidence>> UnsafeEvidenceByToken => _unsafeEvidenceByToken.Value;
+
     public ImmutableArray<Finding<DirectCall>> InspectCallSites(int methodToken)
     {
         if (!CallsByCaller.TryGetValue(methodToken, out var calls) || calls.Count == 0)
@@ -24,31 +48,15 @@ public sealed record ResearchAssemblyContext(
             new FindingSubject(subject.Id, subject.Display));
     }
 
-    public static ResearchAssemblyContext Create(LibraryBodyIndex index)
-    {
-        var leverage = index.TopLeverage(int.MaxValue)
-            .ToDictionary(entry => entry.Method.MetadataToken, entry => entry);
-        var callsByCaller = index.DirectCalls
-            .GroupBy(call => call.Caller.MetadataToken)
-            .ToDictionary(
-                group => group.Key,
-                group => (IReadOnlyList<DirectCall>)group.ToArray());
-        var unsafeEvidence = index.UnsafeEvidence
-            .GroupBy(evidence => evidence.Member.MetadataToken)
-            .ToDictionary(
-                group => group.Key,
-                group => (IReadOnlyList<UnsafeEvidence>)group.ToArray());
-        return new ResearchAssemblyContext(index, index.GetMethodSignals(), leverage, callsByCaller, unsafeEvidence);
-    }
+    public static ResearchAssemblyContext Create(LibraryBodyIndex index) =>
+        new(index);
 }
 
 /// <summary>
 /// Memoizes <see cref="ResearchAssemblyContext.Create"/> per <see cref="LibraryBodyIndex"/> instance.
-/// <c>Create</c> groups every call site and unsafe-evidence record in the assembly and computes
-/// method signals for the whole body index, so it must be built once per assembly (per the shared,
-/// parsed-once design in docs/design/assembly-inspection-query.md) rather than once per queried
-/// member — callers that resolve a context per method (e.g. a corpus sweep over every method in an
-/// assembly) would otherwise redo this whole-assembly work on every call.
+/// The context's assembly-wide projections are lazy, and sharing the context
+/// ensures each projection is computed at most once for an index when multiple
+/// producers or member queries request it.
 /// </summary>
 static class ResearchAssemblyContextCache
 {
@@ -74,7 +82,62 @@ static class ResearchAssemblyContextCache
 public sealed record ResearchFactContext(
     MetadataSource Source,
     IrFunction Imported,
-    ResearchAssemblyContext? Assembly = null);
+    ResearchAssemblyContext? Assembly = null,
+    IReadOnlyList<DirectCall>? CallSites = null);
+
+/// <summary>How much Analysis state one fact producer requires.</summary>
+public enum ResearchAnalysisScope
+{
+    None,
+    Member,
+    Assembly,
+}
+
+/// <summary>
+/// Analysis acquisition required by a fact producer. The registry unions these
+/// declarations before opening an index.
+/// </summary>
+public readonly record struct ResearchFactRequirements
+{
+    ResearchFactRequirements(
+        ResearchAnalysisScope scope,
+        LibraryBodyAnalysisFeatures features)
+    {
+        Scope = scope;
+        Features = features;
+    }
+
+    public ResearchAnalysisScope Scope { get; }
+    public LibraryBodyAnalysisFeatures Features { get; }
+
+    public static ResearchFactRequirements None { get; } =
+        new(ResearchAnalysisScope.None, LibraryBodyAnalysisFeatures.None);
+
+    public static ResearchFactRequirements ForMember(
+        LibraryBodyAnalysisFeatures features) =>
+        Create(ResearchAnalysisScope.Member, features);
+
+    public static ResearchFactRequirements ForAssembly(
+        LibraryBodyAnalysisFeatures features) =>
+        Create(ResearchAnalysisScope.Assembly, features);
+
+    internal ResearchFactRequirements Union(
+        ResearchFactRequirements other) =>
+        Scope >= other.Scope
+            ? new(Scope, Features | other.Features)
+            : new(other.Scope, Features | other.Features);
+
+    static ResearchFactRequirements Create(
+        ResearchAnalysisScope scope,
+        LibraryBodyAnalysisFeatures features)
+    {
+        if (features == LibraryBodyAnalysisFeatures.None)
+            throw new ArgumentException("An Analysis-backed fact producer must request at least one feature.", nameof(features));
+        if ((features & ~LibraryBodyAnalysisFeatures.All) != 0)
+            throw new ArgumentOutOfRangeException(nameof(features));
+        return new(scope, features);
+    }
+}
 
 public sealed record ResearchHeaderFact(
     AnnotationDescriptor Descriptor,
@@ -91,6 +154,7 @@ public interface IResearchFactProducer
     string Name { get; }
     IReadOnlyList<string> Produces { get; }
     IReadOnlyList<string> DependsOn { get; }
+    ResearchFactRequirements Requirements => ResearchFactRequirements.None;
     IReadOnlyList<IAnnotation> Produce(ResearchFactContext context);
     IReadOnlyList<ResearchHeaderFact> ProduceHeaderFacts(ResearchFactContext context) => [];
 }
@@ -101,12 +165,21 @@ public interface IResearchFactProducer
 /// </summary>
 public sealed class ResearchFactRegistry
 {
+    public const string CallRelationshipDescriptorId = "call.edge";
+
     readonly IReadOnlyList<IResearchFactProducer> _producers;
 
     public ResearchFactRegistry(params IResearchFactProducer[] producers)
-        => _producers = Order(producers);
+    {
+        _producers = Order(producers);
+        Requirements = _producers.Aggregate(
+            ResearchFactRequirements.None,
+            static (requirements, producer) =>
+                requirements.Union(producer.Requirements));
+    }
 
     public IReadOnlyList<string> ProducerNames => [.. _producers.Select(producer => producer.Name)];
+    public ResearchFactRequirements Requirements { get; }
 
     public static ResearchFactRegistry Default { get; } = new(
         new AllocationOccurrenceFactProducer(),
@@ -115,6 +188,17 @@ public sealed class ResearchFactRegistry
         new CallSiteSemanticsFactProducer(),
         new MethodHeaderLeverageFactProducer(),
         new DecompilerLifetimeFactProducer());
+
+    /// <summary>
+    /// The body-local relationship dimension. Its call evidence is supplied by
+    /// the graph session, so producing the document opens no second Analysis
+    /// index. <c>Registry_UnionsProducerAnalysisRequirementsBeforeAcquisition</c>
+    /// and
+    /// <c>AnnotatedMemberDocument_ReusesCalleeLayerAndMapsEveryPhysicalCallSite</c>
+    /// gate that acquisition boundary.
+    /// </summary>
+    public static ResearchFactRegistry CallRelationships { get; } = new(
+        new DirectCallFactProducer());
 
     public IReadOnlyList<IAnnotation> Collect(ResearchFactContext context)
         => [.. _producers.SelectMany(producer => producer.Produce(context)).OrderBy(fact => fact.SourceOffset).ThenBy(fact => fact.Descriptor.Id, StringComparer.Ordinal)];

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -38,7 +38,8 @@ public static partial class ResearchViews
         int? MethodToken = null,
         PrinterOptions? PrinterOptions = null,
         string? CaretFocus = null,
-        bool SourceDocument = false);
+        bool SourceDocument = false,
+        IReadOnlyList<DirectCall>? CallSites = null);
 
     public sealed record MemberProjectionResult(
         DecompilerResult? AnnotatedSource,
@@ -66,7 +67,10 @@ public static partial class ResearchViews
         /// Failure isolated to portable-document production. Sibling projections
         /// remain available when the document's C# printer cannot produce output.
         /// </summary>
-        DecompilerResult? SourceDocumentFailure = null);
+        DecompilerResult? SourceDocumentFailure = null,
+
+        /// <summary>The MethodDef token selected for this projection.</summary>
+        int? SelectedMethodToken = null);
 
     public static MemberProjectionResult ProjectMember(MemberProjectionRequest request)
     {
@@ -84,13 +88,19 @@ public static partial class ResearchViews
             var imported = ImportFunction()
                 ?? throw new InvalidOperationException($"{request.Type}::{request.Method} has no IL body");
 
-            var assembly = ResolveAssemblyContext(imported);
             var effectiveRegistry = request.Registry ?? ResearchFactRegistry.Default;
+            var assembly = ResolveAssemblyContext(
+                imported,
+                effectiveRegistry.Requirements);
             // The reporting half of the data/reporting split: facts are collected
             // once and describe, and this decides which of them this render
             // promotes to the caret gesture.
             var gestures = AnnotationGestureSelector.Focus(request.CaretFocus);
-            var context = new ResearchFactContext(request.Source, imported, assembly);
+            var context = new ResearchFactContext(
+                request.Source,
+                imported,
+                assembly,
+                request.CallSites);
             var facts = effectiveRegistry.Collect(context);
             IReadOnlyList<ResearchHeaderFact> headerFacts = [];
             DecompilerResult? headerFactsFailure = null;
@@ -232,7 +242,8 @@ public static partial class ResearchViews
                 annotatedSource?.Trace ?? costOverlay?.Body.Trace ?? semanticsOverlay?.Trace,
                 UnmatchedFocusAlternatives(request.CaretFocus, gestures, facts),
                 sourceDocument,
-                sourceDocumentFailure);
+                sourceDocumentFailure,
+                imported.MetadataToken);
         }
         catch (Exception ex)
         {
@@ -288,21 +299,37 @@ public static partial class ResearchViews
     {
         var imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
             ?? throw new InvalidOperationException($"{type}::{method} has no IL body");
-        return CollectFacts(source, imported, ResolveAssemblyContext(imported), registry);
+        return CollectFacts(source, imported, registry);
     }
 
     /// <summary>
     /// Every entry point resolves the assembly context through this seam, so producers see a
     /// consistent Assembly (or a consistent absence) rather than each re-deriving it independently.
     /// </summary>
-    static ResearchAssemblyContext? ResolveAssemblyContext(IrFunction imported)
-        => imported.AssemblyPath is { Length: > 0 } path
-            ? ResearchAssemblyContextCache.ForIndex(AnalysisIndexCache.ForPath(path))
+    static ResearchAssemblyContext? ResolveAssemblyContext(
+        IrFunction imported,
+        ResearchFactRequirements requirements)
+        => requirements.Scope != ResearchAnalysisScope.None
+            && imported.AssemblyPath is { Length: > 0 } path
+            ? ResearchAssemblyContextCache.ForIndex(
+                AnalysisIndexCache.ForPath(
+                    path,
+                    requirements,
+                    imported.MetadataToken))
             : null;
 
     public static IReadOnlyList<IAnnotation> CollectFacts(
         MetadataSource source, IrFunction imported, ResearchFactRegistry? registry = null)
-        => CollectFacts(source, imported, ResolveAssemblyContext(imported), registry);
+    {
+        var effectiveRegistry = registry ?? ResearchFactRegistry.Default;
+        return CollectFacts(
+            source,
+            imported,
+            ResolveAssemblyContext(
+                imported,
+                effectiveRegistry.Requirements),
+            effectiveRegistry);
+    }
 
     public static IReadOnlyList<IAnnotation> CollectFacts(
         MetadataSource source, IrFunction imported, ResearchAssemblyContext? assembly, ResearchFactRegistry? registry = null)
@@ -314,8 +341,13 @@ public static partial class ResearchViews
     {
         var imported = IrImporter.Import(source, type, method, overloadIndex, publicOnly)
             ?? throw new InvalidOperationException($"{type}::{method} has no IL body");
-        var context = new ResearchFactContext(source, imported, ResolveAssemblyContext(imported));
         var effectiveRegistry = registry ?? ResearchFactRegistry.Default;
+        var context = new ResearchFactContext(
+            source,
+            imported,
+            ResolveAssemblyContext(
+                imported,
+                effectiveRegistry.Requirements));
         var facts = effectiveRegistry.Collect(context);
         var headerFacts = effectiveRegistry.CollectHeaderFacts(context);
         return BuildFactRows(type, method, imported, facts, headerFacts, source);

--- a/src/ILInspector.Research/UnsafetyOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/UnsafetyOccurrenceFactProducer.cs
@@ -13,6 +13,9 @@ sealed class UnsafetyOccurrenceFactProducer : IResearchFactProducer
     public string Name => "unsafety-occurrences";
     public IReadOnlyList<string> Produces { get; } = ["unsafe.*"];
     public IReadOnlyList<string> DependsOn => [];
+    public ResearchFactRequirements Requirements { get; } =
+        ResearchFactRequirements.ForMember(
+            LibraryBodyAnalysisFeatures.MethodEvidence);
 
     public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
     {


### PR DESCRIPTION
## Summary

Adds the first product-owned annotated call-graph overlay: an already-acquired progressive `MemberCallGraphView` can now produce portable annotated source plus stable graph-edge occurrences without opening another Analysis index or choosing a rendering format.

- Fact producers declare member/assembly Analysis requirements before Research acquires an index; assembly projections are lazy, and the focused Calls profile requires no Analysis state.
- Progressive graph views retain physical focus call sites from the same index that produced their roots.
- `AnnotatedMemberDocumentQuery` joins each projected physical call occurrence to one stable logical edge row and one ordinary `call.edge` source fact. Two call sites may share one edge without sharing a fact or source target.
- Node budgets remain authoritative: truncated outbound edges and their facts are omitted together. Caller-only layers fail visibly because they have no outbound topology.

## Evidence

`Shared.Entry.RunTwice` proves the key shape end to end: two physical calls, two source facts with distinct C#/IL targets, one stable graph edge row, unchanged graph build counts, and no additional workspace source opens.

Validation:

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --no-build --project src/ILInspector.Research.Tests -c Release` — 160/160
- `dotnet run --no-build --project src/DotnetInspector.Queries.Tests -c Release` — 58/58
- focused `CallGraphProjectionTests` — 34/34
- markdownlint on all changed Markdown

## Boundary

This does not change CLI output, Mermaid generation, or the Wasm site. It establishes the reusable data seam those consumers can adopt later and is the first slice of #4023.