### PR TITLE
Refresh package and library query skills

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -25,7 +25,7 @@ dnx dotnet-inspect -y -- <command>
 | Find rendered body syntax | `body-shape ObjectCreationExpression --library path/to.dll`; load `skill decompiler` for stable kinds and coordinates. |
 | Compare APIs | `diff --package Foo@old..new --breaking` (`--additive` new APIs); `--alloc-regressions` for perf regressions (allocations up, hot first). |
 | Trace API evolution | `timeline --package Foo@old..new --type Type --members --at all`; omit `--at` to inspect the vector without acquiring packages. |
-| Inspect packages | `package Foo`; use `-D` to discover sections. `-S @Package` groups package info, signals/statistics, frameworks, signing/vulnerability facts, dependencies, manifest, and the full file list. Load `skill private-feeds` for custom/authenticated sources. |
+| Inspect packages | `package Foo`; use `-D` to discover sections. Load `skill private-feeds` for custom/authenticated sources. |
 | Inspect libraries | `library Foo` or `library path/to.dll`; use `-D` to discover sections. Load `skill metadata` for raw ECMA-335 tables/heaps. |
 | Relationships | `depends Type`, `extensions Type`, `implements Interface`. |
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -25,8 +25,8 @@ dnx dotnet-inspect -y -- <command>
 | Find rendered body syntax | `body-shape ObjectCreationExpression --library path/to.dll`; load `skill decompiler` for stable kinds and coordinates. |
 | Compare APIs | `diff --package Foo@old..new --breaking` (`--additive` new APIs); `--alloc-regressions` for perf regressions (allocations up, hot first). |
 | Trace API evolution | `timeline --package Foo@old..new --type Type --members --at all`; omit `--at` to inspect the vector without acquiring packages. |
-| Inspect packages | `package Foo -D` discovers effective package evidence; bare `-S` is conservative, while `-S @Package` requests the complete package-native lens. Load `skill private-feeds` for authenticated/custom sources. |
-| Inspect libraries | `library Foo -D` is a cheap target-aware catalog; add `--effective` to run full probes. Bare `-S` is conservative; load `skill metadata` for raw ECMA-335 tables/heaps. |
+| Inspect packages | `package Foo -D` discovers effective package evidence; bare `-S` returns high-value fixed-length sections, while `-S @Package` requests the complete package-native lens. Load `skill private-feeds` for authenticated/custom sources. |
+| Inspect libraries | `library Foo -D` is a cheap target-aware catalog; add `--effective` to run full probes. Bare `-S` returns high-value fixed-length sections; load `skill metadata` for raw ECMA-335 tables/heaps. |
 | Relationships | `depends Type`, `extensions Type`, `implements Interface`. |
 
 ## Member lookup
@@ -44,7 +44,7 @@ dnx dotnet-inspect -y -- member System.Text.Json.JsonSerializer.Serialize -S "Me
 
 ## Tips
 
-- Default output is Markdown. `package -D` is effective for a target; `library -D` is a cheap orientation gesture, while named/category discovery is structural unless `--effective` is added. Bare `-S` keeps only effective, fixed-size, network-free base evidence. For the full query model, load `dotnet-inspect skill query`.
+- Default output is Markdown. `package -D` is effective for a target; `library -D` is a cheap orientation gesture, while named/category discovery is structural unless `--effective` is added. Bare `-S` returns high-value, fixed-length, network-free base sections. For the full query model, load `dotnet-inspect skill query`.
 - Add `--project <csproj|dir|project.assets.json>` when project-referenced packages should be in scope; it reads existing restored assets, so restore/build first if dependencies changed.
 - Common BCL types resolve without scope: `type string`, `type 'List<T>'`. Quote generics and patterns: `member 'Dictionary<TKey,TValue>'`, `-S "Async*"`.
 - Unpinned packages use latest stable; add `--preview` for prerelease APIs.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -25,8 +25,8 @@ dnx dotnet-inspect -y -- <command>
 | Find rendered body syntax | `body-shape ObjectCreationExpression --library path/to.dll`; load `skill decompiler` for stable kinds and coordinates. |
 | Compare APIs | `diff --package Foo@old..new --breaking` (`--additive` new APIs); `--alloc-regressions` for perf regressions (allocations up, hot first). |
 | Trace API evolution | `timeline --package Foo@old..new --type Type --members --at all`; omit `--at` to inspect the vector without acquiring packages. |
