### PR TITLE
Recover when a credential plugin dies mid-request

### DIFF
--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -151,6 +151,11 @@ Plugins are started lazily and kept for the process lifetime, because a launch c
 start plus five round trips. A plugin that fails to start, or that does not claim the
 `Authentication` operation, is remembered as unusable rather than retried.
 
+A plugin process or pipe that dies during a request is likewise treated as no credential from
+that plugin. Timeouts, malformed responses, I/O failures, disposed pipes, and invalid process
+state are contained at the request boundary so another provider can answer or the feed's 401 can
+surface normally. Caller cancellation is not a plugin fault and continues to propagate.
+
 ### Unattended by default
 
 Credentials are requested with `IsNonInteractive` set and `CanShowDialog` clear, matching

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -178,6 +178,24 @@ public sealed class PluginProtocolTests : IDisposable
     }
 
     [Fact]
+    public async Task WhenOnePluginDiesDuringTheRequest_TheNextIsTried()
+    {
+        FakePlugin dies = CreatePlugin(
+            "dies",
+            username: "unused",
+            password: "unused",
+            exitOnCredentialRequest: true);
+        FakePlugin answers = CreatePlugin("answers-after-death", username: "right", password: "token");
+
+        await using var provider = new PluginCredentialProvider(null, [dies.Executable, answers.Executable]);
+        PackageSourceCredential? credential = await provider.GetCredentialsAsync(
+            new Uri("https://feed.example/v3/index.json"), false, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(credential);
+        Assert.Equal("right", credential.Username);
+    }
+
+    [Fact]
     public async Task CredentialsRestrictedToOtherAuthSchemesAreNotUsed()
     {
         FakePlugin plugin = CreatePlugin("negotiate", username: "u", password: "p", authenticationTypes: "negotiate");
@@ -257,6 +275,76 @@ public sealed class PluginProtocolTests : IDisposable
         Assert.Equal("p", credential.Password);
     }
 
+    [Fact]
+    public async Task AConnectionDisposedBeforeARequestDegradesToNoCredentials()
+    {
+        FakePlugin plugin = CreatePlugin(
+            "disposed-connection",
+            username: "u",
+            password: "p");
+        PluginConnection? connection = await PluginConnection.StartAsync(
+            plugin.Executable,
+            log: null,
+            TestContext.Current.CancellationToken);
+        Assert.NotNull(connection);
+
+        await connection.DisposeAsync();
+
+        GetAuthenticationCredentialsResponse? response =
+            await connection.GetCredentialsAsync(
+                new Uri("https://feed.example/v3/index.json"),
+                isRetry: false,
+                isNonInteractive: true,
+                canShowDialog: false,
+                TestContext.Current.CancellationToken);
+
+        Assert.Null(response);
+    }
+
+    [Fact]
+    public async Task CallerCancellationContinuesToPropagate()
+    {
+        FakePlugin plugin = CreatePlugin("cancelled-request", username: "u", password: "p");
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken));
+        await using (connection)
+        {
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                connection.GetCredentialsAsync(
+                    new Uri("https://feed.example/v3/index.json"),
+                    isRetry: false,
+                    isNonInteractive: true,
+                    canShowDialog: false,
+                    cancellation.Token));
+        }
+    }
+
+    [Fact]
+    public void RecoverableRequestFailuresExcludeCallerCancellationAndUnrelatedFaults()
+    {
+        Assert.True(PluginConnection.IsRecoverableRequestFailure(
+            new TimeoutException()));
+        Assert.True(PluginConnection.IsRecoverableRequestFailure(
+            new JsonException()));
+        Assert.True(PluginConnection.IsRecoverableRequestFailure(
+            new IOException()));
+        Assert.True(PluginConnection.IsRecoverableRequestFailure(
+            new ObjectDisposedException("plugin pipe")));
+        Assert.True(PluginConnection.IsRecoverableRequestFailure(
+            new InvalidOperationException()));
+
+        Assert.False(PluginConnection.IsRecoverableRequestFailure(
+            new OperationCanceledException()));
+        Assert.False(PluginConnection.IsRecoverableRequestFailure(
+            new ArgumentException()));
+    }
+
     private FakePlugin CreatePlugin(
         string name,
         string username,
@@ -264,7 +352,8 @@ public sealed class PluginProtocolTests : IDisposable
         string claims = "Authentication",
         string responseCode = "Success",
         string? authenticationTypes = null,
-        string? preamble = null)
+        string? preamble = null,
+        bool exitOnCredentialRequest = false)
     {
         // Values are embedded in a double-quoted bash string, so every JSON quote needs a
         // backslash in the emitted script.
@@ -278,6 +367,11 @@ public sealed class PluginProtocolTests : IDisposable
                 + "," + Quoted("AuthenticationTypes") + ":" + types
                 + "," + Quoted("ResponseCode") + ":" + Quoted("Success") + "}"
             : "{" + Quoted("ResponseCode") + ":" + Quoted(responseCode) + "}";
+        string credentialAction = exitOnCredentialRequest
+            ? "exit 0"
+            : """
+              emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"GetAuthenticationCredentials\",\"Payload\":__CREDENTIAL__}"
+              """;
 
         // A non-interpolated raw string with tokens: the script is dense with braces, and
         // interpolation holes would be indistinguishable from JSON.
@@ -300,13 +394,14 @@ public sealed class PluginProtocolTests : IDisposable
                 GetOperationClaims)
                   emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"GetOperationClaims\",\"Payload\":{\"Claims\":[__CLAIMS__]}}" ;;
                 GetAuthenticationCredentials)
-                  emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"GetAuthenticationCredentials\",\"Payload\":__CREDENTIAL__}" ;;
+                  __AUTH_ACTION__ ;;
                 Close)
                   exit 0 ;;
               esac
             done
             """
             .Replace("__CLAIMS__", Quoted(claims))
+            .Replace("__AUTH_ACTION__", credentialAction)
             .Replace("__CREDENTIAL__", credentialPayload)
             .Replace("__PREAMBLE__", preamble ?? string.Empty);
 

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -233,7 +233,7 @@ internal sealed class PluginConnection : IAsyncDisposable
 
             return responsePayload?.Deserialize(responseType);
         }
-        catch (Exception ex) when (ex is TimeoutException or JsonException or IOException)
+        catch (Exception ex) when (IsRecoverableRequestFailure(ex))
         {
             _log?.Invoke($"Credential plugin request '{method}' failed: {ex.Message}");
             return null;
@@ -244,6 +244,17 @@ internal sealed class PluginConnection : IAsyncDisposable
             pending.Dispose();
         }
     }
+
+    internal static bool IsRecoverableRequestFailure(Exception exception) =>
+        exception switch
+        {
+            TimeoutException or JsonException or IOException => true,
+            // ObjectDisposedException is an InvalidOperationException, but keeping it explicit
+            // documents the closed-pipe race this boundary is intended to absorb.
+            ObjectDisposedException => true,
+            InvalidOperationException => true,
+            _ => false,
+        };
 
     private async Task WriteAsync<T>(Envelope<T> envelope, JsonTypeInfo<Envelope<T>> type, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
## Summary

- treat disposed plugin pipes and invalid process state as recoverable request failures
- return no credential so a later provider can answer or the feed can surface its normal 401
- preserve caller cancellation and unrelated faults
- document the request-boundary failure contract

## Tests

- a real protocol plugin exits during `GetAuthenticationCredentials` and the next provider answers
- a disposed connection reproduces the previously uncaught `ObjectDisposedException`
- exact exception classification includes `InvalidOperationException` but excludes cancellation
- restoring the old catch filter makes the disposed-connection regression fail

Closes #3544