### PR TITLE
Adapt union matching for .NET 11 preview 7

### DIFF
--- a/src/ILInspector.Findings/Finding.cs
+++ b/src/ILInspector.Findings/Finding.cs
@@ -190,9 +190,9 @@ public interface IMatchedPairFinding : IPairFinding
 /// <para>
 /// The cases are <em>nested</em> so their four otherwise-generic names stay scoped to the union
 /// (<c>PairFinding&lt;T&gt;.Present</c>) rather than claiming the producer-facing namespace, and each
-/// inherits <typeparamref name="T"/> from the enclosing union. Pattern-match the union itself
-/// (<c>pair switch { PairFinding&lt;T&gt;.Added … }</c>, not <c>pair.Value switch</c>) for
-/// compiler-checked exhaustiveness; a fifth case then breaks the build rather than falling through.
+/// inherits <typeparamref name="T"/> from the enclosing union. Prefer matching the union itself for
+/// compiler-checked exhaustiveness. Where the preview compiler rejects a declaration binding with
+/// CS8780, match <c>Value</c> and include an explicit throwing arm for an unexpected case.
 /// </para>
 /// </summary>
 [Union]

--- a/src/ILInspector.Findings/FindingComparison.cs
+++ b/src/ILInspector.Findings/FindingComparison.cs
@@ -24,25 +24,28 @@ public sealed record FindingComparison<T> where T : notnull
 
     public object Value { get; }
 
-    public FindingInspection<T> OldInspection => this switch
+    public FindingInspection<T> OldInspection => Value switch
     {
         Complete complete => complete.OldInspection,
         Failed failed => failed.OldInspection,
+        _ => throw new InvalidOperationException("Unexpected finding comparison case."),
     };
 
-    public FindingInspection<T> NewInspection => this switch
+    public FindingInspection<T> NewInspection => Value switch
     {
         Complete complete => complete.NewInspection,
         Failed failed => failed.NewInspection,
+        _ => throw new InvalidOperationException("Unexpected finding comparison case."),
     };
 
-    public string? Failure => this switch
+    public string? Failure => Value switch
     {
         Complete => null,
         Failed failed => failed.Failure,
+        _ => throw new InvalidOperationException("Unexpected finding comparison case."),
     };
 
-    public bool IsExact => this is Complete { IsExact: true };
+    public bool IsExact => Value is Complete { IsExact: true };
 
     /// <summary>
     /// Applies producer-owned classification to a completed comparison while preserving the