-| Inspect packages | `package Foo`; use `@Package`, `@Dependencies`, `@Audit`, or `@Files` for an explicit lens. Load `skill private-feeds` for authenticated/custom sources. |
-| Inspect libraries | `library Foo` or `library path/to.dll`; load `skill metadata` for raw ECMA-335 tables/heaps. |
+| Inspect packages | `package Foo -D` discovers effective package evidence; bare `-S` is conservative, while `-S @Package` requests the complete package-native lens. Load `skill private-feeds` for authenticated/custom sources. |
+| Inspect libraries | `library Foo -D` is a cheap target-aware catalog; add `--effective` to run full probes. Bare `-S` is conservative; load `skill metadata` for raw ECMA-335 tables/heaps. |
 | Relationships | `depends Type`, `extensions Type`, `implements Interface`. |
 
 ## Member lookup
@@ -44,7 +44,7 @@ dnx dotnet-inspect -y -- member System.Text.Json.JsonSerializer.Serialize -S "Me
 
 ## Tips
 
-- Default output is Markdown; for formats, `-D`/`-S` discovery, projection, and limits, load `dotnet-inspect skill query`. Decompiled source uses readable synthesized local names when PDB names are unavailable.
+- Default output is Markdown. `package -D` is effective for a target; `library -D` is a cheap orientation gesture, while named/category discovery is structural unless `--effective` is added. Bare `-S` keeps only effective, fixed-size, network-free base evidence. For the full query model, load `dotnet-inspect skill query`.
 - Add `--project <csproj|dir|project.assets.json>` when project-referenced packages should be in scope; it reads existing restored assets, so restore/build first if dependencies changed.
 - Common BCL types resolve without scope: `type string`, `type 'List<T>'`. Quote generics and patterns: `member 'Dictionary<TKey,TValue>'`, `-S "Async*"`.
 - Unpinned packages use latest stable; add `--preview` for prerelease APIs.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -25,8 +25,8 @@ dnx dotnet-inspect -y -- <command>
 | Find rendered body syntax | `body-shape ObjectCreationExpression --library path/to.dll`; load `skill decompiler` for stable kinds and coordinates. |
 | Compare APIs | `diff --package Foo@old..new --breaking` (`--additive` new APIs); `--alloc-regressions` for perf regressions (allocations up, hot first). |
 | Trace API evolution | `timeline --package Foo@old..new --type Type --members --at all`; omit `--at` to inspect the vector without acquiring packages. |
-| Inspect packages | `package Foo -D` discovers effective package evidence; bare `-S` returns high-value fixed-length sections, while `-S @Package` requests the complete package-native lens. Load `skill private-feeds` for authenticated/custom sources. |
-| Inspect libraries | `library Foo -D` is a cheap target-aware catalog; add `--effective` to run full probes. Bare `-S` returns high-value fixed-length sections; load `skill metadata` for raw ECMA-335 tables/heaps. |
+| Inspect packages | `package Foo`; use `-D` to discover sections or `-S @Package` for the complete package-native lens. Load `skill private-feeds` for authenticated/custom sources. |
+| Inspect libraries | `library Foo` or `library path/to.dll`; use `-D` to discover sections. Load `skill metadata` for raw ECMA-335 tables/heaps. |
 | Relationships | `depends Type`, `extensions Type`, `implements Interface`. |
 
 ## Member lookup
@@ -44,7 +44,7 @@ dnx dotnet-inspect -y -- member System.Text.Json.JsonSerializer.Serialize -S "Me
 
 ## Tips
 
-- Default output is Markdown. `package -D` is effective for a target; `library -D` is a cheap orientation gesture, while named/category discovery is structural unless `--effective` is added. Bare `-S` returns high-value, fixed-length, network-free base sections. For the full query model, load `dotnet-inspect skill query`.
+- `package` and `library` produce terse, token-efficient, high-value domain content by default. Output supports Markdown, tables, TSV, JSONL, and JSON; load `dotnet-inspect skill query` for discovery, selection, projection, and limits.
 - Add `--project <csproj|dir|project.assets.json>` when project-referenced packages should be in scope; it reads existing restored assets, so restore/build first if dependencies changed.
 - Common BCL types resolve without scope: `type string`, `type 'List<T>'`. Quote generics and patterns: `member 'Dictionary<TKey,TValue>'`, `-S "Async*"`.
 - Unpinned packages use latest stable; add `--preview` for prerelease APIs.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -25,7 +25,7 @@ dnx dotnet-inspect -y -- <command>
 | Find rendered body syntax | `body-shape ObjectCreationExpression --library path/to.dll`; load `skill decompiler` for stable kinds and coordinates. |
 | Compare APIs | `diff --package Foo@old..new --breaking` (`--additive` new APIs); `--alloc-regressions` for perf regressions (allocations up, hot first). |
 | Trace API evolution | `timeline --package Foo@old..new --type Type --members --at all`; omit `--at` to inspect the vector without acquiring packages. |
