### PR TITLE
Use configured NuGet sources for package metadata

### DIFF
--- a/docs/design/nuget.md
+++ b/docs/design/nuget.md
@@ -4,11 +4,33 @@ This document describes the NuGet APIs used by `dotnet-inspect` for fetching pac
 
 ## Service Index
 
-All NuGet API endpoints are discovered via the service index:
+NuGet API endpoints are discovered from each configured source's V3 service index. NuGet.org's
+index is the default only when source resolution selects it:
 
 ```text
 https://api.nuget.org/v3/index.json
 ```
+
+Package source mapping and acquisition-derived producer restrictions are applied before metadata
+discovery. Sources are considered in configured order. A lower source is consulted only after
+the higher source's registration and flat-container resources authoritatively report that the
+package version is absent; an unreadable or metadata-incapable higher source produces no metadata
+rather than borrowing another feed's answer.
+
+Metadata cache entries include the canonical source identity, so equal package coordinates from
+different feeds cannot share aggregate metadata. The filesystem-derived package inspection cache
+uses the same producer identity for the same reason.
+
+Endpoints on the explicitly configured feed origin use the feed client and its scoped credentials.
+That exact host and port may resolve to private addresses; redirects and cross-origin connections
+must resolve entirely to public addresses. These guarded clients connect directly rather than
+through an ambient HTTP proxy, whose endpoint would hide the redirect destination from the
+address check. Cross-origin URLs discovered from service-index, catalog, or vulnerability data
+never receive feed credentials.
+
+Equivalent endpoints at the selected capability version are tried in service-index order,
+including after malformed successful responses. Failed vulnerability endpoints do not create a
+clean cache entry; the next request retries them.
 
 ## APIs Used
 
@@ -16,7 +38,9 @@ https://api.nuget.org/v3/index.json
 
 **Purpose:** Version-specific package metadata (what the NuGet client uses for restore)
 
-**Endpoint:** `https://api.nuget.org/v3/registration5-semver1/{id-lower}/{version-lower}.json`
+**Service type:** `RegistrationsBaseUrl/*`
+
+**Request:** `{registration-base}/{id-lower}/{version-lower}.json`
 
 **Fields returned:**
 
@@ -30,15 +54,19 @@ https://api.nuget.org/v3/index.json
 
 **Notes:**
 
-- This is static Azure Blob storage (fast, cacheable)
+- Feeds may omit this optional resource
+- When capability versions differ, the highest advertised version is used; equivalent endpoints
+  at that version are tried in advertised order
 - Does NOT include: deprecation, downloads, owners, verified status
-- The `catalogEntry` is a URL, not embedded data
+- The `catalogEntry` may be a URL or an embedded object
 
 ### 2. Search API
 
 **Purpose:** Package discovery and aggregate metadata (what nuget.org website uses)
 
-**Endpoint:** `https://azuresearch-usnc.nuget.org/query?q=packageid:{id}&take=1`
+**Service type:** `SearchQueryService/*`
+
+**Request:** `{search-endpoint}?q={id}&skip={offset}&take=20&prerelease=true&semVerLevel=2.0.0`
 
 **Fields returned:**
 
@@ -59,7 +87,8 @@ https://api.nuget.org/v3/index.json
 
 **Notes:**
 
-- Backed by Azure Search (dynamic, always current)
+- Feed implementations vary; aggregate fields that are absent remain unavailable
+- Results are paged until the exact package ID is found or 1,000 candidates have been examined
 - Best source for: deprecation, downloads, verified status, owners
 - Returns data for latest version only (not version-specific deprecation)
 
@@ -67,7 +96,7 @@ https://api.nuget.org/v3/index.json
 
 **Purpose:** Security vulnerability data for all packages
 
-**Index:** `https://api.nuget.org/v3/vulnerabilities/index.json`
+**Service type:** `VulnerabilityInfo/*`
 
 **Structure:**
 
@@ -108,6 +137,7 @@ Each page is a gzipped JSON dictionary keyed by lowercase package name:
 **Notes:**
 
 - Must check if package version falls within affected range
+- Many private feeds do not advertise vulnerability data
 - Advisory URL typically points to GitHub Security Advisory (GHSA)
 - To get CVE ID, fetch the GHSA from GitHub Advisory API
 
@@ -115,9 +145,14 @@ Each page is a gzipped JSON dictionary keyed by lowercase package name:
 
 **Purpose:** Package content and version listing
 
-**Version list:** `https://api.nuget.org/v3-flatcontainer/{id-lower}/index.json`
+**Service type:** `PackageBaseAddress/*`
 
-**Package download:** `https://api.nuget.org/v3-flatcontainer/{id-lower}/{version-lower}/{id-lower}.{version-lower}.nupkg`
+**Version list:** `{package-base}/{id-lower}/index.json`
+
+**Package download:** `{package-base}/{id-lower}/{version-lower}/{id-lower}.{version-lower}.nupkg`
+
+**Metadata probe:** the package download URL is requested with `Range: bytes=0-0`; the
+response establishes package existence and reports package size without downloading the body.
 
 **Notes:**
 
@@ -176,9 +211,10 @@ NuGet supports two levels of deprecation:
 
 **Access pattern for version-specific deprecation:**
 
-1. Fetch Registration API: `https://api.nuget.org/v3/registration5-semver1/{package}/{version}.json`
-2. Extract `catalogEntry` URL from response
-3. Fetch catalog entry to get `deprecation` field
+1. Discover `RegistrationsBaseUrl/*` from the selected source's service index
+2. Fetch `{registration-base}/{package}/{version}.json`
+3. Extract `catalogEntry` URL from response
+4. Fetch catalog entry to get `deprecation` field
 
 The Search API only returns deprecation for the latest version, so it won't show deprecation for older versions of actively maintained packages.
 

--- a/src/DotnetInspector.Core/HttpClientFactory.cs
+++ b/src/DotnetInspector.Core/HttpClientFactory.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
@@ -27,6 +28,8 @@ public static class HttpClientFactory
     private static HttpClient? _shared;
     private static HttpClient? _sharedUntrustedFetch;
     private static HttpClient? _untrustedFetchOverride;
+    private static readonly ConcurrentDictionary<string, Lazy<HttpClient>>
+        _packageSourceClients = new(StringComparer.Ordinal);
     private static IDisposable? _networkTrafficLoggingSubscription;
     private static Func<HttpMessageHandler, HttpMessageHandler>? _authenticationDecorator;
 
@@ -114,6 +117,12 @@ public static class HttpClientFactory
         _shared = null;
         _sharedUntrustedFetch = null;
         _untrustedFetchOverride = null;
+        foreach (Lazy<HttpClient> client in _packageSourceClients.Values)
+        {
+            if (client.IsValueCreated)
+                client.Value.Dispose();
+        }
+        _packageSourceClients.Clear();
         _networkTrafficLoggingSubscription?.Dispose();
         _networkTrafficLoggingSubscription = null;
     }
@@ -196,13 +205,7 @@ public static class HttpClientFactory
     /// </remarks>
     public static HttpClient CreateUntrustedFetchClient()
     {
-        HttpMessageHandler handler = new SocketsHttpHandler
-        {
-            AutomaticDecompression = DecompressionMethods.All,
-            AllowAutoRedirect = true,
-            MaxAutomaticRedirections = 5,
-            ConnectCallback = SsrfGuardedConnectAsync,
-        };
+        HttpMessageHandler handler = CreateUntrustedSocketsHandler();
 
         if (_options.Offline)
             handler = new OfflineHandler(handler);
@@ -218,19 +221,127 @@ public static class HttpClientFactory
         return client;
     }
 
+    internal static SocketsHttpHandler CreateUntrustedSocketsHandler() =>
+        new()
+        {
+            AutomaticDecompression = DecompressionMethods.All,
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 5,
+            UseProxy = false,
+            ConnectCallback = SsrfGuardedConnectAsync,
+        };
+
+    /// <summary>
+    /// Gets the process-lifetime credential-capable client for one explicitly configured
+    /// package-source origin.
+    /// </summary>
+    /// <remarks>
+    /// Clients are shared by scheme, host, and port so package audits reuse DNS, TCP, and TLS
+    /// state without extending the private-address exception to another origin. Do not dispose
+    /// the returned client.
+    /// </remarks>
+    public static HttpClient GetPackageSourceClient(string sourceUrl)
+    {
+        Uri source = ParsePackageSource(sourceUrl);
+        string originKey =
+            $"{source.Scheme.ToLowerInvariant()}\n"
+            + $"{source.IdnHost.ToLowerInvariant()}\n"
+            + source.Port;
+        var candidate = new Lazy<HttpClient>(
+            () => CreatePackageSourceClient(source.AbsoluteUri),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+        return _packageSourceClients.GetOrAdd(originKey, candidate).Value;
+    }
+
+    /// <summary>
+    /// Creates a credential-capable client for one explicitly configured package-source origin.
+    /// Connections to that exact host and port may use private addresses; redirect and cross-origin
+    /// connections must resolve entirely to public addresses.
+    /// </summary>
+    /// <remarks>The caller owns and must dispose the returned client.</remarks>
+    public static HttpClient CreatePackageSourceClient(string sourceUrl)
+    {
+        Uri source = ParsePackageSource(sourceUrl);
+
+        string trustedHost = source.IdnHost;
+        int trustedPort = source.Port;
+        HttpMessageHandler handler = new SocketsHttpHandler
+        {
+            AutomaticDecompression = DecompressionMethods.All,
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 5,
+            UseProxy = false,
+            ConnectCallback = (context, cancellationToken) =>
+                ConnectWithTrustedOriginAsync(
+                    context,
+                    trustedHost,
+                    trustedPort,
+                    cancellationToken),
+        };
+
+        if (_options.Offline)
+            handler = new OfflineHandler(handler);
+
+        if (InfoTracker.Enabled)
+            handler = new CountingHandler(handler);
+
+        handler = new NetworkTelemetryHandler(handler, NetworkClientKinds.Shared);
+
+        if (_authenticationDecorator is not null)
+            handler = _authenticationDecorator(handler);
+
+        var client = new HttpClient(handler);
+        client.DefaultRequestHeaders.Add("User-Agent", UserAgent);
+        client.Timeout = _options.DefaultTimeout;
+        return client;
+    }
+
+    private static Uri ParsePackageSource(string sourceUrl)
+    {
+        if (!Uri.TryCreate(sourceUrl, UriKind.Absolute, out Uri? source)
+            || source.Scheme is not ("http" or "https"))
+        {
+            throw new ArgumentException(
+                "Package source must be an absolute HTTP or HTTPS URL.",
+                nameof(sourceUrl));
+        }
+
+        return source;
+    }
+
     private static async ValueTask<Stream> SsrfGuardedConnectAsync(
         SocketsHttpConnectionContext context, CancellationToken cancellationToken)
+        => await ConnectWithTrustedOriginAsync(
+            context,
+            trustedHost: null,
+            trustedPort: null,
+            cancellationToken).ConfigureAwait(false);
+
+    private static async ValueTask<Stream> ConnectWithTrustedOriginAsync(
+        SocketsHttpConnectionContext context,
+        string? trustedHost,
+        int? trustedPort,
+        CancellationToken cancellationToken)
     {
         var endpoint = context.DnsEndPoint;
         var addresses = await Dns.GetHostAddressesAsync(endpoint.Host, cancellationToken).ConfigureAwait(false);
         if (addresses.Length == 0)
             throw new HttpRequestException($"Could not resolve host: {endpoint.Host}");
 
-        foreach (var address in addresses)
+        bool isTrustedOrigin = trustedHost is not null
+            && endpoint.Port == trustedPort
+            && string.Equals(
+                endpoint.Host,
+                trustedHost,
+                StringComparison.OrdinalIgnoreCase);
+        if (!isTrustedOrigin)
         {
-            if (IsNonPublic(address))
-                throw new HttpRequestException(
-                    $"Blocked request to non-public address: {endpoint.Host} resolves to {address}");
+            foreach (var address in addresses)
+            {
+                if (IsNonPublic(address))
+                    throw new HttpRequestException(
+                        $"Blocked request to non-public address: {endpoint.Host} resolves to {address}");
+            }
         }
 
         var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };

--- a/src/DotnetInspector.Packages/HttpRetryHelper.cs
+++ b/src/DotnetInspector.Packages/HttpRetryHelper.cs
@@ -224,7 +224,8 @@ public static class HttpRetryHelper
         Action<string>? log = null,
         CancellationToken cancellationToken = default,
         AuthenticationHeaderValue? auth = null,
-        NetworkTrafficKind trafficKind = NetworkTrafficKind.Unknown)
+        NetworkTrafficKind trafficKind = NetworkTrafficKind.Unknown,
+        RangeHeaderValue? range = null)
     {
         return ExecuteWithRetryAsync(
             ct =>
@@ -232,7 +233,13 @@ public static class HttpRetryHelper
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
                 if (auth != null)
                     request.Headers.Authorization = auth;
-                return client.SendAsync(request, ct);
+                request.Headers.Range = range;
+                return range is null
+                    ? client.SendAsync(request, ct)
+                    : client.SendAsync(
+                        request,
+                        HttpCompletionOption.ResponseHeadersRead,
+                        ct);
             },
             url,
             "GET",

--- a/src/DotnetInspector.Packages/NuGetSourceCompat.cs
+++ b/src/DotnetInspector.Packages/NuGetSourceCompat.cs
@@ -18,7 +18,7 @@ public record NuGetSourceOptions
     public string[] Sources { get; init; } = [];
     public string[] AdditionalSources { get; init; } = [];
     public string? ConfigFile { get; init; }
-    internal string[]? AuthorizedSourceUrls { get; init; }
+    internal string[]? AuthorizedSourceKeys { get; init; }
     public static NuGetSourceOptions Default { get; } = new();
 }
 
@@ -66,35 +66,50 @@ public static class NuGetSourceResolver
         IReadOnlyList<string> sourceUrls)
     {
         ArgumentNullException.ThrowIfNull(sourceUrls);
+        return RestrictToSourceKeys(
+            original,
+            [.. sourceUrls.Select(NuGetCache.GetSourceKey)]);
+    }
+
+    /// <summary>
+    /// Restricts payload or metadata fulfillment to canonical producer identities established
+    /// by an earlier package acquisition.
+    /// </summary>
+    public static NuGetSourceOptions? RestrictToSourceKeys(
+        NuGetSourceOptions? original,
+        IReadOnlyList<string> sourceKeys)
+    {
+        ArgumentNullException.ThrowIfNull(sourceKeys);
         return (original ?? NuGetSourceOptions.Default) with
         {
-            AuthorizedSourceUrls = [.. sourceUrls],
+            AuthorizedSourceKeys = [.. sourceKeys],
         };
     }
 
-    internal static IReadOnlyList<NuGetSource> ResolveAuthorizedSources(
+    /// <summary>
+    /// Applies a producer restriction established by an earlier coordinate resolution to an
+    /// already package-mapped source set.
+    /// </summary>
+    public static IReadOnlyList<NuGetSource> ResolveAuthorizedSources(
         NuGetSourceOptions? options,
         IReadOnlyList<NuGetSource> activeSources)
     {
-        if (options?.AuthorizedSourceUrls is not { } authorizedUrls)
+        if (options?.AuthorizedSourceKeys is not { } authorizedKeys)
             return activeSources;
 
-        HashSet<string> authorizedKeys =
-        [
-            .. authorizedUrls.Select(NuGetCache.GetSourceKey),
-        ];
+        HashSet<string> authorizedKeySet = [.. authorizedKeys];
         return
         [
             .. activeSources.Where(source =>
-                authorizedKeys.Contains(NuGetCache.GetSourceKey(source.Url))),
+                authorizedKeySet.Contains(NuGetCache.GetSourceKey(source.Url))),
         ];
     }
 
     internal static NuGetSourceOptions? WithoutSourceRestriction(
         NuGetSourceOptions? options)
-        => options?.AuthorizedSourceUrls is null
+        => options?.AuthorizedSourceKeys is null
             ? options
-            : options with { AuthorizedSourceUrls = null };
+            : options with { AuthorizedSourceKeys = null };
 
     /// <summary>
     /// Resolves sources and reduces them to the identities the package content

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using DotnetInspector.Core;
 using InertText;
 using NuGetFetch;
@@ -787,30 +788,24 @@ public static class PackageExtractor
             cancellationToken: default);
 
     /// <summary>
-    /// Reads a V3 service index and returns the <c>@id</c> of the first resource whose
-    /// <c>@type</c> starts with <paramref name="resourceTypePrefix"/>. Service-index types are
-    /// versioned by suffix (<c>SearchQueryService/3.5.0</c>), so matching is by prefix.
+    /// Reads all resources advertised by a V3 service index.
     /// </summary>
