### PR TITLE
Give package inspection authored category lenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files"
 ```
 
 For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders a bounded default view: `package` and `library` render their curated fixed overview, a single `type Type` renders `Type Info`, a `type` listing renders `API Info`, broad `member Type` summaries use `Method Groups`, `member Type -m Name` uses `Methods` overload rows, and a selected `member Type.Member:N` renders `Signature`. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Curated package and library catalogs do not expose a computed `@All`; select relevant authored categories or explicit sections instead. Workflow categories such as `@Source` and `@Audit` expand to scenario-focused section groups.
+
 Package uses `@Package` and `@Files` for its ordinary evidence, with focused
 `@Dependencies`, `@Audit`, and `@SourceLink` doors. Library similarly uses
 `@Library` and `@Surface` as its ordinary evidence scope.

--- a/README.md
+++ b/README.md
@@ -531,6 +531,9 @@ dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files"
 ```
 
 For target-based queries, `-D` reports the effective schema by default: only sections and columns that can actually render for that query. Add `--schema` for the static schema. Bare `-S` renders a bounded default view: `package` and `library` render their curated fixed overview, a single `type Type` renders `Type Info`, a `type` listing renders `API Info`, broad `member Type` summaries use `Method Groups`, `member Type -m Name` uses `Methods` overload rows, and a selected `member Type.Member:N` renders `Signature`. Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons. Curated package and library catalogs do not expose a computed `@All`; select relevant authored categories or explicit sections instead. Workflow categories such as `@Source` and `@Audit` expand to scenario-focused section groups.
+Package uses `@Package` and `@Files` for its ordinary evidence, with focused
+`@Dependencies`, `@Audit`, and `@SourceLink` doors. Library similarly uses
+`@Library` and `@Surface` as its ordinary evidence scope.
 
 ## Common examples
 
@@ -542,6 +545,9 @@ dotnet-inspect library System.Diagnostics.DiagnosticSource -S OpenTelemetry
 dotnet-inspect library System.Text.Json -S "Signals,SourceLink: Availability,SourceLink: Missing Files"
 dotnet-inspect library System.Text.Json -S "SourceLink: Integrity"
 dotnet-inspect package System.Text.Json -S Signals
+dotnet-inspect package System.Text.Json -S @Package
+dotnet-inspect package System.Text.Json -S @Dependencies
+dotnet-inspect package System.Text.Json -S @Audit
 dotnet-inspect package System.Text.Json -S "SourceLink: Availability,SourceLink: Missing Files"
 dotnet-inspect package System.Text.Json -S "SourceLink: Integrity"
 dotnet-inspect package System.Text.Json --versions

--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -38,6 +38,10 @@ separate lenses such as `@Performance`, `@Metadata`, and `@SourceLink`.
 Automatic verbosity uses only the base-category union. Selecting an exact
 domain category is the gesture that enters that domain.
 
+Library uses `@Library` and `@Surface` as its base categories. Package uses
+`@Package` and `@Files`; package evidence is also cross-listed into
+`@Dependencies`, `@Audit`, and `@SourceLink` domain categories.
+
 There are no user-facing `@All`, `@Default`, or `@Hidden` categories. Users who
 need broad evidence select the relevant authored categories explicitly.
 
@@ -51,6 +55,8 @@ dotnet-inspect library System.Text.Json -S Signals
 dotnet-inspect library System.Text.Json -S "Async*"
 dotnet-inspect library System.Text.Json -S @Performance
 dotnet-inspect library System.Text.Json -S References --tree --depth 2
