### PR TITLE
Build release fixtures before tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,8 @@ jobs:
           restore-keys: |
             nuget-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Build managed tool
-        run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+      - name: Build product, tests, and fixtures
+        run: dotnet build dotnet-inspect.slnx -c Release
 
       - name: Install ilasm/ildasm
         id: iltools

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -687,6 +687,25 @@ public class IlToolsActivationTests
     }
 
     [Fact]
+    public void ReleaseWorkflow_BuildsFixtureGraphBeforeCliTests()
+    {
+        string workflow = File.ReadAllText(
+            Path.Combine(RepoRoot, ".github", "workflows", "release.yml"));
+        int build = workflow.IndexOf(
+            "- name: Build product, tests, and fixtures",
+            StringComparison.Ordinal);
+        int cliTests = workflow.IndexOf(
+            "- name: Run CLI tests (including slow integration)",
+            StringComparison.Ordinal);
+
+        Assert.True(build >= 0);
+        Assert.True(build < cliTests);
+        Assert.Contains(
+            "run: dotnet build dotnet-inspect.slnx -c Release",
+            workflow[build..cliTests]);
+    }
+
+    [Fact]
     public void ReleaseWorkflow_OracleTestLaneBlocksAllPackageJobs()
     {
         string workflow = File.ReadAllText(


### PR DESCRIPTION
## Summary

Fixes the publish test lane so fixture-backed CLI tests run against the complete Release build graph.

- Replaces the tool-only build with the repository's canonical `dotnet build dotnet-inspect.slnx -c Release` command.
- Adds a non-vacuity gate that requires the full graph build before the CLI test step.

The failed 0.17.0 publish run built only `src/dotnet-inspect`, then reported 26 `FileNotFoundException` failures for solution-owned caller-graph, Analysis, and classic-state-machine fixtures. Packaging correctly remained blocked.

Failed run: https://github.com/richlander/dotnet-inspect/actions/runs/31636395945

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `IlToolsActivationTests`: 33 passed
- Representative failures from each missing fixture family: 3 passed