-    private static async Task<string?> GetServiceIndexResourceAsync(
+    /// <returns>
+    /// The advertised resources, an empty list for a valid index with no resources, or
+    /// <see langword="null"/> when the source is not HTTP or its index cannot be read or parsed.
+    /// </returns>
+    public static async Task<IReadOnlyList<ServiceResource>?> GetServiceIndexResourcesAsync(
         HttpClient client,
         NuGetSource source,
-        string resourceTypePrefix,
-        Action<string>? log,
-        CancellationToken cancellationToken)
+        Action<string>? log = null,
+        CancellationToken cancellationToken = default)
     {
-        // Skip non-HTTP sources (e.g. local folder feeds from NuGet.Config).
-        // Passing a file: URL or raw filesystem path to HttpClient throws
-        // NotSupportedException ("net_http_unsupported_requesturi_scheme, file"),
-        // which would crash version resolution / package download. Issue #310.
         if (!IsHttpSource(source))
         {
             log?.Invoke($"Skipping non-HTTP NuGet source '{source.Name}': {source.Url}");
             return null;
         }
 
-        // The source URL should be the V3 index.json. Inspect only the URI
-        // path so a query-bearing service index is not mistaken for a feed
-        // root and corrupted by appending after the query.
         string indexUrl = source.Url;
         var indexUri = new Uri(source.Url, UriKind.Absolute);
         if (!indexUri.AbsolutePath.EndsWith(
@@ -828,7 +823,9 @@ public static class PackageExtractor
         log?.Invoke($"Querying service index: {indexUrl}");
 
         string? json = await HttpRetryHelper.GetStringWithRetryAsync(
-            client, indexUrl, auth: NuGetCredentialScope.AuthFor(source, indexUrl, log),
+            client,
+            indexUrl,
+            auth: NuGetCredentialScope.AuthFor(source, indexUrl, log),
             cancellationToken: cancellationToken,
             trafficKind: NetworkTrafficKind.PackageSourceDiscovery).ConfigureAwait(false);
         if (json == null)
@@ -837,23 +834,115 @@ public static class PackageExtractor
         try
         {
             using var doc = HardenedJson.Parse(json);
-            var resources = doc.RootElement.GetProperty("resources");
-
-            foreach (var resource in resources.EnumerateArray())
+            if (!doc.RootElement.TryGetProperty(
+                    "resources",
+                    out JsonElement resources)
+                || resources.ValueKind != JsonValueKind.Array)
             {
-                var type = resource.GetProperty("@type").GetString();
-                if (type != null && type.StartsWith(resourceTypePrefix, StringComparison.OrdinalIgnoreCase))
+                log?.Invoke($"Invalid service index from '{source.Name}': missing resources array.");
+                return null;
+            }
+            var result = new List<ServiceResource>();
+
+            foreach (JsonElement resource in resources.EnumerateArray())
+            {
+                if (resource.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                string? id = resource.TryGetProperty("@id", out JsonElement idElement)
+                    && idElement.ValueKind == JsonValueKind.String
+                    ? idElement.GetString()
+                    : null;
+                if (string.IsNullOrWhiteSpace(id)
+                    || !resource.TryGetProperty(
+                        "@type",
+                        out JsonElement typeElement))
                 {
-                    return resource.GetProperty("@id").GetString();
+                    continue;
+                }
+
+                IEnumerable<string> types = typeElement.ValueKind switch
+                {
+                    JsonValueKind.String when !string.IsNullOrWhiteSpace(
+                        typeElement.GetString()) =>
+                        [typeElement.GetString()!],
+                    JsonValueKind.Array =>
+                        typeElement
+                            .EnumerateArray()
+                            .Where(item => item.ValueKind == JsonValueKind.String)
+                            .Select(item => item.GetString())
+                            .Where(type => !string.IsNullOrWhiteSpace(type))
+                            .Cast<string>(),
+                    _ => [],
+                };
+                foreach (string type in types)
+                {
+                    bool isHttpEndpoint =
+                        IsServiceType(type, "RegistrationsBaseUrl")
+                        || IsServiceType(type, "SearchQueryService")
+                        || IsServiceType(type, "PackageBaseAddress")
+                        || IsServiceType(type, "VulnerabilityInfo");
+                    if (!isHttpEndpoint)
+                    {
+                        result.Add(new ServiceResource(id, type));
+                    }
+                    else if (Uri.TryCreate(
+                            id,
+                            UriKind.Absolute,
+                            out Uri? resourceUri)
+                        && resourceUri.Scheme is "http" or "https")
+                    {
+                        result.Add(new ServiceResource(
+                            resourceUri.AbsoluteUri,
+                            type));
+                    }
+                    else
+                    {
+                        log?.Invoke(
+                            $"Ignoring invalid {type} resource URL from '{source.Name}'.");
+                    }
                 }
             }
-        }
-        catch
-        {
-            // Invalid service index
-        }
 
-        return null;
+            return result;
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+            log?.Invoke($"Invalid service index from '{source.Name}': {ex.Message}");
+            return null;
+        }
+    }
+
+    private static bool IsServiceType(string type, string prefix) =>
+        type.Equals(prefix, StringComparison.OrdinalIgnoreCase)
+        || type.StartsWith($"{prefix}/", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Reads a V3 service index and returns the <c>@id</c> of the first resource whose
+    /// <c>@type</c> starts with <paramref name="resourceTypePrefix"/>. Service-index types are
+    /// versioned by suffix (<c>SearchQueryService/3.5.0</c>), so matching is by prefix.
+    /// </summary>
+    private static async Task<string?> GetServiceIndexResourceAsync(
+        HttpClient client,
+        NuGetSource source,
+        string resourceTypePrefix,
+        Action<string>? log,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<ServiceResource>? resources =
+            await GetServiceIndexResourcesAsync(
+                client,
+                source,
+                log,
+                cancellationToken).ConfigureAwait(false);
+        if (resources is null)
+            return null;
+
+        return resources
+            .Where(resource =>
+                IsServiceType(resource.Type, resourceTypePrefix))
+            .Select(resource => resource.Id)
+            .FirstOrDefault();
     }
 
     /// Parses a package reference string into name and optional version.

--- a/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Net.Http.Headers;
+using System.Text;
 using DotnetInspector.Core;
 using DotnetInspector.Packages;
 
@@ -135,140 +137,1606 @@ public class PackageMetadataServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task GetPublishedDateAsync_WithCachedMetadata_DoesNotFetch()
+    public async Task GetPublishedDateAsync_StopsAfterRegistrationMetadata()
     {
-        var published = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero);
-        MetadataFieldCache.Set("testpackage@1.0.0", new PackageMetadata { Published = published });
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/query", "@type": "SearchQueryService/3.5.0" },
+                        { "@id": "https://private.example/flat/", "@type": "PackageBaseAddress/3.0.0" },
+                        { "@id": "https://private.example/vulnerabilities/index.json", "@type": "VulnerabilityInfo/6.7.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" =>
+                    Json("""{ "published": "2024-01-02T03:04:05Z" }"""),
+                _ => throw new InvalidOperationException(
+                    $"Published-date lookup made an aggregate request: {request.RequestUri}"),
+            });
 
-        var result = await PackageMetadataService.GetPublishedDateAsync(
-            new HttpClient(new FailingHandler()), "TestPackage", "1.0.0", log: null);
-
-        Assert.Equal(published, result);
-    }
-
-    [Fact]
-    public async Task FetchAllMetadataAsync_CustomSourceDoesNotQueryNuGetOrg()
-    {
-        var handler = new CountingHandler();
-        var messages = new List<string>();
-        MetadataFieldCache.Set(
-            "private.package@1.0.0",
-            new PackageMetadata { Published = DateTimeOffset.UnixEpoch });
-        var sourceOptions = new NuGetSourceOptions
-        {
-            Sources = [Path.Combine(Path.GetTempPath(), $"feed-{Guid.NewGuid():N}")]
-        };
-
-        var result = await PackageMetadataService.FetchAllMetadataAsync(
-            new HttpClient(handler),
-            "Private.Package",
-            "1.0.0",
-            messages.Add,
-            sourceOptions: sourceOptions);
-
-        Assert.Equal(0, handler.RequestCount);
-        Assert.Null(result.Published);
-        Assert.Contains(messages, message => message.Contains(
-            "does not authorize api.nuget.org",
-            StringComparison.Ordinal));
-    }
-
-    [Fact]
-    public async Task FetchAllMetadataAsync_FileSourceNamedApiNuGetOrgDoesNotQueryNuGetOrg()
-    {
-        var handler = new CountingHandler();
-        var sourceOptions = new NuGetSourceOptions
-        {
-            Sources = ["file://api.nuget.org/private-feed"]
-        };
-
-        var result = await PackageMetadataService.FetchAllMetadataAsync(
+        DateTimeOffset? published = await PackageMetadataService.GetPublishedDateAsync(
             new HttpClient(handler),
             "Private.Package",
             "1.0.0",
             log: null,
-            sourceOptions: sourceOptions);
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
 
-        Assert.Equal(0, handler.RequestCount);
-        Assert.Null(result.Published);
-    }
-
-    [Theory]
-    [InlineData("http://api.nuget.org/v3/index.json")]
-    [InlineData("https://api.nuget.org:444/v3/index.json")]
-    [InlineData("https://api.nuget.org/private/v3/index.json")]
-    [InlineData("https://api.nuget.org/v3/index.json?source=custom")]
-    public void SupportsNuGetOrgMetadata_RejectsNoncanonicalEndpoint(string sourceUrl)
-    {
-        var sourceOptions = new NuGetSourceOptions
-        {
-            Sources = [sourceUrl],
-        };
-
-        Assert.False(PackageMetadataService.SupportsNuGetOrgMetadata(
-            sourceOptions,
-            "Private.Package"));
+        Assert.Equal(
+            new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero),
+            published);
+        Assert.Equal(2, handler.Requests.Count);
     }
 
     [Fact]
-    public void SupportsNuGetOrgMetadata_RequiresPackageMappingToAuthorizeNuGetOrg()
+    public async Task GetPublishedDateAsync_DoesNotFallThroughAfterRegistration404WhenPackageExists()
     {
-        string configPath = Path.Combine(
-            Path.GetTempPath(),
-            $"metadata-mapping-{Guid.NewGuid():N}.config");
-        File.WriteAllText(configPath, """
-            <configuration>
-              <packageSources>
-                <clear />
-                <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-                <add key="private" value="https://private.example/v3/index.json" />
-              </packageSources>
-              <packageSourceMapping>
-                <packageSource key="private">
-                  <package pattern="Private.*" />
-                </packageSource>
-                <packageSource key="nuget.org">
-                  <package pattern="Public.*" />
-                </packageSource>
-              </packageSourceMapping>
-            </configuration>
-            """);
-
-        try
+        const string sourceA = "https://a.example/v3/index.json";
+        const string sourceB = "https://b.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
         {
-            var sourceOptions = new NuGetSourceOptions { ConfigFile = configPath };
+            string host = request.RequestUri!.Host;
+            return request.RequestUri.AbsolutePath switch
+            {
+                "/v3/index.json" => Json($$"""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://{{host}}/registration/", "@type": "RegistrationsBaseUrl/3.4.0" },
+                        { "@id": "https://{{host}}/flat/", "@type": "PackageBaseAddress/3.0.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0-alpha.1.json" =>
+                    new HttpResponseMessage(System.Net.HttpStatusCode.NotFound),
+                "/flat/private.package/1.0.0-alpha.1/private.package.1.0.0-alpha.1.nupkg"
+                    when host == "a.example" => Package(length: 1234),
+                _ => throw new InvalidOperationException(
+                    "A present higher-precedence source must stop fallback."),
+            };
+        });
 
-            Assert.False(PackageMetadataService.SupportsNuGetOrgMetadata(
-                sourceOptions,
-                "Private.Package"));
-            Assert.True(PackageMetadataService.SupportsNuGetOrgMetadata(
-                sourceOptions,
-                "Public.Package"));
-        }
-        finally
-        {
-            File.Delete(configPath);
-        }
+        DateTimeOffset? published = await PackageMetadataService.GetPublishedDateAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0-alpha.1",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [sourceA, sourceB] });
+
+        Assert.Null(published);
+        Assert.DoesNotContain(
+            handler.Requests,
+            request => request.Uri.Host == "b.example");
     }
 
-    private sealed class FailingHandler : HttpMessageHandler
+    [Fact]
+    public async Task FetchAllMetadataAsync_UsesConfiguredServiceIndexResources()
     {
+        const string source = "https://private.example/v3/index.json";
+        using var config = new TempNuGetConfig(
+            [("private", source)],
+            credentialedSource: "private");
+        var handler = new RoutingHandler(request => request.RequestUri!.AbsolutePath switch
+        {
+            "/v3/index.json" => Json("""
+                {
+                  "version": "3.0.0",
+                  "resources": [
+                    { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                    { "@id": "https://private.example/query", "@type": "SearchQueryService/3.5.0" },
+                    { "@id": "https://private.example/flat/", "@type": "PackageBaseAddress/3.0.0" },
+                    { "@id": "https://private.example/vulnerabilities/index.json", "@type": "VulnerabilityInfo/6.7.0" }
+                  ]
+                }
+                """),
+            "/registration/private.package/1.0.0.json" => Json("""
+                {
+                  "published": "2024-01-02T03:04:05Z",
+                  "catalogEntry": "/catalog/private.package.1.0.0.json"
+                }
+                """),
+            "/catalog/private.package.1.0.0.json" => Json("""
+                {
+                  "deprecation": {
+                    "reasons": ["Legacy"],
+                    "message": "Use Private.Package.Next"
+                  }
+                }
+                """),
+            "/query" => Json("""
+                {
+                  "data": [
+                    { "id": "Not.The.Package", "totalDownloads": 999 },
+                    {
+                      "id": "Private.Package",
+                      "totalDownloads": "42",
+                      "verified": true,
+                      "owners": "private-owner, second-owner",
+                      "versions": [
+                        { "version": "1.0.0", "downloads": "7" },
+                        { "version": "2.0.0", "downloads": 3 }
+                      ]
+                    }
+                  ]
+                }
+                """),
+            "/vulnerabilities/index.json" => Json(
+                """[{ "@id": "/vulnerabilities/page.json" }]"""),
+            "/vulnerabilities/page.json" => Json("""
+                {
+                  "private.package": [
+                    {
+                      "url": "https://advisories.example/CVE-2024-1",
+                      "severity": 2,
+                      "versions": "[1.0.0, 2.0.0)"
+                    }
+                  ]
+                }
+                """),
+            "/flat/private.package/1.0.0/private.package.1.0.0.nupkg"
+                when request.Method == HttpMethod.Get => Package(length: 1234),
+            _ => new HttpResponseMessage(System.Net.HttpStatusCode.NotFound),
+        });
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { ConfigFile = config.Path });
+
+        Assert.Equal(
+            new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero),
+            result.Published);
+        Assert.Equal(42, result.TotalDownloads);
+        Assert.Equal(7, result.VersionDownloads);
+        Assert.Equal(2, result.VersionCount);
+        Assert.Equal(1234, result.PackageSize);
+        Assert.True(result.IsVerified);
+        Assert.Equal(["private-owner", "second-owner"], result.Owners);
+        Assert.Equal("Legacy - Use Private.Package.Next", result.Deprecation!.Summary);
+        Assert.Equal("High", Assert.Single(result.Vulnerabilities!).Severity);
+        Assert.Equal(
+            "?q=private.package&skip=0&take=20&prerelease=true&semVerLevel=2.0.0",
+            Assert.Single(
+                handler.Requests,
+                request => request.Uri.AbsolutePath == "/query").Uri.Query);
+        Assert.Equal(
+            "bytes=0-0",
+            Assert.Single(
+                handler.Requests,
+                request => request.Uri.AbsolutePath.EndsWith(
+                    ".nupkg",
+                    StringComparison.Ordinal)).Range);
+        Assert.All(handler.Requests, request =>
+        {
+            Assert.Equal("private.example", request.Uri.Host);
+            Assert.NotNull(request.Authorization);
+        });
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_AuthoritativeAbsenceFallsBackInSourceOrder()
+    {
+        const string sourceA = "https://a.example/v3/index.json";
+        const string sourceB = "https://b.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+        {
+            string host = request.RequestUri!.Host;
+            string path = request.RequestUri.AbsolutePath;
+            if (path == "/v3/index.json")
+            {
+                return Json($$"""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://{{host}}/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://{{host}}/flat/", "@type": "PackageBaseAddress/3.0.0" }
+                      ]
+                    }
+                    """);
+            }
+
+            if (host == "b.example"
+                && path == "/registration/contoso.package/1.0.0.json")
+            {
+                return Json("""{ "published": "2025-02-03T00:00:00Z" }""");
+            }
+
+            return new HttpResponseMessage(System.Net.HttpStatusCode.NotFound);
+        });
+
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [sourceA, sourceB] };
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Contoso.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+        int coldRequests = handler.Requests.Count;
+        PackageMetadata warm = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Contoso.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+
+        Assert.Equal(
+            new DateTimeOffset(2025, 2, 3, 0, 0, 0, TimeSpan.Zero),
+            result.Published);
+        Assert.Equal(result.Published, warm.Published);
+        Assert.Equal(coldRequests, handler.Requests.Count);
+        Assert.Contains(handler.Requests, request => request.Uri.Host == "a.example");
+        Assert.Contains(handler.Requests, request => request.Uri.Host == "b.example");
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_UnreadableHigherSourceDoesNotBorrowLowerMetadata()
+    {
+        const string sourceA = "https://a.example/v3/index.json";
+        const string sourceB = "https://b.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.Host == "a.example"
+                ? new HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized)
+                : Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://b.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """));
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Contoso.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [sourceA, sourceB] });
+
+        Assert.Null(result.Published);
+        Assert.DoesNotContain(
+            handler.Requests,
+            request => request.Uri.Host == "b.example");
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_PagesUntilSearchReturnsTheExactPackage()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+        {
+            if (request.RequestUri!.AbsolutePath == "/v3/index.json")
+            {
+                return Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/query", "@type": "SearchQueryService/3.5.0" }
+                      ]
+                    }
+                    """);
+            }
+            if (request.RequestUri.AbsolutePath
+                == "/registration/private.package/1.0.0.json")
+            {
+                return Json("{}");
+            }
+            if (request.RequestUri.AbsolutePath == "/query"
+                && request.RequestUri.Query.Contains("skip=0", StringComparison.Ordinal))
+            {
+                string inexactResults = string.Join(
+                    ',',
+                    Enumerable.Range(0, 10).Select(index =>
+                        $$"""{ "id": "Private.Package.Similar{{index}}" }"""));
+                return Json(
+                    $$"""{ "totalHits": 11, "data": [{{inexactResults}}] }""");
+            }
+            if (request.RequestUri.AbsolutePath == "/query"
+                && request.RequestUri.Query.Contains("skip=10", StringComparison.Ordinal))
+            {
+                return Json("""
+                    {
+                      "data": [
+                        {
+                          "id": "Private.Package",
+                          "totalDownloads": 42,
+                          "versions": [
+                            { "version": "1.0.0", "downloads": 7 }
+                          ]
+                        }
+                      ]
+                    }
+                    """);
+            }
+
+            throw new InvalidOperationException(
+                $"Unexpected metadata request: {request.RequestUri}");
+        });
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
+
+        Assert.Equal(42, result.TotalDownloads);
+        Assert.Equal(7, result.VersionDownloads);
+        Assert.Equal(
+            2,
+            handler.Requests.Count(request =>
+                request.Uri.AbsolutePath == "/query"));
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_TriesEquivalentSearchEndpointsInOrder()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/query-a", "@type": "SearchQueryService/3.5.0" },
+                        { "@id": "https://private.example/query-b", "@type": "SearchQueryService/3.5.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("{}"),
+                "/query-a" => Json("{"),
+                "/query-b" => Json("""
+                    {
+                      "data": [
+                        { "id": "Private.Package", "totalDownloads": 42 }
+                      ]
+                    }
+                    """),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
+
+        Assert.Equal(42, result.TotalDownloads);
+        Assert.Contains(
+            handler.Requests,
+            request => request.Uri.AbsolutePath == "/query-a");
+        Assert.Contains(
+            handler.Requests,
+            request => request.Uri.AbsolutePath == "/query-b");
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_MalformedRegistrationUsesEquivalentEndpoint()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration-a/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/registration-b/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """),
+                "/registration-a/private.package/1.0.0.json" => Json("{"),
+                "/registration-b/private.package/1.0.0.json" =>
+                    Json("""{ "published": "2025-01-02T00:00:00Z" }"""),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
+
+        Assert.Equal(2025, result.Published!.Value.Year);
+        Assert.Contains(
+            handler.Requests,
+            request => request.Uri.AbsolutePath.StartsWith(
+                "/registration-b/",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_TriesEquivalentVulnerabilityEndpoints()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/vulnerabilities-a.json", "@type": "VulnerabilityInfo/6.7.0" },
+                        { "@id": "https://private.example/vulnerabilities-b.json", "@type": "VulnerabilityInfo/6.7.0" },
+                        { "@id": "https://private.example/vulnerabilities-c.json", "@type": "VulnerabilityInfo/6.7.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("{}"),
+                "/vulnerabilities-a.json" =>
+                    Json("""[{ "@id": "/malformed-vulnerability-page.json" }]"""),
+                "/malformed-vulnerability-page.json" => Json("""
+                    {
+                      "private.package": [
+                        {
+                          "url": "https://advisories.example/CVE-2025-1",
+                          "severity": "high",
+                          "versions": "[1.0.0]"
+                        }
+                      ]
+                    }
+                    """),
+                "/vulnerabilities-b.json" =>
+                    Json("""[{ "@id": "/vulnerability-page.json" }]"""),
+                "/vulnerabilities-c.json" =>
+                    Json("""[{ "@id": "/vulnerability-page.json" }]"""),
+                "/vulnerability-page.json" => Json("""
+                    {
+                      "private.package": [
+                        {
+                          "url": "https://advisories.example/CVE-2025-1",
+                          "severity": 2,
+                          "versions": "[1.0.0]"
+                        }
+                      ]
+                    }
+                    """),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
+
+        Assert.Equal(
+            "High",
+            Assert.Single(result.Vulnerabilities!).Severity);
+        Assert.Contains(
+            handler.Requests,
+            request => request.Uri.AbsolutePath == "/vulnerabilities-b.json");
+        Assert.DoesNotContain(
+            handler.Requests,
+            request => request.Uri.AbsolutePath == "/vulnerabilities-c.json");
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_DoesNotCacheFailedVulnerabilityFetch()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/vulnerabilities.json", "@type": "VulnerabilityInfo/6.7.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("{}"),
+                "/vulnerabilities.json" => new HttpResponseMessage(
+                    System.Net.HttpStatusCode.BadRequest),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        _ = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+        int firstRequestCount = handler.Requests.Count;
+        _ = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+
+        Assert.True(handler.Requests.Count > firstRequestCount);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_DoesNotCacheFailedCatalogFetch()
+    {
+        const string source = "https://private.example/v3/index.json";
+        int registrationRequests = 0;
+        int catalogRequests = 0;
+        HttpResponseMessage Registration()
+        {
+            registrationRequests++;
+            return Json("""
+                { "catalogEntry": "/catalog/private.package.json" }
+                """);
+        }
+        HttpResponseMessage Catalog()
+        {
+            catalogRequests++;
+            return registrationRequests == 1
+                ? new HttpResponseMessage(
+                    System.Net.HttpStatusCode.BadGateway)
+                : Json("""
+                    {
+                      "deprecation": {
+                        "reasons": ["Legacy"],
+                        "message": "Use a replacement."
+                      }
+                    }
+                    """);
+        }
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" =>
+                    Registration(),
+                "/catalog/private.package.json" => Catalog(),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata first =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        PackageMetadata second =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.Null(first.Deprecation);
+        Assert.Equal("Use a replacement.", second.Deprecation!.Message);
+        Assert.True(catalogRequests > 1);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_DoesNotCacheFailedSearchFetch()
+    {
+        const string source = "https://private.example/v3/index.json";
+        int registrationRequests = 0;
+        int searchRequests = 0;
+        HttpResponseMessage Registration()
+        {
+            registrationRequests++;
+            return Json("{}");
+        }
+        HttpResponseMessage Search()
+        {
+            searchRequests++;
+            return registrationRequests == 1
+                ? new HttpResponseMessage(
+                    System.Net.HttpStatusCode.BadGateway)
+                : Json("""
+                    {
+                      "data": [
+                        {
+                          "id": "Private.Package",
+                          "totalDownloads": 42
+                        }
+                      ]
+                    }
+                    """);
+        }
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/query", "@type": "SearchQueryService/3.5.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" =>
+                    Registration(),
+                "/query" => Search(),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata first =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        PackageMetadata second =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.Null(first.TotalDownloads);
+        Assert.Equal(42, second.TotalDownloads);
+        Assert.True(searchRequests > 1);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_DoesNotCacheMalformedVulnerabilityIndexAsClean()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/vulnerabilities.json", "@type": "VulnerabilityInfo/6.7.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("{}"),
+                "/vulnerabilities.json" => Json("""[{ "@name": "base" }]"""),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata first =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        int firstRequestCount = handler.Requests.Count;
+        PackageMetadata second =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.Null(first.Vulnerabilities);
+        Assert.Null(second.Vulnerabilities);
+        Assert.True(handler.Requests.Count > firstRequestCount);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_PreservesPartialVulnerabilitiesFromMalformedPage()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/vulnerabilities.json", "@type": "VulnerabilityInfo/6.7.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("{}"),
+                "/vulnerabilities.json" => Json("""
+                    [
+                      { "@id": "/vulnerability-page.json" },
+                      { "@id": "/malformed-page.json" }
+                    ]
+                    """),
+                "/vulnerability-page.json" => Json("""
+                    {
+                      "private.package": [
+                        {
+                          "url": "https://advisories.example/CVE-2025-1",
+                          "severity": 2,
+                          "versions": "[1.0.0]"
+                        }
+                      ]
+                    }
+                    """),
+                "/malformed-page.json" => Json("{"),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata first =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        int firstRequestCount = handler.Requests.Count;
+        PackageMetadata second =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.Equal(
+            "High",
+            Assert.Single(first.Vulnerabilities!).Severity);
+        Assert.Equal(
+            "High",
+            Assert.Single(second.Vulnerabilities!).Severity);
+        Assert.True(handler.Requests.Count > firstRequestCount);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_PreservesPartialVulnerabilitiesWithoutCaching()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/vulnerabilities-a.json", "@type": "VulnerabilityInfo/6.7.0" },
+                        { "@id": "https://private.example/vulnerabilities-b.json", "@type": "VulnerabilityInfo/6.7.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("{}"),
+                "/vulnerabilities-a.json" or "/vulnerabilities-b.json" => Json("""
+                    [
+                      { "@id": "/vulnerability-page.json" },
+                      { "@id": "/failed-page.json" }
+                    ]
+                    """),
+                "/vulnerability-page.json" => Json("""
+                    {
+                      "private.package": [
+                        {
+                          "url": "https://advisories.example/CVE-2025-1",
+                          "severity": 2,
+                          "versions": "[1.0.0]"
+                        }
+                      ]
+                    }
+                    """),
+                "/failed-page.json" => new HttpResponseMessage(
+                    System.Net.HttpStatusCode.BadRequest),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata first =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        int firstRequestCount = handler.Requests.Count;
+        PackageMetadata second =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.Equal(
+            "High",
+            Assert.Single(first.Vulnerabilities!).Severity);
+        Assert.Equal(
+            "High",
+            Assert.Single(second.Vulnerabilities!).Severity);
+        Assert.Contains(
+            handler.Requests,
+            request => request.Uri.AbsolutePath == "/vulnerabilities-a.json");
+        Assert.Contains(
+            handler.Requests,
+            request => request.Uri.AbsolutePath == "/vulnerabilities-b.json");
+        Assert.True(handler.Requests.Count > firstRequestCount);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_HtmlPackageProbeIsIndeterminate()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/flat/", "@type": "PackageBaseAddress/3.0.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("{"),
+                "/flat/private.package/1.0.0/private.package.1.0.0.nupkg" =>
+                    Html("<html>Sign in</html>"),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
+
+        Assert.Null(result.PackageSize);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_DoesNotUsePartialBodyLengthAsPackageSize()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/flat/", "@type": "PackageBaseAddress/3.0.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("{}"),
+                "/flat/private.package/1.0.0/private.package.1.0.0.nupkg" =>
+                    Package(length: null),
+                _ => new HttpResponseMessage(System.Net.HttpStatusCode.NotFound),
+            });
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
+
+        Assert.Null(result.PackageSize);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_CacheIsScopedByProducer()
+    {
+        const string sourceA = "https://a.example/v3/index.json";
+        const string sourceB = "https://b.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+        {
+            string host = request.RequestUri!.Host;
+            return request.RequestUri.AbsolutePath == "/v3/index.json"
+                ? Json($$"""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://{{host}}/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """)
+                : Json(host == "a.example"
+                    ? """{ "published": "2024-01-01T00:00:00Z" }"""
+                    : """{ "published": "2025-01-01T00:00:00Z" }""");
+        });
+        using var client = new HttpClient(handler);
+
+        PackageMetadata fromA = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Same.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [sourceA] });
+        PackageMetadata fromB = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Same.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [sourceB] });
+        int requestsAfterColdRuns = handler.Requests.Count;
+        PackageMetadata warmA = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Same.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [sourceA] });
+
+        Assert.Equal(2024, fromA.Published!.Value.Year);
+        Assert.Equal(2025, fromB.Published!.Value.Year);
+        Assert.Equal(2024, warmA.Published!.Value.Year);
+        Assert.Equal(requestsAfterColdRuns, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_WarmLowerSourceDoesNotOverrideHigherSource()
+    {
+        const string sourceA = "https://a.example/v3/index.json";
+        const string sourceB = "https://b.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+        {
+            string host = request.RequestUri!.Host;
+            return request.RequestUri.AbsolutePath == "/v3/index.json"
+                ? Json($$"""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://{{host}}/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """)
+                : Json(host == "a.example"
+                    ? """{ "published": "2024-01-01T00:00:00Z" }"""
+                    : """{ "published": "2025-01-01T00:00:00Z" }""");
+        });
+        using var client = new HttpClient(handler);
+
+        _ = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Ordered.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [sourceB] });
+        int requestsAfterPrimingB = handler.Requests.Count;
+        PackageMetadata ordered = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Ordered.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [sourceA, sourceB] });
+
+        Assert.Equal(2024, ordered.Published!.Value.Year);
+        Assert.True(handler.Requests.Count > requestsAfterPrimingB);
+        Assert.Equal(
+            "a.example",
+            handler.Requests[requestsAfterPrimingB].Uri.Host);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_IgnoresLegacySourceBlindCacheEntry()
+    {
+        const string source = "https://private.example/v3/index.json";
+        MetadataFieldCache.Set(
+            "legacy.package@1.0.0",
+            new PackageMetadata { Published = DateTimeOffset.UnixEpoch });
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath == "/v3/index.json"
+                ? Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """)
+                : Json("""{ "published": "2024-01-01T00:00:00Z" }"""));
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Legacy.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
+
+        Assert.Equal(2024, result.Published!.Value.Year);
+        Assert.NotEmpty(handler.Requests);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_HonorsAcquisitionProducerRestriction()
+    {
+        const string sourceA = "https://a.example/v3/index.json";
+        const string sourceB = "https://b.example/v3/index.json";
+        NuGetSourceOptions? options = NuGetSourceResolver.RestrictToSourceKeys(
+            new NuGetSourceOptions { Sources = [sourceA, sourceB] },
+            [NuGetCache.GetSourceKey(sourceB)]);
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath == "/v3/index.json"
+                ? Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://b.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """)
+                : Json("""{ "published": "2025-01-01T00:00:00Z" }"""));
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Restricted.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+
+        Assert.Equal(2025, result.Published!.Value.Year);
+        Assert.All(
+            handler.Requests,
+            request => Assert.Equal("b.example", request.Uri.Host));
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_EmptyMetadataResultIsCached()
+    {
+        const string source = "https://empty.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath == "/v3/index.json"
+                ? Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://empty.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """)
+                : Json("{}"));
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        _ = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Empty.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+        int coldRequests = handler.Requests.Count;
+        _ = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Empty.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+
+        Assert.Equal(coldRequests, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_CachedFeedTextCannotInjectAbsenceMarker()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath == "/v3/index.json"
+                ? Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """)
+                : Json("""
+                    {
+                      "published": "2024-01-02T03:04:05Z",
+                      "catalogEntry": {
+                        "deprecation": {
+                          "reasons": ["Legacy"],
+                          "message": "text\nabsent: true"
+                        }
+                      }
+                    }
+                    """));
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata cold = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Injected.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+        int coldRequests = handler.Requests.Count;
+        PackageMetadata warm = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Injected.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+
+        Assert.Equal(cold.Published, warm.Published);
+        Assert.Equal(coldRequests, handler.Requests.Count);
+    }
+
+    [Fact]
+    public void MetadataCache_EncodesEveryFeedControlledField()
+    {
+        string key = $"injection-{Guid.NewGuid():N}";
+        var metadata = new PackageMetadata
+        {
+            Owners = ["owner\nvulnerabilities:"],
+            Deprecation = new PackageDeprecation
+            {
+                Reasons = ["Legacy\nowners:"],
+                Message = "text\nvulnerabilities:",
+                AlternatePackageId = "replacement\nabsent: true",
+            },
+            Vulnerabilities =
+            [
+                new PackageVulnerability
+                {
+                    Severity = "High|Critical",
+                    CveId = "CVE-2025-1\nowners:",
+                    GhsaId = "GHSA-test",
+                    Summary = "summary\nabsent: true",
+                    AdvisoryUrl = "https://advisory.example/a?x=1\nowners:",
+                },
+            ],
+        };
+
+        MetadataFieldCache.Set(key, metadata);
+        MetadataFieldCache.Entry cached =
+            Assert.IsType<MetadataFieldCache.Entry>(
+                MetadataFieldCache.TryGetEntry(key));
+
+        Assert.False(cached.IsAbsent);
+        Assert.Equal(metadata.Owners, cached.Metadata.Owners);
+        Assert.Equal(
+            metadata.Deprecation.Message,
+            cached.Metadata.Deprecation!.Message);
+        Assert.Equal(
+            metadata.Deprecation.Reasons,
+            cached.Metadata.Deprecation.Reasons);
+        Assert.Equal(
+            metadata.Deprecation.AlternatePackageId,
+            cached.Metadata.Deprecation.AlternatePackageId);
+        PackageVulnerability vulnerability =
+            Assert.Single(cached.Metadata.Vulnerabilities!);
+        Assert.Equal("High|Critical", vulnerability.Severity);
+        Assert.Equal("CVE-2025-1\nowners:", vulnerability.CveId);
+        Assert.Equal("summary\nabsent: true", vulnerability.Summary);
+        Assert.Equal(
+            "https://advisory.example/a?x=1\nowners:",
+            vulnerability.AdvisoryUrl);
+    }
+
+    [Fact]
+    public void MetadataCache_PreservesCheckedCleanVulnerabilityState()
+    {
+        string key = $"checked-clean-{Guid.NewGuid():N}";
+        var metadata = new PackageMetadata
+        {
+            Vulnerabilities = [],
+        };
+
+        MetadataFieldCache.Set(key, metadata);
+        MetadataFieldCache.Entry cached =
+            Assert.IsType<MetadataFieldCache.Entry>(
+                MetadataFieldCache.TryGetEntry(key));
+
+        Assert.False(cached.IsAbsent);
+        Assert.Empty(Assert.IsType<List<PackageVulnerability>>(
+            cached.Metadata.Vulnerabilities));
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_WithholdsStaticCredentialFromCrossOriginCatalog()
+    {
+        const string source = "https://private.example/v3/index.json";
+        using var config = new TempNuGetConfig(
+            [("private", source)],
+            credentialedSource: "private");
+        var sourceHandler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" =>
+                    Json("""
+                        {
+                          "version": "3.0.0",
+                          "resources": [
+                            { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                          ]
+                        }
+                        """),
+                "/registration/private.package/1.0.0.json" => Json("""
+                    {
+                      "published": "2024-01-01T00:00:00Z",
+                      "catalogEntry": "https://catalog.example/entry.json"
+                    }
+                    """),
+                _ => throw new InvalidOperationException(
+                    "Cross-origin metadata used the configured-feed client."),
+            });
+        var untrustedHandler = new RoutingHandler(request =>
+            request.RequestUri!.Host == "catalog.example"
+                ? Json("""
+                    {
+                      "deprecation": {
+                        "reasons": ["Legacy"]
+                      }
+                    }
+                    """)
+                : throw new InvalidOperationException(
+                    "Unexpected untrusted metadata request."));
+        using var client = new HttpClient(sourceHandler);
+        using var untrustedClient = new HttpClient(untrustedHandler);
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { ConfigFile = config.Path },
+            untrustedClient: untrustedClient);
+
+        Assert.Equal("Legacy", result.Deprecation!.Summary);
+        Assert.All(
+            sourceHandler.Requests,
+            request => Assert.NotNull(request.Authorization));
+        Assert.Null(Assert.Single(untrustedHandler.Requests).Authorization);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_PackageMappingSelectsTheMetadataProducer()
+    {
+        const string privateSource = "https://private.example/v3/index.json";
+        const string publicSource = "https://public.example/v3/index.json";
+        using var config = new TempNuGetConfig(
+            [("private", privateSource), ("public", publicSource)],
+            mappings: [("private", "Private.*"), ("public", "Public.*")]);
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath == "/v3/index.json"
+                ? Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """)
+                : Json("""{ "published": "2024-01-01T00:00:00Z" }"""));
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { ConfigFile = config.Path });
+
+        Assert.Equal(2024, result.Published!.Value.Year);
+        Assert.All(
+            handler.Requests,
+            request => Assert.Equal("private.example", request.Uri.Host));
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_IgnoresMalformedAdvertisedResourceUrls()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath == "/v3/index.json"
+                ? Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "[", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """)
+                : throw new InvalidOperationException(
+                    "A malformed advertised URL must not be requested."));
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
+
+        Assert.Null(result.Published);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_ArrayValuedResourceTypeDoesNotInvalidateFeed()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "urn:example", "@type": ["Other/1.0.0", "Other"] }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" =>
+                    Json("""{ "published": "2024-01-02T03:04:05Z" }"""),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
+
+        Assert.Equal(2024, result.Published!.Value.Year);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_UsesOnlyBestRegistrationCapabilityVersion()
+    {
+        const string sourceA = "https://a.example/v3/index.json";
+        const string sourceB = "https://b.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+        {
+            string host = request.RequestUri!.Host;
+            return request.RequestUri.AbsolutePath switch
+            {
+                "/v3/index.json" when host == "a.example" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://a.example/registration-36/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://a.example/registration-34/", "@type": "RegistrationsBaseUrl/3.4.0" }
+                      ]
+                    }
+                    """),
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://b.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """),
+                "/registration-36/private.package/1.0.0.json" =>
+                    new HttpResponseMessage(System.Net.HttpStatusCode.NotFound),
+                "/registration-34/private.package/1.0.0.json" =>
+                    new HttpResponseMessage(
+                        System.Net.HttpStatusCode.InternalServerError),
+                "/registration/private.package/1.0.0.json" =>
+                    Json("""{ "published": "2025-01-02T00:00:00Z" }"""),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            };
+        });
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [sourceA, sourceB] });
+
+        Assert.Equal(2025, result.Published!.Value.Year);
+        Assert.DoesNotContain(
+            handler.Requests,
+            request => request.Uri.AbsolutePath.StartsWith(
+                "/registration-34/",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_IgnoresMalformedCatalogReference()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("""
+                    {
+                      "published": "2024-01-02T03:04:05Z",
+                      "catalogEntry": "http://[::1"
+                    }
+                    """),
+                _ => throw new InvalidOperationException(
+                    "A malformed catalog reference must not be requested."),
+            });
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            new HttpClient(handler),
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: new NuGetSourceOptions { Sources = [source] });
+
+        Assert.Equal(
+            new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero),
+            result.Published);
+        Assert.Equal(2, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_LocalSourceDoesNotFallThroughToNuGetOrg()
+    {
+        List<string> log = [];
+
+        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
+            DotnetInspector.Core.HttpClientFactory.Shared,
+            "Private.Package",
+            "1.0.0",
+            log.Add,
+            sourceOptions: new NuGetSourceOptions
+            {
+                Sources = [Path.Combine(
+                    Path.GetTempPath(),
+                    $"feed-{Guid.NewGuid():N}")],
+            });
+
+        Assert.Null(result.Published);
+        Assert.Contains(
+            log,
+            message => message.StartsWith(
+                "Skipping non-HTTP NuGet metadata source",
+                StringComparison.Ordinal));
+    }
+
+    private static HttpResponseMessage Json(string content) =>
+        new(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                content,
+                Encoding.UTF8,
+                "application/json"),
+        };
+
+    private static HttpResponseMessage Html(string content) =>
+        new(System.Net.HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                content,
+                Encoding.UTF8,
+                "text/html"),
+        };
+
+    private static HttpResponseMessage Package(long? length)
+    {
+        var response = new HttpResponseMessage(System.Net.HttpStatusCode.PartialContent)
+        {
+            Content = new ByteArrayContent([0]),
+        };
+        response.Content.Headers.ContentRange = length is null
+            ? new ContentRangeHeaderValue(0, 0)
+            : new ContentRangeHeaderValue(0, 0, length.Value);
+        return response;
+    }
+
+    private sealed class RoutingHandler(
+        Func<HttpRequestMessage, HttpResponseMessage> route) : HttpMessageHandler
+    {
+        public List<RequestSnapshot> Requests { get; } = [];
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            throw new HttpRequestException($"Network access not allowed in test: {request.RequestUri}");
+            Requests.Add(new RequestSnapshot(
+                request.Method,
+                request.RequestUri!,
+                request.Headers.Authorization,
+                request.Headers.Range?.ToString()));
+            return Task.FromResult(route(request));
         }
     }
 
