### PR TITLE
Ignore local Claude state recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -482,7 +482,8 @@ $RECYCLE.BIN/
 *.swp
 *.nettrace
 *.speedscope.json
-.claude/worktrees/
+**/.claude/settings.local.json
+**/.claude/worktrees/
 
 # Local development worktrees (AGENTS.md: all work happens in worktrees)
 .worktrees/


### PR DESCRIPTION
Ignore Claude local settings and generated worktree state at the repository root and in nested linked worktrees.

This keeps tracked `.claude` instructions and skills visible while preventing machine-local state from appearing as untracked content.

Validation: `git check-ignore` with global excludes disabled confirms both patterns at root and nested paths.