@@ -52,10 +55,11 @@ public sealed record FindingComparison<T> where T : notnull
         Func<ImmutableArray<PairFinding<T>>, ImmutableArray<PairFinding<T>>> transform)
     {
         ArgumentNullException.ThrowIfNull(transform);
-        var complete = this switch
+        var complete = Value switch
         {
             Complete value => value,
             Failed => null,
+            _ => throw new InvalidOperationException("Unexpected finding comparison case."),
         };
         if (complete is null)
             return this;
@@ -156,9 +160,9 @@ public sealed record FindingComparison<T> where T : notnull
             get
             {
                 var failures = new List<string>(2);
-                if (OldInspection is FindingInspection<T>.Failed oldFailed)
+                if (OldInspection.Value is FindingInspection<T>.Failed oldFailed)
                     failures.Add($"old: {oldFailed.Error.Reason}");
-                if (NewInspection is FindingInspection<T>.Failed newFailed)
+                if (NewInspection.Value is FindingInspection<T>.Failed newFailed)
                     failures.Add($"new: {newFailed.Error.Reason}");
                 return string.Join("; ", failures);
             }
@@ -168,7 +172,7 @@ public sealed record FindingComparison<T> where T : notnull
     static bool SameInspectionState(
         FindingInspection<T> oldInspection,
         FindingInspection<T> newInspection)
-        => (oldInspection, newInspection) switch
+        => (oldInspection.Value, newInspection.Value) switch
         {
             (FindingInspection<T>.Complete, FindingInspection<T>.Complete) => true,
             (FindingInspection<T>.Absent, FindingInspection<T>.Absent) => true,
@@ -247,11 +251,12 @@ public static class FindingComparison
     internal static ImmutableArray<Finding<T>> InspectionAtoms<T>(
         FindingInspection<T> inspection)
         where T : notnull
-        => inspection switch
+        => inspection.Value switch
         {
             FindingInspection<T>.Complete complete => complete.Findings,
             FindingInspection<T>.Absent => [],
             FindingInspection<T>.Failed => throw new InvalidOperationException(
                 "A failed inspection cannot be matched."),
+            _ => throw new InvalidOperationException("Unexpected finding inspection case."),
         };
 }

--- a/src/ILInspector.Findings/FindingCorrelation.cs
+++ b/src/ILInspector.Findings/FindingCorrelation.cs
@@ -291,7 +291,7 @@ public sealed class FindingCorrelation<T>
 
         foreach (var item in ordered)
         {
-            switch (item.Inspection)
+            switch (item.Inspection.Value)
             {
                 case FindingInspection<T>.Complete complete:
                     var matches = complete.Findings.Where(key.Matches).Take(2).ToArray();

--- a/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
+++ b/src/ILInspector.Metadata/MetadataFindings.Inventory.cs
@@ -274,7 +274,7 @@ public static partial class MetadataFindings
         var builder = ImmutableArray.CreateBuilder<PairFinding<T>>(pairs.Length);
         foreach (var pair in pairs)
         {
-            if (pair is PairFinding<T>.Present present
+            if (pair.Value is PairFinding<T>.Present present
                 && !(payloadsEqual?.Invoke(
                         present.Old.Payload,
                         present.New.Payload)

--- a/src/ILInspector.Research/UnsafetyFindingDiff.cs
+++ b/src/ILInspector.Research/UnsafetyFindingDiff.cs
@@ -87,13 +87,14 @@ internal static class UnsafetyFindingDiff
         Func<T, SafetyProjection> project)
         where T : notnull
     {
-        var complete = comparison switch
+        var complete = comparison.Value switch
         {
             FindingComparison<T>.Complete value => value,
             // Both producer inputs are total Complete censuses. A failed
             // comparison here would violate the Analysis producer contract.
             FindingComparison<T>.Failed failed => throw new InvalidOperationException(
                 $"A comparison of total Analysis censuses cannot fail: {failed.Failure}"),
+            _ => throw new InvalidOperationException("Unexpected finding comparison case."),
         };
         var oldGroups = GroupProjections(complete.OldAtoms, memberKey, project);
         var newGroups = GroupProjections(complete.NewAtoms, memberKey, project);
@@ -102,7 +103,7 @@ internal static class UnsafetyFindingDiff
 
         foreach (var pair in complete.Pairs)
         {
-            switch (pair)
+            switch (pair.Value)
             {
                 case PairFinding<T>.Added added:
                     Increment(addedCounts, added.New.Key.IdentityKey);

--- a/src/ILInspector.SourceLink/SourceLinkFindings.cs
+++ b/src/ILInspector.SourceLink/SourceLinkFindings.cs
@@ -325,7 +325,7 @@ public static class SourceLinkFindings
                 var builder = ImmutableArray.CreateBuilder<PairFinding<T>>(pairs.Length);
                 foreach (var pair in pairs)
                 {
-                    if (pair is PairFinding<T>.Present present
+                    if (pair.Value is PairFinding<T>.Present present
                         && !payloadsEqual(present.Old.Payload, present.New.Payload))
                     {
                         builder.Add(new PairFinding<T>.Changed(

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -1588,7 +1588,7 @@ public class DiffCommand
             toTransitionRow)
         where T : notnull
     {
-        if (retained.Comparison is FindingComparison<T>.Failed failed)
+        if (retained.Comparison.Value is FindingComparison<T>.Failed failed)
         {
             yield return new FindingTransitionRow(
                 "FindingComparison.Failed",
@@ -1602,11 +1602,12 @@ public class DiffCommand
             yield break;
         }
 
-        var complete = retained.Comparison switch
+        var complete = retained.Comparison.Value switch
         {
             FindingComparison<T>.Complete value => value,
             FindingComparison<T>.Failed => throw new InvalidOperationException(
                 "Failed comparisons are handled before completed comparisons."),
+            _ => throw new InvalidOperationException("Unexpected finding comparison case."),
         };
         if (complete.Pairs.IsEmpty)
         {
@@ -1637,19 +1638,21 @@ public class DiffCommand
 
     static string InspectionState<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection switch
+        => inspection.Value switch
         {
             FindingInspection<T>.Complete => "complete",
             FindingInspection<T>.Absent => "absent",
             FindingInspection<T>.Failed => "failed",
+            _ => throw new InvalidOperationException("Unexpected finding inspection case."),
         };
 
     static IReadOnlyList<PairFinding<T>> CompletePairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison switch
+        => comparison.Value switch
         {
             FindingComparison<T>.Complete complete => complete.Pairs,
             FindingComparison<T>.Failed => throw new InvalidOperationException("Finding comparison did not complete."),
+            _ => throw new InvalidOperationException("Unexpected finding comparison case."),
         };
 
     static bool MatchesMemberPair(
@@ -1837,22 +1840,24 @@ public class DiffCommand
 
     static Finding<T>? OldSide<T>(PairFinding<T> pair)
         where T : notnull
-        => pair switch
+        => pair.Value switch
         {
             PairFinding<T>.Added => null,
             PairFinding<T>.Removed removed => removed.Old,
             PairFinding<T>.Present present => present.Old,
             PairFinding<T>.Changed changed => changed.Old,
+            _ => throw new InvalidOperationException("Unexpected pair finding case."),
         };
 
     static Finding<T>? NewSide<T>(PairFinding<T> pair)
         where T : notnull
-        => pair switch
+        => pair.Value switch
         {
             PairFinding<T>.Added added => added.New,
             PairFinding<T>.Removed => null,
             PairFinding<T>.Present present => present.New,
             PairFinding<T>.Changed changed => changed.New,
+            _ => throw new InvalidOperationException("Unexpected pair finding case."),
         };
 
     internal static ApiDiff FilterApiDiffByMemberTargets(ApiDiff diff, ApiSurface fromSurface, ApiSurface toSurface, DiffOptions options)

--- a/src/dotnet-inspect/Commands/TimelineCommand.cs
+++ b/src/dotnet-inspect/Commands/TimelineCommand.cs
@@ -378,8 +378,8 @@ public static class TimelineCommand
         Func<IEnumerable<T>, IEnumerable<T>, FindingSubject, int, FindingComparison<T>> compare)
         where T : notnull
     {
-        if (oldInspection is FindingInspection<T>.Complete oldComplete
-            && newInspection is FindingInspection<T>.Complete newComplete)
+        if (oldInspection.Value is FindingInspection<T>.Complete oldComplete
+            && newInspection.Value is FindingInspection<T>.Complete newComplete)
         {
             return compare(
                 oldComplete.Findings.Select(static finding => finding.Payload),
@@ -641,7 +641,7 @@ public static class TimelineCommand
     static TimelineEvaluationRow BuildCensusEvaluationRow<T>(
         VersionedFindingInspection<T> evaluation)
         where T : notnull
-        => evaluation.Inspection switch
+        => evaluation.Inspection.Value switch
         {
             FindingInspection<T>.Complete complete => new TimelineEvaluationRow(
                 evaluation.Version.Key,
@@ -661,6 +661,7 @@ public static class TimelineCommand
                 "Failed",
                 null,
                 failed.Error.Reason),
+            _ => throw new InvalidOperationException("Unexpected finding inspection case."),
         };
 
     static TimelineEvaluationRow BuildIdentityEvaluationRow<T>(

--- a/src/dotnet-inspect/Models/FindingInspectionExtensions.cs
+++ b/src/dotnet-inspect/Models/FindingInspectionExtensions.cs
@@ -8,13 +8,14 @@ internal static class FindingInspectionExtensions
     public static ImmutableArray<Finding<T>> Findings<T>(
         this FindingInspection<T>? inspection)
         where T : notnull
-        => inspection switch
+        => inspection?.Value switch
         {
             null => [],
             FindingInspection<T>.Complete complete => complete.Findings,
             FindingInspection<T>.Absent => [],
             FindingInspection<T>.Failed failed => throw new InvalidOperationException(
                 $"Finding inspection failed for {failed.Error.Subject.Display}: {failed.Error.Reason}"),
+            _ => throw new InvalidOperationException("Unexpected finding inspection case."),
         };
 
     public static IEnumerable<T> Payloads<T>(
@@ -25,32 +26,32 @@ internal static class FindingInspectionExtensions
     public static bool HasFindings<T>(
         this FindingInspection<T>? inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete { Findings.Length: > 0 };
+        => inspection?.Value is FindingInspection<T>.Complete { Findings.Length: > 0 };
 
     public static int FindingCount<T>(
         this FindingInspection<T>? inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection?.Value is FindingInspection<T>.Complete complete
             ? complete.Findings.Length
             : 0;
 
     public static IEnumerable<T> PayloadsForRendering<T>(
         this FindingInspection<T>? inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection?.Value is FindingInspection<T>.Complete complete
             ? complete.Findings.Select(static finding => finding.Payload)
             : [];
 
     public static InspectionError? Failure<T>(
         this FindingInspection<T>? inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Failed failed ? failed.Error : null;
+        => inspection?.Value is FindingInspection<T>.Failed failed ? failed.Error : null;
 
     public static bool CanRenderWithPresence<T>(
         this FindingInspection<T>? inspection,
         bool hasPresence)
         where T : notnull
-        => inspection is FindingInspection<T>.Failed
+        => inspection?.Value is FindingInspection<T>.Failed
             ? false
             : inspection.HasFindings() || hasPresence;
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataExtensionFindingsTests.cs
@@ -267,13 +267,13 @@ public sealed class MetadataExtensionFindingsTests
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection.Value is FindingInspection<T>.Complete complete
             ? complete.Findings
             : throw new Xunit.Sdk.XunitException($"Expected complete inspection: {inspection}");
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected complete comparison: {comparison.Failure}");
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataFindingsTests.cs
@@ -675,7 +675,7 @@ public class MetadataFindingsTests
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected a complete comparison; failure: {comparison.Failure}");
 
@@ -684,7 +684,7 @@ public class MetadataFindingsTests
         PairKind kind)
         => Pairs(comparison)
             .Where(pair => pair.Kind == kind)
-            .Select(pair => pair switch
+            .Select(pair => pair.Value switch
             {
                 PairFinding<ApiMemberHandle>.Added added => added.New.Key.IdentityKey,
                 PairFinding<ApiMemberHandle>.Removed removed => removed.Old.Key.IdentityKey,

--- a/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataInventoryFindingsTests.cs
@@ -220,13 +220,13 @@ public sealed class MetadataInventoryFindingsTests
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection.Value is FindingInspection<T>.Complete complete
             ? complete.Findings
             : throw new Xunit.Sdk.XunitException("Expected a complete inventory inspection.");
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected a complete comparison: {comparison.Failure}");
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataMethodFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataMethodFindingsTests.cs
@@ -199,13 +199,13 @@ public sealed class MetadataMethodFindingsTests
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection.Value is FindingInspection<T>.Complete complete
             ? complete.Findings
             : throw new Xunit.Sdk.XunitException($"Expected complete inspection: {inspection}");
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected complete comparison: {comparison.Failure}");
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataSemanticFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataSemanticFindingsTests.cs
@@ -148,13 +148,13 @@ public sealed class MetadataSemanticFindingsTests
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection.Value is FindingInspection<T>.Complete complete
             ? complete.Findings
             : throw new Xunit.Sdk.XunitException("Expected a complete semantic inspection.");
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected a complete comparison: {comparison.Failure}");
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataSourceFindingsTests.cs
@@ -999,13 +999,13 @@ public sealed class MetadataSourceFindingsTests
 
     static ImmutableArray<Finding<T>> Findings<T>(FindingInspection<T> inspection)
         where T : notnull
-        => inspection is FindingInspection<T>.Complete complete
+        => inspection.Value is FindingInspection<T>.Complete complete
             ? complete.Findings
             : throw new Xunit.Sdk.XunitException("Expected a complete PDB inspection.");
 
     static ImmutableArray<PairFinding<T>> Pairs<T>(FindingComparison<T> comparison)
         where T : notnull
-        => comparison is FindingComparison<T>.Complete complete
+        => comparison.Value is FindingComparison<T>.Complete complete
             ? complete.Pairs
             : throw new Xunit.Sdk.XunitException($"Expected a complete comparison: {comparison.Failure}");
 }


### PR DESCRIPTION
## Change

**Conclusion: PASS** — .NET 11 SDK preview 7 no longer blocks every
code-touching PR with CS8780.

Preview 7 began applying native union-matching semantics to the repository's
existing `[Union]` wrappers. Declaration bindings at some cross-assembly sites
were rejected as matching either the wrapper or its stored value. Match those
sites through the existing `Value` property instead, preserving the same case
payloads. Switch expressions over `object` add explicit throwing arms so
impossible wrapper state remains visible rather than becoming a fallback.

This is a compiler-compatibility adaptation only. It does not change union case
construction, public contracts, Finding comparison semantics, rendering, or
SDK selection; workflows continue tracking `11.0.x`.

## Evidence

- Reproduced cleanly on `main` with `11.0.100-preview.7.26381.103`: 12 CS8780
  errors in `ILInspector.Findings`, then downstream errors as compilation
  advanced.
- Prior green PR CI used `11.0.100-preview.6.26359.118`; the replacement run
  selected preview 7 and every compile lane failed.
- Preview 7 Release solution rebuild: pass, zero warnings/errors.
- Instructions: 243/243.
- Metadata: 1,353/1,353.
- Research: 157/157.
- CLI fast: 2,421 passed, 2 environment skips.

## Non-action boundary

The native-union compiler behavior remains preview. This change does not pin
the language or SDK, redesign the hand-authored unions, or alter direct wrapper
matching at sites preview 7 still accepts.