-    private sealed class CountingHandler : HttpMessageHandler
-    {
-        public int RequestCount { get; private set; }
+    private sealed record RequestSnapshot(
+        HttpMethod Method,
+        Uri Uri,
+        AuthenticationHeaderValue? Authorization,
+        string? Range);
 
-        protected override Task<HttpResponseMessage> SendAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
+    private sealed class TempNuGetConfig : IDisposable
+    {
+        public TempNuGetConfig(
+            IReadOnlyList<(string Name, string Url)> sources,
+            string? credentialedSource = null,
+            IReadOnlyList<(string Source, string Pattern)>? mappings = null)
         {
-            RequestCount++;
-            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"metadata-sources-{Guid.NewGuid():N}.config");
+            string sourceEntries = string.Join(
+                Environment.NewLine,
+                sources.Select(source =>
+                    $"    <add key=\"{source.Name}\" value=\"{source.Url}\" />"));
+            string credentials = credentialedSource is null
+                ? ""
+                : $$"""
+                    <packageSourceCredentials>
+                      <{{credentialedSource}}>
+                        <add key="Username" value="user" />
+                        <add key="ClearTextPassword" value="token" />
+                      </{{credentialedSource}}>
+                    </packageSourceCredentials>
+                    """;
+            string mapping = mappings is not { Count: > 0 }
+                ? ""
+                : $"""
+                    <packageSourceMapping>
+                    {string.Join(
+                        Environment.NewLine,
+                        mappings.Select(item =>
+                            $"  <packageSource key=\"{item.Source}\"><package pattern=\"{item.Pattern}\" /></packageSource>"))}
+                    </packageSourceMapping>
+                    """;
+            File.WriteAllText(Path, $$"""
+                <configuration>
+                  <packageSources>
+                    <clear />
+                {{sourceEntries}}
+                  </packageSources>
+                {{credentials}}
+                {{mapping}}
+                </configuration>
+                """);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            File.Delete(Path);
         }
     }
 }

