### PR TITLE
Clarify user-directed adversarial review sequencing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,22 @@ Keep the peer-checkout `ProjectReference` edits local and unpushed. After
 Markout lands and releases, restore `PackageReference` and only then raise the
 dotnet-inspect PR.
 
+## User-directed workflow adjustments
+
+The workflow gates in this file establish the default safe sequencing. A user
+may explicitly adjust a process gate for a specific task or PR in the interests
+of speed, including directing work that normally waits on another step to run
+in parallel. Follow that direction rather than refusing solely because the
+default is described as a gate, and preserve every requirement the user did not
+adjust.
+
+An adjustment changes sequencing, not evidence. Record the scope of the
+adjustment and any consequence for what the result proves. Work tied to an
+exact head remains valid only for that head; if parallel validation or a later
+change moves it, apply the fixed-head rules to the new head. A user-directed
+adjustment does not turn failed validation into success or make an unmergeable
+change ready to merge.
+
 ## Before changing files
 
 - `main` is protected. Keep the primary repository checkout attached to
@@ -424,7 +440,14 @@ npx markdownlint-cli <file>
 conflicts. For changes other than documentation-only PRs, it must also be green
 on every check that runs for it — and for a stacked PR, every layer must meet
 the conditions that apply to it.** This is a gate, not a preference: hold the
-round until that state clears.
+round until that state clears unless the user explicitly adjusts the sequencing
+under [User-directed workflow adjustments](#user-directed-workflow-adjustments).
+
+In particular, an explicit user direction to run adversarial review in parallel
+with CI overrides the wait-for-green sequencing requirement. Do not refuse that
+direction because this section calls the default a gate. The review still
+applies only to its exact head, and CI must still pass before the change is
+ready to merge.
 
 Documentation-only PRs covered by the Markdown-only validation rule above are
 the exception to the CI portion of this gate. Their only validation is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,18 +420,25 @@ npx markdownlint-cli <file>
 
 ### Do not start a round until the branch is settled
 
-**A review round does not begin until the PR is stable, free of merge conflicts,
-and green on every check that runs for it — and for a stacked PR, until every
-layer is.** This is a gate, not a preference: hold the round until that state
-clears.
+**A review round does not begin until the PR is stable and free of merge
+conflicts. For changes other than documentation-only PRs, it must also be green
+on every check that runs for it — and for a stacked PR, every layer must meet
+the conditions that apply to it.** This is a gate, not a preference: hold the
+round until that state clears.
+
+Documentation-only PRs covered by the Markdown-only validation rule above are
+the exception to the CI portion of this gate. Their only validation is
+Markdown linting, and waiting for that check to complete is orthogonal to
+adversarial review. Once the exact head is settled and conflict-free, its round
+may start while linting is pending; lint must still pass before merge.
 
 Adversarial review is the scarcest resource in this workflow — several models, a
 self-contained prompt, isolated worktrees, real runs. A branch whose head is
-unpushed or still moving, whose base is stale, whose CI is red, or whose PR
-reports a conflict has no single answer to "what am I reviewing?", so every
-finding it produces is provisional and every clean result is worthless. Reach
-this state before the first round, and reach it again before every subsequent
-round:
+unpushed or still moving, whose base is stale, whose required review-gating CI
+is red, or whose PR reports a conflict has no single answer to "what am I
+reviewing?", so every finding it produces is provisional and every clean result
+is worthless. Reach this state before the first round, and reach it again before
+every subsequent round:
 
 - **The head is pushed, named, and settled.** Reviewers get an exact base and
   head, not a branch that moves under them. Finish your own edits first.
@@ -442,8 +449,9 @@ round:
   where the resolution is itself unreviewed. Once the reviews *are* clean, this
   reverses: see [Clean reviews are not spent by main
   moving](#clean-reviews-are-not-spent-by-main-moving).
-- **The PR is mergeable and green** — two questions, one consolidated status
-  query. Use a single `gh api graphql` request that returns the PR's
+- **For changes other than documentation-only PRs, the PR is mergeable and
+  green** — two questions, one consolidated status query. Use a single
+  `gh api graphql` request that returns the PR's
   `headRefOid`, `mergeable`, `mergeStateStatus`, `statusCheckRollup` state and
   contexts with `pageInfo`, and the query's `rateLimit` cost, remaining quota,
   and reset time. Request enough contexts for the normal check matrix; if
@@ -481,18 +489,20 @@ round:
   yield until its reported reset time rather than sleeping or continuing to
   query. These intervals are minimums, not targets: wait longer when no
   decision depends on an immediate result.
-- **Every PR in a stack meets all of the above**, not only the slice under
-  review — a red or conflicted parent is a red or conflicted base for everything
-  above it. A slice rebases onto its parent, never onto `main`: only the stack's
-  bottom open slice takes `origin/main` as its base, and rebasing an upper slice
-  onto `main` pulls in work its parent has not landed and makes the slice's diff
-  report its parent's changes as its own. `ci.yml` applies no base-branch
-  filter, so every slice schedules the same CI wherever it targets; a slice
-  reporting *no* checks is therefore not green. Re-query after the registration
-  window, following the status-discovery cadence above, and verify the current
-  head; if no matching workflow run appears, that is a scheduling bug to
-  investigate, since a PR that triggers no workflow leaves `ci-required`
-  nothing to block on and displays as MERGEABLE and CLEAN (#3706).
+- **Every PR in a stack meets the applicable conditions above**, not only the
+  slice under review — a conflicted parent, or a non-documentation parent with
+  red CI, is an unsettled base for everything above it. A slice rebases onto its
+  parent, never onto `main`: only the stack's bottom open slice takes
+  `origin/main` as its base, and rebasing an upper slice onto `main` pulls in
+  work its parent has not landed and makes the slice's diff report its parent's
+  changes as its own. `ci.yml` applies no base-branch filter, so every
+  non-documentation slice schedules the same CI wherever it targets; a
+  non-documentation slice reporting *no* checks is therefore not green.
+  Re-query after the registration window, following the status-discovery
+  cadence above, and verify the current head; if no matching workflow run
+  appears, that is a scheduling bug to investigate, since a PR that triggers no
+  workflow leaves `ci-required` nothing to block on and displays as MERGEABLE
+  and CLEAN (#3706).
 
 Do not integrate main under a reviewer mid-read. When integration is what moved
 the head, say so on the PR and name the merge commit, so the re-review reads as
@@ -681,7 +691,8 @@ until it is unreviewable, and over parallel PRs that race in the same files.
   slice above. Use `--force-with-lease`, restack only your own slices, and post
   a `range-diff` proving the restack changed the base and nothing else.
 - **Review depth is per-slice, by that slice's own risk**, not the stack's size.
-- **Green and mergeable is checked stack-wide, before any slice's round** — see
+- **Review readiness is checked stack-wide before any slice's round**, using
+  the documentation-only CI exception where applicable — see
   [Adversarial review](#adversarial-review).
 - **A moved head — including one moved by a restack — needs a clean round at
   the new head**, and a restack never retires an open finding.


### PR DESCRIPTION
## Summary

- Treat repository workflow gates as default safe sequencing that users may explicitly adjust for a specific task or PR.
- State that user-directed adversarial review may run in parallel with CI rather than waiting for green checks.
- Keep review evidence tied to the exact reviewed head, and preserve validation and merge-readiness requirements.
- Exempt documentation-only PRs from waiting on Markdown lint before adversarial review by default.

## Validation

- `npx markdownlint-cli AGENTS.md`

## Non-action boundary

A sequencing adjustment does not turn failed validation into success, carry review across a moved head, or make an unmergeable change ready to merge.