### PR TITLE
Adapt union matching to .NET 11 preview 7

### DIFF
--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -193,6 +193,8 @@ public interface IMatchedPairFinding : IPairFinding
 /// inherits <typeparamref name="T"/> from the enclosing union. Pattern-match the union itself
 /// (<c>pair switch { PairFinding&lt;T&gt;.Added … }</c>, not <c>pair.Value switch</c>) for
 /// compiler-checked exhaustiveness; a fifth case then breaks the build rather than falling through.
+/// Union case patterns discriminate without binding; read the already-selected payload through
+/// <see cref="Value"/> when an arm needs the case value.
 /// </para>
 /// </summary>
 [Union]

--- a/src/ILInspector.Findings/FindingComparison.cs
+++ b/src/ILInspector.Findings/FindingComparison.cs
@@ -26,20 +26,20 @@ public sealed record FindingComparison<T> where T : notnull
 
     public FindingInspection<T> OldInspection => this switch
     {
-        Complete complete => complete.OldInspection,
-        Failed failed => failed.OldInspection,
+        Complete => ((Complete)Value).OldInspection,
+        Failed => ((Failed)Value).OldInspection,
     };
 
     public FindingInspection<T> NewInspection => this switch
     {
-        Complete complete => complete.NewInspection,
-        Failed failed => failed.NewInspection,
+        Complete => ((Complete)Value).NewInspection,
+        Failed => ((Failed)Value).NewInspection,
     };
 
     public string? Failure => this switch
     {
         Complete => null,
-        Failed failed => failed.Failure,
+        Failed => ((Failed)Value).Failure,
     };
 
     public bool IsExact => this is Complete { IsExact: true };
@@ -54,7 +54,7 @@ public sealed record FindingComparison<T> where T : notnull
         ArgumentNullException.ThrowIfNull(transform);
         var complete = this switch
         {
-            Complete value => value,
+            Complete => (Complete)Value,
             Failed => null,
         };
         if (complete is null)
@@ -156,9 +156,9 @@ public sealed record FindingComparison<T> where T : notnull
             get
             {
                 var failures = new List<string>(2);
-                if (OldInspection is FindingInspection<T>.Failed oldFailed)
+                if (OldInspection.Value is FindingInspection<T>.Failed oldFailed)
                     failures.Add($"old: {oldFailed.Error.Reason}");
-                if (NewInspection is FindingInspection<T>.Failed newFailed)
+                if (NewInspection.Value is FindingInspection<T>.Failed newFailed)
                     failures.Add($"new: {newFailed.Error.Reason}");
                 return string.Join("; ", failures);
             }