--- a/src/DotnetInspector.Services/MetadataFieldCache.cs
+++ b/src/DotnetInspector.Services/MetadataFieldCache.cs
@@ -11,20 +11,46 @@ namespace DotnetInspector.Services;
 /// </summary>
 internal static class MetadataFieldCache
 {
+    internal readonly record struct Entry(
+        PackageMetadata Metadata,
+        bool IsAbsent);
+
     private const string Category = "metadata";
     private static readonly TimeSpan Ttl = TimeSpan.FromHours(1);
+    private static ReadOnlySpan<byte> PresentPrefix => "metadata-v4:present\n"u8;
+    private static ReadOnlySpan<byte> AbsentEntry => "metadata-v4:absent\n"u8;
 
     /// <summary>
     /// Tries to load cached metadata. Returns null on cache miss or expiry.
     /// </summary>
     public static PackageMetadata? TryGet(string cacheKey)
     {
+        Entry? entry = TryGetEntry(cacheKey);
+        return entry is { IsAbsent: false }
+            ? entry.Value.Metadata
+            : null;
+    }
+
+    /// <summary>
+    /// Tries to load cached metadata or an authoritative source-absence marker.
+    /// </summary>
+    public static Entry? TryGetEntry(string cacheKey)
+    {
         var bytes = CoreCache.TryGetBytes(Category, cacheKey, Ttl, extension: "md");
         if (bytes is null) return null;
 
         try
         {
-            using var doc = FieldDocument.Parse(bytes);
+            if (bytes.AsSpan().SequenceEqual(AbsentEntry))
+            {
+                return new Entry(new PackageMetadata(), IsAbsent: true);
+            }
+            if (!bytes.AsSpan().StartsWith(PresentPrefix))
+            {
+                return null;
+            }
+
+            using var doc = FieldDocument.Parse(bytes[PresentPrefix.Length..]);
             var metadata = new PackageMetadata
             {
                 IsVerified = doc.GetBool("isVerified") ? true : null,
@@ -49,17 +75,19 @@ internal static class MetadataFieldCache
 
             var owners = doc.GetArrayList("owners");
             if (owners is { Count: > 0 })
-                metadata.Owners = owners;
+                metadata.Owners = owners.Select(DecodeText).ToList();
 
             // Deprecation: flattened fields
-            var reasons = doc.GetString("deprecationReasons");
-            var message = doc.GetString("deprecationMessage");
-            var altPkg = doc.GetString("deprecationAlternate");
-            if (reasons is not null || message is not null)
+            var reasons = doc.GetArrayList("deprecationReasons");
+            var message = DecodeOptionalText(
+                doc.GetString("deprecationMessage"));
+            var altPkg = DecodeOptionalText(
+                doc.GetString("deprecationAlternate"));
+            if (reasons is { Count: > 0 } || message is not null)
             {
                 metadata.Deprecation = new PackageDeprecation
                 {
-                    Reasons = reasons?.Split(", ").ToList(),
+                    Reasons = reasons?.Select(DecodeText).ToList(),
                     Message = message,
                     AlternatePackageId = altPkg,
                 };
@@ -71,8 +99,12 @@ internal static class MetadataFieldCache
             {
                 metadata.Vulnerabilities = vulnItems.Select(ParseVulnerability).ToList();
             }
+            else if (doc.GetBool("vulnerabilitiesChecked"))
+            {
+                metadata.Vulnerabilities = [];
+            }
 
-            return metadata;
+            return new Entry(metadata, IsAbsent: false);
         }
         catch
         {
@@ -84,10 +116,39 @@ internal static class MetadataFieldCache
     /// Caches metadata as a markdown field document.
     /// </summary>
     public static void Set(string cacheKey, PackageMetadata metadata)
+        => SetEntry(cacheKey, metadata, isAbsent: false);
+
+    /// <summary>
+    /// Caches that one producer authoritatively reported the package version absent.
+    /// </summary>
+    public static void SetAbsent(string cacheKey)
+        => SetEntry(cacheKey, new PackageMetadata(), isAbsent: true);
+
+    private static void SetEntry(
+        string cacheKey,
+        PackageMetadata metadata,
+        bool isAbsent)
     {
         try
         {
             var buf = new ArrayBufferWriter<byte>(512);
+
+            if (isAbsent)
+            {
+                Write(buf, AbsentEntry);
+                CoreCache.SetBytes(
+                    Category,
+                    cacheKey,
+                    buf.WrittenSpan.ToArray(),
+                    extension: "md");
+                return;
+            }
+
+            Write(buf, PresentPrefix);
+
+            // Keep even an otherwise empty metadata result parseable. A feed may advertise a
+            // package without any optional aggregate metadata fields.
+            WriteField(buf, "formatVersion"u8, "4");
 
             // Scalars
             if (metadata.Published.HasValue)
@@ -107,21 +168,37 @@ internal static class MetadataFieldCache
             if (metadata.Deprecation is { } dep)
             {
                 if (dep.Reasons is { Count: > 0 })
-                    WriteField(buf, "deprecationReasons"u8, string.Join(", ", dep.Reasons));
+                    WriteArray(
+                        buf,
+                        "deprecationReasons"u8,
+                        dep.Reasons.Select(EncodeText).ToList());
                 if (!string.IsNullOrEmpty(dep.Message))
-                    WriteField(buf, "deprecationMessage"u8, dep.Message);
+                    WriteField(
+                        buf,
+                        "deprecationMessage"u8,
+                        EncodeText(dep.Message));
                 if (!string.IsNullOrEmpty(dep.AlternatePackageId))
-                    WriteField(buf, "deprecationAlternate"u8, dep.AlternatePackageId);
+                    WriteField(
+                        buf,
+                        "deprecationAlternate"u8,
+                        EncodeText(dep.AlternatePackageId));
             }
 
             // Arrays
-            WriteArray(buf, "owners"u8, metadata.Owners);
+            WriteArray(
+                buf,
+                "owners"u8,
+                metadata.Owners?.Select(EncodeText).ToList());
 
             // Vulnerabilities: compact pipe-delimited
-            if (metadata.Vulnerabilities is { Count: > 0 })
+            if (metadata.Vulnerabilities is { } vulnerabilities)
             {
-                var items = metadata.Vulnerabilities.Select(FormatVulnerability).ToList();
-                WriteArray(buf, "vulnerabilities"u8, items);
+                WriteField(buf, "vulnerabilitiesChecked"u8, "true");
+                if (vulnerabilities.Count > 0)
+                {
+                    var items = vulnerabilities.Select(FormatVulnerability).ToList();
+                    WriteArray(buf, "vulnerabilities"u8, items);
+                }
             }
 
             CoreCache.SetBytes(Category, cacheKey, buf.WrittenSpan.ToArray(), extension: "md");
@@ -132,23 +209,53 @@ internal static class MetadataFieldCache
         }
     }
 
-    // ── Vulnerability compact format: "Severity|CveId|GhsaId|Summary" ──
+    // ── Vulnerability compact format: "Severity|CveId|GhsaId|Summary|AdvisoryUrl" ──
 
     private static string FormatVulnerability(PackageVulnerability v)
     {
-        return $"{v.Severity}|{v.CveId ?? ""}|{v.GhsaId ?? ""}|{v.Summary ?? ""}";
+        return string.Join(
+            '|',
+            EncodeText(v.Severity),
+            EncodeText(v.CveId ?? ""),
+            EncodeText(v.GhsaId ?? ""),
+            EncodeText(v.Summary ?? ""),
+            EncodeText(v.AdvisoryUrl ?? ""));
     }
 
     private static PackageVulnerability ParseVulnerability(string raw)
     {
-        var parts = raw.Split('|', 4);
+        var parts = raw.Split('|', 5);
         return new PackageVulnerability
         {
-            Severity = parts.Length > 0 ? parts[0] : "",
-            CveId = parts.Length > 1 && parts[1].Length > 0 ? parts[1] : null,
-            GhsaId = parts.Length > 2 && parts[2].Length > 0 ? parts[2] : null,
-            Summary = parts.Length > 3 && parts[3].Length > 0 ? parts[3] : null,
+            Severity = parts.Length > 0 ? DecodeText(parts[0]) : "",
+            CveId = parts.Length > 1
+                ? DecodeOptionalText(parts[1])
+                : null,
+            GhsaId = parts.Length > 2
+                ? DecodeOptionalText(parts[2])
+                : null,
+            Summary = parts.Length > 3
+                ? DecodeOptionalText(parts[3])
+                : null,
+            AdvisoryUrl = parts.Length > 4
+                ? DecodeOptionalText(parts[4])
+                : null,
         };
+    }
+
+    private static string EncodeText(string value) =>
+        Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+
+    private static string DecodeText(string value) =>
+        Encoding.UTF8.GetString(Convert.FromBase64String(value));
+
+    private static string? DecodeOptionalText(string? value)
+    {
+        if (value is null)
+            return null;
+
+        string decoded = DecodeText(value);
+        return decoded.Length > 0 ? decoded : null;
     }
 
     // ── Field serialization (UTF-8 bytes) ──

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -1,6 +1,11 @@
+using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using DotnetInspector.Core;
 using DotnetInspector.Packages;
+using NuGet.Versioning;
+using PackageSource = NuGetFetch.PackageSource;
+using ServiceResource = NuGetFetch.ServiceResource;
 
 namespace DotnetInspector.Services;
 
@@ -10,6 +15,43 @@ namespace DotnetInspector.Services;
 /// </summary>
 public static class PackageMetadataService
 {
+    private enum SourcePresence
+    {
+        Present,
+        Absent,
+        Indeterminate,
+    }
+
+    private readonly record struct SourceMetadataResult(
+        SourcePresence Presence,
+        PackageMetadata? Metadata = null,
+        bool Cacheable = true);
+
+    private readonly record struct TextFetchResult(
+        string? Content,
+        HttpStatusCode? StatusCode)
+    {
+        public bool IsSuccess => Content is not null;
+        public bool IsNotFound => StatusCode == HttpStatusCode.NotFound;
+    }
+
+    private readonly record struct PackageProbeResult(
+        SourcePresence Presence,
+        long? PackageSize = null);
+
+    private readonly record struct SearchPageResult(
+        bool Found,
+        int ResultCount,
+        long? TotalHits);
+
+    private readonly record struct SearchFetchResult(
+        bool Succeeded,
+        bool Found);
+
+    private readonly record struct VulnerabilityFetchResult(
+        bool Succeeded,
+        List<PackageVulnerability> Vulnerabilities);
+
     /// <summary>
     /// Gets the published date for a specific package version.
     /// </summary>
@@ -18,51 +60,19 @@ public static class PackageMetadataService
         string packageName,
         string version,
         Action<string>? log,
-        NuGetSourceOptions? sourceOptions = null)
+        NuGetSourceOptions? sourceOptions = null,
+        HttpClient? untrustedClient = null)
     {
-        var normalizedName = packageName.ToLowerInvariant();
-        var cacheKey = $"{normalizedName}@{version}";
-        if (!SupportsNuGetOrgMetadata(sourceOptions, packageName, log))
-            return null;
-        PackageMetadata? cached;
-        using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageMetadata))
-        {
-            cached = MetadataFieldCache.TryGet(cacheKey);
-        }
-        if (cached != null)
-        {
-            log?.Invoke("Using cached publish date metadata");
-            return cached.Published;
-        }
-
-        try
-        {
-            string registrationUrl = $"https://api.nuget.org/v3/registration5-semver1/{normalizedName}/{version}.json";
-            log?.Invoke($"Fetching package metadata from: {registrationUrl}");
-
-            string? json = await HttpRetryHelper.GetStringWithRetryAsync(
-                client, registrationUrl,
-                trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
-            if (json == null)
-                return null;
-
-            using var doc = HardenedJson.Parse(json);
-            if (doc.RootElement.TryGetProperty("published", out var publishedElement))
-            {
-                if (DateTimeOffset.TryParse(publishedElement.GetString(), out var published))
-                {
-                    log?.Invoke($"Package published: {published:yyyy-MM-dd}");
-                    MetadataFieldCache.Set(cacheKey, new PackageMetadata { Published = published });
-                    return published;
-                }
-            }
-        }
-        catch (Exception ex) when (ex is not NetworkPolicyException)
-        {
-            log?.Invoke($"Error fetching publish date: {ex.Message}");
-        }
-
-        return null;
+        PackageMetadata metadata = await FetchMetadataAsync(
+            client,
+            packageName,
+            version,
+            log,
+            forceLatest: false,
+            sourceOptions,
+            registrationOnly: true,
+            untrustedClient ?? HttpClientFactory.SharedUntrustedFetch).ConfigureAwait(false);
+        return metadata.Published;
     }
 
     /// <summary>
@@ -75,129 +85,289 @@ public static class PackageMetadataService
         string version,
         Action<string>? log,
         bool forceLatest = false,
-        NuGetSourceOptions? sourceOptions = null)
+        NuGetSourceOptions? sourceOptions = null,
+        HttpClient? untrustedClient = null)
+        => await FetchMetadataAsync(
+            client,
+            packageName,
+            version,
+            log,
+            forceLatest,
+            sourceOptions,
+            registrationOnly: false,
+            untrustedClient ?? HttpClientFactory.SharedUntrustedFetch).ConfigureAwait(false);
+
+    private static async Task<PackageMetadata> FetchMetadataAsync(
+        HttpClient client,
+        string packageName,
+        string version,
+        Action<string>? log,
+        bool forceLatest,
+        NuGetSourceOptions? sourceOptions,
+        bool registrationOnly,
+        HttpClient untrustedClient)
     {
-        var normalizedName = packageName.ToLowerInvariant();
-        string cacheKey = $"{normalizedName}@{version}";
-        if (!SupportsNuGetOrgMetadata(sourceOptions, packageName, log))
-            return new PackageMetadata();
+        string normalizedName = packageName.ToLowerInvariant();
+        string normalizedVersion = NormalizeVersion(version);
+        IReadOnlyList<PackageSource> sources =
+            ResolveMetadataSources(sourceOptions, packageName, log);
 
-        // Try cache first (unless @latest forces refresh)
-        if (!forceLatest)
+        foreach (PackageSource source in sources)
         {
-            PackageMetadata? fromCache;
-            using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageMetadata))
+            string cacheKey = MetadataCacheKey(
+                source,
+                normalizedName,
+                normalizedVersion,
+                registrationOnly);
+            if (!forceLatest)
             {
-                fromCache = MetadataFieldCache.TryGet(cacheKey);
+                MetadataFieldCache.Entry? fromCache;
+                using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageMetadata))
+                {
+                    fromCache = MetadataFieldCache.TryGetEntry(cacheKey);
+                }
+                if (fromCache is { IsAbsent: true })
+                {
+                    continue;
+                }
+                if (fromCache is { } cached)
+                {
+                    log?.Invoke($"Using cached metadata from {source.Name}");
+                    return cached.Metadata;
+                }
             }