+dotnet-inspect package System.Text.Json -S @Package
+dotnet-inspect package System.Text.Json -S @Audit
 ```
 
 Selection controls both rendering and data collection. Only producers needed

--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -76,6 +76,17 @@ The base-category union intentionally excludes separate domains such as
 metadata internals and performance analysis. This keeps ordinary output useful
 without mixing unrelated concepts.
 
+The package command also has two base categories:
+
+| Category | Purpose |
+| --- | --- |
+| `@Package` | Identity, relationships, registry facts, diagnostics, and the whole-package listing |
+| `@Files` | Curated package document and file-kind views |
+
+The whole-package listing is unbounded, so it remains outside every automatic
+verbosity preset even though it belongs to `@Package`. Explicitly selecting
+`@Package` requests the complete package-native lens.
+
 ### Domain categories
 
 Domain categories are separate conceptual lenses. They are explicit doors and
@@ -95,6 +106,11 @@ The library command currently has these domain categories:
 Domain categories can overlap base categories. For example, `Signals`,
 `Symbols`, and `P/Invoke Methods` remain plain-named base evidence while also
 participating in `@Audit`.
+
+At package scope, `@Dependencies` groups direct and runtime-specific package
+dependencies, while `@Audit` cross-lists package signals, signing,
+vulnerabilities, and SourceLink integrity evidence. `@SourceLink` remains a
+separate provenance domain.
 
 ### Category doors
 
@@ -159,7 +175,7 @@ package file family is the primary example:
 - `Package README file`
 
 The `@Files` category owns the curated subsets. The unfiltered `Package files`
-superset is deliberately not a member because selecting the door must not
+superset belongs to `@Package` instead because selecting `@Files` must not
 duplicate every matching path.
 
 Renamed sections keep their prior spellings in
@@ -372,6 +388,21 @@ The library command's current authored ownership is:
 `@Library` and `@Surface` are base categories. The remaining categories are
 domains.
 
+## Package category map
+
+The package command's current authored ownership is:
+
+| Category | Members |
+| --- | --- |
+| `@Package` | `Package Info`, `Signals`, `Statistics`, `Target Frameworks`, `Signature`, `Dependencies`, `Vulnerabilities`, `Manifest`, `Runtime Dependencies`, `Package files` |
+| `@Files` | `Package nuspec file`, `Package README file`, `Package skill files` |
+| `@Dependencies` | `Dependencies`, `Runtime Dependencies` |
+| `@Audit` | `Signals`, `Signature`, `Vulnerabilities`, `SourceLink: Availability`, `SourceLink: Missing Files`, `SourceLink: Integrity` |
+| `@SourceLink` | All `SourceLink:*` sections |
+
+`@Package` and `@Files` are base categories. The remaining categories are
+domains.
+
 ## Registration invariants
 
 The section pipeline enforces these invariants:
@@ -379,7 +410,7 @@ The section pipeline enforces these invariants:
 1. Section names are unique.
 2. Category names are unique and use the `@` prefix.
 3. Every category member names a registered section.
-4. Every selectable library section has authored category ownership.
+4. Every selectable section in an authored-category pipeline has category ownership.
 5. Base categories are explicitly marked; domain categories never enter
    automatic scope by accident.
 6. Every scanner key resolves, and a descriptor cannot understate scanner cost.
@@ -392,9 +423,9 @@ sets so stale and missing entries both fail.
 
 ## Migration
 
-The library model is the reference implementation. Package has adopted the
-same size/cost axes and curated discovery, but its category graph remains
-smaller. Type, member, project, and API commands should migrate incrementally.
+The library model is the reference implementation. Package uses the same
+size/cost axes, base-category scope, authored ownership, and curated discovery.
+Type, member, project, and API commands should migrate incrementally.
 
 During migration:
 

--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -405,12 +405,15 @@ domains.
 
 ## Registration invariants
 
-The section pipeline enforces these invariants:
+The section pipeline and derived catalog gates enforce these invariants:
 
 1. Section names are unique.
 2. Category names are unique and use the `@` prefix.
 3. Every category member names a registered section.
-4. Every selectable section in an authored-category pipeline has category ownership.
+4. Every selectable library and package section has authored category
+   ownership. Gates:
+   `LibraryPipeline_EverySelectableSectionBelongsToAnAuthoredCategory` and
+   `PackagePipeline_EverySelectableSectionBelongsToAnAuthoredCategory`.
 5. Base categories are explicitly marked; domain categories never enter
    automatic scope by accident.
 6. Every scanner key resolves, and a descriptor cannot understate scanner cost.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -25,7 +25,7 @@ dnx dotnet-inspect -y -- <command>
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
 | Compare APIs | `diff --package Foo@old..new --breaking` (`--additive` new APIs); `--alloc-regressions` for perf regressions (allocations up, hot first). |
 | Trace API evolution | `timeline --package Foo@old..new --type Type --members --at all`; omit `--at` to inspect the vector without acquiring packages. |
-| Inspect packages | `package Foo -S Signals`; load `skill private-feeds` for authenticated/custom sources. |
+| Inspect packages | `package Foo`; use `@Package`, `@Dependencies`, `@Audit`, or `@Files` for an explicit lens. Load `skill private-feeds` for authenticated/custom sources. |
 | Inspect libraries | `library Foo` or `library path/to.dll`; load `skill metadata` for raw ECMA-335 tables/heaps. |
 | Relationships | `depends Type`, `extensions Type`, `implements Interface`. |
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -68,9 +68,10 @@ dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Se
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Member Index" --columns "Selector;Stable;Canonical Signature" --tsv
 ```
 
