### PR TITLE
Preserve override declarations in RTS shells

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,7 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
 | Output style | `docs/design/style-guide.md` |
 | Sections and selection | `docs/design/section-model.md` |
 | Metadata and API inspection | `docs/design/assembly-inspection-query.md` |
+| Override-shell authentication and reconstruction | `docs/design/override-shell-authentication.md` |
 | Type, member, or API identity | `docs/design/type-member-api-representation.md` |
 | PDB and source acquisition | `docs/pdb-acquisition.md` |
 | Source Finding producers | `docs/design/source-finding-producers.md` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -743,7 +743,7 @@ Research overlay bridge, and the application layer:
   gate the header grammar's focused positive and close-negative cases.
 - **Metadata** owns PE/PDB extraction and raw typed correlations. It does not know SourceLink maps, GUIDs, URLs, or provenance and does not expose its readers.
 - **SourceLink** owns map extraction and processing, canonical source paths, URL decoration, provenance, high-level resolution, source Findings, and SourceLink-aware audits. SourceLinkFetch remains the single map/provenance grammar owner and does not depend on Metadata.
-- **ReturnToSender** remains tools-only and owns closure discovery, cluster membership, synthesis, accessibility flattening, and body-policy selection. It passes typed requests to CSharp rather than maintaining a parallel declaration model.
+- **ReturnToSender** remains tools-only and owns closure discovery, cluster membership, synthesis, accessibility flattening, and body-policy selection. It consumes the Metadata-owned decisions in [override-shell authentication](design/override-shell-authentication.md) and passes typed requests to CSharp rather than maintaining a parallel declaration model.
 - **Analysis** owns R1 whole-assembly evidence and must not depend on the
   decompiler IR, Roslyn, or inspected-assembly loading. One
   `LibraryBodyAnalysisPlan` normalizes producer dependencies and scope before

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -57,6 +57,12 @@ planning state. This keeps assembly identity, modifiers, primary-constructor
 shape, closure membership, references, and every non-target source byte fixed
 between the experiment and its control.
 
+The metadata proof required before that shell may retain overrides, base
+constructors, or inherited property accessibility is owned by
+[override-shell authentication](design/override-shell-authentication.md). The
+harness consumes those product-owned decisions and does not reconstruct them
+from source or display text.
+
 ReturnToSender's earlier source-corpus lookup is a different, non-authoritative
 operation. It may use `CSharpText.MemberSignatureShape` to discriminate
 same-named candidates, but correspondence remains typed as unique, ambiguous,

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -459,7 +459,8 @@ derived type's exact metadata identity is transitively nested within the constru
 type; unrelated types and the reverse nesting direction remain inaccessible. A Full-body
 constructor retains an explicit `base(...)` initializer only when the printed shell retains a base
 list; record and other flattened shells drop the now-unbindable initializer rather than targeting
-the compiler-implied base.
+the compiler-implied base. That explicit-base-constructor preservation authenticates the full CLI
+constructor shape before trusting a metadata row named `.ctor`.
 Same-assembly override closure also authenticates Roslyn's covariant-return encoding: a virtual
 `NewSlot` method or property/indexer accessor is still a source `override` when an unambiguous
 `MethodImpl` maps its body to a source-declarable virtual method on its base-class chain with
@@ -470,23 +471,34 @@ modifiers, and function-pointer headers; rendered spelling never authenticates t
 resolved return types must prove covariance; when simple reference-type returns are external
 `TypeRef`s, the authenticated slot is preserved and the C# compiler validates the referenced
 hierarchy during compile-back rather than silently severing the slot. Local arrays and constructed
-generic returns are compared structurally, including array element covariance and the declared
-variance of the exact local generic definition. That lookup retains namespace, the root-to-leaf
-nested segment chain, scope, and trusted per-segment introduced arity; an external definition is
-never replaced by a same-spelled local type. Unavailable external variance remains unknown and
-preserves the authenticated slot for compiler validation, while unavailable or ambiguous exact
-current-image definition lookup fails closed. A generic return parameter accepts exact identity,
-conversion to `object` proved by its reference-type constraint, or a conversion established by a
-typed explicit base/interface constraint reachable in the local metadata. Constructed constraints
-require full typed identity or compatibility proved from the exact local generic definition's
-declared variance; definition-only equality never erases constructed arguments. The reference-type
-flag alone never authorizes conversion to an arbitrary reference type, and absence of that flag is
-not inferred to mean reference type. Full member-surface closure queues
+generic returns are compared structurally, including array element covariance, complete
+multi-dimensional `ArrayShape`, modifier/pinned wrappers, and the declared variance of the exact
+local generic definition. That lookup retains namespace, the root-to-leaf nested segment chain,
+scope, and trusted per-segment introduced arity; an external definition is never replaced by a
+same-spelled local type. Exact current-image definition lookup recurses through wrapper and
+container children, so an unavailable or ambiguous current-image definition still fails closed when
+hidden under modifiers, pinning, arrays, or generic arguments. Unavailable external variance
+remains unknown and preserves the authenticated slot for compiler validation, while unavailable or
+ambiguous exact current-image definition lookup fails closed. A generic return parameter accepts
+exact identity, conversion to `object` proved by its reference-type constraint, or a conversion
+established by a typed explicit base/interface constraint reachable in the local metadata. For
+array covariance, an explicit class constraint can prove a generic element is a reference type
+only when metadata authenticates that constraint as a class; interface constraints do not prove
+reference-ness because value types can implement interfaces. Constructed constraints require full
+typed identity or compatibility proved from the exact local generic definition's declared
+variance; definition-only equality never erases constructed arguments. When that constructed
+constraint path stays external, the authenticated slot remains available for compiler validation
+rather than collapsing unknown variance to incompatibility. The reference-type flag alone never
+authorizes conversion to an arbitrary reference type, and absence of that flag is not inferred to
+mean reference type. Full member-surface closure queues
 authenticated `NewSlot` class-MethodImpl members even when they are not the selected target, so an
 unrelated target cannot sever their rebuilt slots. Members discovered during that surface pass
 retain `override` when their authenticated slot declaration is present in the emitted surface.
 Target and synthesized slot declarations are deduplicated first by their shared metadata or
-accessor token, with declaration-shape comparison only as a fallback.
+accessor token, with declaration-shape comparison only as a fallback. Property accessibility
+inheritance follows authenticated single-accessor override chains with a bounded, cycle-detecting
+traversal so malformed self- or mutual-base metadata fails closed instead of recursing until
+process abort.
 Interface, unrelated-class, external, malformed, and ambiguous `MethodImpl` declarations do not
 materialize a class override slot. The reconstructed source must compile back to the same
 `NewSlot` plus class-`MethodImpl` relationship, not merely reproduce the target body.
@@ -590,18 +602,26 @@ requirement's nested-derived scan, and
 `CompileBackTargets_PreservesPrivateEnclosingBaseConstructorForNestedDerived` and
 `CompileBackTargets_DropsUnrelatedPrivateBaseConstructorInitializer` gate private constructor
 accessibility in Selected and All/Full reconstruction, while
-`CompileBackTargets_RecordShellDropsExplicitBaseInitializerWithDroppedBaseList` gates Full-body
-initializer removal when the emitted shell has no base list.
+`CompileBackTargets_RecordShellDropsExplicitBaseInitializerWithDroppedBaseList`,
+`FindAccessibleInstanceConstructor_ReturnsValidConstructor`, and
+`FindAccessibleInstanceConstructor_RejectsMalformedConstructorShapes` gate Full-body initializer
+removal when the emitted shell has no base list and the planner's constructor-shape
+authentication.
 `SameAssemblyOverrideSlot_AllowsReferenceConstrainedGenericCovariantMethodImpl` and
 `CompileBackTargets_AllFullPreservesReferenceConstrainedGenericCovariantMethodImpl` gate
 reference-constrained generic covariance to `object`;
 `SameAssemblyOverrideSlot_DeclinesReferenceConstrainedGenericToArbitraryClass`,
 `SameAssemblyOverrideSlot_AllowsExplicitGenericBaseConstraint`, and
-`SameAssemblyOverrideSlot_DeclinesExplicitConstraintThatDoesNotReachReturn` gate the exact
-generic-parameter conversion boundary. Constructed constraints preserve their arguments and use
-the exact generic definition's variance, gated by
+`SameAssemblyOverrideSlot_DeclinesExplicitConstraintThatDoesNotReachReturn`,
+`SameAssemblyOverrideSlot_AllowsExplicitClassConstrainedGenericArrayCovariance`,
+`SameAssemblyOverrideSlot_DeclinesInterfaceConstrainedGenericArrayCovariance`, and
+`SameAssemblyOverrideSlot_DeclinesArrayCovarianceWhenExplicitConstraintDoesNotReachReturn` gate
+the exact generic-parameter conversion boundary. Constructed constraints preserve their arguments
+and use the exact generic definition's variance, gated by
 `SameAssemblyOverrideSlot_AllowsCovariantConstructedConstraint` and
-`SameAssemblyOverrideSlot_DeclinesInvariantConstructedConstraint`, while
+`SameAssemblyOverrideSlot_DeclinesInvariantConstructedConstraint`,
+`SameAssemblyOverrideSlot_AllowsCompilerProducedExternalConstructedConstraintVariance`, and
+`SameAssemblyOverrideSlot_DeclinesExternalConstructedConstraintForNonGenericCandidate`, while
 `SameAssemblyOverrideSlot_DeclinesIncompatibleCovariantReturn` remains its value-return negative.
 `SameAssemblyOverrideSlot_AuthenticatesCompilerProducedScopedParameterIdentity`,
 `SameAssemblyOverrideSlot_DeclinesSameFqnReturnFromDifferentAssemblies`, and
@@ -611,10 +631,18 @@ authentication.
 `SameAssemblyOverrideSlot_UsesExactNestedGenericVarianceDefinition`, and
 `SameAssemblyOverrideSlot_DeclinesAmbiguousExactLocalGenericDefinition`,
 `SameAssemblyOverrideSlot_DeclinesArrayWrappedAmbiguousExactLocalGenericDefinition`,
+`SameAssemblyOverrideSlot_AllowsModifierWrappedExactLocalGenericCovariance`,
+`SameAssemblyOverrideSlot_DeclinesModifierWrappedAmbiguousExactLocalGenericDefinition`,
+`SameAssemblyOverrideSlot_DeclinesPinnedWrappedAmbiguousExactLocalGenericDefinition`,
+`SameAssemblyOverrideSlot_AllowsMultiDimensionalArrayCovarianceWhenShapeMatches`,
+`SameAssemblyOverrideSlot_DeclinesDifferentMultiDimensionalArrayShape`,
 `SameAssemblyOverrideSlot_AllowsCompilerProducedExternalGenericCovariance`,
 `SameAssemblyOverrideSlot_DoesNotUseLocalVarianceForExternalGeneric`, and
 `CompileBackTargets_PreservesExternalGenericCovariantMethodImpl` gate exact local variance
 definition selection, external unknown preservation, and local-shadow isolation.
+`PropertyDeclaration_DerivesPropertyAccessibilityAcrossAcyclicSetterOnlyOverrideChain`,
+`PropertyDeclaration_SelfBasePropertyCycleFailsClosed`, and
+`PropertyDeclaration_TwoTypePropertyCycleFailsClosed` gate property-access override traversal.
 `CompileBackTargets_AllFullDoesNotDuplicateTargetedOverrideSlot` gates metadata-token slot
 deduplication. `SkeletonEmitsExplicitInterfaceTargets` gates
 selected explicit methods and

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -454,19 +454,34 @@ its member set and therefore does not suppress synthesis; a non-public construct
 still prevents a duplicate signature. Nested types emitted inside the same enclosing requirement
 are checked before that requirement is excluded from direct self-derivation, so a nested type that
 derives from its enclosing type still receives the parameterless base support its implicit
-`base()` needs. A Full-body constructor retains an explicit `base(...)` initializer only when the
-printed shell retains a base list; record and other flattened shells drop the now-unbindable
-initializer rather than targeting the compiler-implied base.
+`base()` needs. Private base constructors are eligible for an explicit initializer only when the
+derived type's exact metadata identity is transitively nested within the constructor's declaring
+type; unrelated types and the reverse nesting direction remain inaccessible. A Full-body
+constructor retains an explicit `base(...)` initializer only when the printed shell retains a base
+list; record and other flattened shells drop the now-unbindable initializer rather than targeting
+the compiler-implied base.
 Same-assembly override closure also authenticates Roslyn's covariant-return encoding: a virtual
 `NewSlot` method or property/indexer accessor is still a source `override` when an unambiguous
 `MethodImpl` maps its body to a source-declarable virtual method on its base-class chain with
-compatible declaration shape. Locally resolved return types must prove covariance; when
-reference-type returns are external `TypeRef`s, the authenticated slot is preserved and the C#
-compiler validates the referenced hierarchy during compile-back rather than silently severing
-the slot. Local arrays and constructed generic returns are compared structurally, including array
-element covariance and the declared variance of local generic parameters. A generic return
-parameter whose metadata carries the reference-type constraint is reference-compatible; absence
-of that flag is not inferred to mean reference type. Full member-surface closure queues
+compatible declaration shape. Parameters and equal returns correspond through complete scoped
+`TypeNode` structural identities, including namespace and nesting boundaries, exact non-platform
+assembly or module scope, typed trusted-platform normalization, by-reference shape, custom
+modifiers, and function-pointer headers; rendered spelling never authenticates them. Locally
+resolved return types must prove covariance; when simple reference-type returns are external
+`TypeRef`s, the authenticated slot is preserved and the C# compiler validates the referenced
+hierarchy during compile-back rather than silently severing the slot. Local arrays and constructed
+generic returns are compared structurally, including array element covariance and the declared
+variance of the exact local generic definition. That lookup retains namespace, the root-to-leaf
+nested segment chain, scope, and trusted per-segment introduced arity; an external definition is
+never replaced by a same-spelled local type. Unavailable external variance remains unknown and
+preserves the authenticated slot for compiler validation, while unavailable or ambiguous exact
+current-image definition lookup fails closed. A generic return parameter accepts exact identity,
+conversion to `object` proved by its reference-type constraint, or a conversion established by a
+typed explicit base/interface constraint reachable in the local metadata. Constructed constraints
+require full typed identity or compatibility proved from the exact local generic definition's
+declared variance; definition-only equality never erases constructed arguments. The reference-type
+flag alone never authorizes conversion to an arbitrary reference type, and absence of that flag is
+not inferred to mean reference type. Full member-surface closure queues
 authenticated `NewSlot` class-MethodImpl members even when they are not the selected target, so an
 unrelated target cannot sever their rebuilt slots. Members discovered during that surface pass
 retain `override` when their authenticated slot declaration is present in the emitted surface.
@@ -572,12 +587,34 @@ structured-return rejection.
 overload retention and emitted-signature-safe synthesis.
 `CompileBackTargets_SelectedSynthesizesConstructorForOwnNestedDerivedType` gates the enclosing
 requirement's nested-derived scan, and
+`CompileBackTargets_PreservesPrivateEnclosingBaseConstructorForNestedDerived` and
+`CompileBackTargets_DropsUnrelatedPrivateBaseConstructorInitializer` gate private constructor
+accessibility in Selected and All/Full reconstruction, while
 `CompileBackTargets_RecordShellDropsExplicitBaseInitializerWithDroppedBaseList` gates Full-body
 initializer removal when the emitted shell has no base list.
 `SameAssemblyOverrideSlot_AllowsReferenceConstrainedGenericCovariantMethodImpl` and
 `CompileBackTargets_AllFullPreservesReferenceConstrainedGenericCovariantMethodImpl` gate
-reference-constrained generic covariance, while
+reference-constrained generic covariance to `object`;
+`SameAssemblyOverrideSlot_DeclinesReferenceConstrainedGenericToArbitraryClass`,
+`SameAssemblyOverrideSlot_AllowsExplicitGenericBaseConstraint`, and
+`SameAssemblyOverrideSlot_DeclinesExplicitConstraintThatDoesNotReachReturn` gate the exact
+generic-parameter conversion boundary. Constructed constraints preserve their arguments and use
+the exact generic definition's variance, gated by
+`SameAssemblyOverrideSlot_AllowsCovariantConstructedConstraint` and
+`SameAssemblyOverrideSlot_DeclinesInvariantConstructedConstraint`, while
 `SameAssemblyOverrideSlot_DeclinesIncompatibleCovariantReturn` remains its value-return negative.
+`SameAssemblyOverrideSlot_AuthenticatesCompilerProducedScopedParameterIdentity`,
+`SameAssemblyOverrideSlot_DeclinesSameFqnReturnFromDifferentAssemblies`, and
+`SameAssemblyOverrideSlot_DeclinesNestedVsNamespaceParameter` gate scoped structural signature
+authentication.
+`SameAssemblyOverrideSlot_AllowsCompilerProducedNestedGenericVariance`,
+`SameAssemblyOverrideSlot_UsesExactNestedGenericVarianceDefinition`, and
+`SameAssemblyOverrideSlot_DeclinesAmbiguousExactLocalGenericDefinition`,
+`SameAssemblyOverrideSlot_DeclinesArrayWrappedAmbiguousExactLocalGenericDefinition`,
+`SameAssemblyOverrideSlot_AllowsCompilerProducedExternalGenericCovariance`,
+`SameAssemblyOverrideSlot_DoesNotUseLocalVarianceForExternalGeneric`, and
+`CompileBackTargets_PreservesExternalGenericCovariantMethodImpl` gate exact local variance
+definition selection, external unknown preservation, and local-shadow isolation.
 `CompileBackTargets_AllFullDoesNotDuplicateTargetedOverrideSlot` gates metadata-token slot
 deduplication. `SkeletonEmitsExplicitInterfaceTargets` gates
 selected explicit methods and

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -451,7 +451,12 @@ Closure constructor surfaces retain each metadata overload. A synthetic paramete
 is added only when no parameterless instance-constructor signature already occupies the C# member
 set. A private or internal metadata constructor omitted from that emitted shell does not occupy
 its member set and therefore does not suppress synthesis; a non-public constructor that is emitted
-still prevents a duplicate signature.
+still prevents a duplicate signature. Nested types emitted inside the same enclosing requirement
+are checked before that requirement is excluded from direct self-derivation, so a nested type that
+derives from its enclosing type still receives the parameterless base support its implicit
+`base()` needs. A Full-body constructor retains an explicit `base(...)` initializer only when the
+printed shell retains a base list; record and other flattened shells drop the now-unbindable
+initializer rather than targeting the compiler-implied base.
 Same-assembly override closure also authenticates Roslyn's covariant-return encoding: a virtual
 `NewSlot` method or property/indexer accessor is still a source `override` when an unambiguous
 `MethodImpl` maps its body to a source-declarable virtual method on its base-class chain with
@@ -459,9 +464,14 @@ compatible declaration shape. Locally resolved return types must prove covarianc
 reference-type returns are external `TypeRef`s, the authenticated slot is preserved and the C#
 compiler validates the referenced hierarchy during compile-back rather than silently severing
 the slot. Local arrays and constructed generic returns are compared structurally, including array
-element covariance and the declared variance of local generic parameters. Full member-surface
-closure queues authenticated `NewSlot` class-MethodImpl members even when they are not the selected
-target, so an unrelated target cannot sever their rebuilt slots.
+element covariance and the declared variance of local generic parameters. A generic return
+parameter whose metadata carries the reference-type constraint is reference-compatible; absence
+of that flag is not inferred to mean reference type. Full member-surface closure queues
+authenticated `NewSlot` class-MethodImpl members even when they are not the selected target, so an
+unrelated target cannot sever their rebuilt slots. Members discovered during that surface pass
+retain `override` when their authenticated slot declaration is present in the emitted surface.
+Target and synthesized slot declarations are deduplicated first by their shared metadata or
+accessor token, with declaration-shape comparison only as a fallback.
 Interface, unrelated-class, external, malformed, and ambiguous `MethodImpl` declarations do not
 materialize a class override slot. The reconstructed source must compile back to the same
 `NewSlot` plus class-`MethodImpl` relationship, not merely reproduce the target body.
@@ -559,8 +569,17 @@ relationships. `SameAssemblyOverrideSlot_DeclinesIncompatibleStructuredReturn` g
 structured-return rejection.
 `CompileBackTargets_AllFullDoesNotDuplicatePrivateParameterlessConstructor` and
 `CompileBackTargets_SelectedSynthesizesConstructorWhenMetadataSignatureIsOmitted` gate constructor
-overload retention and emitted-signature-safe synthesis. `SkeletonEmitsExplicitInterfaceTargets`
-gates
+overload retention and emitted-signature-safe synthesis.
+`CompileBackTargets_SelectedSynthesizesConstructorForOwnNestedDerivedType` gates the enclosing
+requirement's nested-derived scan, and
+`CompileBackTargets_RecordShellDropsExplicitBaseInitializerWithDroppedBaseList` gates Full-body
+initializer removal when the emitted shell has no base list.
+`SameAssemblyOverrideSlot_AllowsReferenceConstrainedGenericCovariantMethodImpl` and
+`CompileBackTargets_AllFullPreservesReferenceConstrainedGenericCovariantMethodImpl` gate
+reference-constrained generic covariance, while
+`SameAssemblyOverrideSlot_DeclinesIncompatibleCovariantReturn` remains its value-return negative.
+`CompileBackTargets_AllFullDoesNotDuplicateTargetedOverrideSlot` gates metadata-token slot
+deduplication. `SkeletonEmitsExplicitInterfaceTargets` gates
 selected explicit methods and
 accessors,
 `SkeletonExplicitInterfaceWholeMemberHonorsRequestedView` gates whole-member production rendering

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -447,6 +447,12 @@ reuse-slot methods and properties as override stubs with metadata accessibility,
 abstract slots remain implemented and target bodies may still construct their own declaring type.
 Recompiled targets are found by canonical member signature rather than their original same-name
 ordinal, so scaffold changes cannot shift a target onto a sibling overload.
+Same-assembly override closure also authenticates Roslyn's covariant-return encoding: a virtual
+`NewSlot` method is still a source `override` when an unambiguous `MethodImpl` maps its body to a
+source-declarable virtual method on its base-class chain with compatible declaration shape.
+Interface, unrelated-class, external, malformed, and ambiguous `MethodImpl` declarations do not
+materialize a class override slot. The reconstructed source must compile back to the same
+`NewSlot` plus class-`MethodImpl` relationship, not merely reproduce the target body.
 Unselected `System.Exception` support types additionally require the referenced assembly to bind
 through the platform scope before retaining their base clause. Manifest-less modules begin from
 the base `TypeRef`'s platform reference, then use the Metadata resolution catalog to follow
@@ -526,8 +532,14 @@ matching and trusted-platform upgrade-only unification,
 `SkeletonRetainsSignalForAbstractExternalBase` and
 `SkeletonKeepsConcreteTypeForAbstractBaseWithoutAbstractMembers` gate concrete abstract-base
 scaffolding, `SkeletonFindsTargetByCanonicalSignatureAfterOverrideScaffolding` gates target
-identity after scaffold changes, `SkeletonEmitsExplicitInterfaceTargets` gates selected explicit
-methods and accessors,
+identity after scaffold changes,
+`SameAssemblyOverrideSlot_UsesCompilerProducedCovariantMethodImpl` and
+`SameAssemblyOverrideSlot_DeclinesInterfaceMethodImpl` gate covariant class-`MethodImpl`
+authentication, `SameAssemblyOverrideSlot_DeclinesUnauthenticatedClassMethodImpl` gates unrelated
+and ambiguous class declarations, and
+`CompileBackTargets_PreservesCompilerProducedCovariantMethodImpl` gates the rebuilt metadata
+relationship. `SkeletonEmitsExplicitInterfaceTargets` gates selected explicit methods and
+accessors,
 `SkeletonExplicitInterfaceWholeMemberHonorsRequestedView` gates whole-member production rendering
 the requested body view and printer options,
 `SkeletonDoesNotTreatOrdinaryAccessorPrefixesAsSemantics` gates token mapping, and

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -449,15 +449,19 @@ Recompiled targets are found by canonical member signature rather than their ori
 ordinal, so scaffold changes cannot shift a target onto a sibling overload.
 Closure constructor surfaces retain each metadata overload. A synthetic parameterless constructor
 is added only when no parameterless instance-constructor signature already occupies the C# member
-set; private accessibility can make an existing constructor unusable to a derived shell, but it
-cannot authorize a duplicate signature.
+set. A private or internal metadata constructor omitted from that emitted shell does not occupy
+its member set and therefore does not suppress synthesis; a non-public constructor that is emitted
+still prevents a duplicate signature.
 Same-assembly override closure also authenticates Roslyn's covariant-return encoding: a virtual
 `NewSlot` method or property/indexer accessor is still a source `override` when an unambiguous
 `MethodImpl` maps its body to a source-declarable virtual method on its base-class chain with
 compatible declaration shape. Locally resolved return types must prove covariance; when
 reference-type returns are external `TypeRef`s, the authenticated slot is preserved and the C#
 compiler validates the referenced hierarchy during compile-back rather than silently severing
-the slot.
+the slot. Local arrays and constructed generic returns are compared structurally, including array
+element covariance and the declared variance of local generic parameters. Full member-surface
+closure queues authenticated `NewSlot` class-MethodImpl members even when they are not the selected
+target, so an unrelated target cannot sever their rebuilt slots.
 Interface, unrelated-class, external, malformed, and ambiguous `MethodImpl` declarations do not
 materialize a class override slot. The reconstructed source must compile back to the same
 `NewSlot` plus class-`MethodImpl` relationship, not merely reproduce the target body.
@@ -549,9 +553,14 @@ and ambiguous class declarations, and
 `CompileBackTargets_PreservesCompilerProducedCovariantMethodImpl`,
 `CompileBackTargets_PreservesExternalCovariantMethodImpl`,
 `CompileBackTargets_PreservesCovariantPropertyMethodImpl`, and
-`CompileBackTargets_PreservesCovariantIndexerMethodImpl` gate rebuilt metadata relationships.
-`CompileBackTargets_AllFullDoesNotDuplicatePrivateParameterlessConstructor` gates constructor
-overload retention and signature-safe synthesis. `SkeletonEmitsExplicitInterfaceTargets` gates
+`CompileBackTargets_PreservesCovariantIndexerMethodImpl`, and
+`CompileBackTargets_AllFullPreservesUnrelatedCovariantMethodImpl` gate rebuilt metadata
+relationships. `SameAssemblyOverrideSlot_DeclinesIncompatibleStructuredReturn` gates local
+structured-return rejection.
+`CompileBackTargets_AllFullDoesNotDuplicatePrivateParameterlessConstructor` and
+`CompileBackTargets_SelectedSynthesizesConstructorWhenMetadataSignatureIsOmitted` gate constructor
+overload retention and emitted-signature-safe synthesis. `SkeletonEmitsExplicitInterfaceTargets`
+gates
 selected explicit methods and
 accessors,
 `SkeletonExplicitInterfaceWholeMemberHonorsRequestedView` gates whole-member production rendering

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -430,6 +430,13 @@ accessible-parameterless-constructor and abstractness facts onto transient
 constructor shape: special and runtime-special names, a default managed signature with no
 explicit `this`, no generic parameters, `void` return, no parameters, and accessible
 visibility.
+
+The source-level override, constructor, property-accessibility, and harness-consumption
+decisions built from these facts are owned by
+[override-shell authentication](override-shell-authentication.md). This document owns the
+resolution and provenance inputs; the focused document owns the downstream authentication
+decisions and their enforcement map.
+
 Missing or ambiguous base bindings produce no evidence, so the harness cannot substitute a
 same-named type from another assembly. The compile-back reference resolver matches the
 case-insensitive assembly name plus culture and public-key token exactly (normalizing only neutral
@@ -447,61 +454,10 @@ reuse-slot methods and properties as override stubs with metadata accessibility,
 abstract slots remain implemented and target bodies may still construct their own declaring type.
 Recompiled targets are found by canonical member signature rather than their original same-name
 ordinal, so scaffold changes cannot shift a target onto a sibling overload.
-Closure constructor surfaces retain each metadata overload. A synthetic parameterless constructor
-is added only when no parameterless instance-constructor signature already occupies the C# member
-set. A private or internal metadata constructor omitted from that emitted shell does not occupy
-its member set and therefore does not suppress synthesis; a non-public constructor that is emitted
-still prevents a duplicate signature. Nested types emitted inside the same enclosing requirement
-are checked before that requirement is excluded from direct self-derivation, so a nested type that
-derives from its enclosing type still receives the parameterless base support its implicit
-`base()` needs. Private base constructors are eligible for an explicit initializer only when the
-derived type's exact metadata identity is transitively nested within the constructor's declaring
-type; unrelated types and the reverse nesting direction remain inaccessible. A Full-body
-constructor retains an explicit `base(...)` initializer only when the printed shell retains a base
-list; record and other flattened shells drop the now-unbindable initializer rather than targeting
-the compiler-implied base. That explicit-base-constructor preservation authenticates the full CLI
-constructor shape before trusting a metadata row named `.ctor`.
-Same-assembly override closure also authenticates Roslyn's covariant-return encoding: a virtual
-`NewSlot` method or property/indexer accessor is still a source `override` when an unambiguous
-`MethodImpl` maps its body to a source-declarable virtual method on its base-class chain with
-compatible declaration shape. Parameters and equal returns correspond through complete scoped
-`TypeNode` structural identities, including namespace and nesting boundaries, exact non-platform
-assembly or module scope, typed trusted-platform normalization, by-reference shape, custom
-modifiers, and function-pointer headers; rendered spelling never authenticates them. Locally
-resolved return types must prove covariance; when simple reference-type returns are external
-`TypeRef`s, the authenticated slot is preserved and the C# compiler validates the referenced
-hierarchy during compile-back rather than silently severing the slot. Local arrays and constructed
-generic returns are compared structurally, including array element covariance, complete
-multi-dimensional `ArrayShape`, modifier/pinned wrappers, and the declared variance of the exact
-local generic definition. That lookup retains namespace, the root-to-leaf nested segment chain,
-scope, and trusted per-segment introduced arity; an external definition is never replaced by a
-same-spelled local type. Exact current-image definition lookup recurses through wrapper and
-container children, so an unavailable or ambiguous current-image definition still fails closed when
-hidden under modifiers, pinning, arrays, or generic arguments. Unavailable external variance
-remains unknown and preserves the authenticated slot for compiler validation, while unavailable or
-ambiguous exact current-image definition lookup fails closed. A generic return parameter accepts
-exact identity, conversion to `object` proved by its reference-type constraint, or a conversion
-established by a typed explicit base/interface constraint reachable in the local metadata. For
-array covariance, an explicit class constraint can prove a generic element is a reference type
-only when metadata authenticates that constraint as a class; interface constraints do not prove
-reference-ness because value types can implement interfaces. Constructed constraints require full
-typed identity or compatibility proved from the exact local generic definition's declared
-variance; definition-only equality never erases constructed arguments. When that constructed
-constraint path stays external, the authenticated slot remains available for compiler validation
-rather than collapsing unknown variance to incompatibility. The reference-type flag alone never
-authorizes conversion to an arbitrary reference type, and absence of that flag is not inferred to
-mean reference type. Full member-surface closure queues
-authenticated `NewSlot` class-MethodImpl members even when they are not the selected target, so an
-unrelated target cannot sever their rebuilt slots. Members discovered during that surface pass
-retain `override` when their authenticated slot declaration is present in the emitted surface.
-Target and synthesized slot declarations are deduplicated first by their shared metadata or
-accessor token, with declaration-shape comparison only as a fallback. Property accessibility
-inheritance follows authenticated single-accessor override chains with a bounded, cycle-detecting
-traversal so malformed self- or mutual-base metadata fails closed instead of recursing until
-process abort.
-Interface, unrelated-class, external, malformed, and ambiguous `MethodImpl` declarations do not
-materialize a class override slot. The reconstructed source must compile back to the same
-`NewSlot` plus class-`MethodImpl` relationship, not merely reproduce the target body.
+Constructor retention and synthesis, same-assembly covariant override closure, generic
+conversion evidence, full member-surface preservation, property accessibility, and malformed
+relationship traversal follow
+[override-shell authentication](override-shell-authentication.md).
 Unselected `System.Exception` support types additionally require the referenced assembly to bind
 through the platform scope before retaining their base clause. Manifest-less modules begin from
 the base `TypeRef`'s platform reference, then use the Metadata resolution catalog to follow
@@ -582,69 +538,9 @@ matching and trusted-platform upgrade-only unification,
 `SkeletonKeepsConcreteTypeForAbstractBaseWithoutAbstractMembers` gate concrete abstract-base
 scaffolding, `SkeletonFindsTargetByCanonicalSignatureAfterOverrideScaffolding` gates target
 identity after scaffold changes,
-`SameAssemblyOverrideSlot_UsesCompilerProducedCovariantMethodImpl` and
-`PropertyDeclaration_UsesCompilerProducedCovariantMethodImpl` and
-`SameAssemblyOverrideSlot_DeclinesInterfaceMethodImpl` gate covariant class-`MethodImpl`
-authentication, `SameAssemblyOverrideSlot_DeclinesUnauthenticatedClassMethodImpl` gates unrelated
-and ambiguous class declarations, and
-`CompileBackTargets_PreservesCompilerProducedCovariantMethodImpl`,
-`CompileBackTargets_PreservesExternalCovariantMethodImpl`,
-`CompileBackTargets_PreservesCovariantPropertyMethodImpl`, and
-`CompileBackTargets_PreservesCovariantIndexerMethodImpl`, and
-`CompileBackTargets_AllFullPreservesUnrelatedCovariantMethodImpl` gate rebuilt metadata
-relationships. `SameAssemblyOverrideSlot_DeclinesIncompatibleStructuredReturn` gates local
-structured-return rejection.
-`CompileBackTargets_AllFullDoesNotDuplicatePrivateParameterlessConstructor` and
-`CompileBackTargets_SelectedSynthesizesConstructorWhenMetadataSignatureIsOmitted` gate constructor
-overload retention and emitted-signature-safe synthesis.
-`CompileBackTargets_SelectedSynthesizesConstructorForOwnNestedDerivedType` gates the enclosing
-requirement's nested-derived scan, and
-`CompileBackTargets_PreservesPrivateEnclosingBaseConstructorForNestedDerived` and
-`CompileBackTargets_DropsUnrelatedPrivateBaseConstructorInitializer` gate private constructor
-accessibility in Selected and All/Full reconstruction, while
-`CompileBackTargets_RecordShellDropsExplicitBaseInitializerWithDroppedBaseList`,
-`FindAccessibleInstanceConstructor_ReturnsValidConstructor`, and
-`FindAccessibleInstanceConstructor_RejectsMalformedConstructorShapes` gate Full-body initializer
-removal when the emitted shell has no base list and the planner's constructor-shape
-authentication.
-`SameAssemblyOverrideSlot_AllowsReferenceConstrainedGenericCovariantMethodImpl` and
-`CompileBackTargets_AllFullPreservesReferenceConstrainedGenericCovariantMethodImpl` gate
-reference-constrained generic covariance to `object`;
-`SameAssemblyOverrideSlot_DeclinesReferenceConstrainedGenericToArbitraryClass`,
-`SameAssemblyOverrideSlot_AllowsExplicitGenericBaseConstraint`, and
-`SameAssemblyOverrideSlot_DeclinesExplicitConstraintThatDoesNotReachReturn`,
-`SameAssemblyOverrideSlot_AllowsExplicitClassConstrainedGenericArrayCovariance`,
-`SameAssemblyOverrideSlot_DeclinesInterfaceConstrainedGenericArrayCovariance`, and
-`SameAssemblyOverrideSlot_DeclinesArrayCovarianceWhenExplicitConstraintDoesNotReachReturn` gate
-the exact generic-parameter conversion boundary. Constructed constraints preserve their arguments
-and use the exact generic definition's variance, gated by
-`SameAssemblyOverrideSlot_AllowsCovariantConstructedConstraint` and
-`SameAssemblyOverrideSlot_DeclinesInvariantConstructedConstraint`,
-`SameAssemblyOverrideSlot_AllowsCompilerProducedExternalConstructedConstraintVariance`, and
-`SameAssemblyOverrideSlot_DeclinesExternalConstructedConstraintForNonGenericCandidate`, while
-`SameAssemblyOverrideSlot_DeclinesIncompatibleCovariantReturn` remains its value-return negative.
-`SameAssemblyOverrideSlot_AuthenticatesCompilerProducedScopedParameterIdentity`,
-`SameAssemblyOverrideSlot_DeclinesSameFqnReturnFromDifferentAssemblies`, and
-`SameAssemblyOverrideSlot_DeclinesNestedVsNamespaceParameter` gate scoped structural signature
-authentication.
-`SameAssemblyOverrideSlot_AllowsCompilerProducedNestedGenericVariance`,
-`SameAssemblyOverrideSlot_UsesExactNestedGenericVarianceDefinition`, and
-`SameAssemblyOverrideSlot_DeclinesAmbiguousExactLocalGenericDefinition`,
-`SameAssemblyOverrideSlot_DeclinesArrayWrappedAmbiguousExactLocalGenericDefinition`,
-`SameAssemblyOverrideSlot_AllowsModifierWrappedExactLocalGenericCovariance`,
-`SameAssemblyOverrideSlot_DeclinesModifierWrappedAmbiguousExactLocalGenericDefinition`,
-`SameAssemblyOverrideSlot_DeclinesPinnedWrappedAmbiguousExactLocalGenericDefinition`,
-`SameAssemblyOverrideSlot_AllowsMultiDimensionalArrayCovarianceWhenShapeMatches`,
-`SameAssemblyOverrideSlot_DeclinesDifferentMultiDimensionalArrayShape`,
-`SameAssemblyOverrideSlot_AllowsCompilerProducedExternalGenericCovariance`,
-`SameAssemblyOverrideSlot_DoesNotUseLocalVarianceForExternalGeneric`, and
-`CompileBackTargets_PreservesExternalGenericCovariantMethodImpl` gate exact local variance
-definition selection, external unknown preservation, and local-shadow isolation.
-`PropertyDeclaration_DerivesPropertyAccessibilityAcrossAcyclicSetterOnlyOverrideChain`,
-`PropertyDeclaration_SelfBasePropertyCycleFailsClosed`, and
-`PropertyDeclaration_TwoTypePropertyCycleFailsClosed` gate property-access override traversal.
-`CompileBackTargets_AllFullDoesNotDuplicateTargetedOverrideSlot` gates metadata-token slot
-deduplication. `SkeletonEmitsExplicitInterfaceTargets` gates
+and the focused constructor, override, covariance, property-traversal, and compile-back gates are
+indexed by [override-shell authentication](override-shell-authentication.md).
+`SkeletonEmitsExplicitInterfaceTargets` gates
 selected explicit methods and
 accessors,
 `SkeletonExplicitInterfaceWholeMemberHonorsRequestedView` gates whole-member production rendering

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -447,9 +447,17 @@ reuse-slot methods and properties as override stubs with metadata accessibility,
 abstract slots remain implemented and target bodies may still construct their own declaring type.
 Recompiled targets are found by canonical member signature rather than their original same-name
 ordinal, so scaffold changes cannot shift a target onto a sibling overload.
+Closure constructor surfaces retain each metadata overload. A synthetic parameterless constructor
+is added only when no parameterless instance-constructor signature already occupies the C# member
+set; private accessibility can make an existing constructor unusable to a derived shell, but it
+cannot authorize a duplicate signature.
 Same-assembly override closure also authenticates Roslyn's covariant-return encoding: a virtual
-`NewSlot` method is still a source `override` when an unambiguous `MethodImpl` maps its body to a
-source-declarable virtual method on its base-class chain with compatible declaration shape.
+`NewSlot` method or property/indexer accessor is still a source `override` when an unambiguous
+`MethodImpl` maps its body to a source-declarable virtual method on its base-class chain with
+compatible declaration shape. Locally resolved return types must prove covariance; when
+reference-type returns are external `TypeRef`s, the authenticated slot is preserved and the C#
+compiler validates the referenced hierarchy during compile-back rather than silently severing
+the slot.
 Interface, unrelated-class, external, malformed, and ambiguous `MethodImpl` declarations do not
 materialize a class override slot. The reconstructed source must compile back to the same
 `NewSlot` plus class-`MethodImpl` relationship, not merely reproduce the target body.
@@ -534,11 +542,17 @@ matching and trusted-platform upgrade-only unification,
 scaffolding, `SkeletonFindsTargetByCanonicalSignatureAfterOverrideScaffolding` gates target
 identity after scaffold changes,
 `SameAssemblyOverrideSlot_UsesCompilerProducedCovariantMethodImpl` and
+`PropertyDeclaration_UsesCompilerProducedCovariantMethodImpl` and
 `SameAssemblyOverrideSlot_DeclinesInterfaceMethodImpl` gate covariant class-`MethodImpl`
 authentication, `SameAssemblyOverrideSlot_DeclinesUnauthenticatedClassMethodImpl` gates unrelated
 and ambiguous class declarations, and
-`CompileBackTargets_PreservesCompilerProducedCovariantMethodImpl` gates the rebuilt metadata
-relationship. `SkeletonEmitsExplicitInterfaceTargets` gates selected explicit methods and
+`CompileBackTargets_PreservesCompilerProducedCovariantMethodImpl`,
+`CompileBackTargets_PreservesExternalCovariantMethodImpl`,
+`CompileBackTargets_PreservesCovariantPropertyMethodImpl`, and
+`CompileBackTargets_PreservesCovariantIndexerMethodImpl` gate rebuilt metadata relationships.
+`CompileBackTargets_AllFullDoesNotDuplicatePrivateParameterlessConstructor` gates constructor
+overload retention and signature-safe synthesis. `SkeletonEmitsExplicitInterfaceTargets` gates
+selected explicit methods and
 accessors,
 `SkeletonExplicitInterfaceWholeMemberHonorsRequestedView` gates whole-member production rendering
 the requested body view and printer options,

--- a/docs/design/override-shell-authentication.md
+++ b/docs/design/override-shell-authentication.md
@@ -173,6 +173,7 @@ the authenticated base slot.
 | Constructed local generics | One exact local generic definition resolves uniquely; arity and every argument correspond under its declared variance | Aggregate argument result |
 | Constructed external generics | Definition identities correspond, no current-image dependency is missing, and local variance metadata is unavailable | `Unknown` for compiler validation |
 | Local named types | Both exact definitions resolve uniquely | `Compatible` only when the implementation is the same as or derives from or implements the declaration |
+| Local named ancestry through constructed bases or interfaces | Every step is a same-image `TypeDef` or a constructed `TypeSpec` over a definition in this image, with substituted arguments carried forward | `Compatible` only on an exact definition-token and exact-instantiation match within the shared budget |
 | External named types | Exact scopes authenticate but hierarchy is unavailable | `Unknown`, unless same-name/different-scope evidence disproves correspondence |
 | Generic implementation parameter | The generic-parameter rules below establish equality or conversion | Rule result |
 | Generic declaration parameter only | No covariant conversion can be proved | `Incompatible` |
@@ -182,6 +183,22 @@ Invariant generic arguments require exact structural correspondence. Covariant
 and contravariant arguments recurse in their declared direction. A local
 same-spelled generic definition never supplies variance for an external
 definition.
+
+Local named ancestry is a metadata walk on the same terms as slot
+authentication, not a `TypeDef` walk. `Dog : Middle<int>` and
+`Middle<T> : Animal` reach `Animal` through a constructed `TypeSpec` base, and a
+covariant return declared as an interface reaches it through a constructed
+`TypeSpec` interface row, so the ancestry search reads same-image `TypeDef` and
+constructed-`TypeSpec` base and interface rows alike and substitutes each step's
+exact arguments into the next. A step matches only on an exact definition token
+*and* an exact instantiation: `Middle<int>` never answers for `Middle<string>`,
+and a raw definition never answers for a constructed one. Variance is not
+applied here — corresponding definitions are already decided by the constructed
+local generic row above, and this search is the different-definition fallback.
+A `TypeSpec` that is not a generic instantiation of a definition in this image,
+an arity that disagrees with the definition, a degraded decode, an unreadable
+row, and an ancestry that outruns the shared relationship budget or node cap all
+decline. No step matches a rendered name.
 
 ## Generic-parameter evidence
 
@@ -210,6 +227,15 @@ non-generic or differently shaped candidate remains `Incompatible`.
 
 Generic-parameter traversal tracks active handles. A cycle, malformed
 constraint, degraded decode, or exhausted relationship budget fails closed.
+
+Degradation is a property of the whole constraint set, not of one constraint.
+Every constraint on a parameter is decoded before any of them may yield
+`Compatible`, so a constraint that decodes degraded or whose exact local
+definition is unavailable or ambiguous makes the parameter `Incompatible` even
+when a sibling constraint would have proved the conversion. Skipping the
+degraded row and accepting the sibling would let metadata order decide whether
+malformed current-image evidence is fatal. Among fully decoded constraints the
+rule stays existential: any one of them may establish the conversion.
 
 ## Constructor authentication
 
@@ -325,6 +351,11 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `SameAssemblyOverrideSlot_AuthenticatesSyntheticConstructedGenericMethodImpl`
 - `SameAssemblyOverrideSlot_DeclinesConstructedGenericMethodImplWithMismatchedInstantiation`
 - `SameAssemblyOverrideSlot_DeclinesConstructedGenericMethodImplRootedInExternalDefinition`
+- `SameAssemblyOverrideSlot_AuthenticatesCovariantReturnThroughConstructedGenericAncestry`
+- `SameAssemblyOverrideSlot_AuthenticatesCovariantInterfaceReturnThroughConstructedGenericAncestry`
+- `SameAssemblyOverrideSlot_AuthenticatesDirectCovariantReturnThroughTypeDefAncestry`
+- `SameAssemblyOverrideSlot_AuthenticatesConstructedGenericAncestryWithMatchingArgument`
+- `SameAssemblyOverrideSlot_DeclinesConstructedGenericAncestryWithDifferentArgument`
 - `AuthenticatedObjectSlotOverride_AcceptsSameImageChainToObject`
 - `AuthenticatedObjectSlotOverride_DeclinesOverrideOfExternalBase`
 - `AuthenticatedObjectSlotOverride_DeclinesNewSlotObjectShapedVirtual`
@@ -338,6 +369,8 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `SameAssemblyOverrideSlot_WideGenericParameterDagFailsClosedWithinBudget`
 - `SameAssemblyOverrideSlot_DeepGenericParameterChainFailsClosed`
 - `SameAssemblyOverrideSlot_DeepGenericParameterChainDoesNotCrashProcess`
+- `SameAssemblyOverrideSlot_CyclicConstructedAncestryFailsClosed`
+- `SameAssemblyOverrideSlot_ExpandingConstructedAncestryFailsClosedWithinBudget`
 
 ### Wrappers, arrays, and local definition trust
 
@@ -366,6 +399,9 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `SameAssemblyOverrideSlot_UsesExactNestedGenericVarianceDefinition`
 - `SameAssemblyOverrideSlot_AllowsCompilerProducedExternalGenericCovariance`
 - `SameAssemblyOverrideSlot_DoesNotUseLocalVarianceForExternalGeneric`
+- `SameAssemblyOverrideSlot_AllowsValidOnlyExplicitConstraintSet`
+- `SameAssemblyOverrideSlot_DeclinesDegradedOnlyConstraint`
+- `SameAssemblyOverrideSlot_DeclinesMixedDegradedAndValidConstraintSet`
 - `CompileBackTargets_PreservesExternalGenericCovariantMethodImpl`
 
 ### Constructor planning

--- a/docs/design/override-shell-authentication.md
+++ b/docs/design/override-shell-authentication.md
@@ -101,6 +101,36 @@ or unavailable declaration does not materialize a class override slot.
 Metadata tokens deduplicate the target and synthesized slot first; structural
 shape is only the fallback when no shared token exists.
 
+The base-class chain is a metadata walk, not a `TypeDef` walk. A compiler emits
+`Derived : Base<string>` and `Derived<T> : Base<T>` with a `TypeSpec` `extends`
+row, and emits the covariant-return `MethodImpl` declaration as a `MemberRef`
+rooted in that `TypeSpec` rather than as a `MethodDef`. Metadata therefore walks
+same-image `TypeDef` and constructed-generic `TypeSpec` bases alike, carrying
+each step's exact generic arguments and substituting them into the declaration's
+decoded signature, so the slot is authenticated by definition token and
+substituted structural identity. A `TypeSpec` that is not a generic
+instantiation of a definition in this image, a `MemberRef` that does not resolve
+to exactly one method on an authenticated chain step, and an instantiation whose
+arguments do not correspond all decline. No step matches a rendered name.
+
+A reconstructed shell spells a same-assembly base reached directly, and one
+reached through a constructed generic `TypeSpec` when the same Metadata-owned
+traversal resolves it to a definition in this image *and* the derived type reuses
+a virtual slot it did not introduce. A constructed base is otherwise left
+dropped, because a closed instantiation whose only constructor is parameterized
+carries the same implicit-`base()` exposure an external base does. An external
+base is always dropped because the shell cannot own its construction, and
+dropping a base drops `override` from every member whose slot that base owned.
+
+An `Object` intrinsic slot is authenticated the same way. `ToString`,
+`GetHashCode`, and `Equals(object)` reuse `System.Object`'s slot only when the
+method is non-static, non-`NewSlot`, non-generic, its signature matches the
+intrinsic read from primitive element types rather than from a rendered name,
+and its same-image base chain terminates at the strong-name-authenticated
+corelib `System.Object`. A base that leaves the image is not proof of the
+`Object` slot, because that base may declare its own `NewSlot` virtual of the
+same shape.
+
 The full member-surface pass applies the same authentication to unselected
 members. Reconstructing only the selected target must not sever another
 authenticated slot needed for the type to compile.
@@ -195,8 +225,11 @@ constructor only when all of these hold:
 - the return type is `void`.
 
 The planner applies parameter and accessibility matching only after that
-predicate succeeds. A method with the right name or rendered parameters but an
-invalid constructor shape is not a constructor.
+predicate succeeds, on every path that discovers a constructor: primary
+constructor detection, instance-constructor counting, member requirements, and
+the full member-surface pass. A method with the right name or rendered
+parameters but an invalid constructor shape is not a constructor, and is skipped
+rather than reclassified as an ordinary method.
 
 External base-definition extraction exports only authenticated, non-generic,
 public-class facts and accessible parameterless-constructor availability.
@@ -231,6 +264,10 @@ and override predicates rather than restating their metadata rules.
 
 The harness does not:
 
+- decide from a name and signature that a member occupies an `Object` intrinsic
+  slot; that predicate is Metadata-owned, because a flattened external base can
+  declare its own `NewSlot` virtual of the same shape and keeping `override`
+  would silently rebind the member to `System.Object`;
 - infer a relationship from rendered text;
 - substitute a same-named type from another assembly;
 - repair malformed metadata into a plausible relationship;
@@ -247,7 +284,17 @@ as compile-back failure; it is not converted into a different shell.
 
 All traversals use SRM and repository safety bounds. Cycles, malformed rows,
 decode failures, ambiguous current-image definitions, and exhausted budgets
-decline authentication. API extraction retains unavailable `MethodImpl`
+decline authentication.
+
+Return-type compatibility is recursive over generic-parameter constraints, so
+active-path cycle detection alone is not a bound: a constraint graph that is a
+DAG rather than a cycle enumerates exponentially many acyclic paths, and a long
+acyclic chain exhausts the stack before any node repeats. The comparison
+therefore carries one budget for the whole comparison, charging cumulative
+relationship work and capping recursion depth. Exhausting either budget refuses
+the slot outright rather than yielding `Unknown`, because `Unknown` is the
+retain-and-let-the-compiler-decide state and would turn budget exhaustion into a
+success path. API extraction retains unavailable `MethodImpl`
 provenance and a typed inspection failure where that surface promises
 disclosure; the shell planner never converts unavailable evidence into a valid
 override or constructor.
@@ -270,6 +317,27 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `SameAssemblyOverrideSlot_DeclinesIncompatibleStructuredReturn`
 - `CompileBackTargets_AllFullDoesNotDuplicateTargetedOverrideSlot`
 - `CompileBackTargets_AllFullPreservesUnrelatedCovariantMethodImpl`
+
+### Constructed generic bases and object intrinsic slots
+
+- `SameAssemblyOverrideSlot_AuthenticatesConstructedGenericBaseCovariantMethodImpl`
+- `SameAssemblyOverrideSlot_AuthenticatesConstructedGenericBaseSubstitutedParameter`
+- `SameAssemblyOverrideSlot_AuthenticatesSyntheticConstructedGenericMethodImpl`
+- `SameAssemblyOverrideSlot_DeclinesConstructedGenericMethodImplWithMismatchedInstantiation`
+- `SameAssemblyOverrideSlot_DeclinesConstructedGenericMethodImplRootedInExternalDefinition`
+- `AuthenticatedObjectSlotOverride_AcceptsSameImageChainToObject`
+- `AuthenticatedObjectSlotOverride_DeclinesOverrideOfExternalBase`
+- `AuthenticatedObjectSlotOverride_DeclinesNewSlotObjectShapedVirtual`
+- `CompileBackTargets_PrefersSameAssemblyToStringSlotOverIntrinsicObjectShortcut`
+- `CompileBackTargets_DoesNotRebindFlattenedExternalObjectShapedSlotToObject`
+- `CompileBackTargets_AllFullPreservesReferenceConstrainedGenericCovariantMethodImpl`
+- `CompileBackTargets_DoesNotReconstructGenericBaseClass`
+
+### Comparison boundedness
+
+- `SameAssemblyOverrideSlot_WideGenericParameterDagFailsClosedWithinBudget`
+- `SameAssemblyOverrideSlot_DeepGenericParameterChainFailsClosed`
+- `SameAssemblyOverrideSlot_DeepGenericParameterChainDoesNotCrashProcess`
 
 ### Wrappers, arrays, and local definition trust
 
@@ -312,6 +380,7 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `CompileBackTargets_PreservesPrivateEnclosingBaseConstructorForNestedDerived`
 - `CompileBackTargets_DropsUnrelatedPrivateBaseConstructorInitializer`
 - `CompileBackTargets_RecordShellDropsExplicitBaseInitializerWithDroppedBaseList`
+- `CompileBackTargets_DoesNotPlanMalformedConstructorNamedMethod`
 
 ### Property traversal and malformed cycles
 

--- a/docs/design/override-shell-authentication.md
+++ b/docs/design/override-shell-authentication.md
@@ -92,8 +92,15 @@ A virtual `NewSlot` method or property accessor is reconstructed as a source
    static/instance shape.
 3. Parameters correspond exactly by scoped structural identity and
    ref/out/in shape.
-4. Return modifiers correspond exactly.
-5. Return types are equal or the compatibility matrix below permits a
+4. The two signature headers correspond in every source-relevant fact: both
+   are managed method signatures with instance `this`, no explicit `this`, the
+   default calling convention rather than vararg, the same generic arity, and
+   the same required parameter count. A header fact the decoded parameter list
+   never shows -- a vararg sentinel splitting that list, a receiver passed as a
+   declared parameter, a static slot no instance declaration occupies -- is
+   refused on both sides rather than compared away.
+5. Return modifiers correspond exactly.
+6. Return types are equal or the compatibility matrix below permits a
    covariant conversion.
 
 An interface declaration, unrelated class declaration, ambiguous declaration,
@@ -113,10 +120,29 @@ instantiation of a definition in this image, a `MemberRef` that does not resolve
 to exactly one method on an authenticated chain step, and an instantiation whose
 arguments do not correspond all decline. No step matches a rendered name.
 
+Each supertype step is also validated for the role its metadata row claims. An
+`extends` target must be a class and an `InterfaceImpl` target must be an
+interface, whether the row names a `TypeDef` directly or a constructed
+`TypeSpec` over one. Nothing in the format enforces that pairing, and the roles
+carry different authority: a class base owns virtual slots and constructor
+exposure, while an interface row does not. An `InterfaceImpl` naming a class,
+or an `extends` naming an interface, is malformed evidence about the hierarchy
+and declines rather than being read as the other kind. The base-only walks --
+the class chain and the walk to the authenticated `System.Object` root -- accept
+class steps alone for the same reason.
+
 A reconstructed shell spells a same-assembly base reached directly, and one
 reached through a constructed generic `TypeSpec` when the same Metadata-owned
 traversal resolves it to a definition in this image *and* the derived type reuses
-a virtual slot it did not introduce. A constructed base is otherwise left
+a virtual slot it did not introduce. That reuse is itself authenticated: either
+the type declares a virtual method that is not `NewSlot` -- the inherited-slot
+flags a compiler emits for an implicit `override` -- or one of its `MethodImpl`
+rows resolves to an authenticated class override slot on the base chain. The
+presence of a `MethodImpl` row alone is not reuse. An explicit interface
+implementation is a private `newslot virtual final` method plus a `MethodImpl`,
+so it carries the same row while occupying a slot the interface introduced, and
+retaining a constructed generic base on that evidence would spell a base the
+type never inherited a slot from. A constructed base is otherwise left
 dropped, because a closed instantiation whose only constructor is parameterized
 carries the same implicit-`base()` exposure an external base does. An external
 base is always dropped because the shell cannot own its construction, and
@@ -124,9 +150,12 @@ dropping a base drops `override` from every member whose slot that base owned.
 
 An `Object` intrinsic slot is authenticated the same way. `ToString`,
 `GetHashCode`, and `Equals(object)` reuse `System.Object`'s slot only when the
-method is non-static, non-`NewSlot`, non-generic, its signature matches the
-intrinsic read from primitive element types rather than from a rendered name,
-and its same-image base chain terminates at the strong-name-authenticated
+method is non-static, non-`NewSlot`, non-generic, its signature header is one a
+source declaration can occupy -- a managed method signature with instance
+`this`, no explicit `this`, the default calling convention rather than vararg,
+and a parameter list its own required count agrees with -- its signature matches
+the intrinsic read from primitive element types rather than from a rendered
+name, and its same-image base chain terminates at the strong-name-authenticated
 corelib `System.Object`. A base that leaves the image is not proof of the
 `Object` slot, because that base may declare its own `NewSlot` virtual of the
 same shape.
@@ -159,6 +188,19 @@ Every current-image named definition reachable through the structural tree must
 resolve uniquely. Wrapper nodes preserve their own shape while current-image
 fail-closed inspection descends into their children.
 
+Identity is also the visited state of the ancestry walk, and a substituted
+ancestry step is a DAG whose nodes are shared while its structural identity is
+the expanded tree. A base that instantiates itself over a pair of its own
+argument -- `Middle<T> : Middle<Pair<T, T>>` -- therefore doubles that tree per
+step and exhausts hundreds of megabytes long before the relationship node
+ceiling is reached, because the ceiling counts steps rather than the size of
+each step. The expanded size is bounded before any text is materialized: each
+step's identity is charged to the shared comparison budget from the arguments'
+precomputed size estimates, refused outright above the exact-identity character
+cap, and memoized per node so a shared subgraph is spelled once. The identity
+that results is still exact -- nothing is hashed, truncated, or approximated --
+and a step whose identity cannot be taken exactly declines.
+
 ## Return compatibility matrix
 
 In the table, *implementation* is the reconstructed member and *declaration* is
@@ -171,18 +213,37 @@ the authenticated base slot.
 | SZ arrays | Both are SZ arrays; both element types are authenticated reference types; recurse covariantly on elements | Element result |
 | Multidimensional arrays | Both are MD arrays with identical rank, sizes, and lower bounds; both elements are authenticated reference types; recurse covariantly | Element result |
 | Constructed local generics | One exact local generic definition resolves uniquely; arity and every argument correspond under its declared variance | Aggregate argument result |
-| Constructed external generics | Definition identities correspond, no current-image dependency is missing, and local variance metadata is unavailable | `Unknown` for compiler validation |
+| Constructed external generics | Definition identities correspond, no current-image dependency is missing, argument counts agree with each other and with the arity each encoded definition name declares, and local variance metadata is unavailable | `Unknown` for compiler validation |
+| Constructed external generics whose argument counts disagree | Counts differ between the two sides, or a side's count differs from the arity its own encoded definition name declares | `Incompatible` |
 | Local named types | Both exact definitions resolve uniquely | `Compatible` only when the implementation is the same as or derives from or implements the declaration |
 | Local named ancestry through constructed bases or interfaces | Every step is a same-image `TypeDef` or a constructed `TypeSpec` over a definition in this image, with substituted arguments carried forward | `Compatible` only on an exact definition-token and exact-instantiation match within the shared budget |
 | External named types | Exact scopes authenticate but hierarchy is unavailable | `Unknown`, unless same-name/different-scope evidence disproves correspondence |
 | Generic implementation parameter | The generic-parameter rules below establish equality or conversion | Rule result |
 | Generic declaration parameter only | No covariant conversion can be proved | `Incompatible` |
+| Declaration is plain `object` | The implementation is an unwrapped named, constructed, array, primitive, or generic-parameter shape whose every reachable current-image definition resolves uniquely, and that shape is an authenticated reference type | `Compatible` |
 | Value or degraded shape | No authenticated reference conversion exists | `Incompatible` |
 
 Invariant generic arguments require exact structural correspondence. Covariant
 and contravariant arguments recurse in their declared direction. A local
 same-spelled generic definition never supplies variance for an external
 definition.
+
+Variance flags are honored only from a definition the CLI lets declare them: an
+interface, or a delegate whose base resolves through the authenticated core
+library on the same terms as the `System.Object` root. A class may not declare
+a variant type parameter at all, so honoring the flag on a class owner would let
+a malformed image widen an invariant argument comparison into a covariant one
+the runtime never performs. A variance flag on an ineligible owner fails the
+comparison closed rather than being ignored, because ignoring it would silently
+accept the malformed row as invariant metadata.
+
+Conversion to a plain `object` declaration is decided in that order too. Wrapper
+symmetry and unique current-image resolution are established first, so a
+modified or pinned implementation returning plain `object` declines for
+asymmetry rather than being read through its wrapper, and an implementation
+whose exact local definition is unavailable or ambiguous declines rather than
+being accepted as some reference type. Only a shape that survives both checks is
+asked whether it is an authenticated reference type.
 
 Local named ancestry is a metadata walk on the same terms as slot
 authentication, not a `TypeDef` walk. `Dog : Middle<int>` and
@@ -237,6 +298,13 @@ degraded row and accepting the sibling would let metadata order decide whether
 malformed current-image evidence is fatal. Among fully decoded constraints the
 rule stays existential: any one of them may establish the conversion.
 
+The reference-type flag is subject to the same rule. Before that flag may
+authenticate `T`-to-`object` correspondence or generic array covariance, the
+parameter's complete constraint set is decoded under the shared budget, so a
+malformed or degraded sibling constraint fails the relationship closed instead
+of being bypassed by the flag. A parameter constrained only by the flag has an
+empty constraint set, decodes trivially, and keeps its existing meaning.
+
 ## Constructor authentication
 
 Metadata owns the reusable CLI constructor predicate. A method is an instance
@@ -273,6 +341,14 @@ Flattened shells that omit the base list also omit an explicit base initializer.
 Property accessibility begins with the best accessor present on the property.
 When only one accessor exists, Metadata may follow its authenticated override
 slot to the base property to recover the source-level property accessibility.
+
+The accessor's property association must be unique. Well-formed metadata
+associates an accessor with at most one property, but nothing in the format
+enforces it, and that association decides which declaration's accessibility the
+reconstructed property inherits. Taking the first matching row would let the
+answer depend on metadata row order, so the scan continues past the first match
+and declines when a second property claims the same accessor; both row orders
+therefore produce the same refusal.
 
 The traversal is iterative, tracks visited accessor handles, and is bounded by
 the metadata relationship limit. A self-base cycle, mutual-base cycle,
@@ -341,6 +417,11 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `SameAssemblyOverrideSlot_DeclinesNestedVsNamespaceParameter`
 - `SameAssemblyOverrideSlot_DeclinesIncompatibleCovariantReturn`
 - `SameAssemblyOverrideSlot_DeclinesIncompatibleStructuredReturn`
+- `SameAssemblyOverrideSlot_DeclinesMalformedSignatureHeader`
+- `SameAssemblyOverrideSlot_AllowsSourceDeclarableSignatureHeader`
+- `ReusesInheritedVirtualSlot_DeclinesExplicitInterfaceOnlyMethodImpl`
+- `ReusesInheritedVirtualSlot_AcceptsAuthenticatedClassMethodImpl`
+- `ReusesInheritedVirtualSlot_AcceptsInheritedVirtualSlotFlags`
 - `CompileBackTargets_AllFullDoesNotDuplicateTargetedOverrideSlot`
 - `CompileBackTargets_AllFullPreservesUnrelatedCovariantMethodImpl`
 
@@ -356,9 +437,14 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `SameAssemblyOverrideSlot_AuthenticatesDirectCovariantReturnThroughTypeDefAncestry`
 - `SameAssemblyOverrideSlot_AuthenticatesConstructedGenericAncestryWithMatchingArgument`
 - `SameAssemblyOverrideSlot_DeclinesConstructedGenericAncestryWithDifferentArgument`
+- `SameAssemblyOverrideSlot_AuthenticatesInterfaceAncestryThroughInterfaceImplementation`
+- `SameAssemblyOverrideSlot_DeclinesInterfaceImplementationNamingAClass`
+- `SameAssemblyOverrideSlot_DeclinesBaseTypeNamingAnInterface`
 - `AuthenticatedObjectSlotOverride_AcceptsSameImageChainToObject`
 - `AuthenticatedObjectSlotOverride_DeclinesOverrideOfExternalBase`
 - `AuthenticatedObjectSlotOverride_DeclinesNewSlotObjectShapedVirtual`
+- `AuthenticatedObjectSlotOverride_DeclinesMalformedSignatureHeader`
+- `AuthenticatedObjectSlotOverride_AcceptsSourceDeclarableSignatureHeader`
 - `CompileBackTargets_PrefersSameAssemblyToStringSlotOverIntrinsicObjectShortcut`
 - `CompileBackTargets_DoesNotRebindFlattenedExternalObjectShapedSlotToObject`
 - `CompileBackTargets_AllFullPreservesReferenceConstrainedGenericCovariantMethodImpl`
@@ -371,6 +457,8 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `SameAssemblyOverrideSlot_DeepGenericParameterChainDoesNotCrashProcess`
 - `SameAssemblyOverrideSlot_CyclicConstructedAncestryFailsClosed`
 - `SameAssemblyOverrideSlot_ExpandingConstructedAncestryFailsClosedWithinBudget`
+- `SameAssemblyOverrideSlot_BranchingConstructedAncestryFailsClosed`
+- `SameAssemblyOverrideSlot_BranchingConstructedAncestryFailsClosedWithinMemory`
 
 ### Wrappers, arrays, and local definition trust
 
@@ -381,6 +469,10 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `SameAssemblyOverrideSlot_DeclinesDifferentMultiDimensionalArrayShape`
 - `SameAssemblyOverrideSlot_DeclinesAmbiguousExactLocalGenericDefinition`
 - `SameAssemblyOverrideSlot_DeclinesArrayWrappedAmbiguousExactLocalGenericDefinition`
+- `SameAssemblyOverrideSlot_DeclinesModifiedReturnAgainstObjectDeclaration`
+- `SameAssemblyOverrideSlot_DeclinesAmbiguousExactLocalReturnAgainstObjectDeclaration`
+- `SameAssemblyOverrideSlot_AllowsExactLocalReferenceReturnAgainstObjectDeclaration`
+- `SameAssemblyOverrideSlot_AllowsSyntheticExactLocalReferenceReturnAgainstObjectDeclaration`
 
 ### Generic conversions and external unknowns
 
@@ -402,6 +494,14 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `SameAssemblyOverrideSlot_AllowsValidOnlyExplicitConstraintSet`
 - `SameAssemblyOverrideSlot_DeclinesDegradedOnlyConstraint`
 - `SameAssemblyOverrideSlot_DeclinesMixedDegradedAndValidConstraintSet`
+- `SameAssemblyOverrideSlot_DeclinesDegradedSiblingConstraintForObjectReturn`
+- `SameAssemblyOverrideSlot_DeclinesDegradedSiblingConstraintForArrayCovariance`
+- `SameAssemblyOverrideSlot_AllowsAuthenticatedReferenceConstraintForObjectReturn`
+- `SameAssemblyOverrideSlot_AllowsReferenceFlagOnlyConstraintForArrayCovariance`
+- `SameAssemblyOverrideSlot_DeclinesExternalConstructedArityMismatch`
+- `SameAssemblyOverrideSlot_AllowsMatchingExternalConstruction`
+- `SameAssemblyOverrideSlot_DeclinesVarianceOnIneligibleOwner`
+- `SameAssemblyOverrideSlot_AllowsVarianceOnEligibleOwner`
 - `CompileBackTargets_PreservesExternalGenericCovariantMethodImpl`
 
 ### Constructor planning
@@ -424,6 +524,8 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `PropertyDeclaration_DerivesPropertyAccessibilityAcrossAcyclicSetterOnlyOverrideChain`
 - `PropertyDeclaration_SelfBasePropertyCycleFailsClosed`
 - `PropertyDeclaration_TwoTypePropertyCycleFailsClosed`
+- `PropertyDeclaration_DeclinesAccessorClaimedByMultipleProperties`
+- `PropertyDeclaration_UsesUniquePropertyAssociationForAccessor`
 
 ### End-to-end compile-back
 

--- a/docs/design/override-shell-authentication.md
+++ b/docs/design/override-shell-authentication.md
@@ -1,0 +1,329 @@
+# Override-shell authentication
+
+> The owning design for deciding when metadata proves that a reconstructed
+> compile-back shell may emit a C# `override`, retain a base constructor call,
+> or inherit property accessibility from a base declaration.
+
+This document owns the authentication decisions shared by Metadata and the
+ReturnToSender compile-back planner. The extraction and resolution machinery
+that supplies those decisions remains in
+[assembly inspection query](assembly-inspection-query.md). The immutable source
+artifact and compile-back experiment remain in
+[the decompiler correctness pipeline](../decompiler-correctness-pipeline.md).
+
+## The decision in one paragraph
+
+A source-level relationship is emitted only after Metadata authenticates its
+metadata relationship and complete structural shape. Current-image evidence is
+fail-closed: every definition needed to decide the relationship must resolve
+uniquely, including definitions nested under arrays, generic arguments,
+modifiers, pinning, pointers, byrefs, and function pointers. Exact external
+evidence is different: once the same-assembly slot itself is authenticated,
+hierarchy or variance that is unavailable outside the image remains `Unknown`
+and may be validated by the C# compiler. `Unknown` is never a substitute for
+missing or ambiguous current-image evidence. The harness consumes these
+product-owned decisions; it does not reconstruct them from names or rendered
+text.
+
+The enforcement map at the end of this document names the tests that gate each
+property.
+
+## Scope
+
+This design owns:
+
+- same-assembly class `MethodImpl` authentication for source-level override
+  methods, properties, and indexers;
+- exact parameter correspondence and covariant return compatibility;
+- generic-parameter and constructed-generic conversion evidence;
+- complete CLI constructor-shape authentication used by compile-back planning;
+- property accessibility inherited through authenticated override chains;
+- the boundary between product-owned evidence, harness planning, C# rendering,
+  and compiler validation; and
+- fail-closed behavior for malformed, cyclic, ambiguous, or over-budget
+  metadata encountered on those paths.
+
+This design does not own:
+
+- general API extraction or cross-assembly acquisition;
+- source rendering or C# syntax policy;
+- method-body decompilation and raising;
+- arbitrary CLR assignability;
+- hostile in-process callers bypassing the typed product APIs; or
+- a promise that every valid CLR relationship is expressible in C#.
+
+## Ownership pipeline
+
+| Stage | Owner | Authoritative input and output |
+| --- | --- | --- |
+| Relationship evidence | `ILInspector.Metadata` | SRM rows, `TypeNode`, exact handles, typed provenance, authenticated slot or refusal |
+| External base facts | `ILInspector.Metadata` | Frozen resolution evidence, typed base facts, no reader or catalog handle leakage |
+| Closure and target planning | ReturnToSender in `tools/DecompilerHarness` | Product-owned facts and exact metadata identities, producing typed CSharp requests |
+| Source composition | `ILInspector.CSharp` | Typed requests, producing the immutable compile-back shell |
+| Final external validation | C# compiler | Only relationships already authenticated except for explicitly retained external `Unknown` compatibility |
+
+Rendered names are presentation at every stage. They never prove definition
+identity, signature correspondence, accessibility, or constructor shape.
+
+## Authentication states
+
+The implementation uses a three-way compatibility result because absence of
+local proof has two materially different meanings.
+
+| State | Meaning | Consequence |
+| --- | --- | --- |
+| `Compatible` | The current image proves the required correspondence or conversion. | The authenticated relationship may be retained. |
+| `Incompatible` | The image disproves the relationship, the shapes differ, or required current-image evidence is unavailable or ambiguous. | Decline the source-level relationship. |
+| `Unknown` | The slot and exact external identities are authenticated, but external hierarchy or variance is not available in the current image. | Preserve the relationship for compiler validation. |
+
+`Unknown` is allowed only after the `MethodImpl` slot, declaration shape, and
+all current-image dependencies have authenticated. A same-spelled local type,
+an unresolved current-image definition, malformed metadata, or a scope
+mismatch is `Incompatible`, not `Unknown`.
+
+## Slot authentication
+
+A virtual `NewSlot` method or property accessor is reconstructed as a source
+`override` only when all of the following hold:
+
+1. An unambiguous class `MethodImpl` maps the body to a virtual declaration on
+   the base-class chain.
+2. The declaration is source-declarable and has compatible accessibility and
+   static/instance shape.
+3. Parameters correspond exactly by scoped structural identity and
+   ref/out/in shape.
+4. Return modifiers correspond exactly.
+5. Return types are equal or the compatibility matrix below permits a
+   covariant conversion.
+
+An interface declaration, unrelated class declaration, ambiguous declaration,
+or unavailable declaration does not materialize a class override slot.
+Metadata tokens deduplicate the target and synthesized slot first; structural
+shape is only the fallback when no shared token exists.
+
+The full member-surface pass applies the same authentication to unselected
+members. Reconstructing only the selected target must not sever another
+authenticated slot needed for the type to compile.
+
+## Structural identity
+
+Parameters and equal returns use complete scoped `TypeNode` identities. The
+identity retains:
+
+- namespace and root-to-leaf nested segments;
+- exact non-platform assembly or module scope;
+- typed trusted-platform normalization as a separate projection;
+- raw class/value-type kind and introduced arity;
+- every generic argument and encoded argument count;
+- SZ-array versus multidimensional-array shape, including rank, sizes, and
+  lower bounds;
+- pointer, byref, pinned, and required/optional modifier structure; and
+- function-pointer calling convention, generic arity, return, parameters, and
+  modifiers.
+
+Trusted-platform normalization may replace only independently authenticated
+platform scopes. It never erases a namespace, nesting boundary, argument,
+modifier, raw type kind, function-pointer header, or non-platform scope.
+
+Every current-image named definition reachable through the structural tree must
+resolve uniquely. Wrapper nodes preserve their own shape while current-image
+fail-closed inspection descends into their children.
+
+## Return compatibility matrix
+
+In the table, *implementation* is the reconstructed member and *declaration* is
+the authenticated base slot.
+
+| Implementation and declaration shape | Required evidence | Result |
+| --- | --- | --- |
+| Exact structural identities | Exact or permitted platform-normalized correspondence | `Compatible` |
+| One side modified or pinned | Both sides have the same wrapper kind; modifiers correspond; recurse into the inner type | Inner result, otherwise `Incompatible` |
+| SZ arrays | Both are SZ arrays; both element types are authenticated reference types; recurse covariantly on elements | Element result |
+| Multidimensional arrays | Both are MD arrays with identical rank, sizes, and lower bounds; both elements are authenticated reference types; recurse covariantly | Element result |
+| Constructed local generics | One exact local generic definition resolves uniquely; arity and every argument correspond under its declared variance | Aggregate argument result |
+| Constructed external generics | Definition identities correspond, no current-image dependency is missing, and local variance metadata is unavailable | `Unknown` for compiler validation |
+| Local named types | Both exact definitions resolve uniquely | `Compatible` only when the implementation is the same as or derives from or implements the declaration |
+| External named types | Exact scopes authenticate but hierarchy is unavailable | `Unknown`, unless same-name/different-scope evidence disproves correspondence |
+| Generic implementation parameter | The generic-parameter rules below establish equality or conversion | Rule result |
+| Generic declaration parameter only | No covariant conversion can be proved | `Incompatible` |
+| Value or degraded shape | No authenticated reference conversion exists | `Incompatible` |
+
+Invariant generic arguments require exact structural correspondence. Covariant
+and contravariant arguments recurse in their declared direction. A local
+same-spelled generic definition never supplies variance for an external
+definition.
+
+## Generic-parameter evidence
+
+A generic implementation return accepts:
+
+- exact positional identity;
+- conversion to `object` when the reference-type constraint or an authenticated
+  class-constraint chain proves reference type; or
+- conversion established by a typed explicit class or interface constraint
+  reachable in the local metadata.
+
+The reference-type flag alone proves conversion only to `object`; it does not
+prove conversion to an arbitrary class. Absence of that flag does not prove
+value type.
+
+Array covariance needs stronger evidence because a value type can implement an
+interface. An explicit constraint proves a generic array element is a reference
+type only when Metadata authenticates the constraint as a class. An interface
+constraint may establish conversion to that interface, but it does not
+establish reference-ness for array covariance.
+
+Constructed constraints retain the exact generic definition and every
+argument. Local variance is read only from the uniquely resolved local
+definition. Exact external constructed constraints may remain `Unknown`; a
+non-generic or differently shaped candidate remains `Incompatible`.
+
+Generic-parameter traversal tracks active handles. A cycle, malformed
+constraint, degraded decode, or exhausted relationship budget fails closed.
+
+## Constructor authentication
+
+Metadata owns the reusable CLI constructor predicate. A method is an instance
+constructor only when all of these hold:
+
+- the name is exactly `.ctor`;
+- `SpecialName` and `RTSpecialName` are present;
+- the method is not static;
+- the signature is a default managed method signature with instance `this` and
+  no explicit `this`;
+- neither the signature nor the metadata rows declare generic parameters; and
+- the return type is `void`.
+
+The planner applies parameter and accessibility matching only after that
+predicate succeeds. A method with the right name or rendered parameters but an
+invalid constructor shape is not a constructor.
+
+External base-definition extraction exports only authenticated, non-generic,
+public-class facts and accessible parameterless-constructor availability.
+Private base constructors are eligible for an explicit initializer only when
+the derived type's exact metadata identity is transitively nested in the
+constructor's declaring type. The reverse direction and unrelated types remain
+inaccessible.
+
+A synthetic parameterless constructor is emitted only when the C# member set
+does not already contain a retained parameterless instance constructor.
+Flattened shells that omit the base list also omit an explicit base initializer.
+
+## Property accessibility
+
+Property accessibility begins with the best accessor present on the property.
+When only one accessor exists, Metadata may follow its authenticated override
+slot to the base property to recover the source-level property accessibility.
+
+The traversal is iterative, tracks visited accessor handles, and is bounded by
+the metadata relationship limit. A self-base cycle, mutual-base cycle,
+malformed property map, or exhausted bound fails closed. A missing initial slot
+provides no inherited accessibility. After at least one authenticated hop, the
+absence of another slot terminates the chain at the best accessor on that
+authenticated base property. A valid acyclic single-accessor chain may also
+terminate at a normal two-accessor property.
+
+## Harness and compiler boundary
+
+ReturnToSender may orchestrate closure discovery, select authenticated metadata
+members, and choose body policy. It must call the Metadata-owned constructor
+and override predicates rather than restating their metadata rules.
+
+The harness does not:
+
+- infer a relationship from rendered text;
+- substitute a same-named type from another assembly;
+- repair malformed metadata into a plausible relationship;
+- parse source to construct or normalize the shell later compiled as product
+  evidence; or
+- treat compiler success as authentication of a slot the product did not
+  identify.
+
+The compiler is an independent validator only for exact external relationships
+whose remaining compatibility is `Unknown`. Compiler rejection remains visible
+as compile-back failure; it is not converted into a different shell.
+
+## Failure and boundedness
+
+All traversals use SRM and repository safety bounds. Cycles, malformed rows,
+decode failures, ambiguous current-image definitions, and exhausted budgets
+decline authentication. API extraction retains unavailable `MethodImpl`
+provenance and a typed inspection failure where that surface promises
+disclosure; the shell planner never converts unavailable evidence into a valid
+override or constructor.
+
+The shipped product path remains Roslyn-free and never loads the inspected
+assembly. Roslyn participates only in the tools-only compile-back experiment.
+
+## Enforcement map
+
+### Slot and scoped identity
+
+- `SameAssemblyOverrideSlot_UsesCompilerProducedCovariantMethodImpl`
+- `PropertyDeclaration_UsesCompilerProducedCovariantMethodImpl`
+- `SameAssemblyOverrideSlot_DeclinesInterfaceMethodImpl`
+- `SameAssemblyOverrideSlot_DeclinesUnauthenticatedClassMethodImpl`
+- `SameAssemblyOverrideSlot_AuthenticatesCompilerProducedScopedParameterIdentity`
+- `SameAssemblyOverrideSlot_DeclinesSameFqnReturnFromDifferentAssemblies`
+- `SameAssemblyOverrideSlot_DeclinesNestedVsNamespaceParameter`
+- `SameAssemblyOverrideSlot_DeclinesIncompatibleCovariantReturn`
+- `SameAssemblyOverrideSlot_DeclinesIncompatibleStructuredReturn`
+- `CompileBackTargets_AllFullDoesNotDuplicateTargetedOverrideSlot`
+- `CompileBackTargets_AllFullPreservesUnrelatedCovariantMethodImpl`
+
+### Wrappers, arrays, and local definition trust
+
+- `SameAssemblyOverrideSlot_AllowsModifierWrappedExactLocalGenericCovariance`
+- `SameAssemblyOverrideSlot_DeclinesModifierWrappedAmbiguousExactLocalGenericDefinition`
+- `SameAssemblyOverrideSlot_DeclinesPinnedWrappedAmbiguousExactLocalGenericDefinition`
+- `SameAssemblyOverrideSlot_AllowsMultiDimensionalArrayCovarianceWhenShapeMatches`
+- `SameAssemblyOverrideSlot_DeclinesDifferentMultiDimensionalArrayShape`
+- `SameAssemblyOverrideSlot_DeclinesAmbiguousExactLocalGenericDefinition`
+- `SameAssemblyOverrideSlot_DeclinesArrayWrappedAmbiguousExactLocalGenericDefinition`
+
+### Generic conversions and external unknowns
+
+- `SameAssemblyOverrideSlot_AllowsReferenceConstrainedGenericCovariantMethodImpl`
+- `SameAssemblyOverrideSlot_DeclinesReferenceConstrainedGenericToArbitraryClass`
+- `SameAssemblyOverrideSlot_AllowsExplicitGenericBaseConstraint`
+- `SameAssemblyOverrideSlot_DeclinesExplicitConstraintThatDoesNotReachReturn`
+- `SameAssemblyOverrideSlot_AllowsExplicitClassConstrainedGenericArrayCovariance`
+- `SameAssemblyOverrideSlot_DeclinesInterfaceConstrainedGenericArrayCovariance`
+- `SameAssemblyOverrideSlot_DeclinesArrayCovarianceWhenExplicitConstraintDoesNotReachReturn`
+- `SameAssemblyOverrideSlot_AllowsCovariantConstructedConstraint`
+- `SameAssemblyOverrideSlot_DeclinesInvariantConstructedConstraint`
+- `SameAssemblyOverrideSlot_AllowsCompilerProducedExternalConstructedConstraintVariance`
+- `SameAssemblyOverrideSlot_DeclinesExternalConstructedConstraintForNonGenericCandidate`
+- `SameAssemblyOverrideSlot_AllowsCompilerProducedNestedGenericVariance`
+- `SameAssemblyOverrideSlot_UsesExactNestedGenericVarianceDefinition`
+- `SameAssemblyOverrideSlot_AllowsCompilerProducedExternalGenericCovariance`
+- `SameAssemblyOverrideSlot_DoesNotUseLocalVarianceForExternalGeneric`
+- `CompileBackTargets_PreservesExternalGenericCovariantMethodImpl`
+
+### Constructor planning
+
+- `DirectDefinition_CarriesAccessibilityAndConstructorFacts`
+- `Extract_DoesNotTreatNamedMethodAsConstructor`
+- `FindAccessibleInstanceConstructor_ReturnsValidConstructor`
+- `FindAccessibleInstanceConstructor_RejectsMalformedConstructorShapes`
+- `CompileBackTargets_AllFullDoesNotDuplicatePrivateParameterlessConstructor`
+- `CompileBackTargets_SelectedSynthesizesConstructorWhenMetadataSignatureIsOmitted`
+- `CompileBackTargets_SelectedSynthesizesConstructorForOwnNestedDerivedType`
+- `CompileBackTargets_PreservesPrivateEnclosingBaseConstructorForNestedDerived`
+- `CompileBackTargets_DropsUnrelatedPrivateBaseConstructorInitializer`
+- `CompileBackTargets_RecordShellDropsExplicitBaseInitializerWithDroppedBaseList`
+
+### Property traversal and malformed cycles
+
+- `PropertyDeclaration_DerivesPropertyAccessibilityFromAuthenticatedBaseWhenOnlySetterIsPresent`
+- `PropertyDeclaration_DerivesPropertyAccessibilityAcrossAcyclicSetterOnlyOverrideChain`
+- `PropertyDeclaration_SelfBasePropertyCycleFailsClosed`
+- `PropertyDeclaration_TwoTypePropertyCycleFailsClosed`
+
+### End-to-end compile-back
+
+- `CompileBackTargets_PreservesCompilerProducedCovariantMethodImpl`
+- `CompileBackTargets_PreservesExternalCovariantMethodImpl`
+- `CompileBackTargets_PreservesCovariantPropertyMethodImpl`
+- `CompileBackTargets_PreservesCovariantIndexerMethodImpl`
+- `CompileBackTargets_AllFullPreservesReferenceConstrainedGenericCovariantMethodImpl`

--- a/docs/design/override-shell-authentication.md
+++ b/docs/design/override-shell-authentication.md
@@ -86,8 +86,9 @@ mismatch is `Incompatible`, not `Unknown`.
 A virtual `NewSlot` method or property accessor is reconstructed as a source
 `override` only when all of the following hold:
 
-1. An unambiguous class `MethodImpl` maps the body to a virtual declaration on
-   the base-class chain.
+1. An unambiguous class `MethodImpl` owned by the body method's declaring type
+   maps that body to a virtual declaration on the base-class chain. A row owned
+   by one type cannot borrow a sibling type's authenticated body.
 2. The declaration is source-declarable and has compatible accessibility and
    static/instance shape.
 3. Parameters correspond exactly by scoped structural identity and
@@ -420,6 +421,8 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 - `SameAssemblyOverrideSlot_DeclinesMalformedSignatureHeader`
 - `SameAssemblyOverrideSlot_AllowsSourceDeclarableSignatureHeader`
 - `ReusesInheritedVirtualSlot_DeclinesExplicitInterfaceOnlyMethodImpl`
+- `ReusesInheritedVirtualSlot_DeclinesCrossOwnerMethodImplBody`
+- `ReusesInheritedVirtualSlot_AcceptsSameOwnerMethodImplBody`
 - `ReusesInheritedVirtualSlot_AcceptsAuthenticatedClassMethodImpl`
 - `ReusesInheritedVirtualSlot_AcceptsInheritedVirtualSlotFlags`
 - `CompileBackTargets_AllFullDoesNotDuplicateTargetedOverrideSlot`
@@ -452,6 +455,7 @@ assembly. Roslyn participates only in the tools-only compile-back experiment.
 
 ### Comparison boundedness
 
+- `TypeSurface_ManyMethodsThreadsHandlesWithoutQuadraticAllocation`
 - `SameAssemblyOverrideSlot_WideGenericParameterDagFailsClosedWithinBudget`
 - `SameAssemblyOverrideSlot_DeepGenericParameterChainFailsClosed`
 - `SameAssemblyOverrideSlot_DeepGenericParameterChainDoesNotCrashProcess`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -82,7 +82,7 @@ substrates, and inspection producers that will extend that space.
   for `AnnotatedSourceDocument`: it derives lines from the canonical text buffer,
   resolves facts through targets to multi-span nodes, filters the stable node-kind
   vocabulary, and keeps unanchored facts visible without inventing coordinates.
-- `tools/DecompilerHarness/` owns ReturnToSender closure discovery and type-cluster planning. RTS specifies the required Metadata/CSharp request shape; `ILInspector.CSharp` owns rendering it.
+- `tools/DecompilerHarness/` owns ReturnToSender closure discovery and type-cluster planning. RTS specifies the required Metadata/CSharp request shape; `ILInspector.CSharp` owns rendering it. Metadata proof for overrides, constructors, and inherited property accessibility is defined by [override-shell authentication](design/override-shell-authentication.md).
 
 ## Engineering guidance
 

--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -247,6 +247,31 @@ public sealed class TypeShellProducerTests
         Assert.True(body.IsReplacementTarget);
     }
 
+    [Theory]
+    [InlineData(CSharpShellAccessibility.Public, "public")]
+    [InlineData(CSharpShellAccessibility.Protected, "protected")]
+    [InlineData(CSharpShellAccessibility.Internal, "internal")]
+    [InlineData(CSharpShellAccessibility.PrivateProtected, "private protected")]
+    [InlineData(CSharpShellAccessibility.ProtectedInternal, "protected internal")]
+    [InlineData(CSharpShellAccessibility.Private, "private")]
+    public void MemberShellProducer_PreservesAccessibility(
+        CSharpShellAccessibility accessibility,
+        string expected)
+    {
+        var policy = CSharpMemberShellProducer.BuildPolicy(new CSharpMemberShellSpec(
+            Name: "Run",
+            Kind: CSharpShellMemberKind.Method,
+            IsStatic: false,
+            Parameters: [],
+            ReturnType: "void",
+            TypeParameters: [],
+            BodyKind: CSharpShellBodyKind.Throw,
+            Body: null,
+            Accessibility: accessibility));
+
+        Assert.Equal(expected, policy.Member.Accessibility);
+    }
+
     [Fact]
     public void MemberShellProducer_ComposesExplicitInterfaceMethodDeclaration()
     {
@@ -266,6 +291,7 @@ public sealed class TypeShellProducerTests
             ],
             BodyKind: CSharpShellBodyKind.TargetBody,
             Body: "return default;",
+            Accessibility: CSharpShellAccessibility.Private,
             ExplicitInterfaceMemberName: "Samples.IRunner.Run",
             DeclarationSignature: "this harness text must not be used"));
 
@@ -287,6 +313,10 @@ public sealed class TypeShellProducerTests
 
         Assert.Contains(
             "T? Samples.IRunner.Run<T>(ref int value)",
+            Assert.Single(result.Units).Source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "private T? Samples.IRunner.Run<T>(ref int value)",
             Assert.Single(result.Units).Source,
             StringComparison.Ordinal);
         Assert.Contains(

--- a/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
+++ b/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
@@ -39,6 +39,10 @@ public enum CSharpShellAccessibility
 {
     Public,
     Protected,
+    Internal,
+    PrivateProtected,
+    ProtectedInternal,
+    Private,
 }
 
 public sealed record CSharpShellParameter(
@@ -273,6 +277,10 @@ public static class CSharpMemberShellProducer
             {
                 CSharpShellAccessibility.Public => "public",
                 CSharpShellAccessibility.Protected => "protected",
+                CSharpShellAccessibility.Internal => "internal",
+                CSharpShellAccessibility.PrivateProtected => "private protected",
+                CSharpShellAccessibility.ProtectedInternal => "protected internal",
+                CSharpShellAccessibility.Private => "private",
                 _ => throw new NotSupportedException(
                     $"Unsupported C# shell accessibility '{spec.Accessibility}'."),
             },

--- a/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
+++ b/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
@@ -81,6 +81,8 @@ public sealed record CSharpMemberShellSpec(
     int? MetadataToken = null,
     int? GetterToken = null,
     int? SetterToken = null,
+    string? GetterAccessibility = null,
+    string? SetterAccessibility = null,
     int? AdderToken = null,
     int? RemoverToken = null);
 
@@ -582,13 +584,26 @@ public static class CSharpMemberShellProducer
             accessors.Add(new ApiAccessor
             {
                 Kind = "get",
+                Accessibility = spec.GetterAccessibility,
                 ReturnAttributes = spec.ReturnAttributes?.ToList() ?? [],
             });
         }
         if (hasSetter)
-            accessors.Add(new ApiAccessor { Kind = setterIsInit ? "init" : "set" });
+        {
+            accessors.Add(new ApiAccessor
+            {
+                Kind = setterIsInit ? "init" : "set",
+                Accessibility = spec.SetterAccessibility,
+            });
+        }
         if (isAutoGetInit)
-            accessors.Add(new ApiAccessor { Kind = "init" });
+        {
+            accessors.Add(new ApiAccessor
+            {
+                Kind = "init",
+                Accessibility = spec.SetterAccessibility,
+            });
+        }
         return accessors;
     }
 

--- a/src/ILInspector.CSharp/TypeShellProducer.cs
+++ b/src/ILInspector.CSharp/TypeShellProducer.cs
@@ -101,11 +101,13 @@ public static class TypeShellProducer
     /// be dropped (left to its compiler-implied default).
     ///
     /// Attributes always keep their <c>System.Attribute</c> base. Otherwise only a
-    /// same-assembly (<see cref="HandleKind.TypeDefinition"/>) non-generic plain
-    /// class base is reconstructed: external (TypeReference) and generic
-    /// instantiation (TypeSpecification) bases are dropped because the shell cannot
-    /// own their construction, and object-family / value-type / delegate bases are
-    /// left implicit to avoid conflicts. <paramref name="isClass"/> is the caller's
+    /// same-assembly plain class base is reconstructed, reached either directly
+    /// (<see cref="HandleKind.TypeDefinition"/>) or through a constructed generic
+    /// <see cref="HandleKind.TypeSpecification"/> that the Metadata-owned bounded
+    /// traversal resolves to a definition in this image and whose derived type
+    /// reuses an inherited virtual slot: external (TypeReference) bases are
+    /// dropped because the shell cannot own their construction, and object-family
+    /// / value-type / delegate bases are left implicit to avoid conflicts. <paramref name="isClass"/> is the caller's
     /// resolved kind (records/structs/enums/delegates pass <see langword="false"/>).
     /// </summary>
     public static string? ReconstructedBaseTypeName(MetadataReader reader, TypeDefinition typeDef, bool isClass)
@@ -130,13 +132,33 @@ public static class TypeShellProducer
         // Attributes must derive from System.Attribute (existing behavior).
         if (baseType is "System.Attribute")
             return baseType;
-        // Only reconstruct same-assembly base classes. External (TypeReference) and
-        // generic-instantiation (TypeSpecification) bases are dropped: the shell
-        // cannot own their construction, so an external base whose only constructor
-        // is parameterized would make the derived stub's implicit `: base()` fail
-        // (CS7036) where the baseline compiled without a base.
-        if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
+        // Only reconstruct same-assembly base classes. An external (TypeReference)
+        // base is dropped: the shell cannot own its construction, so an external
+        // base whose only constructor is parameterized would make the derived
+        // stub's implicit `: base()` fail (CS7036) where the baseline compiled
+        // without a base. A constructed generic (TypeSpecification) base stays
+        // dropped by default -- a closed instantiation whose only constructor is
+        // parameterized has the same CS7036 exposure -- and is reconstructed only
+        // when two things hold: the Metadata-owned bounded traversal resolves it
+        // to a definition in this image, and the type reuses a virtual slot it did
+        // not introduce. Dropping the base in that second case would sever the
+        // slot the member overrides, which is a worse answer than spelling a base
+        // this image owns.
+        if (typeDef.BaseType.Kind == HandleKind.TypeSpecification)
+        {
+            if (!MetadataDeclarationQuery.TryGetSameAssemblyConstructedBaseDefinition(
+                    reader,
+                    typeDef,
+                    out _)
+                || !MetadataDeclarationQuery.ReusesInheritedVirtualSlot(reader, typeDef))
+            {
+                return null;
+            }
+        }
+        else if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
+        {
             return null;
+        }
         // Only plain classes reconstruct a real base class; records/structs/enums/
         // delegates keep their compiler-implied base to avoid primary-constructor
         // and value-type conflicts. A generic type's base can reference its own type

--- a/src/ILInspector.CSharp/TypeShellProducer.cs
+++ b/src/ILInspector.CSharp/TypeShellProducer.cs
@@ -97,7 +97,7 @@ public static class TypeShellProducer
 
     /// <summary>
     /// The base type name a skeletal type shape should reconstruct for
-    /// <paramref name="typeDef"/>, or <see langword="null"/> when the base should
+    /// <paramref name="typeHandle"/>, or <see langword="null"/> when the base should
     /// be dropped (left to its compiler-implied default).
     ///
     /// Attributes always keep their <c>System.Attribute</c> base. Otherwise only a
@@ -110,8 +110,12 @@ public static class TypeShellProducer
     /// / value-type / delegate bases are left implicit to avoid conflicts. <paramref name="isClass"/> is the caller's
     /// resolved kind (records/structs/enums/delegates pass <see langword="false"/>).
     /// </summary>
-    public static string? ReconstructedBaseTypeName(MetadataReader reader, TypeDefinition typeDef, bool isClass)
+    public static string? ReconstructedBaseTypeName(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        bool isClass)
     {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
         if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
             return null;
         if (typeDef.BaseType.IsNil)
@@ -150,9 +154,11 @@ public static class TypeShellProducer
                     reader,
                     typeDef,
                     out _)
-                || !MetadataDeclarationQuery.ReusesInheritedVirtualSlot(reader, typeDef))
+            || !MetadataDeclarationQuery.ReusesInheritedVirtualSlot(
+                reader,
+                typeHandle))
             {
-                return null;
+            return null;
             }
         }
         else if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
@@ -188,9 +194,12 @@ public static class TypeShellProducer
     /// surface-representability gate (<see cref="IsUnsupportedSurfaceSignature"/>) so
     /// the seam owns the full base-type spelling decision end to end.
     /// </summary>
-    public static string? ReconstructedBaseTypeDisplay(MetadataReader reader, TypeDefinition typeDef, bool isClass)
+    public static string? ReconstructedBaseTypeDisplay(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        bool isClass)
     {
-        var baseType = ReconstructedBaseTypeName(reader, typeDef, isClass);
+        var baseType = ReconstructedBaseTypeName(reader, typeHandle, isClass);
         if (baseType is null)
             return null;
         string display = CSharpFormatter.CleanTypeDisplay(baseType);
@@ -237,7 +246,10 @@ public static class TypeShellProducer
                     reader,
                     spec.Handle),
             Kind = TypeKindText(spec.Kind),
-            BaseType = ReconstructedBaseTypeDisplay(reader, typeDef, spec.Kind == CSharpTypeShellKind.Class),
+            BaseType = ReconstructedBaseTypeDisplay(
+                reader,
+                spec.Handle,
+                spec.Kind == CSharpTypeShellKind.Class),
             TypeParameters = MetadataDeclarationQuery.GetTypeParameters(reader, typeDef).ToList(),
             Interfaces = spec.InterfaceDisplayNames.ToList(),
             Members = members,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -10,6 +10,7 @@ using DotnetInspector.Services;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Reflection;
+using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
@@ -162,6 +163,69 @@ public class ReturnToSenderPrototypeTests
 
             rebuiltPath = CompileFixture(result.Source);
             AssertCovariantMethodImpl(rebuiltPath);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (rebuiltPath is not null)
+                DeleteFixture(rebuiltPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesExternalGenericCovariantMethodImpl()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public class Base
+            {
+                public virtual System.Collections.Generic.IEnumerable<Animal>
+                    Values() => [];
+            }
+
+            public class Derived : Base
+            {
+                public override System.Collections.Generic.IEnumerable<Dog>
+                    Values() => [];
+            }
+            """);
+        string? rebuiltPath = null;
+        try
+        {
+            AssertCovariantMethodImpl(
+                assemblyPath,
+                "Values");
+
+            var result = Assert.Single(
+                ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget(
+                        "Derived",
+                        "Values",
+                        0)]));
+
+            Assert.Contains(
+                "override IEnumerable<Dog> Values()",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.True(
+                result.Status
+                    == FidelityCheck
+                        .CompileBackStatus
+                        .Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+
+            rebuiltPath = CompileFixture(result.Source);
+            AssertCovariantMethodImpl(
+                rebuiltPath,
+                "Values");
         }
         finally
         {
@@ -5677,6 +5741,103 @@ public class ReturnToSenderPrototypeTests
                 $"{result.Source}{Environment.NewLine}{result.Detail}");
             Assert.Contains("public Base()", result.Source, StringComparison.Ordinal);
             Assert.DoesNotContain("CS7036", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Theory]
+    [InlineData(
+        RoundTripScope.Cluster,
+        RoundTripBodyPolicy.Selected)]
+    [InlineData(
+        RoundTripScope.All,
+        RoundTripBodyPolicy.Full)]
+    public void CompileBackTargets_PreservesPrivateEnclosingBaseConstructorForNestedDerived(
+        RoundTripScope scope,
+        RoundTripBodyPolicy bodyPolicy)
+    {
+        var assemblyPath = CompileFixture("""
+            public class Outer
+            {
+                private Outer(int seed)
+                {
+                    Seed = seed;
+                }
+
+                public int Seed { get; }
+
+                public class Nested : Outer
+                {
+                    public Nested(int seed) : base(seed)
+                    {
+                    }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(
+                ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget(
+                        "Outer.Nested",
+                        ".ctor",
+                        0)],
+                    scope,
+                    bodyPolicy));
+
+            Assert.False(
+                result.UsedCompileBackFloor,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+            Assert.NotEqual(
+                FidelityCheck.CompileBackStatus.RecompileFail,
+                result.Status);
+            Assert.Contains(
+                ": base(seed)",
+                result.Source,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Theory]
+    [InlineData(
+        RoundTripScope.Cluster,
+        RoundTripBodyPolicy.Selected)]
+    [InlineData(
+        RoundTripScope.All,
+        RoundTripBodyPolicy.Full)]
+    public void CompileBackTargets_DropsUnrelatedPrivateBaseConstructorInitializer(
+        RoundTripScope scope,
+        RoundTripBodyPolicy bodyPolicy)
+    {
+        string assemblyPath =
+            EmitUnrelatedPrivateBaseConstructorCall();
+        try
+        {
+            var result = Assert.Single(
+                ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget(
+                        "Derived",
+                        ".ctor",
+                        0)],
+                    scope,
+                    bodyPolicy));
+
+            Assert.NotEqual(
+                FidelityCheck.CompileBackStatus.RecompileFail,
+                result.Status);
+            Assert.DoesNotContain(
+                ": base(seed)",
+                result.Source,
+                StringComparison.Ordinal);
         }
         finally
         {
@@ -11811,6 +11972,80 @@ public class ReturnToSenderPrototypeTests
             File.Exists(dllPath),
             $"ilasm did not produce an assembly:{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
         return dllPath;
+    }
+
+    static string EmitUnrelatedPrivateBaseConstructorCall()
+    {
+        var assemblyName =
+            new AssemblyName(
+                "UnrelatedPrivateBaseConstructorCall");
+        var assembly =
+            new PersistedAssemblyBuilder(
+                assemblyName,
+                typeof(object).Assembly);
+        ModuleBuilder module =
+            assembly.DefineDynamicModule(
+                assemblyName.Name!);
+
+        TypeBuilder baseBuilder =
+            module.DefineType(
+                "Base",
+                TypeAttributes.Public);
+        ConstructorBuilder privateConstructor =
+            baseBuilder.DefineConstructor(
+                MethodAttributes.Private,
+                CallingConventions.Standard,
+                [typeof(int)]);
+        privateConstructor.GetILGenerator()
+            .Emit(OpCodes.Ret);
+        ConstructorBuilder publicConstructor =
+            baseBuilder.DefineConstructor(
+                MethodAttributes.Public,
+                CallingConventions.Standard,
+                Type.EmptyTypes);
+        ILGenerator publicIl =
+            publicConstructor.GetILGenerator();
+        publicIl.Emit(OpCodes.Ldarg_0);
+        publicIl.Emit(
+            OpCodes.Call,
+            typeof(object).GetConstructor(
+                Type.EmptyTypes)!);
+        publicIl.Emit(OpCodes.Ret);
+        Type baseType = baseBuilder.CreateType();
+
+        TypeBuilder derivedBuilder =
+            module.DefineType(
+                "Derived",
+                TypeAttributes.Public,
+                baseType);
+        ConstructorBuilder derivedConstructor =
+            derivedBuilder.DefineConstructor(
+                MethodAttributes.Public,
+                CallingConventions.Standard,
+                [typeof(int)]);
+        derivedConstructor.DefineParameter(
+            1,
+            ParameterAttributes.None,
+            "seed");
+        ILGenerator derivedIl =
+            derivedConstructor.GetILGenerator();
+        derivedIl.Emit(OpCodes.Ldarg_0);
+        derivedIl.Emit(OpCodes.Ldarg_1);
+        derivedIl.Emit(
+            OpCodes.Call,
+            privateConstructor);
+        derivedIl.Emit(OpCodes.Ret);
+        derivedBuilder.CreateType();
+
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(
+            directory,
+            $"{assemblyName.Name}.dll");
+        assembly.Save(path);
+        return path;
     }
 
     static string CompileFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -430,36 +430,158 @@ public class ReturnToSenderPrototypeTests
     [Fact]
     public void CompileBackTargets_AllFullPreservesReferenceConstrainedGenericCovariantMethodImpl()
     {
+        // The base is a constructed generic, which is the shape a compiler
+        // actually emits: `extends` is a TypeSpec and the covariant-return
+        // MethodImpl declaration is a MemberRef rooted in that TypeSpec, not a
+        // MethodDef. Authenticating the slot therefore has to substitute the
+        // base's exact generic arguments rather than read a MethodDef token.
         var assemblyPath = CompileFixture("""
-            public class Base
+            public class Base<TItem>
+                where TItem : class
             {
-                public virtual object Value() => "base";
+                public virtual TItem Value() => default!;
             }
 
-            public class Derived<T> : Base
-                where T : class
+            public class Derived : Base<object>
             {
-                public override T Value() => default!;
+                public override string Value() => "derived";
 
                 public int Call() => 1;
             }
             """);
+        AssertConstructedGenericCovariantOverrideSlot(assemblyPath);
+        string? rebuiltPath = null;
         try
         {
             var result = Assert.Single(ReturnToSender.CompileBackTargets(
                 assemblyPath,
-                [new ReturnToSender.RequestedTarget("Derived`1", "Call", 0)],
+                [new ReturnToSender.RequestedTarget("Derived", "Call", 0)],
                 RoundTripScope.All,
                 RoundTripBodyPolicy.Full));
 
             Assert.True(
                 result.Status == FidelityCheck.CompileBackStatus.Exact,
                 $"{result.Source}{Environment.NewLine}{result.Detail}");
-            Assert.True(
-                result.Source.Contains("override T Value()", StringComparison.Ordinal),
-                result.Source);
+
+            // The engaged reconstruction has to carry this, not the sanitized
+            // compile-back floor: the floor drops the very slot under test, so
+            // a floored run would assert nothing about authentication.
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(
+                "override string Value()",
+                result.Source,
+                StringComparison.Ordinal);
             Assert.DoesNotContain(
-                "public virtual T Value()",
+                "virtual string Value()",
+                result.Source,
+                StringComparison.Ordinal);
+
+            // Compile the exact immutable source the run produced and read the
+            // rebuilt metadata back, so the claim is about the slot and base
+            // identity the rebuilt image really carries, not about spelling.
+            rebuiltPath = CompileFixture(result.Source);
+            AssertConstructedGenericCovariantOverrideSlot(rebuiltPath);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (rebuiltPath is not null)
+                DeleteFixture(rebuiltPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DoesNotRebindFlattenedExternalObjectShapedSlotToObject()
+    {
+        // The external base declares its own new virtual ToString, so
+        // `Derived.ToString` occupies that base's slot, not System.Object's.
+        // The base lives in a directory the recompile closure cannot see, so
+        // the shell has to drop it -- and dropping it must drop `override`
+        // too. Keeping `override` would silently rebind the member to
+        // System.Object's slot.
+        var fixtureDir = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-{Guid.NewGuid():N}");
+        var referenceDir = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-{Guid.NewGuid():N}");
+        var referencePath = CompileFixture(
+            """
+            namespace RtsExternalSlot
+            {
+                public class ExternalToStringBase
+                {
+                    public new virtual string ToString() => "external";
+                }
+            }
+            """,
+            directory: referenceDir,
+            assemblyName: "RtsExternalSlotContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public class Derived : RtsExternalSlot.ExternalToStringBase
+            {
+                public override string ToString() => "derived";
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences:
+                [MetadataReference.CreateFromFile(referencePath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "ToString", 0)]));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            if (!result.Source.Contains(
+                    "RtsExternalSlot.ExternalToStringBase",
+                    StringComparison.Ordinal))
+            {
+                Assert.DoesNotContain(
+                    "override string ToString()",
+                    result.Source,
+                    StringComparison.Ordinal);
+            }
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (Directory.Exists(referenceDir))
+                Directory.Delete(referenceDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DoesNotPlanMalformedConstructorNamedMethod()
+    {
+        // A static method literally named `.ctor` carries the constructor name
+        // and nothing else the CLI requires of a constructor. Classifying it by
+        // name would plan a constructor the source form cannot express.
+        var assemblyPath = EmitMalformedConstructorNamedMethod();
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "MalformedCtorHost",
+                    "Probe",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.DoesNotContain(
+                "static MalformedCtorHost(",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                ".ctor",
                 result.Source,
                 StringComparison.Ordinal);
         }
@@ -12072,6 +12194,133 @@ public class ReturnToSenderPrototypeTests
 
         var emit = compilation.Emit(path);
         Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return path;
+    }
+
+    /// <summary>
+    /// Asserts that <paramref name="assemblyPath"/> carries the
+    /// compiler-produced constructed-generic covariant override shape and
+    /// that the product authenticates the exact base slot from it: a
+    /// <c>TypeSpec</c> base over <c>Base`1</c>, a <c>MethodImpl</c> whose
+    /// declaration is a <c>MemberRef</c> rooted in that <c>TypeSpec</c>, and a
+    /// same-assembly override slot resolving to <c>Base`1.Value</c>.
+    /// </summary>
+    static void AssertConstructedGenericCovariantOverrideSlot(
+        string assemblyPath)
+    {
+        using var peReader = new PEReader(File.OpenRead(assemblyPath));
+        var reader = peReader.GetMetadataReader();
+        var baseHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "Base`1");
+        var derivedHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "Derived");
+        var derived = reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = derived.GetMethods().Single(handle =>
+            reader.GetString(reader.GetMethodDefinition(handle).Name) == "Value");
+
+        Assert.Equal(HandleKind.TypeSpecification, derived.BaseType.Kind);
+        Assert.Equal(
+            baseHandle,
+            ConstructedTypeSpecDefinition(
+                reader,
+                (TypeSpecificationHandle)derived.BaseType));
+
+        var implementation = Assert.Single(
+            derived.GetMethodImplementations().Select(reader.GetMethodImplementation),
+            candidate => candidate.MethodBody == methodHandle);
+        Assert.Equal(
+            HandleKind.MemberReference,
+            implementation.MethodDeclaration.Kind);
+        var declaration = reader.GetMemberReference(
+            (MemberReferenceHandle)implementation.MethodDeclaration);
+        Assert.Equal(HandleKind.TypeSpecification, declaration.Parent.Kind);
+        Assert.Equal(
+            baseHandle,
+            ConstructedTypeSpecDefinition(
+                reader,
+                (TypeSpecificationHandle)declaration.Parent));
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+        Assert.Equal(baseHandle, slot.DeclaringType);
+        Assert.Equal(
+            reader.GetTypeDefinition(baseHandle).GetMethods().Single(handle =>
+                reader.GetString(reader.GetMethodDefinition(handle).Name)
+                    == "Value"),
+            slot.Method);
+    }
+
+    /// <summary>
+    /// Reads the <c>TypeDef</c> a <c>GENERICINST</c> <c>TypeSpec</c>
+    /// instantiates straight from the blob, so the assertion compares tokens
+    /// rather than rendered names.
+    /// </summary>
+    static TypeDefinitionHandle ConstructedTypeSpecDefinition(
+        MetadataReader reader,
+        TypeSpecificationHandle handle)
+    {
+        var blob = reader.GetBlobReader(
+            reader.GetTypeSpecification(handle).Signature);
+        Assert.Equal(0x15, blob.ReadCompressedInteger());
+        Assert.Equal(0x12, blob.ReadCompressedInteger());
+        return (TypeDefinitionHandle)blob.ReadTypeHandle();
+    }
+
+    /// <summary>
+    /// Emits a type carrying a static, non-<c>RTSpecialName</c> method whose
+    /// metadata name is <c>.ctor</c> alongside a real constructor and an
+    /// ordinary method, which no C# compiler produces.
+    /// </summary>
+    static string EmitMalformedConstructorNamedMethod()
+    {
+        var assemblyName = new AssemblyName("MalformedConstructorName");
+        var assembly = new PersistedAssemblyBuilder(
+            assemblyName,
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        var host = module.DefineType(
+            "MalformedCtorHost",
+            TypeAttributes.Public);
+
+        var realConstructor = host.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            Type.EmptyTypes);
+        var realIl = realConstructor.GetILGenerator();
+        realIl.Emit(OpCodes.Ldarg_0);
+        realIl.Emit(
+            OpCodes.Call,
+            typeof(object).GetConstructor(Type.EmptyTypes)!);
+        realIl.Emit(OpCodes.Ret);
+
+        var malformed = host.DefineMethod(
+            ".ctor",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(int),
+            Type.EmptyTypes);
+        var malformedIl = malformed.GetILGenerator();
+        malformedIl.Emit(OpCodes.Ldc_I4_7);
+        malformedIl.Emit(OpCodes.Ret);
+
+        var probe = host.DefineMethod(
+            "Probe",
+            MethodAttributes.Public,
+            typeof(int),
+            Type.EmptyTypes);
+        var probeIl = probe.GetILGenerator();
+        probeIl.Emit(OpCodes.Ldc_I4_3);
+        probeIl.Emit(OpCodes.Ret);
+        host.CreateType();
+
+        string directory = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, $"{assemblyName.Name}.dll");
+        assembly.Save(path);
         return path;
     }
 

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -334,6 +334,87 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PreservesSetterOnlyOverridePropertyAccessibilityAndAccessorAccessibility()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual int Value
+                {
+                    get => 0;
+                    protected set
+                    {
+                    }
+                }
+            }
+
+            public class Derived : Base
+            {
+                public override int Value
+                {
+                    protected set
+                    {
+                    }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "set_Value", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("public override int Value", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("protected override int Value", result.Source, StringComparison.Ordinal);
+            Assert.Contains("protected set", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("public set", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PrefersSameAssemblyToStringSlotOverIntrinsicObjectShortcut()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                protected new virtual string ToString() => nameof(Base);
+            }
+
+            public class Derived : Base
+            {
+                protected override string ToString() => nameof(Derived);
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "ToString", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("protected override string ToString()", result.Source, StringComparison.Ordinal);
+            Assert.NotNull(result.DonorPe);
+
+            var rebuilt = Assembly.Load(result.DonorPe);
+            var method = rebuilt.GetType("Derived")!.GetMethod(
+                nameof(object.ToString),
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)!;
+            Assert.Equal("Base", method.GetBaseDefinition().DeclaringType?.Name);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_MatchesRenamedGenericMethodParametersByPosition()
     {
         var assemblyPath = CompileFixture("""
@@ -5235,6 +5316,107 @@ public class ReturnToSenderPrototypeTests
 
             Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
             Assert.Contains("class Widget : Base", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullPreservesClosureConstructorBaseInitializerWhenBaseParameterlessConstructorIsPrivate()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                private Base()
+                {
+                }
+
+                public Base(int seed)
+                {
+                    Seed = seed;
+                }
+
+                public int Seed { get; }
+            }
+
+            public class Derived : Base
+            {
+                public Derived(int seed) : base(seed)
+                {
+                }
+            }
+
+            public static class Factory
+            {
+                public static Derived Create()
+                {
+                    Base b = new Base(1);
+                    _ = b.Seed;
+                    return new Derived(21);
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Factory", "Create", 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Full));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(": base(seed)", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("public Base()", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ClusterFullConstructorTargetPreservesExplicitBaseInitializerWithoutSyntheticBaseConstructor()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                private Base()
+                {
+                }
+
+                protected Base(int value)
+                {
+                }
+            }
+
+            public class Derived : Base
+            {
+                private readonly int _field;
+
+                public Derived() : base(1)
+                {
+                    _field = 1;
+                }
+
+                public int Read() => _field;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", ".ctor", 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(": base(1)", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("public Base()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Derived(int", result.Source, StringComparison.Ordinal);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -22,6 +22,413 @@ namespace ILInspector.Decompiler.Tests;
 [Trait("Area", "RoundTrip")]
 public class ReturnToSenderPrototypeTests
 {
+    [Theory]
+    [InlineData("Derived", "public override int Value()")]
+    [InlineData("SealedDerived", "public sealed override int Value()")]
+    [InlineData("InternalDerived", "internal override int Value()")]
+    [InlineData("PrivateProtectedDerived", "private protected override int Value()")]
+    public void CompileBackTargets_PreservesProductOwnedOverrideDeclaration(
+        string typeName,
+        string expectedDeclaration)
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual int Value() => 1;
+            }
+
+            public class Derived : Base
+            {
+                public override int Value() => 2;
+
+                public int Call() => Value();
+            }
+
+            public class SealedDerived : Base
+            {
+                public sealed override int Value() => 3;
+
+                public int Call() => Value();
+            }
+
+            public class InternalBase
+            {
+                internal virtual int Value() => 4;
+            }
+
+            public class InternalDerived : InternalBase
+            {
+                internal override int Value() => 5;
+            }
+
+            public class PrivateProtectedBase
+            {
+                private protected virtual int Value() => 6;
+            }
+
+            public class PrivateProtectedDerived : PrivateProtectedBase
+            {
+                private protected override int Value() => 7;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(typeName, "Value", 0)]));
+
+            Assert.Contains(expectedDeclaration, result.Source, StringComparison.Ordinal);
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullPreservesUnrelatedOverrideDeclaration()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual int Value() => 1;
+            }
+
+            public class Derived : Base
+            {
+                public override int Value() => 2;
+
+                public int Call() => Value();
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "Call", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(
+                FidelityCheck.CompileBackStatus.Exact,
+                result.Status);
+            Assert.Contains("public override int Value()", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullDoesNotIntroduceFilteredGenericOverrideObligation()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class Base
+            {
+                public abstract T Echo<T>(T value);
+            }
+
+            public class Derived : Base
+            {
+                public override T Echo<T>(T value) => value;
+
+                public int Call() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "Call", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.DoesNotContain("abstract T Echo<T>", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("CS0534", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullDoesNotIntroduceFilteredIndexerOverrideObligation()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class Base
+            {
+                public abstract int this[int index] { get; }
+            }
+
+            public class Derived : Base
+            {
+                public override int this[int index] => index;
+
+                public int Call() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "Call", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.DoesNotContain("abstract int this[", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("CS0534", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullPreservesNestedOverrideDeclaration()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual int Value() => 1;
+            }
+
+            public class Outer
+            {
+                public class Nested : Base
+                {
+                    public override int Value() => 2;
+
+                    public int Call() => Value();
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Outer.Nested", "Call", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Contains("public override int Value()", result.Source, StringComparison.Ordinal);
+            Assert.Contains("public virtual int Value()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("CS0115", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesPropertyOverrideAndBaseSlot()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual int Value => 1;
+            }
+
+            public class Derived : Base
+            {
+                public override int Value => 2;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "get_Value", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public override int Value", result.Source, StringComparison.Ordinal);
+            Assert.Contains("public virtual int Value", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesEventOverrideAndBaseSlot()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+
+            public class Derived : Base
+            {
+                public override event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "add_Changed", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Contains("public override event Action Changed", result.Source, StringComparison.Ordinal);
+            Assert.Contains("public virtual event Action Changed", result.Source, StringComparison.Ordinal);
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesOverrideAcrossIntermediateBase()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual int Value() => 1;
+            }
+
+            public class Middle : Base
+            {
+            }
+
+            public class Derived : Middle
+            {
+                public override int Value() => 2;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "Value", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public class Derived : Middle", result.Source, StringComparison.Ordinal);
+            Assert.Contains("public class Middle : Base", result.Source, StringComparison.Ordinal);
+            Assert.Contains("public virtual int Value()", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_MatchesRenamedGenericMethodParametersByPosition()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual T Echo<T>(T value) => value;
+            }
+
+            public class Derived : Base
+            {
+                public override U Echo<U>(U value) => value;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "Echo", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public override U Echo<U>(U value)", result.Source, StringComparison.Ordinal);
+            Assert.Contains("public virtual T Echo<T>(T value)", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DropsOverrideWhenGenericShellDropsBase()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual int Value() => 1;
+            }
+
+            public class Derived<T> : Base
+            {
+                public sealed override int Value() => 2;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived`1", "Value", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.DoesNotContain("override int Value()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("sealed", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(": Base", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DropsOverrideWhenExternalBaseIsNotReconstructed()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var dependencyPath = CompileFixture("""
+            namespace External;
+
+            public class Base
+            {
+                public virtual int Value() => 1;
+            }
+            """, directory, "ExternalLib");
+        var assemblyPath = CompileFixture("""
+            public class Derived : External.Base
+            {
+                public override int Value() => 2;
+            }
+            """, directory, "Fixture", [MetadataReference.CreateFromFile(dependencyPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "Value", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.DoesNotContain("override int Value()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(": External.Base", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     [Fact]
     public void CompileBackTargets_AllFullReconstructsUnrelatedExplicitInterfaceEventAccessors()
     {
@@ -8524,7 +8931,7 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackTargets_DoesNotMarkUserBaseOverrideWithoutBaseShell()
+    public void CompileBackTargets_PreservesOverrideWithAbstractBaseSlot()
     {
         var assemblyPath = CompileFixture("""
             public abstract class BaseNode
@@ -8544,8 +8951,8 @@ public class ReturnToSenderPrototypeTests
                 [new ReturnToSender.RequestedTarget("DerivedNode", "Describe", 0)]));
 
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-            Assert.Contains("public string Describe()", result.Source);
-            Assert.DoesNotContain("override string Describe", result.Source);
+            Assert.Contains("public override string Describe()", result.Source);
+            Assert.Contains("public abstract string Describe();", result.Source);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -89,6 +89,46 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PreservesCompilerProducedCovariantMethodImpl()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual object Value() => "base";
+            }
+
+            public class Derived : Base
+            {
+                public override string Value() => "derived";
+            }
+            """);
+        string? rebuiltPath = null;
+        try
+        {
+            AssertCovariantMethodImpl(assemblyPath);
+
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "Value", 0)]));
+
+            Assert.Contains("public override string Value()", result.Source, StringComparison.Ordinal);
+            Assert.Contains("public virtual object Value()", result.Source, StringComparison.Ordinal);
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+
+            rebuiltPath = CompileFixture(result.Source);
+            AssertCovariantMethodImpl(rebuiltPath);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (rebuiltPath is not null)
+                DeleteFixture(rebuiltPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_AllFullPreservesUnrelatedOverrideDeclaration()
     {
         var assemblyPath = CompileFixture("""
@@ -11305,6 +11345,30 @@ public class ReturnToSenderPrototypeTests
         var emit = compilation.Emit(path);
         Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
         return path;
+    }
+
+    static void AssertCovariantMethodImpl(string assemblyPath)
+    {
+        using var peReader = new PEReader(File.OpenRead(assemblyPath));
+        var reader = peReader.GetMetadataReader();
+        var baseHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "Base");
+        var derivedHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "Derived");
+        var derived = reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = derived.GetMethods().Single(handle =>
+            reader.GetString(reader.GetMethodDefinition(handle).Name) == "Value");
+        var method = reader.GetMethodDefinition(methodHandle);
+        var implementation = Assert.Single(
+            derived.GetMethodImplementations().Select(reader.GetMethodImplementation),
+            candidate => candidate.MethodBody == methodHandle);
+
+        Assert.True((method.Attributes & MethodAttributes.NewSlot) != 0);
+        Assert.Equal(HandleKind.MethodDefinition, implementation.MethodDeclaration.Kind);
+        Assert.Equal(
+            baseHandle,
+            reader.GetMethodDefinition(
+                (MethodDefinitionHandle)implementation.MethodDeclaration).GetDeclaringType());
     }
 
     static void DeleteFixture(string assemblyPath)

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -313,6 +313,57 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_AllFullPreservesUnrelatedCovariantMethodImpl()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual object Value() => "base";
+            }
+
+            public class Derived : Base
+            {
+                public override string Value() => "derived";
+
+                public int Call() => 1;
+            }
+            """);
+        string? rebuiltPath = null;
+        try
+        {
+            AssertCovariantMethodImpl(assemblyPath);
+
+            var result = Assert.Single(
+                ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget(
+                        "Derived",
+                        "Call",
+                        0)],
+                    RoundTripScope.All,
+                    RoundTripBodyPolicy.Full));
+
+            Assert.Contains(
+                "public override string Value()",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.True(
+                result.Status
+                    == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+
+            rebuiltPath = CompileFixture(result.Source);
+            AssertCovariantMethodImpl(rebuiltPath);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (rebuiltPath is not null)
+                DeleteFixture(rebuiltPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_AllFullDoesNotIntroduceFilteredGenericOverrideObligation()
     {
         var assemblyPath = CompileFixture("""
@@ -5505,6 +5556,73 @@ public class ReturnToSenderPrototypeTests
 
             Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
             Assert.Contains("class Widget : Base", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Theory]
+    [InlineData("private")]
+    [InlineData("internal")]
+    public void CompileBackTargets_SelectedSynthesizesConstructorWhenMetadataSignatureIsOmitted(
+        string accessibility)
+    {
+        var assemblyPath = CompileFixture($$"""
+            public class Base
+            {
+                {{accessibility}} Base()
+                {
+                }
+
+                public Base(int seed)
+                {
+                    Seed = seed;
+                }
+
+                public int Seed { get; }
+            }
+
+            public class Widget : Base
+            {
+                public Widget(int seed) : base(seed)
+                {
+                }
+            }
+
+            public static class Factory
+            {
+                public static Widget Create()
+                {
+                    Base value = new Base(1);
+                    _ = value.Seed;
+                    return new Widget(21);
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(
+                ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget(
+                        "Factory",
+                        "Create",
+                        0)],
+                    RoundTripScope.Cluster,
+                    RoundTripBodyPolicy.Selected));
+
+            Assert.False(
+                result.UsedCompileBackFloor,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+            Assert.NotEqual(
+                FidelityCheck.CompileBackStatus.RecompileFail,
+                result.Status);
+            Assert.Contains(
+                "public Base()",
+                result.Source,
+                StringComparison.Ordinal);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -129,6 +129,155 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PreservesExternalCovariantMethodImpl()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual System.IO.Stream Value() =>
+                    System.IO.Stream.Null;
+            }
+
+            public class Derived : Base
+            {
+                public override System.IO.MemoryStream Value() => new();
+            }
+            """);
+        string? rebuiltPath = null;
+        try
+        {
+            AssertCovariantMethodImpl(assemblyPath);
+
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived", "Value", 0)]));
+
+            Assert.Contains(
+                "public override MemoryStream Value()",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+
+            rebuiltPath = CompileFixture(result.Source);
+            AssertCovariantMethodImpl(rebuiltPath);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (rebuiltPath is not null)
+                DeleteFixture(rebuiltPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesCovariantPropertyMethodImpl()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public class Base
+            {
+                public virtual Animal Value => new();
+            }
+
+            public class Derived : Base
+            {
+                public override Dog Value => new();
+            }
+            """);
+        string? rebuiltPath = null;
+        try
+        {
+            AssertCovariantMethodImpl(assemblyPath, "get_Value");
+
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Derived",
+                    "get_Value",
+                    0)]));
+
+            Assert.Contains(
+                "public override Dog Value",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+
+            rebuiltPath = CompileFixture(result.Source);
+            AssertCovariantMethodImpl(rebuiltPath, "get_Value");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (rebuiltPath is not null)
+                DeleteFixture(rebuiltPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesCovariantIndexerMethodImpl()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Animal
+            {
+            }
+
+            public class Dog : Animal
+            {
+            }
+
+            public class Base
+            {
+                public virtual Animal this[int index] => new();
+            }
+
+            public class Derived : Base
+            {
+                public override Dog this[int index] => new();
+            }
+            """);
+        string? rebuiltPath = null;
+        try
+        {
+            AssertCovariantMethodImpl(assemblyPath, "get_Item");
+
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Derived",
+                    "get_Item",
+                    0)]));
+
+            Assert.Contains(
+                "public override Dog this[int index]",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+
+            rebuiltPath = CompileFixture(result.Source);
+            AssertCovariantMethodImpl(rebuiltPath, "get_Item");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+            if (rebuiltPath is not null)
+                DeleteFixture(rebuiltPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_AllFullPreservesUnrelatedOverrideDeclaration()
     {
         var assemblyPath = CompileFixture("""
@@ -5410,6 +5559,67 @@ public class ReturnToSenderPrototypeTests
             Assert.False(result.UsedCompileBackFloor, result.Detail);
             Assert.Contains(": base(seed)", result.Source, StringComparison.Ordinal);
             Assert.DoesNotContain("public Base()", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullDoesNotDuplicatePrivateParameterlessConstructor()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                private Base()
+                {
+                }
+
+                public Base(int seed)
+                {
+                }
+            }
+
+            public class Derived : Base
+            {
+                public Derived(int seed) : base(seed)
+                {
+                }
+            }
+
+            public static class Factory
+            {
+                public static Derived Create() => new(1);
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Factory",
+                    "Create",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(
+                "private Base()",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "public Base()",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "CS0111",
+                result.Detail,
+                StringComparison.Ordinal);
         }
         finally
         {
@@ -11347,7 +11557,9 @@ public class ReturnToSenderPrototypeTests
         return path;
     }
 
-    static void AssertCovariantMethodImpl(string assemblyPath)
+    static void AssertCovariantMethodImpl(
+        string assemblyPath,
+        string methodName = "Value")
     {
         using var peReader = new PEReader(File.OpenRead(assemblyPath));
         var reader = peReader.GetMetadataReader();
@@ -11357,7 +11569,8 @@ public class ReturnToSenderPrototypeTests
             reader.GetString(reader.GetTypeDefinition(handle).Name) == "Derived");
         var derived = reader.GetTypeDefinition(derivedHandle);
         var methodHandle = derived.GetMethods().Single(handle =>
-            reader.GetString(reader.GetMethodDefinition(handle).Name) == "Value");
+            reader.GetString(reader.GetMethodDefinition(handle).Name)
+                == methodName);
         var method = reader.GetMethodDefinition(methodHandle);
         var implementation = Assert.Single(
             derived.GetMethodImplementations().Select(reader.GetMethodImplementation),

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -364,6 +364,86 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_AllFullPreservesReferenceConstrainedGenericCovariantMethodImpl()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual object Value() => "base";
+            }
+
+            public class Derived<T> : Base
+                where T : class
+            {
+                public override T Value() => default!;
+
+                public int Call() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Derived`1", "Call", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+            Assert.True(
+                result.Source.Contains("override T Value()", StringComparison.Ordinal),
+                result.Source);
+            Assert.DoesNotContain(
+                "public virtual T Value()",
+                result.Source,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullDoesNotDuplicateTargetedOverrideSlot()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public virtual string Value() => "base";
+            }
+
+            public class Derived : Base
+            {
+                public override string Value() => "derived";
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Base", "Value", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+            const string declaration = "public virtual string Value()";
+            Assert.Contains(declaration, result.Source, StringComparison.Ordinal);
+            Assert.Equal(
+                result.Source.IndexOf(declaration, StringComparison.Ordinal),
+                result.Source.LastIndexOf(declaration, StringComparison.Ordinal));
+            Assert.DoesNotContain("CS0111", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_AllFullDoesNotIntroduceFilteredGenericOverrideObligation()
     {
         var assemblyPath = CompileFixture("""
@@ -5563,6 +5643,47 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Fact]
+    public void CompileBackTargets_SelectedSynthesizesConstructorForOwnNestedDerivedType()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Base
+            {
+                public Base(int seed)
+                {
+                }
+
+                public class Nested : Base
+                {
+                    public Nested(int seed) : base(seed)
+                    {
+                    }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Base", ".ctor", 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Selected));
+
+            Assert.False(
+                result.UsedCompileBackFloor,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+            Assert.True(
+                result.Status != FidelityCheck.CompileBackStatus.RecompileFail,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+            Assert.Contains("public Base()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("CS7036", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     [Theory]
     [InlineData("private")]
     [InlineData("internal")]
@@ -5677,6 +5798,50 @@ public class ReturnToSenderPrototypeTests
             Assert.False(result.UsedCompileBackFloor, result.Detail);
             Assert.Contains(": base(seed)", result.Source, StringComparison.Ordinal);
             Assert.DoesNotContain("public Base()", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RecordShellDropsExplicitBaseInitializerWithDroppedBaseList()
+    {
+        var assemblyPath = CompileFixture("""
+            public record B
+            {
+                public B(int seed)
+                {
+                }
+            }
+
+            public record R : B
+            {
+                public int Value { get; init; }
+
+                public R(int seed) : base(seed)
+                {
+                }
+
+                public R Copy() => this with { Value = 1 };
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("R", "Copy", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.False(
+                result.UsedCompileBackFloor,
+                $"{result.Source}{Environment.NewLine}{result.Detail}");
+            Assert.Contains("record R", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(": base(", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("CS1729", result.Detail, StringComparison.Ordinal);
+            Assert.DoesNotContain("CS8868", result.Detail, StringComparison.Ordinal);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderTypePlannerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderTypePlannerTests.cs
@@ -1,0 +1,229 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+public sealed class ReturnToSenderTypePlannerTests
+{
+    static readonly MethodInfo s_findAccessibleInstanceConstructor =
+        typeof(CompileBackSourceComposer)
+            .GetMethod(
+                "FindAccessibleInstanceConstructor",
+                BindingFlags.NonPublic
+                | BindingFlags.Static)!
+        ?? throw new InvalidOperationException(
+            "Could not find FindAccessibleInstanceConstructor.");
+
+    public enum ConstructorShape
+    {
+        Valid,
+        MissingSpecialName,
+        MissingRtSpecialName,
+        VarArgCallingConvention,
+        ExplicitThis,
+        GenericArity,
+        NonVoidReturn,
+        Static,
+    }
+
+    [Theory]
+    [InlineData(ConstructorShape.MissingSpecialName)]
+    [InlineData(ConstructorShape.MissingRtSpecialName)]
+    [InlineData(ConstructorShape.VarArgCallingConvention)]
+    [InlineData(ConstructorShape.ExplicitThis)]
+    [InlineData(ConstructorShape.GenericArity)]
+    [InlineData(ConstructorShape.NonVoidReturn)]
+    [InlineData(ConstructorShape.Static)]
+    public void FindAccessibleInstanceConstructor_RejectsMalformedConstructorShapes(
+        ConstructorShape shape)
+    {
+        using var stream = new MemoryStream(
+            BuildConstructorLookupImage(shape));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var baseHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+            == "Base");
+        var derivedHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+            == "Derived");
+
+        Assert.Null(
+            FindAccessibleInstanceConstructor(
+                reader,
+                baseHandle,
+                derivedHandle,
+                []));
+    }
+
+    [Fact]
+    public void FindAccessibleInstanceConstructor_ReturnsValidConstructor()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructorLookupImage(
+                ConstructorShape.Valid));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var baseHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+            == "Base");
+        var derivedHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+            == "Derived");
+
+        object? result = FindAccessibleInstanceConstructor(
+            reader,
+            baseHandle,
+            derivedHandle,
+            []);
+
+        var handle = Assert.IsType<MethodDefinitionHandle>(result);
+        Assert.Equal(
+            ".ctor",
+            reader.GetString(
+                reader.GetMethodDefinition(handle).Name));
+    }
+
+    static object? FindAccessibleInstanceConstructor(
+        MetadataReader reader,
+        TypeDefinitionHandle declaringTypeHandle,
+        TypeDefinitionHandle derivedTypeHandle,
+        IReadOnlyList<string> parameterTypes)
+        => s_findAccessibleInstanceConstructor.Invoke(
+            null,
+            [reader, declaringTypeHandle, derivedTypeHandle, parameterTypes]);
+
+    static byte[] BuildConstructorLookupImage(
+        ConstructorShape shape)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("ConstructorLookup.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("ConstructorLookup"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        var runtime = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Runtime"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        var objectType = metadata.AddTypeReference(
+            runtime,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("Derived"),
+            baseType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.HideBySig;
+        if (shape != ConstructorShape.MissingSpecialName)
+            attributes |= MethodAttributes.SpecialName;
+        if (shape != ConstructorShape.MissingRtSpecialName)
+            attributes |= MethodAttributes.RTSpecialName;
+        if (shape == ConstructorShape.Static)
+            attributes |= MethodAttributes.Static;
+
+        MethodDefinitionHandle constructor =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString(".ctor"),
+                BuildConstructorSignature(
+                    metadata,
+                    shape),
+                bodyOffset: -1,
+                parameterList: MetadataTokens.ParameterHandle(1));
+        if (shape == ConstructorShape.GenericArity)
+        {
+            metadata.AddGenericParameter(
+                constructor,
+                GenericParameterAttributes.None,
+                metadata.GetOrAddString("T"),
+                index: 0);
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(
+                metadata,
+                suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static BlobHandle BuildConstructorSignature(
+        MetadataBuilder metadata,
+        ConstructorShape shape)
+    {
+        var signature = new BlobBuilder();
+        switch (shape)
+        {
+            case ConstructorShape.VarArgCallingConvention:
+                signature.WriteByte(0x25);
+                signature.WriteCompressedInteger(0);
+                signature.WriteByte(0x01);
+                break;
+            case ConstructorShape.ExplicitThis:
+                signature.WriteByte(0x60);
+                signature.WriteCompressedInteger(0);
+                signature.WriteByte(0x01);
+                break;
+            case ConstructorShape.GenericArity:
+                signature.WriteByte(0x30);
+                signature.WriteCompressedInteger(1);
+                signature.WriteCompressedInteger(0);
+                signature.WriteByte(0x01);
+                break;
+            case ConstructorShape.NonVoidReturn:
+                signature.WriteByte(0x20);
+                signature.WriteCompressedInteger(0);
+                signature.WriteByte(0x08);
+                break;
+            default:
+                signature.WriteByte(0x20);
+                signature.WriteCompressedInteger(0);
+                signature.WriteByte(0x01);
+                break;
+        }
+
+        return metadata.GetOrAddBlob(signature);
+    }
+}

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -3666,6 +3666,67 @@ public static class ApiSurfaceExtractor
         }
     }
 
+    /// <summary>
+    /// True when <paramref name="typeHandle"/> is the base a delegate
+    /// definition carries: <c>System.Delegate</c> or
+    /// <c>System.MulticastDelegate</c>, authenticated the same way the object
+    /// root is rather than accepted on spelling.
+    ///
+    /// A cross-assembly reference must resolve through a recognized core
+    /// library, matched by assembly name and strong-name public-key token. A
+    /// same-image definition counts only when this image is itself that core
+    /// library, so an arbitrary assembly cannot manufacture delegate-ness by
+    /// declaring its own <c>System.MulticastDelegate</c>. Every other handle
+    /// kind, including a constructed <c>TypeSpec</c>, fails closed.
+    /// </summary>
+    internal static bool IsCoreLibraryDelegateBaseType(
+        MetadataReader reader,
+        EntityHandle typeHandle)
+    {
+        try
+        {
+            switch (typeHandle.Kind)
+            {
+                case HandleKind.TypeReference:
+                    TypeReference typeRef =
+                        reader.GetTypeReference(
+                            (TypeReferenceHandle)typeHandle);
+                    return reader.StringComparer.Equals(
+                            typeRef.Namespace,
+                            "System")
+                        && IsDelegateRootName(reader, typeRef.Name)
+                        && ResolvesThroughCoreLibrary(
+                            reader,
+                            typeRef.ResolutionScope);
+                case HandleKind.TypeDefinition:
+                    TypeDefinition definition =
+                        reader.GetTypeDefinition(
+                            (TypeDefinitionHandle)typeHandle);
+                    return definition.GetDeclaringType().IsNil
+                        && reader.StringComparer.Equals(
+                            definition.Namespace,
+                            "System")
+                        && IsDelegateRootName(reader, definition.Name)
+                        && CoreLibraryRootAuthentication
+                            .DeclaresUniqueTopLevelCoreLibraryRoot(reader);
+                default:
+                    return false;
+            }
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+
+        static bool IsDelegateRootName(
+            MetadataReader reader,
+            StringHandle name)
+            => reader.StringComparer.Equals(name, "MulticastDelegate")
+                || reader.StringComparer.Equals(name, "Delegate");
+    }
+
     // The reference assemblies and runtime cores that define the real
     // System.Object, paired with the strong-name public-key token(s) each is
     // legitimately signed with. `mscorlib` shipped under several Microsoft

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -3627,7 +3627,7 @@ public static class ApiSurfaceExtractor
     }
 
     /// <summary>True when <paramref name="typeHandle"/> resolves to <c>System.Object</c>.</summary>
-    private static bool IsSystemObjectType(
+    internal static bool IsSystemObjectType(
         MetadataReader reader,
         EntityHandle typeHandle,
         Action<int>? beforeDecodeWork = null)

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -181,7 +181,7 @@ public static class MetadataDeclarationQuery
             if (methodName.StartsWith('<'))
                 continue;
 
-            var declaration = GetMethod(reader, typeDef, method);
+            var declaration = GetMethod(reader, typeDef, methodHandle);
             if (!includeNonPublicMembers && declaration.Accessibility != "public")
                 continue;
 
@@ -337,17 +337,24 @@ public static class MetadataDeclarationQuery
             expectedIndex: inheritedCount);
     }
 
+    /// <summary>
+    /// Projects one method declaration from its exact metadata handle. Requiring
+    /// the handle keeps type-surface extraction linear in the number of methods;
+    /// <c>TypeSurface_ManyMethodsThreadsHandlesWithoutQuadraticAllocation</c>
+    /// gates that wiring.
+    /// </summary>
     public static MetadataMethodDeclaration GetMethod(
         MetadataReader reader,
         TypeDefinition typeDef,
-        MethodDefinition method)
+        MethodDefinitionHandle methodHandle)
     {
+        var method = reader.GetMethodDefinition(methodHandle);
         var result = GuardedSignatureText.MethodText(
             reader,
             method,
             GenericContext.ForMethod(reader, typeDef, method));
         var signature = ProjectDecode(result, DegradedMethodSignature, out var status);
-        return GetMethod(reader, typeDef, method, signature) with
+        return GetMethod(reader, typeDef, methodHandle, signature) with
         {
             SignatureDecodeStatus = status,
         };
@@ -422,9 +429,10 @@ public static class MetadataDeclarationQuery
     public static MetadataMethodDeclaration GetMethod(
         MetadataReader reader,
         TypeDefinition typeDef,
-        MethodDefinition method,
+        MethodDefinitionHandle methodHandle,
         MethodSignature<string> signature)
     {
+        var method = reader.GetMethodDefinition(methodHandle);
         var name = reader.GetString(method.Name);
         var attributes = method.Attributes;
         var access = attributes & MethodAttributes.MemberAccessMask;
@@ -432,9 +440,7 @@ public static class MetadataDeclarationQuery
         var isSourceDeclarable = IsSourceDeclarableAccessibility(access);
         var isVirtual = (attributes & MethodAttributes.Virtual) != 0;
         var isNewSlot = (attributes & MethodAttributes.NewSlot) != 0;
-        var methodHandle = FindMethodDefinitionHandle(reader, typeDef, method);
         var hasClassMethodImplOverride = isNewSlot
-            && !methodHandle.IsNil
             && GetAuthenticatedClassMethodImplOverrideSlot(
                 reader,
                 method.GetDeclaringType(),
@@ -500,23 +506,7 @@ public static class MetadataDeclarationQuery
     }
 
     /// <summary>
-    /// The same-image class definition instantiated by
-    /// <paramref name="derivedType"/>'s constructed generic base, when it has
-    /// one.
-    ///
-    /// A compiler encodes <c>Derived : Base&lt;string&gt;</c> and
-    /// <c>Derived&lt;T&gt; : Base&lt;T&gt;</c> as a <c>TypeSpec</c> base, so a
-    /// consumer that only reads a <c>TypeDef</c> base cannot see the definition
-    /// the base instantiates. This resolves exactly that one step and keeps the
-    /// exact definition token; it never matches a rendered name.
-    ///
-    /// Fails closed: a base that is not a <c>TypeSpec</c>, a <c>TypeSpec</c>
-    /// that is not a generic instantiation of a definition in this image, and
-    /// an undecodable or over-budget signature all return
-    /// <see langword="false"/>.
-    /// </summary>
-    /// <summary>
-    /// True when <paramref name="typeDef"/> declares a member that occupies a
+    /// True when <paramref name="typeHandle"/> declares a member that occupies a
     /// virtual slot on its base class that it did not introduce: a virtual
     /// method that is not <see cref="MethodAttributes.NewSlot"/>, or the body
     /// of a <c>MethodImpl</c> row whose declaration authenticates to a class
@@ -537,17 +527,22 @@ public static class MetadataDeclarationQuery
     /// rows only; no name or rendered signature participates. A malformed row
     /// fails closed to <see langword="false"/>, which is the drop-the-base
     /// answer. Gated by
+    /// <c>ReusesInheritedVirtualSlot_DeclinesCrossOwnerMethodImplBody</c> and
     /// <c>ReusesInheritedVirtualSlot_DeclinesExplicitInterfaceOnlyMethodImpl</c>,
     /// with
+    /// <c>ReusesInheritedVirtualSlot_AcceptsSameOwnerMethodImplBody</c>,
     /// <c>ReusesInheritedVirtualSlot_AcceptsAuthenticatedClassMethodImpl</c>
     /// and <c>ReusesInheritedVirtualSlot_AcceptsInheritedVirtualSlotFlags</c>
     /// as its non-vacuity controls.
     /// </summary>
-    public static bool ReusesInheritedVirtualSlot(MetadataReader reader, TypeDefinition typeDef)
+    public static bool ReusesInheritedVirtualSlot(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle)
     {
         ArgumentNullException.ThrowIfNull(reader);
         try
         {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var attributes = reader.GetMethodDefinition(methodHandle).Attributes;
@@ -570,10 +565,15 @@ public static class MetadataDeclarationQuery
 
                 var bodyHandle =
                     (MethodDefinitionHandle)implementation.MethodBody;
+                if (reader.GetMethodDefinition(bodyHandle).GetDeclaringType()
+                    != typeHandle)
+                {
+                    continue;
+                }
+
                 if (GetSameAssemblyOverrideSlot(
                         reader,
-                        reader.GetMethodDefinition(bodyHandle)
-                            .GetDeclaringType(),
+                        typeHandle,
                         bodyHandle) is not null)
                 {
                     return true;
@@ -591,6 +591,22 @@ public static class MetadataDeclarationQuery
         return false;
     }
 
+    /// <summary>
+    /// The same-image class definition instantiated by
+    /// <paramref name="derivedType"/>'s constructed generic base, when it has
+    /// one.
+    ///
+    /// A compiler encodes <c>Derived : Base&lt;string&gt;</c> and
+    /// <c>Derived&lt;T&gt; : Base&lt;T&gt;</c> as a <c>TypeSpec</c> base, so a
+    /// consumer that only reads a <c>TypeDef</c> base cannot see the definition
+    /// the base instantiates. This resolves exactly that one step and keeps the
+    /// exact definition token; it never matches a rendered name.
+    ///
+    /// Fails closed: a base that is not a <c>TypeSpec</c>, a <c>TypeSpec</c>
+    /// that is not a generic instantiation of a definition in this image, and
+    /// an undecodable or over-budget signature all return
+    /// <see langword="false"/>.
+    /// </summary>
     public static bool TryGetSameAssemblyConstructedBaseDefinition(
         MetadataReader reader,
         TypeDefinition derivedType,
@@ -740,6 +756,9 @@ public static class MetadataDeclarationQuery
         MethodDefinitionHandle methodHandle)
     {
         var method = reader.GetMethodDefinition(methodHandle);
+        if (method.GetDeclaringType() != declaringTypeHandle)
+            return null;
+
         if ((method.Attributes & MethodAttributes.Static) != 0
             || (method.Attributes & MethodAttributes.Virtual) == 0)
         {
@@ -824,20 +843,6 @@ public static class MetadataDeclarationQuery
         }
 
         return null;
-    }
-
-    static MethodDefinitionHandle FindMethodDefinitionHandle(
-        MetadataReader reader,
-        TypeDefinition typeDef,
-        MethodDefinition method)
-    {
-        foreach (var candidateHandle in typeDef.GetMethods())
-        {
-            if (reader.GetMethodDefinition(candidateHandle).Equals(method))
-                return candidateHandle;
-        }
-
-        return default;
     }
 
     static MetadataOverrideSlot? GetAuthenticatedClassMethodImplOverrideSlot(
@@ -2500,7 +2505,7 @@ public static class MetadataDeclarationQuery
     /// </summary>
     static bool EncodedArgumentCountAgrees(GenericTypeNode type)
     {
-        if (type.MetadataNameParts is not { } parts)
+        if (type.MetadataName is not { } parts)
             return true;
 
         if (parts.IntroducedTypeParameterCounts is { } counts)

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -711,6 +711,18 @@ public static class MetadataDeclarationQuery
         if (methodReturnType is "object" or "System.Object")
             return false;
 
+        OverrideCompatibility structuredCompatibility =
+            CompareStructuredReturnTypes(
+                reader,
+                methodReturnNode,
+                candidateReturnNode);
+        if (structuredCompatibility
+            != OverrideCompatibility.Unknown)
+        {
+            return structuredCompatibility
+                == OverrideCompatibility.Compatible;
+        }
+
         var hasMethodReturnDefinition =
             TryFindTypeDefinitionByRenderedName(
                 reader,
@@ -731,6 +743,215 @@ public static class MetadataDeclarationQuery
         }
 
         return IsSameOrDerivedOrImplements(reader, methodReturnHandle, candidateReturnHandle);
+    }
+
+    enum OverrideCompatibility
+    {
+        Unknown,
+        Compatible,
+        Incompatible,
+    }
+
+    static OverrideCompatibility CompareStructuredReturnTypes(
+        MetadataReader reader,
+        TypeNode method,
+        TypeNode candidate)
+    {
+        if (method.StructuralIdentity()
+            == candidate.StructuralIdentity())
+        {
+            return OverrideCompatibility.Compatible;
+        }
+
+        if (method is SZArrayTypeNode methodSz
+            && candidate is SZArrayTypeNode candidateSz)
+        {
+            if (!methodSz.ElementType.IsReferenceType
+                || !candidateSz.ElementType.IsReferenceType)
+            {
+                return OverrideCompatibility.Incompatible;
+            }
+            return CompareVariantTypeArguments(
+                reader,
+                methodSz.ElementType,
+                candidateSz.ElementType);
+        }
+
+        if (method is MDArrayTypeNode methodMd
+            && candidate is MDArrayTypeNode candidateMd)
+        {
+            return methodMd.Rank == candidateMd.Rank
+                && methodMd.ElementType.IsReferenceType
+                && candidateMd.ElementType.IsReferenceType
+                ? CompareVariantTypeArguments(
+                    reader,
+                    methodMd.ElementType,
+                    candidateMd.ElementType)
+                : OverrideCompatibility.Incompatible;
+        }
+
+        if (method is not GenericTypeNode methodGeneric
+            || candidate is not GenericTypeNode candidateGeneric
+            || NormalizeGenericDefinitionName(
+                   methodGeneric.DefinitionName)
+                != NormalizeGenericDefinitionName(
+                   candidateGeneric.DefinitionName)
+            || methodGeneric.Arguments.Length
+                != candidateGeneric.Arguments.Length
+            || !TryFindGenericTypeDefinition(
+                reader,
+                methodGeneric.DefinitionName,
+                methodGeneric.Arguments.Length,
+                out TypeDefinitionHandle genericDefinitionHandle))
+        {
+            return OverrideCompatibility.Unknown;
+        }
+
+        var genericParameters = reader
+            .GetTypeDefinition(genericDefinitionHandle)
+            .GetGenericParameters()
+            .Select(reader.GetGenericParameter)
+            .ToArray();
+        if (genericParameters.Length
+            != methodGeneric.Arguments.Length)
+        {
+            return OverrideCompatibility.Unknown;
+        }
+
+        bool hasUnknown = false;
+        for (int index = 0;
+            index < genericParameters.Length;
+            index++)
+        {
+            TypeNode methodArgument =
+                methodGeneric.Arguments[index];
+            TypeNode candidateArgument =
+                candidateGeneric.Arguments[index];
+            GenericParameterAttributes variance =
+                genericParameters[index].Attributes
+                & GenericParameterAttributes.VarianceMask;
+            OverrideCompatibility argumentCompatibility =
+                variance switch
+                {
+                    GenericParameterAttributes.None =>
+                        methodArgument.StructuralIdentity()
+                            == candidateArgument
+                                .StructuralIdentity()
+                            ? OverrideCompatibility.Compatible
+                            : OverrideCompatibility.Incompatible,
+                    GenericParameterAttributes.Covariant =>
+                        CompareVariantTypeArguments(
+                            reader,
+                            methodArgument,
+                            candidateArgument),
+                    GenericParameterAttributes.Contravariant =>
+                        CompareVariantTypeArguments(
+                            reader,
+                            candidateArgument,
+                            methodArgument),
+                    _ => OverrideCompatibility.Incompatible,
+                };
+            if (argumentCompatibility
+                == OverrideCompatibility.Incompatible)
+            {
+                return OverrideCompatibility.Incompatible;
+            }
+            hasUnknown |= argumentCompatibility
+                == OverrideCompatibility.Unknown;
+        }
+
+        return hasUnknown
+            ? OverrideCompatibility.Unknown
+            : OverrideCompatibility.Compatible;
+    }
+
+    static OverrideCompatibility CompareVariantTypeArguments(
+        MetadataReader reader,
+        TypeNode method,
+        TypeNode candidate)
+    {
+        OverrideCompatibility structured =
+            CompareStructuredReturnTypes(
+                reader,
+                method,
+                candidate);
+        if (structured != OverrideCompatibility.Unknown)
+            return structured;
+
+        if (!TryFindTypeDefinitionByRenderedName(
+                reader,
+                method.RenderCanonical(),
+                out TypeDefinitionHandle methodHandle)
+            || !TryFindTypeDefinitionByRenderedName(
+                reader,
+                candidate.RenderCanonical(),
+                out TypeDefinitionHandle candidateHandle))
+        {
+            return OverrideCompatibility.Unknown;
+        }
+
+        return IsSameOrDerivedOrImplements(
+                reader,
+                methodHandle,
+                candidateHandle)
+            ? OverrideCompatibility.Compatible
+            : OverrideCompatibility.Incompatible;
+    }
+
+    static bool TryFindGenericTypeDefinition(
+        MetadataReader reader,
+        string metadataName,
+        int arity,
+        out TypeDefinitionHandle handle)
+    {
+        string normalized =
+            NormalizeGenericDefinitionName(metadataName);
+        foreach (TypeDefinitionHandle candidateHandle
+            in reader.TypeDefinitions)
+        {
+            TypeDefinition definition =
+                reader.GetTypeDefinition(candidateHandle);
+            if (definition.GetGenericParameters().Count != arity
+                || NormalizeGenericDefinitionName(
+                    TypeResolver.GetFullName(
+                        reader,
+                        definition))
+                    != normalized)
+            {
+                continue;
+            }
+
+            handle = candidateHandle;
+            return true;
+        }
+
+        handle = default;
+        return false;
+    }
+
+    static string NormalizeGenericDefinitionName(
+        string typeName)
+    {
+        var result = new StringBuilder(typeName.Length);
+        for (int index = 0; index < typeName.Length; index++)
+        {
+            if (typeName[index] != '`')
+            {
+                result.Append(typeName[index] == '+'
+                    ? '.'
+                    : typeName[index]);
+                continue;
+            }
+
+            index++;
+            while (index < typeName.Length
+                && char.IsDigit(typeName[index]))
+            {
+                index++;
+            }
+            index--;
+        }
+        return result.ToString();
     }
 
     static bool HasByRefReturnModifier(string returnType)

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -377,9 +377,16 @@ public static class MetadataDeclarationQuery
         var isSourceDeclarable = IsSourceDeclarableAccessibility(access);
         var isVirtual = (attributes & MethodAttributes.Virtual) != 0;
         var isNewSlot = (attributes & MethodAttributes.NewSlot) != 0;
+        var methodHandle = FindMethodDefinitionHandle(reader, typeDef, method);
+        var hasClassMethodImplOverride = isNewSlot
+            && !methodHandle.IsNil
+            && GetAuthenticatedClassMethodImplOverrideSlot(
+                reader,
+                method.GetDeclaringType(),
+                methodHandle) is not null;
         var isOverride = isSourceDeclarable
             && isVirtual
-            && !isNewSlot
+            && (!isNewSlot || hasClassMethodImplOverride)
             && (attributes & MethodAttributes.Static) == 0
             && (typeDef.Attributes & TypeAttributes.Interface) == 0;
         var typeParameters = MethodTypeParameters(reader, typeDef, method);
@@ -399,7 +406,8 @@ public static class MetadataDeclarationQuery
                 && isVirtual
                 && (attributes & MethodAttributes.Abstract) == 0
                 && (attributes & MethodAttributes.Final) == 0
-                && isNewSlot,
+                && isNewSlot
+                && !hasClassMethodImplOverride,
             isOverride,
             isOverride && (attributes & MethodAttributes.Final) != 0,
             new ApiSignature
@@ -415,8 +423,10 @@ public static class MetadataDeclarationQuery
 
     /// <summary>
     /// Locates the nearest same-assembly virtual slot reused by
-    /// <paramref name="methodHandle"/>, or returns <see langword="null"/> for a
-    /// new slot or a base outside this metadata reader.
+    /// <paramref name="methodHandle"/>, including a source override encoded as
+    /// <c>NewSlot</c> with a class <c>MethodImpl</c>. Returns
+    /// <see langword="null"/> for an actual new slot or a base outside this
+    /// metadata reader.
     /// </summary>
     public static MetadataOverrideSlot? GetSameAssemblyOverrideSlot(
         MetadataReader reader,
@@ -425,8 +435,7 @@ public static class MetadataDeclarationQuery
     {
         var method = reader.GetMethodDefinition(methodHandle);
         if ((method.Attributes & MethodAttributes.Static) != 0
-            || (method.Attributes & MethodAttributes.Virtual) == 0
-            || (method.Attributes & MethodAttributes.NewSlot) != 0)
+            || (method.Attributes & MethodAttributes.Virtual) == 0)
         {
             return null;
         }
@@ -436,6 +445,14 @@ public static class MetadataDeclarationQuery
             || !IsSourceDeclarableAccessibility(method.Attributes & MethodAttributes.MemberAccessMask))
         {
             return null;
+        }
+
+        if ((method.Attributes & MethodAttributes.NewSlot) != 0)
+        {
+            return GetAuthenticatedClassMethodImplOverrideSlot(
+                reader,
+                declaringTypeHandle,
+                methodHandle);
         }
 
         var methodName = reader.GetString(method.Name);
@@ -448,6 +465,7 @@ public static class MetadataDeclarationQuery
         {
             return null;
         }
+
         var methodShape = GetOverrideSlotShape(reader, method, methodSignature);
 
         var baseTypeHandle = declaringType.BaseType;
@@ -493,6 +511,112 @@ public static class MetadataDeclarationQuery
         }
 
         return null;
+    }
+
+    static MethodDefinitionHandle FindMethodDefinitionHandle(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method)
+    {
+        foreach (var candidateHandle in typeDef.GetMethods())
+        {
+            if (reader.GetMethodDefinition(candidateHandle).Equals(method))
+                return candidateHandle;
+        }
+
+        return default;
+    }
+
+    static MetadataOverrideSlot? GetAuthenticatedClassMethodImplOverrideSlot(
+        MetadataReader reader,
+        TypeDefinitionHandle declaringTypeHandle,
+        MethodDefinitionHandle methodHandle)
+    {
+        var declaringType = reader.GetTypeDefinition(declaringTypeHandle);
+        var method = reader.GetMethodDefinition(methodHandle);
+        var methodName = reader.GetString(method.Name);
+        var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
+        if (!GuardedSignatureText.MethodText(
+            reader,
+            method,
+            PositionalGenericContext(declaringType, method))
+            .TryGetValue(out var methodSignature))
+        {
+            return null;
+        }
+
+        var methodShape = GetOverrideSlotShape(reader, method, methodSignature);
+        MetadataOverrideSlot? match = null;
+        foreach (var implementationHandle in declaringType.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody != methodHandle
+                || implementation.MethodDeclaration.Kind != HandleKind.MethodDefinition)
+            {
+                continue;
+            }
+
+            var declarationHandle = (MethodDefinitionHandle)implementation.MethodDeclaration;
+            var declaration = reader.GetMethodDefinition(declarationHandle);
+            var declarationTypeHandle = declaration.GetDeclaringType();
+            if (!IsStrictSameAssemblyBase(
+                    reader,
+                    declaringType,
+                    declarationTypeHandle)
+                || (reader.GetTypeDefinition(declarationTypeHandle).Attributes & TypeAttributes.Interface) != 0
+                || reader.GetString(declaration.Name) != methodName
+                || (declaration.Attributes & MethodAttributes.Virtual) == 0
+                || (declaration.Attributes & MethodAttributes.Final) != 0
+                || (declaration.Attributes & MethodAttributes.Static) != 0
+                || (declaration.Attributes & MethodAttributes.MemberAccessMask) != methodAccess
+                || !IsSourceDeclarableAccessibility(
+                    declaration.Attributes & MethodAttributes.MemberAccessMask)
+                || declaration.GetGenericParameters().Count != method.GetGenericParameters().Count)
+            {
+                continue;
+            }
+
+            var declarationType = reader.GetTypeDefinition(declarationTypeHandle);
+            if (!GuardedSignatureText.MethodText(
+                reader,
+                declaration,
+                PositionalGenericContext(declarationType, declaration))
+                .TryGetValue(out var declarationSignature)
+                || !MatchesOverrideSlotShape(
+                    reader,
+                    methodShape,
+                    GetOverrideSlotShape(reader, declaration, declarationSignature)))
+            {
+                continue;
+            }
+
+            if (match is not null)
+                return null;
+
+            match = new MetadataOverrideSlot(declarationTypeHandle, declarationHandle);
+        }
+
+        return match;
+    }
+
+    static bool IsStrictSameAssemblyBase(
+        MetadataReader reader,
+        TypeDefinition declaringType,
+        TypeDefinitionHandle candidateHandle)
+    {
+        var baseType = declaringType.BaseType;
+        var visited = new HashSet<TypeDefinitionHandle>();
+        while (baseType.Kind == HandleKind.TypeDefinition
+            && visited.Add((TypeDefinitionHandle)baseType))
+        {
+            var baseHandle = (TypeDefinitionHandle)baseType;
+            if (baseHandle == candidateHandle)
+                return true;
+
+            baseType = reader.GetTypeDefinition(baseHandle).BaseType;
+        }
+
+        return false;
     }
 
     static GenericContext PositionalGenericContext(

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -55,6 +55,13 @@ public sealed record MetadataFieldDeclaration(
 }
 
 /// <summary>
+/// A same-assembly virtual slot inherited by an overriding method.
+/// </summary>
+public sealed record MetadataOverrideSlot(
+    TypeDefinitionHandle DeclaringType,
+    MethodDefinitionHandle Method);
+
+/// <summary>
 /// Handle-based declaration questions over SRM metadata. This layer is safe for
 /// NativeAOT and compile-back source composition: it does not load inspected
 /// assemblies and does not depend on Roslyn or the decompiler.
@@ -367,9 +374,14 @@ public static class MetadataDeclarationQuery
         var attributes = method.Attributes;
         var access = attributes & MethodAttributes.MemberAccessMask;
         var isPublicOrProtected = IsPublicOrProtected(access);
+        var isSourceDeclarable = IsSourceDeclarableAccessibility(access);
         var isVirtual = (attributes & MethodAttributes.Virtual) != 0;
         var isNewSlot = (attributes & MethodAttributes.NewSlot) != 0;
-        var isOverride = isVirtual && !isNewSlot;
+        var isOverride = isSourceDeclarable
+            && isVirtual
+            && !isNewSlot
+            && (attributes & MethodAttributes.Static) == 0
+            && (typeDef.Attributes & TypeAttributes.Interface) == 0;
         var typeParameters = MethodTypeParameters(reader, typeDef, method);
         var csharpName = SanitizeIdentifier(name);
         var methodName = typeParameters.Count == 0
@@ -382,8 +394,8 @@ public static class MetadataDeclarationQuery
             AccessibilityKeyword(access),
             isPublicOrProtected,
             (attributes & MethodAttributes.Static) != 0,
-            isPublicOrProtected && (attributes & MethodAttributes.Abstract) != 0,
-            isPublicOrProtected
+            isSourceDeclarable && (attributes & MethodAttributes.Abstract) != 0,
+            isSourceDeclarable
                 && isVirtual
                 && (attributes & MethodAttributes.Abstract) == 0
                 && (attributes & MethodAttributes.Final) == 0
@@ -400,6 +412,99 @@ public static class MetadataDeclarationQuery
             },
             RenderMemberAttributes(reader, method.GetCustomAttributes()));
     }
+
+    /// <summary>
+    /// Locates the nearest same-assembly virtual slot reused by
+    /// <paramref name="methodHandle"/>, or returns <see langword="null"/> for a
+    /// new slot or a base outside this metadata reader.
+    /// </summary>
+    public static MetadataOverrideSlot? GetSameAssemblyOverrideSlot(
+        MetadataReader reader,
+        TypeDefinitionHandle declaringTypeHandle,
+        MethodDefinitionHandle methodHandle)
+    {
+        var method = reader.GetMethodDefinition(methodHandle);
+        if ((method.Attributes & MethodAttributes.Static) != 0
+            || (method.Attributes & MethodAttributes.Virtual) == 0
+            || (method.Attributes & MethodAttributes.NewSlot) != 0)
+        {
+            return null;
+        }
+
+        var declaringType = reader.GetTypeDefinition(declaringTypeHandle);
+        if ((declaringType.Attributes & TypeAttributes.Interface) != 0
+            || !IsSourceDeclarableAccessibility(method.Attributes & MethodAttributes.MemberAccessMask))
+        {
+            return null;
+        }
+
+        var methodName = reader.GetString(method.Name);
+        var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
+        if (!GuardedSignatureText.MethodText(
+            reader,
+            method,
+            PositionalGenericContext(declaringType, method))
+            .TryGetValue(out var methodSignature))
+        {
+            return null;
+        }
+
+        var baseTypeHandle = declaringType.BaseType;
+        var visited = new HashSet<TypeDefinitionHandle>();
+        while (baseTypeHandle.Kind == HandleKind.TypeDefinition
+            && visited.Add((TypeDefinitionHandle)baseTypeHandle))
+        {
+            var baseDefinitionHandle = (TypeDefinitionHandle)baseTypeHandle;
+            var baseDefinition = reader.GetTypeDefinition(baseDefinitionHandle);
+            foreach (var candidateHandle in baseDefinition.GetMethods())
+            {
+                var candidate = reader.GetMethodDefinition(candidateHandle);
+                if (reader.GetString(candidate.Name) != methodName
+                    || (candidate.Attributes & MethodAttributes.Virtual) == 0
+                    || (candidate.Attributes & MethodAttributes.Final) != 0
+                    || (candidate.Attributes & MethodAttributes.MemberAccessMask) != methodAccess
+                    || !IsSourceDeclarableAccessibility(candidate.Attributes & MethodAttributes.MemberAccessMask)
+                    || candidate.GetGenericParameters().Count != method.GetGenericParameters().Count)
+                {
+                    continue;
+                }
+
+                if (!GuardedSignatureText.MethodText(
+                    reader,
+                    candidate,
+                    PositionalGenericContext(baseDefinition, candidate))
+                    .TryGetValue(out var candidateSignature))
+                {
+                    continue;
+                }
+
+                // Return types intentionally do not participate: C# permits
+                // covariant returns while the parameter and generic arities
+                // continue to identify the reused virtual slot.
+                if (candidateSignature.ParameterTypes.SequenceEqual(
+                    methodSignature.ParameterTypes,
+                    StringComparer.Ordinal))
+                {
+                    return new MetadataOverrideSlot(baseDefinitionHandle, candidateHandle);
+                }
+            }
+
+            baseTypeHandle = baseDefinition.BaseType;
+        }
+
+        return null;
+    }
+
+    static GenericContext PositionalGenericContext(
+        TypeDefinition type,
+        MethodDefinition method)
+        => new(
+            Enumerable.Range(0, type.GetGenericParameters().Count)
+                .Select(index => $"!{index}")
+                .ToArray(),
+            Enumerable.Range(0, method.GetGenericParameters().Count)
+                .Select(index => $"!!{index}")
+                .ToArray());
 
     public static MetadataPropertyDeclaration GetProperty(
         MetadataReader reader,
@@ -434,7 +539,12 @@ public static class MetadataDeclarationQuery
             : default;
         var isVirtual = (accessorAttributes & MethodAttributes.Virtual) != 0;
         var isNewSlot = (accessorAttributes & MethodAttributes.NewSlot) != 0;
-        var isOverride = isVirtual && !isNewSlot;
+        var isSourceDeclarable = IsSourceDeclarableAccessibility(bestAccess);
+        var isOverride = isSourceDeclarable
+            && isVirtual
+            && !isNewSlot
+            && (accessorAttributes & MethodAttributes.Static) == 0
+            && (typeDef.Attributes & TypeAttributes.Interface) == 0;
         var isPublicOrProtected = IsPublicOrProtected(bestAccess);
 
         var accessorParameters = !accessors.Getter.IsNil
@@ -476,8 +586,8 @@ public static class MetadataDeclarationQuery
             !accessors.Getter.IsNil || !accessors.Setter.IsNil
                 ? (accessorAttributes & MethodAttributes.Static) != 0
                 : false,
-            isPublicOrProtected && (accessorAttributes & MethodAttributes.Abstract) != 0,
-            isPublicOrProtected
+            isSourceDeclarable && (accessorAttributes & MethodAttributes.Abstract) != 0,
+            isSourceDeclarable
                 && isVirtual
                 && (accessorAttributes & MethodAttributes.Abstract) == 0
                 && (accessorAttributes & MethodAttributes.Final) == 0
@@ -670,6 +780,25 @@ public static class MetadataDeclarationQuery
 
     public static bool IsVirtualMethod(MethodDefinition method)
         => IsPublicOrProtected(method)
+            && (method.Attributes & MethodAttributes.Virtual) != 0
+            && (method.Attributes & MethodAttributes.Abstract) == 0
+            && (method.Attributes & MethodAttributes.Final) == 0
+            && (method.Attributes & MethodAttributes.NewSlot) != 0;
+
+    /// <summary>
+    /// True when the method flags can be represented by a C# abstract member
+    /// declaration, including non-API internal accessibility.
+    /// </summary>
+    public static bool IsSourceDeclarableAbstractMethod(MethodDefinition method)
+        => IsSourceDeclarableAccessibility(method.Attributes & MethodAttributes.MemberAccessMask)
+            && (method.Attributes & MethodAttributes.Abstract) != 0;
+
+    /// <summary>
+    /// True when the method flags can be represented by a C# new-slot virtual
+    /// declaration, including non-API internal accessibility.
+    /// </summary>
+    public static bool IsSourceDeclarableVirtualMethod(MethodDefinition method)
+        => IsSourceDeclarableAccessibility(method.Attributes & MethodAttributes.MemberAccessMask)
             && (method.Attributes & MethodAttributes.Virtual) != 0
             && (method.Attributes & MethodAttributes.Abstract) == 0
             && (method.Attributes & MethodAttributes.Final) == 0
@@ -942,6 +1071,10 @@ public static class MetadataDeclarationQuery
 
     static bool IsPublicOrProtected(MethodAttributes access)
         => access is MethodAttributes.Public or MethodAttributes.Family or MethodAttributes.FamORAssem;
+
+    static bool IsSourceDeclarableAccessibility(MethodAttributes access)
+        => access is not MethodAttributes.Private
+            and not MethodAttributes.PrivateScope;
 
     static MethodAttributes BestAccessorAccess(
         MethodDefinition getter,

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -708,11 +708,26 @@ public static class MetadataDeclarationQuery
 
         if (candidateReturnType is "object" or "System.Object")
             return true;
-
-        if (!TryFindTypeDefinitionByRenderedName(reader, methodReturnType, out var methodReturnHandle)
-            || !TryFindTypeDefinitionByRenderedName(reader, candidateReturnType, out var candidateReturnHandle))
-        {
+        if (methodReturnType is "object" or "System.Object")
             return false;
+
+        var hasMethodReturnDefinition =
+            TryFindTypeDefinitionByRenderedName(
+                reader,
+                methodReturnType,
+                out var methodReturnHandle);
+        var hasCandidateReturnDefinition =
+            TryFindTypeDefinitionByRenderedName(
+                reader,
+                candidateReturnType,
+                out var candidateReturnHandle);
+        if (!hasMethodReturnDefinition || !hasCandidateReturnDefinition)
+        {
+            // The MethodImpl already authenticates the exact base slot. If either
+            // reference-type return lives outside this image, local metadata cannot
+            // prove or disprove covariance; preserve the slot and let the C#
+            // compiler validate the referenced hierarchy during compile-back.
+            return true;
         }
 
         return IsSameOrDerivedOrImplements(reader, methodReturnHandle, candidateReturnHandle);
@@ -840,7 +855,12 @@ public static class MetadataDeclarationQuery
         var setter = accessors.Setter.IsNil ? default : reader.GetMethodDefinition(accessors.Setter);
 
         var bestAccess = BestAccessorAccess(getter, setter, accessors);
-        if (TryGetAuthenticatedOverridePropertyAccess(reader, accessors, out var authenticatedPropertyAccess))
+        var hasClassMethodImplOverride =
+            TryGetAuthenticatedOverridePropertyAccess(
+                reader,
+                accessors,
+                out var authenticatedPropertyAccess);
+        if (hasClassMethodImplOverride)
             bestAccess = authenticatedPropertyAccess;
         var primaryAccessor = !accessors.Getter.IsNil ? getter : setter;
         var accessorAttributes = !accessors.Getter.IsNil || !accessors.Setter.IsNil
@@ -851,7 +871,7 @@ public static class MetadataDeclarationQuery
         var isSourceDeclarable = IsSourceDeclarableAccessibility(bestAccess);
         var isOverride = isSourceDeclarable
             && isVirtual
-            && !isNewSlot
+            && (!isNewSlot || hasClassMethodImplOverride)
             && (accessorAttributes & MethodAttributes.Static) == 0
             && (typeDef.Attributes & TypeAttributes.Interface) == 0;
         var isPublicOrProtected = IsPublicOrProtected(bestAccess);
@@ -900,7 +920,8 @@ public static class MetadataDeclarationQuery
                 && isVirtual
                 && (accessorAttributes & MethodAttributes.Abstract) == 0
                 && (accessorAttributes & MethodAttributes.Final) == 0
-                && isNewSlot,
+                && isNewSlot
+                && !hasClassMethodImplOverride,
             isOverride,
             isOverride && (accessorAttributes & MethodAttributes.Final) != 0,
             new ApiSignature

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -516,28 +517,64 @@ public static class MetadataDeclarationQuery
     /// </summary>
     /// <summary>
     /// True when <paramref name="typeDef"/> declares a member that occupies a
-    /// virtual slot it did not introduce: a virtual method that is not
-    /// <see cref="MethodAttributes.NewSlot"/>, or the body of a
-    /// <c>MethodImpl</c> row. A base type owns such a slot, so a shell that
-    /// drops the base must drop the member's <c>override</c> with it.
+    /// virtual slot on its base class that it did not introduce: a virtual
+    /// method that is not <see cref="MethodAttributes.NewSlot"/>, or the body
+    /// of a <c>MethodImpl</c> row whose declaration authenticates to a class
+    /// slot on this image's base chain. A base type owns such a slot, so a
+    /// shell that drops the base must drop the member's <c>override</c> with
+    /// it.
     ///
-    /// Read from method attribute flags and <c>MethodImpl</c> rows only; no
-    /// name or rendered signature participates. A malformed row fails closed to
-    /// <see langword="false"/>, which is the drop-the-base answer.
+    /// A <c>MethodImpl</c> row alone is not that evidence. An explicit
+    /// interface implementation is also a <c>MethodImpl</c>, and the interface
+    /// declaration it names is owned by the interface rather than the base
+    /// class, so counting rows would retain a constructed generic base for a
+    /// type that inherits no slot from it. Each row is therefore authenticated
+    /// through <see cref="GetSameAssemblyOverrideSlot"/>, which resolves the
+    /// declaration to a unique non-interface method on the authenticated base
+    /// chain and refuses anything else.
+    ///
+    /// Read from method attribute flags and authenticated <c>MethodImpl</c>
+    /// rows only; no name or rendered signature participates. A malformed row
+    /// fails closed to <see langword="false"/>, which is the drop-the-base
+    /// answer. Gated by
+    /// <c>ReusesInheritedVirtualSlot_DeclinesExplicitInterfaceOnlyMethodImpl</c>,
+    /// with
+    /// <c>ReusesInheritedVirtualSlot_AcceptsAuthenticatedClassMethodImpl</c>
+    /// and <c>ReusesInheritedVirtualSlot_AcceptsInheritedVirtualSlotFlags</c>
+    /// as its non-vacuity controls.
     /// </summary>
     public static bool ReusesInheritedVirtualSlot(MetadataReader reader, TypeDefinition typeDef)
     {
         ArgumentNullException.ThrowIfNull(reader);
         try
         {
-            if (typeDef.GetMethodImplementations().Count != 0)
-                return true;
-
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var attributes = reader.GetMethodDefinition(methodHandle).Attributes;
                 if ((attributes & MethodAttributes.Virtual) != 0
                     && (attributes & MethodAttributes.NewSlot) == 0)
+                {
+                    return true;
+                }
+            }
+
+            foreach (var implementationHandle in typeDef.GetMethodImplementations())
+            {
+                var implementation =
+                    reader.GetMethodImplementation(implementationHandle);
+                if (implementation.MethodBody.Kind
+                    != HandleKind.MethodDefinition)
+                {
+                    continue;
+                }
+
+                var bodyHandle =
+                    (MethodDefinitionHandle)implementation.MethodBody;
+                if (GetSameAssemblyOverrideSlot(
+                        reader,
+                        reader.GetMethodDefinition(bodyHandle)
+                            .GetDeclaringType(),
+                        bodyHandle) is not null)
                 {
                     return true;
                 }
@@ -617,11 +654,19 @@ public static class MetadataDeclarationQuery
     }
 
     /// <summary>
-    /// True when <paramref name="method"/> has the exact name and signature of
-    /// one of <c>System.Object</c>'s three overridable members. Every type
-    /// position is read as a primitive element type, so a hostile image cannot
-    /// satisfy this with a type reference that merely renders as
-    /// <c>string</c>, <c>int</c>, <c>bool</c>, or <c>object</c>.
+    /// True when <paramref name="method"/> has the exact name, signature
+    /// header, and signature of one of <c>System.Object</c>'s three
+    /// overridable members. Every type position is read as a primitive element
+    /// type, so a hostile image cannot satisfy this with a type reference that
+    /// merely renders as <c>string</c>, <c>int</c>, <c>bool</c>, or
+    /// <c>object</c>, and the header is required to be the source-declarable
+    /// instance default-calling-convention shape an intrinsic slot actually
+    /// has. A vararg, explicit-<c>this</c>, generic, or missing-<c>HASTHIS</c>
+    /// signature is a different slot no matter how its parameters render.
+    /// Gated by
+    /// <c>AuthenticatedObjectSlotOverride_DeclinesMalformedSignatureHeader</c>,
+    /// whose non-vacuity control is
+    /// <c>AuthenticatedObjectSlotOverride_AcceptsSameImageChainToObject</c>.
     /// </summary>
     static bool MatchesObjectIntrinsicSlot(
         MetadataReader reader,
@@ -644,6 +689,9 @@ public static class MetadataDeclarationQuery
             return false;
 
         MethodSignature<TypeNode> signature = decoded.Value;
+        if (!IsSourceDeclarableInstanceSignature(signature))
+            return false;
+
         return reader.GetString(method.Name) switch
         {
             "ToString" => signature.ParameterTypes.Length == 0
@@ -660,6 +708,24 @@ public static class MetadataDeclarationQuery
             => node is PrimitiveTypeNode primitive
                 && primitive.Name == name;
     }
+
+    /// <summary>
+    /// True when a decoded method signature carries the header a
+    /// source-declarable instance method has: the method signature kind, the
+    /// default managed calling convention, an implicit <c>this</c>, no
+    /// explicit <c>this</c>, and no vararg sentinel splitting the parameter
+    /// list. Every other header describes a member C# cannot declare and whose
+    /// slot correspondence this image therefore cannot authenticate.
+    /// </summary>
+    static bool IsSourceDeclarableInstanceSignature(
+        MethodSignature<TypeNode> signature)
+        => signature.Header.Kind == SignatureKind.Method
+            && signature.Header.CallingConvention
+                == SignatureCallingConvention.Default
+            && signature.Header.IsInstance
+            && !signature.Header.HasExplicitThis
+            && signature.RequiredParameterCount
+                == signature.ParameterTypes.Length;
 
     /// <summary>
     /// Locates the nearest same-assembly virtual slot reused by
@@ -1175,6 +1241,9 @@ public static class MetadataDeclarationQuery
         OverrideModifier ReturnModifier,
         OverrideTypeContext TypeContext,
         IReadOnlyList<OverrideParameterShape> Parameters,
+        SignatureHeader Header,
+        int GenericParameterCount,
+        int RequiredParameterCount,
         bool IsDegraded);
 
     static OverrideSlotShape GetOverrideSlotShape(
@@ -1298,6 +1367,9 @@ public static class MetadataDeclarationQuery
                 [.. typeDef.GetGenericParameters()],
                 [.. method.GetGenericParameters()]),
             parameterShapes,
+            nodeSignature.Header,
+            nodeSignature.GenericParameterCount,
+            nodeSignature.RequiredParameterCount,
             isDegraded);
     }
 
@@ -1354,8 +1426,12 @@ public static class MetadataDeclarationQuery
         OverrideSlotShape method,
         OverrideSlotShape candidate)
     {
-        if (method.IsDegraded || candidate.IsDegraded)
+        if (method.IsDegraded
+            || candidate.IsDegraded
+            || !SignatureHeadersCorrespond(method, candidate))
+        {
             return false;
+        }
 
         var budget = new OverrideCompatibilityBudget();
         bool matches = ParametersMatch(
@@ -1370,6 +1446,47 @@ public static class MetadataDeclarationQuery
                 budget);
         return matches && !budget.IsExhausted;
     }
+
+    /// <summary>
+    /// True when the implementation and the base declaration carry the same
+    /// source-relevant method signature header: signature kind, calling
+    /// convention, implicit <c>this</c>, explicit <c>this</c>, generic arity,
+    /// and required parameter count.
+    ///
+    /// Parameter and return correspondence alone does not decide slot
+    /// correspondence, because the header carries facts the decoded type list
+    /// never shows. A vararg signature's sentinel splits its parameter list, an
+    /// explicit-<c>this</c> signature passes its receiver as a declared
+    /// parameter, and a signature without <c>HASTHIS</c> is a static slot no
+    /// instance declaration occupies. Each is refused on both sides, and the
+    /// two headers must then be identical, so a source <c>override</c> is never
+    /// reconstructed over a header C# cannot spell. Gated by
+    /// <c>SameAssemblyOverrideSlot_DeclinesMalformedSignatureHeader</c> over
+    /// the vararg, explicit-<c>this</c>, and missing-<c>HASTHIS</c> shapes,
+    /// whose non-vacuity controls are
+    /// <c>SameAssemblyOverrideSlot_AllowsSourceDeclarableSignatureHeader</c>
+    /// and
+    /// <c>SameAssemblyOverrideSlot_UsesCompilerProducedCovariantMethodImpl</c>.
+    /// </summary>
+    static bool SignatureHeadersCorrespond(
+        OverrideSlotShape method,
+        OverrideSlotShape candidate)
+        => IsSourceDeclarableInstanceHeader(method)
+            && IsSourceDeclarableInstanceHeader(candidate)
+            && method.Header.RawValue == candidate.Header.RawValue
+            && method.GenericParameterCount
+                == candidate.GenericParameterCount
+            && method.RequiredParameterCount
+                == candidate.RequiredParameterCount;
+
+    static bool IsSourceDeclarableInstanceHeader(
+        OverrideSlotShape shape)
+        => shape.Header.Kind == SignatureKind.Method
+            && shape.Header.CallingConvention
+                == SignatureCallingConvention.Default
+            && shape.Header.IsInstance
+            && !shape.Header.HasExplicitThis
+            && shape.RequiredParameterCount == shape.Parameters.Count;
 
     static bool ParametersMatch(
         MetadataReader reader,
@@ -1448,7 +1565,13 @@ public static class MetadataDeclarationQuery
         }
 
         if (IsObject(candidate.ReturnTypeNode))
-            return true;
+        {
+            return ConvertsToObjectReturn(
+                reader,
+                method.ReturnTypeNode,
+                method.TypeContext,
+                budget);
+        }
         if (IsObject(method.ReturnTypeNode))
             return false;
 
@@ -1509,6 +1632,64 @@ public static class MetadataDeclarationQuery
             methodReturnHandle,
             candidate.ReturnTypeNode,
             candidateReturnHandle,
+            budget);
+    }
+
+    /// <summary>
+    /// True when the implementation return converts to a base declaration
+    /// whose return is a plain <c>object</c>.
+    ///
+    /// Every reference type converts to <c>object</c> in the CLR, but a
+    /// reconstructed source <c>override</c> needs more than that. The
+    /// declaration carries no wrapper, so a modified, pinned, byref, or
+    /// otherwise wrapped implementation return is the wrapper asymmetry the
+    /// modifier rules already refuse -- the shapes are checked here rather than
+    /// assumed, because a wrapper's reference-ness reads through to its inner
+    /// type and would otherwise answer for the wrapper itself. Every
+    /// current-image definition the implementation return reaches must also
+    /// resolve uniquely, so an ambiguous or unavailable local definition
+    /// declines instead of riding the universal conversion. The remaining
+    /// shapes prove reference-ness through
+    /// <see cref="TypeIsAuthenticatedReferenceType"/>, which validates a
+    /// generic parameter's whole constraint set first. Gated by
+    /// <c>SameAssemblyOverrideSlot_DeclinesModifiedReturnAgainstObjectDeclaration</c>
+    /// and
+    /// <c>SameAssemblyOverrideSlot_DeclinesAmbiguousExactLocalReturnAgainstObjectDeclaration</c>,
+    /// whose non-vacuity control is
+    /// <c>SameAssemblyOverrideSlot_AllowsExactLocalReferenceReturnAgainstObjectDeclaration</c>.
+    /// </summary>
+    static bool ConvertsToObjectReturn(
+        MetadataReader reader,
+        TypeNode implementation,
+        OverrideTypeContext context,
+        OverrideCompatibilityBudget budget)
+    {
+        if (!budget.TryCharge() || implementation.IsDegraded)
+            return false;
+
+        // An allow list rather than a rejection list: a shape this comparison
+        // does not know is not proof of anything.
+        if (implementation is not (NamedTypeNode
+            or GenericTypeNode
+            or SZArrayTypeNode
+            or MDArrayTypeNode
+            or PrimitiveTypeNode
+            or GenericParameterNode))
+        {
+            return false;
+        }
+
+        if (HasUnavailableOrAmbiguousExactLocalDefinition(
+                reader,
+                implementation))
+        {
+            return false;
+        }
+
+        return TypeIsAuthenticatedReferenceType(
+            reader,
+            implementation,
+            context,
             budget);
     }
 
@@ -1622,11 +1803,13 @@ public static class MetadataDeclarationQuery
                 || !TypeIsAuthenticatedReferenceType(
                     reader,
                     methodSz.ElementType,
-                    methodContext)
+                    methodContext,
+                    budget)
                 || !TypeIsAuthenticatedReferenceType(
                     reader,
                     candidateSz.ElementType,
-                    candidateContext))
+                    candidateContext,
+                    budget))
             {
                 return OverrideCompatibility.Incompatible;
             }
@@ -1650,11 +1833,13 @@ public static class MetadataDeclarationQuery
                 && TypeIsAuthenticatedReferenceType(
                     reader,
                     methodMd.ElementType,
-                    methodContext)
+                    methodContext,
+                    budget)
                 && TypeIsAuthenticatedReferenceType(
                     reader,
                     candidateMd.ElementType,
-                    candidateContext)
+                    candidateContext,
+                    budget)
                 ? CompareVariantTypeArguments(
                     reader,
                     methodMd.ElementType,
@@ -1668,14 +1853,30 @@ public static class MetadataDeclarationQuery
         if (method is not GenericTypeNode methodGeneric
             || candidate is not GenericTypeNode candidateGeneric
             || !GenericDefinitionsCorrespond(
-               methodGeneric,
-               candidateGeneric)
-            || methodGeneric.Arguments.Length
-               != candidateGeneric.Arguments.Length
-            || !TryFindExactLocalTypeDefinition(
-               reader,
-               methodGeneric,
-               out TypeDefinitionHandle genericDefinitionHandle))
+                methodGeneric,
+                candidateGeneric))
+        {
+            return OverrideCompatibility.Unknown;
+        }
+
+        // Corresponding definitions whose constructions disagree on how many
+        // arguments they carry -- against each other, or against the arity the
+        // definition's own encoded name declares -- are structurally different
+        // types. That is a disproof this image owns even when the definition
+        // itself lives outside it, so it is Incompatible rather than the
+        // let-the-compiler-decide Unknown an exact external construction earns.
+        if (methodGeneric.Arguments.Length
+                != candidateGeneric.Arguments.Length
+            || !EncodedArgumentCountAgrees(methodGeneric)
+            || !EncodedArgumentCountAgrees(candidateGeneric))
+        {
+            return OverrideCompatibility.Incompatible;
+        }
+
+        if (!TryFindExactLocalTypeDefinition(
+                reader,
+                methodGeneric,
+                out TypeDefinitionHandle genericDefinitionHandle))
         {
             return OverrideCompatibility.Unknown;
         }
@@ -1703,6 +1904,9 @@ public static class MetadataDeclarationQuery
             return OverrideCompatibility.Unknown;
         }
 
+        bool ownerMayDeclareVariance = OwnerMayDeclareVariance(
+            reader,
+            genericDefinitionHandle);
         bool hasUnknown = false;
         for (int index = 0;
             index < genericParameters.Length;
@@ -1718,6 +1922,12 @@ public static class MetadataDeclarationQuery
             GenericParameterAttributes variance =
                 genericParameters[index].Attributes
                 & GenericParameterAttributes.VarianceMask;
+            if (variance != GenericParameterAttributes.None
+                && !ownerMayDeclareVariance)
+            {
+                return OverrideCompatibility.Incompatible;
+            }
+
             OverrideCompatibility argumentCompatibility =
                 variance switch
                 {
@@ -1874,15 +2084,18 @@ public static class MetadataDeclarationQuery
 
         if (IsObject(candidate))
         {
-            return TypeParameterKindClassifier.Classify(
+            // The reference-type flag proves conversion to object, but only
+            // once the parameter's whole constraint set is known to decode:
+            // a degraded or non-uniquely-resolving sibling constraint is
+            // malformed current-image evidence about this very parameter, and
+            // accepting the flag anyway would let metadata order decide
+            // whether that evidence is fatal.
+            return GenericParameterProvesReferenceType(
                     reader,
+                    method,
                     parameterHandle,
-                    method.HasValueTypeConstraint,
-                    method.HasReferenceTypeConstraint,
-                    new TypeParameterKindClassifier
-                        .ChainState())
-                    == TypeParameterTypeKind
-                        .ReferenceType
+                    methodContext,
+                    budget)
                 ? OverrideCompatibility.Compatible
                 : OverrideCompatibility.Incompatible;
         }
@@ -2124,7 +2337,8 @@ public static class MetadataDeclarationQuery
     static bool TypeIsAuthenticatedReferenceType(
         MetadataReader reader,
         TypeNode type,
-        OverrideTypeContext context)
+        OverrideTypeContext context,
+        OverrideCompatibilityBudget budget)
     {
         if (type.IsDegraded)
             return false;
@@ -2133,7 +2347,8 @@ public static class MetadataDeclarationQuery
             return TypeIsAuthenticatedReferenceType(
                 reader,
                 passthrough.Inner,
-                context);
+                context,
+                budget);
 
         if (type is not GenericParameterNode parameter)
             return type.IsReferenceType;
@@ -2142,15 +2357,72 @@ public static class MetadataDeclarationQuery
                 parameter,
                 context,
                 out GenericParameterHandle parameterHandle)
-            && TypeParameterKindClassifier.Classify(
+            && GenericParameterProvesReferenceType(
+                reader,
+                parameter,
+                parameterHandle,
+                context,
+                budget);
+    }
+
+    /// <summary>
+    /// True when a type parameter's own metadata proves it is a reference
+    /// type: its complete constraint set decodes cleanly under
+    /// <paramref name="budget"/>, and the classifier then reports
+    /// <see cref="TypeParameterTypeKind.ReferenceType"/>.
+    ///
+    /// The constraint-set validation is not redundant with the classifier. The
+    /// classifier answers from the reference-type flag and the constraint
+    /// chain it needs, so a sibling constraint that decodes degraded or does
+    /// not resolve to a unique local definition never reaches it. That sibling
+    /// is malformed evidence about this parameter, and reference-ness is what
+    /// authorizes both <c>T</c>-to-object correspondence and generic array
+    /// covariance, so it fails the relationship closed rather than being
+    /// ignored. A parameter constrained only by the reference-type flag has an
+    /// empty constraint set, decodes trivially, and remains accepted. Gated by
+    /// <c>SameAssemblyOverrideSlot_DeclinesDegradedSiblingConstraintForObjectReturn</c>
+    /// and
+    /// <c>SameAssemblyOverrideSlot_DeclinesDegradedSiblingConstraintForArrayCovariance</c>,
+    /// whose non-vacuity controls are
+    /// <c>SameAssemblyOverrideSlot_AllowsReferenceConstrainedGenericCovariantMethodImpl</c>,
+    /// <c>SameAssemblyOverrideSlot_AllowsAuthenticatedReferenceConstraintForObjectReturn</c>,
+    /// and
+    /// <c>SameAssemblyOverrideSlot_AllowsReferenceFlagOnlyConstraintForArrayCovariance</c>.
+    /// </summary>
+    static bool GenericParameterProvesReferenceType(
+        MetadataReader reader,
+        GenericParameterNode parameter,
+        GenericParameterHandle parameterHandle,
+        OverrideTypeContext context,
+        OverrideCompatibilityBudget budget)
+    {
+        try
+        {
+            if (!TryDecodeConstraintSet(
                     reader,
-                    parameterHandle,
-                    parameter.HasValueTypeConstraint,
-                    parameter.HasReferenceTypeConstraint,
-                    new TypeParameterKindClassifier
-                        .ChainState())
-                == TypeParameterTypeKind
-                    .ReferenceType;
+                    reader.GetGenericParameter(parameterHandle),
+                    context,
+                    budget,
+                    out _))
+            {
+                return false;
+            }
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+            return false;
+        }
+
+        return TypeParameterKindClassifier.Classify(
+                reader,
+                parameterHandle,
+                parameter.HasValueTypeConstraint,
+                parameter.HasReferenceTypeConstraint,
+                new TypeParameterKindClassifier.ChainState())
+            == TypeParameterTypeKind.ReferenceType;
     }
 
     static bool ArrayShapesCorrespond(
@@ -2216,6 +2488,72 @@ public static class MetadataDeclarationQuery
         GenericTypeNode left,
         GenericTypeNode right)
         => TypeDefinitionsCorrespond(left, right);
+
+    /// <summary>
+    /// True when a constructed generic carries exactly as many arguments as
+    /// the arity its own encoded definition name declares, summed over every
+    /// nested segment. A construction that disagrees with its definition's
+    /// encoded arity is malformed, and the disagreement is readable without
+    /// resolving the definition, so it disproves correspondence for external
+    /// definitions too. A node that carries no encoded counts states no arity
+    /// to disagree with and is left to the checks that follow.
+    /// </summary>
+    static bool EncodedArgumentCountAgrees(GenericTypeNode type)
+    {
+        if (type.MetadataNameParts is not { } parts)
+            return true;
+
+        if (parts.IntroducedTypeParameterCounts is { } counts)
+            return counts.Sum() == type.Arguments.Length;
+
+        // A reference has no metadata-verified counts -- reading them would
+        // mean loading the referenced assembly, which this product does not do
+        // -- so its own encoded name is the only arity it states. A name that
+        // carries no canonical suffix at all states none, and is left to the
+        // checks that follow.
+        int declared = GenericArity(parts.Segments);
+        return declared == 0
+            || declared == type.Arguments.Length;
+    }
+
+    /// <summary>
+    /// True when a generic definition in this image is a kind the CLI lets
+    /// declare variant type parameters: an interface, or a delegate whose base
+    /// resolves through an authenticated core library.
+    ///
+    /// Variance is metadata a class may not carry, so honoring a variance flag
+    /// on a class owner would let a malformed image widen argument
+    /// correspondence into a covariant or contravariant comparison the runtime
+    /// never performs. Delegate-ness is authenticated the same way the object
+    /// root is, because a local type merely spelled <c>System.MulticastDelegate</c>
+    /// is not evidence. Gated by
+    /// <c>SameAssemblyOverrideSlot_DeclinesVarianceOnIneligibleOwner</c> over
+    /// the class and impersonating-delegate owners, whose non-vacuity controls
+    /// are <c>SameAssemblyOverrideSlot_AllowsVarianceOnEligibleOwner</c> over
+    /// the interface and delegate owners and
+    /// <c>SameAssemblyOverrideSlot_AllowsCompilerProducedNestedGenericVariance</c>.
+    /// </summary>
+    static bool OwnerMayDeclareVariance(
+        MetadataReader reader,
+        TypeDefinitionHandle definitionHandle)
+    {
+        try
+        {
+            TypeDefinition definition =
+                reader.GetTypeDefinition(definitionHandle);
+            return (definition.Attributes & TypeAttributes.Interface) != 0
+                || ApiSurfaceExtractor.IsCoreLibraryDelegateBaseType(
+                    reader,
+                    definition.BaseType);
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+            return false;
+        }
+    }
 
     static bool HasGenericShape(TypeNode type)
         => type is GenericTypeNode
@@ -2458,7 +2796,10 @@ public static class MetadataDeclarationQuery
     /// predicate is consulted.
     ///
     /// Fails closed. A supertype outside this image, an unrecorded
-    /// instantiation, a degraded or undecodable row, a cycle, more than
+    /// instantiation, a degraded or undecodable row, a cycle, an instantiation
+    /// whose exact identity would expand past
+    /// <see cref="MetadataSafetyPolicy.MaxExactInstantiationIdentityChars"/>,
+    /// more than
     /// <see cref="MetadataSafetyPolicy.MaxRelationshipNodes"/> distinct
     /// ancestors, and an exhausted comparison budget all decline rather than
     /// authenticate. Gated by
@@ -2491,6 +2832,8 @@ public static class MetadataDeclarationQuery
 
         var pending = new Queue<OverrideBaseInstantiation>();
         var visited = new HashSet<string>(StringComparer.Ordinal);
+        var identities = new Dictionary<TypeNode, string>(
+            ReferenceEqualityComparer.Instance);
         var supertypes = new List<OverrideBaseInstantiation>();
         pending.Enqueue(
             new OverrideBaseInstantiation(
@@ -2506,7 +2849,16 @@ public static class MetadataDeclarationQuery
             }
 
             OverrideBaseInstantiation current = pending.Dequeue();
-            if (!visited.Add(InstantiationKey(current)))
+            if (!TryGetInstantiationKey(
+                    current,
+                    identities,
+                    budget,
+                    out string? key))
+            {
+                return false;
+            }
+
+            if (!visited.Add(key))
                 continue;
 
             if (current.Definition == declarationHandle
@@ -2611,26 +2963,92 @@ public static class MetadataDeclarationQuery
     /// Identifies one ancestry step by its exact definition token and the
     /// exact structural identity of every argument, so a diamond is visited
     /// once while two different instantiations of the same definition stay
-    /// distinct. A self-referential base that keeps producing new
-    /// instantiations is bounded by the caller's node cap and comparison
-    /// budget rather than by this set.
+    /// distinct.
+    ///
+    /// A substituted step is a DAG whose nodes are shared, but its structural
+    /// identity is the expanded tree, and a base that squares its own
+    /// instantiation each step doubles that tree per step. The expanded size
+    /// is therefore charged to <paramref name="budget"/> and checked against
+    /// <see cref="MetadataSafetyPolicy.MaxExactInstantiationIdentityChars"/>
+    /// from each argument's precomputed estimate <em>before</em> any text is
+    /// materialized, so the walk declines within bounded memory instead of
+    /// exhausting it below the node ceiling. Identity remains exact: nothing
+    /// is truncated or hashed, and a step whose identity cannot be taken
+    /// exactly is refused, never approximated. Gated by
+    /// <c>SameAssemblyOverrideSlot_BranchingConstructedAncestryFailsClosed</c>
+    /// and
+    /// <c>SameAssemblyOverrideSlot_BranchingConstructedAncestryFailsClosedWithinMemory</c>,
+    /// whose non-vacuity control is the exact-instantiation assertion
+    /// <c>BranchingConstructedAncestryWorker</c> makes in the same
+    /// heap-limited child process, plus
+    /// <c>SameAssemblyOverrideSlot_AuthenticatesCovariantReturnThroughConstructedGenericAncestry</c>.
     /// </summary>
-    static string InstantiationKey(OverrideBaseInstantiation type)
+    static bool TryGetInstantiationKey(
+        OverrideBaseInstantiation type,
+        Dictionary<TypeNode, string> identities,
+        OverrideCompatibilityBudget budget,
+        [NotNullWhen(true)] out string? key)
     {
+        key = null;
+        if (!budget.TryCharge())
+            return false;
+
         var builder = new StringBuilder();
         builder.Append(
             MetadataTokens.GetToken(type.Definition)
                 .ToString(CultureInfo.InvariantCulture));
         if (type.TypeArguments is { } arguments)
         {
+            long estimate = 0;
+            foreach (TypeNode argument in arguments)
+            {
+                estimate += argument.EstimatedRenderedLength;
+                if (estimate
+                    > MetadataSafetyPolicy
+                        .MaxExactInstantiationIdentityChars)
+                {
+                    return false;
+                }
+            }
+
+            // One charge per node-sized unit of the expansion about to be
+            // materialized, so a step whose identity is legitimately large
+            // still spends budget proportional to the work it costs.
+            for (long charged = 0; charged < estimate; charged += 64)
+            {
+                if (!budget.TryCharge())
+                    return false;
+            }
+
             foreach (TypeNode argument in arguments)
             {
                 builder.Append('|');
-                builder.Append(argument.StructuralIdentity());
+                builder.Append(
+                    ExactStructuralIdentity(argument, identities));
             }
         }
 
-        return builder.ToString();
+        key = builder.ToString();
+        return true;
+    }
+
+    /// <summary>
+    /// The exact structural identity of one argument node, memoized by
+    /// reference across a single ancestry walk. Substitution shares node
+    /// instances between steps, so memoizing keeps a repeated argument from
+    /// re-expanding; the expansion itself is already bounded by
+    /// <see cref="TryGetInstantiationKey"/>.
+    /// </summary>
+    static string ExactStructuralIdentity(
+        TypeNode node,
+        Dictionary<TypeNode, string> identities)
+    {
+        if (identities.TryGetValue(node, out string? identity))
+            return identity;
+
+        identity = node.StructuralIdentity();
+        identities[node] = identity;
+        return identity;
     }
 
     public static MetadataPropertyDeclaration GetProperty(
@@ -2822,26 +3240,51 @@ public static class MetadataDeclarationQuery
         }
     }
 
+    /// <summary>
+    /// The unique property in <paramref name="typeHandle"/> that
+    /// <paramref name="accessorHandle"/> is an accessor of.
+    ///
+    /// Well-formed metadata associates an accessor with at most one property,
+    /// but nothing in the format enforces it, and the association decides
+    /// which declaration's accessibility a reconstructed accessor inherits.
+    /// Taking the first matching row would let the answer depend on row order,
+    /// so a second association refuses instead: the scan continues past the
+    /// first match and declines when more than one property claims the
+    /// accessor. Gated by
+    /// <c>PropertyDeclaration_DeclinesAccessorClaimedByMultipleProperties</c>
+    /// over both metadata row orders, whose non-vacuity control is
+    /// <c>PropertyDeclaration_UsesUniquePropertyAssociationForAccessor</c>.
+    /// </summary>
     static bool TryGetPropertyForAccessor(
         MetadataReader reader,
         TypeDefinitionHandle typeHandle,
         MethodDefinitionHandle accessorHandle,
         out PropertyDefinition property)
     {
+        property = default;
+        bool found = false;
         var typeDef = reader.GetTypeDefinition(typeHandle);
         foreach (var propertyHandle in typeDef.GetProperties())
         {
             var candidate = reader.GetPropertyDefinition(propertyHandle);
             var accessors = candidate.GetAccessors();
-            if (accessors.Getter == accessorHandle || accessors.Setter == accessorHandle)
+            if (accessors.Getter != accessorHandle
+                && accessors.Setter != accessorHandle)
             {
-                property = candidate;
-                return true;
+                continue;
             }
+
+            if (found)
+            {
+                property = default;
+                return false;
+            }
+
+            property = candidate;
+            found = true;
         }
 
-        property = default;
-        return false;
+        return found;
     }
 
     public static MetadataFieldDeclaration GetField(

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -630,10 +630,37 @@ public static class MetadataDeclarationQuery
                 .Select(index => $"!!{index}")
                 .ToArray());
 
+    enum OverrideModifier
+    {
+        None,
+        Ref,
+        RefReadOnly,
+        In,
+        Out,
+        Params,
+    }
+
+    readonly record struct OverrideTypeIdentity(
+        string Exact,
+        string PlatformNormalized,
+        bool IsDegraded);
+
+    readonly record struct OverrideParameterShape(
+        OverrideTypeIdentity Type,
+        OverrideModifier Modifier);
+
+    readonly record struct OverrideTypeContext(
+        GenericContext GenericContext,
+        IReadOnlyList<GenericParameterHandle> TypeParameters,
+        IReadOnlyList<GenericParameterHandle> MethodParameters);
+
     readonly record struct OverrideSlotShape(
-        string ReturnType,
+        OverrideTypeIdentity ReturnType,
         TypeNode ReturnTypeNode,
-        IReadOnlyList<ApiParameter> Parameters);
+        OverrideModifier ReturnModifier,
+        OverrideTypeContext TypeContext,
+        IReadOnlyList<OverrideParameterShape> Parameters,
+        bool IsDegraded);
 
     static OverrideSlotShape GetOverrideSlotShape(
         MetadataReader reader,
@@ -641,43 +668,83 @@ public static class MetadataDeclarationQuery
         MethodSignature<string> textSignature)
     {
         var typeDef = reader.GetTypeDefinition(method.GetDeclaringType());
+        GenericContext context =
+            GenericContext.ForMethod(reader, typeDef, method);
         var nodeSignature = GuardedProviderDecode.Method(
             reader,
             method,
-            TypeNodeProvider.Instance,
-            GenericContext.ForMethod(reader, typeDef, method),
+            new TypeNodeProvider(
+                scopeNamedTypeIdentity: true,
+                requireScopedNamedTypeIdentity: true),
+            context,
             (TypeNode)new DegradedTypeNode());
+        IReadOnlyList<ApiParameter> parameters =
+            MethodParameters(reader, method, textSignature);
+        bool isDegraded =
+            nodeSignature.ReturnType.IsDegraded
+            || nodeSignature.ParameterTypes.Any(
+                parameter => parameter.IsDegraded)
+            || nodeSignature.ParameterTypes.Length
+                != parameters.Count;
+        var parameterShapes =
+            new List<OverrideParameterShape>(
+                nodeSignature.ParameterTypes.Length);
+        for (int index = 0;
+            index < nodeSignature.ParameterTypes.Length;
+            index++)
+        {
+            parameterShapes.Add(
+                new OverrideParameterShape(
+                    TypeIdentity(
+                        nodeSignature.ParameterTypes[index]),
+                    index < parameters.Count
+                        ? ParameterModifier(
+                            parameters[index].Modifier)
+                        : OverrideModifier.None));
+        }
         return new OverrideSlotShape(
-            FormatMethodReturnType(reader, textSignature.ReturnType, method.GetParameters()),
+            TypeIdentity(nodeSignature.ReturnType),
             nodeSignature.ReturnType,
-            MethodParameters(reader, method, textSignature));
+            ReturnModifier(
+                reader,
+                method,
+                nodeSignature.ReturnType),
+            new OverrideTypeContext(
+                context,
+                [.. typeDef.GetGenericParameters()],
+                [.. method.GetGenericParameters()]),
+            parameterShapes,
+            isDegraded);
     }
 
     static bool MatchesOverrideSlotShape(
         MetadataReader reader,
         OverrideSlotShape method,
         OverrideSlotShape candidate)
-        => ParametersMatch(method.Parameters, candidate.Parameters)
+        => !method.IsDegraded
+            && !candidate.IsDegraded
+            && ParametersMatch(
+                method.Parameters,
+                candidate.Parameters)
             && ReturnTypesAreOverrideCompatible(
                 reader,
-                method.ReturnType,
-                method.ReturnTypeNode,
-                candidate.ReturnType,
-                candidate.ReturnTypeNode);
+                method,
+                candidate);
 
     static bool ParametersMatch(
-        IReadOnlyList<ApiParameter> methodParameters,
-        IReadOnlyList<ApiParameter> candidateParameters)
+        IReadOnlyList<OverrideParameterShape> methodParameters,
+        IReadOnlyList<OverrideParameterShape> candidateParameters)
     {
         if (methodParameters.Count != candidateParameters.Count)
             return false;
 
         for (var index = 0; index < methodParameters.Count; index++)
         {
-            if (!string.Equals(
-                    methodParameters[index].CanonicalTypeWithModifier,
-                    candidateParameters[index].CanonicalTypeWithModifier,
-                    StringComparison.Ordinal))
+            if (methodParameters[index].Modifier
+                    != candidateParameters[index].Modifier
+                || !TypeIdentitiesCorrespond(
+                    methodParameters[index].Type,
+                    candidateParameters[index].Type))
             {
                 return false;
             }
@@ -688,34 +755,63 @@ public static class MetadataDeclarationQuery
 
     static bool ReturnTypesAreOverrideCompatible(
         MetadataReader reader,
-        string methodReturnType,
-        TypeNode methodReturnNode,
-        string candidateReturnType,
-        TypeNode candidateReturnNode)
+        OverrideSlotShape method,
+        OverrideSlotShape candidate)
     {
-        if (string.Equals(methodReturnType, candidateReturnType, StringComparison.Ordinal))
-            return true;
+        if (method.ReturnModifier != candidate.ReturnModifier)
+            return false;
 
-        if (HasByRefReturnModifier(methodReturnType)
-            || HasByRefReturnModifier(candidateReturnType)
-            || methodReturnNode.IsDegraded
-            || candidateReturnNode.IsDegraded
-            || !methodReturnNode.IsReferenceType
-            || !candidateReturnNode.IsReferenceType)
+        if (TypeIdentitiesCorrespond(
+                method.ReturnType,
+                candidate.ReturnType))
+        {
+            return true;
+        }
+
+        if (method.ReturnModifier != OverrideModifier.None
+            || method.ReturnTypeNode.IsDegraded
+            || candidate.ReturnTypeNode.IsDegraded)
         {
             return false;
         }
 
-        if (candidateReturnType is "object" or "System.Object")
+        if (method.ReturnTypeNode is GenericParameterNode
+            methodParameter)
+        {
+            return CompareGenericParameterReturn(
+                    reader,
+                    methodParameter,
+                    method.TypeContext,
+                    candidate.ReturnTypeNode,
+                    candidate.TypeContext,
+                    [])
+                == OverrideCompatibility.Compatible;
+        }
+
+        if (candidate.ReturnTypeNode
+            is GenericParameterNode)
+        {
+            return false;
+        }
+
+        if (!method.ReturnTypeNode.IsReferenceType
+            || !candidate.ReturnTypeNode.IsReferenceType)
+        {
+            return false;
+        }
+
+        if (IsObject(candidate.ReturnTypeNode))
             return true;
-        if (methodReturnType is "object" or "System.Object")
+        if (IsObject(method.ReturnTypeNode))
             return false;
 
         OverrideCompatibility structuredCompatibility =
             CompareStructuredReturnTypes(
                 reader,
-                methodReturnNode,
-                candidateReturnNode);
+                method.ReturnTypeNode,
+                method.TypeContext,
+                candidate.ReturnTypeNode,
+                candidate.TypeContext);
         if (structuredCompatibility
             != OverrideCompatibility.Unknown)
         {
@@ -723,17 +819,34 @@ public static class MetadataDeclarationQuery
                 == OverrideCompatibility.Compatible;
         }
 
+        if (HaveSameDefinitionNameDifferentScope(
+                method.ReturnTypeNode,
+                candidate.ReturnTypeNode))
+        {
+            return false;
+        }
+
         var hasMethodReturnDefinition =
-            TryFindTypeDefinitionByRenderedName(
+            TryFindExactLocalTypeDefinition(
                 reader,
-                methodReturnType,
+                method.ReturnTypeNode,
                 out var methodReturnHandle);
         var hasCandidateReturnDefinition =
-            TryFindTypeDefinitionByRenderedName(
+            TryFindExactLocalTypeDefinition(
                 reader,
-                candidateReturnType,
+                candidate.ReturnTypeNode,
                 out var candidateReturnHandle);
-        if (!hasMethodReturnDefinition || !hasCandidateReturnDefinition)
+        if ((RequiresExactLocalDefinition(
+                        method.ReturnTypeNode)
+                    && !hasMethodReturnDefinition)
+            || (RequiresExactLocalDefinition(
+                        candidate.ReturnTypeNode)
+                    && !hasCandidateReturnDefinition))
+        {
+            return false;
+        }
+        if (!hasMethodReturnDefinition
+            || !hasCandidateReturnDefinition)
         {
             // The MethodImpl already authenticates the exact base slot. If either
             // reference-type return lives outside this image, local metadata cannot
@@ -745,6 +858,17 @@ public static class MetadataDeclarationQuery
         return IsSameOrDerivedOrImplements(reader, methodReturnHandle, candidateReturnHandle);
     }
 
+    static bool RequiresExactLocalDefinition(
+        TypeNode type)
+        => TryGetNamedDefinition(
+                type,
+                out _,
+                out ScopedNamedTypeIdentity? scope)
+            && string.Equals(
+                scope.Scope,
+                "current",
+                StringComparison.Ordinal);
+
     enum OverrideCompatibility
     {
         Unknown,
@@ -755,13 +879,31 @@ public static class MetadataDeclarationQuery
     static OverrideCompatibility CompareStructuredReturnTypes(
         MetadataReader reader,
         TypeNode method,
-        TypeNode candidate)
+        OverrideTypeContext methodContext,
+        TypeNode candidate,
+        OverrideTypeContext candidateContext)
     {
-        if (method.StructuralIdentity()
-            == candidate.StructuralIdentity())
+        if (TypeIdentitiesCorrespond(
+                TypeIdentity(method),
+                TypeIdentity(candidate)))
         {
             return OverrideCompatibility.Compatible;
         }
+
+        if (method is GenericParameterNode
+            methodParameter)
+        {
+            return CompareGenericParameterReturn(
+                reader,
+                methodParameter,
+                methodContext,
+                candidate,
+                candidateContext,
+                []);
+        }
+
+        if (candidate is GenericParameterNode)
+            return OverrideCompatibility.Incompatible;
 
         if (method is SZArrayTypeNode methodSz
             && candidate is SZArrayTypeNode candidateSz)
@@ -774,7 +916,9 @@ public static class MetadataDeclarationQuery
             return CompareVariantTypeArguments(
                 reader,
                 methodSz.ElementType,
-                candidateSz.ElementType);
+                methodContext,
+                candidateSz.ElementType,
+                candidateContext);
         }
 
         if (method is MDArrayTypeNode methodMd
@@ -786,30 +930,42 @@ public static class MetadataDeclarationQuery
                 ? CompareVariantTypeArguments(
                     reader,
                     methodMd.ElementType,
-                    candidateMd.ElementType)
+                    methodContext,
+                    candidateMd.ElementType,
+                    candidateContext)
                 : OverrideCompatibility.Incompatible;
         }
 
         if (method is not GenericTypeNode methodGeneric
             || candidate is not GenericTypeNode candidateGeneric
-            || NormalizeGenericDefinitionName(
-                   methodGeneric.DefinitionName)
-                != NormalizeGenericDefinitionName(
-                   candidateGeneric.DefinitionName)
+            || !GenericDefinitionsCorrespond(
+               methodGeneric,
+               candidateGeneric)
             || methodGeneric.Arguments.Length
-                != candidateGeneric.Arguments.Length
-            || !TryFindGenericTypeDefinition(
-                reader,
-                methodGeneric.DefinitionName,
-                methodGeneric.Arguments.Length,
-                out TypeDefinitionHandle genericDefinitionHandle))
+               != candidateGeneric.Arguments.Length
+            || !TryFindExactLocalTypeDefinition(
+               reader,
+               methodGeneric,
+               out TypeDefinitionHandle genericDefinitionHandle))
         {
             return OverrideCompatibility.Unknown;
         }
 
-        var genericParameters = reader
-            .GetTypeDefinition(genericDefinitionHandle)
-            .GetGenericParameters()
+        GenericParameterHandleCollection genericParameterHandles =
+            reader
+                .GetTypeDefinition(genericDefinitionHandle)
+                .GetGenericParameters();
+        try
+        {
+            GenericContext.ValidateParameterIndices(
+                reader,
+                genericParameterHandles);
+        }
+        catch (BadImageFormatException)
+        {
+            return OverrideCompatibility.Unknown;
+        }
+        var genericParameters = genericParameterHandles
             .Select(reader.GetGenericParameter)
             .ToArray();
         if (genericParameters.Length
@@ -834,21 +990,25 @@ public static class MetadataDeclarationQuery
                 variance switch
                 {
                     GenericParameterAttributes.None =>
-                        methodArgument.StructuralIdentity()
-                            == candidateArgument
-                                .StructuralIdentity()
+                        TypeIdentitiesCorrespond(
+                            TypeIdentity(methodArgument),
+                            TypeIdentity(candidateArgument))
                             ? OverrideCompatibility.Compatible
                             : OverrideCompatibility.Incompatible,
                     GenericParameterAttributes.Covariant =>
                         CompareVariantTypeArguments(
                             reader,
                             methodArgument,
-                            candidateArgument),
+                            methodContext,
+                            candidateArgument,
+                            candidateContext),
                     GenericParameterAttributes.Contravariant =>
                         CompareVariantTypeArguments(
                             reader,
                             candidateArgument,
-                            methodArgument),
+                            candidateContext,
+                            methodArgument,
+                            methodContext),
                     _ => OverrideCompatibility.Incompatible,
                 };
             if (argumentCompatibility
@@ -868,24 +1028,39 @@ public static class MetadataDeclarationQuery
     static OverrideCompatibility CompareVariantTypeArguments(
         MetadataReader reader,
         TypeNode method,
-        TypeNode candidate)
+        OverrideTypeContext methodContext,
+        TypeNode candidate,
+        OverrideTypeContext candidateContext)
     {
         OverrideCompatibility structured =
             CompareStructuredReturnTypes(
                 reader,
                 method,
-                candidate);
+                methodContext,
+                candidate,
+                candidateContext);
         if (structured != OverrideCompatibility.Unknown)
             return structured;
 
-        if (!TryFindTypeDefinitionByRenderedName(
+        bool hasMethodDefinition =
+            TryFindExactLocalTypeDefinition(
                 reader,
-                method.RenderCanonical(),
-                out TypeDefinitionHandle methodHandle)
-            || !TryFindTypeDefinitionByRenderedName(
+                method,
+                out TypeDefinitionHandle methodHandle);
+        bool hasCandidateDefinition =
+            TryFindExactLocalTypeDefinition(
                 reader,
-                candidate.RenderCanonical(),
-                out TypeDefinitionHandle candidateHandle))
+                candidate,
+                out TypeDefinitionHandle candidateHandle);
+        if ((RequiresExactLocalDefinition(method)
+                    && !hasMethodDefinition)
+            || (RequiresExactLocalDefinition(candidate)
+                    && !hasCandidateDefinition))
+        {
+            return OverrideCompatibility.Incompatible;
+        }
+        if (!hasMethodDefinition
+            || !hasCandidateDefinition)
         {
             return OverrideCompatibility.Unknown;
         }
@@ -898,97 +1073,405 @@ public static class MetadataDeclarationQuery
             : OverrideCompatibility.Incompatible;
     }
 
-    static bool TryFindGenericTypeDefinition(
+    static OverrideCompatibility CompareGenericParameterReturn(
         MetadataReader reader,
-        string metadataName,
-        int arity,
-        out TypeDefinitionHandle handle)
+        GenericParameterNode method,
+        OverrideTypeContext methodContext,
+        TypeNode candidate,
+        OverrideTypeContext candidateContext,
+        HashSet<GenericParameterHandle> visited)
     {
-        string normalized =
-            NormalizeGenericDefinitionName(metadataName);
-        foreach (TypeDefinitionHandle candidateHandle
-            in reader.TypeDefinitions)
+        if (TypeIdentitiesCorrespond(
+                TypeIdentity(method),
+                TypeIdentity(candidate)))
         {
-            TypeDefinition definition =
-                reader.GetTypeDefinition(candidateHandle);
-            if (definition.GetGenericParameters().Count != arity
-                || NormalizeGenericDefinitionName(
-                    TypeResolver.GetFullName(
+            return OverrideCompatibility.Compatible;
+        }
+
+        if (!TryGetGenericParameterHandle(
+                method,
+                methodContext,
+                out GenericParameterHandle parameterHandle))
+        {
+            return OverrideCompatibility.Incompatible;
+        }
+
+        if (IsObject(candidate))
+        {
+            return TypeParameterKindClassifier.Classify(
+                    reader,
+                    parameterHandle,
+                    method.HasValueTypeConstraint,
+                    method.HasReferenceTypeConstraint,
+                    new TypeParameterKindClassifier
+                        .ChainState())
+                    == TypeParameterTypeKind
+                        .ReferenceType
+                ? OverrideCompatibility.Compatible
+                : OverrideCompatibility.Incompatible;
+        }
+
+        if (!visited.Add(parameterHandle))
+            return OverrideCompatibility.Incompatible;
+
+        try
+        {
+            GenericParameter parameter =
+                reader.GetGenericParameter(parameterHandle);
+            foreach (GenericParameterConstraintHandle constraintHandle
+                in parameter.GetConstraints())
+            {
+                GenericParameterConstraint constraint =
+                    reader.GetGenericParameterConstraint(
+                        constraintHandle);
+                TypeNode constraintType = DecodeConstraintType(
+                    reader,
+                    constraint.Type,
+                    methodContext);
+                if (constraintType.IsDegraded)
+                    continue;
+
+                if (constraintType is GenericParameterNode
+                    constrainedParameter)
+                {
+                    if (CompareGenericParameterReturn(
+                            reader,
+                            constrainedParameter,
+                            methodContext,
+                            candidate,
+                            candidateContext,
+                            visited)
+                            == OverrideCompatibility.Compatible)
+                    {
+                        return OverrideCompatibility.Compatible;
+                    }
+                    continue;
+                }
+
+                OverrideCompatibility constraintCompatibility =
+                    CompareStructuredReturnTypes(
                         reader,
-                        definition))
-                    != normalized)
-            {
-                continue;
+                        constraintType,
+                        methodContext,
+                        candidate,
+                        candidateContext);
+                if (constraintCompatibility
+                    == OverrideCompatibility.Compatible)
+                {
+                    return OverrideCompatibility.Compatible;
+                }
+                if (constraintCompatibility
+                        == OverrideCompatibility.Incompatible
+                    || HasGenericShape(candidate))
+                {
+                    // Definition-only ancestry cannot prove a conversion to a
+                    // constructed or raw generic target without preserving arguments.
+                    continue;
+                }
+
+                if (TryFindExactLocalTypeDefinition(
+                        reader,
+                        constraintType,
+                        out TypeDefinitionHandle constraintDefinition)
+                    && TryFindExactLocalTypeDefinition(
+                        reader,
+                        candidate,
+                        out TypeDefinitionHandle candidateDefinition)
+                    && IsSameOrDerivedOrImplements(
+                        reader,
+                        constraintDefinition,
+                        candidateDefinition))
+                {
+                    return OverrideCompatibility.Compatible;
+                }
             }
-
-            handle = candidateHandle;
-            return true;
         }
-
-        handle = default;
-        return false;
-    }
-
-    static string NormalizeGenericDefinitionName(
-        string typeName)
-    {
-        var result = new StringBuilder(typeName.Length);
-        for (int index = 0; index < typeName.Length; index++)
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
         {
-            if (typeName[index] != '`')
-            {
-                result.Append(typeName[index] == '+'
-                    ? '.'
-                    : typeName[index]);
-                continue;
-            }
-
-            index++;
-            while (index < typeName.Length
-                && char.IsDigit(typeName[index]))
-            {
-                index++;
-            }
-            index--;
+            return OverrideCompatibility.Incompatible;
         }
-        return result.ToString();
+        finally
+        {
+            visited.Remove(parameterHandle);
+        }
+
+        return OverrideCompatibility.Incompatible;
     }
 
-    static bool HasByRefReturnModifier(string returnType)
-        => returnType.StartsWith("ref ", StringComparison.Ordinal)
-            || returnType.StartsWith("ref readonly ", StringComparison.Ordinal);
+    static OverrideTypeIdentity TypeIdentity(
+        TypeNode type)
+        => new(
+            type.StructuralIdentity(),
+            type.PlatformNormalizedStructuralIdentity(),
+            type.IsDegraded);
 
-    static bool TryFindTypeDefinitionByRenderedName(
+    static bool TypeIdentitiesCorrespond(
+        OverrideTypeIdentity left,
+        OverrideTypeIdentity right)
+        => !left.IsDegraded
+            && !right.IsDegraded
+            && (string.Equals(
+                    left.Exact,
+                    right.Exact,
+                    StringComparison.Ordinal)
+                || string.Equals(
+                    left.PlatformNormalized,
+                    right.PlatformNormalized,
+                    StringComparison.Ordinal));
+
+    static OverrideModifier ParameterModifier(
+        string? modifier)
+        => modifier switch
+        {
+            null or "" => OverrideModifier.None,
+            "ref" => OverrideModifier.Ref,
+            "in" => OverrideModifier.In,
+            "out" => OverrideModifier.Out,
+            "params" => OverrideModifier.Params,
+            _ => OverrideModifier.None,
+        };
+
+    static OverrideModifier ReturnModifier(
         MetadataReader reader,
-        string typeName,
-        out TypeDefinitionHandle handle)
+        MethodDefinition method,
+        TypeNode returnType)
+        => returnType is not ByRefTypeNode
+            ? OverrideModifier.None
+            : ReturnIsReadOnlyRef(
+                reader,
+                method.GetParameters())
+                ? OverrideModifier.RefReadOnly
+                : OverrideModifier.Ref;
+
+    static bool IsObject(TypeNode type)
+        => type is PrimitiveTypeNode
+        {
+            Name: "object" or "System.Object",
+        };
+
+    static bool TryGetGenericParameterHandle(
+        GenericParameterNode parameter,
+        OverrideTypeContext context,
+        out GenericParameterHandle handle)
     {
-        typeName = NormalizeRenderedTypeName(typeName);
-        if (typeName.Length == 0
-            || typeName.IndexOfAny(['<', '[', '*', '&']) >= 0
-            || typeName.Contains(',', StringComparison.Ordinal))
+        IReadOnlyList<GenericParameterHandle> parameters =
+            parameter.IsMethodParameter
+                ? context.MethodParameters
+                : context.TypeParameters;
+        if ((uint)parameter.Index
+            >= (uint)parameters.Count)
         {
             handle = default;
             return false;
         }
 
-        foreach (var candidateHandle in reader.TypeDefinitions)
-        {
-            var definition = reader.GetTypeDefinition(candidateHandle);
-            if (NormalizeRenderedTypeName(TypeResolver.GetTypeNameFromDefinition(reader, candidateHandle)) == typeName
-                || NormalizeRenderedTypeName(TypeResolver.GetFullName(reader, definition)) == typeName)
-            {
-                handle = candidateHandle;
-                return true;
-            }
-        }
-
-        handle = default;
-        return false;
+        handle = parameters[parameter.Index];
+        return !handle.IsNil;
     }
 
-    static string NormalizeRenderedTypeName(string typeName)
-        => typeName.TrimEnd('?').Replace('+', '.');
+    static TypeNode DecodeConstraintType(
+        MetadataReader reader,
+        EntityHandle handle,
+        OverrideTypeContext context)
+    {
+        var provider = new TypeNodeProvider(
+            scopeNamedTypeIdentity: true,
+            requireScopedNamedTypeIdentity: true);
+        return handle.Kind switch
+        {
+            HandleKind.TypeDefinition =>
+                provider.GetTypeFromDefinition(
+                    reader,
+                    (TypeDefinitionHandle)handle,
+                    rawTypeKind: 0x12),
+            HandleKind.TypeReference =>
+                provider.GetTypeFromReference(
+                    reader,
+                    (TypeReferenceHandle)handle,
+                    rawTypeKind: 0x12),
+            HandleKind.TypeSpecification =>
+                GuardedProviderDecode.TypeSpec(
+                    reader,
+                    (TypeSpecificationHandle)handle,
+                    provider,
+                    context.GenericContext,
+                    (TypeNode)new DegradedTypeNode()),
+            _ => new DegradedTypeNode(),
+        };
+    }
+
+    static bool GenericDefinitionsCorrespond(
+        GenericTypeNode left,
+        GenericTypeNode right)
+        => TypeDefinitionsCorrespond(left, right);
+
+    static bool HasGenericShape(TypeNode type)
+        => type is GenericTypeNode
+            || TryGetNamedDefinition(
+                    type,
+                    out MetadataTypeNameParts? name,
+                    out _)
+                && name.IntroducedTypeParameterCounts
+                    is { } counts
+                && counts.Any(count => count != 0);
+
+    static bool TypeDefinitionsCorrespond(
+        TypeNode left,
+        TypeNode right)
+        => TryGetNamedDefinition(
+                left,
+                out MetadataTypeNameParts? leftName,
+                out ScopedNamedTypeIdentity? leftScope)
+            && TryGetNamedDefinition(
+                right,
+                out MetadataTypeNameParts? rightName,
+                out ScopedNamedTypeIdentity? rightScope)
+            && NamesCorrespond(leftName, rightName)
+            && ScopesCorrespond(leftScope, rightScope);
+
+    static bool HaveSameDefinitionNameDifferentScope(
+        TypeNode left,
+        TypeNode right)
+        => TryGetNamedDefinition(
+                left,
+                out MetadataTypeNameParts? leftName,
+                out ScopedNamedTypeIdentity? leftScope)
+            && TryGetNamedDefinition(
+                right,
+                out MetadataTypeNameParts? rightName,
+                out ScopedNamedTypeIdentity? rightScope)
+            && NamesCorrespond(leftName, rightName)
+            && !ScopesCorrespond(leftScope, rightScope);
+
+    static bool TryGetNamedDefinition(
+        TypeNode type,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
+        out MetadataTypeNameParts? name,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
+        out ScopedNamedTypeIdentity? scope)
+    {
+        switch (type)
+        {
+            case NamedTypeNode
+            {
+                MetadataName: { } named,
+                ScopedIdentity: { } namedScope,
+            }:
+                name = named;
+                scope = namedScope;
+                return true;
+            case GenericTypeNode
+            {
+                MetadataName: { } generic,
+                ScopedIdentity: { } genericScope,
+            }:
+                name = generic;
+                scope = genericScope;
+                return true;
+            default:
+                name = null;
+                scope = null;
+                return false;
+        }
+    }
+
+    static bool NamesCorrespond(
+        MetadataTypeNameParts left,
+        MetadataTypeNameParts right)
+        => string.Equals(
+                left.Namespace,
+                right.Namespace,
+                StringComparison.Ordinal)
+            && left.Segments.SequenceEqual(
+                right.Segments,
+                StringComparer.Ordinal);
+
+    static bool ScopesCorrespond(
+        ScopedNamedTypeIdentity left,
+        ScopedNamedTypeIdentity right)
+        => string.Equals(
+                left.Scope,
+                right.Scope,
+                StringComparison.Ordinal)
+            || string.Equals(
+                left.PlatformNormalizedScope,
+                right.PlatformNormalizedScope,
+                StringComparison.Ordinal);
+
+    static bool TryFindExactLocalTypeDefinition(
+        MetadataReader reader,
+        TypeNode type,
+        out TypeDefinitionHandle handle)
+    {
+        handle = default;
+        if (!TryGetNamedDefinition(
+                type,
+                out MetadataTypeNameParts? requested,
+                out ScopedNamedTypeIdentity? scope)
+            || !string.Equals(
+                scope.Scope,
+                "current",
+                StringComparison.Ordinal)
+            || requested.IntroducedTypeParameterCounts
+                is not { } requestedCounts
+            || requestedCounts.Count
+                != requested.Segments.Count)
+        {
+            return false;
+        }
+
+        if (type is GenericTypeNode generic
+            && requestedCounts.Sum()
+                != generic.Arguments.Length)
+        {
+            return false;
+        }
+
+        TypeDefinitionHandle match = default;
+        foreach (TypeDefinitionHandle candidateHandle
+            in reader.TypeDefinitions)
+        {
+            try
+            {
+                MetadataTypeNameParts candidate =
+                    TypeResolver
+                        .GetTypeNamePartsFromDefinition(
+                            reader,
+                            candidateHandle)
+                        .WithIntroducedTypeParameterCounts(
+                            GetIntroducedTypeParameterCounts(
+                                reader,
+                                candidateHandle));
+                if (!NamesCorrespond(
+                        requested,
+                        candidate)
+                    || !requestedCounts.SequenceEqual(
+                        candidate
+                            .IntroducedTypeParameterCounts!))
+                {
+                    continue;
+                }
+            }
+            catch (Exception exception)
+                when (exception
+                    is BadImageFormatException
+                    or ArgumentException
+                    or InvalidOperationException)
+            {
+                return false;
+            }
+
+            if (!match.IsNil)
+                return false;
+            match = candidateHandle;
+        }
+
+        handle = match;
+        return !handle.IsNil;
+    }
 
     static bool IsSameOrDerivedOrImplements(
         MetadataReader reader,
@@ -1007,14 +1490,15 @@ public static class MetadataDeclarationQuery
                 return true;
 
             var current = reader.GetTypeDefinition(currentHandle);
-            if (TryResolveSameAssemblyTypeDefinition(reader, current.BaseType, out var baseHandle))
+            if (TryResolveSameAssemblyTypeDefinition(
+                    current.BaseType,
+                    out var baseHandle))
                 pending.Enqueue(baseHandle);
 
             foreach (var implementationHandle in current.GetInterfaceImplementations())
             {
                 var interfaceImplementation = reader.GetInterfaceImplementation(implementationHandle);
                 if (TryResolveSameAssemblyTypeDefinition(
-                        reader,
                         interfaceImplementation.Interface,
                         out var interfaceHandle))
                 {
@@ -1027,7 +1511,6 @@ public static class MetadataDeclarationQuery
     }
 
     static bool TryResolveSameAssemblyTypeDefinition(
-        MetadataReader reader,
         EntityHandle handle,
         out TypeDefinitionHandle resolvedHandle)
     {
@@ -1035,14 +1518,6 @@ public static class MetadataDeclarationQuery
         {
             resolvedHandle = (TypeDefinitionHandle)handle;
             return true;
-        }
-
-        if (handle.Kind == HandleKind.TypeReference)
-        {
-            return TryFindTypeDefinitionByRenderedName(
-                reader,
-                TypeResolver.GetTypeNameFromReference(reader, (TypeReferenceHandle)handle),
-                out resolvedHandle);
         }
 
         resolvedHandle = default;

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -364,6 +364,59 @@ public static class MetadataDeclarationQuery
         return FormatMethodReturnType(reader, signature.ReturnType, method.GetParameters());
     }
 
+    public static bool TryGetCliInstanceConstructorSignature(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method,
+        out MethodSignature<string> signature)
+    {
+        signature = default;
+        const MethodAttributes constructorFlags =
+            MethodAttributes.SpecialName
+            | MethodAttributes.RTSpecialName;
+        if ((method.Attributes & MethodAttributes.Static) != 0
+            || (method.Attributes & constructorFlags) != constructorFlags
+            || !reader.StringComparer.Equals(
+                method.Name,
+                ".ctor")
+            || method.GetGenericParameters().Count != 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            signature = GuardedSignatureText.MethodText(
+                reader,
+                method,
+                GenericContext.ForMethod(
+                    reader,
+                    typeDef,
+                    method))
+                .GetValueOrThrow();
+        }
+        catch (Exception ex)
+            when (ex is BadImageFormatException
+                or InvalidOperationException
+                or ArgumentException)
+        {
+            signature = default;
+            return false;
+        }
+
+        return signature.Header.Kind
+                == SignatureKind.Method
+            && signature.Header.CallingConvention
+                == SignatureCallingConvention.Default
+            && signature.Header.IsInstance
+            && !signature.Header.IsGeneric
+            && !signature.Header.HasExplicitThis
+            && string.Equals(
+                signature.ReturnType,
+                "void",
+                StringComparison.Ordinal);
+    }
+
     public static MetadataMethodDeclaration GetMethod(
         MetadataReader reader,
         TypeDefinition typeDef,
@@ -647,6 +700,7 @@ public static class MetadataDeclarationQuery
 
     readonly record struct OverrideParameterShape(
         OverrideTypeIdentity Type,
+        TypeNode TypeNode,
         OverrideModifier Modifier);
 
     readonly record struct OverrideTypeContext(
@@ -697,6 +751,7 @@ public static class MetadataDeclarationQuery
                 new OverrideParameterShape(
                     TypeIdentity(
                         nodeSignature.ParameterTypes[index]),
+                    nodeSignature.ParameterTypes[index],
                     index < parameters.Count
                         ? ParameterModifier(
                             parameters[index].Modifier)
@@ -724,6 +779,7 @@ public static class MetadataDeclarationQuery
         => !method.IsDegraded
             && !candidate.IsDegraded
             && ParametersMatch(
+                reader,
                 method.Parameters,
                 candidate.Parameters)
             && ReturnTypesAreOverrideCompatible(
@@ -732,6 +788,7 @@ public static class MetadataDeclarationQuery
                 candidate);
 
     static bool ParametersMatch(
+        MetadataReader reader,
         IReadOnlyList<OverrideParameterShape> methodParameters,
         IReadOnlyList<OverrideParameterShape> candidateParameters)
     {
@@ -742,9 +799,10 @@ public static class MetadataDeclarationQuery
         {
             if (methodParameters[index].Modifier
                     != candidateParameters[index].Modifier
-                || !TypeIdentitiesCorrespond(
-                    methodParameters[index].Type,
-                    candidateParameters[index].Type))
+                || !TypeNodesCorrespond(
+                    reader,
+                    methodParameters[index].TypeNode,
+                    candidateParameters[index].TypeNode))
             {
                 return false;
             }
@@ -761,9 +819,10 @@ public static class MetadataDeclarationQuery
         if (method.ReturnModifier != candidate.ReturnModifier)
             return false;
 
-        if (TypeIdentitiesCorrespond(
-                method.ReturnType,
-                candidate.ReturnType))
+        if (TypeNodesCorrespond(
+                reader,
+                method.ReturnTypeNode,
+                candidate.ReturnTypeNode))
         {
             return true;
         }
@@ -785,7 +844,7 @@ public static class MetadataDeclarationQuery
                     candidate.ReturnTypeNode,
                     candidate.TypeContext,
                     [])
-                == OverrideCompatibility.Compatible;
+                != OverrideCompatibility.Incompatible;
         }
 
         if (candidate.ReturnTypeNode
@@ -836,12 +895,12 @@ public static class MetadataDeclarationQuery
                 reader,
                 candidate.ReturnTypeNode,
                 out var candidateReturnHandle);
-        if ((RequiresExactLocalDefinition(
-                        method.ReturnTypeNode)
-                    && !hasMethodReturnDefinition)
-            || (RequiresExactLocalDefinition(
-                        candidate.ReturnTypeNode)
-                    && !hasCandidateReturnDefinition))
+        if (HasUnavailableOrAmbiguousExactLocalDefinition(
+                reader,
+                method.ReturnTypeNode)
+            || HasUnavailableOrAmbiguousExactLocalDefinition(
+                reader,
+                candidate.ReturnTypeNode))
         {
             return false;
         }
@@ -858,17 +917,6 @@ public static class MetadataDeclarationQuery
         return IsSameOrDerivedOrImplements(reader, methodReturnHandle, candidateReturnHandle);
     }
 
-    static bool RequiresExactLocalDefinition(
-        TypeNode type)
-        => TryGetNamedDefinition(
-                type,
-                out _,
-                out ScopedNamedTypeIdentity? scope)
-            && string.Equals(
-                scope.Scope,
-                "current",
-                StringComparison.Ordinal);
-
     enum OverrideCompatibility
     {
         Unknown,
@@ -883,11 +931,46 @@ public static class MetadataDeclarationQuery
         TypeNode candidate,
         OverrideTypeContext candidateContext)
     {
-        if (TypeIdentitiesCorrespond(
-                TypeIdentity(method),
-                TypeIdentity(candidate)))
+        if (TypeNodesCorrespond(
+                reader,
+                method,
+                candidate))
         {
             return OverrideCompatibility.Compatible;
+        }
+
+        if (method is ModifiedTypeNode
+            || candidate is ModifiedTypeNode)
+        {
+            return method is ModifiedTypeNode methodModified
+                && candidate is ModifiedTypeNode candidateModified
+                && methodModified.IsRequired
+                    == candidateModified.IsRequired
+                && TypeNodesCorrespond(
+                    reader,
+                    methodModified.Modifier,
+                    candidateModified.Modifier)
+                ? CompareStructuredReturnTypes(
+                    reader,
+                    methodModified.Inner,
+                    methodContext,
+                    candidateModified.Inner,
+                    candidateContext)
+                : OverrideCompatibility.Incompatible;
+        }
+
+        if (method is PinnedTypeNode
+            || candidate is PinnedTypeNode)
+        {
+            return method is PinnedTypeNode methodPinned
+                && candidate is PinnedTypeNode candidatePinned
+                ? CompareStructuredReturnTypes(
+                    reader,
+                    methodPinned.Inner,
+                    methodContext,
+                    candidatePinned.Inner,
+                    candidateContext)
+                : OverrideCompatibility.Incompatible;
         }
 
         if (method is GenericParameterNode
@@ -905,11 +988,19 @@ public static class MetadataDeclarationQuery
         if (candidate is GenericParameterNode)
             return OverrideCompatibility.Incompatible;
 
-        if (method is SZArrayTypeNode methodSz
-            && candidate is SZArrayTypeNode candidateSz)
+        if (method is SZArrayTypeNode
+            || candidate is SZArrayTypeNode)
         {
-            if (!methodSz.ElementType.IsReferenceType
-                || !candidateSz.ElementType.IsReferenceType)
+            if (method is not SZArrayTypeNode methodSz
+                || candidate is not SZArrayTypeNode candidateSz
+                || !TypeIsAuthenticatedReferenceType(
+                    reader,
+                    methodSz.ElementType,
+                    methodContext)
+                || !TypeIsAuthenticatedReferenceType(
+                    reader,
+                    candidateSz.ElementType,
+                    candidateContext))
             {
                 return OverrideCompatibility.Incompatible;
             }
@@ -921,12 +1012,22 @@ public static class MetadataDeclarationQuery
                 candidateContext);
         }
 
-        if (method is MDArrayTypeNode methodMd
-            && candidate is MDArrayTypeNode candidateMd)
+        if (method is MDArrayTypeNode
+            || candidate is MDArrayTypeNode)
         {
-            return methodMd.Rank == candidateMd.Rank
-                && methodMd.ElementType.IsReferenceType
-                && candidateMd.ElementType.IsReferenceType
+            return method is MDArrayTypeNode methodMd
+                && candidate is MDArrayTypeNode candidateMd
+                && ArrayShapesCorrespond(
+                    methodMd.Shape,
+                    candidateMd.Shape)
+                && TypeIsAuthenticatedReferenceType(
+                    reader,
+                    methodMd.ElementType,
+                    methodContext)
+                && TypeIsAuthenticatedReferenceType(
+                    reader,
+                    candidateMd.ElementType,
+                    candidateContext)
                 ? CompareVariantTypeArguments(
                     reader,
                     methodMd.ElementType,
@@ -990,9 +1091,10 @@ public static class MetadataDeclarationQuery
                 variance switch
                 {
                     GenericParameterAttributes.None =>
-                        TypeIdentitiesCorrespond(
-                            TypeIdentity(methodArgument),
-                            TypeIdentity(candidateArgument))
+                        TypeNodesCorrespond(
+                            reader,
+                            methodArgument,
+                            candidateArgument)
                             ? OverrideCompatibility.Compatible
                             : OverrideCompatibility.Incompatible,
                     GenericParameterAttributes.Covariant =>
@@ -1052,10 +1154,12 @@ public static class MetadataDeclarationQuery
                 reader,
                 candidate,
                 out TypeDefinitionHandle candidateHandle);
-        if ((RequiresExactLocalDefinition(method)
-                    && !hasMethodDefinition)
-            || (RequiresExactLocalDefinition(candidate)
-                    && !hasCandidateDefinition))
+        if (HasUnavailableOrAmbiguousExactLocalDefinition(
+                reader,
+                method)
+            || HasUnavailableOrAmbiguousExactLocalDefinition(
+                reader,
+                candidate))
         {
             return OverrideCompatibility.Incompatible;
         }
@@ -1081,9 +1185,10 @@ public static class MetadataDeclarationQuery
         OverrideTypeContext candidateContext,
         HashSet<GenericParameterHandle> visited)
     {
-        if (TypeIdentitiesCorrespond(
-                TypeIdentity(method),
-                TypeIdentity(candidate)))
+        if (TypeNodesCorrespond(
+                reader,
+                method,
+                candidate))
         {
             return OverrideCompatibility.Compatible;
         }
@@ -1116,6 +1221,7 @@ public static class MetadataDeclarationQuery
 
         try
         {
+            bool hasUnknownConstraintCompatibility = false;
             GenericParameter parameter =
                 reader.GetGenericParameter(parameterHandle);
             foreach (GenericParameterConstraintHandle constraintHandle
@@ -1160,23 +1266,47 @@ public static class MetadataDeclarationQuery
                 {
                     return OverrideCompatibility.Compatible;
                 }
+                if (HasUnavailableOrAmbiguousExactLocalDefinition(
+                        reader,
+                        constraintType)
+                    || HasUnavailableOrAmbiguousExactLocalDefinition(
+                        reader,
+                        candidate))
+                {
+                    continue;
+                }
+
+                bool candidateHasGenericShape =
+                    HasGenericShape(candidate);
+                bool hasConstraintDefinition =
+                    TryFindExactLocalTypeDefinition(
+                        reader,
+                        constraintType,
+                        out TypeDefinitionHandle constraintDefinition);
+                bool hasCandidateDefinition =
+                    TryFindExactLocalTypeDefinition(
+                        reader,
+                        candidate,
+                        out TypeDefinitionHandle candidateDefinition);
+                if (constraintCompatibility
+                        == OverrideCompatibility.Unknown
+                    && candidateHasGenericShape
+                    && (!hasConstraintDefinition
+                        || !hasCandidateDefinition))
+                {
+                    hasUnknownConstraintCompatibility = true;
+                }
                 if (constraintCompatibility
                         == OverrideCompatibility.Incompatible
-                    || HasGenericShape(candidate))
+                    || candidateHasGenericShape)
                 {
                     // Definition-only ancestry cannot prove a conversion to a
                     // constructed or raw generic target without preserving arguments.
                     continue;
                 }
 
-                if (TryFindExactLocalTypeDefinition(
-                        reader,
-                        constraintType,
-                        out TypeDefinitionHandle constraintDefinition)
-                    && TryFindExactLocalTypeDefinition(
-                        reader,
-                        candidate,
-                        out TypeDefinitionHandle candidateDefinition)
+                if (hasConstraintDefinition
+                    && hasCandidateDefinition
                     && IsSameOrDerivedOrImplements(
                         reader,
                         constraintDefinition,
@@ -1185,6 +1315,10 @@ public static class MetadataDeclarationQuery
                     return OverrideCompatibility.Compatible;
                 }
             }
+
+            return hasUnknownConstraintCompatibility
+                ? OverrideCompatibility.Unknown
+                : OverrideCompatibility.Incompatible;
         }
         catch (Exception exception)
             when (exception is BadImageFormatException
@@ -1197,8 +1331,6 @@ public static class MetadataDeclarationQuery
         {
             visited.Remove(parameterHandle);
         }
-
-        return OverrideCompatibility.Incompatible;
     }
 
     static OverrideTypeIdentity TypeIdentity(
@@ -1221,6 +1353,20 @@ public static class MetadataDeclarationQuery
                     left.PlatformNormalized,
                     right.PlatformNormalized,
                     StringComparison.Ordinal));
+
+    static bool TypeNodesCorrespond(
+        MetadataReader reader,
+        TypeNode left,
+        TypeNode right)
+        => !HasUnavailableOrAmbiguousExactLocalDefinition(
+                reader,
+                left)
+            && !HasUnavailableOrAmbiguousExactLocalDefinition(
+                reader,
+                right)
+            && TypeIdentitiesCorrespond(
+                TypeIdentity(left),
+                TypeIdentity(right));
 
     static OverrideModifier ParameterModifier(
         string? modifier)
@@ -1251,6 +1397,46 @@ public static class MetadataDeclarationQuery
         {
             Name: "object" or "System.Object",
         };
+
+    static bool TypeIsAuthenticatedReferenceType(
+        MetadataReader reader,
+        TypeNode type,
+        OverrideTypeContext context)
+    {
+        if (type.IsDegraded)
+            return false;
+
+        if (type is PassthroughTypeNode passthrough)
+            return TypeIsAuthenticatedReferenceType(
+                reader,
+                passthrough.Inner,
+                context);
+
+        if (type is not GenericParameterNode parameter)
+            return type.IsReferenceType;
+
+        return TryGetGenericParameterHandle(
+                parameter,
+                context,
+                out GenericParameterHandle parameterHandle)
+            && TypeParameterKindClassifier.Classify(
+                    reader,
+                    parameterHandle,
+                    parameter.HasValueTypeConstraint,
+                    parameter.HasReferenceTypeConstraint,
+                    new TypeParameterKindClassifier
+                        .ChainState())
+                == TypeParameterTypeKind
+                    .ReferenceType;
+    }
+
+    static bool ArrayShapesCorrespond(
+        ArrayShape left,
+        ArrayShape right)
+        => left.Rank == right.Rank
+            && left.Sizes.SequenceEqual(right.Sizes)
+            && left.LowerBounds.SequenceEqual(
+                right.LowerBounds);
 
     static bool TryGetGenericParameterHandle(
         GenericParameterNode parameter,
@@ -1345,6 +1531,64 @@ public static class MetadataDeclarationQuery
                 out ScopedNamedTypeIdentity? rightScope)
             && NamesCorrespond(leftName, rightName)
             && !ScopesCorrespond(leftScope, rightScope);
+
+    static bool HasUnavailableOrAmbiguousExactLocalDefinition(
+        MetadataReader reader,
+        TypeNode type)
+    {
+        if (TryGetNamedDefinition(
+                type,
+                out _,
+                out ScopedNamedTypeIdentity? scope)
+            && string.Equals(
+                scope.Scope,
+                "current",
+                StringComparison.Ordinal)
+            && !TryFindExactLocalTypeDefinition(
+                reader,
+                type,
+                out _))
+        {
+            return true;
+        }
+
+        foreach (TypeNode child in StructuralChildren(type))
+        {
+            if (HasUnavailableOrAmbiguousExactLocalDefinition(
+                    reader,
+                    child))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static IEnumerable<TypeNode> StructuralChildren(
+        TypeNode type)
+        => type switch
+        {
+            ModifiedTypeNode modified =>
+                [modified.Modifier, modified.Inner],
+            GenericTypeNode generic =>
+                generic.Arguments,
+            SZArrayTypeNode array =>
+                [array.ElementType],
+            MDArrayTypeNode array =>
+                [array.ElementType],
+            PointerTypeNode pointer =>
+                [pointer.ElementType],
+            ByRefTypeNode byRef =>
+                [byRef.ElementType],
+            FunctionPointerTypeNode functionPointer =>
+                functionPointer.ChildTypes,
+            PinnedTypeNode pinned =>
+                [pinned.Inner],
+            PassthroughTypeNode passthrough =>
+                [passthrough.Inner],
+            _ => [],
+        };
 
     static bool TryGetNamedDefinition(
         TypeNode type,
@@ -1641,25 +1885,76 @@ public static class MetadataDeclarationQuery
         out MethodAttributes access)
     {
         access = default;
-        if (accessors.Getter.IsNil == accessors.Setter.IsNil)
-            return false;
-
-        var accessorHandle = accessors.Getter.IsNil
-            ? accessors.Setter
-            : accessors.Getter;
-        var accessor = reader.GetMethodDefinition(accessorHandle);
-        if (GetSameAssemblyOverrideSlot(
-                reader,
-                accessor.GetDeclaringType(),
-                accessorHandle) is not { } slot
-            || !TryGetPropertyForAccessor(reader, slot.DeclaringType, slot.Method, out var baseProperty))
+        bool followedOverride = false;
+        var visited = new HashSet<MethodDefinitionHandle>();
+        while (true)
         {
-            return false;
-        }
+            if (accessors.Getter.IsNil
+                && accessors.Setter.IsNil)
+            {
+                return false;
+            }
 
-        var baseType = reader.GetTypeDefinition(slot.DeclaringType);
-        access = AccessibilityValue(GetProperty(reader, baseType, baseProperty).Accessibility);
-        return true;
+            MethodDefinition getter =
+                accessors.Getter.IsNil
+                    ? default
+                    : reader.GetMethodDefinition(
+                        accessors.Getter);
+            MethodDefinition setter =
+                accessors.Setter.IsNil
+                    ? default
+                    : reader.GetMethodDefinition(
+                        accessors.Setter);
+            MethodAttributes bestAccess =
+                BestAccessorAccess(
+                    getter,
+                    setter,
+                    accessors);
+            if (accessors.Getter.IsNil
+                == accessors.Setter.IsNil)
+            {
+                if (!followedOverride)
+                    return false;
+
+                access = bestAccess;
+                return true;
+            }
+
+            var accessorHandle = accessors.Getter.IsNil
+                ? accessors.Setter
+                : accessors.Getter;
+            if (!visited.Add(accessorHandle)
+                || visited.Count
+                    > MetadataSafetyPolicy
+                        .MaxRelationshipNodes)
+            {
+                return false;
+            }
+
+            MethodDefinition accessor =
+                reader.GetMethodDefinition(
+                    accessorHandle);
+            if (GetSameAssemblyOverrideSlot(
+                    reader,
+                    accessor.GetDeclaringType(),
+                    accessorHandle) is not { } slot
+                || !TryGetPropertyForAccessor(
+                    reader,
+                    slot.DeclaringType,
+                    slot.Method,
+                    out PropertyDefinition baseProperty))
+            {
+                if (!followedOverride)
+                    return false;
+
+                access = bestAccess;
+                return true;
+            }
+
+            followedOverride = true;
+            accessors =
+                baseProperty.GetAccessors();
+        }
     }
 
     static bool TryGetPropertyForAccessor(

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -448,6 +448,7 @@ public static class MetadataDeclarationQuery
         {
             return null;
         }
+        var methodShape = GetOverrideSlotShape(reader, method, methodSignature);
 
         var baseTypeHandle = declaringType.BaseType;
         var visited = new HashSet<TypeDefinitionHandle>();
@@ -462,6 +463,7 @@ public static class MetadataDeclarationQuery
                 if (reader.GetString(candidate.Name) != methodName
                     || (candidate.Attributes & MethodAttributes.Virtual) == 0
                     || (candidate.Attributes & MethodAttributes.Final) != 0
+                    || (candidate.Attributes & MethodAttributes.Static) != 0
                     || (candidate.Attributes & MethodAttributes.MemberAccessMask) != methodAccess
                     || !IsSourceDeclarableAccessibility(candidate.Attributes & MethodAttributes.MemberAccessMask)
                     || candidate.GetGenericParameters().Count != method.GetGenericParameters().Count)
@@ -478,12 +480,10 @@ public static class MetadataDeclarationQuery
                     continue;
                 }
 
-                // Return types intentionally do not participate: C# permits
-                // covariant returns while the parameter and generic arities
-                // continue to identify the reused virtual slot.
-                if (candidateSignature.ParameterTypes.SequenceEqual(
-                    methodSignature.ParameterTypes,
-                    StringComparer.Ordinal))
+                if (MatchesOverrideSlotShape(
+                    reader,
+                    methodShape,
+                    GetOverrideSlotShape(reader, candidate, candidateSignature)))
                 {
                     return new MetadataOverrideSlot(baseDefinitionHandle, candidateHandle);
                 }
@@ -505,6 +505,189 @@ public static class MetadataDeclarationQuery
             Enumerable.Range(0, method.GetGenericParameters().Count)
                 .Select(index => $"!!{index}")
                 .ToArray());
+
+    readonly record struct OverrideSlotShape(
+        string ReturnType,
+        TypeNode ReturnTypeNode,
+        IReadOnlyList<ApiParameter> Parameters);
+
+    static OverrideSlotShape GetOverrideSlotShape(
+        MetadataReader reader,
+        MethodDefinition method,
+        MethodSignature<string> textSignature)
+    {
+        var typeDef = reader.GetTypeDefinition(method.GetDeclaringType());
+        var nodeSignature = GuardedProviderDecode.Method(
+            reader,
+            method,
+            TypeNodeProvider.Instance,
+            GenericContext.ForMethod(reader, typeDef, method),
+            (TypeNode)new DegradedTypeNode());
+        return new OverrideSlotShape(
+            FormatMethodReturnType(reader, textSignature.ReturnType, method.GetParameters()),
+            nodeSignature.ReturnType,
+            MethodParameters(reader, method, textSignature));
+    }
+
+    static bool MatchesOverrideSlotShape(
+        MetadataReader reader,
+        OverrideSlotShape method,
+        OverrideSlotShape candidate)
+        => ParametersMatch(method.Parameters, candidate.Parameters)
+            && ReturnTypesAreOverrideCompatible(
+                reader,
+                method.ReturnType,
+                method.ReturnTypeNode,
+                candidate.ReturnType,
+                candidate.ReturnTypeNode);
+
+    static bool ParametersMatch(
+        IReadOnlyList<ApiParameter> methodParameters,
+        IReadOnlyList<ApiParameter> candidateParameters)
+    {
+        if (methodParameters.Count != candidateParameters.Count)
+            return false;
+
+        for (var index = 0; index < methodParameters.Count; index++)
+        {
+            if (!string.Equals(
+                    methodParameters[index].CanonicalTypeWithModifier,
+                    candidateParameters[index].CanonicalTypeWithModifier,
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static bool ReturnTypesAreOverrideCompatible(
+        MetadataReader reader,
+        string methodReturnType,
+        TypeNode methodReturnNode,
+        string candidateReturnType,
+        TypeNode candidateReturnNode)
+    {
+        if (string.Equals(methodReturnType, candidateReturnType, StringComparison.Ordinal))
+            return true;
+
+        if (HasByRefReturnModifier(methodReturnType)
+            || HasByRefReturnModifier(candidateReturnType)
+            || methodReturnNode.IsDegraded
+            || candidateReturnNode.IsDegraded
+            || !methodReturnNode.IsReferenceType
+            || !candidateReturnNode.IsReferenceType)
+        {
+            return false;
+        }
+
+        if (candidateReturnType is "object" or "System.Object")
+            return true;
+
+        if (!TryFindTypeDefinitionByRenderedName(reader, methodReturnType, out var methodReturnHandle)
+            || !TryFindTypeDefinitionByRenderedName(reader, candidateReturnType, out var candidateReturnHandle))
+        {
+            return false;
+        }
+
+        return IsSameOrDerivedOrImplements(reader, methodReturnHandle, candidateReturnHandle);
+    }
+
+    static bool HasByRefReturnModifier(string returnType)
+        => returnType.StartsWith("ref ", StringComparison.Ordinal)
+            || returnType.StartsWith("ref readonly ", StringComparison.Ordinal);
+
+    static bool TryFindTypeDefinitionByRenderedName(
+        MetadataReader reader,
+        string typeName,
+        out TypeDefinitionHandle handle)
+    {
+        typeName = NormalizeRenderedTypeName(typeName);
+        if (typeName.Length == 0
+            || typeName.IndexOfAny(['<', '[', '*', '&']) >= 0
+            || typeName.Contains(',', StringComparison.Ordinal))
+        {
+            handle = default;
+            return false;
+        }
+
+        foreach (var candidateHandle in reader.TypeDefinitions)
+        {
+            var definition = reader.GetTypeDefinition(candidateHandle);
+            if (NormalizeRenderedTypeName(TypeResolver.GetTypeNameFromDefinition(reader, candidateHandle)) == typeName
+                || NormalizeRenderedTypeName(TypeResolver.GetFullName(reader, definition)) == typeName)
+            {
+                handle = candidateHandle;
+                return true;
+            }
+        }
+
+        handle = default;
+        return false;
+    }
+
+    static string NormalizeRenderedTypeName(string typeName)
+        => typeName.TrimEnd('?').Replace('+', '.');
+
+    static bool IsSameOrDerivedOrImplements(
+        MetadataReader reader,
+        TypeDefinitionHandle methodReturnHandle,
+        TypeDefinitionHandle candidateReturnHandle)
+    {
+        var pending = new Queue<TypeDefinitionHandle>();
+        var visited = new HashSet<TypeDefinitionHandle>();
+        pending.Enqueue(methodReturnHandle);
+        while (pending.Count != 0)
+        {
+            var currentHandle = pending.Dequeue();
+            if (!visited.Add(currentHandle))
+                continue;
+            if (currentHandle == candidateReturnHandle)
+                return true;
+
+            var current = reader.GetTypeDefinition(currentHandle);
+            if (TryResolveSameAssemblyTypeDefinition(reader, current.BaseType, out var baseHandle))
+                pending.Enqueue(baseHandle);
+
+            foreach (var implementationHandle in current.GetInterfaceImplementations())
+            {
+                var interfaceImplementation = reader.GetInterfaceImplementation(implementationHandle);
+                if (TryResolveSameAssemblyTypeDefinition(
+                        reader,
+                        interfaceImplementation.Interface,
+                        out var interfaceHandle))
+                {
+                    pending.Enqueue(interfaceHandle);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryResolveSameAssemblyTypeDefinition(
+        MetadataReader reader,
+        EntityHandle handle,
+        out TypeDefinitionHandle resolvedHandle)
+    {
+        if (handle.Kind == HandleKind.TypeDefinition)
+        {
+            resolvedHandle = (TypeDefinitionHandle)handle;
+            return true;
+        }
+
+        if (handle.Kind == HandleKind.TypeReference)
+        {
+            return TryFindTypeDefinitionByRenderedName(
+                reader,
+                TypeResolver.GetTypeNameFromReference(reader, (TypeReferenceHandle)handle),
+                out resolvedHandle);
+        }
+
+        resolvedHandle = default;
+        return false;
+    }
 
     public static MetadataPropertyDeclaration GetProperty(
         MetadataReader reader,
@@ -533,6 +716,8 @@ public static class MetadataDeclarationQuery
         var setter = accessors.Setter.IsNil ? default : reader.GetMethodDefinition(accessors.Setter);
 
         var bestAccess = BestAccessorAccess(getter, setter, accessors);
+        if (TryGetAuthenticatedOverridePropertyAccess(reader, accessors, out var authenticatedPropertyAccess))
+            bestAccess = authenticatedPropertyAccess;
         var primaryAccessor = !accessors.Getter.IsNil ? getter : setter;
         var accessorAttributes = !accessors.Getter.IsNil || !accessors.Setter.IsNil
             ? primaryAccessor.Attributes
@@ -607,6 +792,55 @@ public static class MetadataDeclarationQuery
             RenderMemberAttributes(reader, property.GetCustomAttributes()),
             accessors.Getter,
             accessors.Setter);
+    }
+
+    static bool TryGetAuthenticatedOverridePropertyAccess(
+        MetadataReader reader,
+        PropertyAccessors accessors,
+        out MethodAttributes access)
+    {
+        access = default;
+        if (accessors.Getter.IsNil == accessors.Setter.IsNil)
+            return false;
+
+        var accessorHandle = accessors.Getter.IsNil
+            ? accessors.Setter
+            : accessors.Getter;
+        var accessor = reader.GetMethodDefinition(accessorHandle);
+        if (GetSameAssemblyOverrideSlot(
+                reader,
+                accessor.GetDeclaringType(),
+                accessorHandle) is not { } slot
+            || !TryGetPropertyForAccessor(reader, slot.DeclaringType, slot.Method, out var baseProperty))
+        {
+            return false;
+        }
+
+        var baseType = reader.GetTypeDefinition(slot.DeclaringType);
+        access = AccessibilityValue(GetProperty(reader, baseType, baseProperty).Accessibility);
+        return true;
+    }
+
+    static bool TryGetPropertyForAccessor(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinitionHandle accessorHandle,
+        out PropertyDefinition property)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        foreach (var propertyHandle in typeDef.GetProperties())
+        {
+            var candidate = reader.GetPropertyDefinition(propertyHandle);
+            var accessors = candidate.GetAccessors();
+            if (accessors.Getter == accessorHandle || accessors.Setter == accessorHandle)
+            {
+                property = candidate;
+                return true;
+            }
+        }
+
+        property = default;
+        return false;
     }
 
     public static MetadataFieldDeclaration GetField(
@@ -1096,6 +1330,17 @@ public static class MetadataDeclarationQuery
 
     static string? AccessorAccessibility(MethodAttributes access, MethodAttributes bestAccess)
         => access == bestAccess ? null : NonPublicAccessibility(access);
+
+    static MethodAttributes AccessibilityValue(string accessibility)
+        => accessibility switch
+        {
+            "private" => MethodAttributes.Private,
+            "private protected" => MethodAttributes.FamANDAssem,
+            "internal" => MethodAttributes.Assembly,
+            "protected" => MethodAttributes.Family,
+            "protected internal" => MethodAttributes.FamORAssem,
+            _ => MethodAttributes.Public,
+        };
 
     static string AccessibilityKeyword(MethodAttributes access)
         => NonPublicAccessibility(access) ?? "public";

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -1503,7 +1503,13 @@ public static class MetadataDeclarationQuery
             return true;
         }
 
-        return IsSameOrDerivedOrImplements(reader, methodReturnHandle, candidateReturnHandle);
+        return IsSameOrDerivedOrImplements(
+            reader,
+            method.ReturnTypeNode,
+            methodReturnHandle,
+            candidate.ReturnTypeNode,
+            candidateReturnHandle,
+            budget);
     }
 
     enum OverrideCompatibility
@@ -1803,8 +1809,11 @@ public static class MetadataDeclarationQuery
 
         return IsSameOrDerivedOrImplements(
                 reader,
+                method,
                 methodHandle,
-                candidateHandle)
+                candidate,
+                candidateHandle,
+                budget)
             ? OverrideCompatibility.Compatible
             : OverrideCompatibility.Incompatible;
     }
@@ -1883,25 +1892,25 @@ public static class MetadataDeclarationQuery
 
         try
         {
-            bool hasUnknownConstraintCompatibility = false;
             GenericParameter parameter =
                 reader.GetGenericParameter(parameterHandle);
-            foreach (GenericParameterConstraintHandle constraintHandle
-                in parameter.GetConstraints())
-            {
-                if (!budget.TryCharge())
-                    return OverrideCompatibility.Incompatible;
-
-                GenericParameterConstraint constraint =
-                    reader.GetGenericParameterConstraint(
-                        constraintHandle);
-                TypeNode constraintType = DecodeConstraintType(
+            if (!TryDecodeConstraintSet(
                     reader,
-                    constraint.Type,
-                    methodContext);
-                if (constraintType.IsDegraded)
-                    continue;
+                    parameter,
+                    methodContext,
+                    budget,
+                    out List<TypeNode> constraintTypes))
+            {
+                return OverrideCompatibility.Incompatible;
+            }
 
+            bool candidateHasUnavailableDefinition =
+                HasUnavailableOrAmbiguousExactLocalDefinition(
+                    reader,
+                    candidate);
+            bool hasUnknownConstraintCompatibility = false;
+            foreach (TypeNode constraintType in constraintTypes)
+            {
                 if (constraintType is GenericParameterNode
                     constrainedParameter)
                 {
@@ -1933,15 +1942,8 @@ public static class MetadataDeclarationQuery
                 {
                     return OverrideCompatibility.Compatible;
                 }
-                if (HasUnavailableOrAmbiguousExactLocalDefinition(
-                        reader,
-                        constraintType)
-                    || HasUnavailableOrAmbiguousExactLocalDefinition(
-                        reader,
-                        candidate))
-                {
+                if (candidateHasUnavailableDefinition)
                     continue;
-                }
 
                 bool candidateHasGenericShape =
                     HasGenericShape(candidate);
@@ -1967,8 +1969,8 @@ public static class MetadataDeclarationQuery
                         == OverrideCompatibility.Incompatible
                     || candidateHasGenericShape)
                 {
-                    // Definition-only ancestry cannot prove a conversion to a
-                    // constructed or raw generic target without preserving arguments.
+                    // A constructed or raw generic target needs the argument
+                    // correspondence the structured comparison above decides.
                     continue;
                 }
 
@@ -1976,8 +1978,11 @@ public static class MetadataDeclarationQuery
                     && hasCandidateDefinition
                     && IsSameOrDerivedOrImplements(
                         reader,
+                        constraintType,
                         constraintDefinition,
-                        candidateDefinition))
+                        candidate,
+                        candidateDefinition,
+                        budget))
                 {
                     return OverrideCompatibility.Compatible;
                 }
@@ -1998,6 +2003,57 @@ public static class MetadataDeclarationQuery
         {
             visited.Remove(parameterHandle);
         }
+    }
+
+    /// <summary>
+    /// Decodes every constraint on one generic parameter before any of them
+    /// may authenticate a conversion.
+    ///
+    /// The constraint set is existential among constraints this image fully
+    /// decodes, so degraded evidence has to be decided for the whole set
+    /// first: skipping a degraded constraint and then accepting a later valid
+    /// one would let metadata order decide whether malformed current-image
+    /// evidence is fail-closed. A degraded decode, a constraint whose
+    /// current-image definition does not resolve uniquely, and an exhausted
+    /// comparison budget therefore refuse the whole set. Gated by
+    /// <c>SameAssemblyOverrideSlot_DeclinesMixedDegradedAndValidConstraintSet</c>,
+    /// which runs both metadata orders, and
+    /// <c>SameAssemblyOverrideSlot_DeclinesDegradedOnlyConstraint</c>, whose
+    /// non-vacuity control is
+    /// <c>SameAssemblyOverrideSlot_AllowsValidOnlyExplicitConstraintSet</c>.
+    /// </summary>
+    static bool TryDecodeConstraintSet(
+        MetadataReader reader,
+        GenericParameter parameter,
+        OverrideTypeContext methodContext,
+        OverrideCompatibilityBudget budget,
+        out List<TypeNode> constraintTypes)
+    {
+        constraintTypes = [];
+        foreach (GenericParameterConstraintHandle constraintHandle
+            in parameter.GetConstraints())
+        {
+            if (!budget.TryCharge())
+                return false;
+
+            GenericParameterConstraint constraint =
+                reader.GetGenericParameterConstraint(constraintHandle);
+            TypeNode constraintType = DecodeConstraintType(
+                reader,
+                constraint.Type,
+                methodContext);
+            if (constraintType.IsDegraded
+                || HasUnavailableOrAmbiguousExactLocalDefinition(
+                    reader,
+                    constraintType))
+            {
+                return false;
+            }
+
+            constraintTypes.Add(constraintType);
+        }
+
+        return true;
     }
 
     static OverrideTypeIdentity TypeIdentity(
@@ -2384,55 +2440,197 @@ public static class MetadataDeclarationQuery
         return !handle.IsNil;
     }
 
+    /// <summary>
+    /// True when the implementation type is the declaration type, or derives
+    /// from or implements it, proved from same-image base and interface rows.
+    ///
+    /// The walk is a metadata walk, not a <c>TypeDef</c> walk. A compiler
+    /// writes <c>Dog : Middle&lt;int&gt;</c> and <c>Middle&lt;T&gt; :
+    /// IContract&lt;T&gt;</c> as <c>TypeSpec</c> rows, so a walk restricted to
+    /// <c>TypeDef</c> ancestors stops at the first constructed step and cannot
+    /// see the ancestor a covariant return actually reaches. Every step
+    /// carries its exact generic arguments, substituted into the next row, and
+    /// a match requires both the exact definition token and the exact
+    /// instantiation: <c>Dog : Middle&lt;int&gt;</c> never satisfies a
+    /// declaration returning <c>Middle&lt;string&gt;</c>. Variance is not
+    /// applied here; a variance-bearing pair with corresponding definitions is
+    /// decided by <see cref="CompareStructuredReturnTypes"/> before this
+    /// predicate is consulted.
+    ///
+    /// Fails closed. A supertype outside this image, an unrecorded
+    /// instantiation, a degraded or undecodable row, a cycle, more than
+    /// <see cref="MetadataSafetyPolicy.MaxRelationshipNodes"/> distinct
+    /// ancestors, and an exhausted comparison budget all decline rather than
+    /// authenticate. Gated by
+    /// <c>SameAssemblyOverrideSlot_AuthenticatesCovariantReturnThroughConstructedGenericAncestry</c>,
+    /// <c>SameAssemblyOverrideSlot_DeclinesConstructedGenericAncestryWithDifferentArgument</c>,
+    /// and
+    /// <c>SameAssemblyOverrideSlot_CyclicConstructedAncestryFailsClosed</c>.
+    /// </summary>
     static bool IsSameOrDerivedOrImplements(
         MetadataReader reader,
-        TypeDefinitionHandle methodReturnHandle,
-        TypeDefinitionHandle candidateReturnHandle)
+        TypeNode implementationType,
+        TypeDefinitionHandle implementationHandle,
+        TypeNode declarationType,
+        TypeDefinitionHandle declarationHandle,
+        OverrideCompatibilityBudget budget)
     {
-        var pending = new Queue<TypeDefinitionHandle>();
-        var visited = new HashSet<TypeDefinitionHandle>();
-        pending.Enqueue(methodReturnHandle);
+        if (!TryGetExactInstantiation(
+                reader,
+                implementationType,
+                implementationHandle,
+                out ImmutableArray<TypeNode>? implementationArguments)
+            || !TryGetExactInstantiation(
+                reader,
+                declarationType,
+                declarationHandle,
+                out ImmutableArray<TypeNode>? declarationArguments))
+        {
+            return false;
+        }
+
+        var pending = new Queue<OverrideBaseInstantiation>();
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        var supertypes = new List<OverrideBaseInstantiation>();
+        pending.Enqueue(
+            new OverrideBaseInstantiation(
+                implementationHandle,
+                implementationArguments));
         while (pending.Count != 0)
         {
-            var currentHandle = pending.Dequeue();
-            if (!visited.Add(currentHandle))
-                continue;
-            if (currentHandle == candidateReturnHandle)
-                return true;
-
-            var current = reader.GetTypeDefinition(currentHandle);
-            if (TryResolveSameAssemblyTypeDefinition(
-                    current.BaseType,
-                    out var baseHandle))
-                pending.Enqueue(baseHandle);
-
-            foreach (var implementationHandle in current.GetInterfaceImplementations())
+            if (!budget.TryCharge()
+                || visited.Count
+                    >= MetadataSafetyPolicy.MaxRelationshipNodes)
             {
-                var interfaceImplementation = reader.GetInterfaceImplementation(implementationHandle);
-                if (TryResolveSameAssemblyTypeDefinition(
-                        interfaceImplementation.Interface,
-                        out var interfaceHandle))
-                {
-                    pending.Enqueue(interfaceHandle);
-                }
+                return false;
             }
+
+            OverrideBaseInstantiation current = pending.Dequeue();
+            if (!visited.Add(InstantiationKey(current)))
+                continue;
+
+            if (current.Definition == declarationHandle
+                && InstantiationsCorrespond(
+                    reader,
+                    current.TypeArguments,
+                    declarationArguments,
+                    budget))
+            {
+                return true;
+            }
+
+            supertypes.Clear();
+            OverrideBaseChain.AddDirectSameAssemblySupertypes(
+                reader,
+                current,
+                supertypes);
+            foreach (OverrideBaseInstantiation supertype in supertypes)
+                pending.Enqueue(supertype);
         }
 
         return false;
     }
 
-    static bool TryResolveSameAssemblyTypeDefinition(
-        EntityHandle handle,
-        out TypeDefinitionHandle resolvedHandle)
+    /// <summary>
+    /// The exact instantiation a named or constructed node carries for the
+    /// definition it resolved to. A constructed node must supply exactly the
+    /// definition's arity, and a non-generic definition must carry no
+    /// arguments. A raw generic name with no recorded arguments, an arity
+    /// disagreement, and an unreadable row all fail closed, because ancestry
+    /// is only ever proved instantiation-exactly.
+    /// </summary>
+    static bool TryGetExactInstantiation(
+        MetadataReader reader,
+        TypeNode type,
+        TypeDefinitionHandle handle,
+        out ImmutableArray<TypeNode>? arguments)
     {
-        if (handle.Kind == HandleKind.TypeDefinition)
+        arguments = null;
+        int arity;
+        try
         {
-            resolvedHandle = (TypeDefinitionHandle)handle;
+            arity = reader
+                .GetTypeDefinition(handle)
+                .GetGenericParameters()
+                .Count;
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+            return false;
+        }
+
+        if (type is GenericTypeNode generic)
+        {
+            if (arity == 0
+                || generic.Arguments.Length != arity)
+            {
+                return false;
+            }
+
+            arguments = generic.Arguments;
             return true;
         }
 
-        resolvedHandle = default;
-        return false;
+        return arity == 0;
+    }
+
+    static bool InstantiationsCorrespond(
+        MetadataReader reader,
+        ImmutableArray<TypeNode>? left,
+        ImmutableArray<TypeNode>? right,
+        OverrideCompatibilityBudget budget)
+    {
+        if (left is not { } leftArguments)
+            return right is null;
+
+        if (right is not { } rightArguments
+            || leftArguments.Length != rightArguments.Length)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < leftArguments.Length; index++)
+        {
+            if (!budget.TryCharge()
+                || !TypeNodesCorrespond(
+                    reader,
+                    leftArguments[index],
+                    rightArguments[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Identifies one ancestry step by its exact definition token and the
+    /// exact structural identity of every argument, so a diamond is visited
+    /// once while two different instantiations of the same definition stay
+    /// distinct. A self-referential base that keeps producing new
+    /// instantiations is bounded by the caller's node cap and comparison
+    /// budget rather than by this set.
+    /// </summary>
+    static string InstantiationKey(OverrideBaseInstantiation type)
+    {
+        var builder = new StringBuilder();
+        builder.Append(
+            MetadataTokens.GetToken(type.Definition)
+                .ToString(CultureInfo.InvariantCulture));
+        if (type.TypeArguments is { } arguments)
+        {
+            foreach (TypeNode argument in arguments)
+            {
+                builder.Append('|');
+                builder.Append(argument.StructuralIdentity());
+            }
+        }
+
+        return builder.ToString();
     }
 
     public static MetadataPropertyDeclaration GetProperty(

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -475,6 +476,192 @@ public static class MetadataDeclarationQuery
     }
 
     /// <summary>
+    /// The ordered same-image base classes of
+    /// <paramref name="derivedTypeHandle"/>, nearest first. A constructed
+    /// generic base is followed through its <c>TypeSpec</c> to the definition
+    /// it instantiates, which a walk restricted to <c>TypeDef</c> bases cannot
+    /// do. The walk stops at the first base that leaves this image, is not a
+    /// constructed instantiation of a same-image definition, cannot be
+    /// decoded, or repeats, and is bounded by
+    /// <see cref="MetadataSafetyPolicy.MaxRelationshipNodes"/>.
+    /// </summary>
+    public static IReadOnlyList<TypeDefinitionHandle> GetSameAssemblyBaseChain(
+        MetadataReader reader,
+        TypeDefinitionHandle derivedTypeHandle)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        return
+        [
+            .. OverrideBaseChain
+                .SameAssemblyBases(reader, derivedTypeHandle)
+                .Select(step => step.Definition),
+        ];
+    }
+
+    /// <summary>
+    /// The same-image class definition instantiated by
+    /// <paramref name="derivedType"/>'s constructed generic base, when it has
+    /// one.
+    ///
+    /// A compiler encodes <c>Derived : Base&lt;string&gt;</c> and
+    /// <c>Derived&lt;T&gt; : Base&lt;T&gt;</c> as a <c>TypeSpec</c> base, so a
+    /// consumer that only reads a <c>TypeDef</c> base cannot see the definition
+    /// the base instantiates. This resolves exactly that one step and keeps the
+    /// exact definition token; it never matches a rendered name.
+    ///
+    /// Fails closed: a base that is not a <c>TypeSpec</c>, a <c>TypeSpec</c>
+    /// that is not a generic instantiation of a definition in this image, and
+    /// an undecodable or over-budget signature all return
+    /// <see langword="false"/>.
+    /// </summary>
+    /// <summary>
+    /// True when <paramref name="typeDef"/> declares a member that occupies a
+    /// virtual slot it did not introduce: a virtual method that is not
+    /// <see cref="MethodAttributes.NewSlot"/>, or the body of a
+    /// <c>MethodImpl</c> row. A base type owns such a slot, so a shell that
+    /// drops the base must drop the member's <c>override</c> with it.
+    ///
+    /// Read from method attribute flags and <c>MethodImpl</c> rows only; no
+    /// name or rendered signature participates. A malformed row fails closed to
+    /// <see langword="false"/>, which is the drop-the-base answer.
+    /// </summary>
+    public static bool ReusesInheritedVirtualSlot(MetadataReader reader, TypeDefinition typeDef)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        try
+        {
+            if (typeDef.GetMethodImplementations().Count != 0)
+                return true;
+
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var attributes = reader.GetMethodDefinition(methodHandle).Attributes;
+                if ((attributes & MethodAttributes.Virtual) != 0
+                    && (attributes & MethodAttributes.NewSlot) == 0)
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    public static bool TryGetSameAssemblyConstructedBaseDefinition(
+        MetadataReader reader,
+        TypeDefinition derivedType,
+        out TypeDefinitionHandle baseTypeHandle)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        baseTypeHandle = default;
+        if (derivedType.BaseType.Kind != HandleKind.TypeSpecification)
+            return false;
+
+        return OverrideBaseChain.TryReadConstructedBase(
+            reader,
+            (TypeSpecificationHandle)derivedType.BaseType,
+            derivedType,
+            substitution: null,
+            out baseTypeHandle,
+            out _);
+    }
+
+    /// <summary>
+    /// True when <paramref name="methodHandle"/> reuses a virtual slot that
+    /// authenticated inheritance evidence proves is declared by
+    /// <c>System.Object</c>.
+    ///
+    /// Three facts must all hold. The method reuses an inherited slot rather
+    /// than declaring a new one; its signature is exactly one of the three
+    /// object intrinsics, read from primitive element types rather than from
+    /// any rendered or referenced type name; and every base link from its
+    /// declaring type up to <c>System.Object</c> stays inside this image, with
+    /// the root authenticated as the real <c>System.Object</c> of a recognized
+    /// core library.
+    ///
+    /// The chain requirement is the load-bearing one. Any external base on the
+    /// chain may declare its own <c>NewSlot</c> virtual with the same name and
+    /// signature, so a name-and-signature match alone would silently rebind
+    /// that base's slot to <c>System.Object</c> whenever a consumer flattens
+    /// the external base away. Local metadata cannot prove which slot such a
+    /// method occupies, so this refuses rather than guessing.
+    /// </summary>
+    public static bool IsAuthenticatedObjectSlotOverride(
+        MetadataReader reader,
+        TypeDefinitionHandle declaringTypeHandle,
+        MethodDefinitionHandle methodHandle)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        MethodDefinition method = reader.GetMethodDefinition(methodHandle);
+        if ((method.Attributes & MethodAttributes.Static) != 0
+            || (method.Attributes & MethodAttributes.Virtual) == 0
+            || (method.Attributes & MethodAttributes.NewSlot) != 0
+            || method.GetGenericParameters().Count != 0)
+        {
+            return false;
+        }
+
+        if (!MatchesObjectIntrinsicSlot(reader, declaringTypeHandle, method))
+            return false;
+
+        return OverrideBaseChain.ReachesAuthenticatedObjectRoot(
+            reader,
+            declaringTypeHandle);
+    }
+
+    /// <summary>
+    /// True when <paramref name="method"/> has the exact name and signature of
+    /// one of <c>System.Object</c>'s three overridable members. Every type
+    /// position is read as a primitive element type, so a hostile image cannot
+    /// satisfy this with a type reference that merely renders as
+    /// <c>string</c>, <c>int</c>, <c>bool</c>, or <c>object</c>.
+    /// </summary>
+    static bool MatchesObjectIntrinsicSlot(
+        MetadataReader reader,
+        TypeDefinitionHandle declaringTypeHandle,
+        MethodDefinition method)
+    {
+        GuardedProviderDecode.DecodeResult<MethodSignature<TypeNode>> decoded =
+            GuardedProviderDecode.MethodResult(
+                reader,
+                method,
+                new TypeNodeProvider(
+                    scopeNamedTypeIdentity: true,
+                    requireScopedNamedTypeIdentity: true),
+                GenericContext.ForMethod(
+                    reader,
+                    reader.GetTypeDefinition(declaringTypeHandle),
+                    method),
+                (TypeNode)new DegradedTypeNode());
+        if (decoded.IsDegraded)
+            return false;
+
+        MethodSignature<TypeNode> signature = decoded.Value;
+        return reader.GetString(method.Name) switch
+        {
+            "ToString" => signature.ParameterTypes.Length == 0
+                && IsPrimitive(signature.ReturnType, "string"),
+            "GetHashCode" => signature.ParameterTypes.Length == 0
+                && IsPrimitive(signature.ReturnType, "int"),
+            "Equals" => signature.ParameterTypes.Length == 1
+                && IsPrimitive(signature.ReturnType, "bool")
+                && IsPrimitive(signature.ParameterTypes[0], "object"),
+            _ => false,
+        };
+
+        static bool IsPrimitive(TypeNode node, string name)
+            => node is PrimitiveTypeNode primitive
+                && primitive.Name == name;
+    }
+
+    /// <summary>
     /// Locates the nearest same-assembly virtual slot reused by
     /// <paramref name="methodHandle"/>, including a source override encoded as
     /// <c>NewSlot</c> with a class <c>MethodImpl</c>. Returns
@@ -521,12 +708,10 @@ public static class MetadataDeclarationQuery
 
         var methodShape = GetOverrideSlotShape(reader, method, methodSignature);
 
-        var baseTypeHandle = declaringType.BaseType;
-        var visited = new HashSet<TypeDefinitionHandle>();
-        while (baseTypeHandle.Kind == HandleKind.TypeDefinition
-            && visited.Add((TypeDefinitionHandle)baseTypeHandle))
+        foreach (OverrideBaseInstantiation baseStep
+            in OverrideBaseChain.SameAssemblyBases(reader, declaringTypeHandle))
         {
-            var baseDefinitionHandle = (TypeDefinitionHandle)baseTypeHandle;
+            var baseDefinitionHandle = baseStep.Definition;
             var baseDefinition = reader.GetTypeDefinition(baseDefinitionHandle);
             foreach (var candidateHandle in baseDefinition.GetMethods())
             {
@@ -551,16 +736,25 @@ public static class MetadataDeclarationQuery
                     continue;
                 }
 
+                if (!TryGetSubstitutedOverrideSlotShape(
+                        reader,
+                        candidate,
+                        candidateSignature,
+                        baseStep.TypeArguments,
+                        declaringTypeHandle,
+                        out OverrideSlotShape candidateShape))
+                {
+                    continue;
+                }
+
                 if (MatchesOverrideSlotShape(
                     reader,
                     methodShape,
-                    GetOverrideSlotShape(reader, candidate, candidateSignature)))
+                    candidateShape))
                 {
                     return new MetadataOverrideSlot(baseDefinitionHandle, candidateHandle);
                 }
             }
-
-            baseTypeHandle = baseDefinition.BaseType;
         }
 
         return null;
@@ -599,24 +793,29 @@ public static class MetadataDeclarationQuery
         }
 
         var methodShape = GetOverrideSlotShape(reader, method, methodSignature);
+        List<OverrideBaseInstantiation> bases =
+            OverrideBaseChain.SameAssemblyBases(reader, declaringTypeHandle);
         MetadataOverrideSlot? match = null;
         foreach (var implementationHandle in declaringType.GetMethodImplementations())
         {
             var implementation = reader.GetMethodImplementation(implementationHandle);
-            if (implementation.MethodBody != methodHandle
-                || implementation.MethodDeclaration.Kind != HandleKind.MethodDefinition)
+            if (implementation.MethodBody != methodHandle)
+                continue;
+
+            if (!TryResolveSameAssemblyOverrideDeclaration(
+                    reader,
+                    implementation.MethodDeclaration,
+                    declaringType,
+                    bases,
+                    out MethodDefinitionHandle declarationHandle,
+                    out ImmutableArray<TypeNode>? substitution))
             {
                 continue;
             }
 
-            var declarationHandle = (MethodDefinitionHandle)implementation.MethodDeclaration;
             var declaration = reader.GetMethodDefinition(declarationHandle);
             var declarationTypeHandle = declaration.GetDeclaringType();
-            if (!IsStrictSameAssemblyBase(
-                    reader,
-                    declaringType,
-                    declarationTypeHandle)
-                || (reader.GetTypeDefinition(declarationTypeHandle).Attributes & TypeAttributes.Interface) != 0
+            if ((reader.GetTypeDefinition(declarationTypeHandle).Attributes & TypeAttributes.Interface) != 0
                 || reader.GetString(declaration.Name) != methodName
                 || (declaration.Attributes & MethodAttributes.Virtual) == 0
                 || (declaration.Attributes & MethodAttributes.Final) != 0
@@ -635,10 +834,17 @@ public static class MetadataDeclarationQuery
                 declaration,
                 PositionalGenericContext(declarationType, declaration))
                 .TryGetValue(out var declarationSignature)
+                || !TryGetSubstitutedOverrideSlotShape(
+                    reader,
+                    declaration,
+                    declarationSignature,
+                    substitution,
+                    declaringTypeHandle,
+                    out OverrideSlotShape declarationShape)
                 || !MatchesOverrideSlotShape(
                     reader,
                     methodShape,
-                    GetOverrideSlotShape(reader, declaration, declarationSignature)))
+                    declarationShape))
             {
                 continue;
             }
@@ -652,25 +858,280 @@ public static class MetadataDeclarationQuery
         return match;
     }
 
-    static bool IsStrictSameAssemblyBase(
+    /// <summary>
+    /// Resolves a <c>MethodImpl</c> declaration token to the exact same-image
+    /// base <c>MethodDef</c> it names, together with the instantiation of the
+    /// base that the derived type actually extends. A <c>MethodDef</c>
+    /// declaration must name a type on the authenticated base chain. A
+    /// <c>MemberRef</c> declaration must be rooted in a constructed generic
+    /// <c>TypeSpec</c> whose definition token and whose exact generic
+    /// arguments both equal a chain step's, which is what authenticates the
+    /// slot rather than the spelling of the reference; the referenced member
+    /// is then resolved to a unique <c>MethodDef</c> by structural signature
+    /// correspondence. Any other token kind, any off-chain base, any
+    /// mismatched instantiation, and any ambiguity are refused.
+    /// </summary>
+    static bool TryResolveSameAssemblyOverrideDeclaration(
         MetadataReader reader,
+        EntityHandle declarationToken,
         TypeDefinition declaringType,
-        TypeDefinitionHandle candidateHandle)
+        List<OverrideBaseInstantiation> bases,
+        out MethodDefinitionHandle declarationHandle,
+        out ImmutableArray<TypeNode>? substitution)
     {
-        var baseType = declaringType.BaseType;
-        var visited = new HashSet<TypeDefinitionHandle>();
-        while (baseType.Kind == HandleKind.TypeDefinition
-            && visited.Add((TypeDefinitionHandle)baseType))
+        declarationHandle = default;
+        substitution = null;
+        if (declarationToken.Kind == HandleKind.MethodDefinition)
         {
-            var baseHandle = (TypeDefinitionHandle)baseType;
-            if (baseHandle == candidateHandle)
-                return true;
+            var candidate = (MethodDefinitionHandle)declarationToken;
+            TypeDefinitionHandle owner =
+                reader.GetMethodDefinition(candidate).GetDeclaringType();
+            foreach (OverrideBaseInstantiation step in bases)
+            {
+                if (step.Definition != owner)
+                    continue;
 
-            baseType = reader.GetTypeDefinition(baseHandle).BaseType;
+                declarationHandle = candidate;
+                substitution = step.TypeArguments;
+                return true;
+            }
+
+            return false;
         }
 
-        return false;
+        if (declarationToken.Kind != HandleKind.MemberReference)
+            return false;
+
+        MemberReference reference =
+            reader.GetMemberReference((MemberReferenceHandle)declarationToken);
+        if (reference.GetKind() != MemberReferenceKind.Method
+            || reference.Parent.Kind != HandleKind.TypeSpecification)
+        {
+            return false;
+        }
+
+        TypeDefinition? containing = null;
+        foreach (OverrideBaseInstantiation step in bases)
+        {
+            if (step.TypeArguments is not { } stepArguments
+                || !OverrideBaseChain.TryReadConstructedBase(
+                    reader,
+                    (TypeSpecificationHandle)reference.Parent,
+                    declaringType,
+                    null,
+                    out TypeDefinitionHandle referencedDefinition,
+                    out ImmutableArray<TypeNode> referencedArguments))
+            {
+                continue;
+            }
+
+            if (referencedDefinition != step.Definition
+                || referencedArguments.Length != stepArguments.Length)
+            {
+                continue;
+            }
+
+            bool argumentsMatch = true;
+            for (int index = 0; index < stepArguments.Length; index++)
+            {
+                if (!TypeNodesCorrespond(
+                    reader,
+                    referencedArguments[index],
+                    stepArguments[index]))
+                {
+                    argumentsMatch = false;
+                    break;
+                }
+            }
+
+            if (!argumentsMatch)
+                continue;
+
+            containing = reader.GetTypeDefinition(step.Definition);
+            substitution = stepArguments;
+            break;
+        }
+
+        if (containing is not { } containingType)
+            return false;
+
+        return TryResolveMemberReferenceToUniqueMethod(
+            reader,
+            reference,
+            containingType,
+            out declarationHandle);
     }
+
+    /// <summary>
+    /// Finds the single <c>MethodDef</c> in <paramref name="containingType"/>
+    /// that <paramref name="reference"/> names. The reference signature is
+    /// written in the generic type definition's own scope, so both sides are
+    /// decoded positionally and compared structurally; no rendered name
+    /// participates beyond the exact metadata member name. Ambiguity or an
+    /// undecodable signature fails closed.
+    /// </summary>
+    static bool TryResolveMemberReferenceToUniqueMethod(
+        MetadataReader reader,
+        MemberReference reference,
+        TypeDefinition containingType,
+        out MethodDefinitionHandle resolved)
+    {
+        resolved = default;
+        string referenceName = reader.GetString(reference.Name);
+        int referenceMethodArity = GuardedProviderDecode.MemberRefMethod(
+            reader,
+            reference,
+            new SignatureArityProbe(),
+            default(GenericContext?),
+            (byte)0)
+            .GenericParameterCount;
+        MethodSignature<TypeNode> referenceSignature =
+            GuardedProviderDecode.MemberRefMethod(
+                reader,
+                reference,
+                new TypeNodeProvider(
+                    scopeNamedTypeIdentity: true,
+                    requireScopedNamedTypeIdentity: true),
+                PositionalGenericContext(
+                    containingType.GetGenericParameters().Count,
+                    referenceMethodArity),
+                (TypeNode)new DegradedTypeNode());
+
+        if (referenceSignature.ReturnType.IsDegraded
+            || referenceSignature.ParameterTypes.Any(
+                parameter => parameter.IsDegraded))
+        {
+            return false;
+        }
+
+        bool found = false;
+        foreach (MethodDefinitionHandle candidateHandle
+            in containingType.GetMethods())
+        {
+            MethodDefinition candidate =
+                reader.GetMethodDefinition(candidateHandle);
+            if (reader.GetString(candidate.Name) != referenceName)
+                continue;
+
+            MethodSignature<TypeNode> candidateSignature =
+                GuardedProviderDecode.Method(
+                    reader,
+                    candidate,
+                    new TypeNodeProvider(
+                        scopeNamedTypeIdentity: true,
+                        requireScopedNamedTypeIdentity: true),
+                    PositionalGenericContext(
+                        containingType.GetGenericParameters().Count,
+                        candidate.GetGenericParameters().Count),
+                    (TypeNode)new DegradedTypeNode());
+            if (!MethodSignaturesCorrespond(
+                reader,
+                referenceSignature,
+                candidateSignature))
+            {
+                continue;
+            }
+
+            if (found)
+                return false;
+
+            found = true;
+            resolved = candidateHandle;
+        }
+
+        return found;
+    }
+
+    static bool MethodSignaturesCorrespond(
+        MetadataReader reader,
+        MethodSignature<TypeNode> reference,
+        MethodSignature<TypeNode> candidate)
+    {
+        if (reference.Header.RawValue != candidate.Header.RawValue
+            || reference.GenericParameterCount
+                != candidate.GenericParameterCount
+            || reference.RequiredParameterCount
+                != candidate.RequiredParameterCount
+            || reference.ParameterTypes.Length
+                != candidate.ParameterTypes.Length
+            || candidate.ReturnType.IsDegraded
+            || !TypeNodesCorrespond(
+                reader,
+                reference.ReturnType,
+                candidate.ReturnType))
+        {
+            return false;
+        }
+
+        for (int index = 0;
+            index < reference.ParameterTypes.Length;
+            index++)
+        {
+            if (candidate.ParameterTypes[index].IsDegraded
+                || !TypeNodesCorrespond(
+                    reader,
+                    reference.ParameterTypes[index],
+                    candidate.ParameterTypes[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Reads only the arity of a method signature blob so a
+    /// <c>MemberRef</c> can be decoded with a positional context of the right
+    /// size. Every type position collapses to a single sentinel because no
+    /// type identity is consumed from this probe.
+    /// </summary>
+    sealed class SignatureArityProbe
+        : ISignatureTypeProvider<byte, GenericContext?>
+    {
+        public byte GetArrayType(byte elementType, ArrayShape shape) => 0;
+        public byte GetByReferenceType(byte elementType) => 0;
+        public byte GetFunctionPointerType(MethodSignature<byte> signature) => 0;
+        public byte GetGenericInstantiation(
+            byte genericType,
+            ImmutableArray<byte> typeArguments) => 0;
+        public byte GetGenericMethodParameter(
+            GenericContext? context,
+            int index) => 0;
+        public byte GetGenericTypeParameter(
+            GenericContext? context,
+            int index) => 0;
+        public byte GetModifiedType(
+            byte modifier,
+            byte unmodifiedType,
+            bool isRequired) => 0;
+        public byte GetPinnedType(byte elementType) => 0;
+        public byte GetPointerType(byte elementType) => 0;
+        public byte GetPrimitiveType(PrimitiveTypeCode typeCode) => 0;
+        public byte GetSZArrayType(byte elementType) => 0;
+        public byte GetTypeFromDefinition(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            byte rawTypeKind) => 0;
+        public byte GetTypeFromReference(
+            MetadataReader reader,
+            TypeReferenceHandle handle,
+            byte rawTypeKind) => 0;
+        public byte GetTypeFromSpecification(
+            MetadataReader reader,
+            GenericContext? context,
+            TypeSpecificationHandle handle,
+            byte rawTypeKind) => 0;
+    }
+
+    static GenericContext PositionalGenericContext(
+        int typeParameterCount,
+        int methodParameterCount)
+        => new(
+            [.. Enumerable.Range(0, typeParameterCount)
+                .Select(index => $"!{index}")],
+            [.. Enumerable.Range(0, methodParameterCount)
+                .Select(index => $"!!{index}")]);
 
     static GenericContext PositionalGenericContext(
         TypeDefinition type,
@@ -732,6 +1193,74 @@ public static class MetadataDeclarationQuery
                 requireScopedNamedTypeIdentity: true),
             context,
             (TypeNode)new DegradedTypeNode());
+        return BuildOverrideSlotShape(
+            reader,
+            method,
+            textSignature,
+            nodeSignature,
+            context,
+            typeDef);
+    }
+
+    /// <summary>
+    /// Produces the slot shape of a base declaration as the derived type sees
+    /// it. When the base is reached through a constructed generic
+    /// <c>TypeSpec</c>, every type-parameter position in the declaration's
+    /// signature is replaced by the exact argument that instantiates it, so
+    /// the resulting shape is expressed in the derived type's own generic
+    /// scope and compares against the deriving method without any name
+    /// matching. Returns <see langword="false"/> when the recorded
+    /// instantiation does not match the declaring definition's arity.
+    /// </summary>
+    static bool TryGetSubstitutedOverrideSlotShape(
+        MetadataReader reader,
+        MethodDefinition method,
+        MethodSignature<string> textSignature,
+        ImmutableArray<TypeNode>? substitution,
+        TypeDefinitionHandle derivedTypeHandle,
+        out OverrideSlotShape shape)
+    {
+        if (substitution is not { } arguments)
+        {
+            shape = GetOverrideSlotShape(reader, method, textSignature);
+            return true;
+        }
+
+        TypeDefinition declarationType =
+            reader.GetTypeDefinition(method.GetDeclaringType());
+        if (declarationType.GetGenericParameters().Count
+            != arguments.Length)
+        {
+            shape = default;
+            return false;
+        }
+
+        TypeDefinition derivedType =
+            reader.GetTypeDefinition(derivedTypeHandle);
+        var nodeSignature = GuardedProviderDecode.Method(
+            reader,
+            method,
+            SubstitutedTypeParameterProvider.Create(arguments),
+            GenericContext.ForMethod(reader, declarationType, method),
+            (TypeNode)new DegradedTypeNode());
+        shape = BuildOverrideSlotShape(
+            reader,
+            method,
+            textSignature,
+            nodeSignature,
+            GenericContext.ForMethod(reader, derivedType, method),
+            derivedType);
+        return true;
+    }
+
+    static OverrideSlotShape BuildOverrideSlotShape(
+        MetadataReader reader,
+        MethodDefinition method,
+        MethodSignature<string> textSignature,
+        MethodSignature<TypeNode> nodeSignature,
+        GenericContext context,
+        TypeDefinition typeDef)
+    {
         IReadOnlyList<ApiParameter> parameters =
             MethodParameters(reader, method, textSignature);
         bool isDegraded =
@@ -772,32 +1301,89 @@ public static class MetadataDeclarationQuery
             isDegraded);
     }
 
+    /// <summary>
+    /// Deterministic cumulative work and recursion-depth accounting for one
+    /// override-slot authentication. Active-handle cycle detection alone
+    /// bounds neither a constraint DAG, whose distinct paths grow
+    /// exponentially in its width, nor a constraint chain, which recurses once
+    /// per link on the native stack. Exhaustion is sticky and fails closed:
+    /// every comparison declines and the caller refuses the slot outright, so
+    /// an over-budget decision can never be read as a retained relationship.
+    /// </summary>
+    sealed class OverrideCompatibilityBudget
+    {
+        int remainingWork =
+            MetadataSafetyPolicy.MaxOverrideCompatibilityWork;
+        int depth;
+
+        internal bool IsExhausted { get; private set; }
+
+        internal bool TryEnter()
+        {
+            if (IsExhausted
+                || remainingWork == 0
+                || depth
+                    >= MetadataSafetyPolicy.MaxOverrideCompatibilityDepth)
+            {
+                IsExhausted = true;
+                return false;
+            }
+
+            remainingWork--;
+            depth++;
+            return true;
+        }
+
+        internal void Exit() => depth--;
+
+        internal bool TryCharge()
+        {
+            if (IsExhausted || remainingWork == 0)
+            {
+                IsExhausted = true;
+                return false;
+            }
+
+            remainingWork--;
+            return true;
+        }
+    }
+
     static bool MatchesOverrideSlotShape(
         MetadataReader reader,
         OverrideSlotShape method,
         OverrideSlotShape candidate)
-        => !method.IsDegraded
-            && !candidate.IsDegraded
-            && ParametersMatch(
+    {
+        if (method.IsDegraded || candidate.IsDegraded)
+            return false;
+
+        var budget = new OverrideCompatibilityBudget();
+        bool matches = ParametersMatch(
                 reader,
                 method.Parameters,
-                candidate.Parameters)
+                candidate.Parameters,
+                budget)
             && ReturnTypesAreOverrideCompatible(
                 reader,
                 method,
-                candidate);
+                candidate,
+                budget);
+        return matches && !budget.IsExhausted;
+    }
 
     static bool ParametersMatch(
         MetadataReader reader,
         IReadOnlyList<OverrideParameterShape> methodParameters,
-        IReadOnlyList<OverrideParameterShape> candidateParameters)
+        IReadOnlyList<OverrideParameterShape> candidateParameters,
+        OverrideCompatibilityBudget budget)
     {
         if (methodParameters.Count != candidateParameters.Count)
             return false;
 
         for (var index = 0; index < methodParameters.Count; index++)
         {
-            if (methodParameters[index].Modifier
+            if (!budget.TryCharge()
+                || methodParameters[index].Modifier
                     != candidateParameters[index].Modifier
                 || !TypeNodesCorrespond(
                     reader,
@@ -814,7 +1400,8 @@ public static class MetadataDeclarationQuery
     static bool ReturnTypesAreOverrideCompatible(
         MetadataReader reader,
         OverrideSlotShape method,
-        OverrideSlotShape candidate)
+        OverrideSlotShape candidate,
+        OverrideCompatibilityBudget budget)
     {
         if (method.ReturnModifier != candidate.ReturnModifier)
             return false;
@@ -843,7 +1430,8 @@ public static class MetadataDeclarationQuery
                     method.TypeContext,
                     candidate.ReturnTypeNode,
                     candidate.TypeContext,
-                    [])
+                    [],
+                    budget)
                 != OverrideCompatibility.Incompatible;
         }
 
@@ -870,7 +1458,8 @@ public static class MetadataDeclarationQuery
                 method.ReturnTypeNode,
                 method.TypeContext,
                 candidate.ReturnTypeNode,
-                candidate.TypeContext);
+                candidate.TypeContext,
+                budget);
         if (structuredCompatibility
             != OverrideCompatibility.Unknown)
         {
@@ -929,7 +1518,35 @@ public static class MetadataDeclarationQuery
         TypeNode method,
         OverrideTypeContext methodContext,
         TypeNode candidate,
-        OverrideTypeContext candidateContext)
+        OverrideTypeContext candidateContext,
+        OverrideCompatibilityBudget budget)
+    {
+        if (!budget.TryEnter())
+            return OverrideCompatibility.Incompatible;
+
+        try
+        {
+            return CompareStructuredReturnTypesCore(
+                reader,
+                method,
+                methodContext,
+                candidate,
+                candidateContext,
+                budget);
+        }
+        finally
+        {
+            budget.Exit();
+        }
+    }
+
+    static OverrideCompatibility CompareStructuredReturnTypesCore(
+        MetadataReader reader,
+        TypeNode method,
+        OverrideTypeContext methodContext,
+        TypeNode candidate,
+        OverrideTypeContext candidateContext,
+        OverrideCompatibilityBudget budget)
     {
         if (TypeNodesCorrespond(
                 reader,
@@ -955,7 +1572,8 @@ public static class MetadataDeclarationQuery
                     methodModified.Inner,
                     methodContext,
                     candidateModified.Inner,
-                    candidateContext)
+                    candidateContext,
+                    budget)
                 : OverrideCompatibility.Incompatible;
         }
 
@@ -969,7 +1587,8 @@ public static class MetadataDeclarationQuery
                     methodPinned.Inner,
                     methodContext,
                     candidatePinned.Inner,
-                    candidateContext)
+                    candidateContext,
+                    budget)
                 : OverrideCompatibility.Incompatible;
         }
 
@@ -982,7 +1601,8 @@ public static class MetadataDeclarationQuery
                 methodContext,
                 candidate,
                 candidateContext,
-                []);
+                [],
+                budget);
         }
 
         if (candidate is GenericParameterNode)
@@ -1009,7 +1629,8 @@ public static class MetadataDeclarationQuery
                 methodSz.ElementType,
                 methodContext,
                 candidateSz.ElementType,
-                candidateContext);
+                candidateContext,
+                budget);
         }
 
         if (method is MDArrayTypeNode
@@ -1033,7 +1654,8 @@ public static class MetadataDeclarationQuery
                     methodMd.ElementType,
                     methodContext,
                     candidateMd.ElementType,
-                    candidateContext)
+                    candidateContext,
+                    budget)
                 : OverrideCompatibility.Incompatible;
         }
 
@@ -1084,6 +1706,9 @@ public static class MetadataDeclarationQuery
                 methodGeneric.Arguments[index];
             TypeNode candidateArgument =
                 candidateGeneric.Arguments[index];
+            if (!budget.TryCharge())
+                return OverrideCompatibility.Incompatible;
+
             GenericParameterAttributes variance =
                 genericParameters[index].Attributes
                 & GenericParameterAttributes.VarianceMask;
@@ -1103,14 +1728,16 @@ public static class MetadataDeclarationQuery
                             methodArgument,
                             methodContext,
                             candidateArgument,
-                            candidateContext),
+                            candidateContext,
+                            budget),
                     GenericParameterAttributes.Contravariant =>
                         CompareVariantTypeArguments(
                             reader,
                             candidateArgument,
                             candidateContext,
                             methodArgument,
-                            methodContext),
+                            methodContext,
+                            budget),
                     _ => OverrideCompatibility.Incompatible,
                 };
             if (argumentCompatibility
@@ -1132,15 +1759,20 @@ public static class MetadataDeclarationQuery
         TypeNode method,
         OverrideTypeContext methodContext,
         TypeNode candidate,
-        OverrideTypeContext candidateContext)
+        OverrideTypeContext candidateContext,
+        OverrideCompatibilityBudget budget)
     {
+        if (!budget.TryCharge())
+            return OverrideCompatibility.Incompatible;
+
         OverrideCompatibility structured =
             CompareStructuredReturnTypes(
                 reader,
                 method,
                 methodContext,
                 candidate,
-                candidateContext);
+                candidateContext,
+                budget);
         if (structured != OverrideCompatibility.Unknown)
             return structured;
 
@@ -1183,7 +1815,37 @@ public static class MetadataDeclarationQuery
         OverrideTypeContext methodContext,
         TypeNode candidate,
         OverrideTypeContext candidateContext,
-        HashSet<GenericParameterHandle> visited)
+        HashSet<GenericParameterHandle> visited,
+        OverrideCompatibilityBudget budget)
+    {
+        if (!budget.TryEnter())
+            return OverrideCompatibility.Incompatible;
+
+        try
+        {
+            return CompareGenericParameterReturnCore(
+                reader,
+                method,
+                methodContext,
+                candidate,
+                candidateContext,
+                visited,
+                budget);
+        }
+        finally
+        {
+            budget.Exit();
+        }
+    }
+
+    static OverrideCompatibility CompareGenericParameterReturnCore(
+        MetadataReader reader,
+        GenericParameterNode method,
+        OverrideTypeContext methodContext,
+        TypeNode candidate,
+        OverrideTypeContext candidateContext,
+        HashSet<GenericParameterHandle> visited,
+        OverrideCompatibilityBudget budget)
     {
         if (TypeNodesCorrespond(
                 reader,
@@ -1227,6 +1889,9 @@ public static class MetadataDeclarationQuery
             foreach (GenericParameterConstraintHandle constraintHandle
                 in parameter.GetConstraints())
             {
+                if (!budget.TryCharge())
+                    return OverrideCompatibility.Incompatible;
+
                 GenericParameterConstraint constraint =
                     reader.GetGenericParameterConstraint(
                         constraintHandle);
@@ -1246,7 +1911,8 @@ public static class MetadataDeclarationQuery
                             methodContext,
                             candidate,
                             candidateContext,
-                            visited)
+                            visited,
+                            budget)
                             == OverrideCompatibility.Compatible)
                     {
                         return OverrideCompatibility.Compatible;
@@ -1260,7 +1926,8 @@ public static class MetadataDeclarationQuery
                         constraintType,
                         methodContext,
                         candidate,
-                        candidateContext);
+                        candidateContext,
+                        budget);
                 if (constraintCompatibility
                     == OverrideCompatibility.Compatible)
                 {

--- a/src/ILInspector.Metadata/MetadataTypeDeclarationProbe.cs
+++ b/src/ILInspector.Metadata/MetadataTypeDeclarationProbe.cs
@@ -776,16 +776,12 @@ public static class MetadataTypeDeclarationProbe
             {
                 MethodDefinition method =
                     reader.GetMethodDefinition(handle);
-                const MethodAttributes constructorFlags =
-                    MethodAttributes.SpecialName
-                    | MethodAttributes.RTSpecialName;
-                if ((method.Attributes & MethodAttributes.Static) != 0
-                    || (method.Attributes & constructorFlags)
-                        != constructorFlags
-                    || reader.GetBlobReader(method.Name).Length != 5
-                    || !reader.StringComparer.Equals(
-                        method.Name,
-                        ".ctor"))
+                if (!MetadataDeclarationQuery
+                        .TryGetCliInstanceConstructorSignature(
+                            reader,
+                            type,
+                            method,
+                            out MethodSignature<string> signature))
                 {
                     continue;
                 }
@@ -801,25 +797,8 @@ public static class MetadataTypeDeclarationProbe
                     continue;
                 }
 
-                var signature =
-                    GuardedProviderDecode.MethodResult(
-                        reader,
-                        method,
-                        ILSignatureTypeProvider.Instance,
-                        (GenericContext?)null,
-                        "object");
-                MethodSignature<string> value = signature.Value;
-                if (!signature.IsDegraded
-                    && value.Header.Kind == SignatureKind.Method
-                    && value.Header.CallingConvention
-                        == SignatureCallingConvention.Default
-                    && value.Header.IsInstance
-                    && !value.Header.IsGeneric
-                    && !value.Header.HasExplicitThis
-                    && method.GetGenericParameters().Count == 0
-                    && value.ReturnType == "void"
-                    && value.RequiredParameterCount == 0
-                    && value.ParameterTypes.Length == 0)
+                if (signature.RequiredParameterCount == 0
+                    && signature.ParameterTypes.Length == 0)
                 {
                     return true;
                 }

--- a/src/ILInspector.Metadata/OverrideBaseChain.cs
+++ b/src/ILInspector.Metadata/OverrideBaseChain.cs
@@ -20,11 +20,12 @@ internal readonly record struct OverrideBaseInstantiation(
     ImmutableArray<TypeNode>? TypeArguments);
 
 /// <summary>
-/// Bounded same-image base-class traversal used by override-slot
+/// Bounded same-image base-class and interface traversal used by override-slot
 /// authentication. A compiler encodes <c>Derived&lt;T&gt; : Base&lt;T&gt;</c>
 /// and <c>Derived : Base&lt;string&gt;</c> as a <c>TypeSpec</c> base, so a walk
 /// that only follows <c>TypeDef</c> bases stops at the first constructed
-/// generic base and cannot see the slot the derived type actually overrides.
+/// generic base and cannot see the slot the derived type actually overrides,
+/// nor the ancestor a covariant return actually reaches.
 /// Every step here keeps the exact <c>TypeDef</c> identity and the exact
 /// generic arguments; no step matches a rendered name.
 /// </summary>
@@ -175,8 +176,121 @@ internal static class OverrideBaseChain
     }
 
     /// <summary>
-    /// Decodes a constructed-generic base <c>TypeSpec</c> written in
-    /// <paramref name="declaringType"/>'s generic scope into the same-image
+    /// Appends the direct same-image supertypes of one instantiated type --
+    /// its base class and every interface it implements -- to
+    /// <paramref name="supertypes"/>. Each result keeps the exact generic
+    /// arguments that instantiate it, rewritten through
+    /// <paramref name="type"/>'s own arguments, so the whole set is expressed
+    /// in the scope of the type the caller started from.
+    ///
+    /// Fails closed by omission. A supertype that leaves this image, a
+    /// <c>TypeDef</c> row naming a generic definition whose arguments the row
+    /// cannot carry, a <c>TypeSpec</c> that is not a generic instantiation of
+    /// a same-image definition, and any undecodable, degraded, or over-budget
+    /// row are all left out, so no caller can prove ancestry through evidence
+    /// this image does not carry. Gated by
+    /// <c>SameAssemblyOverrideSlot_AuthenticatesCovariantReturnThroughConstructedGenericAncestry</c>,
+    /// <c>SameAssemblyOverrideSlot_AuthenticatesCovariantInterfaceReturnThroughConstructedGenericAncestry</c>,
+    /// and
+    /// <c>SameAssemblyOverrideSlot_DeclinesConstructedGenericAncestryWithDifferentArgument</c>.
+    /// </summary>
+    internal static void AddDirectSameAssemblySupertypes(
+        MetadataReader reader,
+        OverrideBaseInstantiation type,
+        List<OverrideBaseInstantiation> supertypes)
+    {
+        TypeDefinition definition;
+        EntityHandle baseHandle;
+        try
+        {
+            definition = reader.GetTypeDefinition(type.Definition);
+            baseHandle = definition.BaseType;
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+            return;
+        }
+
+        if (TryReadSupertype(
+                reader,
+                definition,
+                type.TypeArguments,
+                baseHandle,
+                out OverrideBaseInstantiation baseType))
+        {
+            supertypes.Add(baseType);
+        }
+
+        try
+        {
+            foreach (InterfaceImplementationHandle implementationHandle
+                in definition.GetInterfaceImplementations())
+            {
+                EntityHandle interfaceHandle = reader
+                    .GetInterfaceImplementation(implementationHandle)
+                    .Interface;
+                if (TryReadSupertype(
+                        reader,
+                        definition,
+                        type.TypeArguments,
+                        interfaceHandle,
+                        out OverrideBaseInstantiation implemented))
+                {
+                    supertypes.Add(implemented);
+                }
+            }
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+        }
+    }
+
+    static bool TryReadSupertype(
+        MetadataReader reader,
+        TypeDefinition declaringType,
+        ImmutableArray<TypeNode>? substitution,
+        EntityHandle handle,
+        out OverrideBaseInstantiation supertype)
+    {
+        supertype = default;
+        if (handle.IsNil)
+            return false;
+
+        if (handle.Kind == HandleKind.TypeDefinition)
+        {
+            var definition = (TypeDefinitionHandle)handle;
+            if (!IsNonGenericDefinition(reader, definition))
+                return false;
+
+            supertype = new OverrideBaseInstantiation(definition, null);
+            return true;
+        }
+
+        if (handle.Kind != HandleKind.TypeSpecification
+            || !TryReadConstructedBase(
+                reader,
+                (TypeSpecificationHandle)handle,
+                declaringType,
+                substitution,
+                out TypeDefinitionHandle instantiated,
+                out ImmutableArray<TypeNode> arguments))
+        {
+            return false;
+        }
+
+        supertype = new OverrideBaseInstantiation(instantiated, arguments);
+        return true;
+    }
+
+    /// <summary>
+    /// Decodes a constructed-generic base or interface <c>TypeSpec</c> written
+    /// in <paramref name="declaringType"/>'s generic scope into the same-image
     /// definition it instantiates and the exact arguments, rewritten through
     /// <paramref name="substitution"/> so the result is expressed in the
     /// original derived type's scope.

--- a/src/ILInspector.Metadata/OverrideBaseChain.cs
+++ b/src/ILInspector.Metadata/OverrideBaseChain.cs
@@ -34,8 +34,8 @@ internal static class OverrideBaseChain
     /// <summary>
     /// Walks the same-image base chain of <paramref name="derivedHandle"/>,
     /// stopping at the first base that leaves this image, is not a constructed
-    /// generic instantiation of a same-image definition, or cannot be decoded.
-    /// The chain is bounded by
+    /// generic instantiation of a same-image definition, is not a class, or
+    /// cannot be decoded. The chain is bounded by
     /// <see cref="MetadataSafetyPolicy.MaxRelationshipNodes"/>.
     /// </summary>
     internal static List<OverrideBaseInstantiation> SameAssemblyBases(
@@ -93,8 +93,14 @@ internal static class OverrideBaseChain
                 return chain;
             }
 
-            if (!visited.Add(nextHandle))
+            if (!MatchesSupertypeRole(
+                    reader,
+                    nextHandle,
+                    SupertypeRole.BaseClass)
+                || !visited.Add(nextHandle))
+            {
                 return chain;
+            }
 
             chain.Add(new OverrideBaseInstantiation(nextHandle, nextArguments));
             current = nextHandle;
@@ -109,7 +115,8 @@ internal static class OverrideBaseChain
     /// inside this image until the chain terminates at the authenticated
     /// <c>System.Object</c> of a recognized core library. A base that leaves
     /// the image as anything else, an undecodable or non-constructed generic
-    /// base, a cycle, and a chain longer than
+    /// base, a base step that is an interface rather than a class, a cycle,
+    /// and a chain longer than
     /// <see cref="MetadataSafetyPolicy.MaxRelationshipNodes"/> all fail closed,
     /// because each leaves room for an unseen base to own the slot.
     /// </summary>
@@ -166,8 +173,14 @@ internal static class OverrideBaseChain
                 return false;
             }
 
-            if (!visited.Add(next))
+            if (!MatchesSupertypeRole(
+                    reader,
+                    next,
+                    SupertypeRole.BaseClass)
+                || !visited.Add(next))
+            {
                 return false;
+            }
 
             current = next;
         }
@@ -186,9 +199,10 @@ internal static class OverrideBaseChain
     /// Fails closed by omission. A supertype that leaves this image, a
     /// <c>TypeDef</c> row naming a generic definition whose arguments the row
     /// cannot carry, a <c>TypeSpec</c> that is not a generic instantiation of
-    /// a same-image definition, and any undecodable, degraded, or over-budget
-    /// row are all left out, so no caller can prove ancestry through evidence
-    /// this image does not carry. Gated by
+    /// a same-image definition, a row whose target contradicts its role --
+    /// see <see cref="MatchesSupertypeRole"/> -- and any undecodable,
+    /// degraded, or over-budget row are all left out, so no caller can prove
+    /// ancestry through evidence this image does not carry. Gated by
     /// <c>SameAssemblyOverrideSlot_AuthenticatesCovariantReturnThroughConstructedGenericAncestry</c>,
     /// <c>SameAssemblyOverrideSlot_AuthenticatesCovariantInterfaceReturnThroughConstructedGenericAncestry</c>,
     /// and
@@ -219,6 +233,7 @@ internal static class OverrideBaseChain
                 definition,
                 type.TypeArguments,
                 baseHandle,
+                SupertypeRole.BaseClass,
                 out OverrideBaseInstantiation baseType))
         {
             supertypes.Add(baseType);
@@ -237,6 +252,7 @@ internal static class OverrideBaseChain
                         definition,
                         type.TypeArguments,
                         interfaceHandle,
+                        SupertypeRole.Interface,
                         out OverrideBaseInstantiation implemented))
                 {
                     supertypes.Add(implemented);
@@ -256,6 +272,7 @@ internal static class OverrideBaseChain
         TypeDefinition declaringType,
         ImmutableArray<TypeNode>? substitution,
         EntityHandle handle,
+        SupertypeRole role,
         out OverrideBaseInstantiation supertype)
     {
         supertype = default;
@@ -265,8 +282,11 @@ internal static class OverrideBaseChain
         if (handle.Kind == HandleKind.TypeDefinition)
         {
             var definition = (TypeDefinitionHandle)handle;
-            if (!IsNonGenericDefinition(reader, definition))
+            if (!IsNonGenericDefinition(reader, definition)
+                || !MatchesSupertypeRole(reader, definition, role))
+            {
                 return false;
+            }
 
             supertype = new OverrideBaseInstantiation(definition, null);
             return true;
@@ -279,7 +299,8 @@ internal static class OverrideBaseChain
                 declaringType,
                 substitution,
                 out TypeDefinitionHandle instantiated,
-                out ImmutableArray<TypeNode> arguments))
+                out ImmutableArray<TypeNode> arguments)
+            || !MatchesSupertypeRole(reader, instantiated, role))
         {
             return false;
         }
@@ -433,6 +454,57 @@ internal static class OverrideBaseChain
                 (TypeNode)new DegradedTypeNode());
             decoded = node as GenericTypeNode;
             return decoded is not null;
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The role a supertype row plays for the type that carries it. A
+    /// <c>TypeDef.Extends</c> row is a base class; an
+    /// <c>InterfaceImpl.Interface</c> row is an interface.
+    /// </summary>
+    internal enum SupertypeRole
+    {
+        BaseClass,
+        Interface,
+    }
+
+    /// <summary>
+    /// True when a same-image supertype definition is the kind its row claims
+    /// it is: a class for a base-class row, an interface for an
+    /// <c>InterfaceImpl</c> row.
+    ///
+    /// The two roles carry different slot semantics -- a base class supplies
+    /// inherited virtual slots and a covariant return's class ancestry, an
+    /// interface supplies neither -- and the CLI never lets one stand in for
+    /// the other. Nothing in the format prevents a malformed image from
+    /// writing an interface into <c>Extends</c> or a class into
+    /// <c>InterfaceImpl</c>, so the claim is checked against the target's own
+    /// <see cref="TypeAttributes.Interface"/> flag rather than trusted. Gated
+    /// by
+    /// <c>SameAssemblyOverrideSlot_DeclinesInterfaceImplementationNamingAClass</c>
+    /// and
+    /// <c>SameAssemblyOverrideSlot_DeclinesBaseTypeNamingAnInterface</c>,
+    /// whose non-vacuity control is
+    /// <c>SameAssemblyOverrideSlot_AuthenticatesCovariantInterfaceReturnThroughConstructedGenericAncestry</c>.
+    /// </summary>
+    static bool MatchesSupertypeRole(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        SupertypeRole role)
+    {
+        try
+        {
+            bool isInterface =
+                (reader.GetTypeDefinition(handle).Attributes
+                    & TypeAttributes.Interface) != 0;
+            return isInterface == (role == SupertypeRole.Interface);
         }
         catch (Exception exception)
             when (exception is BadImageFormatException

--- a/src/ILInspector.Metadata/OverrideBaseChain.cs
+++ b/src/ILInspector.Metadata/OverrideBaseChain.cs
@@ -1,0 +1,462 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// One same-image base class reached from a derived type, together with the
+/// exact generic arguments that instantiate it, expressed in the derived
+/// type's own generic scope.
+/// </summary>
+/// <param name="Definition">The base <c>TypeDef</c> in this image.</param>
+/// <param name="TypeArguments">
+/// The instantiation of <paramref name="Definition"/>'s type parameters, or
+/// <see langword="null"/> when no substitution applies because the base is
+/// reached without a <c>TypeSpec</c> (the identity case).
+/// </param>
+internal readonly record struct OverrideBaseInstantiation(
+    TypeDefinitionHandle Definition,
+    ImmutableArray<TypeNode>? TypeArguments);
+
+/// <summary>
+/// Bounded same-image base-class traversal used by override-slot
+/// authentication. A compiler encodes <c>Derived&lt;T&gt; : Base&lt;T&gt;</c>
+/// and <c>Derived : Base&lt;string&gt;</c> as a <c>TypeSpec</c> base, so a walk
+/// that only follows <c>TypeDef</c> bases stops at the first constructed
+/// generic base and cannot see the slot the derived type actually overrides.
+/// Every step here keeps the exact <c>TypeDef</c> identity and the exact
+/// generic arguments; no step matches a rendered name.
+/// </summary>
+internal static class OverrideBaseChain
+{
+    /// <summary>
+    /// Walks the same-image base chain of <paramref name="derivedHandle"/>,
+    /// stopping at the first base that leaves this image, is not a constructed
+    /// generic instantiation of a same-image definition, or cannot be decoded.
+    /// The chain is bounded by
+    /// <see cref="MetadataSafetyPolicy.MaxRelationshipNodes"/>.
+    /// </summary>
+    internal static List<OverrideBaseInstantiation> SameAssemblyBases(
+        MetadataReader reader,
+        TypeDefinitionHandle derivedHandle)
+    {
+        var chain = new List<OverrideBaseInstantiation>();
+        var visited = new HashSet<TypeDefinitionHandle> { derivedHandle };
+        TypeDefinitionHandle current = derivedHandle;
+        ImmutableArray<TypeNode>? currentArguments = null;
+
+        while (chain.Count < MetadataSafetyPolicy.MaxRelationshipNodes)
+        {
+            TypeDefinition currentType;
+            EntityHandle baseHandle;
+            try
+            {
+                currentType = reader.GetTypeDefinition(current);
+                baseHandle = currentType.BaseType;
+            }
+            catch (Exception exception)
+                when (exception is BadImageFormatException
+                    or ArgumentException
+                    or InvalidOperationException)
+            {
+                return chain;
+            }
+
+            TypeDefinitionHandle nextHandle;
+            ImmutableArray<TypeNode>? nextArguments;
+            if (baseHandle.Kind == HandleKind.TypeDefinition)
+            {
+                nextHandle = (TypeDefinitionHandle)baseHandle;
+                if (!IsNonGenericDefinition(reader, nextHandle))
+                    return chain;
+                nextArguments = null;
+            }
+            else if (baseHandle.Kind == HandleKind.TypeSpecification)
+            {
+                if (!TryReadConstructedBase(
+                        reader,
+                        (TypeSpecificationHandle)baseHandle,
+                        currentType,
+                        currentArguments,
+                        out nextHandle,
+                        out ImmutableArray<TypeNode> decodedArguments))
+                {
+                    return chain;
+                }
+
+                nextArguments = decodedArguments;
+            }
+            else
+            {
+                return chain;
+            }
+
+            if (!visited.Add(nextHandle))
+                return chain;
+
+            chain.Add(new OverrideBaseInstantiation(nextHandle, nextArguments));
+            current = nextHandle;
+            currentArguments = nextArguments;
+        }
+
+        return chain;
+    }
+
+    /// <summary>
+    /// True when every base link above <paramref name="derivedHandle"/> stays
+    /// inside this image until the chain terminates at the authenticated
+    /// <c>System.Object</c> of a recognized core library. A base that leaves
+    /// the image as anything else, an undecodable or non-constructed generic
+    /// base, a cycle, and a chain longer than
+    /// <see cref="MetadataSafetyPolicy.MaxRelationshipNodes"/> all fail closed,
+    /// because each leaves room for an unseen base to own the slot.
+    /// </summary>
+    internal static bool ReachesAuthenticatedObjectRoot(
+        MetadataReader reader,
+        TypeDefinitionHandle derivedHandle)
+    {
+        var visited = new HashSet<TypeDefinitionHandle> { derivedHandle };
+        TypeDefinitionHandle current = derivedHandle;
+
+        for (int step = 0;
+            step < MetadataSafetyPolicy.MaxRelationshipNodes;
+            step++)
+        {
+            EntityHandle baseHandle;
+            try
+            {
+                baseHandle = reader.GetTypeDefinition(current).BaseType;
+            }
+            catch (Exception exception)
+                when (exception is BadImageFormatException
+                    or ArgumentException
+                    or InvalidOperationException)
+            {
+                return false;
+            }
+
+            if (baseHandle.IsNil)
+                return false;
+
+            if ((baseHandle.Kind is HandleKind.TypeReference
+                    or HandleKind.TypeDefinition)
+                && ApiSurfaceExtractor.IsSystemObjectType(reader, baseHandle))
+            {
+                return true;
+            }
+
+            TypeDefinitionHandle next;
+            if (baseHandle.Kind == HandleKind.TypeDefinition)
+            {
+                next = (TypeDefinitionHandle)baseHandle;
+            }
+            else if (baseHandle.Kind == HandleKind.TypeSpecification
+                && TryReadGenericInstantiationHeader(
+                    reader,
+                    (TypeSpecificationHandle)baseHandle,
+                    out TypeDefinitionHandle instantiated,
+                    out _))
+            {
+                next = instantiated;
+            }
+            else
+            {
+                return false;
+            }
+
+            if (!visited.Add(next))
+                return false;
+
+            current = next;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Decodes a constructed-generic base <c>TypeSpec</c> written in
+    /// <paramref name="declaringType"/>'s generic scope into the same-image
+    /// definition it instantiates and the exact arguments, rewritten through
+    /// <paramref name="substitution"/> so the result is expressed in the
+    /// original derived type's scope.
+    /// </summary>
+    internal static bool TryReadConstructedBase(
+        MetadataReader reader,
+        TypeSpecificationHandle specificationHandle,
+        TypeDefinition declaringType,
+        ImmutableArray<TypeNode>? substitution,
+        out TypeDefinitionHandle definition,
+        out ImmutableArray<TypeNode> arguments)
+    {
+        definition = default;
+        arguments = [];
+        if (!TryReadGenericInstantiationHeader(
+                reader,
+                specificationHandle,
+                out TypeDefinitionHandle instantiated,
+                out int argumentCount))
+        {
+            return false;
+        }
+
+        GenericParameterHandleCollection parameters;
+        try
+        {
+            parameters = reader
+                .GetTypeDefinition(instantiated)
+                .GetGenericParameters();
+            GenericContext.ValidateParameterIndices(reader, parameters);
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+            return false;
+        }
+
+        if (parameters.Count != argumentCount)
+            return false;
+
+        if (!TryDecodeConstructedBase(
+                reader,
+                specificationHandle,
+                declaringType,
+                substitution,
+                out GenericTypeNode? decoded)
+            || decoded.Arguments.Length != argumentCount
+            || decoded.IsDegraded)
+        {
+            return false;
+        }
+
+        definition = instantiated;
+        arguments = decoded.Arguments;
+        return true;
+    }
+
+    /// <summary>
+    /// Reads the <c>GENERICINST</c> header of a <c>TypeSpec</c> and returns the
+    /// exact same-image <c>TypeDef</c> it instantiates. A value-type
+    /// instantiation, an external definition, or any other shape is refused;
+    /// the definition identity never comes from a name.
+    /// </summary>
+    static bool TryReadGenericInstantiationHeader(
+        MetadataReader reader,
+        TypeSpecificationHandle specificationHandle,
+        out TypeDefinitionHandle definition,
+        out int argumentCount)
+    {
+        const int GenericTypeInstance = 0x15;
+        const int ElementTypeClass = 0x12;
+        definition = default;
+        argumentCount = 0;
+        try
+        {
+            BlobHandle signature =
+                reader.GetTypeSpecification(specificationHandle).Signature;
+            if (!SignatureBlobGuard.IsSafeToDecode(
+                    reader,
+                    signature,
+                    SignatureBlobGuard.Kind.TypeSpecification))
+            {
+                return false;
+            }
+
+            BlobReader blob = reader.GetBlobReader(signature);
+            if (blob.ReadCompressedInteger() != GenericTypeInstance
+                || blob.ReadCompressedInteger() != ElementTypeClass)
+            {
+                return false;
+            }
+
+            EntityHandle definitionHandle = blob.ReadTypeHandle();
+            if (definitionHandle.Kind != HandleKind.TypeDefinition
+                || definitionHandle.IsNil)
+            {
+                return false;
+            }
+
+            int count = blob.ReadCompressedInteger();
+            if (count <= 0
+                || count > MetadataSafetyPolicy.MaxRelationshipNodes)
+            {
+                return false;
+            }
+
+            definition = (TypeDefinitionHandle)definitionHandle;
+            argumentCount = count;
+            return true;
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    static bool TryDecodeConstructedBase(
+        MetadataReader reader,
+        TypeSpecificationHandle specificationHandle,
+        TypeDefinition declaringType,
+        ImmutableArray<TypeNode>? substitution,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
+        out GenericTypeNode? decoded)
+    {
+        decoded = null;
+        try
+        {
+            GenericContext context =
+                GenericContext.ForType(reader, declaringType);
+            TypeNode node = GuardedProviderDecode.TypeSpec(
+                reader,
+                specificationHandle,
+                SubstitutedTypeParameterProvider.Create(substitution),
+                context,
+                (TypeNode)new DegradedTypeNode());
+            decoded = node as GenericTypeNode;
+            return decoded is not null;
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    static bool IsNonGenericDefinition(
+        MetadataReader reader,
+        TypeDefinitionHandle handle)
+    {
+        try
+        {
+            return reader
+                .GetTypeDefinition(handle)
+                .GetGenericParameters()
+                .Count == 0;
+        }
+        catch (Exception exception)
+            when (exception is BadImageFormatException
+                or ArgumentException
+                or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+}
+
+/// <summary>
+/// Decodes a signature written in a generic type definition's scope while
+/// replacing every type-parameter position with the exact argument that
+/// instantiates it. Method type parameters, named types, and every composite
+/// shape pass through to the wrapped scoped <see cref="TypeNodeProvider"/>, so
+/// the substituted tree carries the same exact scoped identities as an
+/// unsubstituted decode.
+/// </summary>
+internal sealed class SubstitutedTypeParameterProvider
+    : ISignatureTypeProvider<TypeNode, GenericContext?>
+{
+    readonly TypeNodeProvider _inner;
+    readonly ImmutableArray<TypeNode>? _typeArguments;
+
+    SubstitutedTypeParameterProvider(
+        ImmutableArray<TypeNode>? typeArguments)
+    {
+        _inner = new TypeNodeProvider(
+            scopeNamedTypeIdentity: true,
+            requireScopedNamedTypeIdentity: true);
+        _typeArguments = typeArguments;
+    }
+
+    /// <summary>
+    /// Creates a provider that substitutes <paramref name="typeArguments"/> for
+    /// type-parameter positions. A <see langword="null"/> argument list decodes
+    /// type parameters unchanged (the identity substitution).
+    /// </summary>
+    internal static SubstitutedTypeParameterProvider Create(
+        ImmutableArray<TypeNode>? typeArguments)
+        => new(typeArguments);
+
+    public TypeNode GetGenericTypeParameter(
+        GenericContext? context,
+        int index)
+    {
+        if (_typeArguments is not { } arguments)
+            return _inner.GetGenericTypeParameter(context, index);
+
+        return (uint)index < (uint)arguments.Length
+            ? arguments[index]
+            : new DegradedTypeNode();
+    }
+
+    public TypeNode GetTypeFromSpecification(
+        MetadataReader reader,
+        GenericContext? context,
+        TypeSpecificationHandle handle,
+        byte rawTypeKind)
+    {
+        if (!TypeSpecGuard.TryEnter(reader, handle, out var scope))
+            return new DegradedTypeNode();
+        using (scope)
+        {
+            return reader
+                .GetTypeSpecification(handle)
+                .DecodeSignature(this, context);
+        }
+    }
+
+    public TypeNode GetGenericMethodParameter(
+        GenericContext? context,
+        int index)
+        => _inner.GetGenericMethodParameter(context, index);
+
+    public TypeNode GetPrimitiveType(PrimitiveTypeCode typeCode)
+        => _inner.GetPrimitiveType(typeCode);
+
+    public TypeNode GetTypeFromDefinition(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        byte rawTypeKind)
+        => _inner.GetTypeFromDefinition(reader, handle, rawTypeKind);
+
+    public TypeNode GetTypeFromReference(
+        MetadataReader reader,
+        TypeReferenceHandle handle,
+        byte rawTypeKind)
+        => _inner.GetTypeFromReference(reader, handle, rawTypeKind);
+
+    public TypeNode GetSZArrayType(TypeNode elementType)
+        => _inner.GetSZArrayType(elementType);
+
+    public TypeNode GetArrayType(TypeNode elementType, ArrayShape shape)
+        => _inner.GetArrayType(elementType, shape);
+
+    public TypeNode GetByReferenceType(TypeNode elementType)
+        => _inner.GetByReferenceType(elementType);
+
+    public TypeNode GetPointerType(TypeNode elementType)
+        => _inner.GetPointerType(elementType);
+
+    public TypeNode GetGenericInstantiation(
+        TypeNode genericType,
+        ImmutableArray<TypeNode> typeArguments)
+        => _inner.GetGenericInstantiation(genericType, typeArguments);
+
+    public TypeNode GetFunctionPointerType(
+        MethodSignature<TypeNode> signature)
+        => _inner.GetFunctionPointerType(signature);
+
+    public TypeNode GetModifiedType(
+        TypeNode modifier,
+        TypeNode unmodifiedType,
+        bool isRequired)
+        => _inner.GetModifiedType(modifier, unmodifiedType, isRequired);
+
+    public TypeNode GetPinnedType(TypeNode elementType)
+        => _inner.GetPinnedType(elementType);
+}

--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -858,6 +858,8 @@ internal class PassthroughTypeNode(TypeNode inner) : TypeNode
 /// <summary>Custom-modified types pass through for rendering while preserving declaration-site evidence.</summary>
 internal sealed class ModifiedTypeNode(TypeNode modifier, TypeNode inner, bool isRequired) : PassthroughTypeNode(inner)
 {
+    public TypeNode Modifier => modifier;
+    public bool IsRequired => isRequired;
     internal override bool HasStructuralPayload => true;
     public override bool IsDegraded => modifier.IsDegraded || base.IsDegraded;
 

--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -402,6 +402,8 @@ internal sealed class GenericTypeNode(
     public ApiAssemblyIdentity? DefinitionAssemblyIdentity =>
         definitionAssemblyIdentity;
     public MetadataTypeNameParts? MetadataName => metadataName;
+    internal ScopedNamedTypeIdentity? ScopedIdentity
+        => scopedIdentity;
     public ImmutableArray<TypeNode> Arguments => arguments;
     public override bool IsReferenceType => isReferenceType;
     public override bool IsDegraded => degradedGenericType
@@ -715,6 +717,14 @@ internal sealed class GenericParameterNode(
     bool isMethodParameter,
     int index) : TypeNode
 {
+    internal bool HasValueTypeConstraint
+        => hasValueTypeConstraint;
+    internal bool HasReferenceTypeConstraint
+        => hasReferenceTypeConstraint;
+    internal bool IsMethodParameter
+        => isMethodParameter;
+    internal int Index
+        => index;
     public override bool IsReferenceType => hasReferenceTypeConstraint;
     public override long EstimatedRenderedLength => name.Length + 1L;
 

--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -711,10 +711,11 @@ internal sealed class ByRefTypeNode(TypeNode elementType) : TypeNode
 internal sealed class GenericParameterNode(
     string name,
     bool hasValueTypeConstraint,
+    bool hasReferenceTypeConstraint,
     bool isMethodParameter,
     int index) : TypeNode
 {
-    public override bool IsReferenceType => false;
+    public override bool IsReferenceType => hasReferenceTypeConstraint;
     public override long EstimatedRenderedLength => name.Length + 1L;
 
     internal override string StructuralIdentity()

--- a/src/ILInspector.Metadata/TypeNodeProvider.cs
+++ b/src/ILInspector.Metadata/TypeNodeProvider.cs
@@ -581,6 +581,7 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
         return new GenericParameterNode(
             name,
             hasValueTypeConstraint: context?.HasMethodParameterValueTypeConstraint(index) == true,
+            hasReferenceTypeConstraint: context?.HasMethodParameterReferenceTypeConstraint(index) == true,
             isMethodParameter: true,
             index);
     }
@@ -593,6 +594,7 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
         return new GenericParameterNode(
             name,
             hasValueTypeConstraint: context?.HasTypeParameterValueTypeConstraint(index) == true,
+            hasReferenceTypeConstraint: context?.HasTypeParameterReferenceTypeConstraint(index) == true,
             isMethodParameter: false,
             index);
     }

--- a/src/ILInspector.Metadata/TypeNodeProvider.cs
+++ b/src/ILInspector.Metadata/TypeNodeProvider.cs
@@ -14,6 +14,7 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
     readonly Action<string>? _beforeRetain;
     readonly Action<int>? _beforeMaterialize;
     readonly bool _scopeNamedTypeIdentity;
+    readonly bool _requireScopedNamedTypeIdentity;
     readonly AssemblyReferenceProjectionCache?
         _assemblyReferenceProjection;
     readonly ConditionalWeakTable<MetadataReader, ReaderNameCache> _readerNames = new();
@@ -22,12 +23,15 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
         Action<string>? beforeRetain = null,
         Action<int>? beforeMaterialize = null,
         bool scopeNamedTypeIdentity = false,
+        bool requireScopedNamedTypeIdentity = false,
         AssemblyReferenceProjectionCache?
             assemblyReferenceProjection = null)
     {
         _beforeRetain = beforeRetain;
         _beforeMaterialize = beforeMaterialize;
         _scopeNamedTypeIdentity = scopeNamedTypeIdentity;
+        _requireScopedNamedTypeIdentity =
+            requireScopedNamedTypeIdentity;
         _assemblyReferenceProjection =
             assemblyReferenceProjection;
     }
@@ -151,16 +155,23 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
             _beforeRetain?.Invoke(read.Name!);
             RetainAssemblyIdentity(read.AssemblyIdentity);
             bool isRef = rawTypeKind != 0x11; // 0x11 = ELEMENT_TYPE_VALUETYPE
-            return new NamedTypeNode(
-                read.Name!,
-                isRef,
-                metadataName: read.MetadataName,
-                scopedIdentity: _scopeNamedTypeIdentity
+            ScopedNamedTypeIdentity? scopedIdentity =
+                _scopeNamedTypeIdentity
                     ? ScopedNamedTypeIdentity(
                         reader,
                         handle,
                         rawTypeKind)
-                    : null,
+                    : null;
+            if (_requireScopedNamedTypeIdentity
+                && scopedIdentity is null)
+            {
+                return new DegradedTypeNode();
+            }
+            return new NamedTypeNode(
+                read.Name!,
+                isRef,
+                metadataName: read.MetadataName,
+                scopedIdentity: scopedIdentity,
                 assemblyIdentity: read.AssemblyIdentity);
         }
 

--- a/src/ILInspector.MetadataPrimitives/GenericContext.cs
+++ b/src/ILInspector.MetadataPrimitives/GenericContext.cs
@@ -11,12 +11,14 @@ public class GenericContext
 {
     readonly IReadOnlyList<bool> _typeValueTypeConstraints;
     readonly IReadOnlyList<bool> _methodValueTypeConstraints;
+    readonly IReadOnlyList<bool> _typeReferenceTypeConstraints;
+    readonly IReadOnlyList<bool> _methodReferenceTypeConstraints;
 
     public IReadOnlyList<string> TypeParameters { get; }
     public IReadOnlyList<string> MethodParameters { get; }
 
     public GenericContext(IReadOnlyList<string> typeParameters, IReadOnlyList<string> methodParameters)
-        : this(typeParameters, methodParameters, [], [])
+        : this(typeParameters, methodParameters, [], [], [], [])
     {
     }
 
@@ -24,12 +26,16 @@ public class GenericContext
         IReadOnlyList<string> typeParameters,
         IReadOnlyList<string> methodParameters,
         IReadOnlyList<bool> typeValueTypeConstraints,
-        IReadOnlyList<bool> methodValueTypeConstraints)
+        IReadOnlyList<bool> methodValueTypeConstraints,
+        IReadOnlyList<bool> typeReferenceTypeConstraints,
+        IReadOnlyList<bool> methodReferenceTypeConstraints)
     {
         TypeParameters = typeParameters;
         MethodParameters = methodParameters;
         _typeValueTypeConstraints = typeValueTypeConstraints;
         _methodValueTypeConstraints = methodValueTypeConstraints;
+        _typeReferenceTypeConstraints = typeReferenceTypeConstraints;
+        _methodReferenceTypeConstraints = methodReferenceTypeConstraints;
     }
 
     /// <summary>
@@ -47,6 +53,18 @@ public class GenericContext
     /// </summary>
     public bool HasMethodParameterValueTypeConstraint(int index)
         => HasValueTypeConstraint(_methodValueTypeConstraints, index);
+
+    /// <summary>
+    /// Whether the indexed type parameter carries the metadata reference-type constraint flag.
+    /// </summary>
+    public bool HasTypeParameterReferenceTypeConstraint(int index)
+        => HasConstraint(_typeReferenceTypeConstraints, index);
+
+    /// <summary>
+    /// Whether the indexed method parameter carries the metadata reference-type constraint flag.
+    /// </summary>
+    public bool HasMethodParameterReferenceTypeConstraint(int index)
+        => HasConstraint(_methodReferenceTypeConstraints, index);
 
     /// <summary>
     /// Creates a context for a type definition (type parameters only).
@@ -68,7 +86,13 @@ public class GenericContext
             reader,
             typeDef.GetGenericParameters(),
             beforeMaterialize);
-        return new GenericContext(typeParameters.Names, [], typeParameters.ValueTypeConstraints, []);
+        return new GenericContext(
+            typeParameters.Names,
+            [],
+            typeParameters.ValueTypeConstraints,
+            [],
+            typeParameters.ReferenceTypeConstraints,
+            []);
     }
 
     /// <summary>
@@ -89,7 +113,9 @@ public class GenericContext
             typeParameters.Names,
             methodParameters.Names,
             typeParameters.ValueTypeConstraints,
-            methodParameters.ValueTypeConstraints);
+            methodParameters.ValueTypeConstraints,
+            typeParameters.ReferenceTypeConstraints,
+            methodParameters.ReferenceTypeConstraints);
     }
 
     static void ValidateDeclaringTypeParameterCounts(
@@ -161,10 +187,15 @@ public class GenericContext
             typeContext.TypeParameters,
             methodParameters.Names,
             typeContext._typeValueTypeConstraints,
-            methodParameters.ValueTypeConstraints);
+            methodParameters.ValueTypeConstraints,
+            typeContext._typeReferenceTypeConstraints,
+            methodParameters.ReferenceTypeConstraints);
     }
 
-    static (List<string> Names, List<bool> ValueTypeConstraints) ReadParameters(
+    static (
+        List<string> Names,
+        List<bool> ValueTypeConstraints,
+        List<bool> ReferenceTypeConstraints) ReadParameters(
         MetadataReader reader,
         GenericParameterHandleCollection handles,
         Action<int>? beforeMaterialize)
@@ -178,6 +209,7 @@ public class GenericContext
 
         var names = new List<string>(handles.Count);
         var valueTypeConstraints = new List<bool>(handles.Count);
+        var referenceTypeConstraints = new List<bool>(handles.Count);
         int totalNameLength = 0;
         foreach (var handle in handles)
         {
@@ -202,8 +234,10 @@ public class GenericContext
             names.Add(name);
             valueTypeConstraints.Add(
                 (parameter.Attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0);
+            referenceTypeConstraints.Add(
+                (parameter.Attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0);
         }
-        return (names, valueTypeConstraints);
+        return (names, valueTypeConstraints, referenceTypeConstraints);
     }
 
     public static void ValidateParameterIndices(
@@ -224,5 +258,8 @@ public class GenericContext
     }
 
     static bool HasValueTypeConstraint(IReadOnlyList<bool> constraints, int index)
+        => HasConstraint(constraints, index);
+
+    static bool HasConstraint(IReadOnlyList<bool> constraints, int index)
         => index >= 0 && index < constraints.Count && constraints[index];
 }

--- a/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
@@ -118,6 +118,24 @@ public static class MetadataSafetyPolicy
     public const int MaxOverrideCompatibilityWork = 16 * MaxRelationshipNodes;
 
     /// <summary>
+    /// Maximum estimated expanded size, in characters, of the exact structural
+    /// identity computed for one ancestry step while authenticating an
+    /// override slot.
+    ///
+    /// A substituted ancestry step is a shared-node DAG, but its exact
+    /// structural identity is the expanded <em>tree</em>. A base that squares
+    /// its own instantiation each step -- <c>Middle&lt;T&gt; :
+    /// Middle&lt;Pair&lt;T, T&gt;&gt;</c> -- doubles that tree per step, so
+    /// the identity of the eighth step is already millions of characters and
+    /// exhausts memory long before the node ceiling is reached. The estimate
+    /// is available without materializing text, so the expanded work is
+    /// charged and refused before it is done. Real constructed ancestry is
+    /// orders of magnitude smaller than this ceiling. Gated by
+    /// <c>SameAssemblyOverrideSlot_BranchingConstructedAncestryFailsClosedWithinMemory</c>.
+    /// </summary>
+    public const int MaxExactInstantiationIdentityChars = 8 * 1024;
+
+    /// <summary>
     /// Maximum characters in one structured type name: its namespace plus every root-to-leaf
     /// segment, plus one delimiter per segment boundary.
     /// </summary>

--- a/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
@@ -98,6 +98,26 @@ public static class MetadataSafetyPolicy
     public const int MaxRelationshipNodes = 256;
 
     /// <summary>
+    /// Maximum nested comparison steps entered while deciding one override
+    /// return/parameter compatibility question. Active-handle cycle detection
+    /// alone does not bound a constraint <em>chain</em>, which recurses once
+    /// per link on the native stack. Gated by
+    /// <c>SameAssemblyOverrideSlot_DeepGenericParameterChainFailsClosed</c> and
+    /// <c>SameAssemblyOverrideSlot_DeepGenericParameterChainDoesNotCrashProcess</c>.
+    /// </summary>
+    public const int MaxOverrideCompatibilityDepth = MaxRelationshipNodes;
+
+    /// <summary>
+    /// Maximum comparison steps charged cumulatively across one override-slot
+    /// authentication, covering every parameter and the return. Active-path
+    /// cycle detection admits a constraint <em>DAG</em> whose distinct paths
+    /// grow exponentially in its width, so depth alone does not bound the
+    /// work. Gated by
+    /// <c>SameAssemblyOverrideSlot_WideGenericParameterDagFailsClosedWithinBudget</c>.
+    /// </summary>
+    public const int MaxOverrideCompatibilityWork = 16 * MaxRelationshipNodes;
+
+    /// <summary>
     /// Maximum characters in one structured type name: its namespace plus every root-to-leaf
     /// segment, plus one delimiter per segment boundary.
     /// </summary>

--- a/tests/ILInspector.Metadata.Tests/CSharpKeywordsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpKeywordsTests.cs
@@ -34,7 +34,7 @@ public sealed class CSharpKeywordsTests
             var declaration = MetadataDeclarationQuery.GetMethod(
                 reader,
                 type,
-                reader.GetMethodDefinition(methodHandle));
+                methodHandle);
             Assert.Equal($"@{keyword}", declaration.CSharpName);
         }
     }

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -286,6 +286,42 @@ public sealed class MetadataDeclarationQueryTests
         Assert.Equal((MethodDefinitionHandle)implementation.MethodDeclaration, slot.Method);
     }
 
+    [Theory]
+    [InlineData(
+        typeof(MetadataDeclarationQueryFixtures.CovariantPropertyDerived),
+        "Value",
+        "get_Value")]
+    [InlineData(
+        typeof(MetadataDeclarationQueryFixtures.CovariantIndexerDerived),
+        "Item",
+        "get_Item")]
+    public void PropertyDeclaration_UsesCompilerProducedCovariantMethodImpl(
+        Type derivedType,
+        string propertyName,
+        string accessorName)
+    {
+        var derivedHandle = GetTypeDefinitionHandle(derivedType);
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var property = GetProperty(derived, propertyName);
+        var accessorHandle = GetMethodHandle(derived, accessorName);
+        var accessor = Reader.GetMethodDefinition(accessorHandle);
+
+        Assert.True((accessor.Attributes & MethodAttributes.NewSlot) != 0);
+        Assert.Contains(
+            derived.GetMethodImplementations()
+                .Select(Reader.GetMethodImplementation),
+            implementation => implementation.MethodBody == accessorHandle);
+
+        var declaration =
+            MetadataDeclarationQuery.GetProperty(
+                Reader,
+                derived,
+                property);
+
+        Assert.True(declaration.IsOverride);
+        Assert.False(declaration.IsVirtual);
+    }
+
     [Fact]
     public void SameAssemblyOverrideSlot_DeclinesInterfaceMethodImpl()
     {
@@ -1129,6 +1165,26 @@ public class MetadataDeclarationQueryFixtures
     public class CovariantReturnDerived : CovariantReturnBase
     {
         public override CovariantDog Value() => new();
+    }
+
+    public class CovariantPropertyBase
+    {
+        public virtual CovariantAnimal Value => new();
+    }
+
+    public class CovariantPropertyDerived : CovariantPropertyBase
+    {
+        public override CovariantDog Value => new();
+    }
+
+    public class CovariantIndexerBase
+    {
+        public virtual CovariantAnimal this[int index] => new();
+    }
+
+    public class CovariantIndexerDerived : CovariantIndexerBase
+    {
+        public override CovariantDog this[int index] => new();
     }
 
     public class ObjectCovariantReturnBase

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -407,6 +407,258 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void SameAssemblyOverrideSlot_AuthenticatesConstructedGenericBaseCovariantMethodImpl()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .ConstructedGenericCovariantReturnDerived<>));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+        var implementation = Reader.GetMethodImplementation(
+            Assert.Single(derived.GetMethodImplementations()));
+
+        // The shape this gate exists for: Roslyn writes the base as a
+        // TypeSpec and the MethodImpl declaration as a MemberRef rooted in it.
+        Assert.Equal(
+            HandleKind.TypeSpecification,
+            derived.BaseType.Kind);
+        Assert.Equal(
+            HandleKind.MemberReference,
+            implementation.MethodDeclaration.Kind);
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        var baseHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .ConstructedGenericCovariantReturnBase<>));
+        Assert.Equal(baseHandle, slot.DeclaringType);
+        Assert.Equal(
+            GetMethodHandle(
+                Reader.GetTypeDefinition(baseHandle),
+                "Value"),
+            slot.Method);
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AuthenticatesConstructedGenericBaseSubstitutedParameter()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .ConstructedGenericSubstitutionDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Describe");
+
+        // A plain override on a constructed generic base carries no
+        // MethodImpl, so the slot is reachable only by walking the TypeSpec
+        // base and substituting string for the base's type parameter.
+        Assert.Equal(
+            HandleKind.TypeSpecification,
+            derived.BaseType.Kind);
+        Assert.Empty(derived.GetMethodImplementations());
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        var baseHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .ConstructedGenericSubstitutionBase<>));
+        Assert.Equal(baseHandle, slot.DeclaringType);
+        Assert.Equal(
+            GetMethodHandle(
+                Reader.GetTypeDefinition(baseHandle),
+                "Describe"),
+            slot.Method);
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AuthenticatesSyntheticConstructedGenericMethodImpl()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructedGenericMethodImplImage(
+                ConstructedGenericMethodImplShape.MatchingInstantiation));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.Equal(
+            "Base`1",
+            reader.GetString(
+                reader.GetTypeDefinition(slot.DeclaringType).Name));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesConstructedGenericMethodImplWithMismatchedInstantiation()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructedGenericMethodImplImage(
+                ConstructedGenericMethodImplShape.MismatchedInstantiation));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesConstructedGenericMethodImplRootedInExternalDefinition()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructedGenericMethodImplImage(
+                ConstructedGenericMethodImplShape.ExternalDefinition));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_WideGenericParameterDagFailsClosedWithinBudget()
+    {
+        using var stream = new MemoryStream(
+            BuildGenericParameterConstraintGraphImage(
+                parameterCount: 64,
+                GenericParameterConstraintGraph.Dag));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        // Path count in this DAG grows like the Fibonacci numbers, so 64
+        // parameters is roughly 10^13 distinct constraint paths. Only a
+        // cumulative work bound can answer at all.
+        var elapsed = System.Diagnostics.Stopwatch.StartNew();
+        var slot = MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+            reader,
+            derivedHandle,
+            methodHandle);
+        elapsed.Stop();
+
+        Assert.Null(slot);
+        Assert.True(
+            elapsed.Elapsed < TimeSpan.FromSeconds(30),
+            $"Bounded DAG traversal took {elapsed.Elapsed}.");
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeepGenericParameterChainFailsClosed()
+    {
+        using var stream = new MemoryStream(
+            BuildGenericParameterConstraintGraphImage(
+                parameterCount: 2_000,
+                GenericParameterConstraintGraph.Chain));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeepGenericParameterChainDoesNotCrashProcess()
+    {
+        using var stream = new MemoryStream(
+            BuildGenericParameterConstraintGraphImage(
+                parameterCount: 60_000,
+                GenericParameterConstraintGraph.Chain));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        // A recursion-per-link walk overflows the native stack here, which no
+        // managed catch can contain: reaching the assertion at all is the
+        // evidence, because a stack overflow would take this process down.
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void AuthenticatedObjectSlotOverride_AcceptsSameImageChainToObject()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .SameImageObjectSlotDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+
+        foreach (string name in (string[])
+            ["ToString", "GetHashCode", "Equals"])
+        {
+            Assert.True(
+                MetadataDeclarationQuery.IsAuthenticatedObjectSlotOverride(
+                    Reader,
+                    derivedHandle,
+                    GetMethodHandle(derived, name)),
+                name);
+        }
+    }
+
+    [Fact]
+    public void AuthenticatedObjectSlotOverride_DeclinesOverrideOfExternalBase()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.ExternalOverride));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+
+        // System.Exception declares its own ToString slot, so local metadata
+        // cannot tell whether this method occupies Object's slot or the
+        // external base's; a flattening consumer must not rebind it.
+        Assert.Equal(HandleKind.TypeReference, derived.BaseType.Kind);
+        Assert.False(
+            MetadataDeclarationQuery.IsAuthenticatedObjectSlotOverride(
+                Reader,
+                derivedHandle,
+                GetMethodHandle(derived, "ToString")));
+    }
+
+    [Fact]
+    public void AuthenticatedObjectSlotOverride_DeclinesNewSlotObjectShapedVirtual()
+    {
+        var declarerHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .NewSlotToStringDeclarer));
+        var declarer = Reader.GetTypeDefinition(declarerHandle);
+
+        Assert.False(
+            MetadataDeclarationQuery.IsAuthenticatedObjectSlotOverride(
+                Reader,
+                declarerHandle,
+                GetMethodHandle(declarer, "ToString")));
+    }
+
+    [Fact]
     public void SameAssemblyOverrideSlot_AllowsExplicitGenericBaseConstraint()
     {
         var derivedHandle = GetTypeDefinitionHandle(
@@ -1286,6 +1538,291 @@ public sealed class MetadataDeclarationQueryTests
             derived,
             Assert.Single(
                 reader.GetTypeDefinition(derived).GetMethods()));
+    }
+
+    enum ConstructedGenericMethodImplShape
+    {
+        MatchingInstantiation,
+        MismatchedInstantiation,
+        ExternalDefinition,
+    }
+
+    /// <summary>
+    /// Builds <c>Derived : Base&lt;Animal&gt;</c> where <c>Base&lt;T&gt;</c>
+    /// declares <c>T Value()</c> and <c>Derived</c> declares
+    /// <c>Dog Value()</c> with a class <c>MethodImpl</c> whose declaration is a
+    /// <c>MemberRef</c> rooted in a <c>TypeSpec</c>. The shape controls which
+    /// instantiation that <c>MemberRef</c> names, so a match can only come from
+    /// substituting the exact base arguments rather than from the member's
+    /// spelling.
+    /// </summary>
+    static byte[] BuildConstructedGenericMethodImplImage(
+        ConstructedGenericMethodImplShape shape)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("ConstructedGenericMethodImpl");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(metadata, "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+        TypeReferenceHandle externalBase =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("External"),
+                metadata.GetOrAddString("Base`1"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                animal,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base`1"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+
+        TypeSpecificationHandle extendsSpec =
+            shape == ConstructedGenericMethodImplShape.ExternalDefinition
+                ? AddSyntheticConstructedTypeSpec(
+                    metadata,
+                    externalBase,
+                    animal)
+                : AddSyntheticConstructedTypeSpec(
+                    metadata,
+                    baseType,
+                    animal);
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                extendsSpec,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        metadata.AddGenericParameter(
+            baseType,
+            GenericParameterAttributes.ReferenceTypeConstraint,
+            metadata.GetOrAddString("T"),
+            index: 0);
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        metadata.AddMethodDefinition(
+            attributes,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Value"),
+            AddSyntheticGenericParameterReturnSignature(metadata),
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticMethodSignature(metadata, dog),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+
+        EntityHandle declarationParent = shape switch
+        {
+            ConstructedGenericMethodImplShape.MismatchedInstantiation =>
+                AddSyntheticConstructedTypeSpec(metadata, baseType, dog),
+            ConstructedGenericMethodImplShape.ExternalDefinition =>
+                extendsSpec,
+            _ => extendsSpec,
+        };
+        MemberReferenceHandle declaration =
+            metadata.AddMemberReference(
+                declarationParent,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericParameterReturnSignature(metadata));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            declaration);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    enum GenericParameterConstraintGraph
+    {
+        Chain,
+        Dag,
+    }
+
+    /// <summary>
+    /// Builds <c>Derived&lt;T0..Tn&gt; : Base</c> whose <c>Value()</c> returns
+    /// <c>!0</c> against a base slot returning <c>Animal</c>, with a
+    /// type-parameter constraint graph no path of which reaches <c>Animal</c>.
+    /// A chain forces one recursion per link; a DAG whose every parameter is
+    /// constrained by its next two neighbours has a path count that grows like
+    /// the Fibonacci numbers, so neither terminates in reasonable time or
+    /// stack without a cumulative bound.
+    /// </summary>
+    static byte[] BuildGenericParameterConstraintGraphImage(
+        int parameterCount,
+        GenericParameterConstraintGraph graph)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("GenericParameterConstraintGraph");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(metadata, "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        var parameters = new GenericParameterHandle[parameterCount];
+        for (int index = 0; index < parameterCount; index++)
+        {
+            parameters[index] = metadata.AddGenericParameter(
+                derivedType,
+                GenericParameterAttributes.ReferenceTypeConstraint,
+                metadata.GetOrAddString(
+                    string.Create(
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        $"T{index}")),
+                index);
+        }
+
+        var parameterSpecs = new TypeSpecificationHandle[parameterCount];
+        for (int index = 0; index < parameterCount; index++)
+        {
+            parameterSpecs[index] =
+                AddSyntheticGenericParameterTypeSpec(metadata, index);
+        }
+
+        int neighbours =
+            graph == GenericParameterConstraintGraph.Dag ? 2 : 1;
+        for (int index = 0; index < parameterCount; index++)
+        {
+            for (int step = 1; step <= neighbours; step++)
+            {
+                int target = index + step;
+                if (target >= parameterCount)
+                    continue;
+
+                metadata.AddGenericParameterConstraint(
+                    parameters[index],
+                    parameterSpecs[target]);
+            }
+        }
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticMethodSignature(metadata, animal),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericParameterReturnSignature(metadata),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static TypeSpecificationHandle AddSyntheticConstructedTypeSpec(
+        MetadataBuilder metadata,
+        EntityHandle definition,
+        EntityHandle argument)
+    {
+        var blob = new BlobBuilder();
+        new BlobEncoder(blob)
+            .TypeSpecificationSignature()
+            .GenericInstantiation(
+                definition,
+                genericArgumentCount: 1,
+                isValueType: false)
+            .AddArgument()
+            .Type(argument, isValueType: false);
+        return metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(blob));
+    }
+
+    static TypeSpecificationHandle AddSyntheticGenericParameterTypeSpec(
+        MetadataBuilder metadata,
+        int index)
+    {
+        var blob = new BlobBuilder();
+        new BlobEncoder(blob)
+            .TypeSpecificationSignature()
+            .GenericTypeParameter(index);
+        return metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(blob));
     }
 
     static byte[] BuildScopedSignatureCollisionImage(
@@ -3378,6 +3915,60 @@ public class MetadataDeclarationQueryFixtures
     public class ObjectCovariantReturnDerived : ObjectCovariantReturnBase
     {
         public override string Value() => "";
+    }
+
+    public class ConstructedGenericCovariantReturnBase<TItem>
+        where TItem : CovariantAnimal
+    {
+        public virtual CovariantAnimal Value() => new();
+    }
+
+    /// <summary>
+    /// Roslyn encodes this base as a <c>TypeSpec</c> and the covariant-return
+    /// <c>MethodImpl</c> declaration as a <c>MemberRef</c> rooted in that
+    /// <c>TypeSpec</c>, which is the compiler-produced shape same-image
+    /// override authentication has to read.
+    /// </summary>
+    public class ConstructedGenericCovariantReturnDerived<TItem>
+        : ConstructedGenericCovariantReturnBase<TItem>
+        where TItem : CovariantDog
+    {
+        public override TItem Value() => default!;
+    }
+
+    public class ConstructedGenericSubstitutionBase<TItem>
+    {
+        public virtual string Describe(TItem value) => "";
+    }
+
+    /// <summary>
+    /// A plain override on a constructed generic base. Roslyn emits no
+    /// <c>MethodImpl</c> here, so the slot is only reachable by walking the
+    /// <c>TypeSpec</c> base and substituting <c>string</c> for
+    /// <c>TItem</c> in the base signature.
+    /// </summary>
+    public class ConstructedGenericSubstitutionDerived
+        : ConstructedGenericSubstitutionBase<string>
+    {
+        public override string Describe(string value) => value;
+    }
+
+    public class SameImageObjectSlotBase
+    {
+    }
+
+    public class SameImageObjectSlotDerived : SameImageObjectSlotBase
+    {
+        public override string ToString() => nameof(SameImageObjectSlotDerived);
+
+        public override int GetHashCode() => 0;
+
+        public override bool Equals(object? obj) => false;
+    }
+
+    public class NewSlotToStringDeclarer
+    {
+        public new virtual string ToString() => "";
     }
 
     public class StaticShadowBase

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using ILInspector.Metadata;
@@ -253,6 +254,83 @@ public sealed class MetadataDeclarationQueryTests
         {
             File.Delete(path);
         }
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_UsesCompilerProducedCovariantMethodImpl()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.CovariantReturnDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+        var method = Reader.GetMethodDefinition(methodHandle);
+        var implementation = Assert.Single(
+            derived.GetMethodImplementations().Select(Reader.GetMethodImplementation),
+            candidate => candidate.MethodBody == methodHandle);
+
+        Assert.True((method.Attributes & MethodAttributes.NewSlot) != 0);
+        Assert.Equal(HandleKind.MethodDefinition, implementation.MethodDeclaration.Kind);
+
+        var declaration = MetadataDeclarationQuery.GetMethod(Reader, derived, method);
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.True(declaration.IsOverride);
+        Assert.False(declaration.IsVirtual);
+        Assert.Equal(
+            GetTypeDefinitionHandle(typeof(MetadataDeclarationQueryFixtures.CovariantReturnBase)),
+            slot.DeclaringType);
+        Assert.Equal((MethodDefinitionHandle)implementation.MethodDeclaration, slot.Method);
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesInterfaceMethodImpl()
+    {
+        string path = EmitNewSlotInterfaceMethodImpl();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            var typeHandle = reader.TypeDefinitions.Single(handle =>
+                reader.GetString(reader.GetTypeDefinition(handle).Name) == "Implementation");
+            var type = reader.GetTypeDefinition(typeHandle);
+            var methodHandle = type.GetMethods().Single(handle =>
+                reader.GetString(reader.GetMethodDefinition(handle).Name) == "Value");
+
+            Assert.Null(MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                typeHandle,
+                methodHandle));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SameAssemblyOverrideSlot_DeclinesUnauthenticatedClassMethodImpl(
+        bool ambiguousBaseDeclarations)
+    {
+        using var stream = new MemoryStream(
+            BuildUnauthenticatedClassMethodImplImage(ambiguousBaseDeclarations));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "Derived");
+        var type = reader.GetTypeDefinition(typeHandle);
+        var methodHandle = Assert.Single(type.GetMethods());
+
+        Assert.Null(MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+            reader,
+            typeHandle,
+            methodHandle));
     }
 
     [Fact]
@@ -676,6 +754,152 @@ public sealed class MetadataDeclarationQueryTests
         string path = Path.Combine(Path.GetTempPath(), $"CovariantReturnOverride-{Guid.NewGuid():N}.dll");
         assembly.Save(path);
         return path;
+    }
+
+    static string EmitNewSlotInterfaceMethodImpl()
+    {
+        var assemblyName = new AssemblyName("NewSlotInterfaceMethodImpl");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+
+        var interfaceType = module.DefineType(
+            "IContract",
+            TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract);
+        var declaration = interfaceType.DefineMethod(
+            "Value",
+            MethodAttributes.Public
+                | MethodAttributes.Abstract
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot,
+            typeof(object),
+            Type.EmptyTypes);
+        var createdInterface = interfaceType.CreateType();
+
+        var implementationType = module.DefineType("Implementation", TypeAttributes.Public);
+        implementationType.AddInterfaceImplementation(createdInterface);
+        var body = implementationType.DefineMethod(
+            "Value",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.NewSlot,
+            typeof(object),
+            Type.EmptyTypes);
+        body.GetILGenerator().Emit(OpCodes.Ldnull);
+        body.GetILGenerator().Emit(OpCodes.Ret);
+        implementationType.DefineMethodOverride(body, declaration);
+        implementationType.CreateType();
+
+        string path = Path.Combine(Path.GetTempPath(), $"NewSlotInterfaceMethodImpl-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static byte[] BuildUnauthenticatedClassMethodImplImage(
+        bool ambiguousBaseDeclarations)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("ClassMethodImpl.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("ClassMethodImpl"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        var runtime = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Runtime"),
+            new Version(11, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        var objectType = metadata.AddTypeReference(
+            runtime,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var baseType = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("Base"),
+            objectType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var middleOrUnrelatedType = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString(
+                ambiguousBaseDeclarations ? "Middle" : "Unrelated"),
+            ambiguousBaseDeclarations ? baseType : objectType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        var derivedType = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("Derived"),
+            ambiguousBaseDeclarations ? middleOrUnrelatedType : baseType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(3));
+
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(
+            SignatureCallingConvention.Default,
+            genericParameterCount: 0,
+            isInstanceMethod: true).Parameters(
+                0,
+                returnType => returnType.Void(),
+                _ => { });
+        var signatureHandle = metadata.GetOrAddBlob(signature);
+        var attributes = MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        var baseMethod = metadata.AddMethodDefinition(
+            attributes,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Value"),
+            signatureHandle,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        var middleOrUnrelatedMethod = metadata.AddMethodDefinition(
+            attributes,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Value"),
+            signatureHandle,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        var derivedMethod = metadata.AddMethodDefinition(
+            attributes,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Value"),
+            signatureHandle,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            middleOrUnrelatedMethod);
+        if (ambiguousBaseDeclarations)
+            metadata.AddMethodImplementation(derivedType, derivedMethod, baseMethod);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
     }
 
     static string EmitIncompatibleReturnOverride()

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
@@ -2010,12 +2011,13 @@ public sealed class MetadataDeclarationQueryTests
         Dag,
     }
 
-    enum ConstructedGenericAncestryShape
+    public enum ConstructedGenericAncestryShape
     {
         MatchingArgument,
         DifferentArgument,
         Cyclic,
         Expanding,
+        BranchingExpansion,
     }
 
     /// <summary>
@@ -2052,6 +2054,8 @@ public sealed class MetadataDeclarationQueryTests
             MetadataTokens.TypeDefinitionHandle(3);
         TypeDefinitionHandle dog =
             MetadataTokens.TypeDefinitionHandle(4);
+        TypeDefinitionHandle pair =
+            MetadataTokens.TypeDefinitionHandle(5);
 
         EntityHandle middleBase = shape switch
         {
@@ -2060,6 +2064,11 @@ public sealed class MetadataDeclarationQueryTests
                 AddSyntheticNestedSelfInstantiationTypeSpec(
                     metadata,
                     middle),
+            ConstructedGenericAncestryShape.BranchingExpansion =>
+                AddSyntheticBranchingSelfInstantiationTypeSpec(
+                    metadata,
+                    middle,
+                    pair),
             _ => objectType,
         };
         EntityHandle dogBase = AddSyntheticConstructedTypeSpec(
@@ -2103,6 +2112,19 @@ public sealed class MetadataDeclarationQueryTests
                 dogBase,
                 MetadataTokens.FieldDefinitionHandle(1),
                 MetadataTokens.MethodDefinitionHandle(1)));
+        if (shape == ConstructedGenericAncestryShape.BranchingExpansion)
+        {
+            Assert.Equal(
+                pair,
+                metadata.AddTypeDefinition(
+                    TypeAttributes.Public,
+                    default,
+                    metadata.GetOrAddString("Pair`2"),
+                    objectType,
+                    MetadataTokens.FieldDefinitionHandle(1),
+                    MetadataTokens.MethodDefinitionHandle(1)));
+        }
+
         TypeDefinitionHandle baseType =
             metadata.AddTypeDefinition(
                 TypeAttributes.Public,
@@ -2125,6 +2147,19 @@ public sealed class MetadataDeclarationQueryTests
             GenericParameterAttributes.None,
             metadata.GetOrAddString("T"),
             index: 0);
+        if (shape == ConstructedGenericAncestryShape.BranchingExpansion)
+        {
+            metadata.AddGenericParameter(
+                pair,
+                GenericParameterAttributes.None,
+                metadata.GetOrAddString("TFirst"),
+                index: 0);
+            metadata.AddGenericParameter(
+                pair,
+                GenericParameterAttributes.None,
+                metadata.GetOrAddString("TSecond"),
+                index: 1);
+        }
 
         BlobHandle declaredReturn = shape
             is ConstructedGenericAncestryShape.MatchingArgument
@@ -3531,6 +3566,1638 @@ public sealed class MetadataDeclarationQueryTests
         return SerializeSyntheticMetadata(metadata);
     }
 
+    // ---- Round-27 authentication gates ----------------------------------
+
+    [Theory]
+    [InlineData(ReferenceConstraintAuthenticationShape.FlagOnly)]
+    [InlineData(
+        ReferenceConstraintAuthenticationShape.FlagWithValidConstraint)]
+    public void SameAssemblyOverrideSlot_AllowsAuthenticatedReferenceConstraintForObjectReturn(
+        ReferenceConstraintAuthenticationShape shape)
+    {
+        using var stream = new MemoryStream(
+            BuildReferenceConstraintAuthenticationImage(
+                shape,
+                arrayReturn: false));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesDegradedSiblingConstraintForObjectReturn()
+    {
+        using var stream = new MemoryStream(
+            BuildReferenceConstraintAuthenticationImage(
+                ReferenceConstraintAuthenticationShape
+                    .FlagWithDegradedConstraint,
+                arrayReturn: false));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsReferenceFlagOnlyConstraintForArrayCovariance()
+    {
+        using var stream = new MemoryStream(
+            BuildReferenceConstraintAuthenticationImage(
+                ReferenceConstraintAuthenticationShape.FlagOnly,
+                arrayReturn: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesDegradedSiblingConstraintForArrayCovariance()
+    {
+        using var stream = new MemoryStream(
+            BuildReferenceConstraintAuthenticationImage(
+                ReferenceConstraintAuthenticationShape
+                    .FlagWithDegradedConstraint,
+                arrayReturn: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_BranchingConstructedAncestryFailsClosed()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructedGenericAncestryImage(
+                ConstructedGenericAncestryShape.BranchingExpansion));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    /// <summary>
+    /// A base that squares its own instantiation each ancestry step expands the
+    /// exact structural identity exponentially, which exhausted hundreds of
+    /// megabytes before the node ceiling was ever reached. The child process
+    /// runs under a hard GC heap limit far below what the unbounded expansion
+    /// needed, so the containment is proved by the child completing rather than
+    /// by a managed catch, which an <see cref="OutOfMemoryException"/> of that
+    /// shape does not reliably permit.
+    /// </summary>
+    [Fact]
+    public void SameAssemblyOverrideSlot_BranchingConstructedAncestryFailsClosedWithinMemory()
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(
+            typeof(MetadataDeclarationQueryTests).Assembly.Location);
+        startInfo.ArgumentList.Add("-method");
+        startInfo.ArgumentList.Add(
+            $"*{nameof(BranchingConstructedAncestryWorker)}*");
+        startInfo.Environment[BranchingAncestryWorkerVariable] =
+            nameof(BranchingConstructedAncestryWorker);
+        startInfo.Environment["DOTNET_GCHeapHardLimit"] = "0x10000000";
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        string standardOutput = process.StandardOutput.ReadToEnd();
+        string standardError = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(
+            process.ExitCode == 0,
+            $"The branching-ancestry worker exited {process.ExitCode}.\n"
+                + $"stdout:\n{standardOutput}\n"
+                + $"stderr:\n{standardError}");
+    }
+
+    /// <summary>
+    /// Runs inside the child process started by
+    /// <see cref="SameAssemblyOverrideSlot_BranchingConstructedAncestryFailsClosedWithinMemory"/>.
+    /// The exact-instantiation control runs in the same constrained process, so
+    /// a bound that declined everything could not pass this worker.
+    /// </summary>
+    [Fact]
+    public void BranchingConstructedAncestryWorker()
+    {
+        if (Environment.GetEnvironmentVariable(
+                BranchingAncestryWorkerVariable)
+            != nameof(BranchingConstructedAncestryWorker))
+        {
+            return;
+        }
+
+        AssertConstructedAncestry(
+            ConstructedGenericAncestryShape.BranchingExpansion,
+            authenticated: false);
+        AssertConstructedAncestry(
+            ConstructedGenericAncestryShape.MatchingArgument,
+            authenticated: true);
+
+        static void AssertConstructedAncestry(
+            ConstructedGenericAncestryShape shape,
+            bool authenticated)
+        {
+            using var stream = new MemoryStream(
+                BuildConstructedGenericAncestryImage(shape));
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            var (derivedHandle, methodHandle) =
+                GetSyntheticDerivedMethod(reader);
+
+            MetadataOverrideSlot? slot =
+                MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                    reader,
+                    derivedHandle,
+                    methodHandle);
+            if (authenticated)
+                Assert.NotNull(slot);
+            else
+                Assert.Null(slot);
+        }
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsExactLocalReferenceReturnAgainstObjectDeclaration()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .LocalReferenceObjectCovariantReturnDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                GetMethodHandle(derived, "Value")));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsSyntheticExactLocalReferenceReturnAgainstObjectDeclaration()
+    {
+        using var stream = new MemoryStream(
+            BuildObjectReturnConversionImage(
+                ObjectReturnConversionShape.ExactLocalReference));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesModifiedReturnAgainstObjectDeclaration()
+    {
+        using var stream = new MemoryStream(
+            BuildObjectReturnConversionImage(
+                ObjectReturnConversionShape.ModifiedLocalReference));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesAmbiguousExactLocalReturnAgainstObjectDeclaration()
+    {
+        using var stream = new MemoryStream(
+            BuildObjectReturnConversionImage(
+                ObjectReturnConversionShape.AmbiguousLocalReference));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AuthenticatesInterfaceAncestryThroughInterfaceImplementation()
+    {
+        using var stream = new MemoryStream(
+            BuildSupertypeRoleImage(
+                SupertypeRoleShape.ValidInterfaceImplementation));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesInterfaceImplementationNamingAClass()
+    {
+        using var stream = new MemoryStream(
+            BuildSupertypeRoleImage(
+                SupertypeRoleShape.InterfaceImplementationNamesClass));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesBaseTypeNamingAnInterface()
+    {
+        using var stream = new MemoryStream(
+            BuildSupertypeRoleImage(
+                SupertypeRoleShape.BaseTypeNamesInterface));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void ReusesInheritedVirtualSlot_DeclinesExplicitInterfaceOnlyMethodImpl()
+    {
+        var type = Reader.GetTypeDefinition(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures
+                    .ExplicitInterfaceOnlyImplementation)));
+
+        // The MethodImpl is present; what is absent is any inherited class
+        // virtual slot for it to reuse.
+        Assert.NotEmpty(type.GetMethodImplementations());
+        Assert.False(
+            MetadataDeclarationQuery.ReusesInheritedVirtualSlot(
+                Reader,
+                type));
+    }
+
+    [Fact]
+    public void ReusesInheritedVirtualSlot_AcceptsAuthenticatedClassMethodImpl()
+    {
+        var type = Reader.GetTypeDefinition(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures
+                    .CovariantReturnDerived)));
+
+        // A covariant return is newslot virtual final plus a MethodImpl, so the
+        // attribute test alone cannot see the reuse.
+        Assert.NotEmpty(type.GetMethodImplementations());
+        Assert.True(
+            MetadataDeclarationQuery.ReusesInheritedVirtualSlot(
+                Reader,
+                type));
+    }
+
+    [Fact]
+    public void ReusesInheritedVirtualSlot_AcceptsInheritedVirtualSlotFlags()
+    {
+        var type = Reader.GetTypeDefinition(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures
+                    .PlainOverrideDerived)));
+
+        Assert.Empty(type.GetMethodImplementations());
+        Assert.True(
+            MetadataDeclarationQuery.ReusesInheritedVirtualSlot(
+                Reader,
+                type));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsSourceDeclarableSignatureHeader()
+    {
+        using var stream = new MemoryStream(
+            BuildOverrideSignatureHeaderImage(
+                OverrideSignatureHeaderShape.SourceDeclarable));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Theory]
+    [InlineData(OverrideSignatureHeaderShape.VarArg)]
+    [InlineData(OverrideSignatureHeaderShape.ExplicitThis)]
+    [InlineData(OverrideSignatureHeaderShape.MissingHasThis)]
+    public void SameAssemblyOverrideSlot_DeclinesMalformedSignatureHeader(
+        OverrideSignatureHeaderShape shape)
+    {
+        // Both sides carry the same malformed header, so the refusal cannot
+        // come from the two headers merely disagreeing.
+        using var stream = new MemoryStream(
+            BuildOverrideSignatureHeaderImage(shape));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void AuthenticatedObjectSlotOverride_AcceptsSourceDeclarableSignatureHeader()
+    {
+        using var stream = new MemoryStream(
+            BuildObjectIntrinsicSignatureHeaderImage(
+                OverrideSignatureHeaderShape.SourceDeclarable));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.True(
+            MetadataDeclarationQuery.IsAuthenticatedObjectSlotOverride(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Theory]
+    [InlineData(OverrideSignatureHeaderShape.VarArg)]
+    [InlineData(OverrideSignatureHeaderShape.ExplicitThis)]
+    [InlineData(OverrideSignatureHeaderShape.MissingHasThis)]
+    public void AuthenticatedObjectSlotOverride_DeclinesMalformedSignatureHeader(
+        OverrideSignatureHeaderShape shape)
+    {
+        using var stream = new MemoryStream(
+            BuildObjectIntrinsicSignatureHeaderImage(shape));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.False(
+            MetadataDeclarationQuery.IsAuthenticatedObjectSlotOverride(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsMatchingExternalConstruction()
+    {
+        using var stream = new MemoryStream(
+            BuildExternalConstructedArityImage(
+                ExternalConstructedArityShape.MatchingArity));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        // The construction is external, so local metadata cannot decide the
+        // hierarchy: the slot is preserved for the compiler to validate.
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Theory]
+    [InlineData(ExternalConstructedArityShape.MismatchedArgumentCount)]
+    [InlineData(ExternalConstructedArityShape.MismatchedEncodedCount)]
+    public void SameAssemblyOverrideSlot_DeclinesExternalConstructedArityMismatch(
+        ExternalConstructedArityShape shape)
+    {
+        using var stream = new MemoryStream(
+            BuildExternalConstructedArityImage(shape));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Theory]
+    [InlineData(VarianceOwnerKind.Interface)]
+    [InlineData(VarianceOwnerKind.Delegate)]
+    public void SameAssemblyOverrideSlot_AllowsVarianceOnEligibleOwner(
+        VarianceOwnerKind kind)
+    {
+        using var stream = new MemoryStream(
+            BuildVarianceOwnerKindImage(kind));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Theory]
+    [InlineData(VarianceOwnerKind.Class)]
+    [InlineData(VarianceOwnerKind.ImpersonatingDelegate)]
+    public void SameAssemblyOverrideSlot_DeclinesVarianceOnIneligibleOwner(
+        VarianceOwnerKind kind)
+    {
+        using var stream = new MemoryStream(
+            BuildVarianceOwnerKindImage(kind));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void PropertyDeclaration_UsesUniquePropertyAssociationForAccessor()
+    {
+        Assert.Equal(
+            "public",
+            ResolveDuplicateAssociationAccessibility(
+                DuplicatePropertyAssociationShape.Unique));
+    }
+
+    [Theory]
+    [InlineData(DuplicatePropertyAssociationShape.DecoyFirst)]
+    [InlineData(DuplicatePropertyAssociationShape.DecoyLast)]
+    public void PropertyDeclaration_DeclinesAccessorClaimedByMultipleProperties(
+        DuplicatePropertyAssociationShape shape)
+    {
+        // Both row orders answer the same way: the accessor's association is
+        // not unique, so the base property's accessibility is not adopted.
+        Assert.Equal(
+            "protected",
+            ResolveDuplicateAssociationAccessibility(shape));
+    }
+
+    static string ResolveDuplicateAssociationAccessibility(
+        DuplicatePropertyAssociationShape shape)
+    {
+        using var stream = new MemoryStream(
+            BuildDuplicatePropertyAssociationImage(shape));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        TypeDefinitionHandle derivedHandle =
+            reader.TypeDefinitions.Single(handle =>
+                reader.GetString(
+                    reader.GetTypeDefinition(handle).Name)
+                == "Derived");
+        TypeDefinition derived =
+            reader.GetTypeDefinition(derivedHandle);
+
+        return MetadataDeclarationQuery.GetProperty(
+                reader,
+                derived,
+                GetProperty(derived, "Value", reader))
+            .Accessibility;
+    }
+
+    const string BranchingAncestryWorkerVariable =
+        "DOTNET_INSPECT_BRANCHING_ANCESTRY_WORKER";
+
+    public enum ReferenceConstraintAuthenticationShape
+    {
+        FlagOnly,
+        FlagWithValidConstraint,
+        FlagWithDegradedConstraint,
+    }
+
+    /// <summary>
+    /// Builds <c>Derived&lt;T&gt; : Base</c> whose <c>T Value()</c> -- or
+    /// <c>T[] Value()</c> -- carries a class <c>MethodImpl</c> onto a base slot
+    /// returning <c>object</c> (or <c>object[]</c>), with <c>T</c> always
+    /// carrying the reference-type flag and the requested constraint set
+    /// beside it. Only reference-ness authorizes either conversion, so a
+    /// constraint the shared budget cannot decode is malformed evidence about
+    /// the very parameter the answer rests on.
+    /// </summary>
+    static byte[] BuildReferenceConstraintAuthenticationImage(
+        ReferenceConstraintAuthenticationShape shape,
+        bool arrayReturn)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("ReferenceConstraintAuthentication");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(metadata, "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+        GenericParameterHandle parameter =
+            metadata.AddGenericParameter(
+                derivedType,
+                GenericParameterAttributes.ReferenceTypeConstraint,
+                metadata.GetOrAddString("T"),
+                index: 0);
+        switch (shape)
+        {
+            case ReferenceConstraintAuthenticationShape
+                .FlagWithValidConstraint:
+                metadata.AddGenericParameterConstraint(parameter, animal);
+                break;
+            case ReferenceConstraintAuthenticationShape
+                .FlagWithDegradedConstraint:
+                metadata.AddGenericParameterConstraint(
+                    parameter,
+                    AddSyntheticOverDeepArrayTypeSpec(
+                        metadata,
+                        animal,
+                        depth: SignatureBlobGuard.DefaultMaxDepth + 64));
+                break;
+        }
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticObjectReturnSignature(metadata, arrayReturn),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                arrayReturn
+                    ? AddSyntheticGenericParameterArrayReturnSignature(
+                        metadata)
+                    : AddSyntheticGenericParameterReturnSignature(metadata),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    public enum ObjectReturnConversionShape
+    {
+        ExactLocalReference,
+        ModifiedLocalReference,
+        AmbiguousLocalReference,
+    }
+
+    /// <summary>
+    /// Builds <c>Derived : Base</c> whose <c>Animal Value()</c> carries a class
+    /// <c>MethodImpl</c> onto a base slot returning plain <c>object</c>. The
+    /// shape wraps that return in a custom modifier the declaration cannot
+    /// carry, or adds a second <c>Animal</c> definition so the return no longer
+    /// resolves to a unique current-image definition.
+    /// </summary>
+    static byte[] BuildObjectReturnConversionImage(
+        ObjectReturnConversionShape shape)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("ObjectReturnConversion");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(metadata, "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+        TypeReferenceHandle modifierType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString(
+                    "System.Runtime.CompilerServices"),
+                metadata.GetOrAddString("IsVolatile"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        if (shape == ObjectReturnConversionShape.AmbiguousLocalReference)
+        {
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        }
+
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticObjectReturnSignature(
+                    metadata,
+                    wrapInArray: false),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                shape == ObjectReturnConversionShape.ModifiedLocalReference
+                    ? AddSyntheticModifiedReturnSignature(
+                        metadata,
+                        modifierType,
+                        animal)
+                    : AddSyntheticMethodSignature(metadata, animal),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    public enum SupertypeRoleShape
+    {
+        ValidInterfaceImplementation,
+        InterfaceImplementationNamesClass,
+        BaseTypeNamesInterface,
+    }
+
+    /// <summary>
+    /// Builds <c>Derived : Base</c> whose <c>Dog Value()</c> carries a class
+    /// <c>MethodImpl</c> onto a base slot whose declared return is only
+    /// reachable through one same-image supertype row of <c>Dog</c>. The shape
+    /// controls whether that row's target is the kind the row claims: an
+    /// interface reached through <c>InterfaceImpl</c>, a class written into
+    /// <c>InterfaceImpl</c>, or an interface written into <c>Extends</c>.
+    /// </summary>
+    static byte[] BuildSupertypeRoleImage(SupertypeRoleShape shape)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("SupertypeRole");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(metadata, "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle contract =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public
+                    | TypeAttributes.Interface
+                    | TypeAttributes.Abstract,
+                default,
+                metadata.GetOrAddString("IContract"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                shape == SupertypeRoleShape.BaseTypeNamesInterface
+                    ? contract
+                    : objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        if (shape != SupertypeRoleShape.BaseTypeNamesInterface)
+        {
+            metadata.AddInterfaceImplementation(
+                dog,
+                shape == SupertypeRoleShape
+                    .InterfaceImplementationNamesClass
+                    ? animal
+                    : contract);
+        }
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticMethodSignature(
+                    metadata,
+                    shape == SupertypeRoleShape
+                        .InterfaceImplementationNamesClass
+                        ? animal
+                        : contract),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticMethodSignature(metadata, dog),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    public enum OverrideSignatureHeaderShape
+    {
+        SourceDeclarable,
+        VarArg,
+        ExplicitThis,
+        MissingHasThis,
+    }
+
+    static byte SignatureHeaderByte(OverrideSignatureHeaderShape shape)
+        => shape switch
+        {
+            // HASTHIS | VARARG
+            OverrideSignatureHeaderShape.VarArg => 0x25,
+            // HASTHIS | EXPLICITTHIS | DEFAULT
+            OverrideSignatureHeaderShape.ExplicitThis => 0x60,
+            // DEFAULT with no HASTHIS
+            OverrideSignatureHeaderShape.MissingHasThis => 0x00,
+            _ => 0x20,
+        };
+
+    /// <summary>
+    /// Builds <c>Derived : Base</c> where both <c>Animal Value()</c>
+    /// signatures carry the same calling-convention header, so a refusal can
+    /// only come from that header not being one a source <c>override</c> can
+    /// declare -- never from the two sides disagreeing.
+    /// </summary>
+    static byte[] BuildOverrideSignatureHeaderImage(
+        OverrideSignatureHeaderShape shape)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("OverrideSignatureHeader");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(metadata, "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        BlobHandle signature = AddSyntheticRawHeaderReturnSignature(
+            metadata,
+            SignatureHeaderByte(shape),
+            animal);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Value"),
+            signature,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Virtual,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Value"),
+            signature,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    /// <summary>
+    /// Builds <c>Derived : object</c> declaring a virtual, non-newslot
+    /// <c>ToString</c> whose calling-convention header follows
+    /// <paramref name="shape"/>. The base reference carries a real core-library
+    /// public-key token, so the object root authenticates and the header is the
+    /// only thing under test.
+    /// </summary>
+    static byte[] BuildObjectIntrinsicSignatureHeaderImage(
+        OverrideSignatureHeaderShape shape)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("ObjectIntrinsicSignatureHeader");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticCoreLibraryReference(metadata);
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("Derived"),
+            objectType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public
+                | MethodAttributes.Virtual
+                | MethodAttributes.HideBySig,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("ToString"),
+            AddSyntheticRawHeaderStringReturnSignature(
+                metadata,
+                SignatureHeaderByte(shape)),
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    public enum ExternalConstructedArityShape
+    {
+        MatchingArity,
+        MismatchedArgumentCount,
+        MismatchedEncodedCount,
+    }
+
+    /// <summary>
+    /// Builds <c>Derived : Base</c> whose returns are constructions of an
+    /// external generic definition this image cannot resolve. A matching
+    /// construction stays eligible for compiler validation; a construction
+    /// whose argument count disagrees with the other side, or with the arity
+    /// its own encoded definition name declares, is structurally a different
+    /// type and needs no resolution to disprove.
+    /// </summary>
+    static byte[] BuildExternalConstructedArityImage(
+        ExternalConstructedArityShape shape)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("ExternalConstructedArity");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(metadata, "System.Runtime");
+        AssemblyReferenceHandle external =
+            AddSyntheticAssemblyReference(metadata, "ExternalContracts");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+        TypeReferenceHandle externalGeneric =
+            metadata.AddTypeReference(
+                external,
+                metadata.GetOrAddString("External"),
+                metadata.GetOrAddString(
+                    shape == ExternalConstructedArityShape
+                        .MismatchedEncodedCount
+                        ? "Variant`2"
+                        : "Variant`1"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                animal,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericReturnSignature(
+                    metadata,
+                    externalGeneric,
+                    animal),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                shape == ExternalConstructedArityShape
+                    .MismatchedArgumentCount
+                    ? AddSyntheticGenericReturnSignature(
+                        metadata,
+                        externalGeneric,
+                        dog,
+                        animal)
+                    : AddSyntheticGenericReturnSignature(
+                        metadata,
+                        externalGeneric,
+                        dog),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    public enum VarianceOwnerKind
+    {
+        Interface,
+        Delegate,
+        Class,
+        ImpersonatingDelegate,
+    }
+
+    /// <summary>
+    /// Builds <c>Derived : Base</c> whose <c>Variant&lt;Dog&gt; Value()</c>
+    /// carries a class <c>MethodImpl</c> onto <c>Variant&lt;Animal&gt;
+    /// Value()</c>, where <c>Variant`1</c>'s single type parameter is always
+    /// marked covariant and only the owning definition's kind changes. A class
+    /// may not declare variance at all, and delegate-ness counts only when the
+    /// base resolves through an authenticated core library, so a local type
+    /// merely named <c>System.MulticastDelegate</c> does not buy it.
+    /// </summary>
+    static byte[] BuildVarianceOwnerKindImage(VarianceOwnerKind kind)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("VarianceOwnerKind");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticCoreLibraryReference(metadata);
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+        TypeReferenceHandle multicastDelegate =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("MulticastDelegate"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle impersonatingDelegate =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("MulticastDelegate"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle variant =
+            metadata.AddTypeDefinition(
+                kind == VarianceOwnerKind.Interface
+                    ? TypeAttributes.Public
+                        | TypeAttributes.Interface
+                        | TypeAttributes.Abstract
+                    : TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Variant`1"),
+                kind switch
+                {
+                    VarianceOwnerKind.Interface => default,
+                    VarianceOwnerKind.Delegate => multicastDelegate,
+                    VarianceOwnerKind.ImpersonatingDelegate =>
+                        impersonatingDelegate,
+                    _ => objectType,
+                },
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                animal,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        metadata.AddGenericParameter(
+            variant,
+            GenericParameterAttributes.Covariant,
+            metadata.GetOrAddString("T"),
+            index: 0);
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericReturnSignature(
+                    metadata,
+                    variant,
+                    animal),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericReturnSignature(
+                    metadata,
+                    variant,
+                    dog),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    public enum DuplicatePropertyAssociationShape
+    {
+        Unique,
+        DecoyFirst,
+        DecoyLast,
+    }
+
+    /// <summary>
+    /// Builds <c>Derived : Base</c> where <c>Base.Value</c> pairs a public
+    /// getter with a protected setter and <c>Derived</c> overrides the setter
+    /// alone. The reconstructed property is then as accessible as the base
+    /// property -- public -- but only while the overridden accessor's property
+    /// association is unique. The decoy shapes add a second <c>Base</c>
+    /// property claiming that same setter, in either metadata row order. That
+    /// decoy is public in its own right, so taking the first matching row
+    /// answers <c>public</c> in both orders while a unique association is
+    /// genuinely absent.
+    /// </summary>
+    static byte[] BuildDuplicatePropertyAssociationImage(
+        DuplicatePropertyAssociationShape shape)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("DuplicatePropertyAssociation");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(metadata, "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(4));
+
+        BlobHandle getterSignature =
+            AddSyntheticMethodSignature(metadata, animal);
+        BlobHandle setterSignature =
+            AddSyntheticMethodSignature(
+                metadata,
+                default,
+                animal,
+                parameterCount: 1);
+        const MethodAttributes accessorFlags =
+            MethodAttributes.Virtual
+            | MethodAttributes.SpecialName
+            | MethodAttributes.HideBySig;
+        MethodDefinitionHandle baseGetter =
+            metadata.AddMethodDefinition(
+                MethodAttributes.Public
+                    | MethodAttributes.NewSlot
+                    | accessorFlags,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("get_Value"),
+                getterSignature,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle baseSetter =
+            metadata.AddMethodDefinition(
+                MethodAttributes.Family
+                    | MethodAttributes.NewSlot
+                    | accessorFlags,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("set_Value"),
+                setterSignature,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+
+        // Declared in every shape so the three images differ only in their
+        // property rows: the decoy pairs this public getter with the very
+        // setter Derived overrides, which is what makes first-row-wins visible.
+        MethodDefinitionHandle shadowGetter =
+            metadata.AddMethodDefinition(
+                MethodAttributes.Public | accessorFlags,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("get_Shadow"),
+                getterSignature,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedSetter =
+            metadata.AddMethodDefinition(
+                MethodAttributes.Family | accessorFlags,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("set_Value"),
+                setterSignature,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+
+        BlobHandle propertySignature =
+            AddSyntheticClassPropertySignature(metadata, animal);
+        var decoyProperties = new List<PropertyDefinitionHandle>();
+        PropertyDefinitionHandle firstBaseProperty = default;
+        if (shape == DuplicatePropertyAssociationShape.DecoyFirst)
+        {
+            firstBaseProperty =
+                metadata.AddProperty(
+                    PropertyAttributes.None,
+                    metadata.GetOrAddString("Shadow"),
+                    propertySignature);
+            decoyProperties.Add(firstBaseProperty);
+        }
+
+        PropertyDefinitionHandle baseProperty =
+            metadata.AddProperty(
+                PropertyAttributes.None,
+                metadata.GetOrAddString("Value"),
+                propertySignature);
+        if (firstBaseProperty.IsNil)
+            firstBaseProperty = baseProperty;
+        if (shape == DuplicatePropertyAssociationShape.DecoyLast)
+        {
+            decoyProperties.Add(
+                metadata.AddProperty(
+                    PropertyAttributes.None,
+                    metadata.GetOrAddString("Shadow"),
+                    propertySignature));
+        }
+
+        PropertyDefinitionHandle derivedProperty =
+            metadata.AddProperty(
+                PropertyAttributes.None,
+                metadata.GetOrAddString("Value"),
+                propertySignature);
+        metadata.AddPropertyMap(baseType, firstBaseProperty);
+        metadata.AddPropertyMap(derivedType, derivedProperty);
+
+        // The decoy claims the very accessor Derived overrides, so the base
+        // property the walk would adopt is no longer uniquely determined. Its
+        // semantics rows are emitted in property-row order so the shapes differ
+        // only in which row the reader reaches first.
+        void AddBaseSemantics()
+        {
+            metadata.AddMethodSemantics(
+                baseProperty,
+                MethodSemanticsAttributes.Getter,
+                baseGetter);
+            metadata.AddMethodSemantics(
+                baseProperty,
+                MethodSemanticsAttributes.Setter,
+                baseSetter);
+        }
+
+        void AddDecoySemantics()
+        {
+            foreach (PropertyDefinitionHandle decoy in decoyProperties)
+            {
+                metadata.AddMethodSemantics(
+                    decoy,
+                    MethodSemanticsAttributes.Getter,
+                    shadowGetter);
+                metadata.AddMethodSemantics(
+                    decoy,
+                    MethodSemanticsAttributes.Setter,
+                    baseSetter);
+            }
+        }
+
+        if (shape == DuplicatePropertyAssociationShape.DecoyFirst)
+        {
+            AddDecoySemantics();
+            AddBaseSemantics();
+        }
+        else
+        {
+            AddBaseSemantics();
+            AddDecoySemantics();
+        }
+
+        metadata.AddMethodSemantics(
+            derivedProperty,
+            MethodSemanticsAttributes.Setter,
+            derivedSetter);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static AssemblyReferenceHandle AddSyntheticCoreLibraryReference(
+        MetadataBuilder metadata)
+        => metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Runtime"),
+            new Version(1, 0, 0, 0),
+            default,
+            metadata.GetOrAddBlob(
+                new byte[]
+                {
+                    0xb0, 0x3f, 0x5f, 0x7f, 0x11, 0xd5, 0x0a, 0x3a,
+                }),
+            default,
+            default);
+
+    /// <summary>
+    /// A parameterless instance method signature returning
+    /// <c>ELEMENT_TYPE_OBJECT</c>, optionally as an SZ array. Encoding the
+    /// primitive element type is what makes the return a plain <c>object</c>
+    /// rather than a named reference to <c>System.Object</c>.
+    /// </summary>
+    static BlobHandle AddSyntheticObjectReturnSignature(
+        MetadataBuilder metadata,
+        bool wrapInArray)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20);
+        signature.WriteCompressedInteger(0);
+        if (wrapInArray)
+            signature.WriteByte(0x1d);
+        signature.WriteByte(0x1c);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticModifiedReturnSignature(
+        MetadataBuilder metadata,
+        EntityHandle modifierType,
+        EntityHandle returnType)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x20);
+        WriteTypeDefOrRefEncoded(signature, modifierType);
+        WriteReferenceTypeSignature(signature, returnType);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    /// <summary>
+    /// A parameterless method signature whose calling-convention header byte is
+    /// written verbatim, so a test can encode the vararg, explicit-<c>this</c>,
+    /// and missing-<c>HASTHIS</c> headers no C# compiler emits for an override.
+    /// </summary>
+    static BlobHandle AddSyntheticRawHeaderReturnSignature(
+        MetadataBuilder metadata,
+        byte header,
+        EntityHandle returnType)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(header);
+        signature.WriteCompressedInteger(0);
+        WriteReferenceTypeSignature(signature, returnType);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticRawHeaderStringReturnSignature(
+        MetadataBuilder metadata,
+        byte header)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(header);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x0e);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticClassPropertySignature(
+        MetadataBuilder metadata,
+        EntityHandle type)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x28);
+        signature.WriteCompressedInteger(0);
+        WriteReferenceTypeSignature(signature, type);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    /// <summary>
+    /// A <c>TypeSpec</c> for <c>Definition&lt;Pair&lt;!0, !0&gt;&gt;</c>, which
+    /// as a base row makes every ancestry step square the size of the previous
+    /// instantiation rather than merely producing a new one.
+    /// </summary>
+    static TypeSpecificationHandle
+        AddSyntheticBranchingSelfInstantiationTypeSpec(
+            MetadataBuilder metadata,
+            EntityHandle definition,
+            EntityHandle pair)
+    {
+        var blob = new BlobBuilder();
+        GenericTypeArgumentsEncoder pairArguments =
+            new BlobEncoder(blob)
+                .TypeSpecificationSignature()
+                .GenericInstantiation(
+                    definition,
+                    genericArgumentCount: 1,
+                    isValueType: false)
+                .AddArgument()
+                .GenericInstantiation(
+                    pair,
+                    genericArgumentCount: 2,
+                    isValueType: false);
+        pairArguments.AddArgument().GenericTypeParameter(0);
+        pairArguments.AddArgument().GenericTypeParameter(0);
+        return metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(blob));
+    }
+
     static MetadataBuilder CreateSyntheticMetadata(
         string assemblyName)
     {
@@ -4573,6 +6240,49 @@ public class MetadataDeclarationQueryFixtures
     public class ObjectCovariantReturnDerived : ObjectCovariantReturnBase
     {
         public override string Value() => "";
+    }
+
+    /// <summary>
+    /// A compiler-produced covariant return whose implementation type is an
+    /// unwrapped current-image definition, which is the shape the
+    /// return-to-object conversion has to keep accepting.
+    /// </summary>
+    public class LocalReferenceObjectCovariantReturnDerived
+        : ObjectCovariantReturnBase
+    {
+        public override CovariantDog Value() => new();
+    }
+
+    public interface IExplicitOnlyContract
+    {
+        void Run();
+    }
+
+    /// <summary>
+    /// An explicit interface implementation is a private newslot virtual final
+    /// method plus a <c>MethodImpl</c>, so it carries the row an override
+    /// carries while reusing no inherited class virtual slot.
+    /// </summary>
+    public class ExplicitInterfaceOnlyImplementation
+        : IExplicitOnlyContract
+    {
+        void IExplicitOnlyContract.Run()
+        {
+        }
+    }
+
+    public class PlainVirtualBase
+    {
+        public virtual void Run()
+        {
+        }
+    }
+
+    public class PlainOverrideDerived : PlainVirtualBase
+    {
+        public override void Run()
+        {
+        }
     }
 
     public class ConstructedGenericCovariantReturnBase<TItem>

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -536,6 +536,339 @@ public sealed class MetadataDeclarationQueryTests
                 methodHandle));
     }
 
+    /// <summary>
+    /// The all-<c>TypeDef</c> control for
+    /// <see cref="SameAssemblyOverrideSlot_AuthenticatesCovariantReturnThroughConstructedGenericAncestry"/>:
+    /// the same compiler-produced covariant-return shape whose returned type
+    /// reaches the declared return through direct <c>TypeDef</c> base rows,
+    /// which authenticates both before and after constructed-generic ancestry
+    /// exists.
+    /// </summary>
+    [Fact]
+    public void SameAssemblyOverrideSlot_AuthenticatesDirectCovariantReturnThroughTypeDefAncestry()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.CovariantReturnDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+        var dog = Reader.GetTypeDefinition(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures.CovariantDog)));
+
+        Assert.Equal(HandleKind.TypeDefinition, dog.BaseType.Kind);
+        Assert.Empty(dog.GetInterfaceImplementations());
+        Assert.Equal(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures.CovariantAnimal)),
+            (TypeDefinitionHandle)dog.BaseType);
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.Equal(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures.CovariantReturnBase)),
+            slot.DeclaringType);
+    }
+
+    /// <summary>
+    /// Covariant-return ancestry is a metadata walk, not a <c>TypeDef</c>
+    /// walk. <c>Dog : Middle&lt;int&gt; : Animal</c> reaches its declared
+    /// return only through a constructed generic step, and the all-<c>TypeDef</c>
+    /// control for the same authentication is
+    /// <see cref="SameAssemblyOverrideSlot_AuthenticatesDirectCovariantReturnThroughTypeDefAncestry"/>.
+    /// </summary>
+    [Fact]
+    public void SameAssemblyOverrideSlot_AuthenticatesCovariantReturnThroughConstructedGenericAncestry()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .ConstructedAncestryCovariantReturnDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+        var method = Reader.GetMethodDefinition(methodHandle);
+        var implementation = Assert.Single(
+            derived.GetMethodImplementations()
+                .Select(Reader.GetMethodImplementation),
+            candidate => candidate.MethodBody == methodHandle);
+
+        // The shape this gate exists for: the compiler emits the covariant
+        // return as NewSlot plus a MethodImpl, and writes the returned type's
+        // own base as a TypeSpec, so its ancestry is invisible to a TypeDef
+        // walk.
+        Assert.True((method.Attributes & MethodAttributes.NewSlot) != 0);
+        Assert.Equal(
+            HandleKind.MethodDefinition,
+            implementation.MethodDeclaration.Kind);
+        Assert.Equal(
+            HandleKind.TypeSpecification,
+            Reader.GetTypeDefinition(
+                GetTypeDefinitionHandle(
+                    typeof(MetadataDeclarationQueryFixtures
+                        .CovariantDogThroughConstructedMiddle)))
+                .BaseType.Kind);
+
+        var declaration =
+            MetadataDeclarationQuery.GetMethod(Reader, derived, method);
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.True(declaration.IsOverride);
+        Assert.Equal(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures
+                    .ConstructedAncestryCovariantReturnBase)),
+            slot.DeclaringType);
+        Assert.Equal(
+            (MethodDefinitionHandle)implementation.MethodDeclaration,
+            slot.Method);
+    }
+
+    /// <summary>
+    /// The same walk carries interface ancestry, and carries each step's exact
+    /// arguments into it: <c>Middle&lt;TValue&gt;</c> implements
+    /// <c>ICovariantContract&lt;TValue&gt;</c> through a <c>TypeSpec</c>, so
+    /// only substituting <c>int</c> proves the declared
+    /// <c>ICovariantContract&lt;int&gt;</c> return.
+    /// </summary>
+    [Fact]
+    public void SameAssemblyOverrideSlot_AuthenticatesCovariantInterfaceReturnThroughConstructedGenericAncestry()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .ConstructedAncestryCovariantReturnDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Contract");
+        var middle = Reader.GetTypeDefinition(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures
+                    .CovariantConstructedMiddle<>)));
+
+        Assert.Equal(
+            HandleKind.TypeSpecification,
+            Reader.GetInterfaceImplementation(
+                Assert.Single(middle.GetInterfaceImplementations()))
+                .Interface.Kind);
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.Equal(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures
+                    .ConstructedAncestryCovariantReturnBase)),
+            slot.DeclaringType);
+    }
+
+    /// <summary>
+    /// The non-vacuity control for
+    /// <see cref="SameAssemblyOverrideSlot_DeclinesConstructedGenericAncestryWithDifferentArgument"/>:
+    /// the two images differ only in the argument the returned type's
+    /// constructed base carries.
+    /// </summary>
+    [Fact]
+    public void SameAssemblyOverrideSlot_AuthenticatesConstructedGenericAncestryWithMatchingArgument()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructedGenericAncestryImage(
+                ConstructedGenericAncestryShape.MatchingArgument));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.Equal(
+            "Base",
+            reader.GetString(
+                reader.GetTypeDefinition(slot.DeclaringType).Name));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesConstructedGenericAncestryWithDifferentArgument()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructedGenericAncestryImage(
+                ConstructedGenericAncestryShape.DifferentArgument));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        // Dog : Middle<Animal> is not a Middle<Dog>; ancestry may not erase
+        // the instantiation to the definition it instantiates.
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_CyclicConstructedAncestryFailsClosed()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructedGenericAncestryImage(
+                ConstructedGenericAncestryShape.Cyclic));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_ExpandingConstructedAncestryFailsClosedWithinBudget()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructedGenericAncestryImage(
+                ConstructedGenericAncestryShape.Expanding));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        // Middle<T> : Middle<Middle<T>> never repeats an instantiation, so
+        // only the node cap and the comparison budget can answer at all.
+        var elapsed = System.Diagnostics.Stopwatch.StartNew();
+        var slot = MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+            reader,
+            derivedHandle,
+            methodHandle);
+        elapsed.Stop();
+
+        Assert.Null(slot);
+        Assert.True(
+            elapsed.Elapsed < TimeSpan.FromSeconds(30),
+            $"Bounded ancestry traversal took {elapsed.Elapsed}.");
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsValidOnlyExplicitConstraintSet()
+    {
+        using var stream = new MemoryStream(
+            BuildDegradedConstraintSetImage(
+                DegradedConstraintSetShape.ValidOnly));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.Equal(
+            "Base",
+            reader.GetString(
+                reader.GetTypeDefinition(slot.DeclaringType).Name));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesDegradedOnlyConstraint()
+    {
+        using var stream = new MemoryStream(
+            BuildDegradedConstraintSetImage(
+                DegradedConstraintSetShape.DegradedOnly));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        AssertDegradedConstraintIsUndecodable(reader);
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    /// <summary>
+    /// Malformed current-image constraint evidence is sticky across the whole
+    /// constraint set, so a valid constraint that would otherwise authenticate
+    /// cannot rescue it, in either metadata order. The valid constraint alone
+    /// authenticates in
+    /// <see cref="SameAssemblyOverrideSlot_AllowsValidOnlyExplicitConstraintSet"/>.
+    /// </summary>
+    [Theory]
+    [InlineData(DegradedConstraintSetShape.DegradedFirst)]
+    [InlineData(DegradedConstraintSetShape.ValidFirst)]
+    public void SameAssemblyOverrideSlot_DeclinesMixedDegradedAndValidConstraintSet(
+        DegradedConstraintSetShape shape)
+    {
+        using var stream = new MemoryStream(
+            BuildDegradedConstraintSetImage(shape));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        AssertDegradedConstraintIsUndecodable(reader);
+        Assert.Equal(
+            2,
+            reader.GetGenericParameter(
+                reader.GetTypeDefinition(derivedHandle)
+                    .GetGenericParameters()
+                    .Single())
+                .GetConstraints()
+                .Count);
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    /// <summary>
+    /// Proves the degraded constraint really reaches the fail-closed path
+    /// rather than being declined for some unrelated reason: its
+    /// <c>TypeSpec</c> is over-deep, so the shared signature guard refuses to
+    /// decode it and the constraint can only decode as degraded.
+    /// </summary>
+    static void AssertDegradedConstraintIsUndecodable(MetadataReader reader)
+    {
+        TypeSpecificationHandle constraintSpec = Assert.Single(
+            reader.GetGenericParameter(
+                reader.TypeDefinitions
+                    .Select(reader.GetTypeDefinition)
+                    .Single(type =>
+                        reader.GetString(type.Name) == "Derived")
+                    .GetGenericParameters()
+                    .Single())
+                .GetConstraints()
+                .Select(handle =>
+                    reader.GetGenericParameterConstraint(handle).Type)
+                .Where(type => type.Kind == HandleKind.TypeSpecification)
+                .Select(type => (TypeSpecificationHandle)type));
+
+        Assert.False(
+            SignatureBlobGuard.IsSafeToDecode(
+                reader,
+                reader.GetTypeSpecification(constraintSpec).Signature,
+                SignatureBlobGuard.Kind.TypeSpecification));
+    }
+
     [Fact]
     public void SameAssemblyOverrideSlot_WideGenericParameterDagFailsClosedWithinBudget()
     {
@@ -1675,6 +2008,331 @@ public sealed class MetadataDeclarationQueryTests
     {
         Chain,
         Dag,
+    }
+
+    enum ConstructedGenericAncestryShape
+    {
+        MatchingArgument,
+        DifferentArgument,
+        Cyclic,
+        Expanding,
+    }
+
+    /// <summary>
+    /// Builds <c>Derived : Base</c> whose <c>Dog Value()</c> carries a class
+    /// <c>MethodImpl</c> onto a base slot, where the only ancestry evidence for
+    /// the covariant return runs through <c>Dog</c>'s own constructed generic
+    /// base. The shape controls that base and the declared return, so a
+    /// definition-only ancestry answer and an instantiation-exact one differ:
+    /// <see cref="ConstructedGenericAncestryShape.MatchingArgument"/> declares
+    /// <c>Middle&lt;Dog&gt;</c> against <c>Dog : Middle&lt;Dog&gt;</c> and
+    /// <see cref="ConstructedGenericAncestryShape.DifferentArgument"/> declares
+    /// the same return against <c>Dog : Middle&lt;Animal&gt;</c>. The remaining
+    /// shapes declare an unreachable <c>Animal</c> return over a cyclic and an
+    /// endlessly expanding base chain.
+    /// </summary>
+    static byte[] BuildConstructedGenericAncestryImage(
+        ConstructedGenericAncestryShape shape)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("ConstructedGenericAncestry");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(metadata, "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        // TypeSpec rows have to name types whose definitions are added later,
+        // so the row numbers are fixed up front and checked on the way out.
+        TypeDefinitionHandle animal =
+            MetadataTokens.TypeDefinitionHandle(2);
+        TypeDefinitionHandle middle =
+            MetadataTokens.TypeDefinitionHandle(3);
+        TypeDefinitionHandle dog =
+            MetadataTokens.TypeDefinitionHandle(4);
+
+        EntityHandle middleBase = shape switch
+        {
+            ConstructedGenericAncestryShape.Cyclic => dog,
+            ConstructedGenericAncestryShape.Expanding =>
+                AddSyntheticNestedSelfInstantiationTypeSpec(
+                    metadata,
+                    middle),
+            _ => objectType,
+        };
+        EntityHandle dogBase = AddSyntheticConstructedTypeSpec(
+            metadata,
+            middle,
+            shape == ConstructedGenericAncestryShape.DifferentArgument
+                ? animal
+                : dog);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        Assert.Equal(
+            animal,
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1)));
+        Assert.Equal(
+            middle,
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Middle`1"),
+                middleBase,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1)));
+        Assert.Equal(
+            dog,
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                dogBase,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1)));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        metadata.AddGenericParameter(
+            middle,
+            GenericParameterAttributes.None,
+            metadata.GetOrAddString("T"),
+            index: 0);
+
+        BlobHandle declaredReturn = shape
+            is ConstructedGenericAncestryShape.MatchingArgument
+            or ConstructedGenericAncestryShape.DifferentArgument
+            ? AddSyntheticGenericReturnSignature(metadata, middle, dog)
+            : AddSyntheticMethodSignature(metadata, animal);
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                declaredReturn,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticMethodSignature(metadata, dog),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    /// <summary>
+    /// The shapes of one generic parameter's constraint set: a valid explicit
+    /// constraint that proves the covariant return, an over-deep
+    /// <c>TypeSpec</c> constraint the shared signature guard refuses to decode,
+    /// and both together in either metadata order.
+    /// </summary>
+    public enum DegradedConstraintSetShape
+    {
+        ValidOnly,
+        DegradedOnly,
+        DegradedFirst,
+        ValidFirst,
+    }
+
+    /// <summary>
+    /// Builds <c>Derived&lt;T&gt; : Base</c> whose <c>T Value()</c> carries a
+    /// class <c>MethodImpl</c> onto <c>Animal Value()</c>, with <c>T</c>
+    /// constrained by the requested mix of a valid <c>Dog</c> constraint and an
+    /// undecodable over-deep <c>TypeSpec</c> constraint.
+    /// </summary>
+    static byte[] BuildDegradedConstraintSetImage(
+        DegradedConstraintSetShape shape)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata("DegradedConstraintSet");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(metadata, "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                animal,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+        GenericParameterHandle parameter =
+            metadata.AddGenericParameter(
+                derivedType,
+                GenericParameterAttributes.None,
+                metadata.GetOrAddString("T"),
+                index: 0);
+
+        foreach (bool degraded in ConstraintOrder(shape))
+        {
+            metadata.AddGenericParameterConstraint(
+                parameter,
+                degraded
+                    ? AddSyntheticOverDeepArrayTypeSpec(
+                        metadata,
+                        animal,
+                        depth: SignatureBlobGuard.DefaultMaxDepth + 64)
+                    : dog);
+        }
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticMethodSignature(metadata, animal),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericParameterReturnSignature(metadata),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static IEnumerable<bool> ConstraintOrder(
+        DegradedConstraintSetShape shape)
+        => shape switch
+        {
+            DegradedConstraintSetShape.ValidOnly => [false],
+            DegradedConstraintSetShape.DegradedOnly => [true],
+            DegradedConstraintSetShape.DegradedFirst => [true, false],
+            _ => [false, true],
+        };
+
+    /// <summary>
+    /// A <c>TypeSpec</c> nesting <paramref name="depth"/> SZ arrays around
+    /// <paramref name="elementType"/>, which exceeds
+    /// <see cref="SignatureBlobGuard.DefaultMaxDepth"/> so every guarded decode
+    /// of it degrades.
+    /// </summary>
+    static TypeSpecificationHandle AddSyntheticOverDeepArrayTypeSpec(
+        MetadataBuilder metadata,
+        EntityHandle elementType,
+        int depth)
+    {
+        var blob = new BlobBuilder();
+        SignatureTypeEncoder encoder =
+            new BlobEncoder(blob).TypeSpecificationSignature();
+        for (int index = 0; index < depth; index++)
+            encoder = encoder.SZArray();
+        encoder.Type(elementType, isValueType: false);
+        return metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(blob));
+    }
+
+    /// <summary>
+    /// A <c>TypeSpec</c> for <c>Definition&lt;Definition&lt;!0&gt;&gt;</c>,
+    /// which as a base row makes every ancestry step produce a new
+    /// instantiation that no visited set can ever repeat.
+    /// </summary>
+    static TypeSpecificationHandle
+        AddSyntheticNestedSelfInstantiationTypeSpec(
+            MetadataBuilder metadata,
+            EntityHandle definition)
+    {
+        var blob = new BlobBuilder();
+        new BlobEncoder(blob)
+            .TypeSpecificationSignature()
+            .GenericInstantiation(
+                definition,
+                genericArgumentCount: 1,
+                isValueType: false)
+            .AddArgument()
+            .GenericInstantiation(
+                definition,
+                genericArgumentCount: 1,
+                isValueType: false)
+            .AddArgument()
+            .GenericTypeParameter(0);
+        return metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(blob));
     }
 
     /// <summary>
@@ -3951,6 +4609,44 @@ public class MetadataDeclarationQueryFixtures
         : ConstructedGenericSubstitutionBase<string>
     {
         public override string Describe(string value) => value;
+    }
+
+    public interface ICovariantContract<TValue>
+    {
+    }
+
+    public class CovariantConstructedMiddle<TValue>
+        : CovariantAnimal, ICovariantContract<TValue>
+    {
+    }
+
+    /// <summary>
+    /// Roslyn writes this base as a <c>TypeSpec</c>, so every path from this
+    /// type to <see cref="CovariantAnimal"/> and to
+    /// <c>ICovariantContract&lt;int&gt;</c> runs through a constructed generic
+    /// step. An ancestry walk restricted to <c>TypeDef</c> rows sees neither.
+    /// </summary>
+    public class CovariantDogThroughConstructedMiddle
+        : CovariantConstructedMiddle<int>
+    {
+    }
+
+    public class ConstructedAncestryCovariantReturnBase
+    {
+        public virtual CovariantAnimal Value() => new();
+
+        public virtual ICovariantContract<int> Contract() =>
+            new CovariantConstructedMiddle<int>();
+    }
+
+    public class ConstructedAncestryCovariantReturnDerived
+        : ConstructedAncestryCovariantReturnBase
+    {
+        public override CovariantDogThroughConstructedMiddle Value() =>
+            new();
+
+        public override CovariantDogThroughConstructedMiddle Contract() =>
+            new();
     }
 
     public class SameImageObjectSlotBase

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -286,6 +286,36 @@ public sealed class MetadataDeclarationQueryTests
         Assert.Equal((MethodDefinitionHandle)implementation.MethodDeclaration, slot.Method);
     }
 
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsReferenceConstrainedGenericCovariantMethodImpl()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.GenericCovariantReturnDerived<>));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+        var method = Reader.GetMethodDefinition(methodHandle);
+        var implementation = Assert.Single(
+            derived.GetMethodImplementations().Select(Reader.GetMethodImplementation),
+            candidate => candidate.MethodBody == methodHandle);
+
+        Assert.True((method.Attributes & MethodAttributes.NewSlot) != 0);
+        Assert.Equal(HandleKind.MethodDefinition, implementation.MethodDeclaration.Kind);
+
+        var declaration = MetadataDeclarationQuery.GetMethod(Reader, derived, method);
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.True(declaration.IsOverride);
+        Assert.False(declaration.IsVirtual);
+        Assert.Equal(
+            GetTypeDefinitionHandle(typeof(MetadataDeclarationQueryFixtures.ObjectCovariantReturnBase)),
+            slot.DeclaringType);
+        Assert.Equal((MethodDefinitionHandle)implementation.MethodDeclaration, slot.Method);
+    }
+
     [Theory]
     [InlineData(
         typeof(MetadataDeclarationQueryFixtures.CovariantPropertyDerived),
@@ -1279,6 +1309,12 @@ public class MetadataDeclarationQueryFixtures
     public class CovariantReturnDerived : CovariantReturnBase
     {
         public override CovariantDog Value() => new();
+    }
+
+    public class GenericCovariantReturnDerived<T> : ObjectCovariantReturnBase
+        where T : class
+    {
+        public override T Value() => default!;
     }
 
     public class CovariantPropertyBase

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -435,6 +435,46 @@ public sealed class MetadataDeclarationQueryTests
         }
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SameAssemblyOverrideSlot_DeclinesIncompatibleStructuredReturn(
+        bool arrayReturn)
+    {
+        string path =
+            EmitIncompatibleStructuredReturnOverride(
+                arrayReturn);
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            var derivedHandle =
+                reader.TypeDefinitions.Single(handle =>
+                    reader.GetString(
+                        reader.GetTypeDefinition(handle).Name)
+                    == "Derived");
+            var derived =
+                reader.GetTypeDefinition(derivedHandle);
+            var methodHandle =
+                derived.GetMethods().Single(handle =>
+                    reader.GetString(
+                        reader.GetMethodDefinition(handle).Name)
+                    == "Value");
+
+            Assert.Null(
+                MetadataDeclarationQuery
+                    .GetSameAssemblyOverrideSlot(
+                        reader,
+                        derivedHandle,
+                        methodHandle));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
     [Fact]
     public void StaticAbstractInterfaceMethod_IsNotClassifiedAsOverride()
     {
@@ -965,6 +1005,80 @@ public sealed class MetadataDeclarationQueryTests
         derivedType.CreateType();
 
         string path = Path.Combine(Path.GetTempPath(), $"IncompatibleReturnOverride-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitIncompatibleStructuredReturnOverride(
+        bool arrayReturn)
+    {
+        var assemblyName = new AssemblyName(
+            "IncompatibleStructuredReturnOverride");
+        var assembly = new PersistedAssemblyBuilder(
+            assemblyName,
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(
+            assemblyName.Name!);
+
+        Type first = module
+            .DefineType("First", TypeAttributes.Public)
+            .CreateType();
+        Type second = module
+            .DefineType("Second", TypeAttributes.Public)
+            .CreateType();
+        Type baseReturn;
+        Type derivedReturn;
+        if (arrayReturn)
+        {
+            baseReturn = first.MakeArrayType();
+            derivedReturn = second.MakeArrayType();
+        }
+        else
+        {
+            var boxBuilder = module.DefineType(
+                "Box`1",
+                TypeAttributes.Public);
+            boxBuilder.DefineGenericParameters("T");
+            Type box = boxBuilder.CreateType();
+            baseReturn = box.MakeGenericType(first);
+            derivedReturn = box.MakeGenericType(second);
+        }
+
+        var baseBuilder = module.DefineType(
+            "Base",
+            TypeAttributes.Public);
+        var baseMethod = baseBuilder.DefineMethod(
+            "Value",
+            MethodAttributes.Public
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot,
+            baseReturn,
+            Type.EmptyTypes);
+        baseMethod.GetILGenerator().Emit(OpCodes.Ldnull);
+        baseMethod.GetILGenerator().Emit(OpCodes.Ret);
+        Type baseType = baseBuilder.CreateType();
+
+        var derivedBuilder = module.DefineType(
+            "Derived",
+            TypeAttributes.Public,
+            baseType);
+        var derivedMethod = derivedBuilder.DefineMethod(
+            "Value",
+            MethodAttributes.Public
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot,
+            derivedReturn,
+            Type.EmptyTypes);
+        derivedMethod.GetILGenerator().Emit(OpCodes.Ldnull);
+        derivedMethod.GetILGenerator().Emit(OpCodes.Ret);
+        derivedBuilder.DefineMethodOverride(
+            derivedMethod,
+            baseMethod);
+        derivedBuilder.CreateType();
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"IncompatibleStructuredReturnOverride-{Guid.NewGuid():N}.dll");
         assembly.Save(path);
         return path;
     }

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -287,6 +287,62 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void SameAssemblyOverrideSlot_AuthenticatesCompilerProducedScopedParameterIdentity()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.ScopedParameterCovariantReturnDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.Equal(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures.ScopedParameterCovariantReturnBase)),
+            slot.DeclaringType);
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesSameFqnReturnFromDifferentAssemblies()
+    {
+        using var stream = new MemoryStream(
+            BuildScopedSignatureCollisionImage(
+                ScopedSignatureCollision.CrossAssemblyReturn));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesNestedVsNamespaceParameter()
+    {
+        using var stream = new MemoryStream(
+            BuildScopedSignatureCollisionImage(
+                ScopedSignatureCollision.NestedVsNamespaceParameter));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
     public void SameAssemblyOverrideSlot_AllowsReferenceConstrainedGenericCovariantMethodImpl()
     {
         var derivedHandle = GetTypeDefinitionHandle(
@@ -314,6 +370,215 @@ public sealed class MetadataDeclarationQueryTests
             GetTypeDefinitionHandle(typeof(MetadataDeclarationQueryFixtures.ObjectCovariantReturnBase)),
             slot.DeclaringType);
         Assert.Equal((MethodDefinitionHandle)implementation.MethodDeclaration, slot.Method);
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesReferenceConstrainedGenericToArbitraryClass()
+    {
+        using var stream = new MemoryStream(
+            BuildGenericParameterCovarianceImage(
+                referenceTypeConstraint: true,
+                explicitConstraint: GenericConstraintTarget.None,
+                baseReturnsDog: false));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsExplicitGenericBaseConstraint()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.ExplicitConstraintCovariantReturnDerived<>));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.Equal(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures.AnimalCovariantReturnBase)),
+            slot.DeclaringType);
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsCovariantConstructedConstraint()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructedConstraintImage(
+                GenericParameterAttributes.Covariant));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesInvariantConstructedConstraint()
+    {
+        using var stream = new MemoryStream(
+            BuildConstructedConstraintImage(
+                GenericParameterAttributes.None));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesExplicitConstraintThatDoesNotReachReturn()
+    {
+        using var stream = new MemoryStream(
+            BuildGenericParameterCovarianceImage(
+                referenceTypeConstraint: false,
+                explicitConstraint: GenericConstraintTarget.Animal,
+                baseReturnsDog: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsCompilerProducedNestedGenericVariance()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.NestedVariantReturnDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SameAssemblyOverrideSlot_UsesExactNestedGenericVarianceDefinition(
+        bool nestedIsCovariant)
+    {
+        using var stream = new MemoryStream(
+            BuildNestedVarianceCollisionImage(
+                nestedIsCovariant));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        MetadataOverrideSlot? slot =
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle);
+
+        Assert.Equal(nestedIsCovariant, slot is not null);
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesAmbiguousExactLocalGenericDefinition()
+    {
+        using var stream = new MemoryStream(
+            BuildNestedVarianceCollisionImage(
+                nestedIsCovariant: true,
+                duplicateExactDefinition: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesArrayWrappedAmbiguousExactLocalGenericDefinition()
+    {
+        using var stream = new MemoryStream(
+            BuildNestedVarianceCollisionImage(
+                nestedIsCovariant: true,
+                duplicateExactDefinition: true,
+                wrapReturnsInArray: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsCompilerProducedExternalGenericCovariance()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.ExternalGenericCovariantReturnDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Values");
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SameAssemblyOverrideSlot_DoesNotUseLocalVarianceForExternalGeneric(
+        bool localShadowIsCovariant)
+    {
+        using var stream = new MemoryStream(
+            BuildExternalGenericShadowImage(
+                localShadowIsCovariant));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
     }
 
     [Theory]
@@ -739,6 +1004,883 @@ public sealed class MetadataDeclarationQueryTests
         Assert.True(exact.HasRequiredModifier("System.Runtime.CompilerServices", "IsVolatile"));
         Assert.False(wrongNamespace.HasRequiredModifier("System.Runtime.CompilerServices", "IsVolatile"));
         Assert.False(globalNamespace.HasRequiredModifier("System.Runtime.CompilerServices", "IsVolatile"));
+    }
+
+    enum ScopedSignatureCollision
+    {
+        CrossAssemblyReturn,
+        NestedVsNamespaceParameter,
+    }
+
+    enum GenericConstraintTarget
+    {
+        None,
+        Animal,
+        Dog,
+    }
+
+    static (
+        TypeDefinitionHandle Derived,
+        MethodDefinitionHandle Method)
+        GetSyntheticDerivedMethod(MetadataReader reader)
+    {
+        TypeDefinitionHandle derived =
+            reader.TypeDefinitions.Single(handle =>
+                reader.GetString(
+                    reader.GetTypeDefinition(handle).Name)
+                == "Derived");
+        return (
+            derived,
+            Assert.Single(
+                reader.GetTypeDefinition(derived).GetMethods()));
+    }
+
+    static byte[] BuildScopedSignatureCollisionImage(
+        ScopedSignatureCollision collision)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata(
+                "ScopedSignatureCollision");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+        AssemblyReferenceHandle firstAssembly =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "CollisionA");
+        AssemblyReferenceHandle secondAssembly =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "CollisionB");
+
+        EntityHandle baseReturn = default;
+        EntityHandle derivedReturn = default;
+        EntityHandle baseParameter = default;
+        EntityHandle derivedParameter = default;
+        int parameterCount = 0;
+        if (collision
+            == ScopedSignatureCollision.CrossAssemblyReturn)
+        {
+            baseReturn = metadata.AddTypeReference(
+                firstAssembly,
+                metadata.GetOrAddString("Collision"),
+                metadata.GetOrAddString("Value"));
+            derivedReturn = metadata.AddTypeReference(
+                secondAssembly,
+                metadata.GetOrAddString("Collision"),
+                metadata.GetOrAddString("Value"));
+        }
+        else
+        {
+            TypeReferenceHandle outer =
+                metadata.AddTypeReference(
+                    firstAssembly,
+                    metadata.GetOrAddString("Collision"),
+                    metadata.GetOrAddString("Outer"));
+            baseParameter = metadata.AddTypeReference(
+                firstAssembly,
+                metadata.GetOrAddString(
+                    "Collision.Outer"),
+                metadata.GetOrAddString("Value"));
+            derivedParameter = metadata.AddTypeReference(
+                outer,
+                default,
+                metadata.GetOrAddString("Value"));
+            parameterCount = 1;
+        }
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        BlobHandle baseSignature =
+            AddSyntheticMethodSignature(
+                metadata,
+                baseReturn,
+                baseParameter,
+                parameterCount);
+        BlobHandle derivedSignature =
+            AddSyntheticMethodSignature(
+                metadata,
+                derivedReturn,
+                derivedParameter,
+                parameterCount);
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                baseSignature,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                derivedSignature,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static byte[] BuildConstructedConstraintImage(
+        GenericParameterAttributes variance)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata(
+                "InvariantConstructedConstraint");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                animal,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle invariant =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public
+                    | TypeAttributes.Interface
+                    | TypeAttributes.Abstract,
+                default,
+                metadata.GetOrAddString("IInvariant`1"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddGenericParameter(
+            invariant,
+            variance,
+            metadata.GetOrAddString("TValue"),
+            index: 0);
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+        GenericParameterHandle parameter =
+            metadata.AddGenericParameter(
+                derivedType,
+                GenericParameterAttributes.None,
+                metadata.GetOrAddString("T"),
+                index: 0);
+        TypeSpecificationHandle dogContainer =
+            AddSyntheticGenericTypeSpecification(
+                metadata,
+                invariant,
+                dog);
+        metadata.AddGenericParameterConstraint(
+            parameter,
+            dogContainer);
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericReturnSignature(
+                    metadata,
+                    invariant,
+                    animal),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericParameterReturnSignature(
+                    metadata),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static byte[] BuildGenericParameterCovarianceImage(
+        bool referenceTypeConstraint,
+        GenericConstraintTarget explicitConstraint,
+        bool baseReturnsDog)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata(
+                "GenericParameterCovariance");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                animal,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        GenericParameterHandle parameter =
+            metadata.AddGenericParameter(
+                derivedType,
+                referenceTypeConstraint
+                    ? GenericParameterAttributes
+                        .ReferenceTypeConstraint
+                    : GenericParameterAttributes.None,
+                metadata.GetOrAddString("T"),
+                index: 0);
+        EntityHandle explicitConstraintType =
+            explicitConstraint switch
+            {
+                GenericConstraintTarget.Animal => animal,
+                GenericConstraintTarget.Dog => dog,
+                _ => default,
+            };
+        if (!explicitConstraintType.IsNil)
+        {
+            metadata.AddGenericParameterConstraint(
+                parameter,
+                explicitConstraintType);
+        }
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticMethodSignature(
+                    metadata,
+                    baseReturnsDog ? dog : animal),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericParameterReturnSignature(
+                    metadata),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static byte[] BuildNestedVarianceCollisionImage(
+        bool nestedIsCovariant,
+        bool duplicateExactDefinition = false,
+        bool wrapReturnsInArray = false)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata(
+                "NestedVarianceCollision");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle flattenedDecoy =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public
+                    | TypeAttributes.Interface
+                    | TypeAttributes.Abstract,
+                metadata.GetOrAddString(
+                    "Collision.Outer"),
+                metadata.GetOrAddString("Variant`2"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle outer =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("Collision"),
+                metadata.GetOrAddString("Outer`1"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle nested =
+            metadata.AddTypeDefinition(
+                TypeAttributes.NestedPublic
+                    | TypeAttributes.Interface
+                    | TypeAttributes.Abstract,
+                default,
+                metadata.GetOrAddString("Variant`1"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddNestedType(nested, outer);
+        TypeDefinitionHandle duplicateNested =
+            duplicateExactDefinition
+                ? metadata.AddTypeDefinition(
+                    TypeAttributes.NestedPublic
+                        | TypeAttributes.Interface
+                        | TypeAttributes.Abstract,
+                    default,
+                    metadata.GetOrAddString("Variant`1"),
+                    default,
+                    MetadataTokens.FieldDefinitionHandle(1),
+                    MetadataTokens.MethodDefinitionHandle(1))
+                : default;
+        if (!duplicateNested.IsNil)
+            metadata.AddNestedType(duplicateNested, outer);
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                animal,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        metadata.AddGenericParameter(
+            flattenedDecoy,
+            GenericParameterAttributes.None,
+            metadata.GetOrAddString("TOuter"),
+            index: 0);
+        metadata.AddGenericParameter(
+            flattenedDecoy,
+            nestedIsCovariant
+                ? GenericParameterAttributes.None
+                : GenericParameterAttributes.Covariant,
+            metadata.GetOrAddString("TValue"),
+            index: 1);
+        metadata.AddGenericParameter(
+            outer,
+            GenericParameterAttributes.None,
+            metadata.GetOrAddString("TOuter"),
+            index: 0);
+        metadata.AddGenericParameter(
+            nested,
+            GenericParameterAttributes.None,
+            metadata.GetOrAddString("TOuter"),
+            index: 0);
+        metadata.AddGenericParameter(
+            nested,
+            nestedIsCovariant
+                ? GenericParameterAttributes.Covariant
+                : GenericParameterAttributes.None,
+            metadata.GetOrAddString("TValue"),
+            index: 1);
+        if (!duplicateNested.IsNil)
+        {
+            metadata.AddGenericParameter(
+                duplicateNested,
+                GenericParameterAttributes.None,
+                metadata.GetOrAddString("TOuter"),
+                index: 0);
+            metadata.AddGenericParameter(
+                duplicateNested,
+                GenericParameterAttributes.Covariant,
+                metadata.GetOrAddString("TValue"),
+                index: 1);
+        }
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                wrapReturnsInArray
+                    ? AddSyntheticGenericArrayReturnSignature(
+                        metadata,
+                        nested,
+                        objectType,
+                        animal)
+                    : AddSyntheticGenericReturnSignature(
+                        metadata,
+                        nested,
+                        objectType,
+                        animal),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                wrapReturnsInArray
+                    ? AddSyntheticGenericArrayReturnSignature(
+                        metadata,
+                        nested,
+                        objectType,
+                        dog)
+                    : AddSyntheticGenericReturnSignature(
+                        metadata,
+                        nested,
+                        objectType,
+                        dog),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static byte[] BuildExternalGenericShadowImage(
+        bool localShadowIsCovariant)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata(
+                "ExternalGenericShadow");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "System.Runtime");
+        AssemblyReferenceHandle external =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "ExternalContracts");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+        TypeReferenceHandle externalVariant =
+            metadata.AddTypeReference(
+                external,
+                metadata.GetOrAddString("External"),
+                metadata.GetOrAddString("Variant`1"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle localShadow =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public
+                    | TypeAttributes.Interface
+                    | TypeAttributes.Abstract,
+                metadata.GetOrAddString("External"),
+                metadata.GetOrAddString("Variant`1"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                animal,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+        metadata.AddGenericParameter(
+            localShadow,
+            localShadowIsCovariant
+                ? GenericParameterAttributes.Covariant
+                : GenericParameterAttributes.None,
+            metadata.GetOrAddString("T"),
+            index: 0);
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericReturnSignature(
+                    metadata,
+                    externalVariant,
+                    animal),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericReturnSignature(
+                    metadata,
+                    externalVariant,
+                    dog),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static MetadataBuilder CreateSyntheticMetadata(
+        string assemblyName)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString(
+                $"{assemblyName}.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(assemblyName),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        return metadata;
+    }
+
+    static AssemblyReferenceHandle AddSyntheticAssemblyReference(
+        MetadataBuilder metadata,
+        string name)
+        => metadata.AddAssemblyReference(
+            metadata.GetOrAddString(name),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+
+    static BlobHandle AddSyntheticMethodSignature(
+        MetadataBuilder metadata,
+        EntityHandle returnType,
+        EntityHandle parameterType = default,
+        int parameterCount = 0)
+    {
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                parameterCount,
+                encoder =>
+                {
+                    if (returnType.IsNil)
+                        encoder.Void();
+                    else
+                    {
+                        encoder.Type().Type(
+                            returnType,
+                            isValueType: false);
+                    }
+                },
+                parameters =>
+                {
+                    if (parameterCount != 0)
+                    {
+                        parameters
+                            .AddParameter()
+                            .Type()
+                            .Type(
+                                parameterType,
+                                isValueType: false);
+                    }
+                });
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticGenericParameterReturnSignature(
+        MetadataBuilder metadata)
+    {
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                0,
+                returnType => returnType
+                    .Type()
+                    .GenericTypeParameter(0),
+                _ => { });
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticGenericReturnSignature(
+        MetadataBuilder metadata,
+        EntityHandle genericType,
+        params EntityHandle[] arguments)
+    {
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                0,
+                returnType =>
+                {
+                    GenericTypeArgumentsEncoder encodedArguments =
+                        returnType
+                            .Type()
+                            .GenericInstantiation(
+                                genericType,
+                                arguments.Length,
+                                isValueType: false);
+                    foreach (EntityHandle argument
+                        in arguments)
+                    {
+                        encodedArguments
+                            .AddArgument()
+                            .Type(
+                                argument,
+                                isValueType: false);
+                    }
+                },
+                _ => { });
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticGenericArrayReturnSignature(
+        MetadataBuilder metadata,
+        EntityHandle genericType,
+        params EntityHandle[] arguments)
+    {
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                0,
+                returnType =>
+                {
+                    GenericTypeArgumentsEncoder encodedArguments =
+                        returnType
+                            .Type()
+                            .SZArray()
+                            .GenericInstantiation(
+                                genericType,
+                                arguments.Length,
+                                isValueType: false);
+                    foreach (EntityHandle argument
+                        in arguments)
+                    {
+                        encodedArguments
+                            .AddArgument()
+                            .Type(
+                                argument,
+                                isValueType: false);
+                    }
+                },
+                _ => { });
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static TypeSpecificationHandle AddSyntheticGenericTypeSpecification(
+        MetadataBuilder metadata,
+        EntityHandle genericType,
+        params EntityHandle[] arguments)
+    {
+        var signature = new BlobBuilder();
+        GenericTypeArgumentsEncoder encodedArguments =
+            new BlobEncoder(signature)
+                .TypeSpecificationSignature()
+                .GenericInstantiation(
+                    genericType,
+                    arguments.Length,
+                    isValueType: false);
+        foreach (EntityHandle argument in arguments)
+        {
+            encodedArguments
+                .AddArgument()
+                .Type(
+                    argument,
+                    isValueType: false);
+        }
+        return metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(signature));
+    }
+
+    static byte[] SerializeSyntheticMetadata(
+        MetadataBuilder metadata)
+    {
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(
+                metadata,
+                suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
     }
 
     static string EmitMethodWithoutParamRow()
@@ -1311,10 +2453,77 @@ public class MetadataDeclarationQueryFixtures
         public override CovariantDog Value() => new();
     }
 
+    public class ScopedParameterCovariantReturnBase
+    {
+        public virtual CovariantAnimal Value(
+            CovariantAnimal input) => input;
+    }
+
+    public class ScopedParameterCovariantReturnDerived
+        : ScopedParameterCovariantReturnBase
+    {
+        public override CovariantDog Value(
+            CovariantAnimal input) => new();
+    }
+
     public class GenericCovariantReturnDerived<T> : ObjectCovariantReturnBase
         where T : class
     {
         public override T Value() => default!;
+    }
+
+    public class AnimalCovariantReturnBase
+    {
+        public virtual CovariantAnimal Value() => new();
+    }
+
+    public class ExplicitConstraintCovariantReturnDerived<T>
+        : AnimalCovariantReturnBase
+        where T : CovariantDog
+    {
+        public override T Value() => default!;
+    }
+
+    public class VariantOuter<TOuter>
+    {
+        public interface IProducer<out TValue>
+        {
+        }
+
+        public sealed class Producer<TValue>
+            : IProducer<TValue>
+        {
+        }
+    }
+
+    public class NestedVariantReturnBase
+    {
+        public virtual VariantOuter<int>
+            .IProducer<CovariantAnimal> Value() =>
+            new VariantOuter<int>
+                .Producer<CovariantAnimal>();
+    }
+
+    public class NestedVariantReturnDerived
+        : NestedVariantReturnBase
+    {
+        public override VariantOuter<int>
+            .IProducer<CovariantDog> Value() =>
+            new VariantOuter<int>
+                .Producer<CovariantDog>();
+    }
+
+    public class ExternalGenericCovariantReturnBase
+    {
+        public virtual System.Collections.Generic
+            .IEnumerable<CovariantAnimal> Values() => [];
+    }
+
+    public class ExternalGenericCovariantReturnDerived
+        : ExternalGenericCovariantReturnBase
+    {
+        public override System.Collections.Generic
+            .IEnumerable<CovariantDog> Values() => [];
     }
 
     public class CovariantPropertyBase

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -119,6 +119,20 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void PropertyDeclaration_DerivesPropertyAccessibilityAcrossAcyclicSetterOnlyOverrideChain()
+    {
+        var type = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures.SetterOnlyOverrideLeaf));
+        var property = GetProperty(type, "Value");
+
+        var declaration = MetadataDeclarationQuery.GetProperty(Reader, type, property);
+
+        Assert.Equal("public", declaration.Accessibility);
+        var setter = Assert.Single(declaration.Signature.Accessors);
+        Assert.Equal("set", setter.Kind);
+        Assert.Equal("protected", setter.Accessibility);
+    }
+
+    [Fact]
     public void SameAssemblyOverrideSlot_PreservesNonPublicSourceDeclarationFacts()
     {
         var derivedHandle = GetTypeDefinitionHandle(
@@ -413,6 +427,68 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void SameAssemblyOverrideSlot_AllowsExplicitClassConstrainedGenericArrayCovariance()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.ExplicitConstraintArrayCovariantReturnDerived<>));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Values");
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.Equal(
+            GetTypeDefinitionHandle(
+                typeof(MetadataDeclarationQueryFixtures.AnimalArrayCovariantReturnBase)),
+            slot.DeclaringType);
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesInterfaceConstrainedGenericArrayCovariance()
+    {
+        using var stream = new MemoryStream(
+            BuildGenericParameterCovarianceImage(
+                referenceTypeConstraint: false,
+                explicitConstraint: GenericConstraintTarget.Interface,
+                baseReturnsDog: false,
+                wrapReturnInArray: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesArrayCovarianceWhenExplicitConstraintDoesNotReachReturn()
+    {
+        using var stream = new MemoryStream(
+            BuildGenericParameterCovarianceImage(
+                referenceTypeConstraint: false,
+                explicitConstraint: GenericConstraintTarget.Animal,
+                baseReturnsDog: true,
+                wrapReturnInArray: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
     public void SameAssemblyOverrideSlot_AllowsCovariantConstructedConstraint()
     {
         using var stream = new MemoryStream(
@@ -546,6 +622,65 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void SameAssemblyOverrideSlot_AllowsModifierWrappedExactLocalGenericCovariance()
+    {
+        using var stream = new MemoryStream(
+            BuildNestedVarianceCollisionImage(
+                nestedIsCovariant: true,
+                wrapReturnsInOptionalModifier: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesModifierWrappedAmbiguousExactLocalGenericDefinition()
+    {
+        using var stream = new MemoryStream(
+            BuildNestedVarianceCollisionImage(
+                nestedIsCovariant: true,
+                duplicateExactDefinition: true,
+                wrapReturnsInOptionalModifier: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesPinnedWrappedAmbiguousExactLocalGenericDefinition()
+    {
+        using var stream = new MemoryStream(
+            BuildNestedVarianceCollisionImage(
+                nestedIsCovariant: true,
+                duplicateExactDefinition: true,
+                wrapReturnsPinned: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
     public void SameAssemblyOverrideSlot_AllowsCompilerProducedExternalGenericCovariance()
     {
         var derivedHandle = GetTypeDefinitionHandle(
@@ -575,6 +710,39 @@ public sealed class MetadataDeclarationQueryTests
             GetSyntheticDerivedMethod(reader);
 
         Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsCompilerProducedExternalConstructedConstraintVariance()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.ExternalConstructedConstraintCovariantReturnDerived<>));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Values");
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesExternalConstructedConstraintForNonGenericCandidate()
+    {
+        using var stream = new MemoryStream(
+            BuildExternalConstructedConstraintImage(
+                genericCandidate: false));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
             MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
                 reader,
                 derivedHandle,
@@ -615,6 +783,48 @@ public sealed class MetadataDeclarationQueryTests
 
         Assert.True(declaration.IsOverride);
         Assert.False(declaration.IsVirtual);
+    }
+
+    [Fact]
+    public void PropertyDeclaration_SelfBasePropertyCycleFailsClosed()
+    {
+        using var stream = new MemoryStream(
+            BuildPropertyOverrideCycleImage(
+                PropertyOverrideCycleKind.SelfBase));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "Loop");
+        var type = reader.GetTypeDefinition(typeHandle);
+        var property = GetProperty(type, "Value", reader);
+
+        var declaration = MetadataDeclarationQuery.GetProperty(
+            reader,
+            type,
+            property);
+
+        Assert.Equal("protected", declaration.Accessibility);
+    }
+
+    [Fact]
+    public void PropertyDeclaration_TwoTypePropertyCycleFailsClosed()
+    {
+        using var stream = new MemoryStream(
+            BuildPropertyOverrideCycleImage(
+                PropertyOverrideCycleKind.TwoTypeCycle));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name) == "First");
+        var type = reader.GetTypeDefinition(typeHandle);
+        var property = GetProperty(type, "Value", reader);
+
+        var declaration = MetadataDeclarationQuery.GetProperty(
+            reader,
+            type,
+            property);
+
+        Assert.Equal("protected", declaration.Accessibility);
     }
 
     [Fact]
@@ -768,6 +978,42 @@ public sealed class MetadataDeclarationQueryTests
         {
             File.Delete(path);
         }
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsMultiDimensionalArrayCovarianceWhenShapeMatches()
+    {
+        using var stream = new MemoryStream(
+            BuildMultiDimensionalArrayCovarianceImage(
+                differentShape: false));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.NotNull(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesDifferentMultiDimensionalArrayShape()
+    {
+        using var stream = new MemoryStream(
+            BuildMultiDimensionalArrayCovarianceImage(
+                differentShape: true));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (derivedHandle, methodHandle) =
+            GetSyntheticDerivedMethod(reader);
+
+        Assert.Null(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
     }
 
     [Fact]
@@ -1017,6 +1263,13 @@ public sealed class MetadataDeclarationQueryTests
         None,
         Animal,
         Dog,
+        Interface,
+    }
+
+    enum PropertyOverrideCycleKind
+    {
+        SelfBase,
+        TwoTypeCycle,
     }
 
     static (
@@ -1277,7 +1530,8 @@ public sealed class MetadataDeclarationQueryTests
     static byte[] BuildGenericParameterCovarianceImage(
         bool referenceTypeConstraint,
         GenericConstraintTarget explicitConstraint,
-        bool baseReturnsDog)
+        bool baseReturnsDog,
+        bool wrapReturnInArray = false)
     {
         MetadataBuilder metadata =
             CreateSyntheticMetadata(
@@ -1315,6 +1569,16 @@ public sealed class MetadataDeclarationQueryTests
                 animal,
                 MetadataTokens.FieldDefinitionHandle(1),
                 MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle markerInterface =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public
+                    | TypeAttributes.Interface
+                    | TypeAttributes.Abstract,
+                default,
+                metadata.GetOrAddString("IConstraint"),
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
         TypeDefinitionHandle baseType =
             metadata.AddTypeDefinition(
                 TypeAttributes.Public,
@@ -1346,6 +1610,7 @@ public sealed class MetadataDeclarationQueryTests
             {
                 GenericConstraintTarget.Animal => animal,
                 GenericConstraintTarget.Dog => dog,
+                GenericConstraintTarget.Interface => markerInterface,
                 _ => default,
             };
         if (!explicitConstraintType.IsNil)
@@ -1364,9 +1629,13 @@ public sealed class MetadataDeclarationQueryTests
                 attributes,
                 MethodImplAttributes.IL,
                 metadata.GetOrAddString("Value"),
-                AddSyntheticMethodSignature(
-                    metadata,
-                    baseReturnsDog ? dog : animal),
+                wrapReturnInArray
+                    ? AddSyntheticArrayReturnSignature(
+                        metadata,
+                        baseReturnsDog ? dog : animal)
+                    : AddSyntheticMethodSignature(
+                        metadata,
+                        baseReturnsDog ? dog : animal),
                 bodyOffset: -1,
                 MetadataTokens.ParameterHandle(1));
         MethodDefinitionHandle derivedMethod =
@@ -1374,8 +1643,11 @@ public sealed class MetadataDeclarationQueryTests
                 attributes,
                 MethodImplAttributes.IL,
                 metadata.GetOrAddString("Value"),
-                AddSyntheticGenericParameterReturnSignature(
-                    metadata),
+                wrapReturnInArray
+                    ? AddSyntheticGenericParameterArrayReturnSignature(
+                        metadata)
+                    : AddSyntheticGenericParameterReturnSignature(
+                        metadata),
                 bodyOffset: -1,
                 MetadataTokens.ParameterHandle(1));
         metadata.AddMethodImplementation(
@@ -1388,7 +1660,9 @@ public sealed class MetadataDeclarationQueryTests
     static byte[] BuildNestedVarianceCollisionImage(
         bool nestedIsCovariant,
         bool duplicateExactDefinition = false,
-        bool wrapReturnsInArray = false)
+        bool wrapReturnsInArray = false,
+        bool wrapReturnsInOptionalModifier = false,
+        bool wrapReturnsPinned = false)
     {
         MetadataBuilder metadata =
             CreateSyntheticMetadata(
@@ -1402,6 +1676,11 @@ public sealed class MetadataDeclarationQueryTests
                 runtime,
                 metadata.GetOrAddString("System"),
                 metadata.GetOrAddString("Object"));
+        TypeReferenceHandle modifierType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System.Runtime.CompilerServices"),
+                metadata.GetOrAddString("IsVolatile"));
 
         metadata.AddTypeDefinition(
             default,
@@ -1539,17 +1818,9 @@ public sealed class MetadataDeclarationQueryTests
                 attributes,
                 MethodImplAttributes.IL,
                 metadata.GetOrAddString("Value"),
-                wrapReturnsInArray
-                    ? AddSyntheticGenericArrayReturnSignature(
-                        metadata,
-                        nested,
-                        objectType,
-                        animal)
-                    : AddSyntheticGenericReturnSignature(
-                        metadata,
-                        nested,
-                        objectType,
-                        animal),
+                CreateNestedVarianceReturnSignature(
+                    objectType,
+                    animal),
                 bodyOffset: -1,
                 MetadataTokens.ParameterHandle(1));
         MethodDefinitionHandle derivedMethod =
@@ -1557,17 +1828,9 @@ public sealed class MetadataDeclarationQueryTests
                 attributes,
                 MethodImplAttributes.IL,
                 metadata.GetOrAddString("Value"),
-                wrapReturnsInArray
-                    ? AddSyntheticGenericArrayReturnSignature(
-                        metadata,
-                        nested,
-                        objectType,
-                        dog)
-                    : AddSyntheticGenericReturnSignature(
-                        metadata,
-                        nested,
-                        objectType,
-                        dog),
+                CreateNestedVarianceReturnSignature(
+                    objectType,
+                    dog),
                 bodyOffset: -1,
                 MetadataTokens.ParameterHandle(1));
         metadata.AddMethodImplementation(
@@ -1575,6 +1838,43 @@ public sealed class MetadataDeclarationQueryTests
             derivedMethod,
             baseMethod);
         return SerializeSyntheticMetadata(metadata);
+
+        BlobHandle CreateNestedVarianceReturnSignature(
+            EntityHandle outerArgument,
+            EntityHandle valueArgument)
+        {
+            if (wrapReturnsInOptionalModifier)
+            {
+                return AddSyntheticModifiedGenericReturnSignature(
+                    metadata,
+                    modifierType,
+                    isRequired: false,
+                    nested,
+                    outerArgument,
+                    valueArgument);
+            }
+
+            if (wrapReturnsPinned)
+            {
+                return AddSyntheticPinnedGenericReturnSignature(
+                    metadata,
+                    nested,
+                    outerArgument,
+                    valueArgument);
+            }
+
+            return wrapReturnsInArray
+                ? AddSyntheticGenericArrayReturnSignature(
+                    metadata,
+                    nested,
+                    outerArgument,
+                    valueArgument)
+                : AddSyntheticGenericReturnSignature(
+                    metadata,
+                    nested,
+                    outerArgument,
+                    valueArgument);
+        }
     }
 
     static byte[] BuildExternalGenericShadowImage(
@@ -1689,6 +1989,350 @@ public sealed class MetadataDeclarationQueryTests
             derivedType,
             derivedMethod,
             baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static byte[] BuildExternalConstructedConstraintImage(
+        bool genericCandidate)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata(
+                "ExternalConstructedConstraint");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+        TypeReferenceHandle enumerable =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System.Collections.Generic"),
+                metadata.GetOrAddString("IEnumerable`1"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                animal,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        GenericParameterHandle parameter =
+            metadata.AddGenericParameter(
+                derivedType,
+                GenericParameterAttributes.None,
+                metadata.GetOrAddString("T"),
+                index: 0);
+        metadata.AddGenericParameterConstraint(
+            parameter,
+            AddSyntheticGenericTypeSpecification(
+                metadata,
+                enumerable,
+                dog));
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                genericCandidate
+                    ? AddSyntheticGenericReturnSignature(
+                        metadata,
+                        enumerable,
+                        animal)
+                    : AddSyntheticMethodSignature(
+                        metadata,
+                        animal),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticGenericParameterReturnSignature(
+                    metadata),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static byte[] BuildMultiDimensionalArrayCovarianceImage(
+        bool differentShape)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata(
+                "MdArrayCovariance");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle animal =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Animal"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle dog =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Dog"),
+                animal,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle baseType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Base"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle derivedType =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Derived"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+
+        MethodAttributes attributes =
+            MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        MethodDefinitionHandle baseMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticMdArrayReturnSignature(
+                    metadata,
+                    animal,
+                    rank: 2,
+                    sizes: [4],
+                    lowerBounds: [1]),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        MethodDefinitionHandle derivedMethod =
+            metadata.AddMethodDefinition(
+                attributes,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticMdArrayReturnSignature(
+                    metadata,
+                    dog,
+                    rank: 2,
+                    sizes: [4],
+                    lowerBounds: differentShape
+                        ? [0]
+                        : [1]),
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodImplementation(
+            derivedType,
+            derivedMethod,
+            baseMethod);
+        return SerializeSyntheticMetadata(metadata);
+    }
+
+    static byte[] BuildPropertyOverrideCycleImage(
+        PropertyOverrideCycleKind kind)
+    {
+        MetadataBuilder metadata =
+            CreateSyntheticMetadata(
+                $"PropertyOverrideCycle{kind}");
+        AssemblyReferenceHandle runtime =
+            AddSyntheticAssemblyReference(
+                metadata,
+                "System.Runtime");
+        TypeReferenceHandle objectType =
+            metadata.AddTypeReference(
+                runtime,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        if (kind == PropertyOverrideCycleKind.SelfBase)
+        {
+            ParameterHandle valueParameter =
+                metadata.AddParameter(
+                    ParameterAttributes.None,
+                    metadata.GetOrAddString("value"),
+                    sequenceNumber: 1);
+            TypeDefinitionHandle loop =
+                metadata.AddTypeDefinition(
+                    TypeAttributes.Public,
+                    default,
+                    metadata.GetOrAddString("Loop"),
+                    MetadataTokens.TypeDefinitionHandle(2),
+                    MetadataTokens.FieldDefinitionHandle(1),
+                    MetadataTokens.MethodDefinitionHandle(1));
+            MethodDefinitionHandle setter =
+                metadata.AddMethodDefinition(
+                    MethodAttributes.Family
+                        | MethodAttributes.Virtual
+                        | MethodAttributes.SpecialName
+                        | MethodAttributes.HideBySig,
+                    MethodImplAttributes.IL,
+                    metadata.GetOrAddString("set_Value"),
+                    AddSyntheticSetterSignature(
+                        metadata),
+                    bodyOffset: -1,
+                    valueParameter);
+            PropertyDefinitionHandle property =
+                metadata.AddProperty(
+                    PropertyAttributes.None,
+                    metadata.GetOrAddString("Value"),
+                    AddSyntheticPropertySignature(
+                        metadata));
+            metadata.AddPropertyMap(loop, property);
+            metadata.AddMethodSemantics(
+                property,
+                MethodSemanticsAttributes.Setter,
+                setter);
+            return SerializeSyntheticMetadata(metadata);
+        }
+
+        ParameterHandle firstParameter =
+            metadata.AddParameter(
+                ParameterAttributes.None,
+                metadata.GetOrAddString("value"),
+                sequenceNumber: 1);
+        ParameterHandle secondParameter =
+            metadata.AddParameter(
+                ParameterAttributes.None,
+                metadata.GetOrAddString("value"),
+                sequenceNumber: 1);
+        TypeDefinitionHandle first =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("First"),
+                MetadataTokens.TypeDefinitionHandle(3),
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle second =
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString("Second"),
+                MetadataTokens.TypeDefinitionHandle(2),
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(2));
+        MethodDefinitionHandle firstSetter =
+            metadata.AddMethodDefinition(
+                MethodAttributes.Family
+                    | MethodAttributes.Virtual
+                    | MethodAttributes.SpecialName
+                    | MethodAttributes.HideBySig,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("set_Value"),
+                AddSyntheticSetterSignature(
+                    metadata),
+                bodyOffset: -1,
+                firstParameter);
+        MethodDefinitionHandle secondSetter =
+            metadata.AddMethodDefinition(
+                MethodAttributes.Family
+                    | MethodAttributes.Virtual
+                    | MethodAttributes.SpecialName
+                    | MethodAttributes.HideBySig,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("set_Value"),
+                AddSyntheticSetterSignature(
+                    metadata),
+                bodyOffset: -1,
+                secondParameter);
+        PropertyDefinitionHandle firstProperty =
+            metadata.AddProperty(
+                PropertyAttributes.None,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticPropertySignature(
+                    metadata));
+        PropertyDefinitionHandle secondProperty =
+            metadata.AddProperty(
+                PropertyAttributes.None,
+                metadata.GetOrAddString("Value"),
+                AddSyntheticPropertySignature(
+                    metadata));
+        metadata.AddPropertyMap(first, firstProperty);
+        metadata.AddPropertyMap(second, secondProperty);
+        metadata.AddMethodSemantics(
+            firstProperty,
+            MethodSemanticsAttributes.Setter,
+            firstSetter);
+        metadata.AddMethodSemantics(
+            secondProperty,
+            MethodSemanticsAttributes.Setter,
+            secondSetter);
         return SerializeSyntheticMetadata(metadata);
     }
 
@@ -1841,6 +2485,142 @@ public sealed class MetadataDeclarationQueryTests
                 },
                 _ => { });
         return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticArrayReturnSignature(
+        MetadataBuilder metadata,
+        EntityHandle elementType)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x1d);
+        WriteReferenceTypeSignature(signature, elementType);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticGenericParameterArrayReturnSignature(
+        MetadataBuilder metadata)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x1d);
+        signature.WriteByte(0x13);
+        signature.WriteCompressedInteger(0);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticModifiedGenericReturnSignature(
+        MetadataBuilder metadata,
+        EntityHandle modifierType,
+        bool isRequired,
+        EntityHandle genericType,
+        params EntityHandle[] arguments)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(isRequired ? (byte)0x1f : (byte)0x20);
+        WriteTypeDefOrRefEncoded(signature, modifierType);
+        WriteGenericInstantiation(signature, genericType, arguments);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticPinnedGenericReturnSignature(
+        MetadataBuilder metadata,
+        EntityHandle genericType,
+        params EntityHandle[] arguments)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x45);
+        WriteGenericInstantiation(signature, genericType, arguments);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticMdArrayReturnSignature(
+        MetadataBuilder metadata,
+        EntityHandle elementType,
+        int rank,
+        int[]? sizes = null,
+        int[]? lowerBounds = null)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x14);
+        WriteReferenceTypeSignature(signature, elementType);
+        signature.WriteCompressedInteger(rank);
+        sizes ??= [];
+        lowerBounds ??= [];
+        signature.WriteCompressedInteger(sizes.Length);
+        foreach (int size in sizes)
+            signature.WriteCompressedInteger(size);
+        signature.WriteCompressedInteger(lowerBounds.Length);
+        foreach (int lowerBound in lowerBounds)
+            signature.WriteCompressedSignedInteger(lowerBound);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticSetterSignature(
+        MetadataBuilder metadata)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20);
+        signature.WriteCompressedInteger(1);
+        signature.WriteByte(0x01);
+        signature.WriteByte(0x08);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static BlobHandle AddSyntheticPropertySignature(
+        MetadataBuilder metadata)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x28);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x08);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    static void WriteGenericInstantiation(
+        BlobBuilder signature,
+        EntityHandle genericType,
+        params EntityHandle[] arguments)
+    {
+        signature.WriteByte(0x15);
+        WriteReferenceTypeSignature(signature, genericType);
+        signature.WriteCompressedInteger(arguments.Length);
+        foreach (EntityHandle argument in arguments)
+            WriteReferenceTypeSignature(signature, argument);
+    }
+
+    static void WriteReferenceTypeSignature(
+        BlobBuilder signature,
+        EntityHandle type)
+    {
+        signature.WriteByte(0x12);
+        WriteTypeDefOrRefEncoded(signature, type);
+    }
+
+    static void WriteTypeDefOrRefEncoded(
+        BlobBuilder signature,
+        EntityHandle type)
+    {
+        int tag = type.Kind switch
+        {
+            HandleKind.TypeDefinition => 0,
+            HandleKind.TypeReference => 1,
+            HandleKind.TypeSpecification => 2,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(type),
+                $"Unsupported type handle kind '{type.Kind}'."),
+        };
+        signature.WriteCompressedInteger(
+            (MetadataTokens.GetRowNumber(type) << 2)
+            | tag);
     }
 
     static TypeSpecificationHandle AddSyntheticGenericTypeSpecification(
@@ -2288,11 +3068,17 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     static PropertyDefinition GetProperty(TypeDefinition type, string name)
+        => GetProperty(type, name, Reader);
+
+    static PropertyDefinition GetProperty(
+        TypeDefinition type,
+        string name,
+        MetadataReader reader)
     {
         foreach (var handle in type.GetProperties())
         {
-            var property = Reader.GetPropertyDefinition(handle);
-            if (Reader.GetString(property.Name) == name)
+            var property = reader.GetPropertyDefinition(handle);
+            if (reader.GetString(property.Name) == name)
                 return property;
         }
 
@@ -2435,6 +3221,16 @@ public class MetadataDeclarationQueryFixtures
         }
     }
 
+    public class SetterOnlyOverrideLeaf : SetterOnlyOverrideDerived
+    {
+        public override int Value
+        {
+            protected set
+            {
+            }
+        }
+    }
+
     public class CovariantAnimal
     {
     }
@@ -2484,6 +3280,19 @@ public class MetadataDeclarationQueryFixtures
         public override T Value() => default!;
     }
 
+    public class AnimalArrayCovariantReturnBase
+    {
+        public virtual CovariantAnimal[] Values() =>
+            Array.Empty<CovariantAnimal>();
+    }
+
+    public class ExplicitConstraintArrayCovariantReturnDerived<T>
+        : AnimalArrayCovariantReturnBase
+        where T : CovariantDog
+    {
+        public override T[] Values() => Array.Empty<T>();
+    }
+
     public class VariantOuter<TOuter>
     {
         public interface IProducer<out TValue>
@@ -2524,6 +3333,21 @@ public class MetadataDeclarationQueryFixtures
     {
         public override System.Collections.Generic
             .IEnumerable<CovariantDog> Values() => [];
+    }
+
+    public class ExternalConstructedConstraintCovariantReturnBase
+    {
+        public virtual System.Collections.Generic
+            .IEnumerable<CovariantAnimal> Values() => [];
+    }
+
+    public class ExternalConstructedConstraintCovariantReturnDerived<T>
+        : ExternalConstructedConstraintCovariantReturnBase
+        where T : System.Collections.Generic
+            .List<CovariantDog>
+    {
+        public override T Values() =>
+            throw new NotSupportedException();
     }
 
     public class CovariantPropertyBase

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -24,9 +24,12 @@ public sealed class MetadataDeclarationQueryTests
     public void MethodDeclaration_ExposesAccessibilityModifiersParametersAndReturnAttributes()
     {
         var type = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures));
-        var method = GetMethod(type, "ProtectedVirtual");
+        var methodHandle = GetMethodHandle(type, "ProtectedVirtual");
 
-        var declaration = MetadataDeclarationQuery.GetMethod(Reader, type, method);
+        var declaration = MetadataDeclarationQuery.GetMethod(
+            Reader,
+            type,
+            methodHandle);
 
         Assert.Equal("protected", declaration.Accessibility);
         Assert.True(declaration.IsPublicOrProtected);
@@ -47,9 +50,14 @@ public sealed class MetadataDeclarationQueryTests
     public void MethodDeclaration_ExposesAttributedDecimalDefaults()
     {
         var type = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures));
-        var method = GetMethod(type, nameof(MetadataDeclarationQueryFixtures.DecimalDefault));
+        var methodHandle = GetMethodHandle(
+            type,
+            nameof(MetadataDeclarationQueryFixtures.DecimalDefault));
 
-        var declaration = MetadataDeclarationQuery.GetMethod(Reader, type, method);
+        var declaration = MetadataDeclarationQuery.GetMethod(
+            Reader,
+            type,
+            methodHandle);
 
         var parameter = Assert.Single(declaration.Signature.Parameters);
         Assert.Equal("System.Decimal", parameter.Type);
@@ -69,13 +77,18 @@ public sealed class MetadataDeclarationQueryTests
             var typeHandle = reader.TypeDefinitions.Single(handle =>
                 reader.GetString(reader.GetTypeDefinition(handle).Name) == "MissingParamSample");
             var type = reader.GetTypeDefinition(typeHandle);
-            var method = type.GetMethods()
-                .Select(reader.GetMethodDefinition)
-                .Single(candidate => reader.GetString(candidate.Name) == "Echo");
+            var methodHandle = type.GetMethods()
+                .Single(handle =>
+                    reader.GetString(reader.GetMethodDefinition(handle).Name)
+                    == "Echo");
+            var method = reader.GetMethodDefinition(methodHandle);
 
             Assert.Empty(method.GetParameters());
 
-            var declaration = MetadataDeclarationQuery.GetMethod(reader, type, method);
+            var declaration = MetadataDeclarationQuery.GetMethod(
+                reader,
+                type,
+                methodHandle);
             var parameter = Assert.Single(declaration.Signature.Parameters);
 
             Assert.Equal("arg0", parameter.Name);
@@ -142,7 +155,10 @@ public sealed class MetadataDeclarationQueryTests
         var methodHandle = GetMethodHandle(derived, "Value");
         var method = Reader.GetMethodDefinition(methodHandle);
 
-        var declaration = MetadataDeclarationQuery.GetMethod(Reader, derived, method);
+        var declaration = MetadataDeclarationQuery.GetMethod(
+            Reader,
+            derived,
+            methodHandle);
         var slot = MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
             Reader,
             derivedHandle,
@@ -165,7 +181,7 @@ public sealed class MetadataDeclarationQueryTests
         Assert.True(MetadataDeclarationQuery.GetMethod(
             Reader,
             Reader.GetTypeDefinition(resolvedSlot.DeclaringType),
-            baseMethod).IsVirtual);
+            resolvedSlot.Method).IsVirtual);
         Assert.True(MetadataDeclarationQuery.IsSourceDeclarableVirtualMethod(baseMethod));
     }
 
@@ -286,7 +302,10 @@ public sealed class MetadataDeclarationQueryTests
         Assert.True((method.Attributes & MethodAttributes.NewSlot) != 0);
         Assert.Equal(HandleKind.MethodDefinition, implementation.MethodDeclaration.Kind);
 
-        var declaration = MetadataDeclarationQuery.GetMethod(Reader, derived, method);
+        var declaration = MetadataDeclarationQuery.GetMethod(
+            Reader,
+            derived,
+            methodHandle);
         var slot = Assert.IsType<MetadataOverrideSlot>(
             MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
                 Reader,
@@ -372,7 +391,10 @@ public sealed class MetadataDeclarationQueryTests
         Assert.True((method.Attributes & MethodAttributes.NewSlot) != 0);
         Assert.Equal(HandleKind.MethodDefinition, implementation.MethodDeclaration.Kind);
 
-        var declaration = MetadataDeclarationQuery.GetMethod(Reader, derived, method);
+        var declaration = MetadataDeclarationQuery.GetMethod(
+            Reader,
+            derived,
+            methodHandle);
         var slot = Assert.IsType<MetadataOverrideSlot>(
             MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
                 Reader,
@@ -613,7 +635,10 @@ public sealed class MetadataDeclarationQueryTests
                 .BaseType.Kind);
 
         var declaration =
-            MetadataDeclarationQuery.GetMethod(Reader, derived, method);
+            MetadataDeclarationQuery.GetMethod(
+                Reader,
+                derived,
+                methodHandle);
         var slot = Assert.IsType<MetadataOverrideSlot>(
             MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
                 Reader,
@@ -1607,9 +1632,12 @@ public sealed class MetadataDeclarationQueryTests
     {
         var type = GetTypeDefinition(
             typeof(MetadataDeclarationQueryFixtures.IStaticContract));
-        var method = GetMethod(type, "Create");
+        var methodHandle = GetMethodHandle(type, "Create");
 
-        var declaration = MetadataDeclarationQuery.GetMethod(Reader, type, method);
+        var declaration = MetadataDeclarationQuery.GetMethod(
+            Reader,
+            type,
+            methodHandle);
 
         Assert.True(declaration.IsAbstract);
         Assert.False(declaration.IsOverride);
@@ -1632,6 +1660,30 @@ public sealed class MetadataDeclarationQueryTests
         var field = Assert.Single(all.Members, member => member.Name == "_count");
         Assert.Equal("private", field.Accessibility);
         Assert.Equal("int", field.ReturnType);
+    }
+
+    [Fact]
+    public void TypeSurface_ManyMethodsThreadsHandlesWithoutQuadraticAllocation()
+    {
+        const int methodCount = 1_024;
+        using var stream = new MemoryStream(
+            BuildManyMethodSurfaceImage(methodCount));
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var typeHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+            == "ManyMethods");
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        ApiType surface = MetadataDeclarationQuery.GetTypeSurface(
+            reader,
+            typeHandle);
+
+        long allocated =
+            GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Equal(methodCount, surface.Members.Count);
+        Assert.Equal("Method1023", surface.Members[^1].Name);
+        Assert.InRange(allocated, 0, 32 * 1024 * 1024);
     }
 
     [Fact]
@@ -1674,9 +1726,12 @@ public sealed class MetadataDeclarationQueryTests
     public void TypeSurface_EscapesKeywordMemberNames()
     {
         var type = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures));
-        var method = GetMethod(type, "class");
+        var methodHandle = GetMethodHandle(type, "class");
 
-        var declaration = MetadataDeclarationQuery.GetMethod(Reader, type, method);
+        var declaration = MetadataDeclarationQuery.GetMethod(
+            Reader,
+            type,
+            methodHandle);
         var surface = MetadataDeclarationQuery.GetTypeSurface(Reader, GetTypeDefinitionHandle(typeof(MetadataDeclarationQueryFixtures)));
         var property = Assert.Single(surface.Members, member => member.Name == "while");
         var field = Assert.Single(surface.Members, member => member.Name == "event");
@@ -1734,9 +1789,14 @@ public sealed class MetadataDeclarationQueryTests
     public void MethodDeclaration_PreservesNestedGenericTypeArgumentPlacement()
     {
         var type = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures));
-        var method = GetMethod(type, nameof(MetadataDeclarationQueryFixtures.NestedGeneric));
+        var methodHandle = GetMethodHandle(
+            type,
+            nameof(MetadataDeclarationQueryFixtures.NestedGeneric));
 
-        var declaration = MetadataDeclarationQuery.GetMethod(Reader, type, method);
+        var declaration = MetadataDeclarationQuery.GetMethod(
+            Reader,
+            type,
+            methodHandle);
 
         const string nestedType =
             "ILInspector.Metadata.Tests.MetadataDeclarationQueryFixtures.Container<int>.Row<string>";
@@ -3880,10 +3940,10 @@ public sealed class MetadataDeclarationQueryTests
     [Fact]
     public void ReusesInheritedVirtualSlot_DeclinesExplicitInterfaceOnlyMethodImpl()
     {
-        var type = Reader.GetTypeDefinition(
-            GetTypeDefinitionHandle(
-                typeof(MetadataDeclarationQueryFixtures
-                    .ExplicitInterfaceOnlyImplementation)));
+        var typeHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .ExplicitInterfaceOnlyImplementation));
+        var type = Reader.GetTypeDefinition(typeHandle);
 
         // The MethodImpl is present; what is absent is any inherited class
         // virtual slot for it to reuse.
@@ -3891,16 +3951,16 @@ public sealed class MetadataDeclarationQueryTests
         Assert.False(
             MetadataDeclarationQuery.ReusesInheritedVirtualSlot(
                 Reader,
-                type));
+                typeHandle));
     }
 
     [Fact]
     public void ReusesInheritedVirtualSlot_AcceptsAuthenticatedClassMethodImpl()
     {
-        var type = Reader.GetTypeDefinition(
-            GetTypeDefinitionHandle(
-                typeof(MetadataDeclarationQueryFixtures
-                    .CovariantReturnDerived)));
+        var typeHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .CovariantReturnDerived));
+        var type = Reader.GetTypeDefinition(typeHandle);
 
         // A covariant return is newslot virtual final plus a MethodImpl, so the
         // attribute test alone cannot see the reuse.
@@ -3908,22 +3968,74 @@ public sealed class MetadataDeclarationQueryTests
         Assert.True(
             MetadataDeclarationQuery.ReusesInheritedVirtualSlot(
                 Reader,
-                type));
+                typeHandle));
     }
 
     [Fact]
     public void ReusesInheritedVirtualSlot_AcceptsInheritedVirtualSlotFlags()
     {
-        var type = Reader.GetTypeDefinition(
-            GetTypeDefinitionHandle(
-                typeof(MetadataDeclarationQueryFixtures
-                    .PlainOverrideDerived)));
+        var typeHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures
+                .PlainOverrideDerived));
+        var type = Reader.GetTypeDefinition(typeHandle);
 
         Assert.Empty(type.GetMethodImplementations());
         Assert.True(
             MetadataDeclarationQuery.ReusesInheritedVirtualSlot(
                 Reader,
-                type));
+                typeHandle));
+    }
+
+    [Fact]
+    public void ReusesInheritedVirtualSlot_DeclinesCrossOwnerMethodImplBody()
+    {
+        using var stream = new MemoryStream(
+            BuildCrossOwnerMethodImplImage());
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var victimHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+            == "Victim");
+        var implementation = Assert.Single(
+            reader.GetTypeDefinition(victimHandle)
+                .GetMethodImplementations()
+                .Select(reader.GetMethodImplementation));
+        var bodyHandle =
+            (MethodDefinitionHandle)implementation.MethodBody;
+
+        Assert.NotEqual(
+            victimHandle,
+            reader.GetMethodDefinition(bodyHandle).GetDeclaringType());
+        Assert.False(
+            MetadataDeclarationQuery.ReusesInheritedVirtualSlot(
+                reader,
+                victimHandle));
+    }
+
+    [Fact]
+    public void ReusesInheritedVirtualSlot_AcceptsSameOwnerMethodImplBody()
+    {
+        using var stream = new MemoryStream(
+            BuildCrossOwnerMethodImplImage());
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var siblingHandle = reader.TypeDefinitions.Single(handle =>
+            reader.GetString(reader.GetTypeDefinition(handle).Name)
+            == "Sibling");
+        var implementation = Assert.Single(
+            reader.GetTypeDefinition(siblingHandle)
+                .GetMethodImplementations()
+                .Select(reader.GetMethodImplementation));
+        var bodyHandle =
+            (MethodDefinitionHandle)implementation.MethodBody;
+
+        Assert.Equal(
+            siblingHandle,
+            reader.GetMethodDefinition(bodyHandle).GetDeclaringType());
+        Assert.True(
+            MetadataDeclarationQuery.ReusesInheritedVirtualSlot(
+                reader,
+                siblingHandle));
     }
 
     [Fact]
@@ -5785,6 +5897,184 @@ public sealed class MetadataDeclarationQueryTests
         var pe = new ManagedPEBuilder(
             PEHeaderBuilder.CreateLibraryHeader(),
             new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static byte[] BuildCrossOwnerMethodImplImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("CrossOwnerMethodImpl.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("CrossOwnerMethodImpl"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        var runtime = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Runtime"),
+            new Version(11, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        var objectType = metadata.AddTypeReference(
+            runtime,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var baseType = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("Base"),
+            objectType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var siblingType = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("Sibling"),
+            baseType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        var victimType = metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("Victim"),
+            baseType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(3));
+
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(
+            SignatureCallingConvention.Default,
+            genericParameterCount: 0,
+            isInstanceMethod: true).Parameters(
+                0,
+                returnType => returnType.Void(),
+                _ => { });
+        var signatureHandle = metadata.GetOrAddBlob(signature);
+        var attributes = MethodAttributes.Public
+            | MethodAttributes.Virtual
+            | MethodAttributes.NewSlot;
+        var baseMethod = metadata.AddMethodDefinition(
+            attributes,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Value"),
+            signatureHandle,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        var siblingMethod = metadata.AddMethodDefinition(
+            attributes,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Value"),
+            signatureHandle,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+
+        metadata.AddMethodImplementation(
+            siblingType,
+            siblingMethod,
+            baseMethod);
+        metadata.AddMethodImplementation(
+            victimType,
+            siblingMethod,
+            baseMethod);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static byte[] BuildManyMethodSurfaceImage(int methodCount)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("ManyMethods.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("ManyMethods"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        var runtime = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Runtime"),
+            new Version(11, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        var objectType = metadata.AddTypeReference(
+            runtime,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("ManyMethods"),
+            objectType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(
+            SignatureCallingConvention.Default,
+            genericParameterCount: 0,
+            isInstanceMethod: true).Parameters(
+                0,
+                returnType => returnType.Void(),
+                _ => { });
+        var signatureHandle = metadata.GetOrAddBlob(signature);
+        for (int index = 0; index < methodCount; index++)
+        {
+            metadata.AddMethodDefinition(
+                MethodAttributes.Public
+                    | MethodAttributes.Virtual
+                    | MethodAttributes.NewSlot,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString($"Method{index}"),
+                signatureHandle,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata),
             new BlobBuilder(),
             flags: CorFlags.ILOnly);
         var image = new BlobBuilder();

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -104,6 +104,129 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void SameAssemblyOverrideSlot_PreservesNonPublicSourceDeclarationFacts()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.OverrideDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+        var method = Reader.GetMethodDefinition(methodHandle);
+
+        var declaration = MetadataDeclarationQuery.GetMethod(Reader, derived, method);
+        var slot = MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+            Reader,
+            derivedHandle,
+            methodHandle);
+
+        Assert.NotNull(slot);
+        var resolvedSlot = slot!;
+        Assert.Equal("internal", declaration.Accessibility);
+        Assert.True(declaration.IsOverride);
+        Assert.False(declaration.IsVirtual);
+        Assert.False(MetadataDeclarationQuery.IsSourceDeclarableVirtualMethod(method));
+        Assert.Equal(
+            GetTypeDefinitionHandle(typeof(MetadataDeclarationQueryFixtures.OverrideBase)),
+            resolvedSlot.DeclaringType);
+        Assert.Equal(
+            "Value",
+            Reader.GetString(Reader.GetMethodDefinition(resolvedSlot.Method).Name));
+
+        var baseMethod = Reader.GetMethodDefinition(resolvedSlot.Method);
+        Assert.True(MetadataDeclarationQuery.GetMethod(
+            Reader,
+            Reader.GetTypeDefinition(resolvedSlot.DeclaringType),
+            baseMethod).IsVirtual);
+        Assert.True(MetadataDeclarationQuery.IsSourceDeclarableVirtualMethod(baseMethod));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesNewVirtualSlot()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.NewSlotDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+
+        Assert.Null(MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+            Reader,
+            derivedHandle,
+            methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesExternalBase()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.ExternalOverride));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, nameof(object.ToString));
+
+        Assert.Null(MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+            Reader,
+            derivedHandle,
+            methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesAccessibilityChangingOverride()
+    {
+        string path = EmitAccessibilityChangingOverride();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            var derivedHandle = reader.TypeDefinitions.Single(handle =>
+                reader.GetString(reader.GetTypeDefinition(handle).Name) == "AccessDerived");
+            var derived = reader.GetTypeDefinition(derivedHandle);
+            var methodHandle = derived.GetMethods().Single(handle =>
+                reader.GetString(reader.GetMethodDefinition(handle).Name) == "Value");
+
+            Assert.Null(MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_UsesNearestReintroducedSlot()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.OverrideLeaf));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "Value");
+
+        var slot = Assert.IsType<MetadataOverrideSlot>(
+            MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                Reader,
+                derivedHandle,
+                methodHandle));
+
+        Assert.Equal(
+            GetTypeDefinitionHandle(typeof(MetadataDeclarationQueryFixtures.OverrideMiddle)),
+            slot.DeclaringType);
+    }
+
+    [Fact]
+    public void StaticAbstractInterfaceMethod_IsNotClassifiedAsOverride()
+    {
+        var type = GetTypeDefinition(
+            typeof(MetadataDeclarationQueryFixtures.IStaticContract));
+        var method = GetMethod(type, "Create");
+
+        var declaration = MetadataDeclarationQuery.GetMethod(Reader, type, method);
+
+        Assert.True(declaration.IsAbstract);
+        Assert.False(declaration.IsOverride);
+        Assert.False(declaration.IsSealed);
+    }
+
+    [Fact]
     public void TypeSurface_IncludesNonPublicMembersWhenRequested()
     {
         var handle = GetTypeDefinitionHandle(typeof(MetadataDeclarationQueryFixtures));
@@ -346,6 +469,43 @@ public sealed class MetadataDeclarationQueryTests
         return path;
     }
 
+    static string EmitAccessibilityChangingOverride()
+    {
+        var assemblyName = new AssemblyName("AccessibilityChangingOverride");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        var baseType = module.DefineType("AccessBase", TypeAttributes.Public);
+        var baseMethod = baseType.DefineMethod(
+            "Value",
+            MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.NewSlot,
+            typeof(int),
+            Type.EmptyTypes);
+        var baseIl = baseMethod.GetILGenerator();
+        baseIl.Emit(OpCodes.Ldc_I4_1);
+        baseIl.Emit(OpCodes.Ret);
+        var createdBase = baseType.CreateType();
+
+        var derivedType = module.DefineType(
+            "AccessDerived",
+            TypeAttributes.Public,
+            createdBase);
+        var derivedMethod = derivedType.DefineMethod(
+            "Value",
+            MethodAttributes.Public | MethodAttributes.Virtual,
+            typeof(int),
+            Type.EmptyTypes);
+        var derivedIl = derivedMethod.GetILGenerator();
+        derivedIl.Emit(OpCodes.Ldc_I4_2);
+        derivedIl.Emit(OpCodes.Ret);
+        derivedType.CreateType();
+
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"AccessibilityChangingOverride-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
     static TypeDefinition GetTypeDefinition(Type type)
         => Reader.GetTypeDefinition(GetTypeDefinitionHandle(type));
 
@@ -364,12 +524,15 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     static MethodDefinition GetMethod(TypeDefinition type, string name)
+        => Reader.GetMethodDefinition(GetMethodHandle(type, name));
+
+    static MethodDefinitionHandle GetMethodHandle(TypeDefinition type, string name)
     {
         foreach (var handle in type.GetMethods())
         {
             var method = Reader.GetMethodDefinition(handle);
             if (Reader.GetString(method.Name) == name)
-                return method;
+                return handle;
         }
 
         throw new InvalidOperationException($"Method '{name}' was not found.");
@@ -465,6 +628,46 @@ public class MetadataDeclarationQueryFixtures
     public abstract class AbstractBase
     {
         protected abstract string Name { get; set; }
+    }
+
+    public class OverrideBase
+    {
+        internal virtual int Value() => 1;
+    }
+
+    public class OverrideDerived : OverrideBase
+    {
+        internal override int Value() => 2;
+    }
+
+    public class NewSlotDerived : OverrideBase
+    {
+        internal new virtual int Value() => 3;
+    }
+
+    public class ExternalOverride : Exception
+    {
+        public override string ToString() => nameof(ExternalOverride);
+    }
+
+    public class OverrideGrandBase
+    {
+        internal virtual int Value() => 1;
+    }
+
+    public class OverrideMiddle : OverrideGrandBase
+    {
+        internal new virtual int Value() => 2;
+    }
+
+    public class OverrideLeaf : OverrideMiddle
+    {
+        internal override int Value() => 3;
+    }
+
+    public interface IStaticContract
+    {
+        static abstract int Create();
     }
 
     public class Container<T>

--- a/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataDeclarationQueryTests.cs
@@ -104,6 +104,20 @@ public sealed class MetadataDeclarationQueryTests
     }
 
     [Fact]
+    public void PropertyDeclaration_DerivesPropertyAccessibilityFromAuthenticatedBaseWhenOnlySetterIsPresent()
+    {
+        var type = GetTypeDefinition(typeof(MetadataDeclarationQueryFixtures.SetterOnlyOverrideDerived));
+        var property = GetProperty(type, "Value");
+
+        var declaration = MetadataDeclarationQuery.GetProperty(Reader, type, property);
+
+        Assert.Equal("public", declaration.Accessibility);
+        var setter = Assert.Single(declaration.Signature.Accessors);
+        Assert.Equal("set", setter.Kind);
+        Assert.Equal("protected", setter.Accessibility);
+    }
+
+    [Fact]
     public void SameAssemblyOverrideSlot_PreservesNonPublicSourceDeclarationFacts()
     {
         var derivedHandle = GetTypeDefinitionHandle(
@@ -210,6 +224,101 @@ public sealed class MetadataDeclarationQueryTests
         Assert.Equal(
             GetTypeDefinitionHandle(typeof(MetadataDeclarationQueryFixtures.OverrideMiddle)),
             slot.DeclaringType);
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_AllowsCovariantReturnShape()
+    {
+        string path = EmitCovariantReturnOverride();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            var derivedHandle = reader.TypeDefinitions.Single(handle =>
+                reader.GetString(reader.GetTypeDefinition(handle).Name) == "Derived");
+            var derived = reader.GetTypeDefinition(derivedHandle);
+            var methodHandle = derived.GetMethods().Single(handle =>
+                reader.GetString(reader.GetMethodDefinition(handle).Name) == "Value");
+
+            var slot = Assert.IsType<MetadataOverrideSlot>(
+                MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                    reader,
+                    derivedHandle,
+                    methodHandle));
+
+            Assert.Equal("Base", reader.GetString(reader.GetTypeDefinition(slot.DeclaringType).Name));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesRefOutModifierMismatch()
+    {
+        string path = EmitRefOutKindMismatchOverride();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            var derivedHandle = reader.TypeDefinitions.Single(handle =>
+                reader.GetString(reader.GetTypeDefinition(handle).Name) == "Derived");
+            var derived = reader.GetTypeDefinition(derivedHandle);
+            var methodHandle = derived.GetMethods().Single(handle =>
+                reader.GetString(reader.GetMethodDefinition(handle).Name) == "M");
+
+            Assert.Null(MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesStaticMethod()
+    {
+        var derivedHandle = GetTypeDefinitionHandle(
+            typeof(MetadataDeclarationQueryFixtures.StaticShadowDerived));
+        var derived = Reader.GetTypeDefinition(derivedHandle);
+        var methodHandle = GetMethodHandle(derived, "M");
+
+        Assert.Null(MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+            Reader,
+            derivedHandle,
+            methodHandle));
+    }
+
+    [Fact]
+    public void SameAssemblyOverrideSlot_DeclinesIncompatibleCovariantReturn()
+    {
+        string path = EmitIncompatibleReturnOverride();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            var reader = peReader.GetMetadataReader();
+            var derivedHandle = reader.TypeDefinitions.Single(handle =>
+                reader.GetString(reader.GetTypeDefinition(handle).Name) == "Derived");
+            var derived = reader.GetTypeDefinition(derivedHandle);
+            var methodHandle = derived.GetMethods().Single(handle =>
+                reader.GetString(reader.GetMethodDefinition(handle).Name) == "Value");
+
+            Assert.Null(MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                reader,
+                derivedHandle,
+                methodHandle));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     [Fact]
@@ -506,6 +615,100 @@ public sealed class MetadataDeclarationQueryTests
         return path;
     }
 
+    static string EmitRefOutKindMismatchOverride()
+    {
+        var assemblyName = new AssemblyName("RefOutKindMismatchOverride");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        var byRefInt = typeof(int).MakeByRefType();
+
+        var baseType = module.DefineType("Base", TypeAttributes.Public);
+        var baseMethod = baseType.DefineMethod(
+            "M",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.NewSlot,
+            typeof(void),
+            [byRefInt]);
+        baseMethod.DefineParameter(1, ParameterAttributes.None, "value");
+        baseMethod.GetILGenerator().Emit(OpCodes.Ret);
+        var createdBase = baseType.CreateType();
+
+        var derivedType = module.DefineType("Derived", TypeAttributes.Public, createdBase);
+        var derivedMethod = derivedType.DefineMethod(
+            "M",
+            MethodAttributes.Public | MethodAttributes.Virtual,
+            typeof(void),
+            [byRefInt]);
+        derivedMethod.DefineParameter(1, ParameterAttributes.Out, "value");
+        derivedMethod.GetILGenerator().Emit(OpCodes.Ret);
+        derivedType.CreateType();
+
+        string path = Path.Combine(Path.GetTempPath(), $"RefOutKindMismatchOverride-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitCovariantReturnOverride()
+    {
+        var assemblyName = new AssemblyName("CovariantReturnOverride");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+
+        var baseType = module.DefineType("Base", TypeAttributes.Public);
+        var baseMethod = baseType.DefineMethod(
+            "Value",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.NewSlot,
+            typeof(object),
+            Type.EmptyTypes);
+        baseMethod.GetILGenerator().Emit(OpCodes.Ldstr, "base");
+        baseMethod.GetILGenerator().Emit(OpCodes.Ret);
+        var createdBase = baseType.CreateType();
+
+        var derivedType = module.DefineType("Derived", TypeAttributes.Public, createdBase);
+        var derivedMethod = derivedType.DefineMethod(
+            "Value",
+            MethodAttributes.Public | MethodAttributes.Virtual,
+            typeof(string),
+            Type.EmptyTypes);
+        derivedMethod.GetILGenerator().Emit(OpCodes.Ldstr, "derived");
+        derivedMethod.GetILGenerator().Emit(OpCodes.Ret);
+        derivedType.CreateType();
+
+        string path = Path.Combine(Path.GetTempPath(), $"CovariantReturnOverride-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitIncompatibleReturnOverride()
+    {
+        var assemblyName = new AssemblyName("IncompatibleReturnOverride");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+
+        var baseType = module.DefineType("Base", TypeAttributes.Public);
+        var baseMethod = baseType.DefineMethod(
+            "Value",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.NewSlot,
+            typeof(string),
+            Type.EmptyTypes);
+        baseMethod.GetILGenerator().Emit(OpCodes.Ldstr, "base");
+        baseMethod.GetILGenerator().Emit(OpCodes.Ret);
+        var createdBase = baseType.CreateType();
+
+        var derivedType = module.DefineType("Derived", TypeAttributes.Public, createdBase);
+        var derivedMethod = derivedType.DefineMethod(
+            "Value",
+            MethodAttributes.Public | MethodAttributes.Virtual,
+            typeof(object),
+            Type.EmptyTypes);
+        derivedMethod.GetILGenerator().Emit(OpCodes.Ldstr, "derived");
+        derivedMethod.GetILGenerator().Emit(OpCodes.Ret);
+        derivedType.CreateType();
+
+        string path = Path.Combine(Path.GetTempPath(), $"IncompatibleReturnOverride-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
     static TypeDefinition GetTypeDefinition(Type type)
         => Reader.GetTypeDefinition(GetTypeDefinitionHandle(type));
 
@@ -663,6 +866,65 @@ public class MetadataDeclarationQueryFixtures
     public class OverrideLeaf : OverrideMiddle
     {
         internal override int Value() => 3;
+    }
+
+    public class SetterOnlyOverrideBase
+    {
+        public virtual int Value
+        {
+            get => 0;
+            protected set
+            {
+            }
+        }
+    }
+
+    public class SetterOnlyOverrideDerived : SetterOnlyOverrideBase
+    {
+        public override int Value
+        {
+            protected set
+            {
+            }
+        }
+    }
+
+    public class CovariantAnimal
+    {
+    }
+
+    public class CovariantDog : CovariantAnimal
+    {
+    }
+
+    public class CovariantReturnBase
+    {
+        public virtual CovariantAnimal Value() => new();
+    }
+
+    public class CovariantReturnDerived : CovariantReturnBase
+    {
+        public override CovariantDog Value() => new();
+    }
+
+    public class ObjectCovariantReturnBase
+    {
+        public virtual object Value() => "";
+    }
+
+    public class ObjectCovariantReturnDerived : ObjectCovariantReturnBase
+    {
+        public override string Value() => "";
+    }
+
+    public class StaticShadowBase
+    {
+        public virtual int M() => 1;
+    }
+
+    public class StaticShadowDerived : StaticShadowBase
+    {
+        public new static int M() => 2;
     }
 
     public interface IStaticContract

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -635,7 +635,18 @@ public static class CompileBackSourceComposer
                         continue;
                     var produced = Produce(methodToken, $"{request.Type.FullName}.{member.Name}");
                     if (produced.Body is { } body)
+                    {
+                        if (body is CSharpBlockBody
+                            {
+                                ConstructorInitializer.Kind:
+                                    CSharpConstructorInitializerKind.Base
+                            } block
+                            && request.Type.BaseType is null)
+                        {
+                            body = block with { ConstructorInitializer = null };
+                        }
                         policies[member] = new CSharpMemberPolicy(member, CSharpBodyPolicy.Full, body);
+                    }
                     continue;
                 }
 
@@ -2910,6 +2921,7 @@ public static class CompileBackSourceComposer
         if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
 
+        CompileBackTypeKind targetShellKind = ShellKind(reader, targetTypeDef, targetFacts);
         var chainParameterTypes = bodyFacts.ChainParameterTypes;
         string? targetConstructorInitializer = null;
         if (constructorChain is { } chain)
@@ -3092,7 +3104,7 @@ public static class CompileBackSourceComposer
         {
             new(
                 targetIdentity,
-                ShellKind(reader, targetTypeDef, targetFacts),
+                targetShellKind,
                 targetMembers,
                 primaryConstructor,
                 targetFacts)
@@ -3166,7 +3178,10 @@ public static class CompileBackSourceComposer
         {
             if (chainParameterTypes is null
                 || targetTypeDef.BaseType.Kind != HandleKind.TypeDefinition
-                || TypeShellProducer.ReconstructedBaseTypeDisplay(reader, targetTypeDef, isClass: true) is null)
+                || TypeShellProducer.ReconstructedBaseTypeDisplay(
+                    reader,
+                    targetTypeDef,
+                    isClass: targetShellKind == CompileBackTypeKind.Class) is null)
             {
                 return false;
             }
@@ -4750,6 +4765,9 @@ public static class CompileBackSourceComposer
             CompileBackMemberRequirement left,
             CompileBackMemberRequirement right)
         {
+            if (MemberMethodTokens(left).Intersect(MemberMethodTokens(right)).Any())
+                return true;
+
             bool sameKind = left.Kind == right.Kind
                 || left.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
                     && right.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
@@ -4764,6 +4782,7 @@ public static class CompileBackSourceComposer
 
         static void NormalizeOverrideMembers(
             MetadataReader reader,
+            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
             IReadOnlyDictionary<MethodDefinitionHandle, MethodDefinitionHandle> materializedOverrideSlots,
             List<CompileBackMemberRequirement> members)
         {
@@ -4800,7 +4819,29 @@ public static class CompileBackSourceComposer
 
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (!materializedOverrideSlots.TryGetValue(methodHandle, out var slotHandle))
-                    return IsIntrinsicObjectOverride(reader, method.GetDeclaringType(), methodHandle);
+                {
+                    var fallbackSlot = MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                        reader,
+                        method.GetDeclaringType(),
+                        methodHandle);
+                    if (fallbackSlot is null)
+                        return IsIntrinsicObjectOverride(reader, method.GetDeclaringType(), methodHandle);
+
+                    var slotType = reader.GetTypeDefinition(fallbackSlot.DeclaringType);
+                    var slotIdentity = CompileBackTypeIdentity.FromDefinition(reader, slotType);
+                    if (!requirementsByMetadataName.TryGetValue(
+                            slotIdentity.MetadataFullName,
+                            out var slotRequirement)
+                        || !slotRequirement.IncludeMemberSurface
+                            && !slotRequirement.RequiredMembers.Any(member =>
+                                MemberMethodTokens(member).Contains(
+                                    MetadataTokens.GetToken(fallbackSlot.Method))))
+                    {
+                        return false;
+                    }
+
+                    slotHandle = fallbackSlot.Method;
+                }
 
                 var slot = reader.GetMethodDefinition(slotHandle);
                 return (slot.Attributes & MethodAttributes.NewSlot) != 0
@@ -5327,6 +5368,7 @@ public static class CompileBackSourceComposer
             }
             NormalizeOverrideMembers(
                 reader,
+                requirementsByMetadataName,
                 materializedOverrideSlots,
                 members);
             // A synthetic constructor must not collide with a private parameterless
@@ -5674,12 +5716,12 @@ public static class CompileBackSourceComposer
             string metadataFullName = requirement.Type.MetadataFullName;
             foreach (var other in requirementsByMetadataName.Values)
             {
-                if (other.Type.MetadataFullName == metadataFullName)
-                    continue;
                 if (FindType(reader, other.Type.MetadataFullName) is not { } otherHandle)
                     continue;
                 if (NestedTypeDerivesFrom(reader, otherHandle, metadataFullName))
                     return true;
+                if (other.Type.MetadataFullName == metadataFullName)
+                    continue;
                 if (TypeDerivesFrom(reader, otherHandle, metadataFullName)
                     && TypeNeedsImplicitBaseSupport(reader, other, useFullBodies))
                 {

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -3283,6 +3283,10 @@ public static class CompileBackSourceComposer
             {
                 CompileBackAccessibility.Public => CSharpShellAccessibility.Public,
                 CompileBackAccessibility.Protected => CSharpShellAccessibility.Protected,
+                CompileBackAccessibility.Internal => CSharpShellAccessibility.Internal,
+                CompileBackAccessibility.PrivateProtected => CSharpShellAccessibility.PrivateProtected,
+                CompileBackAccessibility.ProtectedInternal => CSharpShellAccessibility.ProtectedInternal,
+                CompileBackAccessibility.Private => CSharpShellAccessibility.Private,
                 _ => throw new NotSupportedException(
                     $"Unsupported compile-back accessibility '{requirement.Accessibility}'."),
             },

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1098,16 +1098,23 @@ public static class CompileBackSourceComposer
 
     static MethodDefinitionHandle? FindAccessibleInstanceConstructor(
         MetadataReader reader,
-        TypeDefinitionHandle typeHandle,
+        TypeDefinitionHandle declaringTypeHandle,
+        TypeDefinitionHandle derivedTypeHandle,
         IReadOnlyList<string> parameterTypes)
     {
-        var typeDef = reader.GetTypeDefinition(typeHandle);
+        var typeDef =
+            reader.GetTypeDefinition(declaringTypeHandle);
         foreach (var methodHandle in typeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
             if (reader.GetString(method.Name) != ".ctor"
                 || method.Attributes.HasFlag(MethodAttributes.Static)
-                || !IsConstructorAccessibleFromDerived(method.Attributes & MethodAttributes.MemberAccessMask))
+                || !IsConstructorAccessibleFromDerived(
+                    reader,
+                    declaringTypeHandle,
+                    derivedTypeHandle,
+                    method.Attributes
+                        & MethodAttributes.MemberAccessMask))
             {
                 continue;
             }
@@ -1130,9 +1137,46 @@ public static class CompileBackSourceComposer
         return null;
     }
 
-    static bool IsConstructorAccessibleFromDerived(MethodAttributes accessibility)
-        => accessibility is not MethodAttributes.Private
-            and not MethodAttributes.PrivateScope;
+    static bool IsConstructorAccessibleFromDerived(
+        MetadataReader reader,
+        TypeDefinitionHandle declaringTypeHandle,
+        TypeDefinitionHandle derivedTypeHandle,
+        MethodAttributes accessibility)
+    {
+        if (accessibility == MethodAttributes.PrivateScope)
+            return false;
+        if (accessibility != MethodAttributes.Private)
+            return true;
+
+        Span<TypeDefinitionHandle> declaringChain =
+            stackalloc TypeDefinitionHandle[
+                MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal
+                .TryWalkTypeDefinitionDeclaringChain(
+                    reader,
+                    derivedTypeHandle,
+                    declaringChain,
+                    out int count,
+                    out EntityHandle terminal,
+                    out _)
+            || !terminal.IsNil)
+        {
+            return false;
+        }
+
+        for (int index = 0;
+            index < count - 1;
+            index++)
+        {
+            if (declaringChain[index]
+                == declaringTypeHandle)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     public static CompileBackSourceResult ComposePropertyGetter(
         string assemblyPath,
@@ -3187,7 +3231,12 @@ public static class CompileBackSourceComposer
             }
 
             var baseHandle = (TypeDefinitionHandle)targetTypeDef.BaseType;
-            if (FindAccessibleInstanceConstructor(reader, baseHandle, chainParameterTypes) is null)
+            if (FindAccessibleInstanceConstructor(
+                    reader,
+                    baseHandle,
+                    targetType,
+                    chainParameterTypes)
+                is null)
                 return false;
 
             effectiveClosureRoots.Add(TopLevelRootOf(reader, baseHandle));
@@ -6388,16 +6437,24 @@ public static class CompileBackSourceComposer
 
         static MethodDefinitionHandle? FindAccessibleInstanceConstructor(
             MetadataReader reader,
-            TypeDefinitionHandle typeHandle,
+            TypeDefinitionHandle declaringTypeHandle,
+            TypeDefinitionHandle derivedTypeHandle,
             IReadOnlyList<string> parameterTypes)
         {
-            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var typeDef =
+                reader.GetTypeDefinition(
+                    declaringTypeHandle);
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (reader.GetString(method.Name) != ".ctor"
                     || method.Attributes.HasFlag(MethodAttributes.Static)
-                    || !IsConstructorAccessibleFromDerived(method.Attributes & MethodAttributes.MemberAccessMask))
+                    || !IsConstructorAccessibleFromDerived(
+                        reader,
+                        declaringTypeHandle,
+                        derivedTypeHandle,
+                        method.Attributes
+                            & MethodAttributes.MemberAccessMask))
                 {
                     continue;
                 }
@@ -6426,8 +6483,16 @@ public static class CompileBackSourceComposer
             return reader.GetMethodDefinition(handle).RelativeVirtualAddress != 0;
         }
 
-        static bool IsConstructorAccessibleFromDerived(MethodAttributes accessibility)
-            => accessibility is not MethodAttributes.Private
-                and not MethodAttributes.PrivateScope;
+        static bool IsConstructorAccessibleFromDerived(
+            MetadataReader reader,
+            TypeDefinitionHandle declaringTypeHandle,
+            TypeDefinitionHandle derivedTypeHandle,
+            MethodAttributes accessibility)
+            => CompileBackSourceComposer
+                .IsConstructorAccessibleFromDerived(
+                    reader,
+                    declaringTypeHandle,
+                    derivedTypeHandle,
+                    accessibility);
     }
 }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1260,7 +1260,11 @@ public static class CompileBackSourceComposer
                     ]
                     : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))],
                 propertyDeclaration.Attributes,
-                MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes,
+                MetadataDeclarationQuery.GetMethod(
+                    reader,
+                    targetTypeDef,
+                    targetGetter,
+                    getterSignature).Signature.ReturnAttributes,
                 IsAbstract: IsAbstractMethod(getter),
                 IsVirtual: IsVirtualMethod(getter),
                 IsOverride: propertyDeclaration.IsOverride,
@@ -2800,9 +2804,13 @@ public static class CompileBackSourceComposer
         var accessorDeclaration = MetadataDeclarationQuery.GetMethod(
             reader,
             targetTypeDef,
+            targetAccessor,
+            signature);
+        var parameters = MethodParameters(
+            reader,
+            targetAccessor,
             accessor,
             signature);
-        var parameters = MethodParameters(reader, accessor, signature);
         if (parameters.Count != 1)
             throw new InvalidOperationException("Event accessors must have exactly one value parameter.");
 
@@ -2942,14 +2950,23 @@ public static class CompileBackSourceComposer
             && (!method.Attributes.HasFlag(MethodAttributes.SpecialName)
                 || reader.GetString(method.Name).StartsWith("op_", StringComparison.Ordinal));
         var methodDeclaration = isSourceMethodDeclaration
-            ? MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, method, signature)
+            ? MetadataDeclarationQuery.GetMethod(
+                reader,
+                targetTypeDef,
+                targetMethod,
+                signature)
             : null;
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         bool isConstructor = function.MethodKind is IrMethodKind.Constructor or IrMethodKind.StaticConstructor;
         string targetMethodName = MemberIdentifierName(methodName, isConstructor);
         var bodyFacts = isConstructor ? MemberBodyFacts.Constructor(function) : ConstructorBodyFacts.None;
         var primaryConstructor = isConstructor
-            ? PrimaryConstructorFromPrologue(reader, method, bodyFacts.PrimaryConstructorPrologue, targetBody)
+            ? PrimaryConstructorFromPrologue(
+                reader,
+                targetMethod,
+                method,
+                bodyFacts.PrimaryConstructorPrologue,
+                targetBody)
             : PrimaryConstructorFromCapturedFields(reader, targetTypeDef, targetBody);
 
         var diagnostics = new List<CompileBackPlanningDiagnostic>();
@@ -2984,8 +3001,15 @@ public static class CompileBackSourceComposer
         var targetReturnType = isConstructor
             ? null
             : CompileBackTypeSignature.Display(MethodReturnType(reader, targetTypeDef, method));
-        var targetParameters = MethodParameters(reader, method, signature);
-        var targetTypeParameters = MethodTypeParameters(reader, method);
+        var targetParameters = MethodParameters(
+            reader,
+            targetMethod,
+            method,
+            signature);
+        var targetTypeParameters = MethodTypeParameters(
+            reader,
+            targetMethod,
+            method);
         // A class method whose metadata name is an explicit-interface spelling
         // (`IType.Member`) must be reconstructed as an explicit-interface implementation,
         // not a plain method with the dotted name sanitized to `IType_Member`. The latter
@@ -3026,7 +3050,9 @@ public static class CompileBackSourceComposer
                 targetBody,
                 [new CompileBackFact("metadata", isConstructor ? "target-constructor" : "target-method", reader.GetString(method.Name))],
                 isConstructor ? null : MemberAttributes(reader, method.GetCustomAttributes()),
-                isConstructor ? null : MethodReturnAttributes(reader, method),
+                isConstructor
+                    ? null
+                    : MethodReturnAttributes(reader, targetMethod, method),
                 IsAbstract: isSourceMethodDeclaration && IsAbstractMethod(method),
                 IsVirtual: isSourceMethodDeclaration && IsVirtualMethod(method),
                 IsOverride: methodDeclaration?.IsOverride ?? false,
@@ -3224,7 +3250,7 @@ public static class CompileBackSourceComposer
                 || targetTypeDef.BaseType.Kind != HandleKind.TypeDefinition
                 || TypeShellProducer.ReconstructedBaseTypeDisplay(
                     reader,
-                    targetTypeDef,
+                    targetType,
                     isClass: targetShellKind == CompileBackTypeKind.Class) is null)
             {
                 return false;
@@ -3403,6 +3429,7 @@ public static class CompileBackSourceComposer
 
     static IReadOnlyList<CompileBackParameter> MethodParameters(
         MetadataReader reader,
+        MethodDefinitionHandle methodHandle,
         MethodDefinition method,
         MethodSignature<string> signature)
     {
@@ -3410,15 +3437,18 @@ public static class CompileBackSourceComposer
         return ToCompileBackParameters(MetadataDeclarationQuery.GetMethod(
             reader,
             declaringType,
-            method,
+            methodHandle,
             signature).Signature.Parameters);
     }
 
-    static IReadOnlyList<string> MethodReturnAttributes(MetadataReader reader, MethodDefinition method)
+    static IReadOnlyList<string> MethodReturnAttributes(
+        MetadataReader reader,
+        MethodDefinitionHandle methodHandle,
+        MethodDefinition method)
         => MetadataDeclarationQuery.GetMethod(
             reader,
             reader.GetTypeDefinition(method.GetDeclaringType()),
-            method).Signature.ReturnAttributes;
+            methodHandle).Signature.ReturnAttributes;
 
     static string MethodReturnType(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
         => MetadataDeclarationQuery.GetMethodReturnType(reader, typeDef, method);
@@ -3450,20 +3480,24 @@ public static class CompileBackSourceComposer
             var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
             if (!OperatorSignaturesMatch(targetSignature, signature))
                 continue;
-            var methodDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
+            var methodDeclaration = MetadataDeclarationQuery.GetMethod(
+                reader,
+                typeDef,
+                methodHandle,
+                signature);
 
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, siblingName, 0, MethodSignatureText(siblingName, signature)),
                 CompileBackMemberKind.Method,
                 method.Attributes.HasFlag(MethodAttributes.Static),
-                MethodParameters(reader, method, signature),
+                MethodParameters(reader, methodHandle, method, signature),
                 CompileBackTypeSignature.Display(signature.ReturnType),
-                MethodTypeParameters(reader, method),
+                MethodTypeParameters(reader, methodHandle, method),
                 CompileBackStubBodyKind.Throw,
                 TargetBody: null,
                 [new CompileBackFact("metadata", "operator-pair-sibling", siblingName)],
                 MemberAttributes(reader, method.GetCustomAttributes()),
-                MethodReturnAttributes(reader, method),
+                MethodReturnAttributes(reader, methodHandle, method),
                 IsAbstract: IsAbstractMethod(method),
                 IsVirtual: IsVirtualMethod(method),
                 IsOverride: methodDeclaration.IsOverride,
@@ -3498,20 +3532,24 @@ public static class CompileBackSourceComposer
             var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
             if (!OperatorSignaturesMatch(targetSignature, signature))
                 continue;
-            var methodDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
+            var methodDeclaration = MetadataDeclarationQuery.GetMethod(
+                reader,
+                typeDef,
+                methodHandle,
+                signature);
 
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, siblingName, 0, MethodSignatureText(siblingName, signature)),
                 CompileBackMemberKind.Method,
                 method.Attributes.HasFlag(MethodAttributes.Static),
-                MethodParameters(reader, method, signature),
+                MethodParameters(reader, methodHandle, method, signature),
                 CompileBackTypeSignature.Display(signature.ReturnType),
-                MethodTypeParameters(reader, method),
+                MethodTypeParameters(reader, methodHandle, method),
                 CompileBackStubBodyKind.Throw,
                 TargetBody: null,
                 [new CompileBackFact("metadata", "operator-pair-sibling", siblingName)],
                 MemberAttributes(reader, method.GetCustomAttributes()),
-                MethodReturnAttributes(reader, method),
+                MethodReturnAttributes(reader, methodHandle, method),
                 IsAbstract: IsAbstractMethod(method),
                 IsVirtual: IsVirtualMethod(method),
                 IsOverride: methodDeclaration.IsOverride,
@@ -3680,20 +3718,24 @@ public static class CompileBackSourceComposer
             {
                 continue;
             }
-            var methodDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
+            var methodDeclaration = MetadataDeclarationQuery.GetMethod(
+                reader,
+                typeDef,
+                methodHandle,
+                signature);
 
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, "Equals", 0, MethodSignatureText("Equals", signature)),
                 CompileBackMemberKind.Method,
                 method.Attributes.HasFlag(MethodAttributes.Static),
-                MethodParameters(reader, method, signature),
+                MethodParameters(reader, methodHandle, method, signature),
                 CompileBackTypeSignature.Display(signature.ReturnType),
-                MethodTypeParameters(reader, method),
+                MethodTypeParameters(reader, methodHandle, method),
                 CompileBackStubBodyKind.Throw,
                 TargetBody: null,
                 [new CompileBackFact("metadata", "record-equals-sibling", "Equals")],
                 MemberAttributes(reader, method.GetCustomAttributes()),
-                MethodReturnAttributes(reader, method),
+                MethodReturnAttributes(reader, methodHandle, method),
                 IsAbstract: IsAbstractMethod(method),
                 IsVirtual: IsVirtualMethod(method),
                 IsOverride: methodDeclaration.IsOverride,
@@ -3765,14 +3807,18 @@ public static class CompileBackSourceComposer
     static IReadOnlyList<string> MemberAttributes(MetadataReader reader, CustomAttributeHandleCollection attributes)
         => MetadataDeclarationQuery.RenderMemberAttributes(reader, attributes);
 
-    static IReadOnlyList<CompileBackTypeParameter> MethodTypeParameters(MetadataReader reader, MethodDefinition method)
+    static IReadOnlyList<CompileBackTypeParameter> MethodTypeParameters(
+        MetadataReader reader,
+        MethodDefinitionHandle methodHandle,
+        MethodDefinition method)
         => ToCompileBackTypeParameters(MetadataDeclarationQuery.GetMethod(
             reader,
             reader.GetTypeDefinition(method.GetDeclaringType()),
-            method).Signature.TypeParameters);
+            methodHandle).Signature.TypeParameters);
 
     static CompileBackPrimaryConstructor? PrimaryConstructorFromPrologue(
         MetadataReader reader,
+        MethodDefinitionHandle methodHandle,
         MethodDefinition method,
         IReadOnlyList<PrimaryConstructorFieldStore>? prologue,
         string renderedBody)
@@ -3839,7 +3885,14 @@ public static class CompileBackSourceComposer
         if (!RenderedBodyMatchesPrimaryConstructorInitializers(renderedBody, initializerTexts))
             return null;
 
-        var parameters = MethodParameters(reader, method, GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, declaringType, method)));
+        var parameters = MethodParameters(
+            reader,
+            methodHandle,
+            method,
+            GuardedSignatureText.MethodText(
+                reader,
+                method,
+                GenericContext.ForMethod(reader, declaringType, method)));
         return new CompileBackPrimaryConstructor(
             string.Join(", ", parameters.Select(RenderParameter)),
             parameters,
@@ -4961,7 +5014,7 @@ public static class CompileBackSourceComposer
                 if (kind != CompileBackTypeKind.Class
                     || TypeShellProducer.ReconstructedBaseTypeDisplay(
                         reader,
-                        type,
+                        current,
                         isClass: true) is null)
                 {
                     return false;
@@ -5252,7 +5305,11 @@ public static class CompileBackSourceComposer
                     reader,
                     accessor,
                     GenericContext.ForMethod(reader, typeDef, accessor));
-                parameters = MethodParameters(reader, accessor, signature);
+                parameters = MethodParameters(
+                    reader,
+                    accessorHandle,
+                    accessor,
+                    signature);
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -5262,7 +5319,11 @@ public static class CompileBackSourceComposer
                 return null;
 
             string eventName = Identifier(reader.GetString(eventDefinition.Name));
-            var accessorDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, accessor, signature);
+            var accessorDeclaration = MetadataDeclarationQuery.GetMethod(
+                reader,
+                typeDef,
+                accessorHandle,
+                signature);
             bool hasNoBody = (typeDef.Attributes & TypeAttributes.Interface) != 0 || IsAbstractMethod(accessor);
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(
@@ -5333,7 +5394,11 @@ public static class CompileBackSourceComposer
             var generatedLocalFunction = IsGeneratedLocalFunctionName(name);
             var methodDeclaration = generatedLocalFunction
                 ? null
-                : MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
+                : MetadataDeclarationQuery.GetMethod(
+                    reader,
+                    typeDef,
+                    methodHandle,
+                    signature);
             var parameters = generatedLocalFunction
                 ? Parameters(reader, method, signature)
                 : ToCompileBackParameters(methodDeclaration!.Signature.Parameters);
@@ -5884,7 +5949,10 @@ public static class CompileBackSourceComposer
         static string? ReconstructedSameAssemblyBaseName(MetadataReader reader, TypeDefinitionHandle handle, CompileBackTypeKind kind)
         {
             var typeDef = reader.GetTypeDefinition(handle);
-            if (TypeShellProducer.ReconstructedBaseTypeDisplay(reader, typeDef, kind == CompileBackTypeKind.Class) is null)
+            if (TypeShellProducer.ReconstructedBaseTypeDisplay(
+                    reader,
+                    handle,
+                    kind == CompileBackTypeKind.Class) is null)
                 return null;
             TypeDefinitionHandle baseHandle;
             if (typeDef.BaseType.Kind == HandleKind.TypeDefinition)
@@ -6266,7 +6334,11 @@ public static class CompileBackSourceComposer
                 var generatedLocalFunction = IsGeneratedLocalFunctionName(name);
                 var methodDeclaration = generatedLocalFunction
                     ? null
-                    : MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
+                    : MetadataDeclarationQuery.GetMethod(
+                        reader,
+                        typeDef,
+                        methodHandle,
+                        signature);
                 var parameters = generatedLocalFunction
                     ? Parameters(reader, method, signature)
                     : ToCompileBackParameters(methodDeclaration!.Signature.Parameters);

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -5323,16 +5323,13 @@ public static class CompileBackSourceComposer
                 reader,
                 materializedOverrideSlots,
                 members);
-            // When this class is reconstructed as the base of another shell type, a
-            // derived stub constructor emits an implicit `: base()`. If the class has
-            // only parameterized constructors (no accessible parameterless one), that
-            // implicit call fails to bind (CS7036/CS1729). Synthesize a parameterless
-            // constructor so base-class reconstruction never breaks the derived shell;
-            // at worst the derived constructor stays at its pre-existing opcode diff.
+            // A synthetic constructor must not collide with a private parameterless
+            // constructor: accessibility affects whether a derived shell can call the
+            // constructor, but not whether its C# signature is already occupied.
             if (kind == CompileBackTypeKind.Class
                 && members.Any(member => member.Kind == CompileBackMemberKind.Constructor)
-                && !HasAccessibleParameterlessConstructor(members)
-                && !HasAccessibleParameterlessInstanceConstructor(reader, typeDef)
+                && !HasParameterlessConstructorSignature(members)
+                && !HasParameterlessInstanceConstructor(reader, typeDef)
                 && NeedsSyntheticParameterlessConstructor(reader, requirement, requirementsByMetadataName, useFullBodies))
             {
                 members.Add(SyntheticParameterlessConstructor(requirement.Type));
@@ -6102,7 +6099,10 @@ public static class CompileBackSourceComposer
                 string identifierName = MemberIdentifierName(name, isConstructor);
                 int existingMethodIndex = members.FindIndex(member =>
                     member.Kind == (isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method)
-                    && member.Identity.Method == identifierName);
+                    && (isConstructor
+                        ? member.MetadataToken
+                            == MetadataTokens.GetToken(methodHandle)
+                        : member.Identity.Method == identifierName));
                 if (existingMethodIndex >= 0)
                 {
                     var existing = members[existingMethodIndex];
@@ -6177,8 +6177,8 @@ public static class CompileBackSourceComposer
             if (requirement.RequiredKind == CompileBackTypeKind.Class
                 && !TypeShellProducer.IsStaticType(typeDef)
                 && requirement.PrimaryConstructor is null
-                && !HasAccessibleParameterlessConstructor(members)
-                && !HasAccessibleParameterlessInstanceConstructor(reader, typeDef)
+                && !HasParameterlessConstructorSignature(members)
+                && !HasParameterlessInstanceConstructor(reader, typeDef)
                 && NeedsSyntheticParameterlessConstructor(reader, requirement, requirementsByMetadataName, useFullBodies))
             {
                 members.Add(new CompileBackMemberRequirement(
@@ -6334,12 +6334,11 @@ public static class CompileBackSourceComposer
             return null;
         }
 
-        static bool HasAccessibleParameterlessConstructor(
+        static bool HasParameterlessConstructorSignature(
             IEnumerable<CompileBackMemberRequirement> members)
             => members.Any(member =>
                 member.Kind == CompileBackMemberKind.Constructor
-                && member.Parameters.Count == 0
-                && member.Accessibility != CompileBackAccessibility.Private);
+                && member.Parameters.Count == 0);
 
         static MethodDefinitionHandle? FindAccessibleInstanceConstructor(
             MetadataReader reader,
@@ -6375,14 +6374,15 @@ public static class CompileBackSourceComposer
             return null;
         }
 
-        static bool HasAccessibleParameterlessInstanceConstructor(MetadataReader reader, TypeDefinition typeDef)
+        static bool HasParameterlessInstanceConstructor(
+            MetadataReader reader,
+            TypeDefinition typeDef)
         {
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (reader.GetString(method.Name) != ".ctor"
-                    || method.Attributes.HasFlag(MethodAttributes.Static)
-                    || !IsConstructorAccessibleFromDerived(method.Attributes & MethodAttributes.MemberAccessMask))
+                    || method.Attributes.HasFlag(MethodAttributes.Static))
                 {
                     continue;
                 }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -273,6 +273,10 @@ public enum CompileBackAccessibility
 {
     Public,
     Protected,
+    Internal,
+    PrivateProtected,
+    ProtectedInternal,
+    Private,
 }
 
 public enum CompileBackTypeSignatureKind
@@ -1160,7 +1164,14 @@ public static class CompileBackSourceComposer
                     : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))],
                 propertyDeclaration.Attributes,
                 MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes,
-                ExplicitInterfaceMemberName: explicitInterfaceMemberName)
+                IsAbstract: IsAbstractMethod(getter),
+                IsVirtual: IsVirtualMethod(getter),
+                IsOverride: propertyDeclaration.IsOverride,
+                IsSealed: propertyDeclaration.IsSealed,
+                Accessibility: DeclarationAccessibility(propertyDeclaration.Accessibility),
+                ExplicitInterfaceMemberName: explicitInterfaceMemberName,
+                GetterToken: MetadataTokens.GetToken(targetGetter),
+                SetterToken: accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter))
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -2600,7 +2611,14 @@ public static class CompileBackSourceComposer
                         new CompileBackFact("metadata", "auto-property", propertyName)
                     ]
                     : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))],
-                ExplicitInterfaceMemberName: explicitInterfaceMemberName)
+                IsAbstract: IsAbstractMethod(setter),
+                IsVirtual: IsVirtualMethod(setter),
+                IsOverride: propertyDeclaration.IsOverride,
+                IsSealed: propertyDeclaration.IsSealed,
+                Accessibility: DeclarationAccessibility(propertyDeclaration.Accessibility),
+                ExplicitInterfaceMemberName: explicitInterfaceMemberName,
+                GetterToken: property.GetAccessors().Getter.IsNil ? null : MetadataTokens.GetToken(property.GetAccessors().Getter),
+                SetterToken: MetadataTokens.GetToken(targetSetter))
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -2669,6 +2687,11 @@ public static class CompileBackSourceComposer
             reader,
             accessor,
             GenericContext.ForMethod(reader, targetTypeDef, accessor));
+        var accessorDeclaration = MetadataDeclarationQuery.GetMethod(
+            reader,
+            targetTypeDef,
+            accessor,
+            signature);
         var parameters = MethodParameters(reader, accessor, signature);
         if (parameters.Count != 1)
             throw new InvalidOperationException("Event accessors must have exactly one value parameter.");
@@ -2710,9 +2733,16 @@ public static class CompileBackSourceComposer
                 targetBody,
                 [new CompileBackFact("metadata", "target-event-accessor", reader.GetString(accessor.Name))],
                 MemberAttributes(reader, eventDefinition.GetCustomAttributes()),
+                IsAbstract: IsAbstractMethod(accessor),
+                IsVirtual: IsVirtualMethod(accessor),
+                IsOverride: accessorDeclaration.IsOverride,
+                IsSealed: accessorDeclaration.IsSealed,
+                Accessibility: DeclarationAccessibility(accessorDeclaration.Accessibility),
                 RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function),
                 ExplicitInterfaceMemberName: explicitEvent?.QualifiedName,
-                SiblingTargetBody: siblingAccessorBody)
+                SiblingTargetBody: siblingAccessorBody,
+                AdderToken: accessors.Adder.IsNil ? null : MetadataTokens.GetToken(accessors.Adder),
+                RemoverToken: accessors.Remover.IsNil ? null : MetadataTokens.GetToken(accessors.Remover))
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -2792,6 +2822,13 @@ public static class CompileBackSourceComposer
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var method = reader.GetMethodDefinition(targetMethod);
         var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, targetTypeDef, method));
+        bool isSourceMethodDeclaration =
+            function.MethodKind is not (IrMethodKind.Constructor or IrMethodKind.StaticConstructor)
+            && (!method.Attributes.HasFlag(MethodAttributes.SpecialName)
+                || reader.GetString(method.Name).StartsWith("op_", StringComparison.Ordinal));
+        var methodDeclaration = isSourceMethodDeclaration
+            ? MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, method, signature)
+            : null;
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string targetMethodName = Identifier(methodName);
         bool isConstructor = function.MethodKind is IrMethodKind.Constructor or IrMethodKind.StaticConstructor;
@@ -2866,16 +2903,21 @@ public static class CompileBackSourceComposer
                 [new CompileBackFact("metadata", isConstructor ? "target-constructor" : "target-method", reader.GetString(method.Name))],
                 isConstructor ? null : MemberAttributes(reader, method.GetCustomAttributes()),
                 isConstructor ? null : MethodReturnAttributes(reader, method),
-                IsAbstract: !isConstructor && IsAbstractMethod(method),
-                IsVirtual: !isConstructor && IsVirtualMethod(method),
-                IsOverride: false,
-                IsSealed: false,
+                IsAbstract: isSourceMethodDeclaration && IsAbstractMethod(method),
+                IsVirtual: isSourceMethodDeclaration && IsVirtualMethod(method),
+                IsOverride: methodDeclaration?.IsOverride ?? false,
+                IsSealed: methodDeclaration?.IsSealed ?? false,
                 IsAsync: !isConstructor
                     && (function.RequiresAsyncBodyModifier
                         || function.IsRuntimeAsync == MetadataFactState.Yes),
+                Accessibility: methodDeclaration is null
+                    ? MethodAccessibility(method)
+                    : DeclarationAccessibility(methodDeclaration.Accessibility),
                 ConstructorInitializer: targetConstructorInitializer,
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
-                RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function))
+                DeclarationSignature: explicitInterfaceDeclarationSignature,
+                RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function),
+                MetadataToken: MetadataTokens.GetToken(targetMethod))
         ];
         if (externalExplicitInterfaceMethod is { AdditionalInterfaceStubs.Count: > 0 })
         {
@@ -3242,6 +3284,7 @@ public static class CompileBackSourceComposer
             var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
             if (!OperatorSignaturesMatch(targetSignature, signature))
                 continue;
+            var methodDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
 
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, siblingName, 0, MethodSignatureText(siblingName, signature)),
@@ -3257,8 +3300,9 @@ public static class CompileBackSourceComposer
                 MethodReturnAttributes(reader, method),
                 IsAbstract: IsAbstractMethod(method),
                 IsVirtual: IsVirtualMethod(method),
-                IsOverride: false,
-                IsSealed: false);
+                IsOverride: methodDeclaration.IsOverride,
+                IsSealed: methodDeclaration.IsSealed,
+                MetadataToken: MetadataTokens.GetToken(methodHandle));
         }
 
         return null;
@@ -3288,6 +3332,7 @@ public static class CompileBackSourceComposer
             var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
             if (!OperatorSignaturesMatch(targetSignature, signature))
                 continue;
+            var methodDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
 
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, siblingName, 0, MethodSignatureText(siblingName, signature)),
@@ -3303,8 +3348,9 @@ public static class CompileBackSourceComposer
                 MethodReturnAttributes(reader, method),
                 IsAbstract: IsAbstractMethod(method),
                 IsVirtual: IsVirtualMethod(method),
-                IsOverride: false,
-                IsSealed: false);
+                IsOverride: methodDeclaration.IsOverride,
+                IsSealed: methodDeclaration.IsSealed,
+                MetadataToken: MetadataTokens.GetToken(methodHandle));
         }
 
         return null;
@@ -3468,6 +3514,7 @@ public static class CompileBackSourceComposer
             {
                 continue;
             }
+            var methodDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
 
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, "Equals", 0, MethodSignatureText("Equals", signature)),
@@ -3483,8 +3530,9 @@ public static class CompileBackSourceComposer
                 MethodReturnAttributes(reader, method),
                 IsAbstract: IsAbstractMethod(method),
                 IsVirtual: IsVirtualMethod(method),
-                IsOverride: false,
-                IsSealed: false);
+                IsOverride: methodDeclaration.IsOverride,
+                IsSealed: methodDeclaration.IsSealed,
+                MetadataToken: MetadataTokens.GetToken(methodHandle));
         }
 
         return null;
@@ -3529,16 +3577,24 @@ public static class CompileBackSourceComposer
         => $"{signature.ReturnType} {name}({string.Join(", ", signature.ParameterTypes)})";
 
     static bool IsAbstractMethod(MethodDefinition method)
-        => MetadataDeclarationQuery.IsAbstractMethod(method);
+        => MetadataDeclarationQuery.IsSourceDeclarableAbstractMethod(method);
 
     static bool IsVirtualMethod(MethodDefinition method)
-        => MetadataDeclarationQuery.IsVirtualMethod(method);
-
-    static bool IsProtectedMethod(MethodDefinition method)
-        => MetadataDeclarationQuery.AccessibilityKeyword(method) is "protected" or "protected internal";
+        => MetadataDeclarationQuery.IsSourceDeclarableVirtualMethod(method);
 
     static CompileBackAccessibility MethodAccessibility(MethodDefinition method)
-        => IsProtectedMethod(method) ? CompileBackAccessibility.Protected : CompileBackAccessibility.Public;
+        => DeclarationAccessibility(MetadataDeclarationQuery.AccessibilityKeyword(method));
+
+    static CompileBackAccessibility DeclarationAccessibility(string accessibility)
+        => accessibility switch
+        {
+            "protected" => CompileBackAccessibility.Protected,
+            "internal" => CompileBackAccessibility.Internal,
+            "private protected" => CompileBackAccessibility.PrivateProtected,
+            "protected internal" => CompileBackAccessibility.ProtectedInternal,
+            "private" => CompileBackAccessibility.Private,
+            _ => CompileBackAccessibility.Public,
+        };
 
     static IReadOnlyList<string> MemberAttributes(MetadataReader reader, CustomAttributeHandleCollection attributes)
         => MetadataDeclarationQuery.RenderMemberAttributes(reader, attributes);
@@ -4325,6 +4381,8 @@ public static class CompileBackSourceComposer
             IReadOnlyList<CompileBackTypeRequirement> requirements,
             List<CompileBackPlanningDiagnostic> diagnostics)
         {
+            var overrideExpansion = AddSameAssemblyOverrideSlots(reader, requirements);
+            requirements = overrideExpansion.Requirements;
             var requests = new List<CSharpTypePrintRequest>();
             var producedRequirements = new List<CompileBackTypeRequirement>();
             var requirementsByMetadataName = requirements.ToDictionary(
@@ -4361,12 +4419,405 @@ public static class CompileBackSourceComposer
                     rootHandle,
                     rootRequirement,
                     requirementsByMetadataName,
+                    overrideExpansion.MaterializedOverrideSlots,
                     producedRequirements,
                     diagnostics);
                 requests.Add(TypeShellProducer.BuildPrintRequest(reader, rootSpec));
             }
 
             return new TypeProduction(requests, producedRequirements);
+        }
+
+        sealed record OverrideSlotExpansion(
+            IReadOnlyList<CompileBackTypeRequirement> Requirements,
+            IReadOnlyDictionary<MethodDefinitionHandle, MethodDefinitionHandle> MaterializedOverrideSlots);
+
+        static OverrideSlotExpansion AddSameAssemblyOverrideSlots(
+            MetadataReader reader,
+            IReadOnlyList<CompileBackTypeRequirement> requirements)
+        {
+            var expanded = requirements.ToList();
+            var byName = expanded.ToDictionary(
+                requirement => requirement.Type.MetadataFullName,
+                requirement => requirement,
+                StringComparer.Ordinal);
+            var pending = new Queue<MethodDefinitionHandle>();
+            var visited = new HashSet<MethodDefinitionHandle>();
+            var surfaceScans = new HashSet<(TypeDefinitionHandle Type, bool IncludeMemberSurface)>();
+            var materializedOverrideSlots =
+                new Dictionary<MethodDefinitionHandle, MethodDefinitionHandle>();
+
+            foreach (var requirement in expanded.ToArray())
+            {
+                if (FindType(reader, requirement.Type.MetadataFullName) is not { } typeHandle)
+                    continue;
+
+                QueueOverrideMembers(requirement);
+                QueueSurfaceOverrideMembers(typeHandle, requirement.IncludeMemberSurface);
+            }
+
+            while (pending.TryDequeue(out var methodHandle))
+            {
+                if (!visited.Add(methodHandle))
+                    continue;
+
+                var method = reader.GetMethodDefinition(methodHandle);
+                var declaringTypeHandle = method.GetDeclaringType();
+                if (IsIntrinsicObjectOverride(reader, declaringTypeHandle, methodHandle)
+                    || MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                        reader,
+                        declaringTypeHandle,
+                        methodHandle) is not { } slot
+                    || !CanReconstructOverridePath(
+                        reader,
+                        declaringTypeHandle,
+                        slot.DeclaringType,
+                        byName))
+                {
+                    continue;
+                }
+
+                var baseMember = RequirementForMethodHandle(
+                    reader,
+                    slot.DeclaringType,
+                    slot.Method,
+                    "override-base-slot");
+                if (baseMember is null)
+                {
+                    continue;
+                }
+
+                EnsureBaseRequirements(declaringTypeHandle, slot.DeclaringType);
+                var baseTypeDef = reader.GetTypeDefinition(slot.DeclaringType);
+                var baseIdentity = CompileBackTypeIdentity.FromDefinition(reader, baseTypeDef);
+                var baseRequirement = byName[baseIdentity.MetadataFullName];
+                var requiredMembers = baseRequirement.RequiredMembers.ToList();
+                int existingIndex = requiredMembers.FindIndex(existing =>
+                    SameSourceDeclaration(existing, baseMember));
+                if (existingIndex >= 0)
+                {
+                    var existing = requiredMembers[existingIndex];
+                    requiredMembers[existingIndex] = existing with
+                    {
+                        MetadataToken = existing.MetadataToken ?? baseMember.MetadataToken,
+                        GetterToken = existing.GetterToken ?? baseMember.GetterToken,
+                        SetterToken = existing.SetterToken ?? baseMember.SetterToken,
+                        AdderToken = existing.AdderToken ?? baseMember.AdderToken,
+                        RemoverToken = existing.RemoverToken ?? baseMember.RemoverToken,
+                    };
+                }
+                else
+                {
+                    requiredMembers.Add(baseMember);
+                }
+
+                baseRequirement = baseRequirement with { RequiredMembers = requiredMembers };
+                byName[baseIdentity.MetadataFullName] = baseRequirement;
+                expanded[expanded.FindIndex(requirement =>
+                    requirement.Type.MetadataFullName == baseIdentity.MetadataFullName)] = baseRequirement;
+                materializedOverrideSlots[methodHandle] = slot.Method;
+                QueueOverrideMembers(baseRequirement);
+            }
+
+            return new OverrideSlotExpansion(expanded, materializedOverrideSlots);
+
+            void QueueOverrideMembers(CompileBackTypeRequirement requirement)
+            {
+                foreach (var member in requirement.RequiredMembers.Where(member => member.IsOverride))
+                {
+                    foreach (var token in MemberMethodTokens(member))
+                    {
+                        var handle = MetadataTokens.EntityHandle(token);
+                        if (handle.Kind == HandleKind.MethodDefinition)
+                            pending.Enqueue((MethodDefinitionHandle)handle);
+                    }
+                }
+            }
+
+            void QueueSurfaceOverrideMembers(
+                TypeDefinitionHandle typeHandle,
+                bool includeMemberSurface)
+            {
+                if (!surfaceScans.Add((typeHandle, includeMemberSurface)))
+                    return;
+
+                var typeDef = reader.GetTypeDefinition(typeHandle);
+                if (includeMemberSurface)
+                {
+                    foreach (var methodHandle in typeDef.GetMethods())
+                    {
+                        var method = reader.GetMethodDefinition(methodHandle);
+                        if ((method.Attributes & MethodAttributes.Virtual) != 0
+                            && (method.Attributes & MethodAttributes.NewSlot) == 0
+                            && CanIncludeClosureOverrideMember(reader, typeDef, methodHandle))
+                        {
+                            pending.Enqueue(methodHandle);
+                        }
+                    }
+                }
+
+                foreach (var nestedHandle in typeDef.GetNestedTypes())
+                {
+                    var nested = reader.GetTypeDefinition(nestedHandle);
+                    var nestedIdentity = CompileBackTypeIdentity.FromDefinition(reader, nested);
+                    bool includeNestedSurface = includeMemberSurface
+                        || byName.TryGetValue(nestedIdentity.MetadataFullName, out var nestedRequirement)
+                            && nestedRequirement.IncludeMemberSurface
+                        || IsGeneratedMetadataName(reader.GetString(nested.Name));
+                    QueueSurfaceOverrideMembers(nestedHandle, includeNestedSurface);
+                }
+            }
+
+            static bool CanIncludeClosureOverrideMember(
+                MetadataReader reader,
+                TypeDefinition typeDef,
+                MethodDefinitionHandle methodHandle)
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (method.GetGenericParameters().Count != 0)
+                    return false;
+
+                foreach (var propertyHandle in typeDef.GetProperties())
+                {
+                    var property = reader.GetPropertyDefinition(propertyHandle);
+                    var accessors = property.GetAccessors();
+                    if (accessors.Getter != methodHandle && accessors.Setter != methodHandle)
+                        continue;
+
+                    try
+                    {
+                        return MetadataDeclarationQuery.GetProperty(reader, typeDef, property)
+                            .Signature.Parameters.Count == 0;
+                    }
+                    catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            void EnsureBaseRequirements(
+                TypeDefinitionHandle derivedTypeHandle,
+                TypeDefinitionHandle slotDeclaringType)
+            {
+                var currentHandle = derivedTypeHandle;
+                while (currentHandle != slotDeclaringType)
+                {
+                    var current = reader.GetTypeDefinition(currentHandle);
+                    if (current.BaseType.Kind != HandleKind.TypeDefinition)
+                        return;
+
+                    var baseHandle = (TypeDefinitionHandle)current.BaseType;
+                    var baseType = reader.GetTypeDefinition(baseHandle);
+                    var baseIdentity = CompileBackTypeIdentity.FromDefinition(reader, baseType);
+                    if (!byName.ContainsKey(baseIdentity.MetadataFullName))
+                    {
+                        var requirement = new CompileBackTypeRequirement(
+                            baseIdentity,
+                            ShellKind(reader, baseType),
+                            RequiredMembers: [],
+                            PrimaryConstructor: null,
+                            SourceFacts: [new CompileBackFact("metadata", "override-base-type", baseIdentity.FullName)]);
+                        expanded.Add(requirement);
+                        byName.Add(baseIdentity.MetadataFullName, requirement);
+                    }
+
+                    currentHandle = baseHandle;
+                }
+            }
+        }
+
+        static bool SameSourceDeclaration(
+            CompileBackMemberRequirement left,
+            CompileBackMemberRequirement right)
+        {
+            bool sameKind = left.Kind == right.Kind
+                || left.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
+                    && right.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
+                || left.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove
+                    && right.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove;
+            return sameKind
+                && left.Identity.Type == right.Identity.Type
+                && left.Identity.Method == right.Identity.Method
+                && left.Identity.Signature == right.Identity.Signature
+                && SameParameters(left.Parameters, right.Parameters);
+        }
+
+        static void NormalizeOverrideMembers(
+            MetadataReader reader,
+            IReadOnlyDictionary<MethodDefinitionHandle, MethodDefinitionHandle> materializedOverrideSlots,
+            List<CompileBackMemberRequirement> members)
+        {
+            for (int i = 0; i < members.Count; i++)
+            {
+                var member = members[i];
+                if (!member.IsOverride)
+                    continue;
+
+                var methodHandles = MemberMethodTokens(member)
+                    .Select(MetadataTokens.EntityHandle)
+                    .Where(handle => handle.Kind == HandleKind.MethodDefinition)
+                    .Select(handle => (MethodDefinitionHandle)handle)
+                    .ToArray();
+                bool canEmitOverride = methodHandles.Length != 0
+                    && methodHandles.All(methodHandle => CanEmitOverride(methodHandle, []));
+
+                if (!canEmitOverride)
+                {
+                    members[i] = member with
+                    {
+                        IsOverride = false,
+                        IsSealed = false,
+                    };
+                }
+            }
+
+            bool CanEmitOverride(
+                MethodDefinitionHandle methodHandle,
+                HashSet<MethodDefinitionHandle> visited)
+            {
+                if (!visited.Add(methodHandle))
+                    return false;
+
+                var method = reader.GetMethodDefinition(methodHandle);
+                var declaringType = method.GetDeclaringType();
+                if (IsIntrinsicObjectOverride(reader, declaringType, methodHandle))
+                    return true;
+                if (!materializedOverrideSlots.TryGetValue(methodHandle, out var slotHandle))
+                    return false;
+
+                var slot = reader.GetMethodDefinition(slotHandle);
+                return (slot.Attributes & MethodAttributes.NewSlot) != 0
+                    || CanEmitOverride(slotHandle, visited);
+            }
+        }
+
+        static bool CanReconstructOverridePath(
+            MetadataReader reader,
+            TypeDefinitionHandle derivedType,
+            TypeDefinitionHandle slotDeclaringType,
+            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName)
+        {
+            var current = derivedType;
+            var visited = new HashSet<TypeDefinitionHandle>();
+            while (current != slotDeclaringType && visited.Add(current))
+            {
+                var type = reader.GetTypeDefinition(current);
+                var identity = CompileBackTypeIdentity.FromDefinition(reader, type);
+                var kind = requirementsByMetadataName.TryGetValue(
+                    identity.MetadataFullName,
+                    out var requirement)
+                    ? requirement.RequiredKind
+                    : ShellKind(reader, type);
+                if (kind != CompileBackTypeKind.Class
+                    || TypeShellProducer.ReconstructedBaseTypeDisplay(
+                        reader,
+                        type,
+                        isClass: true) is null
+                    || type.BaseType.Kind != HandleKind.TypeDefinition)
+                {
+                    return false;
+                }
+
+                current = (TypeDefinitionHandle)type.BaseType;
+            }
+
+            return current == slotDeclaringType;
+        }
+
+        static bool IsIntrinsicObjectOverride(
+            MetadataReader reader,
+            TypeDefinitionHandle declaringTypeHandle,
+            MethodDefinitionHandle methodHandle)
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if ((method.Attributes & MethodAttributes.Static) != 0
+                || method.GetGenericParameters().Count != 0)
+            {
+                return false;
+            }
+
+            var declaringType = reader.GetTypeDefinition(declaringTypeHandle);
+            MethodSignature<string> signature;
+            try
+            {
+                signature = GuardedSignatureText.MethodText(
+                    reader,
+                    method,
+                    GenericContext.ForMethod(reader, declaringType, method));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return false;
+            }
+
+            return reader.GetString(method.Name) switch
+            {
+                "ToString" => signature.ReturnType == "string"
+                    && signature.ParameterTypes.Length == 0,
+                "GetHashCode" => signature.ReturnType == "int"
+                    && signature.ParameterTypes.Length == 0,
+                "Equals" => signature.ReturnType == "bool"
+                    && signature.ParameterTypes is ["object"],
+                _ => false,
+            };
+        }
+
+        static IEnumerable<int> MemberMethodTokens(CompileBackMemberRequirement member)
+        {
+            if (member.MetadataToken is { } methodToken)
+                yield return methodToken;
+            if (member.GetterToken is { } getterToken)
+                yield return getterToken;
+            if (member.SetterToken is { } setterToken)
+                yield return setterToken;
+            if (member.AdderToken is { } adderToken)
+                yield return adderToken;
+            if (member.RemoverToken is { } removerToken)
+                yield return removerToken;
+        }
+
+        static CompileBackMemberRequirement? RequirementForMethodHandle(
+            MetadataReader reader,
+            TypeDefinitionHandle typeHandle,
+            MethodDefinitionHandle methodHandle,
+            string factId)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var identity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
+            foreach (var propertyHandle in typeDef.GetProperties())
+            {
+                var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+                if (accessors.Getter == methodHandle || accessors.Setter == methodHandle)
+                {
+                    return PropertyRequirement(
+                        reader,
+                        typeDef,
+                        identity,
+                        propertyHandle,
+                        reader.GetString(reader.GetMethodDefinition(methodHandle).Name),
+                        factId);
+                }
+            }
+
+            foreach (var eventHandle in typeDef.GetEvents())
+            {
+                var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
+                if (accessors.Adder == methodHandle || accessors.Remover == methodHandle)
+                {
+                    return EventRequirement(
+                        reader,
+                        typeDef,
+                        identity,
+                        eventHandle,
+                        reader.GetString(reader.GetMethodDefinition(methodHandle).Name),
+                        factId);
+                }
+            }
+
+            return MethodRequirement(reader, typeDef, identity, methodHandle, factId);
         }
 
         public sealed record TypeProduction(
@@ -4488,7 +4939,7 @@ public static class CompileBackSourceComposer
             bool isAutoProperty = hasGetter
                 && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
             bool isInitSetter = hasSetter && SetterIsInitOnly(reader, accessors.Setter);
-            bool isAbstractAccessor = !accessor.IsNil && propertyDeclaration.IsAbstract;
+            bool isAbstractAccessor = !accessor.IsNil && IsAbstractMethod(accessorMethod);
             var noBodyProperty = (typeDef.Attributes & TypeAttributes.Interface) != 0 || isAbstractAccessor;
             var stubBody = PropertyStubBody(
                 hasGetter,
@@ -4509,8 +4960,13 @@ public static class CompileBackSourceComposer
                 propertyDeclaration.Attributes,
                 propertyDeclaration.Signature.ReturnAttributes,
                 IsAbstract: isAbstractAccessor,
-                IsVirtual: !accessor.IsNil && propertyDeclaration.IsVirtual,
-                ExplicitInterfaceMemberName: explicitInterfaceMemberName);
+                IsVirtual: !accessor.IsNil && IsVirtualMethod(accessorMethod),
+                IsOverride: !accessor.IsNil && propertyDeclaration.IsOverride,
+                IsSealed: !accessor.IsNil && propertyDeclaration.IsSealed,
+                Accessibility: DeclarationAccessibility(propertyDeclaration.Accessibility),
+                ExplicitInterfaceMemberName: explicitInterfaceMemberName,
+                GetterToken: accessors.Getter.IsNil ? null : MetadataTokens.GetToken(accessors.Getter),
+                SetterToken: accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter));
         }
 
         static CompileBackStubBodyKind PropertyStubBody(
@@ -4594,8 +5050,8 @@ public static class CompileBackSourceComposer
                 return null;
 
             string eventName = Identifier(reader.GetString(eventDefinition.Name));
-            bool isAbstract = IsAbstractMethod(accessor);
-            bool hasNoBody = (typeDef.Attributes & TypeAttributes.Interface) != 0 || isAbstract;
+            var accessorDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, accessor, signature);
+            bool hasNoBody = (typeDef.Attributes & TypeAttributes.Interface) != 0 || IsAbstractMethod(accessor);
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(
                     typeIdentity.FullName,
@@ -4613,8 +5069,13 @@ public static class CompileBackSourceComposer
                 null,
                 [new CompileBackFact("metadata", factId, accessorName)],
                 MemberAttributes(reader, eventDefinition.GetCustomAttributes()),
-                IsAbstract: isAbstract,
-                IsVirtual: IsVirtualMethod(accessor));
+                IsAbstract: IsAbstractMethod(accessor),
+                IsVirtual: IsVirtualMethod(accessor),
+                IsOverride: accessorDeclaration.IsOverride,
+                IsSealed: accessorDeclaration.IsSealed,
+                Accessibility: DeclarationAccessibility(accessorDeclaration.Accessibility),
+                AdderToken: accessors.Adder.IsNil ? null : MetadataTokens.GetToken(accessors.Adder),
+                RemoverToken: accessors.Remover.IsNil ? null : MetadataTokens.GetToken(accessors.Remover));
         }
 
         internal static CompileBackMemberRequirement? MethodRequirement(
@@ -4684,9 +5145,11 @@ public static class CompileBackSourceComposer
                 isConstructor ? null : methodDeclaration?.Signature.ReturnAttributes,
                 IsAbstract: !isConstructor && IsAbstractMethod(method),
                 IsVirtual: !isConstructor && IsVirtualMethod(method),
-                IsOverride: false,
-                IsSealed: false,
-                IsExtension: IsExtensionMethod(reader, typeDef, method));
+                IsOverride: methodDeclaration?.IsOverride ?? false,
+                IsSealed: methodDeclaration?.IsSealed ?? false,
+                IsExtension: IsExtensionMethod(reader, typeDef, method),
+                Accessibility: MethodAccessibility(method),
+                MetadataToken: MetadataTokens.GetToken(methodHandle));
         }
 
         static bool IsExtensionMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
@@ -4716,6 +5179,7 @@ public static class CompileBackSourceComposer
             TypeDefinitionHandle handle,
             CompileBackTypeRequirement requirement,
             IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
+            IReadOnlyDictionary<MethodDefinitionHandle, MethodDefinitionHandle> materializedOverrideSlots,
             List<CompileBackTypeRequirement> producedRequirements,
             List<CompileBackPlanningDiagnostic> diagnostics)
         {
@@ -4736,6 +5200,10 @@ public static class CompileBackSourceComposer
                     requirementsByMetadataName,
                     members);
             }
+            NormalizeOverrideMembers(
+                reader,
+                materializedOverrideSlots,
+                members);
             // When this class is reconstructed as the base of another shell type, a
             // derived stub constructor emits an implicit `: base()`. If the class has
             // only parameterized constructors (no accessible parameterless one), that
@@ -4775,6 +5243,7 @@ public static class CompileBackSourceComposer
                     reader,
                     typeDef,
                     requirementsByMetadataName,
+                    materializedOverrideSlots,
                     includeMemberSurface,
                     producedRequirements,
                     diagnostics));
@@ -4966,14 +5435,13 @@ public static class CompileBackSourceComposer
         }
 
         static List<CompileBackMemberRequirement> RequiredMemberRequirements(CompileBackTypeRequirement requirement)
-            => requirement.RequiredMembers
-                .Select(member => member with { Accessibility = CompileBackAccessibility.Public })
-                .ToList();
+            => requirement.RequiredMembers.ToList();
 
         static IReadOnlyList<CSharpTypeShellSpec> NestedSpecs(
             MetadataReader reader,
             TypeDefinition typeDef,
             IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
+            IReadOnlyDictionary<MethodDefinitionHandle, MethodDefinitionHandle> materializedOverrideSlots,
             bool includeMemberSurface,
             List<CompileBackTypeRequirement> producedRequirements,
             List<CompileBackPlanningDiagnostic> diagnostics)
@@ -5008,6 +5476,7 @@ public static class CompileBackSourceComposer
                     nestedHandle,
                     nestedRequirement,
                     requirementsByMetadataName,
+                    materializedOverrideSlots,
                     producedRequirements,
                     diagnostics));
             }
@@ -5031,6 +5500,7 @@ public static class CompileBackSourceComposer
                             PrimaryConstructor: null,
                             SourceFacts: [new CompileBackFact("metadata", "generated-dynamic-delegate", identity.FullName)]),
                         requirementsByMetadataName,
+                        materializedOverrideSlots,
                         producedRequirements,
                         diagnostics));
                 }
@@ -5325,7 +5795,7 @@ public static class CompileBackSourceComposer
                 bool isAutoProperty = hasGetter
                     && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
                 bool isInitSetter = hasSetter && SetterIsInitOnly(reader, accessors.Setter);
-                bool isAbstractAccessor = !accessor.IsNil && propertyDeclaration.IsAbstract;
+                bool isAbstractAccessor = !accessor.IsNil && IsAbstractMethod(accessorMethod);
                 var noBodyProperty = requirement.RequiredKind == CompileBackTypeKind.Interface || isAbstractAccessor;
                 var stubBody = PropertyStubBody(
                     hasGetter,
@@ -5346,7 +5816,9 @@ public static class CompileBackSourceComposer
                     propertyDeclaration.Attributes,
                     propertyDeclaration.Signature.ReturnAttributes,
                     IsAbstract: isAbstractAccessor,
-                    IsVirtual: !accessor.IsNil && propertyDeclaration.IsVirtual,
+                    IsVirtual: !accessor.IsNil && IsVirtualMethod(accessorMethod),
+                    IsOverride: !accessor.IsNil && propertyDeclaration.IsOverride,
+                    IsSealed: !accessor.IsNil && propertyDeclaration.IsSealed,
                     Accessibility: accessor.IsNil
                         ? CompileBackAccessibility.Public
                         : MethodAccessibility(accessorMethod),
@@ -5490,8 +5962,8 @@ public static class CompileBackSourceComposer
                     isConstructor ? null : methodDeclaration?.Signature.ReturnAttributes,
                     IsAbstract: !isConstructor && IsAbstractMethod(method),
                     IsVirtual: !isConstructor && IsVirtualMethod(method),
-                    IsOverride: false,
-                    IsSealed: false,
+                    IsOverride: methodDeclaration?.IsOverride ?? false,
+                    IsSealed: methodDeclaration?.IsSealed ?? false,
                     Accessibility: MethodAccessibility(method),
                     MetadataToken: MetadataTokens.GetToken(methodHandle)));
             }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2983,7 +2983,6 @@ public static class CompileBackSourceComposer
                     : DeclarationAccessibility(methodDeclaration.Accessibility),
                 ConstructorInitializer: targetConstructorInitializer,
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
-                DeclarationSignature: explicitInterfaceDeclarationSignature,
                 RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function),
                 MetadataToken: MetadataTokens.GetToken(targetMethod))
         ];

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1107,8 +1107,12 @@ public static class CompileBackSourceComposer
         foreach (var methodHandle in typeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
-            if (reader.GetString(method.Name) != ".ctor"
-                || method.Attributes.HasFlag(MethodAttributes.Static)
+            if (!MetadataDeclarationQuery
+                    .TryGetCliInstanceConstructorSignature(
+                        reader,
+                        typeDef,
+                        method,
+                        out MethodSignature<string> signature)
                 || !IsConstructorAccessibleFromDerived(
                     reader,
                     declaringTypeHandle,
@@ -1121,10 +1125,6 @@ public static class CompileBackSourceComposer
 
             try
             {
-                var signature = GuardedSignatureText.MethodText(
-                    reader,
-                    method,
-                    GenericContext.ForMethod(reader, typeDef, method));
                 if (signature.ParameterTypes.SequenceEqual(parameterTypes, StringComparer.Ordinal))
                     return methodHandle;
             }
@@ -6447,8 +6447,12 @@ public static class CompileBackSourceComposer
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
-                if (reader.GetString(method.Name) != ".ctor"
-                    || method.Attributes.HasFlag(MethodAttributes.Static)
+                if (!MetadataDeclarationQuery
+                        .TryGetCliInstanceConstructorSignature(
+                            reader,
+                            typeDef,
+                            method,
+                            out MethodSignature<string> signature)
                     || !IsConstructorAccessibleFromDerived(
                         reader,
                         declaringTypeHandle,
@@ -6461,10 +6465,6 @@ public static class CompileBackSourceComposer
 
                 try
                 {
-                    var signature = GuardedSignatureText.MethodText(
-                        reader,
-                        method,
-                        GenericContext.ForMethod(reader, typeDef, method));
                     if (signature.ParameterTypes.SequenceEqual(parameterTypes, StringComparer.Ordinal))
                         return methodHandle;
                 }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -404,6 +404,8 @@ public sealed record CompileBackMemberRequirement(
     int? MetadataToken = null,
     int? GetterToken = null,
     int? SetterToken = null,
+    string? GetterAccessibility = null,
+    string? SetterAccessibility = null,
     int? AdderToken = null,
     int? RemoverToken = null)
 {
@@ -526,7 +528,8 @@ public static class CompileBackSourceComposer
                 request.SignatureText,
                 closure.Roots,
                 closure.Facts,
-                closure.MemberRequirements),
+                closure.MemberRequirements,
+                request.BodyPolicy),
             EventAccessorArtifactRequest eventAccessor => ComposeEventAccessor(
                 request.AssemblyPath,
                 request.Reader,
@@ -559,7 +562,8 @@ public static class CompileBackSourceComposer
                 closure.Roots,
                 closure.Facts,
                 closure.MemberRequirements,
-                request.TargetBody.ConstructorChain),
+                request.TargetBody.ConstructorChain,
+                request.BodyPolicy),
             _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
         };
 
@@ -1081,6 +1085,44 @@ public static class CompileBackSourceComposer
             facts.Add(fact);
     }
 
+    static MethodDefinitionHandle? FindAccessibleInstanceConstructor(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        IReadOnlyList<string> parameterTypes)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != ".ctor"
+                || method.Attributes.HasFlag(MethodAttributes.Static)
+                || !IsConstructorAccessibleFromDerived(method.Attributes & MethodAttributes.MemberAccessMask))
+            {
+                continue;
+            }
+
+            try
+            {
+                var signature = GuardedSignatureText.MethodText(
+                    reader,
+                    method,
+                    GenericContext.ForMethod(reader, typeDef, method));
+                if (signature.ParameterTypes.SequenceEqual(parameterTypes, StringComparer.Ordinal))
+                    return methodHandle;
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                continue;
+            }
+        }
+
+        return null;
+    }
+
+    static bool IsConstructorAccessibleFromDerived(MethodAttributes accessibility)
+        => accessibility is not MethodAttributes.Private
+            and not MethodAttributes.PrivateScope;
+
     public static CompileBackSourceResult ComposePropertyGetter(
         string assemblyPath,
         MetadataReader reader,
@@ -1171,7 +1213,9 @@ public static class CompileBackSourceComposer
                 Accessibility: DeclarationAccessibility(propertyDeclaration.Accessibility),
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
                 GetterToken: MetadataTokens.GetToken(targetGetter),
-                SetterToken: accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter))
+                SetterToken: accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter),
+                GetterAccessibility: AccessorAccessibility(propertyDeclaration, "get"),
+                SetterAccessibility: AccessorAccessibility(propertyDeclaration, "set"))
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -1199,7 +1243,11 @@ public static class CompileBackSourceComposer
         }
         AddExplicitInterfacePropertyDeclaration(requirements, reader, targetTypeDef, targetGetter);
 
-        var production = TypeProducer.Produce(reader, requirements, diagnostics);
+        var production = TypeProducer.Produce(
+            reader,
+            requirements,
+            diagnostics,
+            useFullBodies: bodyPolicy == RoundTripBodyPolicy.Full);
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
             Usings: BuildUsings(function),
@@ -2555,7 +2603,8 @@ public static class CompileBackSourceComposer
         string signatureText,
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
-        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
+        RoundTripBodyPolicy bodyPolicy)
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var property = reader.GetPropertyDefinition(targetProperty);
@@ -2618,7 +2667,9 @@ public static class CompileBackSourceComposer
                 Accessibility: DeclarationAccessibility(propertyDeclaration.Accessibility),
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
                 GetterToken: property.GetAccessors().Getter.IsNil ? null : MetadataTokens.GetToken(property.GetAccessors().Getter),
-                SetterToken: MetadataTokens.GetToken(targetSetter))
+                SetterToken: MetadataTokens.GetToken(targetSetter),
+                GetterAccessibility: AccessorAccessibility(propertyDeclaration, "get"),
+                SetterAccessibility: AccessorAccessibility(propertyDeclaration, "set"))
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -2645,7 +2696,11 @@ public static class CompileBackSourceComposer
         }
         AddExplicitInterfacePropertyDeclaration(requirements, reader, targetTypeDef, targetSetter);
 
-        var production = TypeProducer.Produce(reader, requirements, diagnostics);
+        var production = TypeProducer.Produce(
+            reader,
+            requirements,
+            diagnostics,
+            useFullBodies: bodyPolicy == RoundTripBodyPolicy.Full);
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
             Usings: BuildUsings(function),
@@ -2787,7 +2842,11 @@ public static class CompileBackSourceComposer
         }
         AddExplicitInterfaceEventDeclaration(requirements, reader, explicitEvent);
 
-        var production = TypeProducer.Produce(reader, requirements, diagnostics);
+        var production = TypeProducer.Produce(
+            reader,
+            requirements,
+            diagnostics,
+            useFullBodies: bodyPolicy == RoundTripBodyPolicy.Full);
         var module = new CompileBackModuleRequirement(
             Usings: BuildUsings(function),
             AssemblyAttributes: [],
@@ -2817,7 +2876,8 @@ public static class CompileBackSourceComposer
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
-        string? constructorChain = null)
+        string? constructorChain = null,
+        RoundTripBodyPolicy bodyPolicy = RoundTripBodyPolicy.Selected)
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var method = reader.GetMethodDefinition(targetMethod);
@@ -2830,8 +2890,8 @@ public static class CompileBackSourceComposer
             ? MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, method, signature)
             : null;
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
-        string targetMethodName = Identifier(methodName);
         bool isConstructor = function.MethodKind is IrMethodKind.Constructor or IrMethodKind.StaticConstructor;
+        string targetMethodName = MemberIdentifierName(methodName, isConstructor);
         var bodyFacts = isConstructor ? MemberBodyFacts.Constructor(function) : ConstructorBodyFacts.None;
         var primaryConstructor = isConstructor
             ? PrimaryConstructorFromPrologue(reader, method, bodyFacts.PrimaryConstructorPrologue, targetBody)
@@ -2839,6 +2899,10 @@ public static class CompileBackSourceComposer
 
         var diagnostics = new List<CompileBackPlanningDiagnostic>();
         var targetRoot = TopLevelRootOf(reader, targetType);
+        var effectiveClosureRoots = new HashSet<TypeDefinitionHandle>(closureRoots);
+        var effectiveClosureFacts = closureFacts.ToDictionary(
+            entry => entry.Key,
+            entry => entry.Value.ToList());
         var targetFacts = new List<CompileBackFact>
         {
             new("metadata", "target-type", targetIdentity.FullName),
@@ -2847,15 +2911,19 @@ public static class CompileBackSourceComposer
             targetFacts.AddRange(targetClosureFacts);
 
         var chainParameterTypes = bodyFacts.ChainParameterTypes;
-        // Only this(...) self-chains are re-emitted as constructor initializers.
-        // RTS shells are flat (object-based, no reconstructed base class), so a
-        // base(args) initializer has no base constructor to bind to and would
-        // fail to compile (CS1729). Leaving those bodies empty keeps the prior
-        // implicit-base() behavior instead of introducing a recompile failure.
-        string? targetConstructorInitializer =
-            constructorChain is { } chain && chain.StartsWith("this(", StringComparison.Ordinal)
-                ? constructorChain
-                : null;
+        string? targetConstructorInitializer = null;
+        if (constructorChain is { } chain)
+        {
+            if (chain.StartsWith("this(", StringComparison.Ordinal))
+            {
+                targetConstructorInitializer = chain;
+            }
+            else if (chain.StartsWith("base(", StringComparison.Ordinal)
+                     && CanPreserveExplicitBaseConstructorInitializer())
+            {
+                targetConstructorInitializer = chain;
+            }
+        }
 
         var targetReturnType = isConstructor
             ? null
@@ -2977,8 +3045,10 @@ public static class CompileBackSourceComposer
         // the oracle surfaces honestly. The only preconditions are structural:
         // the chained-to constructor must be reconstructable in the shell, and a
         // same-arity sibling must be present to serve as its binding target.
+        bool targetUsesThisInitializer = targetConstructorInitializer?.StartsWith("this(", StringComparison.Ordinal) == true;
         bool chainedConstructorReconstructed =
-            chainParameterTypes is { } chainParams
+            targetUsesThisInitializer
+            && chainParameterTypes is { } chainParams
             // The chained-to constructor is reconstructed only when its signature
             // is fully supported (an unsupported parameter such as a function
             // pointer makes the planner drop it, mirroring MethodRequirement).
@@ -2988,7 +3058,7 @@ public static class CompileBackSourceComposer
             && targetMembers.Any(member => member.Kind == CompileBackMemberKind.Constructor
                 && member.StubBody != CompileBackStubBodyKind.TargetBody
                 && member.Parameters.Count == chainParams.Count);
-        if (targetConstructorInitializer is not null && !chainedConstructorReconstructed)
+        if (targetUsesThisInitializer && !chainedConstructorReconstructed)
         {
             // The chained-to constructor was not reconstructed in the shell: either
             // an unsupported parameter dropped it, or no same-arity sibling is
@@ -3035,14 +3105,14 @@ public static class CompileBackSourceComposer
                     : [externalExplicitInterfaceMethod.InterfaceDisplayName],
             }
         };
-        AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
+        AddClosureTypeRequirements(requirements, reader, targetRoot, effectiveClosureFacts, closureMemberRequirements);
 
-        foreach (var dependency in closureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))
+        foreach (var dependency in effectiveClosureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))
         {
             if (dependency == targetRoot)
                 continue;
 
-            AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
+            AddClosureTypeRequirements(requirements, reader, dependency, effectiveClosureFacts, closureMemberRequirements);
         }
 
         if (explicitInterfaceMemberName is not null)
@@ -3074,7 +3144,11 @@ public static class CompileBackSourceComposer
             }
         }
 
-        var production = TypeProducer.Produce(reader, requirements, diagnostics);
+        var production = TypeProducer.Produce(
+            reader,
+            requirements,
+            diagnostics,
+            useFullBodies: bodyPolicy == RoundTripBodyPolicy.Full);
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
             Usings: BuildUsings(function),
@@ -3088,6 +3162,27 @@ public static class CompileBackSourceComposer
             declarations,
             diagnostics);
         return ComposeCompilationUnit(plan);
+
+        bool CanPreserveExplicitBaseConstructorInitializer()
+        {
+            if (chainParameterTypes is null
+                || targetTypeDef.BaseType.Kind != HandleKind.TypeDefinition
+                || TypeShellProducer.ReconstructedBaseTypeDisplay(reader, targetTypeDef, isClass: true) is null)
+            {
+                return false;
+            }
+
+            var baseHandle = (TypeDefinitionHandle)targetTypeDef.BaseType;
+            if (FindAccessibleInstanceConstructor(reader, baseHandle, chainParameterTypes) is null)
+                return false;
+
+            effectiveClosureRoots.Add(TopLevelRootOf(reader, baseHandle));
+            AddClosureFact(
+                effectiveClosureFacts,
+                baseHandle,
+                new CompileBackFact("round-trip", "closure-member", "explicit base constructor"));
+            return true;
+        }
     }
 
     static CompileBackSourceResult ComposeCompilationUnit(CompileBackReconstructionPlan plan)
@@ -3120,6 +3215,8 @@ public static class CompileBackSourceComposer
         return new CompileBackSourceResult(enrichedPlan, rendered.SourceArtifact);
     }
 
+    static string? AccessorAccessibility(MetadataPropertyDeclaration property, string kind)
+        => property.Signature.Accessors.FirstOrDefault(accessor => accessor.Kind == kind)?.Accessibility;
     static CSharpMemberPolicy ToMemberPolicy(
         CompileBackMemberRequirement requirement,
         int primaryConstructorParameterCount)
@@ -3198,6 +3295,8 @@ public static class CompileBackSourceComposer
             MetadataToken: requirement.MetadataToken,
             GetterToken: requirement.GetterToken,
             SetterToken: requirement.SetterToken,
+            GetterAccessibility: requirement.GetterAccessibility,
+            SetterAccessibility: requirement.SetterAccessibility,
             AdderToken: requirement.AdderToken,
             RemoverToken: requirement.RemoverToken);
 
@@ -4379,7 +4478,8 @@ public static class CompileBackSourceComposer
         public static TypeProduction Produce(
             MetadataReader reader,
             IReadOnlyList<CompileBackTypeRequirement> requirements,
-            List<CompileBackPlanningDiagnostic> diagnostics)
+            List<CompileBackPlanningDiagnostic> diagnostics,
+            bool useFullBodies = false)
         {
             var overrideExpansion = AddSameAssemblyOverrideSlots(reader, requirements);
             requirements = overrideExpansion.Requirements;
@@ -4421,7 +4521,8 @@ public static class CompileBackSourceComposer
                     requirementsByMetadataName,
                     overrideExpansion.MaterializedOverrideSlots,
                     producedRequirements,
-                    diagnostics);
+                    diagnostics,
+                    useFullBodies);
                 requests.Add(TypeShellProducer.BuildPrintRequest(reader, rootSpec));
             }
 
@@ -4463,12 +4564,17 @@ public static class CompileBackSourceComposer
 
                 var method = reader.GetMethodDefinition(methodHandle);
                 var declaringTypeHandle = method.GetDeclaringType();
-                if (IsIntrinsicObjectOverride(reader, declaringTypeHandle, methodHandle)
-                    || MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
-                        reader,
-                        declaringTypeHandle,
-                        methodHandle) is not { } slot
-                    || !CanReconstructOverridePath(
+                var slot = MetadataDeclarationQuery.GetSameAssemblyOverrideSlot(
+                    reader,
+                    declaringTypeHandle,
+                    methodHandle);
+                if (slot is null)
+                {
+                    if (IsIntrinsicObjectOverride(reader, declaringTypeHandle, methodHandle))
+                        continue;
+                    continue;
+                }
+                if (!CanReconstructOverridePath(
                         reader,
                         declaringTypeHandle,
                         slot.DeclaringType,
@@ -4502,6 +4608,8 @@ public static class CompileBackSourceComposer
                         MetadataToken = existing.MetadataToken ?? baseMember.MetadataToken,
                         GetterToken = existing.GetterToken ?? baseMember.GetterToken,
                         SetterToken = existing.SetterToken ?? baseMember.SetterToken,
+                        GetterAccessibility = existing.GetterAccessibility ?? baseMember.GetterAccessibility,
+                        SetterAccessibility = existing.SetterAccessibility ?? baseMember.SetterAccessibility,
                         AdderToken = existing.AdderToken ?? baseMember.AdderToken,
                         RemoverToken = existing.RemoverToken ?? baseMember.RemoverToken,
                     };
@@ -4682,11 +4790,8 @@ public static class CompileBackSourceComposer
                     return false;
 
                 var method = reader.GetMethodDefinition(methodHandle);
-                var declaringType = method.GetDeclaringType();
-                if (IsIntrinsicObjectOverride(reader, declaringType, methodHandle))
-                    return true;
                 if (!materializedOverrideSlots.TryGetValue(methodHandle, out var slotHandle))
-                    return false;
+                    return IsIntrinsicObjectOverride(reader, method.GetDeclaringType(), methodHandle);
 
                 var slot = reader.GetMethodDefinition(slotHandle);
                 return (slot.Attributes & MethodAttributes.NewSlot) != 0
@@ -4966,7 +5071,9 @@ public static class CompileBackSourceComposer
                 Accessibility: DeclarationAccessibility(propertyDeclaration.Accessibility),
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
                 GetterToken: accessors.Getter.IsNil ? null : MetadataTokens.GetToken(accessors.Getter),
-                SetterToken: accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter));
+                SetterToken: accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter),
+                GetterAccessibility: AccessorAccessibility(propertyDeclaration, "get"),
+                SetterAccessibility: AccessorAccessibility(propertyDeclaration, "set"));
         }
 
         static CompileBackStubBodyKind PropertyStubBody(
@@ -5181,7 +5288,8 @@ public static class CompileBackSourceComposer
             IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
             IReadOnlyDictionary<MethodDefinitionHandle, MethodDefinitionHandle> materializedOverrideSlots,
             List<CompileBackTypeRequirement> producedRequirements,
-            List<CompileBackPlanningDiagnostic> diagnostics)
+            List<CompileBackPlanningDiagnostic> diagnostics,
+            bool useFullBodies)
         {
             var typeDef = reader.GetTypeDefinition(handle);
             var kind = requirement.RequiredKind;
@@ -5190,7 +5298,14 @@ public static class CompileBackSourceComposer
                 : RequiredMemberRequirements(requirement);
             bool includeMemberSurface = requirement.IncludeMemberSurface;
             if (includeMemberSurface && kind != CompileBackTypeKind.Delegate)
-                AddClosureMemberSurface(reader, typeDef, requirement, members, diagnostics);
+                AddClosureMemberSurface(
+                    reader,
+                    typeDef,
+                    requirement,
+                    requirementsByMetadataName,
+                    members,
+                    diagnostics,
+                    useFullBodies: useFullBodies);
             if (kind is CompileBackTypeKind.Class or CompileBackTypeKind.Record or CompileBackTypeKind.Struct)
             {
                 AddRequiredInterfaceProperties(
@@ -5198,7 +5313,8 @@ public static class CompileBackSourceComposer
                     typeDef,
                     requirement,
                     requirementsByMetadataName,
-                    members);
+                    members,
+                    useFullBodies);
             }
             NormalizeOverrideMembers(
                 reader,
@@ -5212,8 +5328,9 @@ public static class CompileBackSourceComposer
             // at worst the derived constructor stays at its pre-existing opcode diff.
             if (kind == CompileBackTypeKind.Class
                 && members.Any(member => member.Kind == CompileBackMemberKind.Constructor)
-                && !members.Any(member => member.Kind == CompileBackMemberKind.Constructor && member.Parameters.Count == 0)
-                && IsReconstructedBaseOfAnotherType(reader, requirement, requirementsByMetadataName))
+                && !HasAccessibleParameterlessConstructor(members)
+                && !HasAccessibleParameterlessInstanceConstructor(reader, typeDef)
+                && NeedsSyntheticParameterlessConstructor(reader, requirement, requirementsByMetadataName, useFullBodies))
             {
                 members.Add(SyntheticParameterlessConstructor(requirement.Type));
             }
@@ -5246,7 +5363,8 @@ public static class CompileBackSourceComposer
                     materializedOverrideSlots,
                     includeMemberSurface,
                     producedRequirements,
-                    diagnostics));
+                    diagnostics,
+                    useFullBodies));
         }
 
         static void AddRequiredInterfaceProperties(
@@ -5254,7 +5372,8 @@ public static class CompileBackSourceComposer
             TypeDefinition typeDef,
             CompileBackTypeRequirement requirement,
             IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
-            List<CompileBackMemberRequirement> members)
+            List<CompileBackMemberRequirement> members,
+            bool useFullBodies)
         {
             foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
             {
@@ -5280,8 +5399,10 @@ public static class CompileBackSourceComposer
                         reader,
                         interfaceDef,
                         interfaceRequirement,
+                        requirementsByMetadataName,
                         interfaceMembers,
-                        diagnostics: []);
+                        diagnostics: [],
+                        useFullBodies: useFullBodies);
                 }
 
                 foreach (var interfaceMember in interfaceMembers.Where(
@@ -5444,7 +5565,8 @@ public static class CompileBackSourceComposer
             IReadOnlyDictionary<MethodDefinitionHandle, MethodDefinitionHandle> materializedOverrideSlots,
             bool includeMemberSurface,
             List<CompileBackTypeRequirement> producedRequirements,
-            List<CompileBackPlanningDiagnostic> diagnostics)
+            List<CompileBackPlanningDiagnostic> diagnostics,
+            bool useFullBodies)
         {
             var nestedTypes = new List<CSharpTypeShellSpec>();
             foreach (var nestedHandle in typeDef.GetNestedTypes())
@@ -5478,7 +5600,8 @@ public static class CompileBackSourceComposer
                     requirementsByMetadataName,
                     materializedOverrideSlots,
                     producedRequirements,
-                    diagnostics));
+                    diagnostics,
+                    useFullBodies));
             }
 
             if (HasGeneratedCallSiteCache(reader, typeDef))
@@ -5502,7 +5625,8 @@ public static class CompileBackSourceComposer
                         requirementsByMetadataName,
                         materializedOverrideSlots,
                         producedRequirements,
-                        diagnostics));
+                        diagnostics,
+                        useFullBodies));
                 }
             }
 
@@ -5530,45 +5654,119 @@ public static class CompileBackSourceComposer
             }
         }
 
-        // True when some other reconstructed shell type — top-level or nested —
-        // derives from this class via a reconstructed (same-assembly) base
-        // declaration, so its implicit `: base()` depends on this class exposing an
-        // accessible parameterless constructor. Nested types are emitted by
-        // NestedTypes() from their enclosing requirement and are not present in
-        // requirementsByMetadataName, so each requirement's nested tree is walked.
-        static bool IsReconstructedBaseOfAnotherType(
+        // True when some reconstructed shell type still emits an implicit `: base()`
+        // against this class. Concrete constructors under Full will later receive
+        // their real bodies (and therefore their real constructor chains), so only
+        // stub/default constructors still force a synthetic parameterless base.
+        // Nested types are emitted from their enclosing requirement and are not
+        // tracked individually; keep the existing conservative nested scan.
+        static bool NeedsSyntheticParameterlessConstructor(
             MetadataReader reader,
             CompileBackTypeRequirement requirement,
-            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName)
+            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
+            bool useFullBodies)
         {
             string metadataFullName = requirement.Type.MetadataFullName;
             foreach (var other in requirementsByMetadataName.Values)
             {
+                if (other.Type.MetadataFullName == metadataFullName)
+                    continue;
                 if (FindType(reader, other.Type.MetadataFullName) is not { } otherHandle)
                     continue;
-                if (TypeOrNestedDerivesFrom(reader, otherHandle, metadataFullName))
+                if (NestedTypeDerivesFrom(reader, otherHandle, metadataFullName))
+                    return true;
+                if (TypeDerivesFrom(reader, otherHandle, metadataFullName)
+                    && TypeNeedsImplicitBaseSupport(reader, other, useFullBodies))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        static bool NestedTypeDerivesFrom(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            string baseMetadataFullName)
+        {
+            foreach (var nestedHandle in reader.GetTypeDefinition(handle).GetNestedTypes())
+            {
+                if (TypeDerivesFrom(reader, nestedHandle, baseMetadataFullName)
+                    || NestedTypeDerivesFrom(reader, nestedHandle, baseMetadataFullName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        static bool TypeDerivesFrom(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            string baseMetadataFullName)
+        {
+            var currentHandle = handle;
+            var visited = new HashSet<TypeDefinitionHandle>();
+            while (visited.Add(currentHandle))
+            {
+                var current = reader.GetTypeDefinition(currentHandle);
+                var baseName = ReconstructedSameAssemblyBaseName(reader, currentHandle, ShellKind(reader, current));
+                if (baseName is null)
+                    return false;
+                if (baseName == baseMetadataFullName)
+                    return true;
+                if (current.BaseType.Kind != HandleKind.TypeDefinition)
+                    return false;
+                currentHandle = (TypeDefinitionHandle)current.BaseType;
+            }
+
+            return false;
+        }
+
+        static bool TypeNeedsImplicitBaseSupport(
+            MetadataReader reader,
+            CompileBackTypeRequirement requirement,
+            bool useFullBodies)
+        {
+            if (requirement.RequiredKind is not (CompileBackTypeKind.Class or CompileBackTypeKind.Record))
+                return false;
+
+            var constructors = requirement.RequiredMembers
+                .Where(member => member.Kind == CompileBackMemberKind.Constructor)
+                .ToArray();
+            if (constructors.Length == 0)
+                return true;
+
+            foreach (var constructor in constructors)
+            {
+                if (ConstructorNeedsImplicitBaseSupport(reader, constructor, useFullBodies))
                     return true;
             }
 
             return false;
         }
 
-        static bool TypeOrNestedDerivesFrom(MetadataReader reader, TypeDefinitionHandle handle, string baseMetadataFullName)
+        static bool ConstructorNeedsImplicitBaseSupport(
+            MetadataReader reader,
+            CompileBackMemberRequirement constructor,
+            bool useFullBodies)
         {
-            var typeDef = reader.GetTypeDefinition(handle);
-            if (CompileBackTypeIdentity.FromDefinition(reader, typeDef).MetadataFullName != baseMetadataFullName
-                && ReconstructedSameAssemblyBaseName(reader, handle, ShellKind(reader, typeDef)) == baseMetadataFullName)
+            if (constructor.ConstructorInitializer is { } initializer)
             {
-                return true;
+                return !initializer.StartsWith("base(", StringComparison.Ordinal)
+                    && !initializer.StartsWith("this(", StringComparison.Ordinal);
             }
 
-            foreach (var nestedHandle in typeDef.GetNestedTypes())
+            if (useFullBodies
+                && constructor.MetadataToken is { } token
+                && HasConcreteBody(reader, token))
             {
-                if (TypeOrNestedDerivesFrom(reader, nestedHandle, baseMetadataFullName))
-                    return true;
+                return false;
             }
 
-            return false;
+            return true;
         }
 
         // The metadata full name of the class's reconstructed same-assembly base, or
@@ -5641,9 +5839,11 @@ public static class CompileBackSourceComposer
             MetadataReader reader,
             TypeDefinition typeDef,
             CompileBackTypeRequirement requirement,
+            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
             List<CompileBackMemberRequirement> members,
             List<CompileBackPlanningDiagnostic> diagnostics,
-            bool allowUnsafeSurface = false)
+            bool allowUnsafeSurface = false,
+            bool useFullBodies = false)
         {
             if (requirement.RequiredKind == CompileBackTypeKind.Enum)
             {
@@ -5752,16 +5952,6 @@ public static class CompileBackSourceComposer
                 int existingPropertyIndex = members.FindIndex(member =>
                     (member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet or CompileBackMemberKind.Field)
                     && member.Identity.Method == Identifier(propertyName));
-                if (existingPropertyIndex >= 0)
-                {
-                    var existing = members[existingPropertyIndex];
-                    members[existingPropertyIndex] = existing with
-                    {
-                        GetterToken = existing.GetterToken ?? (accessors.Getter.IsNil ? null : MetadataTokens.GetToken(accessors.Getter)),
-                        SetterToken = existing.SetterToken ?? (accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter)),
-                    };
-                    continue;
-                }
 
                 MetadataPropertyDeclaration propertyDeclaration;
                 try
@@ -5771,6 +5961,19 @@ public static class CompileBackSourceComposer
                 catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
                 {
                     diagnostics.Add(new CompileBackPlanningDiagnostic("member surface", "property-signature-decode-failed", propertyName));
+                    continue;
+                }
+
+                if (existingPropertyIndex >= 0)
+                {
+                    var existing = members[existingPropertyIndex];
+                    members[existingPropertyIndex] = existing with
+                    {
+                        GetterToken = existing.GetterToken ?? (accessors.Getter.IsNil ? null : MetadataTokens.GetToken(accessors.Getter)),
+                        SetterToken = existing.SetterToken ?? (accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter)),
+                        GetterAccessibility = existing.GetterAccessibility ?? AccessorAccessibility(propertyDeclaration, "get"),
+                        SetterAccessibility = existing.SetterAccessibility ?? AccessorAccessibility(propertyDeclaration, "set"),
+                    };
                     continue;
                 }
 
@@ -5819,11 +6022,11 @@ public static class CompileBackSourceComposer
                     IsVirtual: !accessor.IsNil && IsVirtualMethod(accessorMethod),
                     IsOverride: !accessor.IsNil && propertyDeclaration.IsOverride,
                     IsSealed: !accessor.IsNil && propertyDeclaration.IsSealed,
-                    Accessibility: accessor.IsNil
-                        ? CompileBackAccessibility.Public
-                        : MethodAccessibility(accessorMethod),
+                    Accessibility: DeclarationAccessibility(propertyDeclaration.Accessibility),
                     GetterToken: accessors.Getter.IsNil ? null : MetadataTokens.GetToken(accessors.Getter),
-                    SetterToken: accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter)));
+                    SetterToken: accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter),
+                    GetterAccessibility: AccessorAccessibility(propertyDeclaration, "get"),
+                    SetterAccessibility: AccessorAccessibility(propertyDeclaration, "set")));
             }
 
             foreach (var eventHandle in typeDef.GetEvents())
@@ -5971,8 +6174,9 @@ public static class CompileBackSourceComposer
             if (requirement.RequiredKind == CompileBackTypeKind.Class
                 && !TypeShellProducer.IsStaticType(typeDef)
                 && requirement.PrimaryConstructor is null
-                && !members.Any(member => member.Kind == CompileBackMemberKind.Constructor && member.Parameters.Count == 0)
-                && !HasParameterlessInstanceConstructor(reader, typeDef))
+                && !HasAccessibleParameterlessConstructor(members)
+                && !HasAccessibleParameterlessInstanceConstructor(reader, typeDef)
+                && NeedsSyntheticParameterlessConstructor(reader, requirement, requirementsByMetadataName, useFullBodies))
             {
                 members.Add(new CompileBackMemberRequirement(
                     new CompileBackMethodIdentity(requirement.Type.FullName, ".ctor", overload, "void .ctor()"),
@@ -6127,13 +6331,58 @@ public static class CompileBackSourceComposer
             return null;
         }
 
-        static bool HasParameterlessInstanceConstructor(MetadataReader reader, TypeDefinition typeDef)
+        static bool HasAccessibleParameterlessConstructor(
+            IEnumerable<CompileBackMemberRequirement> members)
+            => members.Any(member =>
+                member.Kind == CompileBackMemberKind.Constructor
+                && member.Parameters.Count == 0
+                && member.Accessibility != CompileBackAccessibility.Private);
+
+        static MethodDefinitionHandle? FindAccessibleInstanceConstructor(
+            MetadataReader reader,
+            TypeDefinitionHandle typeHandle,
+            IReadOnlyList<string> parameterTypes)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != ".ctor"
+                    || method.Attributes.HasFlag(MethodAttributes.Static)
+                    || !IsConstructorAccessibleFromDerived(method.Attributes & MethodAttributes.MemberAccessMask))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var signature = GuardedSignatureText.MethodText(
+                        reader,
+                        method,
+                        GenericContext.ForMethod(reader, typeDef, method));
+                    if (signature.ParameterTypes.SequenceEqual(parameterTypes, StringComparer.Ordinal))
+                        return methodHandle;
+                }
+                catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+                {
+                    continue;
+                }
+            }
+
+            return null;
+        }
+
+        static bool HasAccessibleParameterlessInstanceConstructor(MetadataReader reader, TypeDefinition typeDef)
         {
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
-                if (reader.GetString(method.Name) != ".ctor" || method.Attributes.HasFlag(MethodAttributes.Static))
+                if (reader.GetString(method.Name) != ".ctor"
+                    || method.Attributes.HasFlag(MethodAttributes.Static)
+                    || !IsConstructorAccessibleFromDerived(method.Attributes & MethodAttributes.MemberAccessMask))
+                {
                     continue;
+                }
 
                 try
                 {
@@ -6143,11 +6392,21 @@ public static class CompileBackSourceComposer
                 }
                 catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
                 {
-                    return true;
+                    continue;
                 }
             }
 
             return false;
         }
+
+        static bool HasConcreteBody(MetadataReader reader, int token)
+        {
+            var handle = MetadataTokens.MethodDefinitionHandle(token & 0x00ffffff);
+            return reader.GetMethodDefinition(handle).RelativeVirtualAddress != 0;
+        }
+
+        static bool IsConstructorAccessibleFromDerived(MethodAttributes accessibility)
+            => accessibility is not MethodAttributes.Private
+                and not MethodAttributes.PrivateScope;
     }
 }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -4659,7 +4659,13 @@ public static class CompileBackSourceComposer
                     {
                         var method = reader.GetMethodDefinition(methodHandle);
                         if ((method.Attributes & MethodAttributes.Virtual) != 0
-                            && (method.Attributes & MethodAttributes.NewSlot) == 0
+                            && ((method.Attributes
+                                    & MethodAttributes.NewSlot) == 0
+                                || MetadataDeclarationQuery
+                                    .GetSameAssemblyOverrideSlot(
+                                        reader,
+                                        typeHandle,
+                                        methodHandle) is not null)
                             && CanIncludeClosureOverrideMember(reader, typeDef, methodHandle))
                         {
                             pending.Enqueue(methodHandle);
@@ -5329,7 +5335,6 @@ public static class CompileBackSourceComposer
             if (kind == CompileBackTypeKind.Class
                 && members.Any(member => member.Kind == CompileBackMemberKind.Constructor)
                 && !HasParameterlessConstructorSignature(members)
-                && !HasParameterlessInstanceConstructor(reader, typeDef)
                 && NeedsSyntheticParameterlessConstructor(reader, requirement, requirementsByMetadataName, useFullBodies))
             {
                 members.Add(SyntheticParameterlessConstructor(requirement.Type));
@@ -6178,7 +6183,6 @@ public static class CompileBackSourceComposer
                 && !TypeShellProducer.IsStaticType(typeDef)
                 && requirement.PrimaryConstructor is null
                 && !HasParameterlessConstructorSignature(members)
-                && !HasParameterlessInstanceConstructor(reader, typeDef)
                 && NeedsSyntheticParameterlessConstructor(reader, requirement, requirementsByMetadataName, useFullBodies))
             {
                 members.Add(new CompileBackMemberRequirement(
@@ -6372,34 +6376,6 @@ public static class CompileBackSourceComposer
             }
 
             return null;
-        }
-
-        static bool HasParameterlessInstanceConstructor(
-            MetadataReader reader,
-            TypeDefinition typeDef)
-        {
-            foreach (var methodHandle in typeDef.GetMethods())
-            {
-                var method = reader.GetMethodDefinition(methodHandle);
-                if (reader.GetString(method.Name) != ".ctor"
-                    || method.Attributes.HasFlag(MethodAttributes.Static))
-                {
-                    continue;
-                }
-
-                try
-                {
-                    var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
-                    if (signature.ParameterTypes.Length == 0)
-                        return true;
-                }
-                catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
-                {
-                    continue;
-                }
-            }
-
-            return false;
         }
 
         static bool HasConcreteBody(MetadataReader reader, int token)

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -3777,11 +3777,10 @@ public static class CompileBackSourceComposer
         IReadOnlyList<PrimaryConstructorFieldStore>? prologue,
         string renderedBody)
     {
-        if (reader.GetString(method.Name) != ".ctor"
-            || method.Attributes.HasFlag(MethodAttributes.Static))
-            return null;
         var declaringHandle = method.GetDeclaringType();
         var declaringType = reader.GetTypeDefinition(declaringHandle);
+        if (!IsPlannableInstanceConstructor(reader, declaringType, method))
+            return null;
         if (CountInstanceConstructors(reader, declaringType) != 1
             || HasInAssemblyDerivedType(reader, declaringHandle))
             return null;
@@ -4086,12 +4085,31 @@ public static class CompileBackSourceComposer
         foreach (var methodHandle in typeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
-            if (reader.GetString(method.Name) == ".ctor"
-                && !method.Attributes.HasFlag(MethodAttributes.Static))
+            if (IsPlannableInstanceConstructor(reader, typeDef, method))
                 count++;
         }
         return count;
     }
+
+    /// <summary>
+    /// True when <paramref name="method"/> is a complete CLI instance
+    /// constructor. Constructor discovery must never settle for the
+    /// <c>.ctor</c> name: the runtime also requires <c>SpecialName</c>,
+    /// <c>RTSpecialName</c>, instance-ness, non-generic arity, the default
+    /// calling convention, and a <c>void</c> return, and the Metadata layer
+    /// owns that complete predicate. A method that carries the name without
+    /// the rest is malformed, and planning it as a constructor would emit a
+    /// declaration the source form cannot express.
+    /// </summary>
+    static bool IsPlannableInstanceConstructor(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method)
+        => MetadataDeclarationQuery.TryGetCliInstanceConstructorSignature(
+            reader,
+            typeDef,
+            method,
+            out _);
 
     static bool HasInAssemblyDerivedType(MetadataReader reader, TypeDefinitionHandle baseHandle)
     {
@@ -4637,8 +4655,11 @@ public static class CompileBackSourceComposer
                     methodHandle);
                 if (slot is null)
                 {
-                    if (IsIntrinsicObjectOverride(reader, declaringTypeHandle, methodHandle))
-                        continue;
+                    // No same-image base declares this slot, so there is no
+                    // base member for the plan to materialize. Whether the
+                    // shell may still spell `override` is decided later by
+                    // NormalizeOverrideMembers against product-authenticated
+                    // evidence.
                     continue;
                 }
                 if (!CanReconstructOverridePath(
@@ -4783,14 +4804,16 @@ public static class CompileBackSourceComposer
                 TypeDefinitionHandle derivedTypeHandle,
                 TypeDefinitionHandle slotDeclaringType)
             {
-                var currentHandle = derivedTypeHandle;
-                while (currentHandle != slotDeclaringType)
-                {
-                    var current = reader.GetTypeDefinition(currentHandle);
-                    if (current.BaseType.Kind != HandleKind.TypeDefinition)
-                        return;
+                if (derivedTypeHandle == slotDeclaringType)
+                    return;
 
-                    var baseHandle = (TypeDefinitionHandle)current.BaseType;
+                // Same product-owned chain the slot itself was authenticated
+                // against, so a constructed generic base is followed through
+                // its TypeSpec instead of stopping the walk.
+                foreach (var baseHandle in MetadataDeclarationQuery.GetSameAssemblyBaseChain(
+                    reader,
+                    derivedTypeHandle))
+                {
                     var baseType = reader.GetTypeDefinition(baseHandle);
                     var baseIdentity = CompileBackTypeIdentity.FromDefinition(reader, baseType);
                     if (!byName.ContainsKey(baseIdentity.MetadataFullName))
@@ -4805,7 +4828,8 @@ public static class CompileBackSourceComposer
                         byName.Add(baseIdentity.MetadataFullName, requirement);
                     }
 
-                    currentHandle = baseHandle;
+                    if (baseHandle == slotDeclaringType)
+                        return;
                 }
             }
         }
@@ -4874,7 +4898,19 @@ public static class CompileBackSourceComposer
                         method.GetDeclaringType(),
                         methodHandle);
                     if (fallbackSlot is null)
-                        return IsIntrinsicObjectOverride(reader, method.GetDeclaringType(), methodHandle);
+                    {
+                        // The only slot a shell can still spell `override`
+                        // against without a same-image base member is
+                        // System.Object's, and only when the product
+                        // authenticates the whole inheritance chain. A
+                        // name-and-signature guess would rebind a flattened
+                        // external base's own new virtual to System.Object.
+                        return MetadataDeclarationQuery
+                            .IsAuthenticatedObjectSlotOverride(
+                                reader,
+                                method.GetDeclaringType(),
+                                methodHandle);
+                    }
 
                     var slotType = reader.GetTypeDefinition(fallbackSlot.DeclaringType);
                     var slotIdentity = CompileBackTypeIdentity.FromDefinition(reader, slotType);
@@ -4905,8 +4941,15 @@ public static class CompileBackSourceComposer
             IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName)
         {
             var current = derivedType;
-            var visited = new HashSet<TypeDefinitionHandle>();
-            while (current != slotDeclaringType && visited.Add(current))
+            if (current == slotDeclaringType)
+                return true;
+
+            // The chain comes from the product so a constructed generic base
+            // is followed through its TypeSpec; a TypeDef-only walk stops at
+            // the first `Derived<T> : Base<T>` and cannot reach the slot.
+            foreach (var next in MetadataDeclarationQuery.GetSameAssemblyBaseChain(
+                reader,
+                derivedType))
             {
                 var type = reader.GetTypeDefinition(current);
                 var identity = CompileBackTypeIdentity.FromDefinition(reader, type);
@@ -4919,54 +4962,17 @@ public static class CompileBackSourceComposer
                     || TypeShellProducer.ReconstructedBaseTypeDisplay(
                         reader,
                         type,
-                        isClass: true) is null
-                    || type.BaseType.Kind != HandleKind.TypeDefinition)
+                        isClass: true) is null)
                 {
                     return false;
                 }
 
-                current = (TypeDefinitionHandle)type.BaseType;
+                current = next;
+                if (current == slotDeclaringType)
+                    return true;
             }
 
-            return current == slotDeclaringType;
-        }
-
-        static bool IsIntrinsicObjectOverride(
-            MetadataReader reader,
-            TypeDefinitionHandle declaringTypeHandle,
-            MethodDefinitionHandle methodHandle)
-        {
-            var method = reader.GetMethodDefinition(methodHandle);
-            if ((method.Attributes & MethodAttributes.Static) != 0
-                || method.GetGenericParameters().Count != 0)
-            {
-                return false;
-            }
-
-            var declaringType = reader.GetTypeDefinition(declaringTypeHandle);
-            MethodSignature<string> signature;
-            try
-            {
-                signature = GuardedSignatureText.MethodText(
-                    reader,
-                    method,
-                    GenericContext.ForMethod(reader, declaringType, method));
-            }
-            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
-            {
-                return false;
-            }
-
-            return reader.GetString(method.Name) switch
-            {
-                "ToString" => signature.ReturnType == "string"
-                    && signature.ParameterTypes.Length == 0,
-                "GetHashCode" => signature.ReturnType == "int"
-                    && signature.ParameterTypes.Length == 0,
-                "Equals" => signature.ReturnType == "bool"
-                    && signature.ParameterTypes is ["object"],
-                _ => false,
-            };
+            return false;
         }
 
         static IEnumerable<int> MemberMethodTokens(CompileBackMemberRequirement member)
@@ -5293,7 +5299,14 @@ public static class CompileBackSourceComposer
         {
             var method = reader.GetMethodDefinition(methodHandle);
             string name = reader.GetString(method.Name);
-            bool isConstructor = name == ".ctor";
+            bool namedConstructor = name == ".ctor";
+            if (namedConstructor
+                && !IsPlannableInstanceConstructor(reader, typeDef, method))
+            {
+                return null;
+            }
+
+            bool isConstructor = namedConstructor;
             if (name == ".cctor"
                 || (name.Contains('<', StringComparison.Ordinal)
                     && CSharpNaming.MethodName(name) == name)
@@ -5871,11 +5884,22 @@ public static class CompileBackSourceComposer
         static string? ReconstructedSameAssemblyBaseName(MetadataReader reader, TypeDefinitionHandle handle, CompileBackTypeKind kind)
         {
             var typeDef = reader.GetTypeDefinition(handle);
-            if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
-                return null;
             if (TypeShellProducer.ReconstructedBaseTypeDisplay(reader, typeDef, kind == CompileBackTypeKind.Class) is null)
                 return null;
-            var baseDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType);
+            TypeDefinitionHandle baseHandle;
+            if (typeDef.BaseType.Kind == HandleKind.TypeDefinition)
+            {
+                baseHandle = (TypeDefinitionHandle)typeDef.BaseType;
+            }
+            else if (!MetadataDeclarationQuery.TryGetSameAssemblyConstructedBaseDefinition(
+                reader,
+                typeDef,
+                out baseHandle))
+            {
+                return null;
+            }
+
+            var baseDef = reader.GetTypeDefinition(baseHandle);
             return CompileBackTypeIdentity.FromDefinition(reader, baseDef).MetadataFullName;
         }
 
@@ -6182,16 +6206,26 @@ public static class CompileBackSourceComposer
             {
                 var method = reader.GetMethodDefinition(methodHandle);
                 string name = reader.GetString(method.Name);
+                bool namedConstructor = name == ".ctor";
+                if (namedConstructor
+                    && !IsPlannableInstanceConstructor(reader, typeDef, method))
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "malformed-constructor-skipped",
+                        name));
+                    continue;
+                }
                 if (accessorMethods.Contains(methodHandle)
                     || name == ".cctor"
                     || (name.Contains('<', StringComparison.Ordinal)
                         && CSharpNaming.MethodName(name) == name)
-                    || (name != ".ctor" && name.Contains('.', StringComparison.Ordinal)))
+                    || (!namedConstructor && name.Contains('.', StringComparison.Ordinal)))
                 {
                     continue;
                 }
 
-                bool isConstructor = name == ".ctor";
+                bool isConstructor = namedConstructor;
                 string identifierName = MemberIdentifierName(name, isConstructor);
                 int existingMethodIndex = members.FindIndex(member =>
                     member.Kind == (isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method)


### PR DESCRIPTION
## Summary

ReturnToSender now preserves product-owned `override`, `sealed`, and source accessibility facts when the emitted C# shell can bind them.

- Adds SRM-only same-assembly override-slot discovery in metadata, including non-public source-declarable slots, positional generic matching, covariant returns, cycle safety, and close-negative boundaries.
- Reconstructs the required base chain and method/property/event slot declarations before product shell rendering, including intermediate and nested full-surface types.
- Suppresses `override` and `sealed` when the shell drops or cannot materialize the base path, while retaining intrinsic `object` overrides.
- Keeps explicit-interface routing and unsupported generic/indexer full-surface behavior unchanged rather than creating new abstract obligations.

## Stack

This is the next slice above #3993 and targets `taste/multiline-generic-constraints`.

It reuses the #3904/#3924 resolution and compile-back context stack. It does not add parallel cross-assembly resolution. External bases and generic `TypeSpecification` base paths that the product shell cannot reconstruct continue to omit the base clause and override modifiers.

## Validation

- Metadata suite: 1,409 passed, 0 skipped.
- Full `ReturnToSenderPrototypeTests`: 220 passed, 0 skipped with `ilasm`/`ildasm` active.
- `SkeletonEmitTests`: 24 passed, 0 skipped.
- Full roundtrip gate: 627 passed, 0 skipped.
- Release solution build succeeded.
