### PR TITLE
Defer credential plugin discovery until authentication is needed

### DIFF
--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -126,6 +126,10 @@ convention directory at all — it only puts `nuget-plugin-microsoft-artifacts-c
 on `PATH`. An implementation that scans `~/.nuget/plugins` alone finds nothing on such a machine
 while `dotnet restore` authenticates happily.
 
+Discovery itself is deferred until a feed first answers with an authentication challenge.
+Commands and public-feed requests therefore do not scan the convention directory or `PATH`.
+Once discovery runs, its result is kept for the process lifetime.
+
 Implementation: [`PluginDiscovery`](../../src/NuGetFetch/Plugins/PluginDiscovery.cs), mirroring
 `PluginDiscoverer.cs` and `PluginDiscoveryUtility.cs` in
 [NuGet.Client](https://github.com/NuGet/NuGet.Client/tree/dev/src/NuGet.Core/NuGet.Protocol/Plugins).

--- a/src/NuGetFetch.Tests/PluginDiscoveryTests.cs
+++ b/src/NuGetFetch.Tests/PluginDiscoveryTests.cs
@@ -34,6 +34,49 @@ public sealed class PluginDiscoveryTests : IDisposable
     }
 
     [Fact]
+    public async Task ProviderConstructionDoesNotRunDiscovery()
+    {
+        int discoveryCalls = 0;
+        await using var provider = new PluginCredentialProvider(null, Discover);
+
+        Assert.True(provider.HasCredentialSources);
+        Assert.Equal(0, discoveryCalls);
+
+        IReadOnlyList<PluginExecutable> Discover()
+        {
+            discoveryCalls++;
+            return [];
+        }
+    }
+
+    [Fact]
+    public async Task FirstCredentialRequestRunsDiscoveryOnce()
+    {
+        int discoveryCalls = 0;
+        await using var provider = new PluginCredentialProvider(null, Discover);
+        var source = new Uri("https://feed.example/v3/index.json");
+
+        Assert.Null(await provider.GetCredentialsAsync(
+            source,
+            isRetry: false,
+            TestContext.Current.CancellationToken));
+        Assert.Equal(1, discoveryCalls);
+        Assert.False(provider.HasCredentialSources);
+
+        Assert.Null(await provider.GetCredentialsAsync(
+            source,
+            isRetry: false,
+            TestContext.Current.CancellationToken));
+        Assert.Equal(1, discoveryCalls);
+
+        IReadOnlyList<PluginExecutable> Discover()
+        {
+            discoveryCalls++;
+            return [];
+        }
+    }
+
+    [Fact]
     public void NetCoreVariable_NamesEntryPointsDirectly()
     {
         string plugin = CreateFile("explicit/CredentialProvider.Microsoft.dll");

--- a/src/NuGetFetch/Plugins/ICredentialSource.cs
+++ b/src/NuGetFetch/Plugins/ICredentialSource.cs
@@ -11,8 +11,9 @@ namespace NuGetFetch.Plugins;
 public interface ICredentialSource
 {
     /// <summary>
-    /// Whether any credential source is available. When false the handler stays out of the way
-    /// entirely, so a machine with no plugins installed pays nothing.
+    /// Whether a credential source may be available. A lazy source may return true until its
+    /// first credential request determines that no source is installed. When false the handler
+    /// stays out of the way entirely.
     /// </summary>
     bool HasCredentialSources { get; }
 

--- a/src/NuGetFetch/Plugins/PluginCredentialProvider.cs
+++ b/src/NuGetFetch/Plugins/PluginCredentialProvider.cs
@@ -11,38 +11,57 @@ namespace NuGetFetch.Plugins;
 /// environment macros, and clear text.
 /// </para>
 /// <para>
-/// Plugins are started lazily and then kept for the lifetime of this object. Starting one costs
-/// a process launch plus a five-message initialization handshake, so re-launching per request
-/// would be a poor trade for a tool that reads several sources.
+/// Plugins are discovered and started lazily, then kept for the lifetime of this object.
+/// Discovery scans the NuGet convention directory and <c>PATH</c>, while starting one costs a
+/// process launch plus a five-message initialization handshake. Deferring both means commands
+/// that never receive an authentication challenge pay neither cost.
 /// </para>
 /// </remarks>
 public sealed class PluginCredentialProvider : ICredentialSource, IAsyncDisposable
 {
     private readonly Action<string>? _log;
     private readonly SemaphoreSlim _gate = new(1, 1);
-    private readonly List<PluginExecutable> _executables;
+    private readonly Lazy<IReadOnlyList<PluginExecutable>> _executables;
     private readonly Dictionary<string, PluginConnection?> _connections = new(StringComparer.Ordinal);
     private bool _disposed;
 
     /// <summary>Creates a provider over the plugins visible to this process.</summary>
     /// <param name="log">Optional diagnostic sink.</param>
     public PluginCredentialProvider(Action<string>? log = null)
-        : this(log, null)
     {
+        _log = log;
+        _executables = new(
+            static () => PluginDiscovery.Discover(),
+            LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
     /// <summary>Creates a provider over an explicit plugin list, bypassing discovery. For tests.</summary>
-    internal PluginCredentialProvider(Action<string>? log, IReadOnlyList<PluginExecutable>? executables)
+    internal PluginCredentialProvider(Action<string>? log, IReadOnlyList<PluginExecutable> executables)
     {
         _log = log;
-        _executables = [.. executables ?? PluginDiscovery.Discover()];
+        PluginExecutable[] snapshot = [.. executables];
+        _executables = new(() => snapshot, LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
-    /// <summary>Whether any plugin was found. When false, callers can skip the credential path entirely.</summary>
-    public bool HasPlugins => _executables.Count > 0;
+    /// <summary>Creates a provider over deferred plugin discovery. For tests.</summary>
+    internal PluginCredentialProvider(
+        Action<string>? log,
+        Func<IReadOnlyList<PluginExecutable>> discover)
+    {
+        _log = log;
+        _executables = new(
+            () => [.. discover()],
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <summary>
+    /// Whether any plugin was found. Accessing this property performs discovery if it has not
+    /// happened yet.
+    /// </summary>
+    public bool HasPlugins => _executables.Value.Count > 0;
 
     /// <inheritdoc/>
-    public bool HasCredentialSources => HasPlugins;
+    public bool HasCredentialSources => !_executables.IsValueCreated || HasPlugins;
 
     /// <summary>
     /// Whether plugins may block for user input. False by default, matching <c>dotnet restore</c>
@@ -68,12 +87,19 @@ public sealed class PluginCredentialProvider : ICredentialSource, IAsyncDisposab
         bool isRetry,
         CancellationToken cancellationToken)
     {
-        if (_disposed || _executables.Count == 0)
+        if (_disposed)
         {
             return null;
         }
 
-        foreach (PluginExecutable executable in _executables)
+        IReadOnlyList<PluginExecutable> executables = _executables.Value;
+
+        if (executables.Count == 0)
+        {
+            return null;
+        }
+
+        foreach (PluginExecutable executable in executables)
         {
             PluginConnection? connection = await GetConnectionAsync(executable, cancellationToken).ConfigureAwait(false);
 

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -101,17 +101,14 @@ try
     });
 
     // Credential plugins are how a private feed is read without a password stored in nuget.config,
-    // and NuGet ranks them as the most secure of the credential mechanisms. Discovery is only a
-    // PATH and directory scan; no plugin process starts unless a source actually answers 401.
+    // and NuGet ranks them as the most secure of the credential mechanisms. The provider defers
+    // both discovery and process launch until a source actually answers 401.
     if (!offline)
     {
         var credentialProvider = new NuGetFetch.Plugins.PluginCredentialProvider();
 
-        if (credentialProvider.HasPlugins)
-        {
-            DotnetInspector.Core.HttpClientFactory.SetAuthenticationDecorator(
-                inner => new NuGetFetch.Plugins.PluginAuthenticationHandler(credentialProvider, inner));
-        }
+        DotnetInspector.Core.HttpClientFactory.SetAuthenticationDecorator(
+            inner => new NuGetFetch.Plugins.PluginAuthenticationHandler(credentialProvider, inner));
     }
     NuGetCache.Initialize("dotnet-inspect", basePath: cacheBasePath, skipNuGetCache: noNuGetCache);
     // The IR invariant check is armed by default so any host that runs the


### PR DESCRIPTION
## Summary

- install the credential authentication decorator without scanning plugin locations
- discover credential providers once, on the first challenged request
- remember an empty discovery result so later requests bypass credential acquisition
- document the lazy discovery contract

## Evidence

- provider construction test proves discovery has not run
- first credential request test proves discovery runs once and an empty result disables later attempts
- restoring eager discovery makes the construction regression fail
- a filesystem trace of the built CLI proves a local invocation does not open a unique directory added to `PATH`
- full `NuGetFetch.Tests` suite and the CLI build pass
- adversarial review found no significant issues

Closes #3541