### PR TITLE
Gate terminal workspace participant release

### DIFF
--- a/src/dotnet-inspect.Tests/PackageIntegrationsWorkspaceTests.cs
+++ b/src/dotnet-inspect.Tests/PackageIntegrationsWorkspaceTests.cs
@@ -294,36 +294,62 @@ public sealed class PackageIntegrationsWorkspaceTests
     [Fact]
     public async Task UseAssemblyAsync_ReleasesParticipantBeforeAdvancing()
     {
-        string first =
-            typeof(PackageIntegrationsWorkspaceTests).Assembly.Location;
-        string second = typeof(PdbContext).Assembly.Location;
-        using var workspace = PackageIntegrationsWorkspace.Create(
-            [
-                new(first, "net11.0"),
-                new(second, "net11.0"),
-            ],
-            "Test.Package",
-            "1.0.0");
+        string directory = Directory.CreateTempSubdirectory(
+            "package-integrations-release-").FullName;
+        try
+        {
+            string first = Path.Combine(directory, "First.dll");
+            string second = Path.Combine(directory, "Second.dll");
+            File.Copy(
+                typeof(PackageIntegrationsWorkspaceTests)
+                    .Assembly.Location,
+                first);
+            File.Copy(typeof(PdbContext).Assembly.Location, second);
+            using var workspace = PackageIntegrationsWorkspace.Create(
+                [
+                    new(first, "net11.0"),
+                    new(second, "net11.0"),
+                ],
+                "Test.Package",
+                "1.0.0");
 
-        await workspace.UseAssemblyAsync(
-            first,
-            (retained, _, _) =>
-            {
-                Assert.NotNull(retained);
-                Assert.True(workspace.RetainedImageBytes > 0);
-                return Task.FromResult(true);
-            });
-        Assert.Equal(0, workspace.RetainedImageBytes);
+            await workspace.UseAssemblyAsync(
+                first,
+                (retained, _, _) =>
+                {
+                    Assert.NotNull(retained);
+                    Assert.True(workspace.RetainedImageBytes > 0);
+                    return Task.FromResult(true);
+                });
+            Assert.Equal(0, workspace.RetainedImageBytes);
 
-        await workspace.UseAssemblyAsync(
-            second,
-            (retained, _, _) =>
-            {
-                Assert.NotNull(retained);
-                Assert.True(workspace.RetainedImageBytes > 0);
-                return Task.FromResult(true);
-            });
-        Assert.Equal(0, workspace.RetainedImageBytes);
+            File.Delete(first);
+            int reacquisitionCallbacks = 0;
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => workspace.UseAssemblyAsync(
+                    first,
+                    (_, _, _) =>
+                    {
+                        reacquisitionCallbacks++;
+                        return Task.FromResult(true);
+                    }));
+            Assert.Equal(0, reacquisitionCallbacks);
+            Assert.Equal(0, workspace.RetainedImageBytes);
+
+            await workspace.UseAssemblyAsync(
+                second,
+                (retained, _, _) =>
+                {
+                    Assert.NotNull(retained);
+                    Assert.True(workspace.RetainedImageBytes > 0);
+                    return Task.FromResult(true);
+                });
+            Assert.Equal(0, workspace.RetainedImageBytes);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 
     [Theory]


### PR DESCRIPTION
## Claim

Strengthens the named package-workspace lifetime gate so terminal participant release cannot regress into source reacquisition. After consuming the first participant, the test removes its source, proves a second use throws before invoking the callback, verifies retained bytes stay zero, and confirms the next participant still advances normally.

Closes #4015.

## Evidence

- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -class "*PackageIntegrationsWorkspaceTests"` — 20/20 passed
- Mutation check: temporarily removing the `participant.Released` guard makes the strengthened test fail with `Assert.Throws() Failure: No exception was thrown`.

## Review

Trivial test-only change: it changes no product behavior and directly gates the already-documented terminal-release invariant, so adversarial review is not required.