-`@` names a category of sections. Examples include `@Library`, `@Surface`,
-`@Audit`, `@Context`, `@Source`, `@SourceLink`, `@Integrations`,
-`@Performance`, and `@Metadata`. `Switches` is a plain section, not a category.
+`@` names a category of sections. Examples include `@Package`, `@Files`,
+`@Dependencies`, `@Library`, `@Surface`, `@Audit`, `@Context`, `@Source`,
+`@SourceLink`, `@Integrations`, `@Performance`, and `@Metadata`. `Switches` is
+a plain section, not a category.
 Some large families expose only their category door in the top-level catalog;
 drill in with `-D @Performance` or `-D @Metadata`. Row formats
 (`--tsv`/`--jsonl`/`--table`) require one concrete section or a supported

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14555,6 +14555,7 @@ public partial class CommandExecutionTests
             Assert.Contains("Manifest", output);
             // SourceLink: Files is reachable through its door rather than the top-level
             // catalog, so the door is what discovery has to advertise.
+            Assert.Contains("| @Package | category |", output);
             Assert.Contains("| @SourceLink | category |", output);
             Assert.DoesNotContain("| SourceLink: Files | section |", output);
             Assert.DoesNotContain("Vulnerabilities", output);
@@ -14615,7 +14616,10 @@ public partial class CommandExecutionTests
             Assert.Contains("Vulnerabilities", output);
             // @All/@Default/@Hidden are internal computed poles, not doors: curated discovery
             // advertises only the real category doors.
+            Assert.Contains("| @Audit | category |", output);
+            Assert.Contains("| @Dependencies | category |", output);
             Assert.Contains("| @Files | category |", output);
+            Assert.Contains("| @Package | category |", output);
             Assert.Contains("| @SourceLink | category |", output);
             Assert.DoesNotContain("@All", output);
             Assert.DoesNotContain("@Default", output);
@@ -14625,6 +14629,21 @@ public partial class CommandExecutionTests
         {
             Directory.Delete(tempDir, recursive: true);
         }