-| Inspect packages | `package Foo`; use `-D` to discover sections or `-S @Package` for the complete package-native lens. Load `skill private-feeds` for authenticated/custom sources. |
+| Inspect packages | `package Foo`; use `-D` to discover sections. `-S @Package` groups package info, signals/statistics, frameworks, signing/vulnerability facts, dependencies, manifest, and the full file list. Load `skill private-feeds` for custom/authenticated sources. |
 | Inspect libraries | `library Foo` or `library path/to.dll`; use `-D` to discover sections. Load `skill metadata` for raw ECMA-335 tables/heaps. |
 | Relationships | `depends Type`, `extensions Type`, `implements Interface`. |
 

--- a/skills/metadata/SKILL.md
+++ b/skills/metadata/SKILL.md
@@ -17,13 +17,15 @@ dnx dotnet-inspect -y -- <command>
 ## Discover before reading
 
 Metadata tables are unbounded and explicit-only: no verbosity or base category
-renders them automatically. Discover the tables present in the image, then
-count or select one:
+renders them automatically. Structural discovery lists the authored metadata
+family without running its producers; add `--effective` to identify the tables
+and heaps that have data for this image:
 
 ```bash
 dnx dotnet-inspect -y -- library MyLib.dll -D @Metadata
+dnx dotnet-inspect -y -- library MyLib.dll -D @Metadata --effective
 dnx dotnet-inspect -y -- library MyLib.dll -S @Metadata --count
-dnx dotnet-inspect -y -- library MyLib.dll -D "Metadata: TypeDef"
+dnx dotnet-inspect -y -- library MyLib.dll -D "Metadata: TypeDef" --effective
 ```
 
 `Metadata: Image` reports image-level facts. Table sections such as
@@ -33,8 +35,8 @@ handles, ranges, heap values, and flags instead of dumping raw integers.
 ## Query one table
 
 The `#` column is the real metadata row id. `--rows` therefore addresses table
-rows by displayed metadata position, including ranges, rather than by the
-current page:
+rows by displayed, 1-based metadata position rather than by the current page.
+Ranges are inclusive, so `100..199` selects 100 rows:
 
 ```bash
 dnx dotnet-inspect -y -- library MyLib.dll \

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -32,12 +32,14 @@ Add `--all` to include non-public members.
 
 Library triage is split into kind-scoped sections under `@Performance`
 (`Performance: Boxing`, `Performance: Arrays`, `Performance: Closures and