-            if (fromCache != null)
+
+            if (!Uri.TryCreate(source.Url, UriKind.Absolute, out Uri? sourceUri)
+                || sourceUri.Scheme is not ("http" or "https"))
             {
-                log?.Invoke("Using cached metadata");
-                return fromCache;
+                log?.Invoke(
+                    $"Skipping non-HTTP NuGet metadata source "
+                    + $"'{source.Name}': {source.Url}");
+                return new PackageMetadata();
             }
+
+            HttpClient sourceClient =
+                ReferenceEquals(client, HttpClientFactory.Shared)
+                    ? HttpClientFactory.GetPackageSourceClient(source.Url)
+                    : client;
+            SourceMetadataResult result = await FetchAllMetadataFromSourceAsync(
+                sourceClient,
+                source,
+                normalizedName,
+                normalizedVersion,
+                log,
+                registrationOnly,
+                untrustedClient).ConfigureAwait(false);
+            if (result.Presence == SourcePresence.Indeterminate)
+            {
+                log?.Invoke(
+                    $"Metadata from higher-precedence source '{source.Name}' is unavailable; "
+                    + "lower sources were not consulted.");
+                return new PackageMetadata();
+            }
+            if (result.Presence == SourcePresence.Absent)
+            {
+                using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageMetadata))
+                {
+                    MetadataFieldCache.SetAbsent(cacheKey);
+                }
+                continue;
+            }
+
+            PackageMetadata metadata = result.Metadata ?? new PackageMetadata();
+            if (result.Cacheable)
+            {
+                using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageMetadata))
+                {
+                    MetadataFieldCache.Set(cacheKey, metadata);
+                }
+            }
+            return metadata;
         }
 
-        var metadata = await FetchAllMetadataFromNetworkAsync(client, normalizedName, version, log).ConfigureAwait(false);
-
-        // Cache the result
-        using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageMetadata))
-        {
-            MetadataFieldCache.Set(cacheKey, metadata);
-        }
-
-        return metadata;
+        return new PackageMetadata();
     }
 
-    internal static bool SupportsNuGetOrgMetadata(
+    private static IReadOnlyList<PackageSource> ResolveMetadataSources(
         NuGetSourceOptions? sourceOptions,
         string packageId,
-        Action<string>? log = null)
+        Action<string>? log)
     {
-        bool supported;
         try
         {
-            supported = NuGetSourceResolver.ResolveSourcesForPackage(
+            List<PackageSource> mapped =
+                NuGetSourceResolver.ResolveSourcesForPackage(
                     sourceOptions,
-                    packageId)
-                .Any(source => source.IsNuGetOrg);
+                    packageId);
+            return NuGetSourceResolver.ResolveAuthorizedSources(
+                sourceOptions,
+                mapped);
         }
         catch (PackageSourceMappingException ex)
             when (ex.Failure is
                 PackageSourceMappingFailure.NoPattern
                 or PackageSourceMappingFailure.InactiveSource)
         {
-            supported = false;
+            log?.Invoke(ex.Message);
+            return [];
         }
-
-        if (!supported)
-        {
-            log?.Invoke(
-                $"NuGet.org aggregate metadata is unavailable for '{packageId}' because "
-                + "package source policy does not authorize api.nuget.org.");
-        }
-        return supported;
     }
 