+    }
+
+    [Fact]
+    public async Task Package_DiscoverPackageCategory_ListsPackageNativeSections()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package", "-D", "@Package", "--schema", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("| Package Info | section |", output);
+        Assert.Contains("| Dependencies | section |", output);
+        Assert.Contains("| Package files | section |", output);
+        Assert.DoesNotContain("| Package README file | section |", output);
+        Assert.DoesNotContain("| SourceLink: Files | section |", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1272,6 +1272,8 @@ public class SectionPipelineTests
         {
             ("library", LibrarySections.CreatePipeline().AllSectionNames,
                 LibrarySections.CreatePipeline().GetCategoryMap()),
+            ("package", PackageSectionDescriptors.CreatePipeline().AllSectionNames,
+                PackageSectionDescriptors.CreatePipeline().GetCategoryMap()),
             ("api-type", ApiTypeSectionDescriptors.CreatePipeline().AllSectionNames,
                 ApiTypeSectionDescriptors.CreatePipeline().GetCategoryMap()),
             ("api-member", ApiMemberSectionDescriptors.CreatePipeline().AllSectionNames,
@@ -4446,6 +4448,133 @@ public class SectionPipelineTests
     }
 
     // ===== Package pipeline tests =====
+
+    [Fact]
+    public void PackagePipeline_EverySelectableSectionBelongsToAnAuthoredCategory()
+    {
+        var pipeline = PackageSectionDescriptors.CreatePipeline();
+        var categorized = pipeline.GetCategoryMap()
+            .SelectMany(pair => pair.Value)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var uncategorized = pipeline.SelectableSectionNames
+            .Where(name => !categorized.Contains(name))
+            .ToArray();
+
+        Assert.True(
+            uncategorized.Length == 0,
+            $"Package section(s) have no authored category: {string.Join(", ", uncategorized)}");
+    }
+
+    [Fact]
+    public void PackagePipeline_BaseScopeIsDerivedFromPackageAndFilesCategories()
+    {
+        var pipeline = PackageSectionDescriptors.CreatePipeline();
+        var categories = pipeline.GetCategoryMap();
+
+        Assert.Equal(
+            [SectionCategoryNames.Files, SectionCategoryNames.Package],
+            pipeline.GetBaseCategoryDoors().OrderBy(name => name, StringComparer.Ordinal));
+
+        var expected = categories[SectionCategoryNames.Package]
+            .Concat(categories[SectionCategoryNames.Files])
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        Assert.Equal(
+            expected.OrderBy(name => name, StringComparer.Ordinal),
+            pipeline.BaseSectionNames.OrderBy(name => name, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void PackagePipeline_CategoryCompositionMatchesPackageEvidenceDomains()
+    {
+        var categories = PackageSectionDescriptors.CreatePipeline().GetCategoryMap();
+
+        Assert.Equal(
+            [
+                PackageSections.PackageInfo,
+                PackageSections.Signals,
+                PackageSections.Statistics,
+                PackageSections.TargetFrameworks,
+                PackageSections.Signature,
+                PackageSections.Dependencies,
+                PackageSections.Vulnerabilities,
+                PackageSections.Manifest,
+                PackageSections.RuntimeDependencies,
+                PackageSections.Files
+            ],
+            categories[SectionCategoryNames.Package]);
+        Assert.Equal(
+            [PackageSections.Dependencies, PackageSections.RuntimeDependencies],
+            categories[SectionCategoryNames.Dependencies]);
+        Assert.Equal(
+            [
+                PackageSections.Signals,
+                PackageSections.Signature,
+                PackageSections.Vulnerabilities,
+                PackageSections.SourceLinkAvailability,
+                PackageSections.SourceLinkMissingFiles,
+                PackageSections.SourceLinkIntegrity
+            ],
+            categories[SectionCategoryNames.Audit]);
+    }
+
+    [Fact]
+    public void PackagePipeline_BaseCategoriesPreserveAutomaticCandidateSets()
+    {
+        var pipeline = PackageSectionDescriptors.CreatePipeline();
+
+        Assert.Equal(
+            [PackageSections.Summary],
+            pipeline.GetCandidateSections(Verbosity.Quiet));
+        Assert.Equal(
+            [PackageSections.PackageInfo],
+            pipeline.GetCandidateSections(Verbosity.Minimal));
+        Assert.Equal(
+            new[]
+            {
+                PackageSections.Summary,
+                PackageSections.PackageInfo,
+                PackageSections.FilesReadme,
+                PackageSections.TargetFrameworks,
+                PackageSections.FilesNuspec,
+                PackageSections.FilesSkills,
+                PackageSections.Signature,
+                PackageSections.Dependencies,
+                PackageSections.Manifest,
+                PackageSections.RuntimeDependencies
+            }.OrderBy(name => name, StringComparer.Ordinal),
+            pipeline.GetCandidateSections(Verbosity.Normal)
+                .OrderBy(name => name, StringComparer.Ordinal));
+        Assert.Equal(
+            new[]
+            {
+                PackageSections.Summary,
+                PackageSections.PackageInfo,
+                PackageSections.FilesReadme,
+                PackageSections.Signals,
+                PackageSections.Statistics,
+                PackageSections.TargetFrameworks,
+                PackageSections.FilesNuspec,
+                PackageSections.FilesSkills,
+                PackageSections.Signature,
+                PackageSections.Dependencies,
+                PackageSections.Vulnerabilities,
+                PackageSections.Manifest,
+                PackageSections.RuntimeDependencies
+            }.OrderBy(name => name, StringComparer.Ordinal),
+            pipeline.GetCandidateSections(Verbosity.Detailed)
+                .OrderBy(name => name, StringComparer.Ordinal));
+        Assert.Equal(
+            [
+                PackageSections.PackageInfo,
+                PackageSections.FilesReadme,
+                PackageSections.FilesNuspec,
+                PackageSections.Signature,
+                PackageSections.Manifest
+            ],
+            pipeline.BareSelectSectionNames);
+    }
 
     [Fact]
     public void PackagePipeline_HasExpectedSectionCount()

--- a/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
@@ -69,10 +69,38 @@ public static class PackageSectionDescriptors
             .Add<Manifest>()
             .Add<RuntimeDependencies>()
             .Add<Files>()
+            // Package-native evidence is the command's primary base category. The unbounded
+            // whole-package listing belongs here rather than @Files: selecting @Package is an
+            // explicit request for the complete package lens, while keeping the listing out of
+            // @Files prevents its curated subsets from rendering the same paths twice.
+            .AddBaseCategory(
+                SectionCategoryNames.Package,
+                PackageSections.PackageInfo,
+                PackageSections.Signals,
+                PackageSections.Statistics,
+                PackageSections.TargetFrameworks,
+                PackageSections.Signature,
+                PackageSections.Dependencies,
+                PackageSections.Vulnerabilities,
+                PackageSections.Manifest,
+                PackageSections.RuntimeDependencies,
+                PackageSections.Files)
             // The package file family. Plain "Package files" is the whole-package listing,
             // so it is deliberately not a member: including it would make
             // -S @Files render most rows twice.
-            .AddCategory(SectionCategoryNames.Files, PackageFileFamily.SectionNames)
+            .AddBaseCategory(SectionCategoryNames.Files, PackageFileFamily.SectionNames)
+            .AddCategory(
+                SectionCategoryNames.Dependencies,
+                PackageSections.Dependencies,
+                PackageSections.RuntimeDependencies)
+            .AddCategory(
+                SectionCategoryNames.Audit,
+                PackageSections.Signals,
+                PackageSections.Signature,
+                PackageSections.Vulnerabilities,
+                PackageSections.SourceLinkAvailability,
+                PackageSections.SourceLinkMissingFiles,
+                PackageSections.SourceLinkIntegrity)
             .AddCategory(
                 SectionCategoryNames.SourceLink,
                 PackageSections.SourceLinkFiles,

--- a/src/dotnet-inspect/Sections/SectionCategoryNames.cs
+++ b/src/dotnet-inspect/Sections/SectionCategoryNames.cs
@@ -11,7 +11,23 @@ public static class SectionCategoryNames
     /// </summary>
     public const string Library = "@Library";
 
+    /// <summary>
+    /// The package command's ordinary identity, relationship, registry, diagnostic, and
+    /// whole-package evidence. Together with <see cref="Files"/>, this forms the package base
+    /// scope.
+    /// </summary>
+    public const string Package = "@Package";
+
+    /// <summary>
+    /// Safety, provenance, integrity, and vulnerability evidence at package or library scope.
+    /// Members that are also ordinary command evidence remain cross-listed in their base category.
+    /// </summary>
     public const string Audit = "@Audit";
+
+    /// <summary>
+    /// Direct package dependencies and runtime-specific package dependencies.
+    /// </summary>
+    public const string Dependencies = "@Dependencies";
 
     /// <summary>
     /// Actual source content: decompiled, original, and annotated source views plus source diffs
@@ -49,7 +65,8 @@ public static class SectionCategoryNames
     public const string Integrations = "@Integrations";
 
     /// <summary>
-    /// Package file listings scoped to a layout root or document kind: the
+    /// Package file listings scoped to a layout root or document kind. This is a package base
+    /// category alongside <see cref="Package"/>. Its members are the
     /// <c>Package &lt;X&gt; file(s)</c> members. The plain <c>Package files</c> section is the
     /// whole-package listing rather than a subset, so it is deliberately not a member;
     /// including it would render most rows twice.

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -1027,6 +1027,12 @@ public sealed class SectionPipeline<TModel>
 
     private bool IsInAutomaticScope(SectionEntry<TModel> entry)
     {
+        // Headless Summary is rendering context rather than selectable evidence, so it does not
+        // belong to an authored category. Commands that register one still need it at -v:q after
+        // adopting base categories.
+        if (IsHeadlessSummary(entry))
+            return true;
+
         if (!HasBaseCategoryScope)
             return true;
 


### PR DESCRIPTION
## Claim

Package inspection now uses the same authored base/domain category model as library inspection. `@Package` and `@Files` define ordinary package evidence, while `@Dependencies`, `@Audit`, and `@SourceLink` provide focused lenses without changing automatic verbosity or bare-`-S` output.

## What changed

- add `@Package` as the package-native base category and make `@Files` the second package base category
- cross-list dependency evidence under `@Dependencies` and package integrity evidence under `@Audit`
- preserve `@SourceLink` as its own provenance domain
- keep the headless `Summary` eligible for `-v:q` without pretending it is selectable category evidence
- gate complete authored ownership, base-scope derivation, category composition, and unchanged automatic candidate sets
- document the package category map in the README, design docs, and shipped skills

## Demo

Top-level discovery now presents package evidence through authored doors:

```console
$ dotnet-inspect package System.Text.Json@9.0.0 -D --tips q
| Name | Kind |
| ---- | ---- |
| @Audit | category |
| @Dependencies | category |
| @Files | category |
| @Package | category |
| @SourceLink | category |
| Dependencies | section |
| Manifest | section |
| Package files | section |
| Package Info | section |
| Package nuspec file | section |
| Package README file | section |
| Signals | section |
| Signature | section |
| Statistics | section |
| Target Frameworks | section |
```

Drill into the complete package-native lens without acquiring or rendering it:

```console
$ dotnet-inspect package System.Text.Json@9.0.0 -D @Package --schema --tips q
| Name | Kind |
| ---- | ---- |
| Dependencies | section |
| Manifest | section |
| Package files | section |
| Package Info | section |
| Runtime Dependencies | section |
| Signals | section |
| Signature | section |
| Statistics | section |
| Target Frameworks | section |
| Vulnerabilities | section |
```

Or render one focused domain directly:

```console
$ dotnet-inspect package System.Text.Json@9.0.0 -S @Dependencies --rows 4 --tips q
# System.Text.Json

## Dependencies

| Target Framework | Package | Version |
| ---------------- | ------- | ------- |
| net8.0 | System.IO.Pipelines | 9.0.0 |
| net8.0 | System.Text.Encodings.Web | 9.0.0 |
| .NETStandard2.0 | Microsoft.Bcl.AsyncInterfaces | 9.0.0 |
| .NETStandard2.0 | System.Buffers | 4.5.1 |
```

## Compatibility

Existing `-v:q`, `-v:m`, `-v:n`, `-v:d`, and bare `-S` candidate sets are unchanged. `Package files` remains excluded from `@Files` to avoid duplicating curated file rows; it belongs to explicit `@Package` instead. No section names, schemas, network policy, or package acquisition behavior change.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- 9 focused package category, ownership, and discovery tests passed on `af901fca3720e084f96290ee09b2c952feb5bf8e`
- changed Markdown passed `markdownlint`
- full CLI suite under fixed-head review: 3,383 passed, 14 skipped
- current-head `ci-required` passed

## Review sequencing

Per maintainer direction, adversarial review ran in parallel with CI. Reviews and validation are pinned to exact head `af901fca3720e084f96290ee09b2c952feb5bf8e`.