-delegates`, and more). Start with discovery or counts, then select the group or
-one concrete kind. Type/member scope keeps the focused `Performance Triage`
-lens.
+delegates`, and more). Structural discovery lists the authored kinds without
+running analysis; add `--effective` to retain only kinds with findings for this
+library. A count executes the selected group and includes zero-row kinds.
+Type/member scope keeps the focused `Performance Triage` lens.
 
 ```bash
 dnx dotnet-inspect -y -- library MyLib.dll -D @Performance
+dnx dotnet-inspect -y -- library MyLib.dll -D @Performance --effective
 dnx dotnet-inspect -y -- library MyLib.dll -S @Performance --count
 dnx dotnet-inspect -y -- library MyLib.dll -S "Performance: Boxing" --jsonl
 dnx dotnet-inspect -y -- library MyLib.dll -S "Performance:*" \

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -75,14 +75,14 @@ effective discovery probes for data. Package and library differ:
 | Gesture | `package` | `library` |
 | ------- | --------- | --------- |
 | `-D` with target | Effective base catalog + category doors. | Cheap target-aware base catalog + category doors. |
-| `-D --effective` | Already default; option not exposed. | Full effective base catalog. |
 | `-D @Category` | Effective members. | Structural members. |
 | `-D @Category --effective` | Not needed. | Effective members. |
 | `-D Section` | Effective fields. | Structural fields; add `--effective` for effective fields. |
 | `-D --schema` | Complete static graph; target optional. | Complete static graph without inspection. |
 
 Without a package target, `package -D` is structural. On library, plain `-D`
-stays cheap; bare `--effective` remains scoped to base evidence.
+stays cheap; `-D --effective` runs full probes and remains scoped to base
+evidence unless a category is named.
 
 | Command | Base categories | Domain categories |
 | ------- | --------------- | ----------------- |

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -87,10 +87,12 @@ evidence unless a category is named.
 | `package` | `@Package`, `@Files` | `@Dependencies`, `@Audit`, `@SourceLink` |
 | `library` | `@Library`, `@Surface` | `@Audit`, `@Performance`, `@SourceLink`, `@Integrations`, `@Metadata`, `@Context` |
 
-`@Package` includes unbounded `Package files`; `@Files` is only the curated
-nuspec, README, and skill-file family. Other commands expose categories such as
-member `@Source`; `Switches` is a section. There are no user-facing `@All`,
-`@Default`, or `@Hidden` categories.
+`@Package` groups `Package Info`, `Signals`, `Statistics`, `Target Frameworks`,
+`Signature`, `Dependencies`, `Vulnerabilities`, `Manifest`, `Runtime
+Dependencies`, and the unbounded `Package files` listing. `@Files` groups the
+curated nuspec, README, and skill-file sections. Other commands expose
+categories such as member `@Source`; `Switches` is a section. There are no
+user-facing `@All`, `@Default`, or `@Hidden` categories.
 
 Bare `-S` returns high-value, fixed-length, network-free sections from the
 package or library base categories. Sections without evidence are omitted.

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -72,16 +72,14 @@ dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Se
 Structural discovery describes authored membership without running producers;
 effective discovery probes for data. Package and library differ:
 
-| Gesture | `package` | `library` |
-| ------- | --------- | --------- |
-| `-D` with target | Effective base catalog + category doors. | Cheap target-aware base catalog + category doors. |
-| `-D @Category` | Effective members. | Structural members. |
-| `-D @Category --effective` | Not needed. | Effective members. |
-| `-D Section` | Effective fields. | Structural fields; add `--effective` for effective fields. |
-| `-D --schema` | Complete static graph; target optional. | Complete static graph without inspection. |
+| Goal | `package` | `library` |
+| ---- | --------- | --------- |
+| Orient to a target | `package X -D` — effective base catalog. | `library X -D` — cheap target-aware base catalog. |
+| Inspect a category | `package X -D @Category` — effective members. | `library X -D @Category` — structural members; add `--effective` for populated members. |
+| Inspect section fields | `package X -D Section` — effective fields. | `library X -D Section` — structural fields; add `--effective` for rendered fields. |
+| Read the static graph | `package -D --schema` | `library -D --schema` |
 
-Without a package target, `package -D` is structural. On library, plain `-D`
-stays cheap; `-D --effective` runs full probes and remains scoped to base
+On library, `-D --effective` runs full probes and remains scoped to base
 evidence unless a category is named.
 
 | Command | Base categories | Domain categories |

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -92,11 +92,12 @@ nuspec, README, and skill-file family. Other commands expose categories such as
 member `@Source`; `Switches` is a section. There are no user-facing `@All`,
 `@Default`, or `@Hidden` categories.
 
-Bare `-S` is deliberately conservative on package and library: it renders only
-effective, fixed-size, network-free base sections. `-S --count` returns their
-count map, including zero rows. Explicit sections/categories override base
-scope and may authorize expensive work. Focused selection omits identity;
-include `Package Info` or `Library Info` when needed.
+Bare `-S` returns high-value, fixed-length, network-free sections from the
+package or library base categories. Sections without evidence are omitted.
+`-S --count` returns the candidate count map, including zero rows. Explicit
+sections/categories override base scope and may authorize expensive work.
+Focused selection omits identity; include `Package Info` or `Library Info` when
+needed.
 
 Some large families expose only their category door in the top-level catalog.
 Use `library X -D @Performance` or `-D @Metadata`; add `--effective` for

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dotnet-inspect-query
 version: 0.1.0
-description: Output formats, -D/-S section discovery and selection, value projection, @ categories, and output limits shared across all commands.
+description: Output formats, curated package/library -D/-S discovery and selection, value projection, @ categories, and output limits shared across commands.
 ---
 
 # dotnet-inspect: query and output system
@@ -31,7 +31,7 @@ Default output is Markdown. Pick a machine or compact shape when you need one:
 - `--bare` — one undecorated payload or URL list.
 - `--count` — a bare row count.
 - `--value` / `--urls` / `--paths` — project one selected section to scalar, URL, or path payloads.
-- `--print` — print one document behind a selected printable row; use `--row N` when multiple printable rows exist.
+- `--print` — print one document behind a selected section row; use `--row N|first|last` when the section renders multiple rows.
 - `--tree` — a standalone tree for graph sections that support tree lowering.
 - `--mermaid` — a standalone diagram; combine it with `--markdown` to embed
   the diagram in a Markdown document.
@@ -58,9 +58,10 @@ format.
 
 ## Discover and select sections
 
-Use `-D` to discover the sections and columns a command can emit, `-S Section` to
-select sections by name or wildcard, and `--columns`/`--fields` to project
-values. Discover first instead of guessing names.
+`-D` and `-S` are the uppercase cross-command query namespace. Use `-D` to
+discover sections and fields, `-S` to select exact names, categories, compatible
+aliases, or wildcards, and `--columns`/`--fields` to project values. Discover
+first instead of guessing names.
 
 ```bash
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -D --tsv
@@ -68,17 +69,42 @@ dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Se
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Member Index" --columns "Selector;Stable;Canonical Signature" --tsv
 ```
 
-`@` names a category of sections. Examples include `@Package`, `@Files`,
-`@Dependencies`, `@Library`, `@Surface`, `@Audit`, `@Context`, `@Source`,
-`@SourceLink`, `@Integrations`, `@Performance`, and `@Metadata`. `Switches` is
-a plain section, not a category.
-Some large families expose only their category door in the top-level catalog;
-drill in with `-D @Performance` or `-D @Metadata`. Row formats
-(`--tsv`/`--jsonl`/`--table`) require one concrete section or a supported
-homogeneous family. `Performance:*` flattens with a leading `Kind` column when
-two or more kinds have rows; if only one kind survives filtering, row formats
-use its concrete schema without `Kind`. Use structured `--json` when the kind
-discriminator must remain explicit.
+Structural discovery describes authored membership without running producers;
+effective discovery probes for data. Package and library differ:
+
+| Gesture | `package` | `library` |
+| ------- | --------- | --------- |
+| `-D` with target | Effective base catalog + category doors. | Cheap target-aware base catalog + category doors. |
+| `-D --effective` | Already default; option not exposed. | Full effective base catalog. |
+| `-D @Category` | Effective members. | Structural members. |
+| `-D @Category --effective` | Not needed. | Effective members. |
+| `-D Section` | Effective fields. | Structural fields; add `--effective` for effective fields. |
+| `-D --schema` | Complete static graph; target optional. | Complete static graph without inspection. |
+
+Without a package target, `package -D` is structural. On library, plain `-D`
+stays cheap; bare `--effective` remains scoped to base evidence.
+
+| Command | Base categories | Domain categories |
+| ------- | --------------- | ----------------- |
+| `package` | `@Package`, `@Files` | `@Dependencies`, `@Audit`, `@SourceLink` |
+| `library` | `@Library`, `@Surface` | `@Audit`, `@Performance`, `@SourceLink`, `@Integrations`, `@Metadata`, `@Context` |
+
+`@Package` includes unbounded `Package files`; `@Files` is only the curated
+nuspec, README, and skill-file family. Other commands expose categories such as
+member `@Source`; `Switches` is a section. There are no user-facing `@All`,
+`@Default`, or `@Hidden` categories.
+
+Bare `-S` is deliberately conservative on package and library: it renders only
+effective, fixed-size, network-free base sections. `-S --count` returns their
+count map, including zero rows. Explicit sections/categories override base
+scope and may authorize expensive work. Focused selection omits identity;
+include `Package Info` or `Library Info` when needed.
+
+Some large families expose only their category door in the top-level catalog.
+Use `library X -D @Performance` or `-D @Metadata`; add `--effective` for
+populated members. Row formats require a concrete section or homogeneous
+family. Heterogeneous categories use Markdown/JSON; `Performance:*` flattens
+kinds and adds `Kind` when multiple kinds have rows.
 
 ## Filter and order performance rows
 
@@ -103,9 +129,15 @@ Prefer built-in limits to shell pipes:
 
 - `-n N` and numeric shorthand like `-6` cap output lines, like `head`.
 - `--tail` takes the same count from the end, like `tail`.
-- `--rows N` caps table data rows; `2..10` is inclusive, `2+10` is start plus count, and `10..` is open-ended.
-- `--tail --rows N` takes table rows from the end; otherwise row windows start at the beginning.
-- With `--print`, `--value`, `--urls`, or `--paths`, `--row N|first|last` chooses the projected row; `-n N` still limits output lines.
+- `--rows N` takes the first N data rows per table, preserving headings and
+  headers; add `--tail` for the last N.
+- `--rows 2..10` is an absolute 1-based inclusive range (nine rows), `2+10`
+  means ten rows starting at row 2, and `10..` runs from row 10 to the end.
+  Ranges reject `--head`/`--tail`; all `--rows` forms reject `-n`.
+- `--row` is not a window. With `--print`, `--value`, `--urls`, or `--paths`,
+  it selects one displayed row, not a compacted projection position.
+  `first`/`last` mean rendered endpoints; missing payloads fail instead of
+  sliding. `-n N` may still limit the result.
 - `--count` counts rows in one selected table.
 
 Command-specific caps: `-t N` for type/find rows, `-m N` for members, and

--- a/skills/signals/SKILL.md
+++ b/skills/signals/SKILL.md
@@ -66,5 +66,4 @@ dnx dotnet-inspect -y -- package System.Text.Json -S "SourceLink: Availability,S
 ```
 
 On `library`, category discovery is structural until `--effective` is added.
