### PR TITLE
Serialize package sweep file app tests

### DIFF
--- a/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
@@ -25,6 +25,7 @@ namespace ILInspector.Decompiler.Tests;
 /// against a scratch cache holding one synthetic package (#3560).</para>
 /// </summary>
 [Trait("Area", "Corpus")]
+[Collection(SweepFileAppCollection.Name)]
 public class EvilPoolPinTests
 {
     const string PinRelativePath = "docs/data/nuget-top-packages.lock.json";

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -55,6 +55,7 @@ namespace ILInspector.Decompiler.Tests;
 /// fixture seeded below.</para>
 /// </summary>
 [Trait("Area", "Corpus")]
+[Collection(SweepFileAppCollection.Name)]
 public class EvilPoolSweepGateTests
 {
     const string FixturePackage = "sweep.fixture";

--- a/src/ILInspector.Decompiler.Tests/SweepFileAppCollection.cs
+++ b/src/ILInspector.Decompiler.Tests/SweepFileAppCollection.cs
@@ -1,0 +1,11 @@
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Serializes tests that restore and build the package-sweep file app through the SDK's
+/// shared runfile output.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class SweepFileAppCollection
+{
+    public const string Name = "Package sweep file app";
+}


### PR DESCRIPTION
## Summary

Prevents the package-sweep test gates from concurrently restoring and building the same .NET file-based app through shared SDK runfile output.

- Assigns `EvilPoolPinTests` and `EvilPoolSweepGateTests` to one focused xUnit collection.
- Preserves parallel execution for every unrelated decompiler test collection.
- Leaves subprocess deadlines, fixture package caches, sweep behavior, and product code unchanged.

## Evidence

A full fast-lane run previously timed out `EvilPoolSweepGateTests.ASweepRefusesAPackageThatShipsNoLibrary` after five minutes, while the same method passed alone in 9.144 seconds. Both affected classes launch the exact same `eng/prepare-decompiler-package-sweep.cs` file app. A controlled two-method run on the unmodified base showed xUnit running one launcher from each class concurrently on both collection threads; both remained active past 60 seconds.

Per-fixture `--artifacts-path` isolation was also measured and rejected: it removed shared output but forced cold full-repository file-app builds, increasing the focused pair to 151 seconds. The collection boundary retains warm build reuse while preventing overlapping writes.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- "Speed=Slow" -reporter quiet`
- Focused pair after collection assignment: 2/2 passed in 51.079 seconds, sequentially within the shared collection.