@@ -249,7 +249,8 @@ public static class FindingComparison
         where T : notnull
         => inspection switch
         {
-            FindingInspection<T>.Complete complete => complete.Findings,
+            FindingInspection<T>.Complete
+                => ((FindingInspection<T>.Complete)inspection.Value!).Findings,
             FindingInspection<T>.Absent => [],
             FindingInspection<T>.Failed => throw new InvalidOperationException(
                 "A failed inspection cannot be matched."),

--- a/src/ILInspector.Findings/FindingCorrelation.cs
+++ b/src/ILInspector.Findings/FindingCorrelation.cs
@@ -293,7 +293,8 @@ public sealed class FindingCorrelation<T>
         {
             switch (item.Inspection)
             {
-                case FindingInspection<T>.Complete complete:
+                case FindingInspection<T>.Complete:
+                    var complete = (FindingInspection<T>.Complete)item.Inspection.Value!;
                     var matches = complete.Findings.Where(key.Matches).Take(2).ToArray();
                     if (matches.Length > 1)
                     {
@@ -313,11 +314,13 @@ public sealed class FindingCorrelation<T>
                     }
                     break;
 
-                case FindingInspection<T>.Absent absent:
+                case FindingInspection<T>.Absent:
+                    var absent = (FindingInspection<T>.Absent)item.Inspection.Value!;
                     timeline.Add(new FindingCorrelationPoint<T>.SubjectAbsent(item.Version, absent.Detail));
                     break;
 
-                case FindingInspection<T>.Failed failed:
+                case FindingInspection<T>.Failed:
+                    var failed = (FindingInspection<T>.Failed)item.Inspection.Value!;
                     timeline.Add(new FindingCorrelationPoint<T>.Failed(item.Version, failed.Error));
                     break;
             }

--- a/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
@@ -274,7 +274,7 @@ public static partial class MetadataFindings
         var builder = ImmutableArray.CreateBuilder<PairFinding<T>>(pairs.Length);
         foreach (var pair in pairs)
         {
-            if (pair is PairFinding<T>.Present present
+            if (pair.Value is PairFinding<T>.Present present
                 && !(payloadsEqual?.Invoke(
                         present.Old.Payload,
                         present.New.Payload)

--- a/src/ILInspector.Research/UnsafetyFindingDiff.cs
+++ b/src/ILInspector.Research/UnsafetyFindingDiff.cs
@@ -89,11 +89,13 @@ internal static class UnsafetyFindingDiff
     {
         var complete = comparison switch
         {
-            FindingComparison<T>.Complete value => value,
+            FindingComparison<T>.Complete
+                => (FindingComparison<T>.Complete)comparison.Value,
             // Both producer inputs are total Complete censuses. A failed
             // comparison here would violate the Analysis producer contract.
-            FindingComparison<T>.Failed failed => throw new InvalidOperationException(
-                $"A comparison of total Analysis censuses cannot fail: {failed.Failure}"),
+            FindingComparison<T>.Failed => throw new InvalidOperationException(
+                $"A comparison of total Analysis censuses cannot fail: " +
+                $"{((FindingComparison<T>.Failed)comparison.Value).Failure}"),
         };
         var oldGroups = GroupProjections(complete.OldAtoms, memberKey, project);
         var newGroups = GroupProjections(complete.NewAtoms, memberKey, project);
@@ -104,10 +106,12 @@ internal static class UnsafetyFindingDiff
         {
             switch (pair)
             {
-                case PairFinding<T>.Added added:
+                case PairFinding<T>.Added:
+                    var added = (PairFinding<T>.Added)pair.Value!;
                     Increment(addedCounts, added.New.Key.IdentityKey);
                     break;
-                case PairFinding<T>.Removed removed:
+                case PairFinding<T>.Removed:
+                    var removed = (PairFinding<T>.Removed)pair.Value!;
                     Increment(removedCounts, removed.Old.Key.IdentityKey);
                     break;
             }

--- a/src/ILInspector.SourceLink/SourceLinkFindings.cs
+++ b/src/ILInspector.SourceLink/SourceLinkFindings.cs
@@ -325,7 +325,7 @@ public static class SourceLinkFindings
                 var builder = ImmutableArray.CreateBuilder<PairFinding<T>>(pairs.Length);
                 foreach (var pair in pairs)
                 {
-                    if (pair is PairFinding<T>.Present present
+                    if (pair.Value is PairFinding<T>.Present present
                         && !payloadsEqual(present.Old.Payload, present.New.Payload))
                     {
                         builder.Add(new PairFinding<T>.Changed(

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -1588,7 +1588,7 @@ public class DiffCommand
             toTransitionRow)
         where T : notnull
     {
-        if (retained.Comparison is FindingComparison<T>.Failed failed)
+        if (retained.Comparison.Value is FindingComparison<T>.Failed failed)
         {
             yield return new FindingTransitionRow(
                 "FindingComparison.Failed",
@@ -1604,7 +1604,8 @@ public class DiffCommand
 
         var complete = retained.Comparison switch
         {
-            FindingComparison<T>.Complete value => value,
+            FindingComparison<T>.Complete
+                => (FindingComparison<T>.Complete)retained.Comparison.Value,
             FindingComparison<T>.Failed => throw new InvalidOperationException(
                 "Failed comparisons are handled before completed comparisons."),
         };
@@ -1648,7 +1649,8 @@ public class DiffCommand
         where T : notnull
         => comparison switch
         {
-            FindingComparison<T>.Complete complete => complete.Pairs,
+            FindingComparison<T>.Complete
+                => ((FindingComparison<T>.Complete)comparison.Value).Pairs,
             FindingComparison<T>.Failed => throw new InvalidOperationException("Finding comparison did not complete."),
         };
 
@@ -1840,19 +1842,19 @@ public class DiffCommand
         => pair switch
         {
             PairFinding<T>.Added => null,
-            PairFinding<T>.Removed removed => removed.Old,
-            PairFinding<T>.Present present => present.Old,
-            PairFinding<T>.Changed changed => changed.Old,
+            PairFinding<T>.Removed => ((PairFinding<T>.Removed)pair.Value!).Old,
+            PairFinding<T>.Present => ((PairFinding<T>.Present)pair.Value!).Old,
+            PairFinding<T>.Changed => ((PairFinding<T>.Changed)pair.Value!).Old,
         };
 
     static Finding<T>? NewSide<T>(PairFinding<T> pair)
         where T : notnull
         => pair switch
         {
-            PairFinding<T>.Added added => added.New,
+            PairFinding<T>.Added => ((PairFinding<T>.Added)pair.Value!).New,
             PairFinding<T>.Removed => null,
-            PairFinding<T>.Present present => present.New,
-            PairFinding<T>.Changed changed => changed.New,
+            PairFinding<T>.Present => ((PairFinding<T>.Present)pair.Value!).New,
+            PairFinding<T>.Changed => ((PairFinding<T>.Changed)pair.Value!).New,
         };
 
     internal static ApiDiff FilterApiDiffByMemberTargets(ApiDiff diff, ApiSurface fromSurface, ApiSurface toSurface, DiffOptions options)

--- a/src/dotnet-inspect/Commands/TimelineCommand.cs
+++ b/src/dotnet-inspect/Commands/TimelineCommand.cs
@@ -378,8 +378,8 @@ public static class TimelineCommand
         Func<IEnumerable<T>, IEnumerable<T>, FindingSubject, int, FindingComparison<T>> compare)
         where T : notnull
     {
-        if (oldInspection is FindingInspection<T>.Complete oldComplete
-            && newInspection is FindingInspection<T>.Complete newComplete)
+        if (oldInspection.Value is FindingInspection<T>.Complete oldComplete
+            && newInspection.Value is FindingInspection<T>.Complete newComplete)
         {
             return compare(
                 oldComplete.Findings.Select(static finding => finding.Payload),
@@ -643,24 +643,24 @@ public static class TimelineCommand
         where T : notnull
         => evaluation.Inspection switch
         {
-            FindingInspection<T>.Complete complete => new TimelineEvaluationRow(
+            FindingInspection<T>.Complete => new TimelineEvaluationRow(
                 evaluation.Version.Key,
                 evaluation.Version.Display,
                 "Complete",
-                complete.Findings.Length,
+                ((FindingInspection<T>.Complete)evaluation.Inspection.Value!).Findings.Length,
                 null),
-            FindingInspection<T>.Absent absent => new TimelineEvaluationRow(
+            FindingInspection<T>.Absent => new TimelineEvaluationRow(
                 evaluation.Version.Key,
                 evaluation.Version.Display,
                 "SubjectAbsent",
                 0,
-                absent.Detail),
-            FindingInspection<T>.Failed failed => new TimelineEvaluationRow(
+                ((FindingInspection<T>.Absent)evaluation.Inspection.Value!).Detail),
+            FindingInspection<T>.Failed => new TimelineEvaluationRow(
                 evaluation.Version.Key,
                 evaluation.Version.Display,
                 "Failed",
                 null,
-                failed.Error.Reason),
+                ((FindingInspection<T>.Failed)evaluation.Inspection.Value!).Error.Reason),
         };
 
     static TimelineEvaluationRow BuildIdentityEvaluationRow<T>(

--- a/src/dotnet-inspect/Models/FindingInspectionExtensions.cs
+++ b/src/dotnet-inspect/Models/FindingInspectionExtensions.cs
@@ -11,10 +11,13 @@ internal static class FindingInspectionExtensions
         => inspection switch
         {
             null => [],
-            FindingInspection<T>.Complete complete => complete.Findings,
+            FindingInspection<T>.Complete
+                => ((FindingInspection<T>.Complete)inspection.Value!).Findings,
             FindingInspection<T>.Absent => [],
-            FindingInspection<T>.Failed failed => throw new InvalidOperationException(
-                $"Finding inspection failed for {failed.Error.Subject.Display}: {failed.Error.Reason}"),
+            FindingInspection<T>.Failed => throw new InvalidOperationException(
+                $"Finding inspection failed for " +
+                $"{((FindingInspection<T>.Failed)inspection.Value!).Error.Subject.Display}: " +
+                $"{((FindingInspection<T>.Failed)inspection.Value!).Error.Reason}"),
         };
 
     public static IEnumerable<T> Payloads<T>(
@@ -30,21 +33,21 @@ internal static class FindingInspectionExtensions
     public static int FindingCount<T>(
         this FindingInspection<T>? inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection?.Value is FindingInspection<T>.Complete complete
             ? complete.Findings.Length
             : 0;
 
     public static IEnumerable<T> PayloadsForRendering<T>(
         this FindingInspection<T>? inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection?.Value is FindingInspection<T>.Complete complete
             ? complete.Findings.Select(static finding => finding.Payload)
             : [];
 
     public static InspectionError? Failure<T>(
         this FindingInspection<T>? inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Failed failed ? failed.Error : null;
+        => inspection?.Value is FindingInspection<T>.Failed failed ? failed.Error : null;
 
     public static bool CanRenderWithPresence<T>(
         this FindingInspection<T>? inspection,

--- a/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
@@ -267,13 +267,13 @@ public sealed class MetadataExtensionFindingsTests
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection.Value is FindingInspection<T>.Complete complete
             ? complete.Findings
             : throw new Xunit.Sdk.XunitException($"Expected complete inspection: {inspection}");
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected complete comparison: {comparison.Failure}");
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
@@ -675,7 +675,7 @@ public class MetadataFindingsTests
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected a complete comparison; failure: {comparison.Failure}");
 

--- a/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
@@ -220,13 +220,13 @@ public sealed class MetadataInventoryFindingsTests
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection.Value is FindingInspection<T>.Complete complete
             ? complete.Findings
             : throw new Xunit.Sdk.XunitException("Expected a complete inventory inspection.");
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected a complete comparison: {comparison.Failure}");
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataMethodFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataMethodFindingsTests.cs
@@ -199,13 +199,13 @@ public sealed class MetadataMethodFindingsTests
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection.Value is FindingInspection<T>.Complete complete
             ? complete.Findings
             : throw new Xunit.Sdk.XunitException($"Expected complete inspection: {inspection}");
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected complete comparison: {comparison.Failure}");
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataSemanticFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataSemanticFindingsTests.cs
@@ -148,13 +148,13 @@ public sealed class MetadataSemanticFindingsTests
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection.Value is FindingInspection<T>.Complete complete
             ? complete.Findings
             : throw new Xunit.Sdk.XunitException("Expected a complete semantic inspection.");
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected a complete comparison: {comparison.Failure}");
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
@@ -999,13 +999,13 @@ public sealed class MetadataSourceFindingsTests
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection.Value is FindingInspection<T>.Complete complete
             ? complete.Findings
             : throw new Xunit.Sdk.XunitException("Expected a complete PDB inspection.");
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected a complete comparison: {comparison.Failure}");
 }


### PR DESCRIPTION
## Summary

Restore clean builds under .NET SDK `11.0.100-preview.7.26381.103`, which rejects variable declarations inside union matching with CS8780.

- keep switch expressions exhaustive by matching each union case without a designation
- read the case payload from `Value` only after the compiler-selected case
- use `Value is Case value` for non-exhaustive tests that need the payload
- update Finding consumers and test helpers reached by the clean solution build

This preserves the existing Finding outcome and transition behavior; it changes only how case payloads are bound under the preview 7 union-matching rules. It does not pin or otherwise change SDK selection.

Closes #4039.

## Validation

Using exact SDK `11.0.100-preview.7.26381.103`:

- clean `dotnet build dotnet-inspect.slnx -c Release --no-restore` — 0 warnings, 0 errors
- `dotnet build src/dotnet-inspect -c Release -p:DefaultTargetFramework=net10.0 -p:PublishAot=false` — 0 warnings, 0 errors
- `dotnet run --no-build --project src/ILInspector.Instructions.Tests -c Release` — 243 passed
- `dotnet run --no-build --project tests/ILInspector.Metadata.Tests -c Release` — 1,353 passed
- `dotnet run --no-build --project src/ILInspector.Research.Tests -c Release` — 157 passed
- `dotnet run --no-build --project src/dotnet-inspect.Tests -c Release` — 3,388 total, 0 failed, 14 environment/platform skips
