### PR TITLE
Adopt Markout 0.35.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Markout" Version="0.35.1" />
-    <PackageVersion Include="Markout.Templates" Version="0.3.0" />
+    <PackageVersion Include="Markout" Version="0.35.2" />
+    <PackageVersion Include="Markout.Templates" Version="0.3.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />


### PR DESCRIPTION
## Summary

- update `Markout` from 0.35.1 to 0.35.2
- update `Markout.Templates` from 0.3.0 to 0.3.2
- consume the published lifecycle, projection, structured-output, and template fixes from richlander/markout#200

## Validation

- Release solution build succeeded on the CI-pinned .NET SDK with 0 errors
- 13 consumer suites passed: 12,300 tests, 0 failures, 4 expected CLI skips
- `ilasm`, `ildasm`, and `mdv` oracle tooling was active
- restored assets resolved `Markout/0.35.2` and `Markout.Templates/0.3.2`

One initial full CLI run hit its existing load-sensitive 10-second constraint-classification timing gate. The unchanged baseline passed, the adoption branch passed three isolated reruns, and a fresh complete 3,389-test CLI run passed.