-    private static async Task<PackageMetadata> FetchAllMetadataFromNetworkAsync(
-        HttpClient client, string normalizedName, string version, Action<string>? log)
+    private static string MetadataCacheKey(
+        PackageSource source,
+        string normalizedName,
+        string normalizedVersion,
+        bool registrationOnly) =>
+        $"v4-{(registrationOnly ? "published" : "full")}-"
+        + $"{NuGetCache.GetSourceKey(source.Url)}-"
+        + $"{normalizedName}@{normalizedVersion}";
+
+    private static string NormalizeVersion(string version) =>
+        NuGetVersion.TryParse(version, out NuGetVersion? parsed)
+            ? parsed.ToNormalizedString().ToLowerInvariant()
+            : version.ToLowerInvariant();
+
+    private static async Task<SourceMetadataResult> FetchAllMetadataFromSourceAsync(
+        HttpClient client,
+        PackageSource source,
+        string normalizedName,
+        string version,
+        Action<string>? log,
+        bool registrationOnly,
+        HttpClient untrustedClient)
     {
+        IReadOnlyList<ServiceResource>? resources =
+            await PackageExtractor.GetServiceIndexResourcesAsync(
+                client,
+                source,
+                log).ConfigureAwait(false);
+        if (resources is null)
+        {
+            return new SourceMetadataResult(SourcePresence.Indeterminate);
+        }
+
         var metadata = new PackageMetadata();
 
-        // Fetch from registration API (published date, catalog entry URL)
+        List<ServiceResource> registrationResources =
+            CompatibleResources(resources, "RegistrationsBaseUrl");
+        List<ServiceResource> packageBaseAddresses =
+            CompatibleResources(resources, "PackageBaseAddress");
+        List<ServiceResource> searchQueryServices =
+            CompatibleResources(resources, "SearchQueryService");
+        List<ServiceResource> vulnerabilityInfos =
+            CompatibleResources(resources, "VulnerabilityInfo");
+
+        bool found = false;
+        bool sawExistenceEndpoint = false;
+        bool sawIndeterminate = false;
         string? catalogEntryUrl = null;
-        try
+
+        foreach (ServiceResource registration in registrationResources)
         {
-            string registrationUrl = $"https://api.nuget.org/v3/registration5-semver1/{normalizedName}/{version}.json";
+            sawExistenceEndpoint = true;
+            string registrationUrl = AppendPath(
+                registration.Id,
+                normalizedName,
+                $"{version}.json");
             log?.Invoke($"Fetching registration metadata: {registrationUrl}");
 
-            string? json = await HttpRetryHelper.GetStringWithRetryAsync(
-                client, registrationUrl,
-                trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
-            if (json != null)
+            TextFetchResult registrationResult = await FetchTextAsync(
+                client,
+                untrustedClient,
+                source,
+                registrationUrl,
+                NetworkTrafficKind.PackageMetadata,
+                log).ConfigureAwait(false);
+            if (registrationResult.IsSuccess)
             {
-                using var doc = HardenedJson.Parse(json);
-                var root = doc.RootElement;
-
-                if (root.TryGetProperty("published", out var publishedElement))
+                try
                 {
-                    if (DateTimeOffset.TryParse(publishedElement.GetString(), out var published))
-                    {
-                        metadata.Published = published;
-                        log?.Invoke($"Published: {published:yyyy-MM-dd}");
-                    }
+                    catalogEntryUrl = ApplyRegistrationMetadata(
+                        registrationResult.Content!,
+                        registrationUrl,
+                        metadata,
+                        log);
+                    found = true;
+                    break;
                 }
-
-                if (root.TryGetProperty("catalogEntry", out var catalogElement))
+                catch (Exception ex) when (ex is
+                    JsonException
+                    or InvalidOperationException
+                    or UriFormatException)
                 {
-                    catalogEntryUrl = catalogElement.GetString();
+                    log?.Invoke($"Invalid registration metadata from {source.Name}: {ex.Message}");
+                    sawIndeterminate = true;
+                }
+                continue;
+            }
+
+            if (!registrationResult.IsNotFound)
+            {
+                sawIndeterminate = true;
+            }
+        }
+
+        if (packageBaseAddresses.Count > 0
+            && (!registrationOnly || !found))
+        {
+            sawExistenceEndpoint = true;
+            foreach (ServiceResource packageBaseAddress in packageBaseAddresses)
+            {
+                PackageProbeResult probe = await ProbePackageAsync(
+                    client,
+                    source,
+                    packageBaseAddress,
+                    normalizedName,
+                    version,
+                    log,
+                    untrustedClient).ConfigureAwait(false);
+                if (probe.Presence == SourcePresence.Present)
+                {
+                    found = true;
+                    metadata.PackageSize = probe.PackageSize;
+                    break;
+                }
+                if (probe.Presence == SourcePresence.Indeterminate)
+                {
+                    sawIndeterminate = true;
                 }
             }
         }
-        catch (Exception ex) when (ex is not NetworkPolicyException)
+
+        if (registrationOnly)
         {
-            log?.Invoke($"Error fetching registration metadata: {ex.Message}");
+            return found
+                ? new SourceMetadataResult(SourcePresence.Present, metadata)
+                : sawExistenceEndpoint && !sawIndeterminate
+                ? new SourceMetadataResult(SourcePresence.Absent)
+                : new SourceMetadataResult(SourcePresence.Indeterminate);
         }
 
-        // Fetch catalog entry for version-specific deprecation
+        if (!found)
+        {
+            return sawExistenceEndpoint && !sawIndeterminate
+                ? new SourceMetadataResult(SourcePresence.Absent)
+                : new SourceMetadataResult(SourcePresence.Indeterminate);
+        }
+
+        bool catalogDataAvailable = true;
         if (!string.IsNullOrEmpty(catalogEntryUrl))
         {
+            catalogDataAvailable = false;
             try
             {
                 log?.Invoke($"Fetching catalog entry: {catalogEntryUrl}");
-                string? catalogJson = await HttpRetryHelper.GetStringWithRetryAsync(
-                    client, catalogEntryUrl,
-                    trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
-                if (catalogJson != null)
+                TextFetchResult catalogResult = await FetchTextAsync(
+                    client,
+                    untrustedClient,
+                    source,
+                    catalogEntryUrl,
+                    NetworkTrafficKind.PackageMetadata,
+                    log).ConfigureAwait(false);
+                if (catalogResult.IsSuccess)
                 {
-                    using var doc = HardenedJson.Parse(catalogJson);
-                    var root = doc.RootElement;
-
-                    if (root.TryGetProperty("deprecation", out var deprecationElement) &&
-                        deprecationElement.ValueKind == JsonValueKind.Object)
-                    {
-                        metadata.Deprecation = ParseDeprecation(deprecationElement);
-                        log?.Invoke($"Deprecation: {metadata.Deprecation.Summary}");
-                    }
+                    ApplyCatalogMetadata(catalogResult.Content!, metadata, log);
+                    catalogDataAvailable = true;
                 }
             }
             catch (Exception ex) when (ex is not NetworkPolicyException)
@@ -206,109 +376,516 @@ public static class PackageMetadataService
             }
         }
 
-        // Fetch from search API (downloads, verified, owners)
-        try
+        bool searchDataAvailable = searchQueryServices.Count == 0;
+        if (searchQueryServices.Count > 0)
         {
-            string searchUrl = $"https://azuresearch-usnc.nuget.org/query?q=packageid:{normalizedName}&take=1";
-            log?.Invoke($"Fetching search metadata: {searchUrl}");
-
-            string? json = await HttpRetryHelper.GetStringWithRetryAsync(
-                client, searchUrl,
-                trafficKind: NetworkTrafficKind.PackageMetadata).ConfigureAwait(false);
-            if (json != null)
+            foreach (ServiceResource searchQueryService in searchQueryServices)
             {
-                using var doc = HardenedJson.Parse(json);
-                if (doc.RootElement.TryGetProperty("data", out var data) &&
-                    data.GetArrayLength() > 0)
+                try
                 {
-                    var pkg = data[0];
-
-                    if (pkg.TryGetProperty("totalDownloads", out var downloads))
+                    SearchFetchResult searchResult =
+                        await FetchSearchMetadataAsync(
+                                client,
+                                source,
+                                searchQueryService,
+                                normalizedName,
+                                version,
+                                metadata,
+                                log,
+                                untrustedClient)
+                            .ConfigureAwait(false);
+                    if (searchResult.Succeeded)
                     {
-                        metadata.TotalDownloads = downloads.GetInt64();
+                        searchDataAvailable = true;
+                        break;
                     }
-
-                    if (pkg.TryGetProperty("versions", out var versions))
-                    {
-                        metadata.VersionCount = versions.GetArrayLength();
-
-                        foreach (var v in versions.EnumerateArray())
-                        {
-                            if (v.TryGetProperty("version", out var versionProp) &&
-                                string.Equals(versionProp.GetString(), version, StringComparison.OrdinalIgnoreCase) &&
-                                v.TryGetProperty("downloads", out var versionDownloads))
-                            {
-                                metadata.VersionDownloads = versionDownloads.GetInt64();
-                                break;
-                            }
-                        }
-                    }
-
-                    if (pkg.TryGetProperty("verified", out var verified))
-                    {
-                        metadata.IsVerified = verified.GetBoolean();
-                    }
-
-                    if (pkg.TryGetProperty("owners", out var owners))
-                    {
-                        metadata.Owners = owners.EnumerateArray()
-                            .Select(o => o.GetString())
-                            .Where(o => o != null)
-                            .Cast<string>()
-                            .ToList();
-                    }
-
-                    // Deprecation (from search API - more reliable than registration API)
-                    if (metadata.Deprecation == null &&
-                        pkg.TryGetProperty("deprecation", out var deprecationElement) &&
-                        deprecationElement.ValueKind == JsonValueKind.Object)
-                    {
-                        metadata.Deprecation = ParseDeprecation(deprecationElement);
-                        log?.Invoke($"Deprecation: {metadata.Deprecation.Summary}");
-                    }
+                }
+                catch (Exception ex) when (ex is not NetworkPolicyException)
+                {
+                    log?.Invoke(
+                        $"Error fetching search metadata from "
+                        + $"{searchQueryService.Id}: {ex.Message}");
                 }
             }
         }
-        catch (Exception ex) when (ex is not NetworkPolicyException)
-        {
-            log?.Invoke($"Error fetching search metadata: {ex.Message}");
-        }
 
-        // Fetch from vulnerability API
-        try
+        bool vulnerabilityDataAvailable = vulnerabilityInfos.Count == 0;
+        List<PackageVulnerability> partialVulnerabilities = [];
+        if (vulnerabilityInfos.Count > 0)
         {
-            var vulnerabilities = await GetPackageVulnerabilitiesAsync(client, normalizedName, version, log).ConfigureAwait(false);
-            if (vulnerabilities.Count > 0)
+            foreach (ServiceResource vulnerabilityInfo in vulnerabilityInfos)
             {
-                metadata.Vulnerabilities = vulnerabilities;
+                try
+                {
+                    VulnerabilityFetchResult result =
+                        await GetPackageVulnerabilitiesAsync(
+                            client,
+                            source,
+                            vulnerabilityInfo.Id,
+                            normalizedName,
+                            version,
+                            log,
+                            untrustedClient).ConfigureAwait(false);
+                    if (!result.Succeeded)
+                    {
+                        if (result.Vulnerabilities.Count
+                            > partialVulnerabilities.Count)
+                        {
+                            partialVulnerabilities =
+                                result.Vulnerabilities;
+                        }
+                        continue;
+                    }
+
+                    vulnerabilityDataAvailable = true;
+                    metadata.Vulnerabilities ??= [];
+                    metadata.Vulnerabilities.AddRange(
+                        result.Vulnerabilities);
+                    break;
+                }
+                catch (Exception ex) when (ex is not NetworkPolicyException)
+                {
+                    log?.Invoke(
+                        $"Error fetching vulnerability data from "
+                        + $"{vulnerabilityInfo.Id}: {ex.Message}");
+                }
             }
         }
-        catch (Exception ex) when (ex is not NetworkPolicyException)
+
+        if (!vulnerabilityDataAvailable
+            && partialVulnerabilities.Count > 0)
         {
-            log?.Invoke($"Error fetching vulnerability data: {ex.Message}");
+            metadata.Vulnerabilities = partialVulnerabilities;
         }
 
-        // Fetch package size via HEAD request
-        try
-        {
-            string nupkgUrl = $"https://api.nuget.org/v3-flatcontainer/{normalizedName}/{version}/{normalizedName}.{version}.nupkg";
-            log?.Invoke($"Fetching package size: {nupkgUrl}");
-
-            var response = await HttpRetryHelper.HeadWithRetryAsync(
-                client, nupkgUrl,
-                trafficKind: NetworkTrafficKind.PackageSizeProbe).ConfigureAwait(false);
-            if (response?.Content.Headers.ContentLength is long contentLength)
-            {
-                metadata.PackageSize = contentLength;
-            }
-        }
-        catch (Exception ex) when (ex is not NetworkPolicyException)
-        {
-            log?.Invoke($"Error fetching package size: {ex.Message}");
-        }
-
-        return metadata;
+        return new SourceMetadataResult(
+            SourcePresence.Present,
+            metadata,
+            Cacheable: catalogDataAvailable
+                && searchDataAvailable
+                && vulnerabilityDataAvailable);
     }
+
+    private static List<ServiceResource> CompatibleResources(
+        IReadOnlyList<ServiceResource> resources,
+        string typePrefix)
+    {
+        List<ServiceResource> matching =
+        [
+            .. resources.Where(resource =>
+                IsServiceType(resource.Type, typePrefix)),
+        ];
+        if (matching.Count == 0)
+            return [];
+
+        System.Version bestVersion = ResourceVersion(matching[0].Type);
+        for (int i = 1; i < matching.Count; i++)
+        {
+            System.Version version = ResourceVersion(matching[i].Type);
+            if (version > bestVersion)
+                bestVersion = version;
+        }
+        return
+        [
+            .. matching.Where(resource =>
+                ResourceVersion(resource.Type) == bestVersion),
+        ];
+    }
+
+    private static System.Version ResourceVersion(string resourceType)
+    {
+        int separator = resourceType.IndexOf('/');
+        return separator >= 0
+            && System.Version.TryParse(
+                resourceType[(separator + 1)..],
+                out System.Version? version)
+                ? version
+                : new System.Version();
+    }
+
+    private static bool IsServiceType(string type, string prefix) =>
+        type.Equals(prefix, StringComparison.OrdinalIgnoreCase)
+        || type.StartsWith($"{prefix}/", StringComparison.OrdinalIgnoreCase);
+
+    private static async Task<TextFetchResult> FetchTextAsync(
+        HttpClient client,
+        HttpClient untrustedClient,
+        PackageSource source,
+        string url,
+        NetworkTrafficKind trafficKind,
+        Action<string>? log)
+    {
+        HttpClient endpointClient = NuGetCredentialScope.IsSameOrigin(
+            source.Url,
+            url)
+                ? client
+                : untrustedClient;
+        HttpRetryHelper.HttpRetryResult result =
+            await HttpRetryHelper.GetWithRetryResultAsync(
+                endpointClient,
+                url,
+                log: log,
+                auth: NuGetCredentialScope.AuthFor(source, url, log),
+                trafficKind: trafficKind).ConfigureAwait(false);
+        using HttpResponseMessage? response = result.Response;
+        if (response is null)
+        {
+            return new TextFetchResult(null, result.StatusCode);
+        }
+
+        string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return new TextFetchResult(content, result.StatusCode);
+    }
+
+    private static async Task<PackageProbeResult> ProbePackageAsync(
+        HttpClient client,
+        PackageSource source,
+        ServiceResource packageBaseAddress,
+        string normalizedName,
+        string version,
+        Action<string>? log,
+        HttpClient untrustedClient)
+    {
+        string nupkgUrl = AppendPath(
+            packageBaseAddress.Id,
+            normalizedName,
+            version,
+            $"{normalizedName}.{version}.nupkg");
+        log?.Invoke($"Fetching package size from {source.Name}: {nupkgUrl}");
+
+        AuthenticationHeaderValue? auth =
+            NuGetCredentialScope.AuthFor(source, nupkgUrl, log);
+        HttpRetryHelper.HttpRetryResult sizeResult =
+            await HttpRetryHelper.GetWithRetryResultAsync(
+                NuGetCredentialScope.IsSameOrigin(source.Url, nupkgUrl)
+                    ? client
+                    : untrustedClient,
+                nupkgUrl,
+                log: log,
+                trafficKind: NetworkTrafficKind.PackageSizeProbe,
+                auth: auth,
+                range: new RangeHeaderValue(0, 0)).ConfigureAwait(false);
+        using HttpResponseMessage? response = sizeResult.Response;
+        if (response is null)
+        {
+            return new PackageProbeResult(
+                sizeResult.IsNotFound
+                    ? SourcePresence.Absent
+                    : SourcePresence.Indeterminate);
+        }
+
+        if (response.StatusCode == HttpStatusCode.OK
+            && string.Equals(
+                response.Content.Headers.ContentType?.MediaType,
+                "text/html",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            log?.Invoke(
+                $"Package endpoint returned HTML instead of package content: "
+                + $"{nupkgUrl}");
+            return new PackageProbeResult(SourcePresence.Indeterminate);
+        }
+
+        long? contentLength = response.StatusCode
+            == HttpStatusCode.PartialContent
+                ? response.Content.Headers.ContentRange?.Length
+                : response.Content.Headers.ContentLength;
+        return new PackageProbeResult(
+            SourcePresence.Present,
+            contentLength);
+    }
+
+    private static async Task<SearchFetchResult> FetchSearchMetadataAsync(
+        HttpClient client,
+        PackageSource source,
+        ServiceResource searchQueryService,
+        string normalizedName,
+        string version,
+        PackageMetadata metadata,
+        Action<string>? log,
+        HttpClient untrustedClient)
+    {
+        const int PageSize = 20;
+        const int MaxSearchResults = 1000;
+        int examined = 0;
+
+        while (examined < MaxSearchResults)
+        {
+            string searchUrl = AddQuery(
+                searchQueryService.Id,
+                $"q={Uri.EscapeDataString(normalizedName)}"
+                + $"&skip={examined}&take={PageSize}"
+                + "&prerelease=true&semVerLevel=2.0.0");
+            log?.Invoke(
+                $"Fetching search metadata from {source.Name}: {searchUrl}");
+
+            TextFetchResult searchResult = await FetchTextAsync(
+                client,
+                untrustedClient,
+                source,
+                searchUrl,
+                NetworkTrafficKind.PackageMetadata,
+                log).ConfigureAwait(false);
+            if (!searchResult.IsSuccess)
+                return new SearchFetchResult(
+                    Succeeded: false,
+                    Found: false);
+
+            SearchPageResult page = ApplySearchMetadata(
+                searchResult.Content!,
+                normalizedName,
+                version,
+                metadata,
+                log);
+            if (page.Found)
+                return new SearchFetchResult(
+                    Succeeded: true,
+                    Found: true);
+            if (page.ResultCount == 0)
+                return new SearchFetchResult(
+                    Succeeded: true,
+                    Found: false);
+
+            examined += page.ResultCount;
+            if (page.TotalHits is > 0 && examined >= page.TotalHits)
+                return new SearchFetchResult(
+                    Succeeded: true,
+                    Found: false);
+        }
+
+        return new SearchFetchResult(
+            Succeeded: true,
+            Found: false);
+    }
+
+    private static string? ApplyRegistrationMetadata(
+        string json,
+        string registrationUrl,
+        PackageMetadata metadata,
+        Action<string>? log)
+    {
+        using var doc = HardenedJson.Parse(json);
+        JsonElement root = doc.RootElement;
+
+        if (root.TryGetProperty("published", out JsonElement publishedElement)
+            && DateTimeOffset.TryParse(
+                publishedElement.GetString(),
+                out DateTimeOffset published))
+        {
+            metadata.Published = published;
+            log?.Invoke($"Published: {published:yyyy-MM-dd}");
+        }
+
+        if (!root.TryGetProperty("catalogEntry", out JsonElement catalogElement))
+        {
+            return null;
+        }
+
+        if (catalogElement.ValueKind == JsonValueKind.Object)
+        {
+            ApplyCatalogElement(catalogElement, metadata, log);
+            return null;
+        }
+
+        string? catalogEntry = catalogElement.GetString();
+        if (string.IsNullOrWhiteSpace(catalogEntry))
+            return null;
+
+        try
+        {
+            return ResolveReference(registrationUrl, catalogEntry);
+        }
+        catch (UriFormatException)
+        {
+            log?.Invoke("Ignoring malformed catalog entry URL.");
+            return null;
+        }
+    }
+
+    private static void ApplyCatalogMetadata(
+        string json,
+        PackageMetadata metadata,
+        Action<string>? log)
+    {
+        using var doc = HardenedJson.Parse(json);
+        ApplyCatalogElement(doc.RootElement, metadata, log);
+    }
+
+    private static void ApplyCatalogElement(
+        JsonElement root,
+        PackageMetadata metadata,
+        Action<string>? log)
+    {
+        if (root.TryGetProperty("published", out JsonElement publishedElement)
+            && DateTimeOffset.TryParse(
+                publishedElement.GetString(),
+                out DateTimeOffset published))
+        {
+            metadata.Published ??= published;
+        }
+
+        if (root.TryGetProperty("deprecation", out JsonElement deprecationElement)
+            && deprecationElement.ValueKind == JsonValueKind.Object)
+        {
+            metadata.Deprecation = ParseDeprecation(deprecationElement);
+            log?.Invoke($"Deprecation: {metadata.Deprecation.Summary}");
+        }
+    }
+
+    private static SearchPageResult ApplySearchMetadata(
+        string json,
+        string normalizedName,
+        string version,
+        PackageMetadata metadata,
+        Action<string>? log)
+    {
+        using var doc = HardenedJson.Parse(json);
+        if (!doc.RootElement.TryGetProperty("data", out JsonElement data)
+            || data.ValueKind != JsonValueKind.Array)
+        {
+            throw new JsonException(
+                "Search metadata did not contain a data array.");
+        }
+
+        int resultCount = data.GetArrayLength();
+        long? totalHits =
+            doc.RootElement.TryGetProperty(
+                "totalHits",
+                out JsonElement totalHitsElement)
+            && TryReadInt64(totalHitsElement, out long parsedTotalHits)
+                ? parsedTotalHits
+                : null;
+        JsonElement? package = data
+            .EnumerateArray()
+            .FirstOrDefault(item =>
+                item.TryGetProperty("id", out JsonElement id)
+                && string.Equals(
+                    id.GetString(),
+                    normalizedName,
+                    StringComparison.OrdinalIgnoreCase));
+        if (package is not JsonElement pkg
+            || pkg.ValueKind != JsonValueKind.Object)
+        {
+            return new SearchPageResult(
+                Found: false,
+                resultCount,
+                totalHits);
+        }
+
+        if (pkg.TryGetProperty("totalDownloads", out JsonElement downloads)
+            && TryReadInt64(downloads, out long totalDownloads))
+        {
+            metadata.TotalDownloads = totalDownloads;
+        }
+
+        if (pkg.TryGetProperty("versions", out JsonElement versions)
+            && versions.ValueKind == JsonValueKind.Array)
+        {
+            metadata.VersionCount = versions.GetArrayLength();
+
+            foreach (JsonElement item in versions.EnumerateArray())
+            {
+                if (item.TryGetProperty("version", out JsonElement versionElement)
+                    && VersionsEqual(versionElement.GetString(), version)
+                    && item.TryGetProperty(
+                        "downloads",
+                        out JsonElement versionDownloads)
+                    && TryReadInt64(
+                        versionDownloads,
+                        out long downloadCount))
+                {
+                    metadata.VersionDownloads = downloadCount;
+                    break;
+                }
+            }
+        }
+
+        if (pkg.TryGetProperty("verified", out JsonElement verified)
+            && verified.ValueKind is JsonValueKind.True or JsonValueKind.False)
+        {
+            metadata.IsVerified = verified.GetBoolean();
+        }
+
+        if (pkg.TryGetProperty("owners", out JsonElement owners))
+        {
+            metadata.Owners = owners.ValueKind switch
+            {
+                JsonValueKind.Array =>
+                [
+                    .. owners
+                        .EnumerateArray()
+                        .Select(owner => owner.GetString())
+                        .Where(owner => !string.IsNullOrWhiteSpace(owner))
+                        .Cast<string>(),
+                ],
+                JsonValueKind.String =>
+                [
+                    .. (owners.GetString() ?? "")
+                        .Split(
+                            ',',
+                            StringSplitOptions.RemoveEmptyEntries
+                                | StringSplitOptions.TrimEntries),
+                ],
+                _ => metadata.Owners,
+            };
+        }
+
+        if (metadata.Deprecation is null
+            && pkg.TryGetProperty(
+                "deprecation",
+                out JsonElement deprecationElement)
+            && deprecationElement.ValueKind == JsonValueKind.Object)
+        {
+            metadata.Deprecation = ParseDeprecation(deprecationElement);
+            log?.Invoke($"Deprecation: {metadata.Deprecation.Summary}");
+        }
+
+        return new SearchPageResult(
+            Found: true,
+            resultCount,
+            totalHits);
+    }
+
+    private static bool TryReadInt64(JsonElement element, out long value)
+    {
+        if (element.ValueKind == JsonValueKind.Number)
+        {
+            return element.TryGetInt64(out value);
+        }
+
+        value = default;
+        return element.ValueKind == JsonValueKind.String
+            && long.TryParse(element.GetString(), out value);
+    }
+
+    private static bool VersionsEqual(string? left, string right) =>
+        NuGetVersion.TryParse(left, out NuGetVersion? parsedLeft)
+        && NuGetVersion.TryParse(right, out NuGetVersion? parsedRight)
+            ? parsedLeft == parsedRight
+            : string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+
+    private static string AppendPath(string baseUrl, params string[] segments)
+    {
+        var builder = new UriBuilder(baseUrl);
+        string suffix = string.Join(
+            '/',
+            segments.Select(Uri.EscapeDataString));
+        builder.Path = $"{builder.Path.TrimEnd('/')}/{suffix}";
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private static string AddQuery(string baseUrl, string query)
+    {
+        var builder = new UriBuilder(baseUrl);
+        string existing = builder.Query.TrimStart('?');
+        builder.Query = string.IsNullOrEmpty(existing)
+            ? query
+            : $"{existing}&{query}";
+        return builder.Uri.AbsoluteUri;
+    }
+
+    private static string ResolveReference(string baseUrl, string reference) =>
+        new Uri(new Uri(baseUrl, UriKind.Absolute), reference).AbsoluteUri;
 
     internal static PackageDeprecation ParseDeprecation(JsonElement deprecationElement)
     {
@@ -335,65 +912,171 @@ public static class PackageMetadataService
         return deprecation;
     }
 
-    private static async Task<List<PackageVulnerability>> GetPackageVulnerabilitiesAsync(
-        HttpClient client, string packageName, string version, Action<string>? log)
+    private static async Task<VulnerabilityFetchResult> GetPackageVulnerabilitiesAsync(
+        HttpClient client,
+        PackageSource source,
+        string indexUrl,
+        string packageName,
+        string version,
+        Action<string>? log,
+        HttpClient untrustedClient)
     {
         List<PackageVulnerability> result = [];
 
         if (!NuGet.Versioning.NuGetVersion.TryParse(version, out var packageVersion))
         {
             log?.Invoke($"Could not parse version: {version}");
-            return result;
+            return new VulnerabilityFetchResult(
+                Succeeded: false,
+                result);
         }
 
-        string indexUrl = "https://api.nuget.org/v3/vulnerabilities/index.json";
-        string? indexJson = await HttpRetryHelper.GetStringWithRetryAsync(
-            client, indexUrl,
-            trafficKind: NetworkTrafficKind.VulnerabilityData).ConfigureAwait(false);
-        if (indexJson == null)
-            return result;
-
-        using var indexDoc = HardenedJson.Parse(indexJson);
-        var pages = indexDoc.RootElement.EnumerateArray()
-            .Select(e => e.GetProperty("@id").GetString())
-            .Where(url => url != null)
-            .ToList();
-
-        foreach (var pageUrl in pages)
+        TextFetchResult indexResult = await FetchTextAsync(
+            client,
+            untrustedClient,
+            source,
+            indexUrl,
+            NetworkTrafficKind.VulnerabilityData,
+            log).ConfigureAwait(false);
+        if (!indexResult.IsSuccess)
         {
-            if (pageUrl == null) continue;
+            return new VulnerabilityFetchResult(
+                Succeeded: false,
+                result);
+        }
 
-            log?.Invoke($"Fetching vulnerability page: {pageUrl}");
-            string? pageJson = await HttpRetryHelper.GetStringWithRetryAsync(
-                client, pageUrl,
-                trafficKind: NetworkTrafficKind.VulnerabilityData).ConfigureAwait(false);
-            if (pageJson == null) continue;
+        using var indexDoc = HardenedJson.Parse(indexResult.Content!);
+        bool allPagesSucceeded = true;
+        if (indexDoc.RootElement.ValueKind != JsonValueKind.Array)
+        {
+            return new VulnerabilityFetchResult(
+                Succeeded: false,
+                result);
+        }
 
-            using var pageDoc = HardenedJson.Parse(pageJson);
-
-            if (pageDoc.RootElement.TryGetProperty(packageName, out var vulnArray))
+        List<string> pages = [];
+        foreach (JsonElement entry in indexDoc.RootElement.EnumerateArray())
+        {
+            if (entry.ValueKind == JsonValueKind.Object
+                && entry.TryGetProperty("@id", out JsonElement id)
+                && id.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(id.GetString()))
             {
-                foreach (var vuln in vulnArray.EnumerateArray())
-                {
-                    string? versionsRange = vuln.TryGetProperty("versions", out var v) ? v.GetString() : null;
-                    int severityNum = vuln.TryGetProperty("severity", out var s) ? s.GetInt32() : 0;
-                    string? advisoryUrl = vuln.TryGetProperty("url", out var u) ? u.GetString() : null;
+                pages.Add(id.GetString()!);
+            }
+            else
+            {
+                allPagesSucceeded = false;
+            }
+        }
 
-                    if (versionsRange != null && IsVersionInRange(packageVersion, versionsRange))
+        foreach (string pageUrl in pages)
+        {
+            string resolvedPageUrl;
+            try
+            {
+                resolvedPageUrl = ResolveReference(indexUrl, pageUrl);
+            }
+            catch (UriFormatException ex)
+            {
+                log?.Invoke(
+                    $"Invalid vulnerability page reference from "
+                    + $"{source.Name}: {ex.Message}");
+                allPagesSucceeded = false;
+                continue;
+            }
+
+            log?.Invoke($"Fetching vulnerability page: {resolvedPageUrl}");
+            TextFetchResult pageResult = await FetchTextAsync(
+                client,
+                untrustedClient,
+                source,
+                resolvedPageUrl,
+                NetworkTrafficKind.VulnerabilityData,
+                log).ConfigureAwait(false);
+            if (!pageResult.IsSuccess)
+            {
+                allPagesSucceeded = false;
+                continue;
+            }
+
+            try
+            {
+                using var pageDoc = HardenedJson.Parse(pageResult.Content!);
+
+                if (pageDoc.RootElement.TryGetProperty(
+                        packageName,
+                        out JsonElement vulnArray))
+                {
+                    if (vulnArray.ValueKind != JsonValueKind.Array)
                     {
+                        allPagesSucceeded = false;
+                        continue;
+                    }
+
+                    foreach (JsonElement vuln in vulnArray.EnumerateArray())
+                    {
+                        if (vuln.ValueKind != JsonValueKind.Object)
+                        {
+                            allPagesSucceeded = false;
+                            continue;
+                        }
+
+                        string? versionsRange =
+                            vuln.TryGetProperty("versions", out JsonElement range)
+                            && range.ValueKind == JsonValueKind.String
+                                ? range.GetString()
+                                : null;
+                        long severityValue = default;
+                        bool hasSeverity =
+                            vuln.TryGetProperty(
+                                "severity",
+                                out JsonElement severity)
+                            && TryReadInt64(
+                                severity,
+                                out severityValue)
+                            && severityValue is >= 0 and <= 3;
+                        string? advisoryUrl =
+                            vuln.TryGetProperty("url", out JsonElement advisory)
+                            && advisory.ValueKind == JsonValueKind.String
+                                ? advisory.GetString()
+                                : null;
+
+                        if (string.IsNullOrWhiteSpace(versionsRange)
+                            || !hasSeverity
+                            || string.IsNullOrWhiteSpace(advisoryUrl)
+                            || !NuGet.Versioning.VersionRange.TryParse(
+                                versionsRange,
+                                out NuGet.Versioning.VersionRange? affectedVersions))
+                        {
+                            allPagesSucceeded = false;
+                            continue;
+                        }
+
+                        if (!affectedVersions.Satisfies(packageVersion))
+                        {
+                            continue;
+                        }
+
                         var vulnerability = new PackageVulnerability
                         {
-                            Severity = SeverityToString(severityNum),
-                            AdvisoryUrl = advisoryUrl
+                            Severity = SeverityToString((int)severityValue),
+                            AdvisoryUrl = advisoryUrl,
                         };
 
-                        if (advisoryUrl != null && advisoryUrl.Contains("github.com/advisories/GHSA-"))
+                        if (advisoryUrl.Contains(
+                                "github.com/advisories/GHSA-",
+                                StringComparison.Ordinal))
                         {
-                            var ghsaId = ExtractGhsaId(advisoryUrl);
-                            if (ghsaId != null)
+                            string? ghsaId = ExtractGhsaId(advisoryUrl);
+                            if (ghsaId is not null)
                             {
                                 vulnerability.GhsaId = ghsaId;
-                                await EnrichFromGitHubAdvisoryAsync(client, vulnerability, ghsaId, log).ConfigureAwait(false);
+                                await EnrichFromGitHubAdvisoryAsync(
+                                    client,
+                                    vulnerability,
+                                    ghsaId,
+                                    log).ConfigureAwait(false);
                             }
                         }
 
@@ -401,9 +1084,20 @@ public static class PackageMetadataService
                     }
                 }
             }
+            catch (Exception ex) when (ex is
+                JsonException
+                or InvalidOperationException)
+            {
+                log?.Invoke(
+                    $"Invalid vulnerability page from "
+                    + $"{source.Name}: {ex.Message}");
+                allPagesSucceeded = false;
+            }
         }
 
-        return result;
+        return new VulnerabilityFetchResult(
+            allPagesSucceeded,
+            result);
     }
 
     private static string? ExtractGhsaId(string url)

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -17635,7 +17635,7 @@ public partial class CommandExecutionTests
             Assert.DoesNotContain("Dependency groups", output);
             Assert.Contains("Direct dependencies", output);
             Assert.DoesNotContain("| Signals | Scope |", output);
-            Assert.Contains("Known vulnerabilities", output);
+            Assert.DoesNotContain("Known vulnerabilities", output);
             Assert.DoesNotContain("Tip:", error);
         }
         finally
@@ -17754,7 +17754,7 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Package_Signals_RendersRegistryBackedRows()
+    public async Task Package_Signals_RendersAvailableRegistryBackedRows()
     {
         var (packagePath, tempDir) = CreateLocalRefPackage("System.Runtime");
         try
@@ -17763,7 +17763,7 @@ public partial class CommandExecutionTests
 
             Assert.Equal(0, exit);
             Assert.Contains("## Signals", output);
-            Assert.Contains("Known vulnerabilities", output);
+            Assert.DoesNotContain("Known vulnerabilities", output);
             Assert.Contains("Dependencies with vulnerabilities", output);
             Assert.Contains("Deprecated dependencies", output);
             Assert.DoesNotContain("| Signals | Scope |", output);

--- a/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
+++ b/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Net.Sockets;
+using System.Text;
 using DotnetInspector.Core;
 using DotnetInspector.Packages;
 
@@ -158,6 +160,77 @@ public class HttpClientFactoryTests : IDisposable
 
         Assert.Equal(HttpClientFactoryOptions.BaselineTimeout, untrusted.Timeout);
         Assert.Equal(TimeSpan.FromSeconds(600), standard.Timeout);
+    }
+
+    [Fact]
+    public void CreateUntrustedFetchClient_DoesNotUseAnAmbientProxy()
+    {
+        using SocketsHttpHandler handler =
+            DotnetInspector.Core.HttpClientFactory.CreateUntrustedSocketsHandler();
+
+        Assert.False(handler.UseProxy);
+    }
+
+    [Fact]
+    public void GetPackageSourceClient_ReusesOneClientPerOrigin()
+    {
+        HttpClient first =
+            DotnetInspector.Core.HttpClientFactory.GetPackageSourceClient(
+                "https://private.example/v3/index.json");
+        HttpClient sameOrigin =
+            DotnetInspector.Core.HttpClientFactory.GetPackageSourceClient(
+                "https://PRIVATE.example/query");
+        HttpClient differentPort =
+            DotnetInspector.Core.HttpClientFactory.GetPackageSourceClient(
+                "https://private.example:8443/v3/index.json");
+
+        Assert.Same(first, sameOrigin);
+        Assert.NotSame(first, differentPort);
+    }
+
+    [Fact]
+    public async Task PackageSourceClient_AllowsConfiguredPrivateOriginButBlocksPrivateRedirect()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int sourcePort =
+            ((IPEndPoint)listener.LocalEndpoint).Port;
+        int redirectPort = sourcePort == ushort.MaxValue
+            ? sourcePort - 1
+            : sourcePort + 1;
+        string sourceUrl = $"http://127.0.0.1:{sourcePort}/index.json";
+        string response =
+            "HTTP/1.1 302 Found\r\n"
+            + $"Location: http://127.0.0.1:{redirectPort}/secret\r\n"
+            + "Content-Length: 0\r\n"
+            + "Connection: close\r\n\r\n";
+
+        Task server = Task.Run(
+            async () =>
+            {
+                using TcpClient connection = await listener.AcceptTcpClientAsync(
+                    TestContext.Current.CancellationToken);
+                await using NetworkStream stream = connection.GetStream();
+                var request = new byte[1024];
+                _ = await stream.ReadAsync(
+                    request,
+                    TestContext.Current.CancellationToken);
+                await stream.WriteAsync(
+                    Encoding.ASCII.GetBytes(response),
+                    TestContext.Current.CancellationToken);
+            },
+            TestContext.Current.CancellationToken);
+
+        using HttpClient client =
+            DotnetInspector.Core.HttpClientFactory.CreatePackageSourceClient(sourceUrl);
+        HttpRequestException exception =
+            await Assert.ThrowsAsync<HttpRequestException>(
+                () => client.GetAsync(
+                    sourceUrl,
+                    TestContext.Current.CancellationToken));
+        await server;
+
+        Assert.Contains("Blocked request to non-public address", exception.ToString());
     }
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/HttpRetryHelperTests.cs
+++ b/src/dotnet-inspect.Tests/HttpRetryHelperTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Sockets;
 using DotnetInspector.Packages;
 
@@ -142,5 +143,62 @@ public class HttpRetryHelperTests
     public void DefaultRetryCount_IsThree()
     {
         Assert.Equal(3, HttpRetryHelper.DefaultRetryCount);
+    }
+
+    [Fact]
+    public async Task GetWithRetryResultAsync_NonRangeRequestBuffersWithinRetryOperation()
+    {
+        using var client = new HttpClient(new ThrowingContentHandler());
+
+        HttpRetryHelper.HttpRetryResult result =
+            await HttpRetryHelper.GetWithRetryResultAsync(
+                client,
+                "https://feed.example/index.json",
+                retryCount: 0,
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess);
+    }
+
+    [Fact]
+    public async Task GetWithRetryResultAsync_RangeRequestReturnsAfterHeaders()
+    {
+        using var client = new HttpClient(new ThrowingContentHandler());
+
+        HttpRetryHelper.HttpRetryResult result =
+            await HttpRetryHelper.GetWithRetryResultAsync(
+                client,
+                "https://feed.example/package.nupkg",
+                retryCount: 0,
+                cancellationToken: TestContext.Current.CancellationToken,
+                range: new RangeHeaderValue(0, 0));
+
+        using HttpResponseMessage? response = result.Response;
+        Assert.NotNull(response);
+    }
+
+    private sealed class ThrowingContentHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ThrowingContent(),
+            });
+    }
+
+    private sealed class ThrowingContent : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(
+            Stream stream,
+            TransportContext? context)
+            => Task.FromException(new HttpRequestException("Broken response body."));
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
     }
 }