-On `package`, target discovery is already effective and does not expose an
-`--effective` option.
+On `package`, target discovery is effective by default.

--- a/skills/signals/SKILL.md
+++ b/skills/signals/SKILL.md
@@ -56,9 +56,15 @@ explicitly.
 
 ```bash
 dnx dotnet-inspect -y -- library System.Text.Json -D @SourceLink
+dnx dotnet-inspect -y -- library System.Text.Json -D @SourceLink --effective
+dnx dotnet-inspect -y -- package System.Text.Json -D @SourceLink
 dnx dotnet-inspect -y -- library MyLib.dll -S "Signals,SourceLink: Diagnostics"
 dnx dotnet-inspect -y -- library System.Text.Json \
   -S "SourceLink: Availability,SourceLink: Missing Files"
 dnx dotnet-inspect -y -- library System.Text.Json -S "SourceLink: Integrity"
 dnx dotnet-inspect -y -- package System.Text.Json -S "SourceLink: Availability,SourceLink: Missing Files"
 ```
+
+On `library`, category discovery is structural until `--effective` is added.
+On `package`, target discovery is already effective and does not expose an
+`--effective` option.

--- a/skills/sourcelink/SKILL.md
+++ b/skills/sourcelink/SKILL.md
@@ -37,7 +37,10 @@ dnx dotnet-inspect -y -- library System.Text.Json --il-offset 0x06000001+0x0
 `-S "Original Source"` returns the original source body when SourceLink can
 resolve it (also part of the `-S @Source` bundle alongside the decompiled and IL
 views). Use `--print` to fetch the source body behind one printable SourceLink
-row; add `--row N` when the selected section has multiple printable rows.
+row. When the section renders multiple rows, add `--row N|first|last`; `N`
+addresses the displayed 1-based row number, while `first` and `last` mean the
+rendered endpoints. If that row has no printable document, the command reports
+it instead of silently choosing another row.
 
 ```bash
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S "Original Source"


### PR DESCRIPTION
## Summary

- teach the modern package and library `-D`/`-S` contracts, including curated base/domain categories and effective discovery
- describe conservative bare `-S` behavior and the package/library discovery asymmetry
- update `--row` displayed-row identity and the closed `--rows` count/range grammar across focused skills
- keep the router skill within its 50-line budget and compress the detailed guidance

## Compatibility

Documentation-only. Product behavior and the package version are unchanged.

## Validation

- `npx markdownlint-cli` on all changed skills
- router skill line-budget check
- `git diff --check`