### PR TITLE
Add workspace acquisition substrate primitives

### DIFF
--- a/src/ILInspector.Metadata/AssemblyAcquisition.cs
+++ b/src/ILInspector.Metadata/AssemblyAcquisition.cs
@@ -34,6 +34,12 @@ public abstract record AssemblyResolutionProvenance
     public static AssemblyResolutionProvenance Local(string resolverSource) =>
         new LocalAsset(resolverSource);
 
+    public static AssemblyResolutionProvenance Embedded(
+        string contentRef,
+        string digest,
+        string declaredName) =>
+        new EmbeddedAsset(contentRef, digest, declaredName);
+
     public sealed record PackageAsset : AssemblyResolutionProvenance
     {
         public PackageAsset(
@@ -106,6 +112,27 @@ public abstract record AssemblyResolutionProvenance
 
         private protected override int Discriminator => 3;
         public string ResolverSource { get; }
+    }
+
+    public sealed record EmbeddedAsset : AssemblyResolutionProvenance
+    {
+        public EmbeddedAsset(
+            string contentRef,
+            string digest,
+            string declaredName)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(contentRef);
+            ArgumentException.ThrowIfNullOrWhiteSpace(digest);
+            ArgumentException.ThrowIfNullOrWhiteSpace(declaredName);
+            ContentRef = contentRef;
+            Digest = digest;
+            DeclaredName = declaredName;
+        }
+
+        private protected override int Discriminator => 4;
+        public string ContentRef { get; }
+        public string Digest { get; }
+        public string DeclaredName { get; }
     }
 }
 

--- a/src/ILInspector.Metadata/NoResolverAssemblyBindingPolicy.cs
+++ b/src/ILInspector.Metadata/NoResolverAssemblyBindingPolicy.cs
@@ -1,0 +1,33 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Binding policy for inspection contexts that have no reference resolver.
+/// It performs no acquisition and never selects an assembly.
+/// </summary>
+public sealed class NoResolverAssemblyBindingPolicy : IAssemblyBindingPolicy
+{
+    public static NoResolverAssemblyBindingPolicy Instance { get; } = new();
+
+    NoResolverAssemblyBindingPolicy()
+    {
+    }
+
+    public AssemblyBindingPolicyVersion Version { get; } = new();
+
+    public AssemblyBindingSelection Select(AssemblyBindingRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return request.Target switch
+        {
+            AssemblyBindingTarget.AssemblyReference =>
+                AssemblyBindingSelection.NotFound(),
+            AssemblyBindingTarget.IntrinsicCoreLibrary =>
+                AssemblyBindingSelection.CannotSelect(
+                    new AssemblyBindingFailure(
+                        AssemblyBindingFailureKind.UnsupportedScope)),
+            _ => AssemblyBindingSelection.Invalid(
+                new AssemblyBindingFailure(
+                    AssemblyBindingFailureKind.InvalidPolicyResult)),
+        };
+    }
+}

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -364,24 +364,8 @@ public sealed class MethodBodyInspectionSession
         {
             IAssemblyBindingPolicy policy => policy,
             not null => new AssemblyReferenceBindingPolicy(resolver),
-            null => MissingAssemblyBindingPolicy.Instance,
+            null => NoResolverAssemblyBindingPolicy.Instance,
         };
-
-    sealed class MissingAssemblyBindingPolicy : IAssemblyBindingPolicy
-    {
-        internal static MissingAssemblyBindingPolicy Instance { get; } =
-            new();
-
-        public AssemblyBindingPolicyVersion Version { get; } = new();
-
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target is AssemblyBindingTarget.IntrinsicCoreLibrary
-                ? AssemblyBindingSelection.CannotSelect(
-                    new AssemblyBindingFailure(
-                        AssemblyBindingFailureKind.UnsupportedScope))
-                : AssemblyBindingSelection.NotFound();
-    }
 }
 
 /// <summary>An inbound call edge targeting a selected member, tagged with its originating assembly.</summary>

--- a/tests/ILInspector.Metadata.Tests/AssemblyReferenceBindingPolicyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AssemblyReferenceBindingPolicyTests.cs
@@ -66,6 +66,24 @@ public class AssemblyReferenceBindingPolicyTests
             unavailable.Failure.Kind);
     }
 
+    [Fact]
+    public void NoResolverPolicy_NeverSelectsAnyBindingTarget()
+    {
+        Assert.IsType<AssemblyBindingSelection.Missing>(
+            NoResolverAssemblyBindingPolicy.Instance.Select(
+                Request(AssemblyBindingTarget.Reference(Reference))));
+        var unavailable = Assert.IsType<AssemblyBindingSelection.Unavailable>(
+            NoResolverAssemblyBindingPolicy.Instance.Select(
+                Request(AssemblyBindingTarget.CoreLibrary())));
+
+        Assert.Equal(
+            AssemblyBindingFailureKind.UnsupportedScope,
+            unavailable.Failure.Kind);
+        Assert.Same(
+            NoResolverAssemblyBindingPolicy.Instance.Version,
+            NoResolverAssemblyBindingPolicy.Instance.Version);
+    }
+
     static AssemblyBindingRequest Request(AssemblyBindingTarget target) =>
         new(
             target,

--- a/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
+++ b/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
@@ -44,6 +44,10 @@ public class InspectionAcquisitionPlanTests
             "Microsoft.NETCore.App",
             "10.0.0",
             "test");
+        var embedded = AssemblyResolutionProvenance.Embedded(
+            "assemblies/Example.dll",
+            "sha256-example",
+            "Example");
 
         Assert.Equal(package, samePackage);
         Assert.NotEqual(package, platform);
@@ -51,6 +55,10 @@ public class InspectionAcquisitionPlanTests
             "Example.Package",
             Assert.IsType<AssemblyResolutionProvenance.PackageAsset>(package)
                 .PackageId);
+        Assert.Equal(
+            "assemblies/Example.dll",
+            Assert.IsType<AssemblyResolutionProvenance.EmbeddedAsset>(embedded)
+                .ContentRef);
     }
 
     [Fact]


### PR DESCRIPTION
## Claim

Implements the first dependency slice of #4033: Metadata can now represent embedded bundle-content provenance, and inspection paths without an assembly resolver share one substrate-owned, no-I/O binding policy. The CLI no longer carries its private copy.

This work intentionally began before #4033 merges, per maintainer direction, from design head `3de9b0dd2`. Minor contract adjustments can follow if the parent moves.

## Stack

Implementation slice 1, stacked on #4033 (`workspace-definitions-design-doc`).

## Behavior

- `AssemblyResolutionProvenance.Embedded` carries `contentRef`, digest, and declared assembly name as the closed fifth provenance arm.
- `NoResolverAssemblyBindingPolicy` returns `Missing` for assembly references and typed `UnsupportedScope` unavailability for intrinsic core-library requests, with no resolver, filesystem, or network path.
- `MethodBodyInspectionSession` consumes the shared policy when no resolver is available.

## Non-action boundary

No workspace serializer, loader, group grammar/lowering, exact platform resolver, packet transposition, or host wiring is included. The updated #4033 design explicitly rejects converting `CorpusManifest` records into workspace coordinates; shared acquisition-owner extraction remains a later slice.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build` (1,354 passed)
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -class DotnetInspector.Tests.MethodBodyInspectionSessionTests` (9 passed)