--- a/src/dotnet-inspect.Tests/InspectionResultTests.cs
+++ b/src/dotnet-inspect.Tests/InspectionResultTests.cs
@@ -306,6 +306,48 @@ public class InspectionResultTests
     }
 
     [Fact]
+    public async Task PackageSignals_OmitsVulnerabilitySignalWhenAdvisoryDataIsUnavailable()
+    {
+        var result = new InspectionResult
+        {
+            PackageName = "Test",
+            Version = "1.0.0",
+            Vulnerabilities = null,
+        };
+
+        await AuditSignalBuilder.PopulatePackageAuditAsync(
+            result,
+            new HttpClient(),
+            new VerboseLogger(false));
+
+        Assert.DoesNotContain(
+            result.AuditSignals!,
+            signal => signal.Signal == "Known vulnerabilities");
+    }
+
+    [Fact]
+    public async Task PackageSignals_ReportsZeroOnlyWhenAdvisoryDataWasAvailable()
+    {
+        var result = new InspectionResult
+        {
+            PackageName = "Test",
+            Version = "1.0.0",
+            Vulnerabilities = [],
+        };
+
+        await AuditSignalBuilder.PopulatePackageAuditAsync(
+            result,
+            new HttpClient(),
+            new VerboseLogger(false));
+
+        AuditSignal signal = Assert.Single(
+            result.AuditSignals!,
+            signal => signal.Signal == "Known vulnerabilities");
+        Assert.Equal("0", signal.Value);
+        Assert.Equal("NuGet advisory data", signal.Evidence);
+    }
+
+    [Fact]
     public async Task PackageSignals_Symbols_ReportsMsdlPdbSource()
     {
         var result = new InspectionResult

--- a/src/dotnet-inspect.Tests/PackageIndexCacheTests.cs
+++ b/src/dotnet-inspect.Tests/PackageIndexCacheTests.cs
@@ -10,6 +10,8 @@ namespace DotnetInspector.Tests;
 [Collection("Console")]
 public sealed class PackageIndexCacheTests
 {
+    private const string ProducerKey = "producer-a";
+
     public PackageIndexCacheTests()
         => CoreCache.Initialize("dotnet-inspect-test");
 
@@ -29,8 +31,9 @@ public sealed class PackageIndexCacheTests
             Authors = "real author"
         };
 
-        PackageIndexCache.Set(packageName, Version, result);
-        InspectionResult cached = PackageIndexCache.TryGet(packageName, Version)!;
+        PackageIndexCache.Set(packageName, Version, ProducerKey, result);
+        InspectionResult cached =
+            PackageIndexCache.TryGet(packageName, Version, ProducerKey)!;
 
         Assert.Equal(description, cached.Description);
         Assert.Equal(
@@ -76,7 +79,11 @@ public sealed class PackageIndexCacheTests
         };
 
         Assert.Throws<InvalidOperationException>(
-            () => PackageIndexCache.Set(packageName, "1.0.0", result));
+            () => PackageIndexCache.Set(
+                packageName,
+                "1.0.0",
+                ProducerKey,
+                result));
     }
 
     [Fact]
