### PR TITLE
Pin CI to .NET 11 Preview 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ on:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  # Preview 7 breaks the repository's union-enabled C# sources (#4042).
+  # Keep CI on the last known-good preview until the compiler-shape fix lands.
+  DOTNET_SDK_VERSION: '11.0.100-preview.6.26359.118'
 
 # Cancel superseded PR runs (e.g. when an agent pushes again to the same branch)
 # so only the latest commit of a PR consumes a full CI run. Pushes to main are
@@ -71,7 +74,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '11.0.x'
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
       # Trend rows are reproducible evidence only when their recorded commit
       # landed on main and its source declared the recorded methodology. This
@@ -558,8 +561,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
@@ -735,8 +737,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
@@ -815,8 +816,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
@@ -887,8 +887,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
       # Caches packages only. Do not add build outputs (artifacts/, bin/, obj/)
       # here. The completeness check compares a discovery listing against XML
@@ -1008,8 +1007,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
@@ -1109,8 +1107,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
       - name: Cache NuGet packages
         uses: actions/cache@v4
@@ -1213,8 +1210,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
       - name: Pack pointer package
         # SelfContained=true forces the pack TFM segment to 'any', so the pointer


### PR DESCRIPTION
## Change

**Conclusion:** Pin every `ci.yml` SDK setup to `11.0.100-preview.6.26359.118`, the exact SDK selected by the last green run before the Preview 7 channel rollover. This restores CI while preserving the complete existing test matrix.

Fixes #4042.

## Stack

Slice 1 of 2. This PR is the temporary CI unblock and targets `main`. The next slice will update union-dependent source and decompiler coverage for Preview 7, then remove this pin.

## Evidence

- Last green setup: `11.0.100-preview.6.26359.118` in run 31518285396.
- First failing setup: `11.0.100-preview.7.26381.103` in run 31522966636.
- The workflow YAML parses successfully and all eight `ci.yml` setup steps use the single exact SDK value.