@@ -89,6 +96,7 @@ public sealed class PackageIndexCacheTests
         PackageIndexCache.Set(
             nullPackage,
             Version,
+            ProducerKey,
             new InspectionResult
             {
                 PackageName = nullPackage,
@@ -98,6 +106,7 @@ public sealed class PackageIndexCacheTests
         PackageIndexCache.Set(
             emptyPackage,
             Version,
+            ProducerKey,
             new InspectionResult
             {
                 PackageName = emptyPackage,
@@ -105,10 +114,46 @@ public sealed class PackageIndexCacheTests
                 Description = InertString.Empty
             });
 
-        Assert.Null(PackageIndexCache.TryGet(nullPackage, Version)?.Description);
-        InertString? empty = PackageIndexCache.TryGet(emptyPackage, Version)?.Description;
+        Assert.Null(
+            PackageIndexCache.TryGet(
+                nullPackage,
+                Version,
+                ProducerKey)?.Description);
+        InertString? empty = PackageIndexCache.TryGet(
+            emptyPackage,
+            Version,
+            ProducerKey)?.Description;
         Assert.NotNull(empty);
         Assert.True(empty.Value.IsEmpty);
+    }
+
+    [Fact]
+    public void EqualCoordinatesFromDifferentProducersDoNotShareInspectionResults()
+    {
+        string packageName = $"Source.Scoped.{Guid.NewGuid():N}";
+        const string Version = "1.0.0";
+        PackageIndexCache.Set(
+            packageName,
+            Version,
+            "producer-a",
+            new InspectionResult
+            {
+                PackageName = packageName,
+                Version = Version,
+                Authors = "producer-a",
+            });
+
+        Assert.Null(
+            PackageIndexCache.TryGet(
+                packageName,
+                Version,
+                "producer-b"));
+        Assert.Equal(
+            "producer-a",
+            PackageIndexCache.TryGet(
+                packageName,
+                Version,
+                "producer-a")!.Authors);
     }
 
     [Theory]
@@ -143,9 +188,16 @@ public sealed class PackageIndexCacheTests
     {
         string packageName = $"Description.Malformed.{suffix}.{Guid.NewGuid():N}";
         const string Version = "1.0.0";
-        string key = $"{packageName.ToLowerInvariant()}@{Version}";
+        string key = PackageIndexCache.CacheKey(
+            packageName,
+            Version,
+            ProducerKey);
         CoreCache.SetBytes(PackageIndexCache.Category, key, bytes, extension: "md");
 
-        Assert.Null(PackageIndexCache.TryGet(packageName, Version));
+        Assert.Null(
+            PackageIndexCache.TryGet(
+                packageName,
+                Version,
+                ProducerKey));
     }
 }

--- a/src/dotnet-inspect.Tests/PackageInspectorMetadataSourceTests.cs
+++ b/src/dotnet-inspect.Tests/PackageInspectorMetadataSourceTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Text;
+using DotnetInspector.Core;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Models;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Tests;
+
+public sealed class PackageInspectorMetadataSourceTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(),
+        $"package-inspector-metadata-{Guid.NewGuid():N}");
+
+    public PackageInspectorMetadataSourceTests()
+    {
+        Directory.CreateDirectory(_root);
+        CoreCache.Initialize("dotnet-inspect-test");
+    }
+
+    [Fact]
+    public async Task InspectAsync_UsesTheAcquiredPackageProducerForMetadata()
+    {
+        const string sourceA = "https://a.example/v3/index.json";
+        const string sourceB = "https://b.example/v3/index.json";
+        bool queriedSourceA = false;
+        using var client = new HttpClient(new RoutingHandler(request =>
+        {
+            if (request.RequestUri!.Host == "a.example")
+            {
+                queriedSourceA = true;
+                return new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            }
+
+            return request.RequestUri.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://b.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json(
+                    """{ "published": "2025-01-02T00:00:00Z" }"""),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+            };
+        }));
+
+        var resolution = new PackageExtractionResult(
+            _root,
+            TempDir: null,
+            PackageName: "Private.Package",
+            Version: "1.0.0",
+            ProducerKey: NuGetCache.GetSourceKey(sourceB));
+        InspectionResult result = await PackageInspector.InspectAsync(
+            resolution,
+            "Wrapper.Package",
+            "1.0.0",
+            isLocalFile: false,
+            localFilePath: null,
+            nuspec: null,
+            client,
+            new VerboseLogger(enabled: false),
+            forceLatest: true,
+            verbosity: Verbosity.Detailed,
+            fetchMetadata: true,
+            sourceOptions: new NuGetSourceOptions
+            {
+                Sources = [sourceA, sourceB],
+            });
+
+        Assert.Equal(2025, result.Published!.Value.Year);
+        Assert.Equal("Private.Package", result.PackageName);
+        Assert.False(queriedSourceA);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private static HttpResponseMessage Json(string content) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content, Encoding.UTF8, "application/json"),
+        };
+
+    private sealed class RoutingHandler(
+        Func<HttpRequestMessage, HttpResponseMessage> route) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+            => Task.FromResult(route(request));
+    }
+}

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -566,6 +566,7 @@ public class PackageCommand
             resolution = outcome.Result!;
 
             extractPath = resolution.ExtractPath;
+            packageName = resolution.PackageName ?? packageName;
             // Update version from resolution (may have been auto-discovered)
             version = resolution.Version ?? version;
 
@@ -643,10 +644,10 @@ public class PackageCommand
                 : null;
 
             var result = await PackageInspector.InspectAsync(
-                extractPath, packageName, version, target.IsLocalFile,
+                resolution, packageName, version, target.IsLocalFile,
                 target.IsLocalFile ? target.OriginalArgument : null,
-                nuspec, client, logger, options.ForceLatest, options.Verbosity,
-                resolution.NupkgPath,
+                nuspec, client, logger,
+                options.ForceLatest, options.Verbosity,
                 fetchMetadata: wantsSignals,
                 sourceOptions: options.SourceOptions);
 
@@ -1549,7 +1550,10 @@ public class PackageCommand
 
             var nuspec = Services.NuspecParser.FindAndParse(extractPath);
 
-            var packageId = nuspec?.PackageName ?? target.PackageName;
+            var packageId =
+                nuspec?.PackageName
+                ?? resolution.PackageName
+                ?? target.PackageName;
             var packageVersion = nuspec?.Version ?? version;
             var packageReadme = PackageFileLister.ResolvePackageReadme(extractPath, nuspec?.ReadmeFile);
             return ReadPackageFileContents(extractPath, packageId, packageVersion, packageReadme, nuspec?.ReadmeFile, options);
@@ -1603,6 +1607,8 @@ public class PackageCommand
             resolution = outcome.Result!;
             extractPath = resolution.ExtractPath;
             version = resolution.Version ?? version;
+            string resolvedPackageName =
+                resolution.PackageName ?? target.PackageName;
 
             var nuspec = Services.NuspecParser.FindAndParse(extractPath);
 
@@ -1616,8 +1622,8 @@ public class PackageCommand
                 ? NetworkTelemetry.Allow(NetworkTrafficKind.VulnerabilityData)
                 : null;
             var result = await PackageInspector.InspectAsync(
-                extractPath,
-                target.PackageName,
+                resolution,
+                resolvedPackageName,
                 version,
                 target.IsLocalFile,
                 target.IsLocalFile ? target.OriginalArgument : null,
@@ -1626,7 +1632,6 @@ public class PackageCommand
                 logger,
                 options.ForceLatest,
                 options.Verbosity,
-                resolution.NupkgPath,
                 fetchMetadata: wantsSignals,
                 sourceOptions: options.SourceOptions);
 
@@ -1649,7 +1654,7 @@ public class PackageCommand
                 await PopulatePackageSourceLinkAsync(
                     result,
                     extractPath,
-                    target.PackageName,
+                    resolvedPackageName,
                     version,
                     options,
                     context,
@@ -1663,7 +1668,7 @@ public class PackageCommand
             if (wantsSignals)
             {
                 result.BinarySignals = await PackageInspector.ScanBinarySignalsAsync(
-                    extractPath, target.PackageName, version, context.HttpClient, logger,
+                    extractPath, resolvedPackageName, version, context.HttpClient, logger,
                     acquirePdb: true, options.SourceOptions);
                 await AuditSignalBuilder.PopulatePackageAuditAsync(
                     result, context.HttpClient, logger, options.SourceOptions);

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -138,6 +138,7 @@ internal static class AuditSignalBuilder
     private readonly record struct DependencySignalSummary(
         int DirectDependencies,
         int CheckedDependencies,
+        int VulnerabilityCheckedDependencies,
         int VulnerableDependencies,
         int DeprecatedDependencies,
         DependencyAgeSummary? AgeSummary);
@@ -150,6 +151,7 @@ internal static class AuditSignalBuilder
     {
         List<int> ages = [];
         int checkedDependencies = 0;
+        int vulnerabilityCheckedDependencies = 0;
         int vulnerableDependencies = 0;
         int deprecatedDependencies = 0;
         foreach (var dep in directDependencies)
@@ -162,8 +164,12 @@ internal static class AuditSignalBuilder
                 httpClient, dep.Id, version, logger.Log, sourceOptions: sourceOptions).ConfigureAwait(false);
             checkedDependencies++;
 
-            if (metadata.Vulnerabilities is { Count: > 0 })
-                vulnerableDependencies++;
+            if (metadata.Vulnerabilities is { } vulnerabilities)
+            {
+                vulnerabilityCheckedDependencies++;
+                if (vulnerabilities.Count > 0)
+                    vulnerableDependencies++;
+            }
             if (metadata.Deprecation != null)
                 deprecatedDependencies++;
             if (metadata.Published is { Year: > 1901 } published)
@@ -184,6 +190,7 @@ internal static class AuditSignalBuilder
         return new DependencySignalSummary(
             directDependencies.Count,
             checkedDependencies,
+            vulnerabilityCheckedDependencies,
             vulnerableDependencies,
             deprecatedDependencies,
             ageSummary);
@@ -468,10 +475,20 @@ internal static class AuditSignalBuilder
                 : null;
 
         private static SignalValue? ResolveNuGetKnownVulnerabilities(in PackageSignalContext context) =>
-            new(FormatCount(context.Result.Vulnerabilities?.Count ?? 0), "NuGet advisory data");
+            context.Result.Vulnerabilities is { } vulnerabilities
+                ? new(FormatCount(vulnerabilities.Count), "NuGet advisory data")
+                : null;
 
         private static SignalValue? ResolveDependenciesWithVulnerabilities(in PackageSignalContext context) =>
-            new(context.DependencySignals.VulnerableDependencies.ToString(), FormatDependencyRegistryEvidence(context.DependencySignals));
+            context.DependencySignals.DirectDependencies == 0
+                ? new("0", "0 direct dependencies")
+                : context.DependencySignals.VulnerabilityCheckedDependencies > 0
+                    ? new(
+                        context.DependencySignals.VulnerableDependencies.ToString(),
+                        $"NuGet advisory data for "
+                        + $"{context.DependencySignals.VulnerabilityCheckedDependencies}/"
+                        + $"{context.DependencySignals.DirectDependencies} direct dependencies")
+                    : null;
 
         private static SignalValue? ResolveDependenciesDeprecatedDependencies(in PackageSignalContext context) =>
             new(context.DependencySignals.DeprecatedDependencies.ToString(), FormatDependencyRegistryEvidence(context.DependencySignals));

--- a/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
+++ b/src/dotnet-inspect/Inspectors/PackageIndexCache.cs
@@ -18,7 +18,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class PackageIndexCache
 {
-    internal const string Category = "pkg-index-v12";
+    internal const string Category = "pkg-index-v13";
     private static ReadOnlySpan<byte> DescriptionLengthPrefix => "description-bytes: "u8;
     private static readonly UTF8Encoding StrictUtf8 =
         new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
@@ -32,9 +32,12 @@ internal static class PackageIndexCache
     /// Tries to load a cached InspectionResult for a package version.
     /// Returns null on cache miss.
     /// </summary>
-    public static InspectionResult? TryGet(string packageName, string version)
+    public static InspectionResult? TryGet(
+        string packageName,
+        string version,
+        string producerKey)
     {
-        string key = $"{packageName.ToLowerInvariant()}@{version}";
+        string key = CacheKey(packageName, version, producerKey);
         var bytes = CoreCache.TryGetBytes(Category, key, extension: "md");
         if (bytes == null) return null;
 
@@ -128,9 +131,13 @@ internal static class PackageIndexCache
     /// Stores the encoded description in a length-delimited UTF-8 envelope followed by plain
     /// fields (<c>key: value</c>).
     /// </summary>
-    public static void Set(string packageName, string version, InspectionResult result)
+    public static void Set(
+        string packageName,
+        string version,
+        string producerKey,
+        InspectionResult result)
     {
-        string key = $"{packageName.ToLowerInvariant()}@{version}";
+        string key = CacheKey(packageName, version, producerKey);
 
         var buf = new ArrayBufferWriter<byte>(1024);
         WriteDescriptionEnvelope(buf, result.Description);
@@ -197,6 +204,12 @@ internal static class PackageIndexCache
 
         CoreCache.SetBytes(Category, key, buf.WrittenSpan.ToArray(), extension: "md");
     }
+
+    internal static string CacheKey(
+        string packageName,
+        string version,
+        string producerKey)
+        => $"{producerKey}:{packageName.ToLowerInvariant()}@{version}";
 
     // ── Description envelope + field serialization ──
 

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -16,9 +16,9 @@ namespace DotnetInspector.Inspectors;
 internal static class PackageInspector
 {
     public static async Task<InspectionResult> InspectAsync(
-        string extractPath,
-        string packageName,
-        string version,
+        PackageExtractionResult resolution,
+        string fallbackPackageName,
+        string fallbackVersion,
         bool isLocalFile,
         string? localFilePath,
         NuspecData? nuspec,
@@ -26,26 +26,42 @@ internal static class PackageInspector
         VerboseLogger logger,
         bool forceLatest = false,
         Verbosity verbosity = Verbosity.Minimal,
-        string? nupkgPath = null,
         bool fetchMetadata = false,
         NuGetSourceOptions? sourceOptions = null)
     {
+        string extractPath = resolution.ExtractPath;
+        string packageName = resolution.PackageName ?? fallbackPackageName;
+        string version = resolution.Version ?? fallbackVersion;
+        string? nupkgPath = resolution.NupkgPath;
         fetchMetadata = !isLocalFile && (fetchMetadata || verbosity >= Verbosity.Detailed);
+        NuGetSourceOptions? metadataSourceOptions = resolution.ProducerKey is null
+            ? sourceOptions
+            : NuGetSourceResolver.RestrictToSourceKeys(
+                sourceOptions,
+                [resolution.ProducerKey]);
 
         // Try package index cache (skips all filesystem scanning)
-        if (!isLocalFile)
+        if (!isLocalFile && resolution.ProducerKey is { } producerKey)
         {
             InspectionResult? cached;
             using (NetworkTelemetry.Scope(NetworkTrafficKind.PackageLoad))
             {
-                cached = PackageIndexCache.TryGet(packageName, version);
+                cached = PackageIndexCache.TryGet(
+                    packageName,
+                    version,
+                    producerKey);
             }
             if (cached != null)
             {
                 if (fetchMetadata)
                 {
                     var metadata = await PackageMetadataService.FetchAllMetadataAsync(
-                        httpClient, packageName, version, logger.Log, forceLatest, sourceOptions);
+                        httpClient,
+                        packageName,
+                        version,
+                        logger.Log,
+                        forceLatest,
+                        metadataSourceOptions);
                     ApplyMetadata(cached, metadata);
                 }
                 return cached;
@@ -144,17 +160,26 @@ internal static class PackageInspector
         }
 
         // Cache the filesystem-derived result (before metadata overlay)
-        if (!isLocalFile)
+        if (!isLocalFile && resolution.ProducerKey is { } writeProducerKey)
         {
             using var cacheScope = NetworkTelemetry.Scope(NetworkTrafficKind.PackageLoad);
-            PackageIndexCache.Set(packageName, version, result);
+            PackageIndexCache.Set(
+                packageName,
+                version,
+                writeProducerKey,
+                result);
         }
 
         // Fetch package metadata from NuGet (only at detailed verbosity)
         if (fetchMetadata)
         {
             var metadata = await PackageMetadataService.FetchAllMetadataAsync(
-                httpClient, packageName, version, logger.Log, forceLatest, sourceOptions);
+                httpClient,
+                packageName,
+                version,
+                logger.Log,
+                forceLatest,
+                metadataSourceOptions);
             ApplyMetadata(result, metadata);
         }
 


### PR DESCRIPTION
Closes #4007.

## Summary

Package metadata now follows the same configured-source policy as package acquisition instead of using hardcoded NuGet.org endpoints.

- Resolves V3 registration, search, flat-container, catalog, and vulnerability resources from eligible configured sources in configured order.
- Applies package-source mapping and restricts root metadata to the source that produced the acquired package, including wrapper redirects.
- Falls through only after authoritative absence; unreadable or malformed higher-precedence sources do not borrow lower-source metadata.
- Negotiates the highest compatible service capability and fails over equivalent endpoints in advertised order.
- Scopes metadata and inspection caches by producer, with framed/Base64-encoded cache values and distinct unavailable versus checked-clean vulnerability states.

## Provider and security behavior

Azure Artifacts search uses plain `q=<id>` with exact response-ID filtering, bounded pagination, prerelease inclusion, and SemVer 2 support. Package size uses an authenticated `bytes=0-0` GET because Azure rejects `HEAD`.

The configured feed origin may resolve privately, while redirects and discovered cross-origin URLs must resolve publicly, bypass ambient proxies, and never receive feed credentials. Per-origin source clients are reused for connection pooling without widening that trust boundary.

Optional catalog, search, or vulnerability failures preserve usable core metadata but prevent an incomplete result from being cached. Malformed advisory indexes, pages, and entries remain non-authoritative; successfully parsed partial advisories are returned without being cached.

## Validation

- Full solution build
- `DotnetInspector.Services.Tests`: 410 passed
- `dotnet-inspect.Tests`: 3,431 passed, 14 skipped
- Cold private Azure Artifacts acceptance for `Markout@99.100.101` through the Azure Artifacts Credential Provider, with acquisition and metadata traffic confined to the configured Azure source
