### PR TITLE
Report artifact text and identifier confusion audit signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,12 +187,22 @@ For libraries, SourceLink presence and map usability are separate observations.
 `Non-normalized Paths` separately lists SourceLink document keys that do not use
 the deterministic `/_/` prefix.
 
+Package Signals also reports `Artifact text containment`. `None` means no
+package-model text needed visual containment; `Required` names only the Unicode
+category kinds that were contained (`Cc`, `Cf`, `Cs`, `Zl`, or `Zp`), never the
+artifact text itself. Literal backslashes do not count as a concern even when
+the invertible encoding must disambiguate them. Library Signals will gain the
+same row when the library presentation model carries `InertString` through its
+complete text surface; until then, the package row does not claim library
+coverage. `PackageSignals_ReportsEveryArtifactTextConcernKindWithoutContent`
+and `PackageSignals_ReportsNoArtifactTextConcernForBackslashes` gate the row.
+
 | Command | Scope | Signals |
 | ------- | ----- | ------- |
 | `library X -S Signals` | Metadata + provenance | Library metadata/provenance signals; a missing library PDB is acquired to resolve SourceLink. |
 | `library X -S "Signals,SourceLink: Availability,SourceLink: Missing Files"` | Detailed SourceLink reachability | Adds the opt-in per-file HEAD pass and reports embedded-source coverage. |
 | `library X -S "SourceLink: Integrity"` | Content verification (slow, opt-in) | Downloads every tracked source file and compares its hash to the PDB checksum; a mismatch exits non-zero. Never runs in a default flow. |
-| `package X -S Signals` | Full package signals | Package and dependency signals, including known vulnerabilities, package age, dependency vulnerability/deprecation counts, and dependency age. |
+| `package X -S Signals` | Full package signals | Package and dependency signals, including artifact-text containment kinds, known vulnerabilities, package age, dependency vulnerability/deprecation counts, and dependency age. |
 | `package X -S "SourceLink: Availability,SourceLink: Missing Files"` | Package SourceLink reachability | Audits the selected package libraries and retains library provenance on missing-file rows. |
 | `package X -S "SourceLink: Integrity"` | Package content verification (slow, opt-in) | Aggregates checksum results across selected package libraries; any mismatch exits non-zero. |
 

--- a/README.md
+++ b/README.md
@@ -198,8 +198,9 @@ row when the library presentation model carries `InertString` through its
 complete text surface; until then, the package row does not claim library
 coverage. `PackageSignals_ReportsEveryArtifactTextConcernKindWithoutContent`,
 `PackageInspectionTextTests.RequiredContainment_CoversEveryPackageTextSourceIndividually`,
-and `PackageArtifactTextAudit_ListsLocationsAndKindsInMarkdownAndJsonl` gate the
-summary, provenance, and listing.
+`Package_MultiplePackages_SignalsIncludePackageFileConcerns`, and
+`PackageArtifactTextAudit_ListsLocationsAndKindsInMarkdownAndJsonl` gate the
+summary, single/multi-package parity, provenance, and listing.
 
 Library and package Signals also report `Identifier confusion` for assembly
 names and package IDs. Every non-ASCII identifier character is reported as an
@@ -212,12 +213,14 @@ content-free locations, classifications, similarity, and code points; the
 Signal and audit rows never repeat the identifier value. This is separate from
 artifact-text containment: a homoglyph is ordinary graphic text and does not
 require `InertString` encoding, while an ASCII backslash triggers neither
-concern.
+concern. Library Signals stays bounded to the selected assembly and its direct
+references. The explicit library audit additionally resolves and inspects the
+transitive reference closure.
 
 | Command | Scope | Signals |
 | ------- | ----- | ------- |
 | `library X -S Signals` | Metadata + provenance | Library metadata/provenance and identifier-confusion signals; a missing library PDB is acquired to resolve SourceLink. |
-| `library X -S "Signals,Audit: Identifier Confusion"` | Identifier audit | Adds content-free assembly-name and reference locations, classifications, similarity, and code points. |
+| `library X -S "Audit: Identifier Confusion"` | Identifier audit | Adds content-free assembly-name, direct-reference, and resolved transitive-reference locations, classifications, similarity, and code points. |
 | `library X -S "Signals,SourceLink: Availability,SourceLink: Missing Files"` | Detailed SourceLink reachability | Adds the opt-in per-file HEAD pass and reports embedded-source coverage. |
 | `library X -S "SourceLink: Integrity"` | Content verification (slow, opt-in) | Downloads every tracked source file and compares its hash to the PDB checksum; a mismatch exits non-zero. Never runs in a default flow. |
 | `package X -S Signals` | Full package signals | Package and dependency signals, including identifier confusion, artifact-text containment kinds, known vulnerabilities, package age, dependency vulnerability/deprecation counts, and dependency age. |

--- a/README.md
+++ b/README.md
@@ -190,12 +190,16 @@ the deterministic `/_/` prefix.
 Package Signals also reports `Artifact text containment`. `None` means no
 package-model text needed visual containment; `Required` names only the Unicode
 category kinds that were contained (`Cc`, `Cf`, `Cs`, `Zl`, or `Zp`), never the
-artifact text itself. Literal backslashes do not count as a concern even when
-the invertible encoding must disambiguate them. Library Signals will gain the
-same row when the library presentation model carries `InertString` through its
+artifact text itself. Select `Audit: Artifact Text` (or `@Audit`) for one
+content-free row per detected package-model field, with `Location` and
+`Concerns` columns. Literal backslashes do not count as a concern even when the
+invertible encoding must disambiguate them. Library Signals will gain the same
+row when the library presentation model carries `InertString` through its
 complete text surface; until then, the package row does not claim library
-coverage. `PackageSignals_ReportsEveryArtifactTextConcernKindWithoutContent`
-and `PackageSignals_ReportsNoArtifactTextConcernForBackslashes` gate the row.
+coverage. `PackageSignals_ReportsEveryArtifactTextConcernKindWithoutContent`,
+`PackageInspectionTextTests.RequiredContainment_CoversEveryPackageTextSourceIndividually`,
+and `PackageArtifactTextAudit_ListsLocationsAndKindsInMarkdownAndJsonl` gate the
+summary, provenance, and listing.
 
 | Command | Scope | Signals |
 | ------- | ----- | ------- |
@@ -203,6 +207,7 @@ and `PackageSignals_ReportsNoArtifactTextConcernForBackslashes` gate the row.
 | `library X -S "Signals,SourceLink: Availability,SourceLink: Missing Files"` | Detailed SourceLink reachability | Adds the opt-in per-file HEAD pass and reports embedded-source coverage. |
 | `library X -S "SourceLink: Integrity"` | Content verification (slow, opt-in) | Downloads every tracked source file and compares its hash to the PDB checksum; a mismatch exits non-zero. Never runs in a default flow. |
 | `package X -S Signals` | Full package signals | Package and dependency signals, including artifact-text containment kinds, known vulnerabilities, package age, dependency vulnerability/deprecation counts, and dependency age. |
+| `package X -S "Signals,Audit: Artifact Text"` | Artifact-text audit | Adds a content-free listing of the package-model field locations and Unicode concern kinds that required containment. |
 | `package X -S "SourceLink: Availability,SourceLink: Missing Files"` | Package SourceLink reachability | Audits the selected package libraries and retains library provenance on missing-file rows. |
 | `package X -S "SourceLink: Integrity"` | Package content verification (slow, opt-in) | Aggregates checksum results across selected package libraries; any mismatch exits non-zero. |
 
@@ -575,6 +580,7 @@ dotnet-inspect library System.Diagnostics.DiagnosticSource -S OpenTelemetry
 dotnet-inspect library System.Text.Json -S "Signals,SourceLink: Availability,SourceLink: Missing Files"
 dotnet-inspect library System.Text.Json -S "SourceLink: Integrity"
 dotnet-inspect package System.Text.Json -S Signals
+dotnet-inspect package System.Text.Json -S "Signals,Audit: Artifact Text"
 dotnet-inspect package System.Text.Json -S @Package
 dotnet-inspect package System.Text.Json -S @Dependencies
 dotnet-inspect package System.Text.Json -S @Audit

--- a/README.md
+++ b/README.md
@@ -204,16 +204,16 @@ summary, single/multi-package parity, provenance, and listing.
 
 Library and package Signals also report `Identifier confusion` for assembly
 names and package IDs. Every non-ASCII identifier character is reported as an
-identity concern. Names whose leading characters are at least 80% similar to
-`System`, `Microsoft`, or `Azure` receive the more specific
-`reserved-prefix homoglyph` classification when a bounded Greek/Cyrillic
-homoglyph check confirms the apparent prefix. The summary reports only counts
-and matched prefixes. Select `Audit: Identifier Confusion` (or `@Audit`) for
-content-free locations, classifications, similarity, and code points; the
-Signal and audit rows never repeat the identifier value. This is separate from
-artifact-text containment: a homoglyph is ordinary graphic text and does not
-require `InertString` encoding, while an ASCII backslash triggers neither
-concern. Library Signals stays bounded to the selected assembly and its direct
+identity concern. Names whose leading characters exactly match `System`,
+`Microsoft`, or `Azure` after a bounded Greek/Cyrillic
+homoglyph fold receive the more specific `reserved-prefix homoglyph`
+classification. The summary reports only counts and matched prefixes. Select
+`Audit: Identifier Confusion` (or `@Audit`) for content-free locations,
+classifications, similarity, and code points; the Signal and audit rows never
+repeat the identifier value. This is separate from artifact-text containment:
+a homoglyph is ordinary graphic text and does not require `InertString`
+encoding, while an ASCII backslash triggers neither concern. Library Signals
+stays bounded to the selected assembly and its direct
 references. The explicit library audit additionally resolves and inspects the
 transitive reference closure.
 

--- a/README.md
+++ b/README.md
@@ -201,13 +201,28 @@ coverage. `PackageSignals_ReportsEveryArtifactTextConcernKindWithoutContent`,
 and `PackageArtifactTextAudit_ListsLocationsAndKindsInMarkdownAndJsonl` gate the
 summary, provenance, and listing.
 
+Library and package Signals also report `Identifier confusion` for assembly
+names and package IDs. Every non-ASCII identifier character is reported as an
+identity concern. Names whose leading characters are at least 80% similar to
+`System`, `Microsoft`, or `Azure` receive the more specific
+`reserved-prefix homoglyph` classification when a bounded Greek/Cyrillic
+homoglyph check confirms the apparent prefix. The summary reports only counts
+and matched prefixes. Select `Audit: Identifier Confusion` (or `@Audit`) for
+content-free locations, classifications, similarity, and code points; the
+Signal and audit rows never repeat the identifier value. This is separate from
+artifact-text containment: a homoglyph is ordinary graphic text and does not
+require `InertString` encoding, while an ASCII backslash triggers neither
+concern.
+
 | Command | Scope | Signals |
 | ------- | ----- | ------- |
-| `library X -S Signals` | Metadata + provenance | Library metadata/provenance signals; a missing library PDB is acquired to resolve SourceLink. |
+| `library X -S Signals` | Metadata + provenance | Library metadata/provenance and identifier-confusion signals; a missing library PDB is acquired to resolve SourceLink. |
+| `library X -S "Signals,Audit: Identifier Confusion"` | Identifier audit | Adds content-free assembly-name and reference locations, classifications, similarity, and code points. |
 | `library X -S "Signals,SourceLink: Availability,SourceLink: Missing Files"` | Detailed SourceLink reachability | Adds the opt-in per-file HEAD pass and reports embedded-source coverage. |
 | `library X -S "SourceLink: Integrity"` | Content verification (slow, opt-in) | Downloads every tracked source file and compares its hash to the PDB checksum; a mismatch exits non-zero. Never runs in a default flow. |
-| `package X -S Signals` | Full package signals | Package and dependency signals, including artifact-text containment kinds, known vulnerabilities, package age, dependency vulnerability/deprecation counts, and dependency age. |
+| `package X -S Signals` | Full package signals | Package and dependency signals, including identifier confusion, artifact-text containment kinds, known vulnerabilities, package age, dependency vulnerability/deprecation counts, and dependency age. |
 | `package X -S "Signals,Audit: Artifact Text"` | Artifact-text audit | Adds a content-free listing of the package-model field locations and Unicode concern kinds that required containment. |
+| `package X -S "Signals,Audit: Identifier Confusion"` | Identifier audit | Adds content-free package-ID and dependency-ID locations, classifications, similarity, and code points. |
 | `package X -S "SourceLink: Availability,SourceLink: Missing Files"` | Package SourceLink reachability | Audits the selected package libraries and retains library provenance on missing-file rows. |
 | `package X -S "SourceLink: Integrity"` | Package content verification (slow, opt-in) | Aggregates checksum results across selected package libraries; any mismatch exits non-zero. |
 

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -128,6 +128,8 @@ artifact-text containment.
 `IdentifierConfusionDetectorTests` gates single and multiple confirmed
 homoglyphs, raw similarity evidence, generic non-ASCII cases, and ASCII close
 negatives.
+`DescribeCharacters_DeduplicatesRepeatedHomoglyphCodePoints` gates stable
+code-point rendering when one substitution occurs more than once.
 `PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`
 gates the content-free Markdown and JSONL shapes, and
 `PackageAudit_InspectsPackageAndDependencyIdentifierLocations` plus
@@ -156,6 +158,8 @@ gates traversal of distinct typed AssemblyRefs that share a simple name;
 gates visible traversal failure for absolute and bare relative library paths.
 That test also gates preservation of healthy `@Audit` sections when the
 identifier-confusion member fails.
+`LibraryPackageIdentifierConfusionAudit_FailsWithoutPartialDocument` gates the
+same content-free hard failure for an exact package-backed library selection.
 `PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`
 gates clean diagnostics, healthy partial results, and nonzero completion for
 survey-mode traversal failure.
@@ -177,7 +181,15 @@ alternate-package metadata demand, producer result, and moderated network cost.
 feed which does not advertise optional deprecation endpoints is complete rather
 than failed;
 `FetchAllMetadataAsync_SearchDeprecationMustMatchRequestedVersion` gates
-version-specific authority for search deprecation metadata, and
+version-specific authority for search deprecation metadata;
+`FetchAllMetadataAsync_DoesNotCacheMismatchedSearchVersion` gates retry after
+that mismatch, while
+`FetchAllMetadataAsync_CachesMatchingSearchVersionWithoutDeprecation` and
+`FetchAllMetadataAsync_CachesCatalogAuthorityDespiteSearchVersionMismatch`
+gate authoritative absence and catalog precedence;
+`FetchAllMetadataAsync_DoesNotCacheMismatchedInlineCatalogIdentity` and
+`FetchAllMetadataAsync_DoesNotCacheMismatchedFetchedCatalogIdentity` gate the
+same identity and retry contract for both catalog forms; and
 `FetchAllMetadataAsync_IgnoresMalformedCatalogReference` gates retry after a
 malformed catalog reference;
 `PackageCommand_IdentifierMetadataFailureIsNonzero` gates nonzero completion

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -63,6 +63,8 @@ The package result is gated by
 `PackageInspectionTextTests.RequiredContainment_CoversEveryPackageTextSourceIndividually`,
 which derives the expected text-source set from the package model and requires
 each source to contribute independently;
+`Package_MultiplePackages_SignalsIncludePackageFileConcerns` gates parity
+between single-package and survey-mode file-path evidence;
 `PackageArtifactTextAudit_ListsLocationsAndKindsInMarkdownAndJsonl` gates the
 content-free detail shapes, and
 `PackageSignals_ReportsNoArtifactTextConcernForBackslashes` gates the close
@@ -76,8 +78,11 @@ coverage.
 
 Library and package Signals include an `Identifier confusion` row. The package
 scope covers the selected package ID, alternate package ID, dependency IDs,
-runtime dependency IDs, and RID companion-package IDs. The library scope covers
-the assembly name plus direct and transitive assembly-reference names.
+runtime dependency IDs, and RID companion-package IDs. Library Signals covers
+the selected assembly name and direct assembly-reference names. The explicit
+library audit additionally resolves and inspects the transitive reference
+closure; that unbounded traversal remains behind the explicit section gesture
+rather than entering Signals.
 
 | Value | Meaning |
 | ----- | ------- |
@@ -98,7 +103,7 @@ Select `Audit: Identifier Confusion` for the detected cases, or select
 `@Audit` to include them with the other audit evidence:
 
 ```bash
-dotnet-inspect library X -S "Signals,Audit: Identifier Confusion"
+dotnet-inspect library X -S "Audit: Identifier Confusion"
 dotnet-inspect package X -S "Signals,Audit: Identifier Confusion"
 ```
 
@@ -114,7 +119,9 @@ homoglyphs, generic non-ASCII cases, and ASCII close negatives.
 `PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`
 gates the content-free Markdown and JSONL shapes, and
 `PackageAudit_InspectsPackageAndDependencyIdentifierLocations` plus
-`LibraryAudit_InspectsAssemblyAndReferenceNames` gate the two identifier scopes.
+`LibraryAudit_InspectsAssemblyAndReferenceNames` gate the typed identifier
+scopes. `LibraryIdentifierConfusionAudit_CollectsDirectAndTransitiveReferenceNames`
+gates the explicit library producer demand.
 
 ## Build Audit Fields
 

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -138,7 +138,10 @@ gates full-effective discovery;
 gates nonzero failure propagation when Signals effective discovery cannot
 inspect direct references;
 `LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure`
-gates direct/closure identity deduplication; and
+gates direct/closure identity deduplication;
+`LibraryIdentifierConfusionAudit_DeduplicatesDiamondClosure` gates one
+projection row per resolved identity when several reference paths converge;
+and
 `AssemblyReferenceTreeResolutionTests.DistinctSameNameReferences_DoNotSuppressResolvableIdentity`
 gates traversal of distinct typed AssemblyRefs that share a simple name;
 `LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
@@ -146,6 +149,8 @@ gates visible traversal failure for absolute and bare relative library paths.
 `PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`
 gates clean diagnostics, healthy partial results, and nonzero completion for
 survey-mode traversal failure.
+`LibraryCommand_TfmAll_PreservesHealthyIdentifierAuditResults` gates the same
+per-source outcome contract across target frameworks.
 `LibraryIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded`
 and
 `PackageAllLibrariesIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded`
@@ -155,6 +160,16 @@ content-free failure category on the public reference-tree projection.
 `PackagePipeline_IdentifierConfusionAudit_DemandsRegistrationMetadata` and
 `InspectAsync_IdentifierAuditMetadataIncludesAlternatePackageId` gate the
 alternate-package metadata demand, producer result, and moderated network cost.
+`InspectAsync_IdentifierAuditMetadataFailureRemainsVisible` gates an
+`Unavailable` result when that registry metadata cannot be established;
+`PackageCommand_IdentifierMetadataFailureIsNonzero` gates nonzero completion
+and content-free diagnostics for that failure;
+`MultiPackageCount_CountsSelectedAuditRows` gates scalar counts against the
+selected audit rows rather than unrelated package-info fields; and
+`MultiPackageCount_PreservesSelectedSectionMap` plus
+`MultiPackageCount_PreservesFixedOverviewMap` gate multi-section count maps.
+`LibraryCommand_SelectedReferences_TreeDedupUsesShallowestPath` gates
+minimum-depth canonicalization under a bounded reference traversal.
 
 ## Build Audit Fields
 

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -42,10 +42,27 @@ echoes the concerning content. A literal backslash is not a concern: it may be
 rewritten solely to keep the visual encoding invertible, and that mechanical
 rewrite does not change the row to `Required`.
 
+Select `Audit: Artifact Text` for the detected cases, or select `@Audit` to
+include it with the other audit evidence:
+
+```bash
+dotnet-inspect package X -S "Signals,Audit: Artifact Text"
+dotnet-inspect package X -S @Audit
+```
+
+The detail table has `Location` and `Concerns` columns. A location is a stable
+package-model path such as `Owners[0]` or `PackageFiles[3].Path`; it is not the
+artifact value. One field produces one row containing all concern kinds found
+in that field. The section is explicit because package-file paths make its row
+count scale with package size. Markdown and JSONL use the same rows, and neither
+format includes the concerning content.
+
 The package result is gated by
 `PackageInspectionTextTests.RequiredContainment_CoversEveryPackageTextSourceIndividually`,
 which derives the expected text-source set from the package model and requires
 each source to contribute independently;
+`PackageArtifactTextAudit_ListsLocationsAndKindsInMarkdownAndJsonl` gates the
+content-free detail shapes, and
 `PackageSignals_ReportsNoArtifactTextConcernForBackslashes` gates the close
 negative. Library Signals does not yet report this row because the library
 presentation model still unwraps containment to bare strings at individual row

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -26,6 +26,33 @@ selected compatible/highest-TFM libraries and retain library provenance.
 See [SourceLink Exposure](sourcelink-exposure.md) for the product surfaces,
 PDB dependency, and network policy behind these sections.
 
+## Artifact text containment
+
+Package Signals includes an `Artifact text containment` row over the complete
+typed package presentation model.
+
+| Value | Meaning |
+| ----- | ------- |
+| `None` | No package-model scalar required visual containment. |
+| `Required` | At least one scalar required containment; Evidence lists its Unicode category kinds. |
+
+The reported kinds are control (`Cc`), format/bidi (`Cf`), unpaired surrogate
+(`Cs`), line separator (`Zl`), and paragraph separator (`Zp`). The row never
+echoes the concerning content. A literal backslash is not a concern: it may be
+rewritten solely to keep the visual encoding invertible, and that mechanical
+rewrite does not change the row to `Required`.
+
+The package result is gated by
+`PackageInspectionTextTests.RequiredContainment_CoversEveryPackageTextSourceIndividually`,
+which derives the expected text-source set from the package model and requires
+each source to contribute independently;
+`PackageSignals_ReportsNoArtifactTextConcernForBackslashes` gates the close
+negative. Library Signals does not yet report this row because the library
+presentation model still unwraps containment to bare strings at individual row
+properties rather than carrying `InertString` through the complete model.
+Reporting a library-wide result before that migration would overstate its
+coverage.
+
 ## Build Audit Fields
 
 ### Deterministic

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -132,7 +132,10 @@ gates full-effective discovery;
 `LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure`
 gates direct/closure identity deduplication; and
 `LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
-gates visible traversal failure.
+gates visible traversal failure for absolute and bare relative library paths.
+`PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`
+gates clean diagnostics, healthy partial results, and nonzero completion for
+survey-mode traversal failure.
 
 ## Build Audit Fields
 

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -4,9 +4,11 @@ The `Signals` section reports package and library observations. It is an evidenc
 
 ```bash
 dotnet-inspect library System.Text.Json -S Signals
+dotnet-inspect library System.Text.Json -S "Signals,Audit: Identifier Confusion"
 dotnet-inspect library System.Text.Json -S "Signals,SourceLink: Availability,SourceLink: Missing Files"
 dotnet-inspect library System.Text.Json -S "SourceLink: Integrity"
 dotnet-inspect package System.Text.Json -S Signals
+dotnet-inspect package System.Text.Json -S "Signals,Audit: Identifier Confusion"
 dotnet-inspect package System.Text.Json -S "SourceLink: Availability,SourceLink: Missing Files"
 dotnet-inspect package System.Text.Json -S "SourceLink: Integrity"
 ```
@@ -69,6 +71,50 @@ presentation model still unwraps containment to bare strings at individual row
 properties rather than carrying `InertString` through the complete model.
 Reporting a library-wide result before that migration would overstate its
 coverage.
+
+## Identifier confusion
+
+Library and package Signals include an `Identifier confusion` row. The package
+scope covers the selected package ID, alternate package ID, dependency IDs,
+runtime dependency IDs, and RID companion-package IDs. The library scope covers
+the assembly name plus direct and transitive assembly-reference names.
+
+| Value | Meaning |
+| ----- | ------- |
+| `None` | Every identifier inspected in that scope uses only ASCII characters. |
+| `Detected` | At least one inspected identifier contains a non-ASCII character. Evidence reports counts and any confirmed reserved prefixes. |
+
+The detector first applies a non-ASCII filter. It then compares the leading
+characters of each candidate with `System`, `Microsoft`, and `Azure`. A raw
+Levenshtein similarity of at least 80% opens a bounded Greek/Cyrillic homoglyph
+check; the stronger `reserved-prefix homoglyph` classification is emitted only
+when each differing prefix character maps to the corresponding ASCII character.
+This is a deliberately high-confidence catalog, not an implementation of the
+complete Unicode confusables table. A non-ASCII identifier can therefore carry
+only the general classification, including when several substitutions lower
+the raw similarity below the threshold.
+
+Select `Audit: Identifier Confusion` for the detected cases, or select
+`@Audit` to include them with the other audit evidence:
+
+```bash
+dotnet-inspect library X -S "Signals,Audit: Identifier Confusion"
+dotnet-inspect package X -S "Signals,Audit: Identifier Confusion"
+```
+
+The detail table reports `Location`, `Kind`, `Concern`, `Reserved Prefix`,
+`Similarity`, and `Characters`. `Characters` contains code-point evidence such
+as `U+0405→S`; neither the Signal nor the audit rows repeat the identifier.
+The filter is scoped to identifiers, so it does not reject ordinary non-English
+prose. An ASCII backslash is not non-ASCII and does not trigger this audit or
+artifact-text containment.
+
+`IdentifierConfusionDetectorTests` gates the similarity threshold, confirmed
+homoglyphs, generic non-ASCII cases, and ASCII close negatives.
+`PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`
+gates the content-free Markdown and JSONL shapes, and
+`PackageAudit_InspectsPackageAndDependencyIdentifierLocations` plus
+`LibraryAudit_InspectsAssemblyAndReferenceNames` gate the two identifier scopes.
 
 ## Build Audit Fields
 

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -88,6 +88,7 @@ rather than entering Signals.
 | ----- | ------- |
 | `None` | Every identifier inspected in that scope uses only ASCII characters. |
 | `Detected` | At least one inspected identifier contains a non-ASCII character. Evidence reports counts and any confirmed reserved prefixes. |
+| `Unavailable` | Required assembly-reference metadata could not be inspected. The command returns nonzero rather than claiming a clean identity scope. |
 
 The detector first applies a non-ASCII filter. It then compares the leading
 characters of each candidate with `System`, `Microsoft`, and `Azure`. A raw
@@ -106,6 +107,10 @@ Select `Audit: Identifier Confusion` for the detected cases, or select
 dotnet-inspect library X -S "Audit: Identifier Confusion"
 dotnet-inspect package X -S "Signals,Audit: Identifier Confusion"
 ```
+
+For remotely acquired packages, the package audit performs bounded registry
+metadata acquisition so that alternate package IDs are part of the declared
+scope even when the identifier audit is selected by itself.
 
 The detail table reports `Location`, `Kind`, `Concern`, `Reserved Prefix`,
 `Similarity`, and `Characters`. `Characters` contains code-point evidence such
@@ -136,6 +141,15 @@ gates visible traversal failure for absolute and bare relative library paths.
 `PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`
 gates clean diagnostics, healthy partial results, and nonzero completion for
 survey-mode traversal failure.
+`LibraryIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded`
+and
+`PackageAllLibrariesIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded`
+gate visible root AssemblyRef decode failure without a false `None` result.
+`LibraryReferenceTree_ReadFailureDiagnosticIsContentFree` gates the same
+content-free failure category on the public reference-tree projection.
+`PackagePipeline_IdentifierConfusionAudit_DemandsRegistrationMetadata` and
+`InspectAsync_IdentifierAuditMetadataIncludesAlternatePackageId` gate the
+alternate-package metadata demand, producer result, and moderated network cost.
 
 ## Build Audit Fields
 

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -139,6 +139,10 @@ gates nonzero failure propagation when Signals effective discovery cannot
 inspect direct references;
 `LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure`
 gates direct/closure identity deduplication;
+`LibraryAudit_PreservesCaseDistinctResolvedNames` gates case-distinct
+direct/closure suppression, while
+`LibraryIdentifierConfusionAudit_PreservesCaseDistinctUnresolvedReferences`
+gates preservation of those spellings through traversal;
 `LibraryIdentifierConfusionAudit_DeduplicatesDiamondClosure` gates one
 projection row per resolved identity when several reference paths converge;
 and
@@ -162,12 +166,20 @@ content-free failure category on the public reference-tree projection.
 alternate-package metadata demand, producer result, and moderated network cost.
 `InspectAsync_IdentifierAuditMetadataFailureRemainsVisible` gates an
 `Unavailable` result when that registry metadata cannot be established;
+`FetchAllMetadataAsync_SearchDeprecationMustMatchRequestedVersion` gates
+version-specific authority for search deprecation metadata, and
+`FetchAllMetadataAsync_IgnoresMalformedCatalogReference` gates retry after a
+malformed catalog reference;
 `PackageCommand_IdentifierMetadataFailureIsNonzero` gates nonzero completion
 and content-free diagnostics for that failure;
 `MultiPackageCount_CountsSelectedAuditRows` gates scalar counts against the
 selected audit rows rather than unrelated package-info fields; and
 `MultiPackageCount_PreservesSelectedSectionMap` plus
 `MultiPackageCount_PreservesFixedOverviewMap` gate multi-section count maps.
+`Package_MultiplePackages_FixedOverviewCountPopulatesSections` gates the
+command path that supplies those fixed-overview sections, and
+`LibraryPackageSignals_FullEffectiveDiscoveryWarnsOnce` gates one diagnostic
+per package effective-discovery failure.
 `LibraryCommand_SelectedReferences_TreeDedupUsesShallowestPath` gates
 minimum-depth canonicalization under a bounded reference traversal.
 

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -91,14 +91,14 @@ rather than entering Signals.
 | `Unavailable` | Required assembly-reference metadata could not be inspected. The command returns nonzero rather than claiming a clean identity scope. |
 
 The detector first applies a non-ASCII filter. It then compares the leading
-characters of each candidate with `System`, `Microsoft`, and `Azure`. A raw
-Levenshtein similarity of at least 80% opens a bounded Greek/Cyrillic homoglyph
-check; the stronger `reserved-prefix homoglyph` classification is emitted only
-when each differing prefix character maps to the corresponding ASCII character.
-This is a deliberately high-confidence catalog, not an implementation of the
-complete Unicode confusables table. A non-ASCII identifier can therefore carry
-only the general classification, including when several substitutions lower
-the raw similarity below the threshold.
+characters of each candidate with `System`, `Microsoft`, and `Azure`. The
+stronger `reserved-prefix homoglyph` classification is emitted only when every
+prefix character is either the corresponding ASCII character or maps to it
+through the bounded Greek/Cyrillic homoglyph catalog. The reported similarity
+is raw Levenshtein evidence, not a classification gate. This is a deliberately
+high-confidence catalog, not an implementation of the complete Unicode
+confusables table. Additional confirmed substitutions therefore cannot remove
+an otherwise exact folded reserved-prefix match.
 
 Select `Audit: Identifier Confusion` for the detected cases, or select
 `@Audit` to include them with the other audit evidence:
@@ -110,7 +110,10 @@ dotnet-inspect package X -S "Signals,Audit: Identifier Confusion"
 
 For remotely acquired packages, the package audit performs bounded registry
 metadata acquisition so that alternate package IDs are part of the declared
-scope even when the identifier audit is selected by itself.
+scope even when the identifier audit is selected by itself. When a valid feed
+advertises no deprecation metadata resource, local package identifiers remain
+authoritative and Signals discloses that the alternate-package scope was not
+available from that source.
 
 The detail table reports `Location`, `Kind`, `Concern`, `Reserved Prefix`,
 `Similarity`, and `Characters`. `Characters` contains code-point evidence such
@@ -122,8 +125,9 @@ The filter is scoped to identifiers, so it does not reject ordinary non-English
 prose. An ASCII backslash is not non-ASCII and does not trigger this audit or
 artifact-text containment.
 
-`IdentifierConfusionDetectorTests` gates the similarity threshold, confirmed
-homoglyphs, generic non-ASCII cases, and ASCII close negatives.
+`IdentifierConfusionDetectorTests` gates single and multiple confirmed
+homoglyphs, raw similarity evidence, generic non-ASCII cases, and ASCII close
+negatives.
 `PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`
 gates the content-free Markdown and JSONL shapes, and
 `PackageAudit_InspectsPackageAndDependencyIdentifierLocations` plus
@@ -150,6 +154,8 @@ and
 gates traversal of distinct typed AssemblyRefs that share a simple name;
 `LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
 gates visible traversal failure for absolute and bare relative library paths.
+That test also gates preservation of healthy `@Audit` sections when the
+identifier-confusion member fails.
 `PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`
 gates clean diagnostics, healthy partial results, and nonzero completion for
 survey-mode traversal failure.
@@ -166,6 +172,10 @@ content-free failure category on the public reference-tree projection.
 alternate-package metadata demand, producer result, and moderated network cost.
 `InspectAsync_IdentifierAuditMetadataFailureRemainsVisible` gates an
 `Unavailable` result when that registry metadata cannot be established;
+`FetchAllMetadataAsync_FlatContainerOnlyCompletesOptionalMetadata` and
+`PackageCommand_FlatContainerOnlyPreservesLocalIdentifierDetection` gate that a
+feed which does not advertise optional deprecation endpoints is complete rather
+than failed;
 `FetchAllMetadataAsync_SearchDeprecationMustMatchRequestedVersion` gates
 version-specific authority for search deprecation metadata, and
 `FetchAllMetadataAsync_IgnoresMalformedCatalogReference` gates retry after a

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -134,8 +134,13 @@ gates the explicit library producer demand;
 gates the survey-mode producer demand;
 `LibraryIdentifierConfusionAudit_FullEffectiveDiscoveryIncludesTransitiveOnlyConcern`
 gates full-effective discovery;
+`LibrarySignals_FullEffectiveDiscoveryPropagatesReferenceFailure`
+gates nonzero failure propagation when Signals effective discovery cannot
+inspect direct references;
 `LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure`
 gates direct/closure identity deduplication; and
+`AssemblyReferenceTreeResolutionTests.DistinctSameNameReferences_DoNotSuppressResolvableIdentity`
+gates traversal of distinct typed AssemblyRefs that share a simple name;
 `LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
 gates visible traversal failure for absolute and bare relative library paths.
 `PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`

--- a/docs/assembly-audit.md
+++ b/docs/assembly-audit.md
@@ -110,6 +110,9 @@ dotnet-inspect package X -S "Signals,Audit: Identifier Confusion"
 The detail table reports `Location`, `Kind`, `Concern`, `Reserved Prefix`,
 `Similarity`, and `Characters`. `Characters` contains code-point evidence such
 as `U+0405→S`; neither the Signal nor the audit rows repeat the identifier.
+Transitive rows use the audit-scoped
+`IdentifierConfusionReferenceClosure[index].Name` location rather than naming
+the separately selected public reference-tree projection.
 The filter is scoped to identifiers, so it does not reject ordinary non-English
 prose. An ASCII backslash is not non-ASCII and does not trigger this audit or
 artifact-text containment.
@@ -121,7 +124,15 @@ gates the content-free Markdown and JSONL shapes, and
 `PackageAudit_InspectsPackageAndDependencyIdentifierLocations` plus
 `LibraryAudit_InspectsAssemblyAndReferenceNames` gate the typed identifier
 scopes. `LibraryIdentifierConfusionAudit_CollectsDirectAndTransitiveReferenceNames`
-gates the explicit library producer demand.
+gates the explicit library producer demand;
+`PackageAllLibrariesIdentifierConfusionAudit_CollectsTransitiveReferences`
+gates the survey-mode producer demand;
+`LibraryIdentifierConfusionAudit_FullEffectiveDiscoveryIncludesTransitiveOnlyConcern`
+gates full-effective discovery;
+`LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure`
+gates direct/closure identity deduplication; and
+`LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
+gates visible traversal failure.
 
 ## Build Audit Fields
 

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -171,6 +171,10 @@ restoration. An audit can therefore aggregate categories without importing the
 decoder or retaining a second raw copy. `RequiredContainment` is exactly
 `Concerns != None`; a literal backslash may affect `VisualForm` to preserve
 invertibility but contributes no concern.
+The package presentation boundary also records the model-field location when a
+source value first becomes an `InertString`. That provenance is kept separately
+from the payload, so `Audit: Artifact Text` can list locations and category
+kinds without retaining or redisplaying artifact content.
 `Concerns_SurviveCompositionRestorationAndBounding` and
 `Concerns_RespectThePolicyThatProducedTheValue` gate that propagation, and
 `Concerns_ClassifyWhyContainmentOccurred` gates the categories.

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -685,6 +685,17 @@ edit. Category rules cannot catch it and none should, since refusing every
 non-Latin letter would break most of the world's text. A corpus containing only
 what the policies catch would quietly imply they are sufficient.
 
+The identifier audit handles that boundary separately from `TextPolicy`.
+Package IDs and assembly names have an identity role in which non-ASCII
+characters are useful evidence even though they are safe graphic text. The
+audit therefore reports every non-ASCII identifier and gives high-similarity
+`System`, `Microsoft`, and `Azure` candidates a bounded Greek/Cyrillic
+homoglyph classification. It does not change or contain the value, and it never
+echoes the identifier in the Signal or audit rows. Keeping this discriminator
+separate means `TextConcern` continues to answer whether rendering required
+containment while the identifier concern answers whether an identity deserves
+review.
+
 ## Placement
 
 `InertText` sits below every other project and references nothing. Every assembly

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -163,6 +163,18 @@ that assumes the payload is dangerous and the wrapper is what holds it back. Her
 the payload is already inert. Losing the wrapper loses provenance, not
 protection.
 
+`TextConcern` retains why visual containment occurred: control, format/bidi,
+unpaired surrogate, line separator, or paragraph separator. The flags are
+captured while the untreated scalar is available and travel with the
+`InertString` through composition, policy tightening, bounding, and persistence
+restoration. An audit can therefore aggregate categories without importing the
+decoder or retaining a second raw copy. `RequiredContainment` is exactly
+`Concerns != None`; a literal backslash may affect `VisualForm` to preserve
+invertibility but contributes no concern.
+`Concerns_SurviveCompositionRestorationAndBounding` and
+`Concerns_RespectThePolicyThatProducedTheValue` gate that propagation, and
+`Concerns_ClassifyWhyContainmentOccurred` gates the categories.
+
 ## Where text becomes inert
 
 The tempting answer is "as early as possible": have every API that returns

--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -688,7 +688,7 @@ what the policies catch would quietly imply they are sufficient.
 The identifier audit handles that boundary separately from `TextPolicy`.
 Package IDs and assembly names have an identity role in which non-ASCII
 characters are useful evidence even though they are safe graphic text. The
-audit therefore reports every non-ASCII identifier and gives high-similarity
+audit therefore reports every non-ASCII identifier and gives exact folded
 `System`, `Microsoft`, and `Azure` candidates a bounded Greek/Cyrillic
 homoglyph classification. It does not change or contain the value, and it never
 echoes the identifier in the Signal or audit rows. Keeping this discriminator

--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -378,7 +378,7 @@ The library command's current authored ownership is:
 | --- | --- |
 | `@Library` | `Library Info`, `Inspection Failures`, `References`, `Signals`, `Symbols` |
 | `@Surface` | `Async Methods`, `Custom Attributes`, `Extension Methods`, `Resources`, `Switches`, `Type Forwarders`, `Union Types`, `P/Invoke Methods` |
-| `@Audit` | `Unsafe Members`, `P/Invoke Methods`, `Non-normalized Paths`, `SourceLink: Diagnostics`, `Signals`, `Symbols` |
+| `@Audit` | `Unsafe Members`, `P/Invoke Methods`, `Non-normalized Paths`, `SourceLink: Diagnostics`, `Signals`, `Audit: Identifier Confusion`, `Symbols` |
 | `@Performance` | All `Performance:*` sections, `Array Pool Escapes`, `Top Leverage` |
 | `@SourceLink` | All `SourceLink:*` sections |
 | `@Integrations` | All integration sections |
@@ -397,7 +397,7 @@ The package command's current authored ownership is:
 | `@Package` | `Package Info`, `Signals`, `Statistics`, `Target Frameworks`, `Signature`, `Dependencies`, `Vulnerabilities`, `Manifest`, `Runtime Dependencies`, `Package files` |
 | `@Files` | `Package nuspec file`, `Package README file`, `Package skill files` |
 | `@Dependencies` | `Dependencies`, `Runtime Dependencies` |
-| `@Audit` | `Signals`, `Signature`, `Vulnerabilities`, `SourceLink: Availability`, `SourceLink: Missing Files`, `SourceLink: Integrity` |
+| `@Audit` | `Signals`, `Audit: Artifact Text`, `Audit: Identifier Confusion`, `Signature`, `Vulnerabilities`, `SourceLink: Availability`, `SourceLink: Missing Files`, `SourceLink: Integrity` |
 | `@SourceLink` | All `SourceLink:*` sections |
 
 `@Package` and `@Files` are base categories. The remaining categories are

--- a/docs/design/section-model.md
+++ b/docs/design/section-model.md
@@ -108,9 +108,9 @@ Domain categories can overlap base categories. For example, `Signals`,
 participating in `@Audit`.
 
 At package scope, `@Dependencies` groups direct and runtime-specific package
-dependencies, while `@Audit` cross-lists package signals, signing,
-vulnerabilities, and SourceLink integrity evidence. `@SourceLink` remains a
-separate provenance domain.
+dependencies, while `@Audit` cross-lists package signals, artifact-text concern
+locations, signing, vulnerabilities, and SourceLink integrity evidence.
+`@SourceLink` remains a separate provenance domain.
 
 ### Category doors
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1047,6 +1047,8 @@ and code points without echoing identifier content.
 `IdentifierConfusionDetectorTests` gates the detector boundary, including
 monotone classification when several confirmed homoglyphs compose one reserved
 prefix,
+`DescribeCharacters_DeduplicatesRepeatedHomoglyphCodePoints` gates stable
+code-point rendering when one substitution occurs more than once,
 `LibraryIdentifierConfusionAudit_CollectsDirectAndTransitiveReferenceNames`
 gates the direct library producer demand,
 `PackageAllLibrariesIdentifierConfusionAudit_CollectsTransitiveReferences`
@@ -1068,6 +1070,8 @@ gates distinct typed AssemblyRefs that share a simple name,
 `LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
 gates visible traversal failure for absolute and bare relative library paths,
 including preservation of the other selected `@Audit` sections,
+`LibraryPackageIdentifierConfusionAudit_FailsWithoutPartialDocument` gates the
+same content-free hard failure for an exact package-backed library selection,
 `PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`
 gates clean diagnostics, healthy partial results, and nonzero completion for
 survey-mode traversal failure,
@@ -1095,7 +1099,15 @@ absent alternate ID.
 complement: absence of optional deprecation resources in a valid service index
 is not an acquisition failure.
 `FetchAllMetadataAsync_SearchDeprecationMustMatchRequestedVersion` gates
-version-specific authority for search deprecation metadata, and
+version-specific authority for search deprecation metadata;
+`FetchAllMetadataAsync_DoesNotCacheMismatchedSearchVersion` gates retry after
+that mismatch, while
+`FetchAllMetadataAsync_CachesMatchingSearchVersionWithoutDeprecation` and
+`FetchAllMetadataAsync_CachesCatalogAuthorityDespiteSearchVersionMismatch`
+gate authoritative absence and catalog precedence;
+`FetchAllMetadataAsync_DoesNotCacheMismatchedInlineCatalogIdentity` and
+`FetchAllMetadataAsync_DoesNotCacheMismatchedFetchedCatalogIdentity` gate the
+same identity and retry contract for both catalog forms; and
 `FetchAllMetadataAsync_IgnoresMalformedCatalogReference` gates retry after a
 malformed catalog reference.
 `PackageCommand_IdentifierMetadataFailureIsNonzero` gates nonzero completion

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1055,13 +1055,17 @@ gates full-effective discovery,
 gates nonzero failure propagation through Signals effective discovery,
 `LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure`
 gates direct/closure identity deduplication,
+`LibraryIdentifierConfusionAudit_DeduplicatesDiamondClosure` gates one
+projection row per resolved identity when several reference paths converge,
 `AssemblyReferenceTreeResolutionTests.DistinctSameNameReferences_DoNotSuppressResolvableIdentity`
 gates distinct typed AssemblyRefs that share a simple name,
 `LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
 gates visible traversal failure for absolute and bare relative library paths,
 `PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`
 gates clean diagnostics, healthy partial results, and nonzero completion for
-survey-mode traversal failure, and
+survey-mode traversal failure,
+`LibraryCommand_TfmAll_PreservesHealthyIdentifierAuditResults` gates the same
+per-source outcome contract across target frameworks, and
 `LibraryIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded`
 plus
 `PackageAllLibrariesIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded`
@@ -1075,7 +1079,18 @@ diagnostic contract on the public reference-tree projection.
 `PackagePipeline_IdentifierConfusionAudit_DemandsRegistrationMetadata` plus
 `InspectAsync_IdentifierAuditMetadataIncludesAlternatePackageId` gate the
 alternate-package metadata demand, producer result, and moderated network
-cost, and
+cost. `InspectAsync_IdentifierAuditMetadataFailureRemainsVisible` gates an
+`Unavailable` result when registry acquisition cannot establish
+alternate-package metadata; a failed acquisition is not interpreted as an
+absent alternate ID.
+`PackageCommand_IdentifierMetadataFailureIsNonzero` gates nonzero completion
+and content-free diagnostics for that failure.
+`MultiPackageCount_CountsSelectedAuditRows` gates scalar counts against the
+selected audit rows rather than unrelated package-info fields;
+`MultiPackageCount_PreservesSelectedSectionMap` plus
+`MultiPackageCount_PreservesFixedOverviewMap` gate multi-section count maps;
+`LibraryCommand_SelectedReferences_TreeDedupUsesShallowestPath` gates
+minimum-depth canonicalization under a bounded reference traversal; and
 `PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`
 gates content-free Markdown and structured output.
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1051,8 +1051,12 @@ gates the direct library producer demand,
 gates survey-mode demand,
 `LibraryIdentifierConfusionAudit_FullEffectiveDiscoveryIncludesTransitiveOnlyConcern`
 gates full-effective discovery,
+`LibrarySignals_FullEffectiveDiscoveryPropagatesReferenceFailure`
+gates nonzero failure propagation through Signals effective discovery,
 `LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure`
 gates direct/closure identity deduplication,
+`AssemblyReferenceTreeResolutionTests.DistinctSameNameReferences_DoNotSuppressResolvableIdentity`
+gates distinct typed AssemblyRefs that share a simple name,
 `LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
 gates visible traversal failure for absolute and bare relative library paths,
 `PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1013,15 +1013,20 @@ structure and must not interpret inspected text as authority.
 > caller, while refusing is a policy only a caller can choose — but it means the
 > trust axis currently exists only where a command line can express it.
 
-The package inspection path now has the enabling boundary, but not the policy:
+The package inspection path now has the enabling boundary and a bounded audit
+summary, but not the refusal policy:
 `PackageInspectionText` carries every package-model text field to Markdown,
 direct JSON, and focused package table/JSONL metadata as `InertString`;
 content-output rows do the same for their package, version, and path framing.
 `InspectionResultView.RequiredContainment` reports the inspection model's
-aggregate before a sink unwraps it. Explicit document payloads remain raw by
-contract. This is intentionally not a global CLI signal. Other commands and
-projections still have their own presentation models, so adopting the flags at
-the root today would claim coverage they do not have.
+aggregate before a sink unwraps it, and package `Signals` reports whether that
+aggregate is empty plus its `TextConcern` category kinds. It reports no content
+or locations, so it is not the survey mode described below. Explicit document
+payloads remain raw by contract.
+`PackageSignals_ReportsEveryArtifactTextConcernKindWithoutContent` gates the
+reporting boundary. This is intentionally not a global CLI signal. Other
+commands and projections still have their own presentation models, so adopting
+the flags at the root today would claim coverage they do not have.
 
 Presentation is **two orthogonal decisions**, and collapsing them into one flag
 is a design error.

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1031,6 +1031,18 @@ summary and detail reporting boundaries. This is intentionally not a global CLI 
 commands and projections still have their own presentation models, so adopting
 the flags at the root today would claim coverage they do not have.
 
+Identifier confusion is a separate semantic risk from rendering. Package IDs
+and assembly names containing non-ASCII characters remain safe to carry as
+graphic text, so `TextConcern` correctly stays empty. Package and library
+Signals nevertheless report those identifiers for review, and a bounded
+high-similarity check confirms Greek/Cyrillic homoglyphs in the ecosystem
+prefixes `System`, `Microsoft`, and `Azure`. The explicit
+`Audit: Identifier Confusion` section exposes model locations, classifications,
+matched prefixes, similarity, and code points without echoing identifier
+content. `IdentifierConfusionDetectorTests` gates the detector boundary and
+`PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`
+gates content-free Markdown and structured output.
+
 Presentation is **two orthogonal decisions**, and collapsing them into one flag
 is a design error.
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1037,14 +1037,16 @@ Identifier confusion is a separate semantic risk from rendering. Package IDs
 and assembly names containing non-ASCII characters remain safe to carry as
 graphic text, so `TextConcern` correctly stays empty. Package Signals and
 library Signals over the selected assembly plus direct references nevertheless
-report those identifiers for review, and a bounded high-similarity check
-confirms Greek/Cyrillic homoglyphs in the ecosystem prefixes `System`,
+report those identifiers for review, and a bounded exact homoglyph fold
+confirms Greek/Cyrillic lookalikes in the ecosystem prefixes `System`,
 `Microsoft`, and `Azure`. The explicit library
 `Audit: Identifier Confusion` section additionally resolves the transitive
 reference closure; the unbounded traversal requires that explicit gesture. The
 section exposes model locations, classifications, matched prefixes, similarity,
 and code points without echoing identifier content.
-`IdentifierConfusionDetectorTests` gates the detector boundary,
+`IdentifierConfusionDetectorTests` gates the detector boundary, including
+monotone classification when several confirmed homoglyphs compose one reserved
+prefix,
 `LibraryIdentifierConfusionAudit_CollectsDirectAndTransitiveReferenceNames`
 gates the direct library producer demand,
 `PackageAllLibrariesIdentifierConfusionAudit_CollectsTransitiveReferences`
@@ -1065,6 +1067,7 @@ projection row per resolved identity when several reference paths converge,
 gates distinct typed AssemblyRefs that share a simple name,
 `LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
 gates visible traversal failure for absolute and bare relative library paths,
+including preservation of the other selected `@Audit` sections,
 `PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`
 gates clean diagnostics, healthy partial results, and nonzero completion for
 survey-mode traversal failure,
@@ -1087,6 +1090,10 @@ cost. `InspectAsync_IdentifierAuditMetadataFailureRemainsVisible` gates an
 `Unavailable` result when registry acquisition cannot establish
 alternate-package metadata; a failed acquisition is not interpreted as an
 absent alternate ID.
+`FetchAllMetadataAsync_FlatContainerOnlyCompletesOptionalMetadata` and
+`PackageCommand_FlatContainerOnlyPreservesLocalIdentifierDetection` gate the
+complement: absence of optional deprecation resources in a valid service index
+is not an acquisition failure.
 `FetchAllMetadataAsync_SearchDeprecationMustMatchRequestedVersion` gates
 version-specific authority for search deprecation metadata, and
 `FetchAllMetadataAsync_IgnoresMalformedCatalogReference` gates retry after a

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1020,11 +1020,14 @@ direct JSON, and focused package table/JSONL metadata as `InertString`;
 content-output rows do the same for their package, version, and path framing.
 `InspectionResultView.RequiredContainment` reports the inspection model's
 aggregate before a sink unwraps it, and package `Signals` reports whether that
-aggregate is empty plus its `TextConcern` category kinds. It reports no content
-or locations, so it is not the survey mode described below. Explicit document
-payloads remain raw by contract.
-`PackageSignals_ReportsEveryArtifactTextConcernKindWithoutContent` gates the
-reporting boundary. This is intentionally not a global CLI signal. Other
+aggregate is empty plus its `TextConcern` category kinds. The explicit
+`Audit: Artifact Text` section lists package-model field locations and concern
+kinds, but never the field values. It is not the scalar-by-scalar refusal survey
+mode described below: it reports one row per contained presentation field and
+does not change rendering policy. Explicit document payloads remain raw by
+contract. `PackageSignals_ReportsEveryArtifactTextConcernKindWithoutContent`
+and `PackageArtifactTextAudit_ListsLocationsAndKindsInMarkdownAndJsonl` gate the
+summary and detail reporting boundaries. This is intentionally not a global CLI signal. Other
 commands and projections still have their own presentation models, so adopting
 the flags at the root today would claim coverage they do not have.
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1026,20 +1026,27 @@ kinds, but never the field values. It is not the scalar-by-scalar refusal survey
 mode described below: it reports one row per contained presentation field and
 does not change rendering policy. Explicit document payloads remain raw by
 contract. `PackageSignals_ReportsEveryArtifactTextConcernKindWithoutContent`
-and `PackageArtifactTextAudit_ListsLocationsAndKindsInMarkdownAndJsonl` gate the
-summary and detail reporting boundaries. This is intentionally not a global CLI signal. Other
-commands and projections still have their own presentation models, so adopting
-the flags at the root today would claim coverage they do not have.
+and `Package_MultiplePackages_SignalsIncludePackageFileConcerns` gate the
+summary across single-package and survey modes;
+`PackageArtifactTextAudit_ListsLocationsAndKindsInMarkdownAndJsonl` gates the
+detail reporting boundary. This is intentionally not a global CLI signal.
+Other commands and projections still have their own presentation models, so
+adopting the flags at the root today would claim coverage they do not have.
 
 Identifier confusion is a separate semantic risk from rendering. Package IDs
 and assembly names containing non-ASCII characters remain safe to carry as
-graphic text, so `TextConcern` correctly stays empty. Package and library
-Signals nevertheless report those identifiers for review, and a bounded
-high-similarity check confirms Greek/Cyrillic homoglyphs in the ecosystem
-prefixes `System`, `Microsoft`, and `Azure`. The explicit
-`Audit: Identifier Confusion` section exposes model locations, classifications,
-matched prefixes, similarity, and code points without echoing identifier
-content. `IdentifierConfusionDetectorTests` gates the detector boundary and
+graphic text, so `TextConcern` correctly stays empty. Package Signals and
+library Signals over the selected assembly plus direct references nevertheless
+report those identifiers for review, and a bounded high-similarity check
+confirms Greek/Cyrillic homoglyphs in the ecosystem prefixes `System`,
+`Microsoft`, and `Azure`. The explicit library
+`Audit: Identifier Confusion` section additionally resolves the transitive
+reference closure; the unbounded traversal requires that explicit gesture. The
+section exposes model locations, classifications, matched prefixes, similarity,
+and code points without echoing identifier content.
+`IdentifierConfusionDetectorTests` gates the detector boundary,
+`LibraryIdentifierConfusionAudit_CollectsDirectAndTransitiveReferenceNames`
+gates the library producer demand, and
 `PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`
 gates content-free Markdown and structured output.
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1054,7 +1054,10 @@ gates full-effective discovery,
 `LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure`
 gates direct/closure identity deduplication,
 `LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
-gates visible traversal failure, and
+gates visible traversal failure for absolute and bare relative library paths,
+`PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`
+gates clean diagnostics, healthy partial results, and nonzero completion for
+survey-mode traversal failure, and
 `PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`
 gates content-free Markdown and structured output.
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1046,7 +1046,15 @@ section exposes model locations, classifications, matched prefixes, similarity,
 and code points without echoing identifier content.
 `IdentifierConfusionDetectorTests` gates the detector boundary,
 `LibraryIdentifierConfusionAudit_CollectsDirectAndTransitiveReferenceNames`
-gates the library producer demand, and
+gates the direct library producer demand,
+`PackageAllLibrariesIdentifierConfusionAudit_CollectsTransitiveReferences`
+gates survey-mode demand,
+`LibraryIdentifierConfusionAudit_FullEffectiveDiscoveryIncludesTransitiveOnlyConcern`
+gates full-effective discovery,
+`LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure`
+gates direct/closure identity deduplication,
+`LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead`
+gates visible traversal failure, and
 `PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`
 gates content-free Markdown and structured output.
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1058,6 +1058,20 @@ gates visible traversal failure for absolute and bare relative library paths,
 `PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure`
 gates clean diagnostics, healthy partial results, and nonzero completion for
 survey-mode traversal failure, and
+`LibraryIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded`
+plus
+`PackageAllLibrariesIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded`
+gate visible root AssemblyRef decode failure without a success-shaped clean
+result. Traversal diagnostics retain caller-known command context, while survey
+warnings identify the package-relative library and a bounded failure category;
+neither repeats the AssemblyRef value, product-owned extraction path, or inner
+exception message.
+`LibraryReferenceTree_ReadFailureDiagnosticIsContentFree` gates that same
+diagnostic contract on the public reference-tree projection.
+`PackagePipeline_IdentifierConfusionAudit_DemandsRegistrationMetadata` plus
+`InspectAsync_IdentifierAuditMetadataIncludesAlternatePackageId` gate the
+alternate-package metadata demand, producer result, and moderated network
+cost, and
 `PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`
 gates content-free Markdown and structured output.
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1055,6 +1055,10 @@ gates full-effective discovery,
 gates nonzero failure propagation through Signals effective discovery,
 `LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure`
 gates direct/closure identity deduplication,
+`LibraryAudit_PreservesCaseDistinctResolvedNames` gates case-distinct
+direct/closure suppression, while
+`LibraryIdentifierConfusionAudit_PreservesCaseDistinctUnresolvedReferences`
+gates preservation of those spellings through traversal,
 `LibraryIdentifierConfusionAudit_DeduplicatesDiamondClosure` gates one
 projection row per resolved identity when several reference paths converge,
 `AssemblyReferenceTreeResolutionTests.DistinctSameNameReferences_DoNotSuppressResolvableIdentity`
@@ -1083,12 +1087,20 @@ cost. `InspectAsync_IdentifierAuditMetadataFailureRemainsVisible` gates an
 `Unavailable` result when registry acquisition cannot establish
 alternate-package metadata; a failed acquisition is not interpreted as an
 absent alternate ID.
+`FetchAllMetadataAsync_SearchDeprecationMustMatchRequestedVersion` gates
+version-specific authority for search deprecation metadata, and
+`FetchAllMetadataAsync_IgnoresMalformedCatalogReference` gates retry after a
+malformed catalog reference.
 `PackageCommand_IdentifierMetadataFailureIsNonzero` gates nonzero completion
 and content-free diagnostics for that failure.
 `MultiPackageCount_CountsSelectedAuditRows` gates scalar counts against the
 selected audit rows rather than unrelated package-info fields;
 `MultiPackageCount_PreservesSelectedSectionMap` plus
 `MultiPackageCount_PreservesFixedOverviewMap` gate multi-section count maps;
+`Package_MultiplePackages_FixedOverviewCountPopulatesSections` gates the
+command path that supplies those fixed-overview sections;
+`LibraryPackageSignals_FullEffectiveDiscoveryWarnsOnce` gates one diagnostic
+per package effective-discovery failure;
 `LibraryCommand_SelectedReferences_TreeDedupUsesShallowestPath` gates
 minimum-depth canonicalization under a bounded reference traversal; and
 `PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent`

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -156,6 +156,9 @@ public class AssemblyDependencyResolverTests
             Assert.Equal(
                 AssemblyBindingFailureKind.CandidateUnavailable,
                 selection.Failure.Kind);
+            Assert.Equal(
+                CandidateOpenFailureKind.InvalidImage,
+                selection.Failure.CandidateFailureKind);
         }
         finally
         {
@@ -201,6 +204,9 @@ public class AssemblyDependencyResolverTests
             Assert.Equal(
                 AssemblyBindingFailureKind.CandidateUnavailable,
                 selection.Failure.Kind);
+            Assert.Equal(
+                CandidateOpenFailureKind.InvalidImage,
+                selection.Failure.CandidateFailureKind);
         }
         finally
         {

--- a/src/DotnetInspector.Services.Tests/IdentifierConfusionDetectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/IdentifierConfusionDetectorTests.cs
@@ -1,0 +1,53 @@
+namespace DotnetInspector.Services.Tests;
+
+public class IdentifierConfusionDetectorTests
+{
+    [Theory]
+    [InlineData("System.Text.Json")]
+    [InlineData("Microsoft.Extensions.Logging")]
+    [InlineData("Azure.Core")]
+    [InlineData("Contoso.Utilities")]
+    [InlineData("System\\Text")]
+    public void AsciiIdentifiersHaveNoConcern(string identifier)
+        => Assert.Null(IdentifierConfusionDetector.Inspect(identifier));
+
+    [Theory]
+    [InlineData("Ѕystem.Text.Json", "System", 0x0405, 's')]
+    [InlineData("Micrοsoft.Extensions", "Microsoft", 0x03BF, 'o')]
+    [InlineData("Αzure.Core", "Azure", 0x0391, 'a')]
+    public void HighSimilarityReservedPrefixesReportConfirmedHomoglyphs(
+        string identifier,
+        string reservedPrefix,
+        int codePoint,
+        char looksLike)
+    {
+        IdentifierConfusion result = Assert.IsType<IdentifierConfusion>(
+            IdentifierConfusionDetector.Inspect(identifier));
+
+        Assert.Equal(
+            IdentifierConcern.NonAscii | IdentifierConcern.ReservedPrefixHomoglyph,
+            result.Concerns);
+        Assert.Equal([codePoint], result.NonAsciiCodePoints);
+        ReservedPrefixHomoglyphMatch match = Assert.IsType<ReservedPrefixHomoglyphMatch>(
+            result.ReservedPrefixMatch);
+        Assert.Equal(reservedPrefix, match.ReservedPrefix);
+        Assert.True(match.Similarity >= IdentifierConfusionDetector.MinimumReservedPrefixSimilarity);
+        Assert.Equal(new IdentifierHomoglyph(codePoint, looksLike), Assert.Single(match.Homoglyphs));
+    }
+
+    [Theory]
+    [InlineData("Systèm.Tools")]
+    [InlineData("Σystem.Tools")]
+    [InlineData("Δelta.Tools")]
+    [InlineData("Ѕyxtem.Tools")]
+    [InlineData("Ѕуѕtеm.Tools")]
+    public void OtherNonAsciiIdentifiersDoNotClaimAReservedPrefixHomoglyph(string identifier)
+    {
+        IdentifierConfusion result = Assert.IsType<IdentifierConfusion>(
+            IdentifierConfusionDetector.Inspect(identifier));
+
+        Assert.Equal(IdentifierConcern.NonAscii, result.Concerns);
+        Assert.NotEmpty(result.NonAsciiCodePoints);
+        Assert.Null(result.ReservedPrefixMatch);
+    }
+}

--- a/src/DotnetInspector.Services.Tests/IdentifierConfusionDetectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/IdentifierConfusionDetectorTests.cs
@@ -50,4 +50,13 @@ public class IdentifierConfusionDetectorTests
         Assert.NotEmpty(result.NonAsciiCodePoints);
         Assert.Null(result.ReservedPrefixMatch);
     }
+
+    [Fact]
+    public void NonAsciiEvidencePreservesFirstSeenDistinctOrder()
+    {
+        IdentifierConfusion result = Assert.IsType<IdentifierConfusion>(
+            IdentifierConfusionDetector.Inspect("Δelta.ΣΔЖΣ"));
+
+        Assert.Equal([0x0394, 0x03A3, 0x0416], result.NonAsciiCodePoints);
+    }
 }

--- a/src/DotnetInspector.Services.Tests/IdentifierConfusionDetectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/IdentifierConfusionDetectorTests.cs
@@ -31,8 +31,31 @@ public class IdentifierConfusionDetectorTests
         ReservedPrefixHomoglyphMatch match = Assert.IsType<ReservedPrefixHomoglyphMatch>(
             result.ReservedPrefixMatch);
         Assert.Equal(reservedPrefix, match.ReservedPrefix);
-        Assert.True(match.Similarity >= IdentifierConfusionDetector.MinimumReservedPrefixSimilarity);
+        Assert.True(match.Similarity > 0);
         Assert.Equal(new IdentifierHomoglyph(codePoint, looksLike), Assert.Single(match.Homoglyphs));
+    }
+
+    [Theory]
+    [InlineData("Ѕуѕtеm.Tools", "System", 4)]
+    [InlineData("Miсrοsoft.Tools", "Microsoft", 2)]
+    [InlineData("ΑΖurе.Tools", "Azure", 3)]
+    public void MultipleConfirmedHomoglyphsRemainReservedPrefixMatches(
+        string identifier,
+        string reservedPrefix,
+        int homoglyphCount)
+    {
+        IdentifierConfusion result = Assert.IsType<IdentifierConfusion>(
+            IdentifierConfusionDetector.Inspect(identifier));
+
+        ReservedPrefixHomoglyphMatch match =
+            Assert.IsType<ReservedPrefixHomoglyphMatch>(
+                result.ReservedPrefixMatch);
+        Assert.Equal(reservedPrefix, match.ReservedPrefix);
+        Assert.Equal(
+            1d - ((double)homoglyphCount / reservedPrefix.Length),
+            match.Similarity,
+            precision: 3);
+        Assert.Equal(homoglyphCount, match.Homoglyphs.Count);
     }
 
     [Theory]
@@ -40,7 +63,6 @@ public class IdentifierConfusionDetectorTests
     [InlineData("Σystem.Tools")]
     [InlineData("Δelta.Tools")]
     [InlineData("Ѕyxtem.Tools")]
-    [InlineData("Ѕуѕtеm.Tools")]
     public void OtherNonAsciiIdentifiersDoNotClaimAReservedPrefixHomoglyph(string identifier)
     {
         IdentifierConfusion result = Assert.IsType<IdentifierConfusion>(

--- a/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
@@ -477,6 +477,70 @@ public class PackageMetadataServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task FetchAllMetadataAsync_SearchDeprecationMustMatchRequestedVersion()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/query", "@type": "SearchQueryService/3.5.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("""
+                    {
+                      "catalogEntry":
+                        "/catalog/private.package.1.0.0.json"
+                    }
+                    """),
+                "/catalog/private.package.1.0.0.json" =>
+                    new HttpResponseMessage(
+                        System.Net.HttpStatusCode.BadGateway),
+                "/query" => Json("""
+                    {
+                      "data": [
+                        {
+                          "id": "Private.Package",
+                          "version": "2.0.0",
+                          "deprecation": {
+                            "reasons": ["Legacy"],
+                            "alternatePackage": {
+                              "id": "\u0405ystem.LatestOnly"
+                            }
+                          },
+                          "versions": [
+                            { "version": "1.0.0", "downloads": 1 },
+                            { "version": "2.0.0", "downloads": 2 }
+                          ]
+                        }
+                      ]
+                    }
+                    """),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+
+        PackageMetadata result =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                new HttpClient(handler),
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                forceLatest: true,
+                sourceOptions:
+                    new NuGetSourceOptions { Sources = [source] });
+
+        Assert.False(result.DeprecationMetadataAvailable);
+        Assert.Null(result.Deprecation);
+        Assert.Equal(1, result.VersionDownloads);
+    }
+
+    [Fact]
     public async Task FetchAllMetadataAsync_TriesEquivalentSearchEndpointsInOrder()
     {
         const string source = "https://private.example/v3/index.json";
@@ -1639,6 +1703,7 @@ public class PackageMetadataServiceTests : IDisposable
     public async Task FetchAllMetadataAsync_IgnoresMalformedCatalogReference()
     {
         const string source = "https://private.example/v3/index.json";
+        int registrationRequests = 0;
         var handler = new RoutingHandler(request =>
             request.RequestUri!.AbsolutePath switch
             {
@@ -1650,28 +1715,60 @@ public class PackageMetadataServiceTests : IDisposable
                       ]
                     }
                     """),
-                "/registration/private.package/1.0.0.json" => Json("""
+                "/registration/private.package/1.0.0.json" =>
+                    Registration(),
+                _ => throw new InvalidOperationException(
+                    "A malformed catalog reference must not be requested."),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata first = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+        PackageMetadata second = await PackageMetadataService.FetchAllMetadataAsync(
+            client,
+            "Private.Package",
+            "1.0.0",
+            log: null,
+            sourceOptions: options);
+
+        Assert.Equal(
+            new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero),
+            first.Published);
+        Assert.False(first.DeprecationMetadataAvailable);
+        Assert.True(second.DeprecationMetadataAvailable);
+        Assert.Equal(
+            "\u0405ystem.Fixed",
+            second.Deprecation!.AlternatePackageId);
+        Assert.True(registrationRequests > 1);
+
+        HttpResponseMessage Registration()
+        {
+            registrationRequests++;
+            return registrationRequests == 1
+                ? Json("""
                     {
                       "published": "2024-01-02T03:04:05Z",
                       "catalogEntry": "http://[::1"
                     }
-                    """),
-                _ => throw new InvalidOperationException(
-                    "A malformed catalog reference must not be requested."),
-            });
-
-        PackageMetadata result = await PackageMetadataService.FetchAllMetadataAsync(
-            new HttpClient(handler),
-            "Private.Package",
-            "1.0.0",
-            log: null,
-            sourceOptions: new NuGetSourceOptions { Sources = [source] });
-
-        Assert.Equal(
-            new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero),
-            result.Published);
-        Assert.False(result.DeprecationMetadataAvailable);
-        Assert.Equal(2, handler.Requests.Count);
+                    """)
+                : Json("""
+                    {
+                      "catalogEntry": {
+                        "deprecation": {
+                          "reasons": ["Legacy"],
+                          "alternatePackage": {
+                            "id": "\u0405ystem.Fixed"
+                          }
+                        }
+                      }
+                    }
+                    """);
+        }
     }
 
     [Fact]

--- a/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
@@ -541,6 +541,336 @@ public class PackageMetadataServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task FetchAllMetadataAsync_DoesNotCacheMismatchedSearchVersion()
+    {
+        const string source = "https://private.example/v3/index.json";
+        int searchRequests = 0;
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/query", "@type": "SearchQueryService/3.5.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" =>
+                    Json("{}"),
+                "/query" => Search(),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata first =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        PackageMetadata second =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.False(first.DeprecationMetadataAvailable);
+        Assert.True(second.DeprecationMetadataAvailable);
+        Assert.Equal(
+            "\u0405ystem.Fixed",
+            second.Deprecation!.AlternatePackageId);
+        Assert.Equal(2, searchRequests);
+
+        HttpResponseMessage Search()
+        {
+            searchRequests++;
+            string version =
+                searchRequests == 1 ? "2.0.0" : "1.0.0";
+            return Json($$"""
+                {
+                  "data": [
+                    {
+                      "id": "Private.Package",
+                      "version": "{{version}}",
+                      "deprecation": {
+                        "alternatePackage": {
+                          "id": "\u0405ystem.Fixed"
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+        }
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_CachesMatchingSearchVersionWithoutDeprecation()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/query", "@type": "SearchQueryService/3.5.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" =>
+                    Json("{}"),
+                "/query" => Json("""
+                    {
+                      "data": [
+                        {
+                          "id": "Private.Package",
+                          "version": "1.0.0"
+                        }
+                      ]
+                    }
+                    """),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata cold =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        int coldRequests = handler.Requests.Count;
+        PackageMetadata warm =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.True(cold.DeprecationMetadataAvailable);
+        Assert.True(warm.DeprecationMetadataAvailable);
+        Assert.Null(cold.Deprecation);
+        Assert.Null(warm.Deprecation);
+        Assert.Equal(coldRequests, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_CachesCatalogAuthorityDespiteSearchVersionMismatch()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/query", "@type": "SearchQueryService/3.5.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("""
+                    {
+                      "catalogEntry": {
+                        "id": "Private.Package",
+                        "version": "1.0.0"
+                      }
+                    }
+                    """),
+                "/query" => Json("""
+                    {
+                      "data": [
+                        {
+                          "id": "Private.Package",
+                          "version": "2.0.0"
+                        }
+                      ]
+                    }
+                    """),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata cold =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        int coldRequests = handler.Requests.Count;
+        PackageMetadata warm =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.True(cold.DeprecationMetadataAvailable);
+        Assert.True(warm.DeprecationMetadataAvailable);
+        Assert.Equal(coldRequests, handler.Requests.Count);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_DoesNotCacheMismatchedInlineCatalogIdentity()
+    {
+        const string source = "https://private.example/v3/index.json";
+        int registrationRequests = 0;
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" =>
+                    Registration(),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata first =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        PackageMetadata second =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.False(first.DeprecationMetadataAvailable);
+        Assert.Null(first.Deprecation);
+        Assert.True(second.DeprecationMetadataAvailable);
+        Assert.Equal(
+            "\u0405ystem.Fixed",
+            second.Deprecation!.AlternatePackageId);
+        Assert.Equal(2, registrationRequests);
+
+        HttpResponseMessage Registration()
+        {
+            registrationRequests++;
+            string version =
+                registrationRequests == 1 ? "2.0.0" : "1.0.0";
+            return Json($$"""
+                {
+                  "catalogEntry": {
+                    "id": "Private.Package",
+                    "version": "{{version}}",
+                    "deprecation": {
+                      "alternatePackage": {
+                        "id": "\u0405ystem.Fixed"
+                      }
+                    }
+                  }
+                }
+                """);
+        }
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_DoesNotCacheMismatchedFetchedCatalogIdentity()
+    {
+        const string source = "https://private.example/v3/index.json";
+        int catalogRequests = 0;
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("""
+                    {
+                      "catalogEntry":
+                        "/catalog/private.package.1.0.0.json"
+                    }
+                    """),
+                "/catalog/private.package.1.0.0.json" =>
+                    Catalog(),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata first =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        PackageMetadata second =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.False(first.DeprecationMetadataAvailable);
+        Assert.Null(first.Deprecation);
+        Assert.True(second.DeprecationMetadataAvailable);
+        Assert.Equal(
+            "\u0405ystem.Fixed",
+            second.Deprecation!.AlternatePackageId);
+        Assert.Equal(2, catalogRequests);
+
+        HttpResponseMessage Catalog()
+        {
+            catalogRequests++;
+            string id = catalogRequests == 1
+                ? "Different.Package"
+                : "Private.Package";
+            return Json($$"""
+                {
+                  "id": "{{id}}",
+                  "version": "1.0.0",
+                  "deprecation": {
+                    "alternatePackage": {
+                      "id": "\u0405ystem.Fixed"
+                    }
+                  }
+                }
+                """);
+        }
+    }
+
+    [Fact]
     public async Task FetchAllMetadataAsync_TriesEquivalentSearchEndpointsInOrder()
     {
         const string source = "https://private.example/v3/index.json";

--- a/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
@@ -735,8 +735,67 @@ public class PackageMetadataServiceTests : IDisposable
                 sourceOptions: options);
 
         Assert.Null(first.Deprecation);
+        Assert.False(first.DeprecationMetadataAvailable);
         Assert.Equal("Use a replacement.", second.Deprecation!.Message);
+        Assert.True(second.DeprecationMetadataAvailable);
         Assert.True(catalogRequests > 1);
+    }
+
+    [Fact]
+    public async Task FetchAllMetadataAsync_DoesNotCacheIndeterminateRegistration()
+    {
+        const string source = "https://private.example/v3/index.json";
+        int registrationRequests = 0;
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/registration/", "@type": "RegistrationsBaseUrl/3.6.0" },
+                        { "@id": "https://private.example/flat/", "@type": "PackageBaseAddress/3.0.0" },
+                        { "@id": "https://private.example/query", "@type": "SearchQueryService/3.5.0" }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" =>
+                    RegistrationFailure(),
+                "/flat/private.package/1.0.0/private.package.1.0.0.nupkg" =>
+                    Package(length: 42),
+                "/query" => Json("""{ "data": [] }"""),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+        var options = new NuGetSourceOptions { Sources = [source] };
+
+        PackageMetadata first =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+        int firstRegistrationRequests = registrationRequests;
+        PackageMetadata second =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions: options);
+
+        Assert.False(first.DeprecationMetadataAvailable);
+        Assert.False(second.DeprecationMetadataAvailable);
+        Assert.True(registrationRequests > firstRegistrationRequests);
+
+        HttpResponseMessage RegistrationFailure()
+        {
+            registrationRequests++;
+            return new HttpResponseMessage(
+                System.Net.HttpStatusCode.BadGateway);
+        }
     }
 
     [Fact]
@@ -1232,14 +1291,16 @@ public class PackageMetadataServiceTests : IDisposable
         using var client = new HttpClient(handler);
         var options = new NuGetSourceOptions { Sources = [source] };
 
-        _ = await PackageMetadataService.FetchAllMetadataAsync(
+        PackageMetadata cold =
+            await PackageMetadataService.FetchAllMetadataAsync(
             client,
             "Empty.Package",
             "1.0.0",
             log: null,
             sourceOptions: options);
         int coldRequests = handler.Requests.Count;
-        _ = await PackageMetadataService.FetchAllMetadataAsync(
+        PackageMetadata warm =
+            await PackageMetadataService.FetchAllMetadataAsync(
             client,
             "Empty.Package",
             "1.0.0",
@@ -1247,6 +1308,8 @@ public class PackageMetadataServiceTests : IDisposable
             sourceOptions: options);
 
         Assert.Equal(coldRequests, handler.Requests.Count);
+        Assert.False(cold.DeprecationMetadataAvailable);
+        Assert.False(warm.DeprecationMetadataAvailable);
     }
 
     [Fact]
@@ -1301,6 +1364,7 @@ public class PackageMetadataServiceTests : IDisposable
         string key = $"injection-{Guid.NewGuid():N}";
         var metadata = new PackageMetadata
         {
+            DeprecationMetadataAvailable = true,
             Owners = ["owner\nvulnerabilities:"],
             Deprecation = new PackageDeprecation
             {
@@ -1327,6 +1391,7 @@ public class PackageMetadataServiceTests : IDisposable
                 MetadataFieldCache.TryGetEntry(key));
 
         Assert.False(cached.IsAbsent);
+        Assert.True(cached.Metadata.DeprecationMetadataAvailable);
         Assert.Equal(metadata.Owners, cached.Metadata.Owners);
         Assert.Equal(
             metadata.Deprecation.Message,
@@ -1605,6 +1670,7 @@ public class PackageMetadataServiceTests : IDisposable
         Assert.Equal(
             new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero),
             result.Published);
+        Assert.False(result.DeprecationMetadataAvailable);
         Assert.Equal(2, handler.Requests.Count);
     }
 

--- a/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageMetadataServiceTests.cs
@@ -863,6 +863,54 @@ public class PackageMetadataServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task FetchAllMetadataAsync_FlatContainerOnlyCompletesOptionalMetadata()
+    {
+        const string source = "https://private.example/v3/index.json";
+        var handler = new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        { "@id": "https://private.example/flat/", "@type": "PackageBaseAddress/3.0.0" }
+                      ]
+                    }
+                    """),
+                "/flat/private.package/1.0.0/private.package.1.0.0.nupkg" =>
+                    Package(length: 42),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected metadata request: {request.RequestUri}"),
+            });
+        using var client = new HttpClient(handler);
+
+        PackageMetadata cold =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions:
+                    new NuGetSourceOptions { Sources = [source] });
+        int coldRequests = handler.Requests.Count;
+        PackageMetadata warm =
+            await PackageMetadataService.FetchAllMetadataAsync(
+                client,
+                "Private.Package",
+                "1.0.0",
+                log: null,
+                sourceOptions:
+                    new NuGetSourceOptions { Sources = [source] });
+
+        Assert.True(cold.DeprecationMetadataAvailable);
+        Assert.True(warm.DeprecationMetadataAvailable);
+        Assert.False(cold.DeprecationMetadataSupported);
+        Assert.False(warm.DeprecationMetadataSupported);
+        Assert.Null(cold.Deprecation);
+        Assert.Equal(coldRequests, handler.Requests.Count);
+    }
+
+    [Fact]
     public async Task FetchAllMetadataAsync_DoesNotCacheFailedSearchFetch()
     {
         const string source = "https://private.example/v3/index.json";

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -97,7 +97,7 @@ public sealed class AssemblyDependencyResolver :
     readonly AssemblyDependencyResolutionOptions _options;
     readonly ConcurrentDictionary<
         string,
-        Lazy<ResolvedAssemblyReference?>> _descriptors =
+        Lazy<AssemblyDescriptorResolution>> _descriptors =
             new(StringComparer.Ordinal);
     IReadOnlyList<ResolvedAssemblyDependency>? _resolved;
     IReadOnlyList<ResolvedAssemblyDependency>? _allCandidates;
@@ -248,7 +248,7 @@ public sealed class AssemblyDependencyResolver :
     {
         var candidates =
             _allCandidates ??= CollectDependencies(deduplicate: false);
-        bool candidateUnavailable = false;
+        CandidateOpenFailureKind? candidateFailure = null;
         CandidateTier? activeTier = null;
 
         foreach (var dependency in candidates)
@@ -264,24 +264,27 @@ public sealed class AssemblyDependencyResolver :
             if (activeTier is { } previousTier
                 && tier != previousTier)
             {
-                if (candidateUnavailable
+                if (candidateFailure is not null
                     || scope != AssemblyResolutionScope.Platform)
                 {
                     return new AssemblyResolutionAttempt(
                         Assembly: null,
-                        candidateUnavailable);
+                        candidateFailure);
                 }
             }
             activeTier = tier;
 
             bool allowVersionRollForward = scope == AssemblyResolutionScope.Platform
                 && _options.AllowPlatformAssemblyVersionRollForward;
-            ResolvedAssemblyReference? selected = Descriptor(
+            AssemblyDescriptorResolution descriptor = DescriptorResult(
                 dependency.Path,
                 ResolutionProvenance(dependency));
+            ResolvedAssemblyReference? selected = descriptor.Assembly;
             if (selected is null)
             {
-                candidateUnavailable = true;
+                candidateFailure ??=
+                    descriptor.FailureKind
+                    ?? CandidateOpenFailureKind.Unreadable;
                 continue;
             }
             if (!identity.MatchesCandidate(
@@ -294,14 +297,14 @@ public sealed class AssemblyDependencyResolver :
 
             return new AssemblyResolutionAttempt(
                 selected,
-                CandidateUnavailable: false);
+                CandidateFailure: null);
         }
 
-        if (candidateUnavailable)
+        if (candidateFailure is not null)
         {
             return new AssemblyResolutionAttempt(
                 Assembly: null,
-                CandidateUnavailable: true);
+                candidateFailure);
         }
 
         // The target may reference an older platform contract than the running
@@ -322,15 +325,18 @@ public sealed class AssemblyDependencyResolver :
                 useRuntimeAssemblies: _options.PreferImplementationAssemblies);
             if (path is not null)
             {
-                ResolvedAssemblyReference? selected = Descriptor(
+                AssemblyDescriptorResolution descriptor = DescriptorResult(
                     path,
                     AssemblyResolutionProvenance.Platform(
                         framework ?? "InstalledPlatform",
                         frameworkVersion: null,
                         AssemblyDependencyProvenance.InstalledPlatformAssembly.ToString()));
+                ResolvedAssemblyReference? selected = descriptor.Assembly;
                 if (selected is null)
                 {
-                    candidateUnavailable = true;
+                    candidateFailure ??=
+                        descriptor.FailureKind
+                        ?? CandidateOpenFailureKind.Unreadable;
                 }
                 else if (identity.MatchesCandidate(
                         selected.Identity,
@@ -339,14 +345,14 @@ public sealed class AssemblyDependencyResolver :
                 {
                     return new AssemblyResolutionAttempt(
                         selected,
-                        CandidateUnavailable: false);
+                        CandidateFailure: null);
                 }
             }
         }
 
         return new AssemblyResolutionAttempt(
             Assembly: null,
-            candidateUnavailable);
+            candidateFailure);
     }
 
     static CandidateTier TierFor(
@@ -403,7 +409,8 @@ public sealed class AssemblyDependencyResolver :
         {
             return AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                    AssemblyBindingFailureKind.CandidateUnavailable,
+                    ClassifyCandidateOpenFailure(ex)));
         }
     }
 
@@ -414,10 +421,11 @@ public sealed class AssemblyDependencyResolver :
         AssemblyResolutionAttempt attempt = ResolveCore(identity, scope);
         if (attempt.Assembly is { } assembly)
             return AssemblyBindingSelection.Found(assembly);
-        return attempt.CandidateUnavailable
+        return attempt.CandidateFailure is { } candidateFailure
             ? AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable))
+                    AssemblyBindingFailureKind.CandidateUnavailable,
+                    candidateFailure))
             : AssemblyBindingSelection.NotFound();
     }
 
@@ -426,16 +434,17 @@ public sealed class AssemblyDependencyResolver :
     {
         string targetPath = Path.GetFullPath(
             _options.TargetAssemblyPath);
-        ResolvedAssemblyReference? target = Descriptor(
+        AssemblyDescriptorResolution target = DescriptorResult(
             targetPath,
             AssemblyResolutionProvenance.Local(
                 "intrinsic core library"));
-        return target is null
+        return target.Assembly is null
             ? AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable))
+                    AssemblyBindingFailureKind.CandidateUnavailable,
+                    target.FailureKind))
             : IntrinsicCoreLibraryBinding.Select(
-                target,
+                target.Assembly,
                 facade => SelectReference(facade, scope));
     }
 
@@ -466,26 +475,37 @@ public sealed class AssemblyDependencyResolver :
     ResolvedAssemblyReference? Descriptor(
         string path,
         AssemblyResolutionProvenance provenance) =>
+        DescriptorResult(path, provenance).Assembly;
+
+    AssemblyDescriptorResolution DescriptorResult(
+        string path,
+        AssemblyResolutionProvenance provenance) =>
         _descriptors.GetOrAdd(
             path,
             (path, provenance) =>
-                new Lazy<ResolvedAssemblyReference?>(
+                new Lazy<AssemblyDescriptorResolution>(
                     () => CreateDescriptor(path, provenance),
                     LazyThreadSafetyMode.ExecutionAndPublication),
             provenance).Value;
 
-    ResolvedAssemblyReference? CreateDescriptor(
+    AssemblyDescriptorResolution CreateDescriptor(
         string path,
         AssemblyResolutionProvenance provenance)
     {
         if (!_options.SnapshotAssemblyImages)
         {
-            return ResolvedAssemblyReference.TryCreateFromPath(
+            bool created = ResolvedAssemblyReference.TryCreateFromPath(
                 path,
                 provenance,
-                out ResolvedAssemblyReference? reference)
-                    ? reference
-                    : null;
+                out ResolvedAssemblyReference? reference,
+                out Exception? failure);
+            return created
+                ? new(reference, FailureKind: null)
+                : new(
+                    Assembly: null,
+                    ClassifyCandidateOpenFailure(
+                        failure
+                        ?? new BadImageFormatException()));
         }
 
         long reservedBytes = 0;
@@ -509,7 +529,11 @@ public sealed class AssemblyDependencyResolver :
             using var reader =
                 new System.Reflection.PortableExecutable.PEReader(stream);
             if (!reader.HasMetadata)
-                return null;
+            {
+                return new(
+                    Assembly: null,
+                    CandidateOpenFailureKind.InvalidImage);
+            }
 
             ResolvedAssemblyReference result =
                 ResolvedAssemblyReference.Create(
@@ -519,14 +543,26 @@ public sealed class AssemblyDependencyResolver :
                 () => new MemoryStream(image, writable: false),
                 provenance);
             reservedBytes = 0;
-            return result;
+            return new(result, FailureKind: null);
+        }
+        catch (AssemblyDependencySnapshotBudgetExceededException)
+        {
+            return new(
+                Assembly: null,
+                CandidateOpenFailureKind.ResourceBudget);
         }
         catch (Exception ex) when (
             ex is IOException
                 or UnauthorizedAccessException
-                or BadImageFormatException)
+                or NotSupportedException
+                or ObjectDisposedException
+                or BadImageFormatException
+                or ArgumentOutOfRangeException
+                or OverflowException)
         {
-            return null;
+            return new(
+                Assembly: null,
+                ClassifyCandidateOpenFailure(ex));
         }
         finally
         {
@@ -556,6 +592,19 @@ public sealed class AssemblyDependencyResolver :
             _snapshotImageBytes -= bytes;
     }
 
+    static CandidateOpenFailureKind ClassifyCandidateOpenFailure(
+        Exception exception) =>
+        exception switch
+        {
+            BadImageFormatException
+                or ArgumentOutOfRangeException
+                or OverflowException =>
+                CandidateOpenFailureKind.InvalidImage,
+            AssemblyDependencySnapshotBudgetExceededException =>
+                CandidateOpenFailureKind.ResourceBudget,
+            _ => CandidateOpenFailureKind.Unreadable,
+        };
+
     readonly record struct AssemblyBindingRequestKey(
         AssemblyBindingTarget Target,
         AssemblyAcquisitionRegistration? Origin,
@@ -581,7 +630,11 @@ public sealed class AssemblyDependencyResolver :
 
     readonly record struct AssemblyResolutionAttempt(
         ResolvedAssemblyReference? Assembly,
-        bool CandidateUnavailable);
+        CandidateOpenFailureKind? CandidateFailure);
+
+    sealed record AssemblyDescriptorResolution(
+        ResolvedAssemblyReference? Assembly,
+        CandidateOpenFailureKind? FailureKind);
 
     public static IReadOnlyList<string> PackageDependencyReferencePaths(string targetPath)
         => PackageDependencyReferencePaths(targetPath, packageRoots: null);

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -474,8 +474,19 @@ public sealed class AssemblyDependencyResolver :
 
     ResolvedAssemblyReference? Descriptor(
         string path,
-        AssemblyResolutionProvenance provenance) =>
-        DescriptorResult(path, provenance).Assembly;
+        AssemblyResolutionProvenance provenance)
+    {
+        AssemblyDescriptorResolution result =
+            DescriptorResult(path, provenance);
+        if (result.FailureKind
+            is CandidateOpenFailureKind.ResourceBudget)
+        {
+            throw new AssemblyDependencySnapshotBudgetExceededException(
+                _options.MaxSnapshotImageBytes);
+        }
+
+        return result.Assembly;
+    }
 
     AssemblyDescriptorResolution DescriptorResult(
         string path,

--- a/src/DotnetInspector.Services/DotnetInspector.Services.csproj
+++ b/src/DotnetInspector.Services/DotnetInspector.Services.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="../CSharpText/CSharpText.csproj" />
     <ProjectReference Include="../DotnetInspector.CSharpBodySlicer/DotnetInspector.CSharpBodySlicer.csproj" />
     <ProjectReference Include="../ILInspector.Metadata/ILInspector.Metadata.csproj" />
+    <ProjectReference Include="../ILInspector.MetadataPrimitives/ILInspector.MetadataPrimitives.csproj" />
     <ProjectReference Include="../ILInspector.SourceLink/ILInspector.SourceLink.csproj" />
     <ProjectReference Include="../ILInspector.Text/ILInspector.Text.csproj" />
     <ProjectReference Include="../DotnetInspector.Core/DotnetInspector.Core.csproj" />

--- a/src/DotnetInspector.Services/IdentifierConfusionDetector.cs
+++ b/src/DotnetInspector.Services/IdentifierConfusionDetector.cs
@@ -42,9 +42,10 @@ public static class IdentifierConfusionDetector
             return null;
 
         List<int> nonAscii = [];
+        HashSet<int> seenNonAscii = [];
         foreach (Rune rune in identifier.EnumerateRunes())
         {
-            if (!rune.IsAscii && !nonAscii.Contains(rune.Value))
+            if (!rune.IsAscii && seenNonAscii.Add(rune.Value))
                 nonAscii.Add(rune.Value);
         }
 

--- a/src/DotnetInspector.Services/IdentifierConfusionDetector.cs
+++ b/src/DotnetInspector.Services/IdentifierConfusionDetector.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using ILInspector.MetadataPrimitives;
 using ILInspector.Text;
 
 namespace DotnetInspector.Services;

--- a/src/DotnetInspector.Services/IdentifierConfusionDetector.cs
+++ b/src/DotnetInspector.Services/IdentifierConfusionDetector.cs
@@ -1,0 +1,134 @@
+using System.Text;
+using ILInspector.Text;
+
+namespace DotnetInspector.Services;
+
+[Flags]
+public enum IdentifierConcern
+{
+    None = 0,
+    NonAscii = 1 << 0,
+    ReservedPrefixHomoglyph = 1 << 1,
+}
+
+public readonly record struct IdentifierHomoglyph(
+    int CodePoint,
+    char LooksLike);
+
+public sealed record ReservedPrefixHomoglyphMatch(
+    string ReservedPrefix,
+    double Similarity,
+    IReadOnlyList<IdentifierHomoglyph> Homoglyphs);
+
+public sealed record IdentifierConfusion(
+    IdentifierConcern Concerns,
+    IReadOnlyList<int> NonAsciiCodePoints,
+    ReservedPrefixHomoglyphMatch? ReservedPrefixMatch);
+
+/// <summary>
+/// Finds non-ASCII identifier characters and a bounded set of cross-script homoglyphs in
+/// package or assembly names that closely resemble reserved ecosystem prefixes.
+/// </summary>
+public static class IdentifierConfusionDetector
+{
+    public const double MinimumReservedPrefixSimilarity = 0.8;
+
+    private static readonly string[] ReservedPrefixes =
+        ["System", "Microsoft", "Azure"];
+
+    public static IdentifierConfusion? Inspect(string? identifier)
+    {
+        if (string.IsNullOrEmpty(identifier))
+            return null;
+
+        List<int> nonAscii = [];
+        foreach (Rune rune in identifier.EnumerateRunes())
+        {
+            if (!rune.IsAscii && !nonAscii.Contains(rune.Value))
+                nonAscii.Add(rune.Value);
+        }
+
+        if (nonAscii.Count == 0)
+            return null;
+
+        ReservedPrefixHomoglyphMatch? bestMatch = null;
+        foreach (string reservedPrefix in ReservedPrefixes)
+        {
+            Rune[] candidate = identifier
+                .EnumerateRunes()
+                .Take(reservedPrefix.Length)
+                .ToArray();
+            if (candidate.Length != reservedPrefix.Length)
+                continue;
+
+            string candidateText = string.Concat(candidate.Select(static rune => rune.ToString()));
+            double similarity = StringDistance.Similarity(
+                candidateText.ToLowerInvariant(),
+                reservedPrefix.ToLowerInvariant());
+            if (similarity < MinimumReservedPrefixSimilarity)
+                continue;
+
+            List<IdentifierHomoglyph> homoglyphs = [];
+            bool matches = true;
+            for (int index = 0; index < candidate.Length; index++)
+            {
+                char target = char.ToLowerInvariant(reservedPrefix[index]);
+                Rune rune = candidate[index];
+                if (rune.IsAscii
+                    && char.ToLowerInvariant((char)rune.Value) == target)
+                {
+                    continue;
+                }
+
+                if (!TryGetAsciiHomoglyph(rune, out char looksLike)
+                    || looksLike != target)
+                {
+                    matches = false;
+                    break;
+                }
+
+                homoglyphs.Add(new IdentifierHomoglyph(rune.Value, looksLike));
+            }
+
+            if (!matches || homoglyphs.Count == 0)
+                continue;
+
+            if (bestMatch is null || similarity > bestMatch.Similarity)
+            {
+                bestMatch = new ReservedPrefixHomoglyphMatch(
+                    reservedPrefix,
+                    similarity,
+                    homoglyphs);
+            }
+        }
+
+        IdentifierConcern concerns = IdentifierConcern.NonAscii;
+        if (bestMatch is not null)
+            concerns |= IdentifierConcern.ReservedPrefixHomoglyph;
+
+        return new IdentifierConfusion(concerns, nonAscii, bestMatch);
+    }
+
+    private static bool TryGetAsciiHomoglyph(Rune rune, out char ascii)
+    {
+        ascii = rune.Value switch
+        {
+            // Greek and Cyrillic characters whose ordinary glyph is confusable with a
+            // Latin character used by System, Microsoft, or Azure. This deliberately
+            // bounded catalog is a high-confidence discriminator, not a claim to implement
+            // the complete Unicode confusables table.
+            0x0391 or 0x0410 or 0x0430 => 'a',
+            0x03F9 or 0x0421 or 0x0441 => 'c',
+            0x0395 or 0x0415 or 0x0435 => 'e',
+            0x0406 or 0x0456 or 0x0399 => 'i',
+            0x039C or 0x041C => 'm',
+            0x039F or 0x03BF or 0x041E or 0x043E => 'o',
+            0x0405 or 0x0455 => 's',
+            0x03A4 or 0x0422 or 0x0442 => 't',
+            0x03A5 or 0x0443 => 'y',
+            0x0396 => 'z',
+            _ => '\0',
+        };
+        return ascii != '\0';
+    }
+}

--- a/src/DotnetInspector.Services/IdentifierConfusionDetector.cs
+++ b/src/DotnetInspector.Services/IdentifierConfusionDetector.cs
@@ -32,8 +32,6 @@ public sealed record IdentifierConfusion(
 /// </summary>
 public static class IdentifierConfusionDetector
 {
-    public const double MinimumReservedPrefixSimilarity = 0.8;
-
     private static readonly string[] ReservedPrefixes =
         ["System", "Microsoft", "Azure"];
 
@@ -63,13 +61,8 @@ public static class IdentifierConfusionDetector
             if (candidate.Length != reservedPrefix.Length)
                 continue;
 
-            string candidateText = string.Concat(candidate.Select(static rune => rune.ToString()));
-            double similarity = StringDistance.Similarity(
-                candidateText.ToLowerInvariant(),
-                reservedPrefix.ToLowerInvariant());
-            if (similarity < MinimumReservedPrefixSimilarity)
-                continue;
-
+            string candidateText = string.Concat(
+                candidate.Select(static rune => rune.ToString()));
             List<IdentifierHomoglyph> homoglyphs = [];
             bool matches = true;
             for (int index = 0; index < candidate.Length; index++)
@@ -94,6 +87,10 @@ public static class IdentifierConfusionDetector
 
             if (!matches || homoglyphs.Count == 0)
                 continue;
+
+            double similarity = StringDistance.Similarity(
+                candidateText.ToLowerInvariant(),
+                reservedPrefix.ToLowerInvariant());
 
             if (bestMatch is null || similarity > bestMatch.Similarity)
             {

--- a/src/DotnetInspector.Services/MetadataFieldCache.cs
+++ b/src/DotnetInspector.Services/MetadataFieldCache.cs
@@ -17,8 +17,8 @@ internal static class MetadataFieldCache
 
     private const string Category = "metadata";
     private static readonly TimeSpan Ttl = TimeSpan.FromHours(1);
-    private static ReadOnlySpan<byte> PresentPrefix => "metadata-v5:present\n"u8;
-    private static ReadOnlySpan<byte> AbsentEntry => "metadata-v5:absent\n"u8;
+    private static ReadOnlySpan<byte> PresentPrefix => "metadata-v6:present\n"u8;
+    private static ReadOnlySpan<byte> AbsentEntry => "metadata-v6:absent\n"u8;
 
     /// <summary>
     /// Tries to load cached metadata. Returns null on cache miss or expiry.
@@ -53,6 +53,8 @@ internal static class MetadataFieldCache
             using var doc = FieldDocument.Parse(bytes[PresentPrefix.Length..]);
             var metadata = new PackageMetadata
             {
+                DeprecationMetadataSupported =
+                    doc.GetBool("deprecationMetadataSupported"),
                 DeprecationMetadataAvailable =
                     doc.GetBool("deprecationMetadataAvailable"),
                 IsVerified = doc.GetBool("isVerified") ? true : null,
@@ -152,7 +154,7 @@ internal static class MetadataFieldCache
 
             // Keep even an otherwise empty metadata result parseable. A feed may advertise a
             // package without any optional aggregate metadata fields.
-            WriteField(buf, "formatVersion"u8, "5");
+            WriteField(buf, "formatVersion"u8, "6");
 
             // Scalars
             if (metadata.Published.HasValue)
@@ -172,6 +174,13 @@ internal static class MetadataFieldCache
                 WriteField(
                     buf,
                     "deprecationMetadataAvailable"u8,
+                    "true");
+            }
+            if (metadata.DeprecationMetadataSupported)
+            {
+                WriteField(
+                    buf,
+                    "deprecationMetadataSupported"u8,
                     "true");
             }
 

--- a/src/DotnetInspector.Services/MetadataFieldCache.cs
+++ b/src/DotnetInspector.Services/MetadataFieldCache.cs
@@ -17,8 +17,8 @@ internal static class MetadataFieldCache
 
     private const string Category = "metadata";
     private static readonly TimeSpan Ttl = TimeSpan.FromHours(1);
-    private static ReadOnlySpan<byte> PresentPrefix => "metadata-v4:present\n"u8;
-    private static ReadOnlySpan<byte> AbsentEntry => "metadata-v4:absent\n"u8;
+    private static ReadOnlySpan<byte> PresentPrefix => "metadata-v5:present\n"u8;
+    private static ReadOnlySpan<byte> AbsentEntry => "metadata-v5:absent\n"u8;
 
     /// <summary>
     /// Tries to load cached metadata. Returns null on cache miss or expiry.
@@ -53,6 +53,8 @@ internal static class MetadataFieldCache
             using var doc = FieldDocument.Parse(bytes[PresentPrefix.Length..]);
             var metadata = new PackageMetadata
             {
+                DeprecationMetadataAvailable =
+                    doc.GetBool("deprecationMetadataAvailable"),
                 IsVerified = doc.GetBool("isVerified") ? true : null,
                 VersionCount = doc.GetInt32("versionCount") is > 0 and var vc ? vc : null,
             };
@@ -83,7 +85,9 @@ internal static class MetadataFieldCache
                 doc.GetString("deprecationMessage"));
             var altPkg = DecodeOptionalText(
                 doc.GetString("deprecationAlternate"));
-            if (reasons is { Count: > 0 } || message is not null)
+            if (reasons is { Count: > 0 }
+                || message is not null
+                || altPkg is not null)
             {
                 metadata.Deprecation = new PackageDeprecation
                 {
@@ -148,7 +152,7 @@ internal static class MetadataFieldCache
 
             // Keep even an otherwise empty metadata result parseable. A feed may advertise a
             // package without any optional aggregate metadata fields.
-            WriteField(buf, "formatVersion"u8, "4");
+            WriteField(buf, "formatVersion"u8, "5");
 
             // Scalars
             if (metadata.Published.HasValue)
@@ -163,6 +167,13 @@ internal static class MetadataFieldCache
                 WriteField(buf, "packageSize"u8, metadata.PackageSize.Value.ToString());
             if (metadata.IsVerified == true)
                 WriteField(buf, "isVerified"u8, "true");
+            if (metadata.DeprecationMetadataAvailable)
+            {
+                WriteField(
+                    buf,
+                    "deprecationMetadataAvailable"u8,
+                    "true");
+            }
 
             // Deprecation: flattened
             if (metadata.Deprecation is { } dep)

--- a/src/DotnetInspector.Services/PackageMetadata.cs
+++ b/src/DotnetInspector.Services/PackageMetadata.cs
@@ -12,6 +12,7 @@ public class PackageMetadata
     public long? PackageSize { get; set; }
     public bool? IsVerified { get; set; }
     public List<string>? Owners { get; set; }
+    public bool DeprecationMetadataAvailable { get; set; }
     public PackageDeprecation? Deprecation { get; set; }
     public List<PackageVulnerability>? Vulnerabilities { get; set; }
 }

--- a/src/DotnetInspector.Services/PackageMetadata.cs
+++ b/src/DotnetInspector.Services/PackageMetadata.cs
@@ -12,6 +12,7 @@ public class PackageMetadata
     public long? PackageSize { get; set; }
     public bool? IsVerified { get; set; }
     public List<string>? Owners { get; set; }
+    public bool DeprecationMetadataSupported { get; set; }
     public bool DeprecationMetadataAvailable { get; set; }
     public PackageDeprecation? Deprecation { get; set; }
     public List<PackageVulnerability>? Vulnerabilities { get; set; }

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -48,6 +48,10 @@ public static class PackageMetadataService
         bool Succeeded,
         bool Found);
 
+    private readonly record struct RegistrationMetadataResult(
+        string? CatalogEntryUrl,
+        bool DeprecationMetadataAvailable);
+
     private readonly record struct VulnerabilityFetchResult(
         bool Succeeded,
         List<PackageVulnerability> Vulnerabilities);
@@ -218,7 +222,7 @@ public static class PackageMetadataService
         string normalizedName,
         string normalizedVersion,
         bool registrationOnly) =>
-        $"v4-{(registrationOnly ? "published" : "full")}-"
+        $"v5-{(registrationOnly ? "published" : "full")}-"
         + $"{NuGetCache.GetSourceKey(source.Url)}-"
         + $"{normalizedName}@{normalizedVersion}";
 
@@ -282,11 +286,17 @@ public static class PackageMetadataService
             {
                 try
                 {
-                    catalogEntryUrl = ApplyRegistrationMetadata(
+                    RegistrationMetadataResult registrationMetadata =
+                        ApplyRegistrationMetadata(
                         registrationResult.Content!,
                         registrationUrl,
                         metadata,
                         log);
+                    catalogEntryUrl =
+                        registrationMetadata.CatalogEntryUrl;
+                    metadata.DeprecationMetadataAvailable =
+                        registrationMetadata
+                            .DeprecationMetadataAvailable;
                     found = true;
                     break;
                 }
@@ -368,6 +378,7 @@ public static class PackageMetadataService
                 {
                     ApplyCatalogMetadata(catalogResult.Content!, metadata, log);
                     catalogDataAvailable = true;
+                    metadata.DeprecationMetadataAvailable = true;
                 }
             }
             catch (Exception ex) when (ex is not NetworkPolicyException)
@@ -397,6 +408,8 @@ public static class PackageMetadataService
                     if (searchResult.Succeeded)
                     {
                         searchDataAvailable = true;
+                        if (searchResult.Found)
+                            metadata.DeprecationMetadataAvailable = true;
                         break;
                     }
                 }
@@ -461,7 +474,8 @@ public static class PackageMetadataService
         return new SourceMetadataResult(
             SourcePresence.Present,
             metadata,
-            Cacheable: catalogDataAvailable
+            Cacheable: !sawIndeterminate
+                && catalogDataAvailable
                 && searchDataAvailable
                 && vulnerabilityDataAvailable);
     }
@@ -665,7 +679,8 @@ public static class PackageMetadataService
             Found: false);
     }
 
-    private static string? ApplyRegistrationMetadata(
+    private static RegistrationMetadataResult
+        ApplyRegistrationMetadata(
         string json,
         string registrationUrl,
         PackageMetadata metadata,
@@ -685,27 +700,41 @@ public static class PackageMetadataService
 
         if (!root.TryGetProperty("catalogEntry", out JsonElement catalogElement))
         {
-            return null;
+            return new RegistrationMetadataResult(
+                CatalogEntryUrl: null,
+                DeprecationMetadataAvailable: false);
         }
 
         if (catalogElement.ValueKind == JsonValueKind.Object)
         {
             ApplyCatalogElement(catalogElement, metadata, log);
-            return null;
+            return new RegistrationMetadataResult(
+                CatalogEntryUrl: null,
+                DeprecationMetadataAvailable: true);
         }
 
         string? catalogEntry = catalogElement.GetString();
         if (string.IsNullOrWhiteSpace(catalogEntry))
-            return null;
+        {
+            return new RegistrationMetadataResult(
+                CatalogEntryUrl: null,
+                DeprecationMetadataAvailable: false);
+        }
 
         try
         {
-            return ResolveReference(registrationUrl, catalogEntry);
+            return new RegistrationMetadataResult(
+                ResolveReference(
+                    registrationUrl,
+                    catalogEntry),
+                DeprecationMetadataAvailable: false);
         }
         catch (UriFormatException)
         {
             log?.Invoke("Ignoring malformed catalog entry URL.");
-            return null;
+            return new RegistrationMetadataResult(
+                CatalogEntryUrl: null,
+                DeprecationMetadataAvailable: false);
         }
     }
 

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -43,12 +43,14 @@ public static class PackageMetadataService
         bool Found,
         int ResultCount,
         long? TotalHits,
-        bool DeprecationMetadataAvailable);
+        bool DeprecationMetadataAvailable,
+        bool Indeterminate = false);
 
     private readonly record struct SearchFetchResult(
         bool Succeeded,
         bool Found,
-        bool DeprecationMetadataAvailable);
+        bool DeprecationMetadataAvailable,
+        bool Indeterminate = false);
 
     private readonly record struct RegistrationMetadataResult(
         string? CatalogEntryUrl,
@@ -298,6 +300,8 @@ public static class PackageMetadataService
                         ApplyRegistrationMetadata(
                         registrationResult.Content!,
                         registrationUrl,
+                        normalizedName,
+                        version,
                         metadata,
                         log);
                     catalogEntryUrl =
@@ -386,9 +390,20 @@ public static class PackageMetadataService
                     log).ConfigureAwait(false);
                 if (catalogResult.IsSuccess)
                 {
-                    ApplyCatalogMetadata(catalogResult.Content!, metadata, log);
-                    catalogDataAvailable = true;
-                    metadata.DeprecationMetadataAvailable = true;
+                    if (ApplyCatalogMetadata(
+                            catalogResult.Content!,
+                            normalizedName,
+                            version,
+                            metadata,
+                            log))
+                    {
+                        catalogDataAvailable = true;
+                        metadata.DeprecationMetadataAvailable = true;
+                    }
+                    else
+                    {
+                        sawIndeterminate = true;
+                    }
                 }
             }
             catch (Exception ex) when (ex is not NetworkPolicyException)
@@ -418,6 +433,8 @@ public static class PackageMetadataService
                     if (searchResult.Succeeded)
                     {
                         searchDataAvailable = true;
+                        if (!metadata.DeprecationMetadataAvailable)
+                            sawIndeterminate |= searchResult.Indeterminate;
                         if (searchResult.DeprecationMetadataAvailable)
                             metadata.DeprecationMetadataAvailable = true;
                         break;
@@ -673,7 +690,8 @@ public static class PackageMetadataService
                 return new SearchFetchResult(
                     Succeeded: true,
                     Found: true,
-                    page.DeprecationMetadataAvailable);
+                    page.DeprecationMetadataAvailable,
+                    page.Indeterminate);
             if (page.ResultCount == 0)
                 return new SearchFetchResult(
                     Succeeded: true,
@@ -698,6 +716,8 @@ public static class PackageMetadataService
         ApplyRegistrationMetadata(
         string json,
         string registrationUrl,
+        string normalizedName,
+        string version,
         PackageMetadata metadata,
         Action<string>? log)
     {
@@ -722,6 +742,20 @@ public static class PackageMetadataService
 
         if (catalogElement.ValueKind == JsonValueKind.Object)
         {
+            if (!CatalogIdentityMatches(
+                    catalogElement,
+                    normalizedName,
+                    version))
+            {
+                log?.Invoke(
+                    "Ignoring catalog metadata for a different "
+                    + "package identity.");
+                return new RegistrationMetadataResult(
+                    CatalogEntryUrl: null,
+                    DeprecationMetadataAvailable: false,
+                    Indeterminate: true);
+            }
+
             ApplyCatalogElement(catalogElement, metadata, log);
             return new RegistrationMetadataResult(
                 CatalogEntryUrl: null,
@@ -754,13 +788,56 @@ public static class PackageMetadataService
         }
     }
 
-    private static void ApplyCatalogMetadata(
+    private static bool ApplyCatalogMetadata(
         string json,
+        string normalizedName,
+        string version,
         PackageMetadata metadata,
         Action<string>? log)
     {
         using var doc = HardenedJson.Parse(json);
+        if (!CatalogIdentityMatches(
+                doc.RootElement,
+                normalizedName,
+                version))
+        {
+            log?.Invoke(
+                "Ignoring catalog metadata for a different "
+                + "package identity.");
+            return false;
+        }
+
         ApplyCatalogElement(doc.RootElement, metadata, log);
+        return true;
+    }
+
+    private static bool CatalogIdentityMatches(
+        JsonElement root,
+        string normalizedName,
+        string version)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+            return false;
+
+        if (root.TryGetProperty("id", out JsonElement id)
+            && (id.ValueKind != JsonValueKind.String
+                || !string.Equals(
+                    id.GetString(),
+                    normalizedName,
+                    StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        if (!root.TryGetProperty(
+                "version",
+                out JsonElement catalogVersion))
+        {
+            return true;
+        }
+
+        return catalogVersion.ValueKind == JsonValueKind.String
+            && VersionsEqual(catalogVersion.GetString(), version);
     }
 
     private static void ApplyCatalogElement(
@@ -904,7 +981,8 @@ public static class PackageMetadataService
             Found: true,
             resultCount,
             totalHits,
-            deprecationMetadataAvailable);
+            deprecationMetadataAvailable,
+            Indeterminate: !deprecationMetadataAvailable);
     }
 
     private static bool TryReadInt64(JsonElement element, out long value)

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -42,15 +42,18 @@ public static class PackageMetadataService
     private readonly record struct SearchPageResult(
         bool Found,
         int ResultCount,
-        long? TotalHits);
+        long? TotalHits,
+        bool DeprecationMetadataAvailable);
 
     private readonly record struct SearchFetchResult(
         bool Succeeded,
-        bool Found);
+        bool Found,
+        bool DeprecationMetadataAvailable);
 
     private readonly record struct RegistrationMetadataResult(
         string? CatalogEntryUrl,
-        bool DeprecationMetadataAvailable);
+        bool DeprecationMetadataAvailable,
+        bool Indeterminate = false);
 
     private readonly record struct VulnerabilityFetchResult(
         bool Succeeded,
@@ -297,6 +300,8 @@ public static class PackageMetadataService
                     metadata.DeprecationMetadataAvailable =
                         registrationMetadata
                             .DeprecationMetadataAvailable;
+                    sawIndeterminate |=
+                        registrationMetadata.Indeterminate;
                     found = true;
                     break;
                 }
@@ -408,7 +413,7 @@ public static class PackageMetadataService
                     if (searchResult.Succeeded)
                     {
                         searchDataAvailable = true;
-                        if (searchResult.Found)
+                        if (searchResult.DeprecationMetadataAvailable)
                             metadata.DeprecationMetadataAvailable = true;
                         break;
                     }
@@ -650,7 +655,8 @@ public static class PackageMetadataService
             if (!searchResult.IsSuccess)
                 return new SearchFetchResult(
                     Succeeded: false,
-                    Found: false);
+                    Found: false,
+                    DeprecationMetadataAvailable: false);
 
             SearchPageResult page = ApplySearchMetadata(
                 searchResult.Content!,
@@ -661,22 +667,26 @@ public static class PackageMetadataService
             if (page.Found)
                 return new SearchFetchResult(
                     Succeeded: true,
-                    Found: true);
+                    Found: true,
+                    page.DeprecationMetadataAvailable);
             if (page.ResultCount == 0)
                 return new SearchFetchResult(
                     Succeeded: true,
-                    Found: false);
+                    Found: false,
+                    DeprecationMetadataAvailable: false);
 
             examined += page.ResultCount;
             if (page.TotalHits is > 0 && examined >= page.TotalHits)
                 return new SearchFetchResult(
                     Succeeded: true,
-                    Found: false);
+                    Found: false,
+                    DeprecationMetadataAvailable: false);
         }
 
         return new SearchFetchResult(
             Succeeded: true,
-            Found: false);
+            Found: false,
+            DeprecationMetadataAvailable: false);
     }
 
     private static RegistrationMetadataResult
@@ -734,7 +744,8 @@ public static class PackageMetadataService
             log?.Invoke("Ignoring malformed catalog entry URL.");
             return new RegistrationMetadataResult(
                 CatalogEntryUrl: null,
-                DeprecationMetadataAvailable: false);
+                DeprecationMetadataAvailable: false,
+                Indeterminate: true);
         }
     }
 
@@ -805,8 +816,15 @@ public static class PackageMetadataService
             return new SearchPageResult(
                 Found: false,
                 resultCount,
-                totalHits);
+                totalHits,
+                DeprecationMetadataAvailable: false);
         }
+
+        bool deprecationMetadataAvailable =
+            pkg.TryGetProperty(
+                "version",
+                out JsonElement packageVersion)
+            && VersionsEqual(packageVersion.GetString(), version);
 
         if (pkg.TryGetProperty("totalDownloads", out JsonElement downloads)
             && TryReadInt64(downloads, out long totalDownloads))
@@ -866,7 +884,8 @@ public static class PackageMetadataService
             };
         }
 
-        if (metadata.Deprecation is null
+        if (deprecationMetadataAvailable
+            && metadata.Deprecation is null
             && pkg.TryGetProperty(
                 "deprecation",
                 out JsonElement deprecationElement)
@@ -879,7 +898,8 @@ public static class PackageMetadataService
         return new SearchPageResult(
             Found: true,
             resultCount,
-            totalHits);
+            totalHits,
+            deprecationMetadataAvailable);
     }
 
     private static bool TryReadInt64(JsonElement element, out long value)

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -225,7 +225,7 @@ public static class PackageMetadataService
         string normalizedName,
         string normalizedVersion,
         bool registrationOnly) =>
-        $"v5-{(registrationOnly ? "published" : "full")}-"
+        $"v6-{(registrationOnly ? "published" : "full")}-"
         + $"{NuGetCache.GetSourceKey(source.Url)}-"
         + $"{normalizedName}@{normalizedVersion}";
 
@@ -263,6 +263,11 @@ public static class PackageMetadataService
             CompatibleResources(resources, "SearchQueryService");
         List<ServiceResource> vulnerabilityInfos =
             CompatibleResources(resources, "VulnerabilityInfo");
+        metadata.DeprecationMetadataSupported =
+            registrationResources.Count > 0
+            || searchQueryServices.Count > 0;
+        metadata.DeprecationMetadataAvailable =
+            !metadata.DeprecationMetadataSupported;
 
         bool found = false;
         bool sawExistenceEndpoint = false;

--- a/src/ILInspector.Metadata/AssemblyBinding.cs
+++ b/src/ILInspector.Metadata/AssemblyBinding.cs
@@ -18,14 +18,25 @@ public enum AssemblyBindingFailureKind
 /// </summary>
 public sealed record AssemblyBindingFailure
 {
-    public AssemblyBindingFailure(AssemblyBindingFailureKind kind)
+    public AssemblyBindingFailure(
+        AssemblyBindingFailureKind kind,
+        CandidateOpenFailureKind? candidateFailureKind = null)
     {
         if (!Enum.IsDefined(kind))
             throw new ArgumentOutOfRangeException(nameof(kind));
+        if (candidateFailureKind is { } candidateFailure
+            && !Enum.IsDefined(candidateFailure))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(candidateFailureKind));
+        }
+
         Kind = kind;
+        CandidateFailureKind = candidateFailureKind;
     }
 
     public AssemblyBindingFailureKind Kind { get; }
+    public CandidateOpenFailureKind? CandidateFailureKind { get; }
 }
 
 /// <summary>

--- a/src/InertText.Tests/InertStringTests.cs
+++ b/src/InertText.Tests/InertStringTests.cs
@@ -475,6 +475,62 @@ public class InertStringTests
         Assert.Equal("[a\\u202Eb]", formatted.ToString());
     }
 
+    [Theory]
+    [InlineData("\u001B", TextConcern.Control)]
+    [InlineData("\u202E", TextConcern.Format)]
+    [InlineData("\u2028", TextConcern.LineSeparator)]
+    [InlineData("\u2029", TextConcern.ParagraphSeparator)]
+    [InlineData("\\", TextConcern.None)]
+    [InlineData("literal \\u202E text", TextConcern.None)]
+    public void Concerns_ClassifyWhyContainmentOccurred(
+        string source,
+        TextConcern expected)
+    {
+        InertString value = new(TextPolicy.Field, source);
+
+        Assert.Equal(expected, value.Concerns);
+        Assert.Equal(expected != TextConcern.None, value.RequiredContainment);
+    }
+
+    [Fact]
+    public void Concerns_ClassifyAnUnpairedSurrogate()
+    {
+        string source = new((char)0xD800, 1);
+
+        InertString value = new(TextPolicy.Field, source);
+
+        Assert.Equal(TextConcern.Surrogate, value.Concerns);
+        Assert.True(value.RequiredContainment);
+    }
+
+    [Fact]
+    public void Concerns_RespectThePolicyThatProducedTheValue()
+    {
+        InertString prose = new(TextPolicy.Prose, "first\nsecond");
+        InertString field = prose.EnsurePermitted(TextPolicy.Field);
+
+        Assert.Equal(TextConcern.None, prose.Concerns);
+        Assert.Equal(TextConcern.Control, field.Concerns);
+    }
+
+    [Fact]
+    public void Concerns_SurviveCompositionRestorationAndBounding()
+    {
+        InertString composed = InertString.Format(
+            TextPolicy.Field,
+            $"{"\\"}{"\u202E"}{"\u001B"}");
+        InertString restored = InertString.FromEncoded(
+            TextPolicy.Field,
+            composed.ToString());
+
+        Assert.Equal(
+            TextConcern.Format | TextConcern.Control,
+            composed.Concerns);
+        Assert.Equal(composed.Concerns, restored.Concerns);
+        Assert.Equal(TextConcern.Format, composed.Truncate(..8).Concerns);
+        Assert.Equal(TextConcern.Control, composed.Truncate(8..).Concerns);
+    }
+
     [Fact]
     public void FromEncoded_StringRetainsTheValidatedInstance()
     {
@@ -484,6 +540,7 @@ public class InertStringTests
 
         Assert.Same(encoded, restored.ToString());
         Assert.Equal(VisualForm.BmpHex, restored.Forms);
+        Assert.Equal(TextConcern.Format, restored.Concerns);
         Assert.False(restored.IsTruncated);
     }
 
@@ -498,6 +555,7 @@ public class InertStringTests
 
         Assert.Equal(Encoded, restored.ToString());
         Assert.Equal(VisualForm.BmpHex, restored.Forms);
+        Assert.Equal(TextConcern.Format, restored.Concerns);
     }
 
     [Fact]
@@ -626,6 +684,7 @@ public class InertStringTests
                 Assert.True(
                     restored.Equals(inert),
                     $"U+{codePoint:X} did not restore under {policy}.");
+                Assert.Equal(inert.Concerns, restored.Concerns);
                 Assert.Same(encoded, restored.ToString());
             }
         }
@@ -647,6 +706,7 @@ public class InertStringTests
             Assert.True(
                 restored.Equals(inert),
                 $"U+{codeUnit:X4} did not restore.");
+            Assert.Equal(TextConcern.Surrogate, restored.Concerns);
             Assert.Same(encoded, restored.ToString());
         }
     }

--- a/src/InertText/InertString.cs
+++ b/src/InertText/InertString.cs
@@ -146,10 +146,15 @@ public readonly struct InertString : IEquatable<InertString>
     // Takes text already spelled by the encoder, so it asserts rather than establishes the
     // invariant. Internal because composition needs it: Join and the interpolation handler
     // build their result piecewise and would otherwise have to re-encode an encoded string.
-    internal InertString(string text, VisualForm forms, bool truncated = false)
+    internal InertString(
+        string text,
+        VisualForm forms,
+        TextConcern concerns,
+        bool truncated = false)
     {
         _text = text;
         Forms = forms;
+        Concerns = concerns;
         _truncated = truncated;
     }
 
@@ -179,7 +184,8 @@ public readonly struct InertString : IEquatable<InertString>
     /// <see cref="ToString"/> and <see cref="GetHashCode"/> about whether the zero value and
     /// <c>Encode("")</c> are the same value.
     /// </remarks>
-    public static InertString Empty { get; } = new(string.Empty, VisualForm.None);
+    public static InertString Empty { get; } =
+        new(string.Empty, VisualForm.None, TextConcern.None);
 
     /// <summary>
     /// Reconstructs an unbounded value from text previously returned by <see cref="ToString"/>.
@@ -197,8 +203,8 @@ public readonly struct InertString : IEquatable<InertString>
     public static InertString FromEncoded(TextPolicy policy, string encoded)
     {
         ArgumentNullException.ThrowIfNull(encoded);
-        VisualForm forms = VisualEncoder.ValidateEncoded(policy, encoded);
-        return new InertString(encoded, forms);
+        (VisualForm forms, TextConcern concerns) = VisualEncoder.ValidateEncoded(policy, encoded);
+        return new InertString(encoded, forms, concerns);
     }
 
     /// <summary>
@@ -208,8 +214,8 @@ public readonly struct InertString : IEquatable<InertString>
         TextPolicy policy,
         ReadOnlySpan<char> encoded)
     {
-        VisualForm forms = VisualEncoder.ValidateEncoded(policy, encoded);
-        return new InertString(encoded.ToString(), forms);
+        (VisualForm forms, TextConcern concerns) = VisualEncoder.ValidateEncoded(policy, encoded);
+        return new InertString(encoded.ToString(), forms, concerns);
     }
 
     /// <summary>The spellings <see cref="InertString"/> emitted while producing this value.</summary>
@@ -220,6 +226,16 @@ public readonly struct InertString : IEquatable<InertString>
     /// </remarks>
     public VisualForm Forms { get; }
 
+    /// <summary>The kinds of artifact-text concern that required visual containment.</summary>
+    /// <remarks>
+    /// Retained at construction and unioned through composition, so an audit can report why
+    /// containment occurred without decoding or retaining the untreated text. Literal
+    /// backslashes do not contribute a concern. The
+    /// <c>Concerns_SurviveCompositionRestorationAndBounding</c> and
+    /// <c>Concerns_RespectThePolicyThatProducedTheValue</c> tests gate this propagation.
+    /// </remarks>
+    public TextConcern Concerns { get; }
+
     /// <summary>
     /// Whether producing this value required containing text rather than merely disambiguating a
     /// literal backslash.
@@ -229,8 +245,7 @@ public readonly struct InertString : IEquatable<InertString>
     /// It reports what happened under the policy used to build this value; it is not a
     /// conformance check for a different policy. Use <see cref="EnsurePermitted"/> for that.
     /// </remarks>
-    public bool RequiredContainment =>
-        (Forms & ~VisualForm.Backslash) != VisualForm.None;
+    public bool RequiredContainment => Concerns != TextConcern.None;
 
     /// <summary>Whether raw rendering must run the visual encoding backwards.</summary>
     public bool NeedsRawDecoding => Forms != VisualForm.None;
@@ -364,7 +379,8 @@ public readonly struct InertString : IEquatable<InertString>
     private InertString Bound(int start, int end)
     {
         string text = Text;
-        (int from, int to, VisualForm forms) = VisualEncoder.WindowWithin(text, start, end);
+        (int from, int to, VisualForm forms, TextConcern concerns) =
+            VisualEncoder.WindowWithin(text, start, end);
 
         // An unbounded request keeps this value rather than rebuilding an identical one, so the
         // common case of a budget nobody is near costs nothing.
@@ -374,7 +390,7 @@ public readonly struct InertString : IEquatable<InertString>
         // Reaching here means the window is a proper subset, so this cut dropped something.
         // Or-ing with what the value already carried is why truncating an already-truncated
         // value cannot report the second cut as the only one.
-        return new InertString(text[from..to], forms, true);
+        return new InertString(text[from..to], forms, concerns, true);
     }
 
     /// <summary>
@@ -436,6 +452,7 @@ public readonly struct InertString : IEquatable<InertString>
         InertString encodedSeparator = VisualEncoder.Encode(policy, separator);
         StringBuilder builder = new();
         VisualForm forms = VisualForm.None;
+        TextConcern concerns = TextConcern.None;
         bool first = true;
 
         // A join whose parts were clipped is missing text, so the result cannot claim to be
@@ -450,16 +467,24 @@ public readonly struct InertString : IEquatable<InertString>
             // single-element join cannot report a form the output does not contain.
             if (!first)
             {
-                VisualEncoder.AppendForComposition(builder, encodedSeparator, ref forms);
+                VisualEncoder.AppendForComposition(
+                    builder,
+                    encodedSeparator,
+                    ref forms,
+                    ref concerns);
             }
 
             InertString conformed = value.EnsurePermitted(policy);
-            VisualEncoder.AppendForComposition(builder, conformed, ref forms);
+            VisualEncoder.AppendForComposition(builder, conformed, ref forms, ref concerns);
             truncated |= conformed.IsTruncated;
             first = false;
         }
 
-        return VisualEncoder.CompleteComposition(builder.ToString(), forms, truncated);
+        return VisualEncoder.CompleteComposition(
+            builder.ToString(),
+            forms,
+            concerns,
+            truncated);
     }
 
     /// <summary>Names the spellings this value contains, one line each.</summary>
@@ -603,7 +628,11 @@ public readonly struct InertString : IEquatable<InertString>
         // and re-spelling under a stricter policy makes the text longer, so a length compared
         // across the two can call a truncated value whole.
         return _truncated
-            ? new InertString(respelled.Text, respelled.Forms, truncated: true)
+            ? new InertString(
+                respelled.Text,
+                respelled.Forms,
+                respelled.Concerns,
+                truncated: true)
             : respelled;
     }
 
@@ -650,6 +679,7 @@ public ref struct InertStringHandler
     private readonly TextPolicy _policy;
     private readonly StringBuilder _builder;
     private VisualForm _forms;
+    private TextConcern _concerns;
     private bool _truncated;
 
     /// <summary>Called by the compiler for an interpolated string argument.</summary>
@@ -661,6 +691,7 @@ public ref struct InertStringHandler
         _policy = policy;
         _builder = new StringBuilder(literalLength + (formattedCount * 12));
         _forms = VisualForm.None;
+        _concerns = TextConcern.None;
     }
 
     /// <summary>Appends a literal part of the interpolated string.</summary>
@@ -733,7 +764,11 @@ public ref struct InertStringHandler
     public void AppendFormatted(InertString value)
     {
         InertString conformed = value.EnsurePermitted(_policy);
-        VisualEncoder.AppendForComposition(_builder, conformed, ref _forms);
+        VisualEncoder.AppendForComposition(
+            _builder,
+            conformed,
+            ref _forms,
+            ref _concerns);
 
         // Splicing a clipped value into a message leaves the message missing that text, so the
         // result carries the fact for the same reason Join does.
@@ -756,7 +791,11 @@ public ref struct InertStringHandler
     }
 
     internal InertString ToInertString() =>
-        VisualEncoder.CompleteComposition(_builder.ToString(), _forms, _truncated);
+        VisualEncoder.CompleteComposition(
+            _builder.ToString(),
+            _forms,
+            _concerns,
+            _truncated);
 
     private void Append(string? value)
     {
@@ -772,6 +811,10 @@ public ref struct InertStringHandler
             return;
 
         InertString encoded = VisualEncoder.Encode(_policy, value);
-        VisualEncoder.AppendForComposition(_builder, encoded, ref _forms);
+        VisualEncoder.AppendForComposition(
+            _builder,
+            encoded,
+            ref _forms,
+            ref _concerns);
     }
 }

--- a/src/InertText/TextConcern.cs
+++ b/src/InertText/TextConcern.cs
@@ -1,0 +1,33 @@
+namespace InertText;
+
+/// <summary>
+/// The kinds of artifact-text concern that required visual containment.
+/// </summary>
+/// <remarks>
+/// These flags retain why an <see cref="InertString"/> was changed without retaining or
+/// recovering the untreated text. A literal backslash is deliberately absent: it may need to be
+/// doubled to keep the encoding invertible, but it is not itself a concern.
+/// <c>Concerns_ClassifyWhyContainmentOccurred</c> and
+/// <c>Concerns_ClassifyAnUnpairedSurrogate</c> gate the classification.
+/// </remarks>
+[Flags]
+public enum TextConcern
+{
+    /// <summary>No concerning scalar required containment.</summary>
+    None = 0,
+
+    /// <summary>A terminal or line-control scalar in Unicode category <c>Cc</c>.</summary>
+    Control = 1 << 0,
+
+    /// <summary>A formatting scalar in Unicode category <c>Cf</c>, including bidi controls.</summary>
+    Format = 1 << 1,
+
+    /// <summary>An unpaired UTF-16 surrogate in Unicode category <c>Cs</c>.</summary>
+    Surrogate = 1 << 2,
+
+    /// <summary>A Unicode line separator in category <c>Zl</c>.</summary>
+    LineSeparator = 1 << 3,
+
+    /// <summary>A Unicode paragraph separator in category <c>Zp</c>.</summary>
+    ParagraphSeparator = 1 << 4,
+}

--- a/src/InertText/TextPolicy.cs
+++ b/src/InertText/TextPolicy.cs
@@ -140,12 +140,17 @@ internal static class ScalarPolicies
     /// decode step.
     /// </remarks>
     internal static bool IsNonGraphic(Rune scalar)
-        => Rune.GetUnicodeCategory(scalar) switch
+        => ConcernFor(Rune.GetUnicodeCategory(scalar)) != TextConcern.None;
+
+    /// <summary>Maps a refused Unicode category to its retained audit classification.</summary>
+    internal static TextConcern ConcernFor(UnicodeCategory category)
+        => category switch
         {
-            UnicodeCategory.Control => true,
-            UnicodeCategory.Format => true,
-            UnicodeCategory.Surrogate => true,
-            UnicodeCategory.LineSeparator or UnicodeCategory.ParagraphSeparator => true,
-            _ => false,
+            UnicodeCategory.Control => TextConcern.Control,
+            UnicodeCategory.Format => TextConcern.Format,
+            UnicodeCategory.Surrogate => TextConcern.Surrogate,
+            UnicodeCategory.LineSeparator => TextConcern.LineSeparator,
+            UnicodeCategory.ParagraphSeparator => TextConcern.ParagraphSeparator,
+            _ => TextConcern.None,
         };
 }

--- a/src/InertText/VisualEncoder.cs
+++ b/src/InertText/VisualEncoder.cs
@@ -72,6 +72,7 @@ public static class VisualEncoder
         ScalarPolicy permits = ScalarPolicies.For(policy);
 
         VisualForm formsUsed = VisualForm.None;
+        TextConcern concerns = TextConcern.None;
         StringBuilder? builder = null;
 
         int i = 0;
@@ -95,10 +96,15 @@ public static class VisualEncoder
             {
                 AppendBmpHex(builder, value[i]);
                 formsUsed |= VisualForm.BmpHex;
+                concerns |= TextConcern.Surrogate;
             }
             else
             {
                 formsUsed |= AppendSpelling(builder, scalar);
+                if (value[i] != '\\')
+                {
+                    concerns |= ScalarPolicies.ConcernFor(Rune.GetUnicodeCategory(scalar));
+                }
             }
 
             i += width;
@@ -108,10 +114,14 @@ public static class VisualEncoder
         {
             return new InertString(
                 original ?? value.ToString(),
-                VisualForm.None);
+                VisualForm.None,
+                TextConcern.None);
         }
 
-        return new InertString(builder?.ToString() ?? original ?? value.ToString(), formsUsed);
+        return new InertString(
+            builder?.ToString() ?? original ?? value.ToString(),
+            formsUsed,
+            concerns);
     }
 
     private static bool CanRetainLiteralBackslashes(ReadOnlySpan<char> value)
@@ -131,7 +141,8 @@ public static class VisualEncoder
     internal static void AppendForComposition(
         StringBuilder builder,
         InertString value,
-        ref VisualForm forms)
+        ref VisualForm forms,
+        ref TextConcern concerns)
     {
         string text = value.ToString();
 
@@ -139,6 +150,7 @@ public static class VisualEncoder
         {
             builder.Append(text);
             forms |= value.Forms;
+            concerns |= value.Concerns;
             return;
         }
 
@@ -159,16 +171,17 @@ public static class VisualEncoder
     internal static InertString CompleteComposition(
         string encoded,
         VisualForm forms,
+        TextConcern concerns,
         bool truncated)
     {
         if (forms == VisualForm.Backslash
             && TryDecode(encoded, out string? original)
             && CanRetainLiteralBackslashes(original))
         {
-            return new InertString(original, VisualForm.None, truncated);
+            return new InertString(original, VisualForm.None, TextConcern.None, truncated);
         }
 
-        return new InertString(encoded, forms, truncated);
+        return new InertString(encoded, forms, concerns, truncated);
     }
 
     /// <summary>
@@ -609,12 +622,13 @@ public static class VisualEncoder
             && char.IsHighSurrogate((char)high)
             && char.IsLowSurrogate((char)low);
 
-    internal static VisualForm ValidateEncoded(
+    internal static (VisualForm Forms, TextConcern Concerns) ValidateEncoded(
         TextPolicy policy,
         ReadOnlySpan<char> encoded)
     {
         ScalarPolicy permits = ScalarPolicies.For(policy);
         VisualForm forms = VisualForm.None;
+        TextConcern concerns = TextConcern.None;
         int rawBackslashIndex = -1;
 
         for (int index = 0; index < encoded.Length;)
@@ -642,6 +656,7 @@ public static class VisualEncoder
             }
 
             forms |= form;
+            concerns |= ConcernForSpelling(encoded, index, form);
             index += width;
         }
 
@@ -652,7 +667,32 @@ public static class VisualEncoder
         if (forms != VisualForm.None && rawBackslashIndex >= 0)
             throw InvalidEncodedText(rawBackslashIndex);
 
-        return forms;
+        return (forms, concerns);
+    }
+
+    private static TextConcern ConcernForSpelling(
+        ReadOnlySpan<char> encoded,
+        int index,
+        VisualForm form)
+    {
+        switch (form)
+        {
+            case VisualForm.Caret:
+            case VisualForm.CaretDelete:
+                return TextConcern.Control;
+            case VisualForm.BmpHex:
+                _ = TryReadHex(encoded, index + 2, 4, out uint bmp);
+                return char.IsSurrogate((char)bmp)
+                    ? TextConcern.Surrogate
+                    : ScalarPolicies.ConcernFor(
+                        Rune.GetUnicodeCategory(new Rune((int)bmp)));
+            case VisualForm.AstralHex:
+                _ = TryReadHex(encoded, index + 2, 8, out uint astral);
+                return ScalarPolicies.ConcernFor(
+                    Rune.GetUnicodeCategory(new Rune((int)astral)));
+            default:
+                return TextConcern.None;
+        }
     }
 
     private static FormatException InvalidEncodedText(int index)
@@ -672,7 +712,7 @@ public static class VisualEncoder
     /// text, and an end below the start gives an empty window, because the end walks from the
     /// start and only ever advances.
     /// </remarks>
-    internal static (int Start, int End, VisualForm Forms) WindowWithin(
+    internal static (int Start, int End, VisualForm Forms, TextConcern Concerns) WindowWithin(
         ReadOnlySpan<char> encoded,
         int start,
         int end)
@@ -685,6 +725,7 @@ public static class VisualEncoder
         }
 
         VisualForm forms = VisualForm.None;
+        TextConcern concerns = TextConcern.None;
         int to = from;
 
         while (to < end && to < encoded.Length)
@@ -697,9 +738,10 @@ public static class VisualEncoder
             }
 
             forms |= form;
+            concerns |= ConcernForSpelling(encoded, to, form);
             to += width;
         }
 
-        return (from, to, forms);
+        return (from, to, forms, concerns);
     }
 }

--- a/src/dotnet-inspect.Tests/AssemblyReferenceTreeResolutionTests.cs
+++ b/src/dotnet-inspect.Tests/AssemblyReferenceTreeResolutionTests.cs
@@ -100,6 +100,95 @@ public class AssemblyReferenceTreeResolutionTests
     }
 
     [Fact]
+    public void ReferenceTreePathIdentity_IsCaseSensitiveOutsideWindows()
+    {
+        Assert.False(
+            LibraryMetadataService.ReferenceTreePathComparer(isWindows: false)
+                .Equals("Bridge.dll", "bridge.dll"));
+        Assert.True(
+            LibraryMetadataService.ReferenceTreePathComparer(isWindows: true)
+                .Equals("Bridge.dll", "bridge.dll"));
+    }
+
+    [Fact]
+    public void CaseDistinctResolvedPaths_DoNotSuppressDistinctCultures()
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-reference-tree-").FullName;
+        try
+        {
+            const string firstConcern = "Micr\u03BFsoft.One";
+            const string secondConcern = "Micr\u03BFsoft.Two";
+            string firstPath = Path.Combine(root, "Bridge.dll");
+            string secondPath = Path.Combine(root, "bridge.dll");
+            File.WriteAllBytes(
+                firstPath,
+                BuildAssembly(
+                    "Bridge",
+                    new Version(1, 0, 0, 0),
+                    "en-US",
+                    new AssemblyReferenceIdentity(
+                        firstConcern,
+                        new Version(1, 0, 0, 0),
+                        null,
+                        null)));
+            File.WriteAllBytes(
+                secondPath,
+                BuildAssembly(
+                    "Bridge",
+                    new Version(1, 0, 0, 0),
+                    "fr-FR",
+                    new AssemblyReferenceIdentity(
+                        secondConcern,
+                        new Version(1, 0, 0, 0),
+                        null,
+                        null)));
+            if (Directory.EnumerateFiles(root, "*.dll").Count() != 2)
+            {
+                Assert.Skip(
+                    "The filesystem does not support case-distinct sibling files.");
+                return;
+            }
+
+            string ownerPath = Path.Combine(root, "Owner.dll");
+            File.WriteAllBytes(
+                ownerPath,
+                BuildAssembly(
+                    "Owner",
+                    new Version(1, 0, 0, 0),
+                    new AssemblyReferenceIdentity(
+                        "Bridge",
+                        new Version(1, 0, 0, 0),
+                        "en-US",
+                        null),
+                    new AssemblyReferenceIdentity(
+                        "Bridge",
+                        new Version(1, 0, 0, 0),
+                        "fr-FR",
+                        null)));
+
+            List<AssemblyReferenceNode> nodes =
+                BuildTree(ownerPath, maxDepth: 2);
+
+            Assert.Equal(
+                2,
+                nodes.Count(node => node.Name == "Bridge"));
+            Assert.Contains(
+                nodes,
+                node => node.Name == firstConcern
+                    && node.Depth == 1);
+            Assert.Contains(
+                nodes,
+                node => node.Name == secondConcern
+                    && node.Depth == 1);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void DistinctSameNameReferences_DoNotSuppressResolvableIdentity()
     {
         string root = Directory.CreateTempSubdirectory(

--- a/src/dotnet-inspect.Tests/AssemblyReferenceTreeResolutionTests.cs
+++ b/src/dotnet-inspect.Tests/AssemblyReferenceTreeResolutionTests.cs
@@ -100,6 +100,62 @@ public class AssemblyReferenceTreeResolutionTests
     }
 
     [Fact]
+    public void DistinctSameNameReferences_DoNotSuppressResolvableIdentity()
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-reference-tree-").FullName;
+        try
+        {
+            const string concerningName = "Micr\u03BFsoft.Hidden";
+            File.WriteAllBytes(
+                Path.Combine(root, "Bridge.dll"),
+                BuildAssembly("Bridge", concerningName));
+
+            var mismatching = new AssemblyReferenceIdentity(
+                "Bridge",
+                new Version(1, 0, 0, 0),
+                null,
+                "0000000000000000");
+            var wildcard = new AssemblyReferenceIdentity(
+                "Bridge",
+                new Version(1, 0, 0, 0),
+                null,
+                null);
+            foreach (AssemblyReferenceIdentity[] references in new[]
+            {
+                new[] { mismatching, wildcard },
+                new[] { wildcard, mismatching },
+            })
+            {
+                string ownerPath = Path.Combine(
+                    root,
+                    $"Owner-{Guid.NewGuid():N}.dll");
+                File.WriteAllBytes(
+                    ownerPath,
+                    BuildAssembly(
+                        Path.GetFileNameWithoutExtension(ownerPath),
+                        new Version(1, 0, 0, 0),
+                        references));
+
+                List<AssemblyReferenceNode> nodes =
+                    BuildTree(ownerPath, maxDepth: 2);
+
+                Assert.Equal(
+                    2,
+                    nodes.Count(node => node.Name == "Bridge"));
+                Assert.Contains(
+                    nodes,
+                    node => node.Name == concerningName
+                        && node.Depth == 1);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task OmittedCultureReference_UsesCulturedSiblingThroughInspectionModel()
     {
         string root = Directory.CreateTempSubdirectory(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -11877,6 +11877,25 @@ public partial class CommandExecutionTests
                 + Environment.NewLine,
                 error);
 
+            var category = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                "@Audit",
+                "--tips",
+                "q");
+
+            Assert.Equal(1, category.Exit);
+            Assert.Contains("## Signals", category.Output);
+            Assert.Contains(
+                "## Audit: Identifier Confusion",
+                category.Output);
+            Assert.Contains("U+0405→S", category.Output);
+            Assert.Equal(
+                "Warning: Identifier audit failed: invalid assembly metadata"
+                + Environment.NewLine,
+                category.Error);
+
             var relative = await RunAppInDirectoryAsync(
                 tempDir,
                 "library",

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -11638,6 +11638,69 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryIdentifierConfusionAudit_DeduplicatesDiamondClosure()
+    {
+        const string concerningName = "Micr\u03BFsoft.Shared";
+        var tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-reference-diamond-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, $"{concerningName}.dll"),
+                concerningName);
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, "Alpha.dll"),
+                "Alpha",
+                concerningName);
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, "Bridge.dll"),
+                "Bridge",
+                "Alpha",
+                concerningName);
+            string rootPath = Path.Combine(tempDir, "Root.dll");
+            WriteReferenceFixtureAssembly(
+                rootPath,
+                "Root",
+                "Bridge");
+
+            var audit = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+            var tree = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                SectionNames.References,
+                "--tree",
+                "--tips",
+                "q");
+
+            Assert.Equal(0, audit.Exit);
+            Assert.Empty(audit.Error);
+            Assert.Equal(
+                1,
+                CountOutput.CountMarkdownTableRows(audit.Output));
+            Assert.Equal(0, tree.Exit);
+            Assert.Empty(tree.Error);
+            Assert.Equal(
+                1,
+                tree.Output.Split(
+                    concerningName,
+                    StringSplitOptions.None).Length - 1);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task PackageAllLibrariesIdentifierConfusionAudit_CollectsTransitiveReferences()
     {
         var (packagePath, tempDir) = CreateIdentifierConfusionReferencePackage();
@@ -12117,6 +12180,63 @@ public partial class CommandExecutionTests
         Assert.Empty(error);
         Assert.Contains("System.Collections", output);
         Assert.DoesNotContain("System.Private.CoreLib", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_SelectedReferences_TreeDedupUsesShallowestPath()
+    {
+        var tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"reference-shallowest-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, "Leaf.dll"),
+                "Leaf");
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, "Target.dll"),
+                "Target",
+                "Leaf");
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, "B.dll"),
+                "B",
+                "Target");
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, "A.dll"),
+                "A",
+                "B");
+            string rootPath = Path.Combine(tempDir, "Root.dll");
+            WriteReferenceFixtureAssembly(
+                rootPath,
+                "Root",
+                "A",
+                "Target");
+
+            var (exit, output, error) = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                SectionNames.References,
+                "--tree",
+                "--depth",
+                "3",
+                "--tips",
+                "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("Leaf", output);
+            Assert.Equal(
+                1,
+                output.Split(
+                    "Target ",
+                    StringSplitOptions.None).Length - 1);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]
@@ -15897,6 +16017,63 @@ public partial class CommandExecutionTests
             Assert.Empty(singleCountError);
             Assert.Empty(multiCountError);
             Assert.Equal(singleCountOutput, multiCountOutput);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryCommand_TfmAll_PreservesHealthyIdentifierAuditResults()
+    {
+        var tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-multitfm-test-{Guid.NewGuid():N}");
+        try
+        {
+            var content = Path.Combine(tempDir, "content");
+            var net8Dir = Path.Combine(content, "lib", "net8.0");
+            var net10Dir = Path.Combine(content, "lib", "net10.0");
+            Directory.CreateDirectory(net8Dir);
+            Directory.CreateDirectory(net10Dir);
+            WriteReferenceFixtureAssembly(
+                Path.Combine(net8Dir, "Lib.dll"),
+                "\u0405ystem.Healthy");
+            WriteReferenceFixtureAssembly(
+                Path.Combine(net10Dir, "Lib.dll"),
+                "Lib",
+                "Bridge");
+            File.WriteAllText(
+                Path.Combine(net10Dir, "Bridge.dll"),
+                "not a managed assembly");
+            var packagePath = Path.Combine(
+                tempDir,
+                "Identifier.MultiTfm.1.0.0.nupkg");
+            ZipFile.CreateFromDirectory(content, packagePath);
+
+            var (exit, output, error) = await RunAppAsync(
+                "library",
+                "Lib.dll",
+                "--package",
+                packagePath,
+                "--tfm",
+                "all",
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.Equal(1, exit);
+            Assert.Contains("### Lib.dll (net8.0)", output);
+            Assert.Contains("U+0405→S", output);
+            Assert.Contains(
+                "Warning: Identifier audit failed for "
+                + "'lib/net10.0/Lib.dll': invalid assembly metadata",
+                error);
+            Assert.DoesNotContain(
+                "IdentifierConfusionReferenceTraversalException",
+                error);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14730,6 +14730,27 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_DiscoverSchema_ListsIdentifierConfusionAuditColumns()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package",
+            "-D",
+            PackageSections.AuditIdentifierConfusion,
+            "--schema",
+            "--tips",
+            "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("| Location | column |", output);
+        Assert.Contains("| Kind | column |", output);
+        Assert.Contains("| Concern | column |", output);
+        Assert.Contains("| Reserved Prefix | column |", output);
+        Assert.Contains("| Similarity | column |", output);
+        Assert.Contains("| Characters | column |", output);
+    }
+
+    [Fact]
     public async Task Package_DiscoverTree_UsesDiscoveryTreeNotFileTree()
     {
         var (packagePath, tempDir) = CreateLocalReadmePackage(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -11701,6 +11701,50 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryIdentifierConfusionAudit_PreservesCaseDistinctUnresolvedReferences()
+    {
+        const string upperName = "Micr\u039fsoft.Hidden";
+        const string lowerName = "micr\u03bfsoft.hidden";
+        string tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-case-distinct-unresolved-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, "Bridge.dll"),
+                "Bridge",
+                upperName,
+                lowerName);
+            string rootPath = Path.Combine(tempDir, "Root.dll");
+            WriteReferenceFixtureAssembly(
+                rootPath,
+                "Root",
+                "Bridge");
+
+            var (exit, output, error) = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Equal(
+                2,
+                CountOutput.CountMarkdownTableRows(output));
+            Assert.Contains("U+039F→O", output);
+            Assert.Contains("U+03BF→O", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task PackageAllLibrariesIdentifierConfusionAudit_CollectsTransitiveReferences()
     {
         var (packagePath, tempDir) = CreateIdentifierConfusionReferencePackage();
@@ -11997,6 +12041,48 @@ public partial class CommandExecutionTests
                     + Environment.NewLine,
                     discovery.Error);
             }
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryPackageSignals_FullEffectiveDiscoveryWarnsOnce()
+    {
+        string tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-package-signals-discovery-test-{Guid.NewGuid():N}");
+        string content = Path.Combine(tempDir, "content");
+        string libraryDirectory = Path.Combine(content, "lib", "net8.0");
+        Directory.CreateDirectory(libraryDirectory);
+        try
+        {
+            WriteMalformedAssemblyReferenceNameAssembly(
+                Path.Combine(libraryDirectory, "Root.dll"));
+            string packagePath = Path.Combine(
+                tempDir,
+                "Identifier.Package.Signals.1.0.0.nupkg");
+            ZipFile.CreateFromDirectory(content, packagePath);
+
+            var discovery = await RunAppAsync(
+                "library",
+                "Root.dll",
+                "--package",
+                packagePath,
+                "-D",
+                SectionNames.Signals,
+                "--effective",
+                "--tips",
+                "q");
+
+            Assert.Equal(1, discovery.Exit);
+            Assert.Contains("| Area | column |", discovery.Output);
+            Assert.Equal(
+                "Warning: Identifier audit failed: invalid assembly metadata"
+                + Environment.NewLine,
+                discovery.Error);
         }
         finally
         {
@@ -21034,6 +21120,41 @@ public partial class CommandExecutionTests
             Assert.Equal(
                 expected.ToString(CultureInfo.InvariantCulture),
                 combinedOutput.Trim());
+        }
+        finally
+        {
+            Directory.Delete(firstTempDir, recursive: true);
+            Directory.Delete(secondTempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_FixedOverviewCountPopulatesSections()
+    {
+        var (firstPackagePath, firstTempDir) =
+            CreateLocalReadmePackage(
+                "Test.FixedOverview.One",
+                "README.md",
+                "one");
+        var (secondPackagePath, secondTempDir) =
+            CreateLocalReadmePackage(
+                "Test.FixedOverview.Two",
+                "README.md",
+                "two");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package",
+                firstPackagePath,
+                secondPackagePath,
+                "-S",
+                "--count",
+                "--json");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("| Package nuspec file | 2 |", output);
+            Assert.Contains("| Signature | 6 |", output);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -229,6 +229,39 @@ public partial class CommandExecutionTests
         return (rootPath, tempDir);
     }
 
+    private static (string PackagePath, string TempDir)
+        CreateIdentifierConfusionReferencePackage()
+    {
+        const string directName = "\u0405ystem.Direct";
+        const string transitiveName = "Micr\u03BFsoft.Transitive";
+        var tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-reference-package-test-{Guid.NewGuid():N}");
+        var packageRoot = Path.Combine(tempDir, "content");
+        var libraryDirectory = Path.Combine(packageRoot, "lib", "net8.0");
+        Directory.CreateDirectory(libraryDirectory);
+
+        WriteReferenceFixtureAssembly(
+            Path.Combine(libraryDirectory, $"{directName}.dll"),
+            directName);
+        WriteReferenceFixtureAssembly(
+            Path.Combine(libraryDirectory, $"{transitiveName}.dll"),
+            transitiveName);
+        WriteReferenceFixtureAssembly(
+            Path.Combine(libraryDirectory, "Bridge.dll"),
+            "Bridge",
+            transitiveName);
+        WriteReferenceFixtureAssembly(
+            Path.Combine(libraryDirectory, "Root.dll"),
+            "Root",
+            directName,
+            "Bridge");
+
+        var packagePath = Path.Combine(tempDir, "Identifier.Reference.1.0.0.nupkg");
+        ZipFile.CreateFromDirectory(packageRoot, packagePath);
+        return (packagePath, tempDir);
+    }
+
     private static void WriteMalformedTypeNameAssembly(string path)
     {
         var metadata = new MetadataBuilder();
@@ -11541,10 +11574,147 @@ public partial class CommandExecutionTests
                 $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
             Assert.Empty(error);
             Assert.Contains("AssemblyInfo.References[", output);
-            Assert.Contains("AssemblyInfo.TransitiveReferences[", output);
+            Assert.Contains("IdentifierConfusionReferenceClosure[", output);
             Assert.Contains("U+0405→S", output);
             Assert.Contains("U+03BF→O", output);
             Assert.Equal(2, CountOutput.CountMarkdownTableRows(output));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PackageAllLibrariesIdentifierConfusionAudit_CollectsTransitiveReferences()
+    {
+        var (packagePath, tempDir) = CreateIdentifierConfusionReferencePackage();
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "package",
+                packagePath,
+                "--all-libraries",
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("Using TFM: net8.0", error);
+            Assert.Contains("IdentifierConfusionReferenceClosure[", output);
+            Assert.Contains("U+03BF→O", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryIdentifierConfusionAudit_FullEffectiveDiscoveryIncludesTransitiveOnlyConcern()
+    {
+        const string transitiveName = "Micr\u03BFsoft.DiscoveryOnly";
+        var tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-reference-discovery-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, $"{transitiveName}.dll"),
+                transitiveName);
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, "Bridge.dll"),
+                "Bridge",
+                transitiveName);
+            string rootPath = Path.Combine(tempDir, "Root.dll");
+            WriteReferenceFixtureAssembly(rootPath, "Root", "Bridge");
+
+            var (exit, output, error) = await RunAppAsync(
+                "library",
+                rootPath,
+                "-D",
+                SectionNames.IdentifierConfusion,
+                "--effective",
+                "--tips",
+                "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("| Location | column |", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryIdentifierConfusionAudit_DoesNotRepeatDirectReferenceFromClosure()
+    {
+        const string concerningName = "\u0405ystem.Duplicate";
+        var tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-reference-duplicate-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, $"{concerningName}.dll"),
+                concerningName);
+            WriteReferenceFixtureAssembly(
+                Path.Combine(tempDir, "Bridge.dll"),
+                "Bridge",
+                concerningName);
+            string rootPath = Path.Combine(tempDir, "Root.dll");
+            WriteReferenceFixtureAssembly(
+                rootPath,
+                "Root",
+                "Bridge",
+                concerningName);
+
+            var (exit, output, error) = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("AssemblyInfo.References[", output);
+            Assert.DoesNotContain("IdentifierConfusionReferenceClosure[", output);
+            Assert.Equal(1, CountOutput.CountMarkdownTableRows(output));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryIdentifierConfusionAudit_FailsWhenResolvedReferenceCannotBeRead()
+    {
+        var (rootPath, tempDir) = CreateIdentifierConfusionReferenceGraph();
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "Bridge.dll"), "not a managed assembly");
+
+            var (exit, output, error) = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains(
+                "Failed to inspect resolved assembly reference 'Bridge'",
+                error);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO.Compression;
 using System.Reflection;
@@ -970,6 +971,29 @@ public partial class CommandExecutionTests
                 "NUGET_PACKAGES",
                 original);
         }
+    }
+
+    private static async Task<(int Exit, string Output, string Error)>
+        RunAppInDirectoryAsync(
+            string workingDirectory,
+            params string[] args)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(typeof(CommandLineBuilder).Assembly.Location);
+        foreach (string arg in args)
+            startInfo.ArgumentList.Add(arg);
+
+        using Process process = Process.Start(startInfo)!;
+        Task<string> output = process.StandardOutput.ReadToEndAsync();
+        Task<string> error = process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        return (process.ExitCode, await output, await error);
     }
 
     private static IEnumerable<string> JsonStrings(JsonElement element)
@@ -11715,6 +11739,68 @@ public partial class CommandExecutionTests
             Assert.Contains(
                 "Failed to inspect resolved assembly reference 'Bridge'",
                 error);
+
+            var relative = await RunAppInDirectoryAsync(
+                tempDir,
+                "library",
+                "Root.dll",
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.Equal(1, relative.Exit);
+            Assert.Empty(relative.Output);
+            Assert.Contains(
+                "Failed to inspect resolved assembly reference 'Bridge'",
+                relative.Error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure()
+    {
+        var (packagePath, tempDir) = CreateIdentifierConfusionReferencePackage();
+        try
+        {
+            string packageRoot = Path.Combine(tempDir, "content");
+            string libraryDirectory = Path.Combine(packageRoot, "lib", "net8.0");
+            WriteReferenceFixtureAssembly(
+                Path.Combine(libraryDirectory, "A.Valid.dll"),
+                "\u0405ystem.Valid");
+            File.WriteAllText(
+                Path.Combine(libraryDirectory, "Bridge.dll"),
+                "not a managed assembly");
+            File.Delete(packagePath);
+            ZipFile.CreateFromDirectory(packageRoot, packagePath);
+
+            var (exit, output, error) = await RunAppAsync(
+                "package",
+                packagePath,
+                "--all-libraries",
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.Equal(1, exit);
+            Assert.Contains("U+0405→S", output);
+            Assert.Equal(
+                [
+                    "Using TFM: net8.0",
+                    "Warning: Identifier audit failed for "
+                    + "'lib/net8.0/Root.dll' while inspecting reference "
+                    + "'Bridge': BadImageFormatException",
+                ],
+                error.ReplaceLineEndings("\n")
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            Assert.DoesNotContain(
+                "IdentifierConfusionReferenceTraversalException",
+                error);
         }
         finally
         {
@@ -11746,6 +11832,32 @@ public partial class CommandExecutionTests
         Assert.Contains("System.Private.CoreLib", output);
         Assert.DoesNotContain("## Dependencies", output);
         Assert.DoesNotContain("Name: System.Text.Json", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_SelectedReferences_TreeResolvesBareRelativePath()
+    {
+        var (_, tempDir) = CreateIdentifierConfusionReferenceGraph();
+        try
+        {
+            var (exit, output, error) = await RunAppInDirectoryAsync(
+                tempDir,
+                "library",
+                "Root.dll",
+                "-S",
+                SectionNames.References,
+                "--tree",
+                "--tips",
+                "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("Micr\u03bFsoft.Transitive", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -11920,6 +11920,51 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryPackageIdentifierConfusionAudit_FailsWithoutPartialDocument()
+    {
+        var (packagePath, tempDir) =
+            CreateIdentifierConfusionReferencePackage();
+        try
+        {
+            string bridgePath = Path.Combine(
+                tempDir,
+                "content",
+                "lib",
+                "net8.0",
+                "Bridge.dll");
+            File.WriteAllText(
+                bridgePath,
+                "not a managed assembly");
+            File.Delete(packagePath);
+            ZipFile.CreateFromDirectory(
+                Path.Combine(tempDir, "content"),
+                packagePath);
+
+            var result = await RunAppAsync(
+                "library",
+                "Root.dll",
+                "--package",
+                packagePath,
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.Equal(1, result.Exit);
+            Assert.Empty(result.Output);
+            Assert.Equal(
+                "Error: Identifier audit could not inspect assembly "
+                + "references: invalid assembly metadata."
+                + Environment.NewLine,
+                result.Error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task PackageAllLibrariesIdentifierConfusionAudit_PreservesHealthyResultsOnTraversalFailure()
     {
         var (packagePath, tempDir) = CreateIdentifierConfusionReferencePackage();

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -205,6 +205,34 @@ public partial class CommandExecutionTests
         File.WriteAllBytes(path, image.ToArray());
     }
 
+    private static void WriteMalformedAssemblyReferenceNameAssembly(
+        string path)
+    {
+        WriteReferenceFixtureAssembly(
+            path,
+            "Malformed.Reference.Root",
+            "System.Runtime");
+        byte[] bytes = File.ReadAllBytes(path);
+        using var peReader = new PEReader(
+            new MemoryStream(bytes, writable: false));
+        MetadataReader reader = peReader.GetMetadataReader();
+        Assert.True(
+            reader.GetHeapSize(HeapIndex.Blob) <= ushort.MaxValue
+            && reader.GetHeapSize(HeapIndex.String) <= ushort.MaxValue);
+        int assemblyReferenceNameOffset =
+            peReader.PEHeaders.MetadataStartOffset
+            + reader.GetTableMetadataOffset(TableIndex.AssemblyRef)
+            + (4 * sizeof(ushort))
+            + sizeof(uint)
+            + sizeof(ushort);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            bytes.AsSpan(
+                assemblyReferenceNameOffset,
+                sizeof(ushort)),
+            ushort.MaxValue);
+        File.WriteAllBytes(path, bytes);
+    }
+
     private static (string RootPath, string TempDir)
         CreateIdentifierConfusionReferenceGraph()
     {
@@ -11736,8 +11764,10 @@ public partial class CommandExecutionTests
 
             Assert.Equal(1, exit);
             Assert.Empty(output);
-            Assert.Contains(
-                "Failed to inspect resolved assembly reference 'Bridge'",
+            Assert.Equal(
+                "Error: Identifier audit could not inspect assembly "
+                + "references: invalid assembly metadata."
+                + Environment.NewLine,
                 error);
 
             var relative = await RunAppInDirectoryAsync(
@@ -11751,8 +11781,10 @@ public partial class CommandExecutionTests
 
             Assert.Equal(1, relative.Exit);
             Assert.Empty(relative.Output);
-            Assert.Contains(
-                "Failed to inspect resolved assembly reference 'Bridge'",
+            Assert.Equal(
+                "Error: Identifier audit could not inspect assembly "
+                + "references: invalid assembly metadata."
+                + Environment.NewLine,
                 relative.Error);
         }
         finally
@@ -11793,14 +11825,152 @@ public partial class CommandExecutionTests
                 [
                     "Using TFM: net8.0",
                     "Warning: Identifier audit failed for "
-                    + "'lib/net8.0/Root.dll' while inspecting reference "
-                    + "'Bridge': BadImageFormatException",
+                    + "'lib/net8.0/Root.dll': invalid assembly metadata",
                 ],
                 error.ReplaceLineEndings("\n")
                     .Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            Assert.DoesNotContain("Bridge", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded()
+    {
+        string tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-reference-decode-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            string rootPath = Path.Combine(tempDir, "Root.dll");
+            WriteMalformedAssemblyReferenceNameAssembly(rootPath);
+
+            var signals = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                SectionNames.Signals,
+                "--tips",
+                "q");
+
+            Assert.Equal(1, signals.Exit);
+            Assert.Equal(
+                "Warning: Identifier audit failed: invalid assembly metadata"
+                + Environment.NewLine,
+                signals.Error);
+            Assert.Contains(
+                "| Identity | Identifier confusion | Unavailable "
+                + "| invalid assembly metadata |",
+                signals.Output);
             Assert.DoesNotContain(
-                "IdentifierConfusionReferenceTraversalException",
-                error);
+                "| Identity | Identifier confusion | None |",
+                signals.Output);
+
+            var audit = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.Equal(1, audit.Exit);
+            Assert.Empty(audit.Output);
+            Assert.Equal(
+                "Error: Identifier audit could not inspect assembly "
+                + "references: invalid assembly metadata."
+                + Environment.NewLine,
+                audit.Error);
+            Assert.DoesNotContain(rootPath, audit.Error);
+
+            var discovery = await RunAppAsync(
+                "library",
+                rootPath,
+                "-D",
+                SectionNames.IdentifierConfusion,
+                "--effective");
+
+            Assert.Equal(1, discovery.Exit);
+            Assert.Empty(discovery.Output);
+            Assert.Equal(audit.Error, discovery.Error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PackageAllLibrariesIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded()
+    {
+        string tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-reference-decode-package-{Guid.NewGuid():N}");
+        string packageRoot = Path.Combine(tempDir, "content");
+        string libraryDirectory = Path.Combine(packageRoot, "lib", "net8.0");
+        Directory.CreateDirectory(libraryDirectory);
+        try
+        {
+            WriteReferenceFixtureAssembly(
+                Path.Combine(libraryDirectory, "A.Valid.dll"),
+                "\u0405ystem.Valid");
+            WriteMalformedAssemblyReferenceNameAssembly(
+                Path.Combine(libraryDirectory, "Root.dll"));
+            string packagePath = Path.Combine(
+                tempDir,
+                "Identifier.Reference.Decode.1.0.0.nupkg");
+            ZipFile.CreateFromDirectory(packageRoot, packagePath);
+
+            var (exit, output, error) = await RunAppAsync(
+                "package",
+                packagePath,
+                "--all-libraries",
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.Equal(1, exit);
+            Assert.Contains("U+0405→S", output);
+            Assert.Equal(
+                [
+                    "Using TFM: net8.0",
+                    "Warning: Identifier audit failed for "
+                    + "'lib/net8.0/Root.dll': invalid assembly metadata",
+                ],
+                error.ReplaceLineEndings("\n")
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            Assert.DoesNotContain("System.Runtime", error);
+
+            var signals = await RunAppAsync(
+                "package",
+                packagePath,
+                "--all-libraries",
+                "-S",
+                SectionNames.Signals,
+                "--tips",
+                "q");
+
+            Assert.Equal(1, signals.Exit);
+            Assert.Contains(
+                "| Identity | Identifier confusion | Unavailable "
+                + "| invalid assembly metadata |",
+                signals.Output);
+            Assert.DoesNotContain(
+                "| Identity | Identifier confusion | None |",
+                signals.Output);
+            Assert.Equal(
+                [
+                    "Using TFM: net8.0",
+                    "Warning: Identifier audit failed for "
+                    + "'lib/net8.0/Root.dll': invalid assembly metadata",
+                ],
+                signals.Error.ReplaceLineEndings("\n")
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries));
         }
         finally
         {
@@ -11853,6 +12023,45 @@ public partial class CommandExecutionTests
             Assert.Equal(0, exit);
             Assert.Empty(error);
             Assert.Contains("Micr\u03bFsoft.Transitive", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryReferenceTree_ReadFailureDiagnosticIsContentFree()
+    {
+        var (rootPath, tempDir) = CreateIdentifierConfusionReferenceGraph();
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(tempDir, "Bridge.dll"),
+                "not a managed assembly");
+
+            var (exit, output, error) = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                SectionNames.References,
+                "--tree",
+                "--verbose",
+                "--tips",
+                "q");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("## References", output);
+            Assert.Equal(
+                [
+                    "Inspecting: Root.dll",
+                    "Warning: Could not inspect a resolved assembly "
+                    + "reference: invalid assembly metadata",
+                ],
+                error.ReplaceLineEndings("\n")
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries));
+            Assert.DoesNotContain("Bridge", error);
+            Assert.DoesNotContain(tempDir, error);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -11905,6 +11905,43 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibrarySignals_FullEffectiveDiscoveryPropagatesReferenceFailure()
+    {
+        string tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-signals-discovery-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            string rootPath = Path.Combine(tempDir, "Root.dll");
+            WriteMalformedAssemblyReferenceNameAssembly(rootPath);
+
+            for (int attempt = 0; attempt < 2; attempt++)
+            {
+                var discovery = await RunAppAsync(
+                    "library",
+                    rootPath,
+                    "-D",
+                    SectionNames.Signals,
+                    "--effective",
+                    "--tips",
+                    "q");
+
+                Assert.Equal(1, discovery.Exit);
+                Assert.Contains("| Area | column |", discovery.Output);
+                Assert.Equal(
+                    "Warning: Identifier audit failed: invalid assembly metadata"
+                    + Environment.NewLine,
+                    discovery.Error);
+            }
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task PackageAllLibrariesIdentifierConfusionAudit_FailsWhenDirectReferencesCannotBeDecoded()
     {
         string tempDir = Path.Combine(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -157,6 +157,78 @@ public partial class CommandExecutionTests
         File.WriteAllBytes(path, image.ToArray());
     }
 
+    private static void WriteReferenceFixtureAssembly(
+        string path,
+        string assemblyName,
+        params string[] references)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString(Path.GetFileName(path)),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(assemblyName),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        foreach (string reference in references)
+        {
+            metadata.AddAssemblyReference(
+                metadata.GetOrAddString(reference),
+                new Version(1, 0, 0, 0),
+                default,
+                default,
+                default,
+                default);
+        }
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        File.WriteAllBytes(path, image.ToArray());
+    }
+
+    private static (string RootPath, string TempDir)
+        CreateIdentifierConfusionReferenceGraph()
+    {
+        const string directName = "\u0405ystem.Direct";
+        const string transitiveName = "Micr\u03BFsoft.Transitive";
+        var tempDir = Path.Combine(
+            Path.GetTempPath(),
+            $"identifier-reference-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        WriteReferenceFixtureAssembly(
+            Path.Combine(tempDir, $"{directName}.dll"),
+            directName);
+        WriteReferenceFixtureAssembly(
+            Path.Combine(tempDir, $"{transitiveName}.dll"),
+            transitiveName);
+        WriteReferenceFixtureAssembly(
+            Path.Combine(tempDir, "Bridge.dll"),
+            "Bridge",
+            transitiveName);
+        string rootPath = Path.Combine(tempDir, "Root.dll");
+        WriteReferenceFixtureAssembly(rootPath, "Root", directName, "Bridge");
+        return (rootPath, tempDir);
+    }
+
     private static void WriteMalformedTypeNameAssembly(string path)
     {
         var metadata = new MetadataBuilder();
@@ -11451,6 +11523,36 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryIdentifierConfusionAudit_CollectsDirectAndTransitiveReferenceNames()
+    {
+        var (rootPath, tempDir) = CreateIdentifierConfusionReferenceGraph();
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "library",
+                rootPath,
+                "-S",
+                SectionNames.IdentifierConfusion,
+                "--tips",
+                "q");
+
+            Assert.True(
+                exit == 0,
+                $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+            Assert.Empty(error);
+            Assert.Contains("AssemblyInfo.References[", output);
+            Assert.Contains("AssemblyInfo.TransitiveReferences[", output);
+            Assert.Contains("U+0405→S", output);
+            Assert.Contains("U+03BF→O", output);
+            Assert.Equal(2, CountOutput.CountMarkdownTableRows(output));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task LibraryCommand_EmptySelectedSection_CountsZero()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -20261,6 +20363,77 @@ public partial class CommandExecutionTests
         {
             Directory.Delete(tempDir, recursive: true);
         }
+    }
+
+    [Fact]
+    public async Task Package_MultiplePackages_SignalsIncludePackageFileConcerns()
+    {
+        var (cleanPackage, cleanTempDir) = CreateLocalReadmePackage(
+            "Test.Containment.Clean",
+            "README.md",
+            "readme");
+        var (hostilePackage, hostileTempDir) = CreateLocalReadmePackage(
+            "Test.Containment.Hostile",
+            "README.md",
+            "readme",
+            extraFiles: [("docs/\u202Esecret.txt", "payload")]);
+        try
+        {
+            var single = await RunAppAsync(
+                "package",
+                hostilePackage,
+                "-v:q",
+                "-S",
+                PackageSections.Signals,
+                "--json",
+                "--tips",
+                "q");
+            var multi = await RunAppAsync(
+                "package",
+                cleanPackage,
+                hostilePackage,
+                "-v:q",
+                "-S",
+                PackageSections.Signals,
+                "--json",
+                "--tips",
+                "q");
+
+            Assert.True(
+                single.Exit == 0,
+                $"exit={single.Exit}\nstdout:\n{single.Output}\nstderr:\n{single.Error}");
+            Assert.True(
+                multi.Exit == 0,
+                $"exit={multi.Exit}\nstdout:\n{multi.Output}\nstderr:\n{multi.Error}");
+            Assert.Empty(single.Error);
+            Assert.Empty(multi.Error);
+
+            using var singleDocument = JsonDocument.Parse(single.Output);
+            using var multiDocument = JsonDocument.Parse(multi.Output);
+            JsonElement singleSignal = Assert.Single(
+                singleDocument.RootElement.GetProperty("audit_signals").EnumerateArray(),
+                IsArtifactTextContainmentSignal);
+            JsonElement hostileResult = Assert.Single(
+                multiDocument.RootElement.EnumerateArray(),
+                package => package.GetProperty("package_name").GetString()
+                    == "Test.Containment.Hostile");
+            JsonElement multiSignal = Assert.Single(
+                hostileResult.GetProperty("audit_signals").EnumerateArray(),
+                IsArtifactTextContainmentSignal);
+
+            Assert.Equal("Required", singleSignal.GetProperty("value").GetString());
+            Assert.Equal("format/bidi (Cf)", singleSignal.GetProperty("evidence").GetString());
+            Assert.Equal("Required", multiSignal.GetProperty("value").GetString());
+            Assert.Equal("format/bidi (Cf)", multiSignal.GetProperty("evidence").GetString());
+        }
+        finally
+        {
+            Directory.Delete(cleanTempDir, recursive: true);
+            Directory.Delete(hostileTempDir, recursive: true);
+        }
+
+        static bool IsArtifactTextContainmentSignal(JsonElement signal)
+            => signal.GetProperty("signal").GetString() == "Artifact text containment";
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14713,6 +14713,23 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_DiscoverSchema_ListsArtifactTextAuditColumns()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "package",
+            "-D",
+            PackageSections.AuditArtifactText,
+            "--schema",
+            "--tips",
+            "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("| Location | column |", output);
+        Assert.Contains("| Concerns | column |", output);
+    }
+
+    [Fact]
     public async Task Package_DiscoverTree_UsesDiscoveryTreeNotFileTree()
     {
         var (packagePath, tempDir) = CreateLocalReadmePackage(

--- a/src/dotnet-inspect.Tests/IdentifierConfusionAuditTests.cs
+++ b/src/dotnet-inspect.Tests/IdentifierConfusionAuditTests.cs
@@ -76,7 +76,7 @@ public class IdentifierConfusionAuditTests
                     new AssemblyReference("Contoso.Δelta", "1.0.0.0", null, null),
                 ],
             },
-            IdentifierConfusionTransitiveReferences =
+            IdentifierConfusionReferenceClosure =
             [
                 new AssemblyReferenceNode { Name = "Micrοsoft.Transitive", Depth = 1 },
             ],
@@ -99,7 +99,7 @@ public class IdentifierConfusionAuditTests
                 null),
             value => AssertCase(
                 value,
-                "AssemblyInfo.TransitiveReferences[0].Name",
+                "IdentifierConfusionReferenceClosure[0].Name",
                 IdentifierConcern.NonAscii | IdentifierConcern.ReservedPrefixHomoglyph,
                 "Microsoft"));
     }
@@ -168,11 +168,11 @@ public class IdentifierConfusionAuditTests
                 [
                     new AssemblyReference("System.Runtime", "1.0.0.0", null, null),
                 ],
-                TransitiveReferences =
-                [
-                    new AssemblyReferenceNode { Name = "Micrοsoft.Transitive" },
-                ],
             },
+            IdentifierConfusionReferenceClosure =
+            [
+                new AssemblyReferenceNode { Name = "Micrοsoft.Transitive", Depth = 1 },
+            ],
         };
 
         AuditSignalBuilder.RefreshLibraryAuditSignals(model);

--- a/src/dotnet-inspect.Tests/IdentifierConfusionAuditTests.cs
+++ b/src/dotnet-inspect.Tests/IdentifierConfusionAuditTests.cs
@@ -166,6 +166,19 @@ public class IdentifierConfusionAuditTests
     }
 
     [Fact]
+    public void DescribeCharacters_DeduplicatesRepeatedHomoglyphCodePoints()
+    {
+        IdentifierConfusion confusion =
+            Assert.IsType<IdentifierConfusion>(
+                IdentifierConfusionDetector.Inspect(
+                    "Micr\u043Es\u043Eft.Extensions"));
+
+        Assert.Equal(
+            "U+043E→O",
+            IdentifierConfusionAudit.DescribeCharacters(confusion));
+    }
+
+    [Fact]
     public async Task PackageSignals_SeparatesIdentifierConfusionFromTextContainment()
     {
         var model = new InspectionResult

--- a/src/dotnet-inspect.Tests/IdentifierConfusionAuditTests.cs
+++ b/src/dotnet-inspect.Tests/IdentifierConfusionAuditTests.cs
@@ -1,0 +1,169 @@
+using DotnetInspector.Inspectors;
+using DotnetInspector.Models;
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+public class IdentifierConfusionAuditTests
+{
+    [Fact]
+    public void PackageAudit_InspectsPackageAndDependencyIdentifierLocations()
+    {
+        var model = new InspectionResult
+        {
+            PackageName = "Contoso.Utilities",
+            Deprecation = new PackageDeprecation { AlternatePackageId = "Δelta.Tools" },
+            DependencyGroups =
+            [
+                new DependencyGroup
+                {
+                    TargetFramework = "net11.0",
+                    Dependencies = [new PackageDependency { Id = "Ѕystem.Text.Json" }],
+                },
+            ],
+            RuntimeDependencies = [new PackageDependency { Id = "Micrοsoft.Runtime" }],
+            RuntimeIdentifierPackages =
+            [
+                new RidPackageReference
+                {
+                    RuntimeIdentifier = "linux-x64",
+                    PackageId = "Αzure.Native",
+                },
+            ],
+        };
+
+        IReadOnlyList<IdentifierConfusionCase> cases =
+            IdentifierConfusionAudit.InspectPackage(model);
+
+        Assert.Equal(4, cases.Count);
+        Assert.Collection(
+            cases,
+            value => AssertCase(
+                value,
+                "Deprecation.AlternatePackageId",
+                IdentifierConcern.NonAscii,
+                null),
+            value => AssertCase(
+                value,
+                "DependencyGroups[0].Dependencies[0].Id",
+                IdentifierConcern.NonAscii | IdentifierConcern.ReservedPrefixHomoglyph,
+                "System"),
+            value => AssertCase(
+                value,
+                "RuntimeDependencies[0].Id",
+                IdentifierConcern.NonAscii | IdentifierConcern.ReservedPrefixHomoglyph,
+                "Microsoft"),
+            value => AssertCase(
+                value,
+                "RuntimeIdentifierPackages[0].PackageId",
+                IdentifierConcern.NonAscii | IdentifierConcern.ReservedPrefixHomoglyph,
+                "Azure"));
+    }
+
+    [Fact]
+    public void LibraryAudit_InspectsAssemblyAndReferenceNames()
+    {
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo
+            {
+                AssemblyName = "Ѕystem.Facade",
+                References =
+                [
+                    new AssemblyReference("Contoso.Δelta", "1.0.0.0", null, null),
+                ],
+                TransitiveReferences =
+                [
+                    new AssemblyReferenceNode { Name = "Micrοsoft.Transitive" },
+                ],
+            },
+        };
+
+        IReadOnlyList<IdentifierConfusionCase> cases =
+            IdentifierConfusionAudit.InspectLibrary(model);
+
+        Assert.Collection(
+            cases,
+            value => AssertCase(
+                value,
+                "AssemblyInfo.AssemblyName",
+                IdentifierConcern.NonAscii | IdentifierConcern.ReservedPrefixHomoglyph,
+                "System"),
+            value => AssertCase(
+                value,
+                "AssemblyInfo.References[0].Name",
+                IdentifierConcern.NonAscii,
+                null),
+            value => AssertCase(
+                value,
+                "AssemblyInfo.TransitiveReferences[0].Name",
+                IdentifierConcern.NonAscii | IdentifierConcern.ReservedPrefixHomoglyph,
+                "Microsoft"));
+    }
+
+    [Fact]
+    public async Task PackageSignals_SeparatesIdentifierConfusionFromTextContainment()
+    {
+        var model = new InspectionResult
+        {
+            PackageName = "Ѕystem.Text.Json",
+            Version = "1.0.0",
+        };
+
+        await AuditSignalBuilder.PopulatePackageAuditAsync(
+            model,
+            new HttpClient(),
+            new VerboseLogger(false));
+
+        AuditSignal identifier = Assert.Single(
+            model.AuditSignals!,
+            value => value.Signal == "Identifier confusion");
+        Assert.Equal("Detected", identifier.Value);
+        Assert.Equal(
+            "1 non-ASCII identifier; 1 reserved-prefix homoglyph (System)",
+            identifier.Evidence);
+
+        AuditSignal containment = Assert.Single(
+            model.AuditSignals!,
+            value => value.Signal == "Artifact text containment");
+        Assert.Equal("None", containment.Value);
+    }
+
+    [Fact]
+    public void LibrarySignals_ReportIdentifierConfusionWithoutContent()
+    {
+        const string secret = "SECRET";
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo
+            {
+                AssemblyName = $"Micrοsoft.{secret}",
+            },
+        };
+
+        AuditSignalBuilder.RefreshLibraryAuditSignals(model);
+
+        AuditSignal signal = Assert.Single(
+            model.AuditSignals!,
+            value => value.Signal == "Identifier confusion");
+        Assert.Equal("Detected", signal.Value);
+        Assert.Equal(
+            "1 non-ASCII identifier; 1 reserved-prefix homoglyph (Microsoft)",
+            signal.Evidence);
+        Assert.DoesNotContain(secret, signal.Evidence, StringComparison.Ordinal);
+    }
+
+    private static void AssertCase(
+        IdentifierConfusionCase value,
+        string location,
+        IdentifierConcern concerns,
+        string? reservedPrefix)
+    {
+        Assert.Equal(location, value.Location);
+        Assert.Equal(concerns, value.Confusion.Concerns);
+        Assert.Equal(reservedPrefix, value.Confusion.ReservedPrefixMatch?.ReservedPrefix);
+    }
+}

--- a/src/dotnet-inspect.Tests/IdentifierConfusionAuditTests.cs
+++ b/src/dotnet-inspect.Tests/IdentifierConfusionAuditTests.cs
@@ -75,11 +75,11 @@ public class IdentifierConfusionAuditTests
                 [
                     new AssemblyReference("Contoso.Δelta", "1.0.0.0", null, null),
                 ],
-                TransitiveReferences =
-                [
-                    new AssemblyReferenceNode { Name = "Micrοsoft.Transitive" },
-                ],
             },
+            IdentifierConfusionTransitiveReferences =
+            [
+                new AssemblyReferenceNode { Name = "Micrοsoft.Transitive", Depth = 1 },
+            ],
         };
 
         IReadOnlyList<IdentifierConfusionCase> cases =
@@ -154,6 +154,34 @@ public class IdentifierConfusionAuditTests
             "1 non-ASCII identifier; 1 reserved-prefix homoglyph (Microsoft)",
             signal.Evidence);
         Assert.DoesNotContain(secret, signal.Evidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LibrarySignals_KeepTransitiveReferenceTraversalExplicit()
+    {
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo
+            {
+                AssemblyName = "Contoso.Root",
+                References =
+                [
+                    new AssemblyReference("System.Runtime", "1.0.0.0", null, null),
+                ],
+                TransitiveReferences =
+                [
+                    new AssemblyReferenceNode { Name = "Micrοsoft.Transitive" },
+                ],
+            },
+        };
+
+        AuditSignalBuilder.RefreshLibraryAuditSignals(model);
+
+        AuditSignal signal = Assert.Single(
+            model.AuditSignals!,
+            value => value.Signal == "Identifier confusion");
+        Assert.Equal("None", signal.Value);
+        Assert.Equal("all inspected assembly names use ASCII characters", signal.Evidence);
     }
 
     private static void AssertCase(

--- a/src/dotnet-inspect.Tests/IdentifierConfusionAuditTests.cs
+++ b/src/dotnet-inspect.Tests/IdentifierConfusionAuditTests.cs
@@ -105,6 +105,67 @@ public class IdentifierConfusionAuditTests
     }
 
     [Fact]
+    public void LibraryAudit_PreservesCaseDistinctResolvedNames()
+    {
+        const string directName = "Micr\u039fsoft.Shared";
+        const string transitiveName = "micr\u03bfsoft.shared";
+        var model = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo
+            {
+                AssemblyName = "Root",
+                References =
+                [
+                    new AssemblyReference(
+                        directName,
+                        "1.0.0.0",
+                        "en-US",
+                        null),
+                ],
+            },
+            IdentifierConfusionReferenceClosure =
+            [
+                new AssemblyReferenceNode
+                {
+                    Name = directName,
+                    Version = "1.0.0.0",
+                    Depth = 0,
+                },
+                new AssemblyReferenceNode
+                {
+                    Name = transitiveName,
+                    Version = "1.0.0.0",
+                    Depth = 1,
+                },
+            ],
+        };
+
+        IReadOnlyList<IdentifierConfusionCase> cases =
+            IdentifierConfusionAudit.InspectLibrary(model);
+
+        Assert.Collection(
+            cases,
+            value =>
+            {
+                Assert.Equal(
+                    "AssemblyInfo.References[0].Name",
+                    value.Location);
+                Assert.Equal(
+                    [0x039F],
+                    value.Confusion.NonAsciiCodePoints);
+            },
+            value =>
+            {
+                Assert.Equal(
+                    "IdentifierConfusionReferenceClosure[1].Name",
+                    value.Location);
+                Assert.Equal(
+                    [0x03BF],
+                    value.Confusion.NonAsciiCodePoints);
+            });
+    }
+
+    [Fact]
     public async Task PackageSignals_SeparatesIdentifierConfusionFromTextContainment()
     {
         var model = new InspectionResult

--- a/src/dotnet-inspect.Tests/InspectionResultTests.cs
+++ b/src/dotnet-inspect.Tests/InspectionResultTests.cs
@@ -437,6 +437,91 @@ public class InspectionResultTests
         Assert.Equal("NuGet advisory data", signal.Evidence);
     }
 
+    [Theory]
+    [InlineData("ordinary text")]
+    [InlineData("C:\\tmp\\package")]
+    [InlineData("literal \\u202E text")]
+    public async Task PackageSignals_ReportsNoArtifactTextConcernForBackslashes(
+        string packageName)
+    {
+        var result = new InspectionResult
+        {
+            PackageName = packageName,
+            Version = "1.0.0",
+        };
+
+        await AuditSignalBuilder.PopulatePackageAuditAsync(
+            result,
+            new HttpClient(),
+            new VerboseLogger(false));
+
+        AuditSignal signal = Assert.Single(
+            result.AuditSignals!,
+            value => value.Signal == "Artifact text containment");
+        Assert.Equal("None", signal.Value);
+        Assert.Equal("no concerning scalars found", signal.Evidence);
+    }
+
+    [Fact]
+    public async Task PackageSignals_ReportsEveryArtifactTextConcernKindWithoutContent()
+    {
+        string unpairedSurrogate = new((char)0xD800, 1);
+        var result = new InspectionResult
+        {
+            PackageName = "prefix\u001B\u202E\u2028\u2029" + unpairedSurrogate + "SECRET",
+            Version = "1.0.0",
+        };
+
+        await AuditSignalBuilder.PopulatePackageAuditAsync(
+            result,
+            new HttpClient(),
+            new VerboseLogger(false));
+
+        AuditSignal signal = Assert.Single(
+            result.AuditSignals!,
+            value => value.Signal == "Artifact text containment");
+        Assert.Equal("Required", signal.Value);
+        Assert.Equal(
+            "control (Cc), format/bidi (Cf), unpaired surrogate (Cs), "
+                + "line separator (Zl), paragraph separator (Zp)",
+            signal.Evidence);
+        Assert.DoesNotContain("SECRET", signal.Evidence, StringComparison.Ordinal);
+
+        string markdown = MarkoutSerializer.Serialize(
+            new InspectionResultView(result),
+            InspectionContext.Default);
+        Assert.Contains(
+            "| Text | Artifact text containment | Required | control (Cc), "
+                + "format/bidi (Cf), unpaired surrogate (Cs), line separator (Zl), "
+                + "paragraph separator (Zp) |",
+            markdown,
+            StringComparison.Ordinal);
+
+        string json = JsonSerializer.Serialize(
+            PackageInspectionJson.Create(result),
+            PackageInspectionJsonContext.Default.PackageInspectionJson);
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement jsonSignal = document.RootElement
+            .GetProperty("audit_signals")
+            .EnumerateArray()
+            .Single(value => value.GetProperty("signal").GetString()
+                == "Artifact text containment");
+        Assert.Equal("Required", jsonSignal.GetProperty("value").GetString());
+        Assert.Equal(signal.Evidence, jsonSignal.GetProperty("evidence").GetString());
+
+        Assert.Equal(
+            new[]
+            {
+                TextConcern.None,
+                TextConcern.Control,
+                TextConcern.Format,
+                TextConcern.Surrogate,
+                TextConcern.LineSeparator,
+                TextConcern.ParagraphSeparator,
+            },
+            Enum.GetValues<TextConcern>());
+    }
+
     [Fact]
     public async Task PackageSignals_Symbols_ReportsMsdlPdbSource()
     {

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -9,6 +9,7 @@ using ILInspector.Metadata;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Packages;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using Markout;
@@ -2771,6 +2772,66 @@ public class OutputFormatterTests
         Assert.Equal("format/bidi (Cf)", owner.RootElement.GetProperty("concerns").GetString());
         Assert.Equal("PackageFiles[0].Path", file.RootElement.GetProperty("location").GetString());
         Assert.Equal("control (Cc)", file.RootElement.GetProperty("concerns").GetString());
+        Assert.DoesNotContain(secret, jsonl, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PackageIdentifierConfusionAudit_ListsClassificationWithoutIdentifierContent()
+    {
+        const string secret = "DO-NOT-REPORT";
+        var result = new InspectionResult
+        {
+            PackageName = "TestPackage",
+            Version = "1.0.0",
+            DependencyGroups =
+            [
+                new DependencyGroup
+                {
+                    TargetFramework = "net11.0",
+                    Dependencies = [new PackageDependency { Id = $"Ѕystem.{secret}" }],
+                },
+            ],
+        };
+        var pipeline = PackageSectionDescriptors.CreatePipeline();
+        var options = new InspectionOptions
+        {
+            Verbosity = Verbosity.Minimal,
+            IncludeSections = [PackageSections.AuditIdentifierConfusion],
+        };
+
+        string markdown = OutputFormatter.FormatResult(result, options, pipeline);
+
+        Assert.Contains("## Audit: Identifier Confusion", markdown, StringComparison.Ordinal);
+        Assert.Contains("DependencyGroups[0].Dependencies[0].Id", markdown, StringComparison.Ordinal);
+        Assert.Contains("Package ID", markdown, StringComparison.Ordinal);
+        Assert.Contains(
+            "non-ASCII characters; reserved-prefix homoglyph",
+            markdown,
+            StringComparison.Ordinal);
+        Assert.Contains("System", markdown, StringComparison.Ordinal);
+        Assert.Contains("83%", markdown, StringComparison.Ordinal);
+        Assert.Contains("U+0405→S", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain(secret, markdown, StringComparison.Ordinal);
+
+        var (jsonl, error) = await ConsoleCapture.RunAsync(() =>
+            OutputFormatter.WritePackageTable(
+                result,
+                options with { Jsonl = true, Tabular = true },
+                pipeline,
+                showHeader: true));
+
+        Assert.Equal(string.Empty, error);
+        using JsonDocument row = JsonDocument.Parse(jsonl);
+        Assert.Equal(
+            "DependencyGroups[0].Dependencies[0].Id",
+            row.RootElement.GetProperty("location").GetString());
+        Assert.Equal("Package ID", row.RootElement.GetProperty("kind").GetString());
+        Assert.Equal(
+            "non-ASCII characters; reserved-prefix homoglyph",
+            row.RootElement.GetProperty("concern").GetString());
+        Assert.Equal("System", row.RootElement.GetProperty("reserved_prefix").GetString());
+        Assert.Equal("83%", row.RootElement.GetProperty("similarity").GetString());
+        Assert.Equal("U+0405→S", row.RootElement.GetProperty("characters").GetString());
         Assert.DoesNotContain(secret, jsonl, StringComparison.Ordinal);
     }
 

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -2713,6 +2713,68 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public async Task PackageArtifactTextAudit_ListsLocationsAndKindsInMarkdownAndJsonl()
+    {
+        const string secret = "DO-NOT-REPORT";
+        var result = new InspectionResult
+        {
+            PackageName = "TestPackage",
+            Version = "1.0.0",
+            Owners = [$"owner\u202E{secret}"],
+            PackageFiles = [new PackageFile($"file\u001B{secret}", 42)],
+            AuditSignals =
+            [
+                new AuditSignal(
+                    "Text",
+                    "Artifact text containment",
+                    "Required",
+                    "control (Cc), format/bidi (Cf)"),
+            ],
+        };
+        var pipeline = PackageSectionDescriptors.CreatePipeline();
+        var options = new InspectionOptions
+        {
+            Verbosity = Verbosity.Minimal,
+            IncludeSections =
+            [
+                PackageSections.Signals,
+                PackageSections.AuditArtifactText,
+            ],
+        };
+
+        string markdown = OutputFormatter.FormatResult(result, options, pipeline);
+
+        Assert.Contains("## Signals", markdown, StringComparison.Ordinal);
+        Assert.Contains("## Audit: Artifact Text", markdown, StringComparison.Ordinal);
+        Assert.Contains("| Owners[0] | format/bidi (Cf) |", markdown, StringComparison.Ordinal);
+        Assert.Contains("| PackageFiles[0].Path | control (Cc) |", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain(secret, markdown, StringComparison.Ordinal);
+
+        var (jsonl, error) = await ConsoleCapture.RunAsync(() =>
+            OutputFormatter.WritePackageTable(
+                result,
+                options with
+                {
+                    IncludeSections = [PackageSections.AuditArtifactText],
+                    Jsonl = true,
+                    Tabular = true,
+                },
+                pipeline,
+                showHeader: true));
+
+        Assert.Equal(string.Empty, error);
+        string[] lines = jsonl.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        using JsonDocument owner = JsonDocument.Parse(lines[0]);
+        using JsonDocument file = JsonDocument.Parse(lines[1]);
+        Assert.Equal("Owners[0]", owner.RootElement.GetProperty("location").GetString());
+        Assert.Equal("format/bidi (Cf)", owner.RootElement.GetProperty("concerns").GetString());
+        Assert.Equal("PackageFiles[0].Path", file.RootElement.GetProperty("location").GetString());
+        Assert.Equal("control (Cc)", file.RootElement.GetProperty("concerns").GetString());
+        Assert.DoesNotContain(secret, jsonl, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ApiQuiet_ThreeLines()
     {
         var api = CreateTestApiSurface();

--- a/src/dotnet-inspect.Tests/PackageInspectionTextTests.cs
+++ b/src/dotnet-inspect.Tests/PackageInspectionTextTests.cs
@@ -200,13 +200,27 @@ public class PackageInspectionTextTests
         {
             InspectionResult result = CompleteResult(Benign);
             makeHostile(result);
+            var text = new PackageInspectionText(result);
 
             Assert.True(
-                new PackageInspectionText(result).RequiredContainment,
+                text.RequiredContainment,
                 $"{path} did not contribute to RequiredContainment.");
-            Assert.Equal(
-                TextConcern.Format,
-                new PackageInspectionText(result).Concerns);
+            Assert.Equal(TextConcern.Format, text.Concerns);
+            PackageTextConcernCase concernCase = Assert.Single(text.ConcernCases);
+            string expectedLocation = path.Replace("[]", "[0]", StringComparison.Ordinal);
+            Type? propertyType = typeof(InspectionResult)
+                .GetProperty(expectedLocation)?
+                .PropertyType;
+            if (!expectedLocation.Contains('[')
+                && ((propertyType?.IsGenericType == true
+                        && propertyType.GetGenericTypeDefinition() == typeof(List<>))
+                    || expectedLocation == $"{nameof(InspectionResult.Deprecation)}."
+                        + nameof(PackageDeprecation.Reasons)))
+            {
+                expectedLocation += "[0]";
+            }
+            Assert.Equal(expectedLocation, concernCase.Location);
+            Assert.Equal(TextConcern.Format, concernCase.Concerns);
         }
     }
 
@@ -220,6 +234,33 @@ public class PackageInspectionTextTests
 
         Assert.Equal(TextConcern.None, text.Concerns);
         Assert.False(text.RequiredContainment);
+        Assert.Empty(text.ConcernCases);
+    }
+
+    [Fact]
+    public void ConcernCases_ListLocationsAndKindsWithoutArtifactContent()
+    {
+        const string secret = "DO-NOT-REPORT";
+        var result = new InspectionResult
+        {
+            PackageName = $"package\u001B{secret}",
+            Owners = [$"owner\u202E{secret}"],
+            PackageFiles = [new PackageFile($"file\u2028{secret}", 42)],
+        };
+
+        var text = new PackageInspectionText(result);
+
+        Assert.Equal(
+            new[]
+            {
+                new PackageTextConcernCase("PackageName", TextConcern.Control),
+                new PackageTextConcernCase("Owners[0]", TextConcern.Format),
+                new PackageTextConcernCase("PackageFiles[0].Path", TextConcern.LineSeparator),
+            },
+            text.ConcernCases);
+        Assert.All(
+            text.ConcernCases,
+            value => Assert.DoesNotContain(secret, value.Location, StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/PackageInspectionTextTests.cs
+++ b/src/dotnet-inspect.Tests/PackageInspectionTextTests.cs
@@ -204,7 +204,22 @@ public class PackageInspectionTextTests
             Assert.True(
                 new PackageInspectionText(result).RequiredContainment,
                 $"{path} did not contribute to RequiredContainment.");
+            Assert.Equal(
+                TextConcern.Format,
+                new PackageInspectionText(result).Concerns);
         }
+    }
+
+    [Theory]
+    [InlineData("ordinary text")]
+    [InlineData("C:\\tmp\\package")]
+    [InlineData("literal \\u202E text")]
+    public void BackslashesDoNotContributeAPackageTextConcern(string value)
+    {
+        PackageInspectionText text = new(CompleteResult(value));
+
+        Assert.Equal(TextConcern.None, text.Concerns);
+        Assert.False(text.RequiredContainment);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/PackageInspectorMetadataSourceTests.cs
+++ b/src/dotnet-inspect.Tests/PackageInspectorMetadataSourceTests.cs
@@ -1,11 +1,14 @@
+using System.IO.Compression;
 using System.Net;
 using System.Text;
 using DotnetInspector.Core;
+using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Views;
 
 namespace DotnetInspector.Tests;
 
@@ -165,6 +168,181 @@ public sealed class PackageInspectorMetadataSourceTests : IDisposable
             identifierCase.Confusion.NonAsciiCodePoints);
     }
 
+    [Fact]
+    public async Task InspectAsync_IdentifierAuditMetadataFailureRemainsVisible()
+    {
+        const string source = "https://audit-failure.example/v3/index.json";
+        using var client = new HttpClient(new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        {
+                          "@id": "https://audit-failure.example/registration/",
+                          "@type": "RegistrationsBaseUrl/3.6.0"
+                        }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json(
+                    """{ "catalogEntry": "/catalog/private.package.json" }"""),
+                "/catalog/private.package.json" =>
+                    new HttpResponseMessage(HttpStatusCode.BadGateway),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+            }));
+
+        var resolution = new PackageExtractionResult(
+            _root,
+            TempDir: null,
+            PackageName: "Private.Package",
+            Version: "1.0.0",
+            ProducerKey: NuGetCache.GetSourceKey(source));
+        var sourceOptions = new NuGetSourceOptions
+        {
+            Sources = [source],
+        };
+
+        InspectionResult result = await PackageInspector.InspectAsync(
+            resolution,
+            "Private.Package",
+            "1.0.0",
+            isLocalFile: false,
+            localFilePath: null,
+            nuspec: null,
+            client,
+            new VerboseLogger(enabled: false),
+            forceLatest: true,
+            verbosity: Verbosity.Normal,
+            fetchMetadata: true,
+            requireIdentifierMetadata: true,
+            sourceOptions: sourceOptions);
+        await AuditSignalBuilder.PopulatePackageAuditAsync(
+            result,
+            client,
+            new VerboseLogger(enabled: false),
+            sourceOptions);
+
+        Assert.Equal(
+            IdentifierConfusionAuditFailureKind.PackageMetadataUnavailable,
+            result.IdentifierConfusionFailure);
+        AuditSignal signal = Assert.Single(
+            result.AuditSignals!,
+            value => value.Signal == "Identifier confusion");
+        Assert.Equal("Unavailable", signal.Value);
+        Assert.Equal(
+            "package registry metadata unavailable",
+            signal.Evidence);
+    }
+
+    [Fact]
+    public async Task PackageCommand_IdentifierMetadataFailureIsNonzero()
+    {
+        string packageId =
+            $"Private.Command.{Guid.NewGuid():N}";
+        string normalizedId = packageId.ToLowerInvariant();
+        const string source =
+            "https://command-audit.example/v3/index.json";
+        byte[] package = CreatePackage(packageId);
+        using var client = new HttpClient(
+            new RoutingHandler(request =>
+                request.RequestUri!.AbsolutePath switch
+                {
+                    "/v3/index.json" => Json($$"""
+                        {
+                          "version": "3.0.0",
+                          "resources": [
+                            {
+                              "@id": "https://command-audit.example/flat/",
+                              "@type": "PackageBaseAddress/3.0.0"
+                            },
+                            {
+                              "@id": "https://command-audit.example/registration/",
+                              "@type": "RegistrationsBaseUrl/3.6.0"
+                            }
+                          ]
+                        }
+                        """),
+                    var path when path
+                        == $"/flat/{normalizedId}/index.json" =>
+                        Json("""{ "versions": [ "1.0.0" ] }"""),
+                    var path when path
+                        == $"/flat/{normalizedId}/1.0.0/"
+                            + $"{normalizedId}.1.0.0.nupkg" =>
+                        Bytes(package),
+                    var path when path
+                        == $"/registration/{normalizedId}/1.0.0.json" =>
+                        Json(
+                            $$"""
+                            {
+                              "catalogEntry":
+                                "/catalog/{{normalizedId}}.json"
+                            }
+                            """),
+                    var path when path
+                        == $"/catalog/{normalizedId}.json" =>
+                        new HttpResponseMessage(
+                            HttpStatusCode.BadGateway),
+                    _ => throw new InvalidOperationException(
+                        $"Unexpected command request: "
+                        + $"{request.Method} {request.RequestUri}"),
+                }));
+        var sourceOptions = new NuGetSourceOptions
+        {
+            Sources = [source],
+        };
+        InspectionOptions Options() => new()
+        {
+            PackageArgs = [$"{packageId}@1.0.0"],
+            ForceLatest = true,
+            Verbosity = Verbosity.Normal,
+            IncludeSections =
+                new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                {
+                    PackageSections.Signals,
+                },
+            SourceOptions = sourceOptions,
+        };
+
+        var rendered = await ConsoleCapture.RunAsync(
+            () => PackageCommand.ExecuteAsync(
+                Options(),
+                new CommandContext(
+                    verbose: false,
+                    client)));
+        InspectionOptions discoveryOptions = Options() with
+        {
+            IncludeSections = null,
+            Discover = [PackageSections.Signals],
+        };
+        var discovered = await ConsoleCapture.RunAsync(
+            () => PackageCommand.ExecuteAsync(
+                discoveryOptions,
+                new CommandContext(
+                    verbose: false,
+                    client)));
+
+        Assert.Equal(1, rendered.ExitCode);
+        Assert.Contains("Identifier confusion", rendered.Output);
+        Assert.Contains("Unavailable", rendered.Output);
+        Assert.Equal(
+            "Warning: Identifier audit failed for package input #1: "
+            + "package registry metadata unavailable"
+            + Environment.NewLine,
+            rendered.Error);
+        Assert.Equal(1, discovered.ExitCode);
+        Assert.Contains("| Signal | column |", discovered.Output);
+        Assert.Equal(
+            "Warning: Identifier audit failed for package input #1: "
+            + "package registry metadata unavailable"
+            + Environment.NewLine,
+            discovered.Error);
+        Assert.DoesNotContain(packageId, rendered.Error);
+        Assert.DoesNotContain(packageId, discovered.Error);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_root))
@@ -178,6 +356,41 @@ public sealed class PackageInspectorMetadataSourceTests : IDisposable
         {
             Content = new StringContent(content, Encoding.UTF8, "application/json"),
         };
+
+    private static HttpResponseMessage Bytes(byte[] content) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(content),
+        };
+
+    private static byte[] CreatePackage(string packageId)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(
+            stream,
+            ZipArchiveMode.Create,
+            leaveOpen: true))
+        {
+            using var writer = new StreamWriter(
+                archive.CreateEntry(
+                    $"{packageId}.nuspec").Open(),
+                new UTF8Encoding(
+                    encoderShouldEmitUTF8Identifier: false));
+            writer.Write(
+                $$"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <package>
+                  <metadata>
+                    <id>{{packageId}}</id>
+                    <version>1.0.0</version>
+                    <authors>Test</authors>
+                    <description>Test package</description>
+                  </metadata>
+                </package>
+                """);
+        }
+        return stream.ToArray();
+    }
 
     private sealed class RoutingHandler(
         Func<HttpRequestMessage, HttpResponseMessage> route) : HttpMessageHandler

--- a/src/dotnet-inspect.Tests/PackageInspectorMetadataSourceTests.cs
+++ b/src/dotnet-inspect.Tests/PackageInspectorMetadataSourceTests.cs
@@ -79,6 +79,92 @@ public sealed class PackageInspectorMetadataSourceTests : IDisposable
         Assert.False(queriedSourceA);
     }
 
+    [Fact]
+    public async Task InspectAsync_IdentifierAuditMetadataIncludesAlternatePackageId()
+    {
+        const string source = "https://audit.example/v3/index.json";
+        using var client = new HttpClient(new RoutingHandler(request =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/v3/index.json" => Json("""
+                    {
+                      "version": "3.0.0",
+                      "resources": [
+                        {
+                          "@id": "https://audit.example/registration/",
+                          "@type": "RegistrationsBaseUrl/3.6.0"
+                        }
+                      ]
+                    }
+                    """),
+                "/registration/private.package/1.0.0.json" => Json("""
+                    {
+                      "catalogEntry": {
+                        "deprecation": {
+                          "reasons": [ "Legacy" ],
+                          "alternatePackage": {
+                            "id": "Δelta.Tools"
+                          }
+                        }
+                      }
+                    }
+                    """),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound),
+            }));
+
+        var resolution = new PackageExtractionResult(
+            _root,
+            TempDir: null,
+            PackageName: "Private.Package",
+            Version: "1.0.0",
+            ProducerKey: NuGetCache.GetSourceKey(source));
+        var sourceOptions = new NuGetSourceOptions
+        {
+            Sources = [source],
+        };
+        InspectionResult withoutMetadata =
+            await PackageInspector.InspectAsync(
+                resolution,
+                "Private.Package",
+                "1.0.0",
+                isLocalFile: false,
+                localFilePath: null,
+                nuspec: null,
+                client,
+                new VerboseLogger(enabled: false),
+                forceLatest: true,
+                verbosity: Verbosity.Normal,
+                fetchMetadata: false,
+                sourceOptions: sourceOptions);
+        Assert.DoesNotContain(
+            IdentifierConfusionAudit.InspectPackage(withoutMetadata),
+            value => value.Location
+                == "Deprecation.AlternatePackageId");
+
+        InspectionResult result = await PackageInspector.InspectAsync(
+            resolution,
+            "Private.Package",
+            "1.0.0",
+            isLocalFile: false,
+            localFilePath: null,
+            nuspec: null,
+            client,
+            new VerboseLogger(enabled: false),
+            forceLatest: true,
+            verbosity: Verbosity.Normal,
+            fetchMetadata: true,
+            sourceOptions: sourceOptions);
+
+        IdentifierConfusionCase identifierCase = Assert.Single(
+            IdentifierConfusionAudit.InspectPackage(result),
+            value => value.Location
+                == "Deprecation.AlternatePackageId");
+        Assert.Equal("Package ID", identifierCase.Kind);
+        Assert.Contains(
+            0x0394,
+            identifierCase.Confusion.NonAsciiCodePoints);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_root))

--- a/src/dotnet-inspect.Tests/PackageInspectorMetadataSourceTests.cs
+++ b/src/dotnet-inspect.Tests/PackageInspectorMetadataSourceTests.cs
@@ -343,6 +343,78 @@ public sealed class PackageInspectorMetadataSourceTests : IDisposable
         Assert.DoesNotContain(packageId, discovered.Error);
     }
 
+    [Fact]
+    public async Task PackageCommand_FlatContainerOnlyPreservesLocalIdentifierDetection()
+    {
+        string packageId =
+            $"Private.Flat.{Guid.NewGuid():N}";
+        string normalizedId = packageId.ToLowerInvariant();
+        const string source =
+            "https://flat-audit.example/v3/index.json";
+        byte[] package = CreatePackage(
+            packageId,
+            dependencyId: "\u0405ystem.Text.Json");
+        using var client = new HttpClient(
+            new RoutingHandler(request =>
+                request.RequestUri!.AbsolutePath switch
+                {
+                    "/v3/index.json" => Json($$"""
+                        {
+                          "version": "3.0.0",
+                          "resources": [
+                            {
+                              "@id": "https://flat-audit.example/flat/",
+                              "@type": "PackageBaseAddress/3.0.0"
+                            }
+                          ]
+                        }
+                        """),
+                    var path when path
+                        == $"/flat/{normalizedId}/index.json" =>
+                        Json("""{ "versions": [ "1.0.0" ] }"""),
+                    var path when path
+                        == $"/flat/{normalizedId}/1.0.0/"
+                            + $"{normalizedId}.1.0.0.nupkg" =>
+                        Bytes(package),
+                    _ => new HttpResponseMessage(
+                        HttpStatusCode.NotFound),
+                }));
+
+        var rendered = await ConsoleCapture.RunAsync(
+            () => PackageCommand.ExecuteAsync(
+                new InspectionOptions
+                {
+                    PackageArgs = [$"{packageId}@1.0.0"],
+                    ForceLatest = true,
+                    Verbosity = Verbosity.Normal,
+                    IncludeSections =
+                        new HashSet<string>(
+                            StringComparer.OrdinalIgnoreCase)
+                        {
+                            PackageSections.Signals,
+                        },
+                    SourceOptions = new NuGetSourceOptions
+                    {
+                        Sources = [source],
+                    },
+                },
+                new CommandContext(
+                    verbose: false,
+                    client)));
+
+        Assert.Equal(0, rendered.ExitCode);
+        Assert.Contains(
+            "| Identity | Identifier confusion | Detected |",
+            rendered.Output);
+        Assert.Contains(
+            "reserved-prefix homoglyph (System)",
+            rendered.Output);
+        Assert.Contains(
+            "source advertises no deprecation metadata",
+            rendered.Output);
+        Assert.Empty(rendered.Error);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_root))
@@ -363,8 +435,17 @@ public sealed class PackageInspectorMetadataSourceTests : IDisposable
             Content = new ByteArrayContent(content),
         };
 
-    private static byte[] CreatePackage(string packageId)
+    private static byte[] CreatePackage(
+        string packageId,
+        string? dependencyId = null)
     {
+        string dependencies = dependencyId is null
+            ? ""
+            : $"""
+                  <dependencies>
+                    <dependency id="{dependencyId}" version="1.0.0" />
+                  </dependencies>
+                """;
         using var stream = new MemoryStream();
         using (var archive = new ZipArchive(
             stream,
@@ -385,6 +466,7 @@ public sealed class PackageInspectorMetadataSourceTests : IDisposable
                     <version>1.0.0</version>
                     <authors>Test</authors>
                     <description>Test package</description>
+                {{dependencies}}
                   </metadata>
                 </package>
                 """);

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1987,7 +1987,7 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void PackageIntegrityExitCode_FailsForMismatchesAndAuditFailures()
+    public async Task PackageIntegrityExitCode_FailsForMismatchesAndAuditFailures()
     {
         var clean = new InspectionResult
         {
@@ -2013,16 +2013,25 @@ public class SectionPipelineTests
                     .PackageMetadataUnavailable,
         };
 
-        Assert.Equal(0, PackageCommand.PackageIntegrityExitCode(clean));
-        Assert.Equal(1, PackageCommand.PackageIntegrityExitCode(clean, mismatch));
+        var (_, error) = await ConsoleCapture.RunAsync(() =>
+        {
+            Assert.Equal(0, PackageCommand.PackageIntegrityExitCode(clean));
+            Assert.Equal(1, PackageCommand.PackageIntegrityExitCode(clean, mismatch));
+            Assert.Equal(
+                1,
+                PackageCommand.PackageIntegrityExitCode(
+                    clean,
+                    auditFailure));
+            Assert.Equal(1, PackageCommand.PackageIntegrityExitCode(1, clean));
+            Assert.Equal(7, PackageCommand.PackageIntegrityExitCode(7, clean));
+            Assert.Equal(1, PackageCommand.PackageIntegrityExitCode(0, mismatch));
+        });
+
         Assert.Equal(
-            1,
-            PackageCommand.PackageIntegrityExitCode(
-                clean,
-                auditFailure));
-        Assert.Equal(1, PackageCommand.PackageIntegrityExitCode(1, clean));
-        Assert.Equal(7, PackageCommand.PackageIntegrityExitCode(7, clean));
-        Assert.Equal(1, PackageCommand.PackageIntegrityExitCode(0, mismatch));
+            "Warning: Identifier audit failed for package input #2: "
+            + "package registry metadata unavailable"
+            + Environment.NewLine,
+            error);
     }
 
     [Theory]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1987,7 +1987,7 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void PackageIntegrityExitCode_FailsOnlyForMismatches()
+    public void PackageIntegrityExitCode_FailsForMismatchesAndAuditFailures()
     {
         var clean = new InspectionResult
         {
@@ -2006,11 +2006,175 @@ public class SectionPipelineTests
         {
             SourceIntegrity = clean.SourceIntegrity with { Mismatched = 1 },
         };
+        var auditFailure = new InspectionResult
+        {
+            IdentifierConfusionFailure =
+                IdentifierConfusionAuditFailureKind
+                    .PackageMetadataUnavailable,
+        };
 
         Assert.Equal(0, PackageCommand.PackageIntegrityExitCode(clean));
         Assert.Equal(1, PackageCommand.PackageIntegrityExitCode(clean, mismatch));
+        Assert.Equal(
+            1,
+            PackageCommand.PackageIntegrityExitCode(
+                clean,
+                auditFailure));
         Assert.Equal(1, PackageCommand.PackageIntegrityExitCode(1, clean));
+        Assert.Equal(7, PackageCommand.PackageIntegrityExitCode(7, clean));
         Assert.Equal(1, PackageCommand.PackageIntegrityExitCode(0, mismatch));
+    }
+
+    [Theory]
+    [InlineData(PackageSections.AuditIdentifierConfusion)]
+    [InlineData(PackageSections.AuditArtifactText)]
+    public void MultiPackageCount_CountsSelectedAuditRows(
+        string section)
+    {
+        string outputPath = Path.Combine(
+            Path.GetTempPath(),
+            $"package-audit-count-{Guid.NewGuid():N}.txt");
+        InspectionResult Result(string suffix) =>
+            section == PackageSections.AuditIdentifierConfusion
+                ? new InspectionResult
+                {
+                    PackageName = $"\u0405ystem.{suffix}",
+                    Version = "1.0.0",
+                }
+                : new InspectionResult
+                {
+                    PackageName = $"Package.{suffix}",
+                    Version = "1.0.0",
+                    PackageFiles =
+                    [
+                        new PackageFile(
+                            $"lib/{suffix}\u001b.dll",
+                            1),
+                    ],
+                };
+
+        try
+        {
+            int exitCode = PackageCommand.WriteMultiPackageCount(
+                [Result("One"), Result("Two")],
+                rowSection: null,
+                new InspectionOptions
+                {
+                    Count = true,
+                    JsonOutput = true,
+                    IncludeSections =
+                        new HashSet<string>(
+                            StringComparer.OrdinalIgnoreCase)
+                        {
+                            section,
+                        },
+                    OutputPath = outputPath,
+                },
+                PackageSectionDescriptors.CreatePipeline());
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal(
+                "2",
+                File.ReadAllText(outputPath).Trim());
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void MultiPackageCount_PreservesSelectedSectionMap()
+    {
+        string outputPath = Path.Combine(
+            Path.GetTempPath(),
+            $"package-count-map-{Guid.NewGuid():N}.txt");
+        var options = new InspectionOptions
+        {
+            Count = true,
+            JsonOutput = true,
+            IncludeSections =
+                new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase)
+                {
+                    PackageSections.PackageInfo,
+                    PackageSections.TargetFrameworks,
+                },
+            OutputPath = outputPath,
+        };
+        var results = new[]
+        {
+            new InspectionResult
+            {
+                PackageName = "One",
+                Version = "1.0.0",
+                TargetFrameworks = ["net8.0"],
+            },
+            new InspectionResult
+            {
+                PackageName = "Two",
+                Version = "1.0.0",
+            },
+        };
+
+        try
+        {
+            int exitCode = PackageCommand.WriteMultiPackageCount(
+                results,
+                rowSection: null,
+                options,
+                PackageSectionDescriptors.CreatePipeline());
+            string output = File.ReadAllText(outputPath);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("| Section | Count |", output);
+            Assert.Contains("| Package Info |", output);
+            Assert.Contains("| Target Frameworks | 1 |", output);
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void MultiPackageCount_PreservesFixedOverviewMap()
+    {
+        string outputPath = Path.Combine(
+            Path.GetTempPath(),
+            $"package-fixed-count-map-{Guid.NewGuid():N}.txt");
+        var pipeline = PackageSectionDescriptors.CreatePipeline();
+
+        try
+        {
+            int exitCode = PackageCommand.WriteMultiPackageCount(
+                [
+                    new InspectionResult
+                    {
+                        PackageName = "One",
+                        Version = "1.0.0",
+                    },
+                ],
+                rowSection: null,
+                new InspectionOptions
+                {
+                    Count = true,
+                    JsonOutput = true,
+                    FixedOverview = true,
+                    OutputPath = outputPath,
+                },
+                pipeline);
+            string output = File.ReadAllText(outputPath);
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("| Section | Count |", output);
+            foreach (string section in pipeline.BareSelectSectionNames)
+                Assert.Contains($"| {section} |", output);
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -5735,6 +5735,38 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void PackagePipeline_IdentifierConfusionAudit_DemandsRegistrationMetadata()
+    {
+        var pipeline = PackageSectionDescriptors.CreatePipeline();
+        var options = new InspectionOptions
+        {
+            IncludeSections =
+            [
+                PackageSections.AuditIdentifierConfusion,
+            ],
+        };
+
+        Assert.True(
+            PackageCommand.RequiresPackageMetadata(options, pipeline));
+        Assert.True(
+            PackageCommand.AllowsVulnerabilityTraffic(options));
+        Assert.Equal(
+            Verbosity.Detailed,
+            pipeline.GetRequiredVerbosity(options.IncludeSections));
+        Assert.True(
+            PackageCommand.RequiresPackageMetadata(
+                options with
+                {
+                    IncludeSections = null,
+                    Discover =
+                    [
+                        PackageSections.AuditIdentifierConfusion,
+                    ],
+                },
+                pipeline));
+    }
+
+    [Fact]
     public void PackagePipeline_VerbosityAutoPromote_ForPackage()
     {
         var pipeline = PackageSectionDescriptors.CreatePipeline();

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -319,7 +319,7 @@ public class SectionPipelineTests
         // trips this. The @Metadata family is derived from MetadataTableProjector.ProjectedTables
         // (see MetadataSectionNames), so it is counted by derivation rather than re-pinned here —
         // otherwise adding a table to the projector would fail an unrelated test.
-        Assert.Equal(53 + MetadataSectionNames.All.Length, pipeline.AllSectionNames.Length);
+        Assert.Equal(54 + MetadataSectionNames.All.Length, pipeline.AllSectionNames.Length);
         Assert.Contains("Integration: AI", pipeline.AllSectionNames);
         Assert.Contains("Integration: ASP.NET Core", pipeline.AllSectionNames);
         Assert.Contains("Integration: Aspire", pipeline.AllSectionNames);
@@ -1308,6 +1308,7 @@ public class SectionPipelineTests
                 SectionNames.NonNormalizedPaths,
                 SectionNames.SourceLinkDiagnostics,
                 SectionNames.Signals,
+                SectionNames.IdentifierConfusion,
                 SectionNames.Symbols
             ],
             sections);
@@ -5350,6 +5351,7 @@ public class SectionPipelineTests
             [
                 PackageSections.Signals,
                 PackageSections.AuditArtifactText,
+                PackageSections.AuditIdentifierConfusion,
                 PackageSections.Signature,
                 PackageSections.Vulnerabilities,
                 PackageSections.SourceLinkAvailability,
@@ -5377,6 +5379,26 @@ public class SectionPipelineTests
         Assert.Equal(
             expected,
             PackageSectionDescriptors.AuditArtifactText.CanRender(model));
+    }
+
+    [Theory]
+    [InlineData("Contoso.Utilities", false)]
+    [InlineData("C:\\tmp\\package", false)]
+    [InlineData("Δelta.Tools", true)]
+    [InlineData("Ѕystem.Text.Json", true)]
+    public void PackagePipeline_IdentifierConfusionEffectivenessUsesTypedConcerns(
+        string packageName,
+        bool expected)
+    {
+        var model = new InspectionResult
+        {
+            PackageName = packageName,
+            Version = "1.0.0",
+        };
+
+        Assert.Equal(
+            expected,
+            PackageSectionDescriptors.AuditIdentifierConfusion.CanRender(model));
     }
 
     [Fact]
@@ -5440,7 +5462,7 @@ public class SectionPipelineTests
     public void PackagePipeline_HasExpectedSectionCount()
     {
         var pipeline = PackageSectionDescriptors.CreatePipeline();
-        Assert.Equal(19, pipeline.AllSectionNames.Length);
+        Assert.Equal(20, pipeline.AllSectionNames.Length);
     }
 
     [Fact]
@@ -5454,6 +5476,7 @@ public class SectionPipelineTests
         Assert.Contains("Package README file", names);
         Assert.Contains("Signals", names);
         Assert.Contains(PackageSections.AuditArtifactText, names);
+        Assert.Contains(PackageSections.AuditIdentifierConfusion, names);
         Assert.Contains("Target Frameworks", names);
         Assert.Contains("Package nuspec file", names);
         Assert.Contains("Statistics", names);
@@ -5774,6 +5797,7 @@ public class SectionPipelineTests
         {
             AssemblyInfo = new AssemblyInfo
             {
+                AssemblyName = "Ѕystem.Test",
                 References = [new AssemblyReference("System.Runtime", "1.0.0.0", null, null)],
                 TransitiveReferences = [new AssemblyReferenceNode { Name = "System.Runtime", Version = "1.0.0.0" }]
             },
@@ -5904,7 +5928,7 @@ public class SectionPipelineTests
             LibraryFiles = ["lib/net8.0/Test.dll"],
             SourceFiles = [new PackageSourceFileInfo("lib/net8.0/Test.dll", "T", "https://example.com/T.cs")],
             SignatureResult = new SignatureVerificationResult { AuthorVerified = true, Publisher = "test" },
-            DependencyGroups = [new DependencyGroup { TargetFramework = "net8.0", Dependencies = [new PackageDependency { Id = "Dep", Version = "1.0" }] }],
+            DependencyGroups = [new DependencyGroup { TargetFramework = "net8.0", Dependencies = [new PackageDependency { Id = "Ѕystem.Dep", Version = "1.0" }] }],
             Vulnerabilities = [new PackageVulnerability { AdvisoryUrl = "https://example.com", Severity = "High" }],
             RuntimeIdentifierPackages = [new RidPackageReference { RuntimeIdentifier = "win-x64", PackageId = "Test.win-x64" }],
             RuntimeDependencies = [new PackageDependency { Id = "Runtime.Dep", Version = "1.0" }],

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -2258,6 +2258,23 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void LibraryIdentifierConfusionSection_DemandsTypedAssemblyReferencesQuery()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        HashSet<string> identifierAudit =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                SectionNames.IdentifierConfusion,
+            };
+
+        HashSet<InspectionQueryDefinition> required = pipeline.GetRequiredQueries(
+            Verbosity.Minimal,
+            identifierAudit);
+
+        Assert.Equal([AssemblyReferencesQuery.Definition], required);
+    }
+
+    [Fact]
     public void AssemblyReferencesQuery_ReturnsDirectReferencesFromBorrowedContent()
     {
         using var session = AssemblyInspectionSession.Open(
@@ -4082,6 +4099,7 @@ public class SectionPipelineTests
             "Metadata: TypeDef",
             "Metadata: TypeRef",
             "Metadata: TypeSpec",
+            SectionNames.IdentifierConfusion,
             SectionNames.SourceLinkAvailability,
             SectionNames.SourceLinkFiles,
             SectionNames.SourceLinkIntegrity,

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -5349,6 +5349,7 @@ public class SectionPipelineTests
         Assert.Equal(
             [
                 PackageSections.Signals,
+                PackageSections.AuditArtifactText,
                 PackageSections.Signature,
                 PackageSections.Vulnerabilities,
                 PackageSections.SourceLinkAvailability,
@@ -5356,6 +5357,26 @@ public class SectionPipelineTests
                 PackageSections.SourceLinkIntegrity
             ],
             categories[SectionCategoryNames.Audit]);
+    }
+
+    [Theory]
+    [InlineData("ordinary text", false)]
+    [InlineData("C:\\tmp\\package", false)]
+    [InlineData("literal \\u202E text", false)]
+    [InlineData("concerning\u202Etext", true)]
+    public void PackagePipeline_ArtifactTextAuditEffectivenessUsesTypedConcerns(
+        string packageName,
+        bool expected)
+    {
+        var model = new InspectionResult
+        {
+            PackageName = packageName,
+            Version = "1.0.0",
+        };
+
+        Assert.Equal(
+            expected,
+            PackageSectionDescriptors.AuditArtifactText.CanRender(model));
     }
 
     [Fact]
@@ -5419,7 +5440,7 @@ public class SectionPipelineTests
     public void PackagePipeline_HasExpectedSectionCount()
     {
         var pipeline = PackageSectionDescriptors.CreatePipeline();
-        Assert.Equal(18, pipeline.AllSectionNames.Length);
+        Assert.Equal(19, pipeline.AllSectionNames.Length);
     }
 
     [Fact]
@@ -5432,6 +5453,7 @@ public class SectionPipelineTests
         Assert.Contains("Package Info", names);
         Assert.Contains("Package README file", names);
         Assert.Contains("Signals", names);
+        Assert.Contains(PackageSections.AuditArtifactText, names);
         Assert.Contains("Target Frameworks", names);
         Assert.Contains("Package nuspec file", names);
         Assert.Contains("Statistics", names);
@@ -5864,6 +5886,7 @@ public class SectionPipelineTests
         {
             PackageName = "Test",
             Version = "1.0.0",
+            Owners = ["audit\u202Ecase"],
             PackageReadmeFile = "README.md",
             PackageFiles =
             [

--- a/src/dotnet-inspect/Commands/CommandContext.cs
+++ b/src/dotnet-inspect/Commands/CommandContext.cs
@@ -21,8 +21,16 @@ public class CommandContext
     /// Creates a new command context with the specified verbosity.
     /// </summary>
     public CommandContext(bool verbose)
+        : this(verbose, HttpClientFactory.Shared)
+    {
+    }
+
+    internal CommandContext(
+        bool verbose,
+        HttpClient httpClient)
     {
         Logger = new VerboseLogger(verbose);
-        HttpClient = HttpClientFactory.Shared;
+        HttpClient = httpClient
+            ?? throw new ArgumentNullException(nameof(httpClient));
     }
 }

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -739,19 +739,17 @@ public class LibraryCommand
                 if (heapExitCode != 0)
                     return heapExitCode;
                 if (discoveryInspection)
-                    return IntegrityExitCode(
-                        Math.Max(
-                            identifierAuditExitCode,
-                            WriteEffectiveSections(
-                                assemblyPaths[0], inspections[0], options,
-                                pipeline, userVerbosity,
-                                fullEffectiveDiscovery,
-                                discoveryExecutionScope,
-                                sourceLinkAvailable,
-                                cache: useEffectiveDiscoveryCache,
-                                inspectedContentHash:
-                                    inspectedContentHash)),
-                        inspections[0]);
+                    return Math.Max(
+                        identifierAuditExitCode,
+                        WriteEffectiveSections(
+                            assemblyPaths[0], inspections[0], options,
+                            pipeline, userVerbosity,
+                            fullEffectiveDiscovery,
+                            discoveryExecutionScope,
+                            sourceLinkAvailable,
+                            cache: useEffectiveDiscoveryCache,
+                            inspectedContentHash:
+                                inspectedContentHash));
                 if (TryWriteLibrarySingletonCount(inspections[0], options))
                     return IntegrityExitCode(
                         identifierAuditExitCode,

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -721,20 +721,30 @@ public class LibraryCommand
                     discoveryInspection && !fullEffectiveDiscovery, trace);
                 List<LibraryInspection> inspections =
                     collection.Inspections;
-                bool identifierAuditIncomplete =
-                    PackageCommand.WriteIdentifierAuditFailures(
-                        collection.IdentifierAuditFailures);
-                int identifierAuditExitCode =
-                    identifierAuditIncomplete ? 1 : 0;
 
                 if (inspections.Count == 0)
                 {
+                    PackageCommand.WriteIdentifierAuditFailures(
+                        collection.IdentifierAuditFailures);
                     CommandError.Write("No libraries could be read from the package.");
                     return 1;
                 }
 
                 foreach (var insp in inspections)
                     insp.Source = SourceKind.NuGet;
+                if (inspections.Count == 1
+                    && RejectFailedExactIdentifierAudit(
+                        inspections[0],
+                        options))
+                {
+                    return 1;
+                }
+
+                bool identifierAuditIncomplete =
+                    PackageCommand.WriteIdentifierAuditFailures(
+                        collection.IdentifierAuditFailures);
+                int identifierAuditExitCode =
+                    identifierAuditIncomplete ? 1 : 0;
 
                 var ilOffsetExitCode = await PopulateILOffsetIfRequestedAsync(
                     inspections[0], assemblyPaths[0], packageName, packageVersion, isPlatformAssembly: false,

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -483,10 +483,14 @@ public class LibraryCommand
         {
             inspectionOptions = inspectionOptions with
             {
-                // Assembly references are a cheap metadata fact. Discovery never needs the
-                // transitive projection because References effectiveness is established directly.
+                // References effectiveness is established from direct metadata. The explicit
+                // identifier audit is different: full-effective discovery must run the same
+                // closure that decides whether that section has rows.
                 CollectReferenceTree = false,
-                CollectIdentifierConfusionReferenceTree = false,
+                CollectIdentifierConfusionReferenceTree =
+                    fullEffectiveDiscovery
+                    && discoveryExecutionScope?.Contains(
+                        SectionNames.IdentifierConfusion) == true,
             };
         }
         else

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -609,6 +609,12 @@ public class LibraryCommand
 
                 inspection.Source = SourceKind.Platform;
                 inspection.PlatformVersion = version;
+                if (RejectFailedExactIdentifierAudit(
+                        inspection,
+                        options))
+                {
+                    return 1;
+                }
 
                 var ilOffsetExitCode = await PopulateILOffsetIfRequestedAsync(
                     inspection, resolvedPath!, null, null, isPlatformAssembly: true, options, context.HttpClient, logger);
@@ -749,10 +755,13 @@ public class LibraryCommand
                             sourceLinkAvailable,
                             cache: useEffectiveDiscoveryCache,
                             inspectedContentHash:
-                                inspectedContentHash));
+                                inspectedContentHash,
+                            reportIdentifierFailures:
+                                !identifierAuditIncomplete));
                 if (TryWriteLibrarySingletonCount(inspections[0], options))
                     return IntegrityExitCode(
                         identifierAuditExitCode,
+                        !identifierAuditIncomplete,
                         inspections[0]);
                 if (options.Print)
                     return IntegrityExitCode(
@@ -761,6 +770,7 @@ public class LibraryCommand
                             await WriteLibraryPrintProjectionAsync(
                                 inspections[0],
                                 options)),
+                        !identifierAuditIncomplete,
                         inspections[0]);
                 if (options.Value || options.Urls || options.Paths)
                     return IntegrityExitCode(
@@ -769,6 +779,7 @@ public class LibraryCommand
                             WriteLibraryShapeProjection(
                                 inspections[0],
                                 options)),
+                        !identifierAuditIncomplete,
                         inspections[0]);
                 if (RejectEmptyExactSection(inspections, options, pipeline))
                     return 1;
@@ -787,6 +798,7 @@ public class LibraryCommand
 
                 return IntegrityExitCode(
                     identifierAuditExitCode,
+                    !identifierAuditIncomplete,
                     [.. inspections]);
             }
             else
@@ -851,6 +863,12 @@ public class LibraryCommand
                 }
 
                 inspection.Source = SourceKind.File;
+                if (RejectFailedExactIdentifierAudit(
+                        inspection,
+                        options))
+                {
+                    return 1;
+                }
 
                 var ilOffsetExitCode = await PopulateILOffsetIfRequestedAsync(
                     inspection, assemblyPath!, null, null, isPlatformAssembly: false,
@@ -908,6 +926,15 @@ public class LibraryCommand
     private static int IntegrityExitCode(
         int currentExitCode,
         params LibraryInspection[] inspections)
+        => IntegrityExitCode(
+            currentExitCode,
+            reportIdentifierFailures: true,
+            inspections);
+
+    private static int IntegrityExitCode(
+        int currentExitCode,
+        bool reportIdentifierFailures,
+        params LibraryInspection[] inspections)
     {
         var identifierFailures = inspections
             .Where(
@@ -918,11 +945,16 @@ public class LibraryCommand
                     inspection.IdentifierConfusionFailure!.Value)
             .Distinct()
             .ToList();
-        foreach (IdentifierConfusionAuditFailureKind failure in identifierFailures)
+        if (reportIdentifierFailures)
         {
-            CommandError.WriteWarning(
-                "Identifier audit failed: "
-                + IdentifierConfusionAudit.DescribeFailure(failure));
+            foreach (
+                IdentifierConfusionAuditFailureKind failure
+                in identifierFailures)
+            {
+                CommandError.WriteWarning(
+                    "Identifier audit failed: "
+                    + IdentifierConfusionAudit.DescribeFailure(failure));
+            }
         }
 
         if (currentExitCode != 0)
@@ -934,6 +966,33 @@ public class LibraryCommand
             || identifierFailures.Count > 0
             ? 1
             : 0;
+    }
+
+    private static bool RejectFailedExactIdentifierAudit(
+        LibraryInspection inspection,
+        LibraryOptions options)
+    {
+        if (inspection.IdentifierConfusionFailure is not { } failure)
+            return false;
+
+        bool exactSelection =
+            options.IncludeSections is { Count: 1 } sections
+            && sections.Contains(SectionNames.IdentifierConfusion)
+            && options.ExactIncludeSections?.Contains(
+                SectionNames.IdentifierConfusion) == true;
+        bool exactDiscovery =
+            options.Discover is { Length: 1 }
+            && options.Discover[0].Equals(
+                SectionNames.IdentifierConfusion,
+                StringComparison.OrdinalIgnoreCase);
+        if (!exactSelection && !exactDiscovery)
+            return false;
+
+        CommandError.Write(
+            "Identifier audit could not inspect assembly references: "
+            + IdentifierConfusionAudit.DescribeFailure(failure)
+            + ".");
+        return true;
     }
 
     private static async Task<int> WriteILCoordinateBatchAsync(
@@ -2056,7 +2115,8 @@ public class LibraryCommand
         HashSet<string>? effectivenessScope,
         bool sourceLinkAvailable = false,
         bool cache = true,
-        string? inspectedContentHash = null)
+        string? inspectedContentHash = null,
+        bool reportIdentifierFailures = true)
     {
         // Seed the network-free SourceLink-availability fact so the SourceLink section family
         // gates on a cached/embedded/adjacent PDB during discovery (never clears a value the
@@ -2123,7 +2183,10 @@ public class LibraryCommand
             projection: options);
         return Math.Max(
             discoveryExitCode,
-            IntegrityExitCode(inspection));
+            IntegrityExitCode(
+                0,
+                reportIdentifierFailures,
+                inspection));
     }
 
     // ── Effective sections cache ──
@@ -2533,6 +2596,12 @@ public class LibraryCommand
             {
                 logger.LogWarning($"Could not read library: {Path.GetFileName(targetPath)}");
                 continue;
+            }
+            if (options.CollectIdentifierConfusionReferenceTree
+                && inspection.IdentifierConfusionFailure is { } failure)
+            {
+                identifierAuditFailures.Add(
+                    (relativePath, failure));
             }
 
             // Populate TFM from path for multi-TFM display

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -2065,14 +2065,17 @@ public class LibraryCommand
             ? FilterSchemaToEffectiveFields(
                 inspection, allEffective, schemaMap, pipeline, allEffective.ToArray())
             : schemaMap;
-        if (cache)
+        bool hasIntegrityFailure =
+            inspection.SourceIntegrityMismatches is { Count: > 0 }
+            || inspection.IdentifierConfusionFailure is not null;
+        if (cache && !hasIntegrityFailure)
             CacheEffective(assemblyPath, inspection.HasSourceLink, allEffective, filteredSchema, inspectedContentHash);
 
         // Apply user filters
         var effective = FilterEffective(allEffective, options);
 
         var rootLabel = Path.GetFileNameWithoutExtension(assemblyPath);
-        return DiscoverOutput.ExecuteEffective(options.Discover, effective, filteredSchema,
+        int discoveryExitCode = DiscoverOutput.ExecuteEffective(options.Discover, effective, filteredSchema,
             tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.Tabular && !options.JsonOutput,
             verbosity: (int)userVerbosity, rootLabel: rootLabel, fullSchema: schemaMap,
             sectionCostAnnotations: pipeline.GetCostAnnotations(),
@@ -2080,12 +2083,15 @@ public class LibraryCommand
             catalogHiddenSections: EffectiveCatalogHidden(pipeline),
             listedCategoryDoors: pipeline.GetListedCategoryDoors(),
             projection: options);
+        return Math.Max(
+            discoveryExitCode,
+            IntegrityExitCode(inspection));
     }
 
     // ── Effective sections cache ──
 
-    // Bumped to v22: effective catalogs can now include SourceLink: Diagnostics.
-    private const string EffectiveCategory = "effective-v22";
+    // Bumped to v23: failed effective inspections are no longer cached as successful catalogs.
+    private const string EffectiveCategory = "effective-v23";
 
     static LibraryCommand()
     {

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -707,11 +707,19 @@ public class LibraryCommand
                                     packageName,
                                     packageVersion))),
                         trace);
-                var inspections = await CollectPackageInspectionsAsync(
+                PackageInspectionCollection collection =
+                    await CollectPackageInspectionsAsync(
                     inspectionPaths, inspectionOptions, logger, packageName, packageVersion,
                     extractPath, context.HttpClient, signatureResult, scanners, scannerRegistry,
                     queries, queryRegistry, integrations,
                     discoveryInspection && !fullEffectiveDiscovery, trace);
+                List<LibraryInspection> inspections =
+                    collection.Inspections;
+                bool identifierAuditIncomplete =
+                    PackageCommand.WriteIdentifierAuditFailures(
+                        collection.IdentifierAuditFailures);
+                int identifierAuditExitCode =
+                    identifierAuditIncomplete ? 1 : 0;
 
                 if (inspections.Count == 0)
                 {
@@ -731,17 +739,39 @@ public class LibraryCommand
                 if (heapExitCode != 0)
                     return heapExitCode;
                 if (discoveryInspection)
-                    return WriteEffectiveSections(
-                        assemblyPaths[0], inspections[0], options, pipeline, userVerbosity,
-                        fullEffectiveDiscovery, discoveryExecutionScope, sourceLinkAvailable,
-                        cache: useEffectiveDiscoveryCache,
-                        inspectedContentHash: inspectedContentHash);
+                    return IntegrityExitCode(
+                        Math.Max(
+                            identifierAuditExitCode,
+                            WriteEffectiveSections(
+                                assemblyPaths[0], inspections[0], options,
+                                pipeline, userVerbosity,
+                                fullEffectiveDiscovery,
+                                discoveryExecutionScope,
+                                sourceLinkAvailable,
+                                cache: useEffectiveDiscoveryCache,
+                                inspectedContentHash:
+                                    inspectedContentHash)),
+                        inspections[0]);
                 if (TryWriteLibrarySingletonCount(inspections[0], options))
-                    return 0;
+                    return IntegrityExitCode(
+                        identifierAuditExitCode,
+                        inspections[0]);
                 if (options.Print)
-                    return await WriteLibraryPrintProjectionAsync(inspections[0], options);
+                    return IntegrityExitCode(
+                        Math.Max(
+                            identifierAuditExitCode,
+                            await WriteLibraryPrintProjectionAsync(
+                                inspections[0],
+                                options)),
+                        inspections[0]);
                 if (options.Value || options.Urls || options.Paths)
-                    return WriteLibraryShapeProjection(inspections[0], options);
+                    return IntegrityExitCode(
+                        Math.Max(
+                            identifierAuditExitCode,
+                            WriteLibraryShapeProjection(
+                                inspections[0],
+                                options)),
+                        inspections[0]);
                 if (RejectEmptyExactSection(inspections, options, pipeline))
                     return 1;
                 WarnEmptySections(inspections, options, pipeline);
@@ -757,7 +787,9 @@ public class LibraryCommand
                     OutputFormatter.WriteLibraryResults(inspections, options, pipeline);
                 }
 
-                return IntegrityExitCode([.. inspections]);
+                return IntegrityExitCode(
+                    identifierAuditExitCode,
+                    [.. inspections]);
             }
             else
             {
@@ -873,6 +905,11 @@ public class LibraryCommand
     }
 
     private static int IntegrityExitCode(params LibraryInspection[] inspections)
+        => IntegrityExitCode(0, inspections);
+
+    private static int IntegrityExitCode(
+        int currentExitCode,
+        params LibraryInspection[] inspections)
     {
         var identifierFailures = inspections
             .Where(
@@ -889,6 +926,9 @@ public class LibraryCommand
                 "Identifier audit failed: "
                 + IdentifierConfusionAudit.DescribeFailure(failure));
         }
+
+        if (currentExitCode != 0)
+            return currentExitCode;
 
         return inspections.Any(
                 inspection =>
@@ -2428,7 +2468,15 @@ public class LibraryCommand
         }
     }
 
-    private static async Task<List<LibraryInspection>> CollectPackageInspectionsAsync(
+    private readonly record struct PackageInspectionCollection(
+        List<LibraryInspection> Inspections,
+        List<(
+            string FileName,
+            IdentifierConfusionAuditFailureKind FailureKind)>
+            IdentifierAuditFailures);
+
+    private static async Task<PackageInspectionCollection>
+        CollectPackageInspectionsAsync(
         List<string> assemblyPaths, LibraryOptions options, VerboseLogger logger,
         string? packageName, string? packageVersion, string extractPath,
         HttpClient httpClient, SignatureVerificationResult? signatureResult,
@@ -2439,28 +2487,50 @@ public class LibraryCommand
         bool discoveryOnly = false, InspectionTrace? trace = null)
     {
         List<LibraryInspection> inspections = [];
+        List<(
+            string FileName,
+            IdentifierConfusionAuditFailureKind FailureKind)>
+            identifierAuditFailures = [];
 
         foreach (var targetPath in assemblyPaths)
         {
             var version = packageVersion ?? (packageName != null ? PackageExtractor.ExtractVersionFromPath(targetPath, packageName) : null);
+            string relativePath = Path.GetRelativePath(
+                    extractPath,
+                    targetPath)
+                .Replace('\\', '/');
 
-            var inspection = await LibraryMetadataService.InspectAsync(
-                targetPath,
-                options,
-                logger,
-                packageName,
-                version,
-                httpClient,
-                scanners: scanners,
-                scannerRegistry: scannerRegistry,
-                queries: queries,
-                queryRegistry: queryRegistry,
-                assemblyReference: integrations?.AssemblyForInspection(targetPath),
-                integrationsEntry: integrations?.EntryFor(targetPath),
-                integrationOpportunitiesEntry:
-                    integrations?.OpportunitiesEntryFor(targetPath),
-                discoveryOnly: discoveryOnly,
-                trace: trace);
+            LibraryInspection? inspection;
+            try
+            {
+                inspection = await LibraryMetadataService.InspectAsync(
+                    targetPath,
+                    options,
+                    logger,
+                    packageName,
+                    version,
+                    httpClient,
+                    scanners: scanners,
+                    scannerRegistry: scannerRegistry,
+                    queries: queries,
+                    queryRegistry: queryRegistry,
+                    assemblyReference:
+                        integrations?.AssemblyForInspection(targetPath),
+                    integrationsEntry:
+                        integrations?.EntryFor(targetPath),
+                    integrationOpportunitiesEntry:
+                        integrations?.OpportunitiesEntryFor(targetPath),
+                    discoveryOnly: discoveryOnly,
+                    trace: trace);
+            }
+            catch (
+                LibraryMetadataService
+                    .IdentifierConfusionReferenceTraversalException ex)
+            {
+                identifierAuditFailures.Add(
+                    (relativePath, ex.FailureKind));
+                continue;
+            }
             if (inspection == null)
             {
                 logger.LogWarning($"Could not read library: {Path.GetFileName(targetPath)}");
@@ -2468,7 +2538,6 @@ public class LibraryCommand
             }
 
             // Populate TFM from path for multi-TFM display
-            var relativePath = Path.GetRelativePath(extractPath, targetPath).Replace('\\', '/');
             inspection.Tfm = TfmResolver.ExtractTfmFromPath(relativePath);
 
             if (signatureResult != null)
@@ -2482,7 +2551,9 @@ public class LibraryCommand
             inspections.Add(inspection);
         }
 
-        return inspections;
+        return new PackageInspectionCollection(
+            inspections,
+            identifierAuditFailures);
     }
 
     private static AssemblyResolutionProvenance PackageIntegrationProvenance(

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -486,6 +486,7 @@ public class LibraryCommand
                 // Assembly references are a cheap metadata fact. Discovery never needs the
                 // transitive projection because References effectiveness is established directly.
                 CollectReferenceTree = false,
+                CollectIdentifierConfusionReferenceTree = false,
             };
         }
         else
@@ -494,8 +495,10 @@ public class LibraryCommand
                 options.Verbosity, options.IncludeSections, options.FixedOverview);
             inspectionOptions = inspectionOptions with
             {
-                CollectReferenceTree = options.Tree
-                    && candidates.Contains(SectionNames.References),
+                CollectReferenceTree =
+                    options.Tree && candidates.Contains(SectionNames.References),
+                CollectIdentifierConfusionReferenceTree =
+                    candidates.Contains(SectionNames.IdentifierConfusion),
             };
         }
 

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -874,7 +874,28 @@ public class LibraryCommand
 
     private static int IntegrityExitCode(params LibraryInspection[] inspections)
     {
-        return inspections.Any(insp => insp.SourceIntegrityMismatches is { Count: > 0 }) ? 1 : 0;
+        var identifierFailures = inspections
+            .Where(
+                inspection =>
+                    inspection.IdentifierConfusionFailure is not null)
+            .Select(
+                inspection =>
+                    inspection.IdentifierConfusionFailure!.Value)
+            .Distinct()
+            .ToList();
+        foreach (IdentifierConfusionAuditFailureKind failure in identifierFailures)
+        {
+            CommandError.WriteWarning(
+                "Identifier audit failed: "
+                + IdentifierConfusionAudit.DescribeFailure(failure));
+        }
+
+        return inspections.Any(
+                inspection =>
+                    inspection.SourceIntegrityMismatches is { Count: > 0 })
+            || identifierFailures.Count > 0
+            ? 1
+            : 0;
     }
 
     private static async Task<int> WriteILCoordinateBatchAsync(

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -3291,6 +3291,16 @@ public class PackageCommand
         if (requiredVerbosity > libraryOptions.Verbosity)
             libraryOptions = libraryOptions with { Verbosity = requiredVerbosity };
 
+        var candidates = pipeline.GetCandidateSections(
+            libraryOptions.Verbosity,
+            libraryOptions.IncludeSections,
+            libraryOptions.FixedOverview);
+        libraryOptions = libraryOptions with
+        {
+            CollectIdentifierConfusionReferenceTree =
+                candidates.Contains(SectionNames.IdentifierConfusion),
+        };
+
         var scanners = pipeline.GetRequiredScanners(libraryOptions.Verbosity, libraryOptions.IncludeSections);
         List<(string Reason, InspectionQueryDefinition Query)> commandQueryDemand = [];
         if (libraryOptions.CollectReferenceTree)

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -650,6 +650,8 @@ public class PackageCommand
 
             bool wantsSignals = options.IncludeSections?.Contains(PackageSections.Signals) == true
                 || DiscoverRequestsSection(options.Discover, PackageSections.Signals, pipeline);
+            bool wantsPackageMetadata =
+                RequiresPackageMetadata(options, pipeline);
             using var vulnerabilityTrafficScope = AllowsVulnerabilityTraffic(options)
                 ? NetworkTelemetry.Allow(NetworkTrafficKind.VulnerabilityData)
                 : null;
@@ -659,7 +661,7 @@ public class PackageCommand
                 target.IsLocalFile ? target.OriginalArgument : null,
                 nuspec, client, logger,
                 options.ForceLatest, options.Verbosity,
-                fetchMetadata: wantsSignals,
+                fetchMetadata: wantsPackageMetadata,
                 sourceOptions: options.SourceOptions);
 
             // Apply package size (not cached in index — comes from nupkg file)
@@ -1907,7 +1909,12 @@ public class PackageCommand
                 packageSize = new FileInfo(resolution.NupkgPath).Length;
 
             bool wantsSignals = options.IncludeSections?.Contains(PackageSections.Signals) == true
-                || DiscoverRequestsSection(options.Discover, PackageSections.Signals, PackageSectionDescriptors.CreatePipeline());
+                || DiscoverRequestsSection(
+                    options.Discover,
+                    PackageSections.Signals,
+                    pipeline);
+            bool wantsPackageMetadata =
+                RequiresPackageMetadata(options, pipeline);
             using var vulnerabilityTrafficScope = AllowsVulnerabilityTraffic(options)
                 ? NetworkTelemetry.Allow(NetworkTrafficKind.VulnerabilityData)
                 : null;
@@ -1922,7 +1929,7 @@ public class PackageCommand
                 logger,
                 options.ForceLatest,
                 options.Verbosity,
-                fetchMetadata: wantsSignals,
+                fetchMetadata: wantsPackageMetadata,
                 sourceOptions: options.SourceOptions);
 
             if (packageSize.HasValue)
@@ -3179,10 +3186,13 @@ public class PackageCommand
 
     private static bool IsNetworkUsingPackageSection(string section) =>
         section.Equals(PackageSections.Signals, StringComparison.OrdinalIgnoreCase)
+        || section.Equals(
+            PackageSections.AuditIdentifierConfusion,
+            StringComparison.OrdinalIgnoreCase)
         || section.Equals(PackageSections.Statistics, StringComparison.OrdinalIgnoreCase)
         || section.Equals(PackageSections.Vulnerabilities, StringComparison.OrdinalIgnoreCase);
 
-    private static bool AllowsVulnerabilityTraffic(InspectionOptions options) =>
+    internal static bool AllowsVulnerabilityTraffic(InspectionOptions options) =>
         options.Verbosity >= Verbosity.Detailed
         || options.IncludeSections?.Any(IsNetworkUsingPackageSection) == true;
 
@@ -3336,7 +3346,7 @@ public class PackageCommand
                 : null;
         List<LibraryInspection> inspections = [];
         List<(string FileName, string Reason)> groupedIntegrationsFailures = [];
-        List<(string FileName, string ReferenceName, string FailureKind)>
+        List<(string FileName, IdentifierConfusionAuditFailureKind FailureKind)>
             identifierAuditFailures = [];
         foreach (var selection in selected)
         {
@@ -3384,7 +3394,6 @@ public class PackageCommand
                 identifierAuditFailures.Add(
                     (
                         relativePath,
-                        ex.ReferenceName,
                         ex.FailureKind));
                 continue;
             }
@@ -3406,6 +3415,16 @@ public class PackageCommand
             integrationsWorkspace is not null
             && WriteGroupedIntegrationsFailures(
                 groupedIntegrationsFailures);
+        identifierAuditFailures.AddRange(
+            inspections
+                .Where(
+                    inspection =>
+                        inspection.IdentifierConfusionFailure is not null)
+                .Select(
+                    inspection =>
+                        (
+                            inspection.FileName,
+                            inspection.IdentifierConfusionFailure!.Value)));
         bool identifierAuditIncomplete =
             WriteIdentifierAuditFailures(identifierAuditFailures);
         int completionExitCode =
@@ -3557,8 +3576,7 @@ public class PackageCommand
     internal static bool WriteIdentifierAuditFailures(
         IEnumerable<(
             string FileName,
-            string ReferenceName,
-            string FailureKind)> auditFailures)
+            IdentifierConfusionAuditFailureKind FailureKind)> auditFailures)
     {
         ArgumentNullException.ThrowIfNull(auditFailures);
 
@@ -3566,11 +3584,11 @@ public class PackageCommand
             .Distinct()
             .ToList();
 
-        foreach (var (fileName, referenceName, failureKind) in failures)
+        foreach (var (fileName, failureKind) in failures)
         {
             CommandError.WriteWarning(
-                $"Identifier audit failed for '{fileName}' while inspecting "
-                + $"reference '{referenceName}': {failureKind}");
+                $"Identifier audit failed for '{fileName}': "
+                + IdentifierConfusionAudit.DescribeFailure(failureKind));
         }
 
         return failures.Count > 0;
@@ -3579,6 +3597,26 @@ public class PackageCommand
     internal static int AllLibrariesCompletionExitCode(
         bool incomplete) =>
         incomplete ? 1 : 0;
+
+    internal static bool RequiresPackageMetadata(
+        InspectionOptions options,
+        SectionPipeline<InspectionResult> pipeline)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(pipeline);
+
+        return options.IncludeSections?.Contains(PackageSections.Signals) == true
+            || options.IncludeSections?.Contains(
+                PackageSections.AuditIdentifierConfusion) == true
+            || DiscoverRequestsSection(
+                options.Discover,
+                PackageSections.Signals,
+                pipeline)
+            || DiscoverRequestsSection(
+                options.Discover,
+                PackageSections.AuditIdentifierConfusion,
+                pipeline);
+    }
 
     private static LibraryOptions CreateLibraryOptions(string? assemblyName, string packageReference, InspectionOptions options)
         => new()

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -3336,6 +3336,8 @@ public class PackageCommand
                 : null;
         List<LibraryInspection> inspections = [];
         List<(string FileName, string Reason)> groupedIntegrationsFailures = [];
+        List<(string FileName, string ReferenceName, string FailureKind)>
+            identifierAuditFailures = [];
         foreach (var selection in selected)
         {
             string relativePath = Path.GetRelativePath(
@@ -3364,15 +3366,29 @@ public class PackageCommand
                     integrationOpportunitiesEntry: opportunities);
             }
 
-            LibraryInspection? inspection =
-                integrationsWorkspace is null
-                    ? await InspectAsync(null, null, null)
-                    : await InspectGroupedAssemblyAsync(
-                        integrationsWorkspace,
-                        selection.Path,
+            LibraryInspection? inspection;
+            try
+            {
+                inspection =
+                    integrationsWorkspace is null
+                        ? await InspectAsync(null, null, null)
+                        : await InspectGroupedAssemblyAsync(
+                            integrationsWorkspace,
+                            selection.Path,
+                            relativePath,
+                            groupedIntegrationsFailures,
+                            InspectAsync);
+            }
+            catch (LibraryMetadataService.IdentifierConfusionReferenceTraversalException ex)
+            {
+                identifierAuditFailures.Add(
+                    (
                         relativePath,
-                        groupedIntegrationsFailures,
-                        InspectAsync);
+                        ex.ReferenceName,
+                        ex.FailureKind));
+                continue;
+            }
+
             if (inspection == null)
             {
                 logger.LogWarning($"Could not read library: {Path.GetFileName(selection.Path)}");
@@ -3390,8 +3406,11 @@ public class PackageCommand
             integrationsWorkspace is not null
             && WriteGroupedIntegrationsFailures(
                 groupedIntegrationsFailures);
+        bool identifierAuditIncomplete =
+            WriteIdentifierAuditFailures(identifierAuditFailures);
         int completionExitCode =
-            AllLibrariesCompletionExitCode(integrationsIncomplete);
+            AllLibrariesCompletionExitCode(
+                integrationsIncomplete || identifierAuditIncomplete);
 
         if (inspections.Count == 0)
         {
@@ -3535,9 +3554,31 @@ public class PackageCommand
         return failures.Count > 0;
     }
 
+    internal static bool WriteIdentifierAuditFailures(
+        IEnumerable<(
+            string FileName,
+            string ReferenceName,
+            string FailureKind)> auditFailures)
+    {
+        ArgumentNullException.ThrowIfNull(auditFailures);
+
+        var failures = auditFailures
+            .Distinct()
+            .ToList();
+
+        foreach (var (fileName, referenceName, failureKind) in failures)
+        {
+            CommandError.WriteWarning(
+                $"Identifier audit failed for '{fileName}' while inspecting "
+                + $"reference '{referenceName}': {failureKind}");
+        }
+
+        return failures.Count > 0;
+    }
+
     internal static int AllLibrariesCompletionExitCode(
-        bool integrationsIncomplete) =>
-        integrationsIncomplete ? 1 : 0;
+        bool incomplete) =>
+        incomplete ? 1 : 0;
 
     private static LibraryOptions CreateLibraryOptions(string? assemblyName, string packageReference, InspectionOptions options)
         => new()

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -28,8 +28,20 @@ namespace DotnetInspector.Commands;
 public class PackageCommand
 {
     public const string Name = "package";
-    public static async Task<int> ExecuteAsync(InspectionOptions options)
+    public static Task<int> ExecuteAsync(InspectionOptions options)
     {
+        ArgumentNullException.ThrowIfNull(options);
+        return ExecuteAsync(
+            options,
+            new CommandContext(options.Verbose));
+    }
+
+    internal static async Task<int> ExecuteAsync(
+        InspectionOptions options,
+        CommandContext context)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(context);
         var packageArgs = options.PackageArgs;
         var explicitVersion = options.ExplicitVersion;
         var catalog = PackageSectionDescriptors.CreateCatalog();
@@ -215,7 +227,6 @@ public class PackageCommand
         if (options.PackageLibrary != null && !ValidatePackageLibraryMode(options))
             return 1;
 
-        var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
 
         if (packageArgs.Length > 1)
@@ -662,6 +673,7 @@ public class PackageCommand
                 nuspec, client, logger,
                 options.ForceLatest, options.Verbosity,
                 fetchMetadata: wantsPackageMetadata,
+                requireIdentifierMetadata: wantsPackageMetadata,
                 sourceOptions: options.SourceOptions);
 
             // Apply package size (not cached in index — comes from nupkg file)
@@ -788,14 +800,34 @@ public class PackageCommand
                     }
                 }
 
-                return DiscoverOutput.ExecuteEffective(options.Discover, effective, schemaMap,
-                    tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.Tabular && !options.JsonOutput,
-                    verbosity: (int)userVerbosity, rootLabel: $"package {packageName}", fullSchema: fullSchemaMap,
-                    sectionCostAnnotations: pipeline.GetCostAnnotations(),
-                    sectionCategories: pipeline.GetCategoryMap(),
-                    catalogHiddenSections: options.Schema ? null : pipeline.GetCatalogHiddenSections(),
-                    listedCategoryDoors: pipeline.GetListedCategoryDoors(),
-                    projection: options);
+                return PackageIntegrityExitCode(
+                    DiscoverOutput.ExecuteEffective(
+                        options.Discover,
+                        effective,
+                        schemaMap,
+                        tree: options.Tree,
+                        json: options.JsonOutput,
+                        tsv: options.Tsv,
+                        jsonl: options.Jsonl,
+                        markdown:
+                            !options.Tabular
+                            && !options.JsonOutput,
+                        verbosity: (int)userVerbosity,
+                        rootLabel: $"package {packageName}",
+                        fullSchema: fullSchemaMap,
+                        sectionCostAnnotations:
+                            pipeline.GetCostAnnotations(),
+                        sectionCategories:
+                            pipeline.GetCategoryMap(),
+                        catalogHiddenSections:
+                            options.Schema
+                                ? null
+                                : pipeline
+                                    .GetCatalogHiddenSections(),
+                        listedCategoryDoors:
+                            pipeline.GetListedCategoryDoors(),
+                        projection: options),
+                    result);
             }
             WarnEmptySections(result, options, pipeline);
             bool hasProjection = options.Fields is { Length: > 0 } || options.Columns is { Length: > 0 };
@@ -991,12 +1023,40 @@ public class PackageCommand
     internal static int PackageIntegrityExitCode(
         int currentExitCode,
         params InspectionResult[] results)
-        => currentExitCode != 0
-            ? currentExitCode
-            : results.Any(
-                static result => result.SourceIntegrity?.Mismatched is > 0)
+    {
+        var identifierFailures = results
+            .Select(
+                (result, index) =>
+                    (
+                        Input: index + 1,
+                        Failure:
+                            result.IdentifierConfusionFailure))
+            .Where(
+                failure =>
+                    failure.Failure is not null)
+            .Select(
+                failure =>
+                    (
+                        failure.Input,
+                        Failure: failure.Failure!.Value))
+            .ToList();
+        foreach (var (input, failure) in identifierFailures)
+        {
+            CommandError.WriteWarning(
+                $"Identifier audit failed for package input #{input}: "
+                + IdentifierConfusionAudit.DescribeFailure(failure));
+        }
+
+        if (currentExitCode != 0)
+            return currentExitCode;
+
+        return results.Any(
+                static result =>
+                    result.SourceIntegrity?.Mismatched is > 0)
+            || identifierFailures.Count > 0
                 ? 1
                 : 0;
+    }
 
     internal static int WriteMultiPackageCount(
         IReadOnlyList<InspectionResult> results,
@@ -1930,6 +1990,7 @@ public class PackageCommand
                 options.ForceLatest,
                 options.Verbosity,
                 fetchMetadata: wantsPackageMetadata,
+                requireIdentifierMetadata: wantsPackageMetadata,
                 sourceOptions: options.SourceOptions);
 
             if (packageSize.HasValue)

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -923,6 +923,8 @@ public class PackageCommand
             || options.IncludeSections?.Any(IsPackageFileSection) == true
             || (options.FixedOverview
                 && pipeline.BareSelectSectionNames.Any(IsPackageFileSection))
+            || options.IncludeSections?.Contains(PackageSections.Signals) == true
+            || options.IncludeSections?.Contains(PackageSections.AuditArtifactText) == true
             || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
         if (!options.Count && !options.JsonOutput && rowSection == null)
         {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -959,6 +959,7 @@ public class PackageCommand
                 && pipeline.BareSelectSectionNames.Any(IsPackageFileSection))
             || options.IncludeSections?.Contains(PackageSections.Signals) == true
             || options.IncludeSections?.Contains(PackageSections.AuditArtifactText) == true
+            || options.FixedOverview
             || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
         if (!options.Count && !options.JsonOutput && rowSection == null)
         {

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -147,27 +147,7 @@ internal static class AuditSignalBuilder
             "Text",
             "Artifact text containment",
             concerns == TextConcern.None ? "None" : "Required",
-            DescribeTextConcerns(concerns));
-    }
-
-    private static string DescribeTextConcerns(TextConcern concerns)
-    {
-        if (concerns == TextConcern.None)
-            return "no concerning scalars found";
-
-        List<string> kinds = [];
-        AddKind(TextConcern.Control, "control (Cc)");
-        AddKind(TextConcern.Format, "format/bidi (Cf)");
-        AddKind(TextConcern.Surrogate, "unpaired surrogate (Cs)");
-        AddKind(TextConcern.LineSeparator, "line separator (Zl)");
-        AddKind(TextConcern.ParagraphSeparator, "paragraph separator (Zp)");
-        return string.Join(", ", kinds);
-
-        void AddKind(TextConcern kind, string description)
-        {
-            if ((concerns & kind) != TextConcern.None)
-                kinds.Add(description);
-        }
+            TextConcernDisplay.Describe(concerns));
     }
 
     private readonly record struct DependencySignalSummary(

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -347,7 +347,7 @@ internal static class AuditSignalBuilder
         private static SignalValue? ResolveIdentityIdentifierConfusion(
             in LibrarySignalContext context) =>
             IdentifierConfusionAudit.Summarize(
-                    IdentifierConfusionAudit.InspectLibrary(context.Inspection),
+                    IdentifierConfusionAudit.InspectLibrarySummary(context.Inspection),
                     "assembly names")
                 .ToSignalValue();
 

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -223,6 +223,7 @@ internal static class AuditSignalBuilder
         [
             LibrarySignalRows.ProvenanceSourceLink,
             LibrarySignalRows.ProvenanceDeterministic,
+            LibrarySignalRows.IdentityIdentifierConfusion,
             LibrarySignalRows.DependenciesDirectAssemblyReferences,
             LibrarySignalRows.CompatibilityAsyncKind,
             LibrarySignalRows.DependenciesTransitiveAssemblyReferences,
@@ -249,6 +250,7 @@ internal static class AuditSignalBuilder
         [
             PackageSignalRows.CompatibilitySupportedTfm,
             PackageSignalRows.CompatibilityPortable,
+            PackageSignalRows.IdentityIdentifierConfusion,
             PackageSignalRows.DocumentationReadme,
             PackageSignalRows.DocumentationAgentDocumentation,
             PackageSignalRows.LegalLicense,
@@ -287,6 +289,9 @@ internal static class AuditSignalBuilder
 
         public static SignalRow<LibrarySignalContext> ProvenanceDeterministic =>
             new("Provenance", "Deterministic", ResolveProvenanceDeterministic);
+
+        public static SignalRow<LibrarySignalContext> IdentityIdentifierConfusion =>
+            new("Identity", "Identifier confusion", ResolveIdentityIdentifierConfusion);
 
         public static SignalRow<LibrarySignalContext> DependenciesDirectAssemblyReferences =>
             new("Dependencies", "Direct assembly references", ResolveDependenciesDirectAssemblyReferences);
@@ -338,6 +343,13 @@ internal static class AuditSignalBuilder
 
         private static SignalValue? ResolveProvenanceDeterministic(in LibrarySignalContext context) =>
             new(FormatBool(context.Inspection.IsDeterministic), "PE debug directory and path normalization");
+
+        private static SignalValue? ResolveIdentityIdentifierConfusion(
+            in LibrarySignalContext context) =>
+            IdentifierConfusionAudit.Summarize(
+                    IdentifierConfusionAudit.InspectLibrary(context.Inspection),
+                    "assembly names")
+                .ToSignalValue();
 
         private static SignalValue? ResolveDependenciesDirectAssemblyReferences(
             in LibrarySignalContext context) =>
@@ -423,6 +435,9 @@ internal static class AuditSignalBuilder
         public static SignalRow<PackageSignalContext> CompatibilityPortable =>
             new("Compatibility", "Portable", ResolveCompatibilityPortable);
 
+        public static SignalRow<PackageSignalContext> IdentityIdentifierConfusion =>
+            new("Identity", "Identifier confusion", ResolveIdentityIdentifierConfusion);
+
         public static SignalRow<PackageSignalContext> DocumentationReadme =>
             new("Documentation", "README", ResolveDocumentationReadme);
 
@@ -461,6 +476,13 @@ internal static class AuditSignalBuilder
 
         private static SignalValue? ResolveCompatibilityPortable(in PackageSignalContext context) =>
             FormatPortability(context.Result).ToSignalValue();
+
+        private static SignalValue? ResolveIdentityIdentifierConfusion(
+            in PackageSignalContext context) =>
+            IdentifierConfusionAudit.Summarize(
+                    IdentifierConfusionAudit.InspectPackage(context.Result),
+                    "package IDs")
+                .ToSignalValue();
 
         private static SignalValue? ResolveDocumentationReadme(in PackageSignalContext context) =>
             new(FormatBool(context.Result.HasReadme), context.Result.PackageReadmeFile ?? "package files");

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -4,6 +4,7 @@ using DotnetInspector.Models;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
+using InertText;
 using NuGetFetch;
 
 namespace DotnetInspector.Inspectors;
@@ -133,6 +134,40 @@ internal static class AuditSignalBuilder
         AddPackageSignals(signals, in context);
 
         result.AuditSignals = signals;
+        AddPackageTextContainmentSignal(result, signals);
+    }
+
+    private static void AddPackageTextContainmentSignal(
+        InspectionResult result,
+        List<AuditSignal> signals)
+    {
+        TextConcern concerns = new PackageInspectionText(result).Concerns;
+        Add(
+            signals,
+            "Text",
+            "Artifact text containment",
+            concerns == TextConcern.None ? "None" : "Required",
+            DescribeTextConcerns(concerns));
+    }
+
+    private static string DescribeTextConcerns(TextConcern concerns)
+    {
+        if (concerns == TextConcern.None)
+            return "no concerning scalars found";
+
+        List<string> kinds = [];
+        AddKind(TextConcern.Control, "control (Cc)");
+        AddKind(TextConcern.Format, "format/bidi (Cf)");
+        AddKind(TextConcern.Surrogate, "unpaired surrogate (Cs)");
+        AddKind(TextConcern.LineSeparator, "line separator (Zl)");
+        AddKind(TextConcern.ParagraphSeparator, "paragraph separator (Zp)");
+        return string.Join(", ", kinds);
+
+        void AddKind(TextConcern kind, string description)
+        {
+            if ((concerns & kind) != TextConcern.None)
+                kinds.Add(description);
+        }
     }
 
     private readonly record struct DependencySignalSummary(

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -487,11 +487,20 @@ internal static class AuditSignalBuilder
             FormatPortability(context.Result).ToSignalValue();
 
         private static SignalValue? ResolveIdentityIdentifierConfusion(
-            in PackageSignalContext context) =>
-            IdentifierConfusionAudit.Summarize(
+            in PackageSignalContext context)
+        {
+            if (context.Result.IdentifierConfusionFailure is { } failure)
+            {
+                return new(
+                    "Unavailable",
+                    IdentifierConfusionAudit.DescribeFailure(failure));
+            }
+
+            return IdentifierConfusionAudit.Summarize(
                     IdentifierConfusionAudit.InspectPackage(context.Result),
                     "package IDs")
                 .ToSignalValue();
+        }
 
         private static SignalValue? ResolveDocumentationReadme(in PackageSignalContext context) =>
             new(FormatBool(context.Result.HasReadme), context.Result.PackageReadmeFile ?? "package files");

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -496,10 +496,15 @@ internal static class AuditSignalBuilder
                     IdentifierConfusionAudit.DescribeFailure(failure));
             }
 
-            return IdentifierConfusionAudit.Summarize(
-                    IdentifierConfusionAudit.InspectPackage(context.Result),
-                    "package IDs")
-                .ToSignalValue();
+            var summary = IdentifierConfusionAudit.Summarize(
+                IdentifierConfusionAudit.InspectPackage(context.Result),
+                "package IDs");
+            return context.Result.IdentifierConfusionRegistryScopeLimited
+                ? new(
+                    summary.Value,
+                    summary.Evidence
+                    + "; source advertises no deprecation metadata")
+                : summary.ToSignalValue();
         }
 
         private static SignalValue? ResolveDocumentationReadme(in PackageSignalContext context) =>

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -345,11 +345,20 @@ internal static class AuditSignalBuilder
             new(FormatBool(context.Inspection.IsDeterministic), "PE debug directory and path normalization");
 
         private static SignalValue? ResolveIdentityIdentifierConfusion(
-            in LibrarySignalContext context) =>
-            IdentifierConfusionAudit.Summarize(
+            in LibrarySignalContext context)
+        {
+            if (context.Inspection.IdentifierConfusionFailure is { } failure)
+            {
+                return new(
+                    "Unavailable",
+                    IdentifierConfusionAudit.DescribeFailure(failure));
+            }
+
+            return IdentifierConfusionAudit.Summarize(
                     IdentifierConfusionAudit.InspectLibrarySummary(context.Inspection),
                     "assembly names")
                 .ToSignalValue();
+        }
 
         private static SignalValue? ResolveDependenciesDirectAssemblyReferences(
             in LibrarySignalContext context) =>

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -715,25 +715,37 @@ internal static class LibraryMetadataService
         VerboseLogger logger,
         int depth = 0,
         bool deduplicate = false,
-        Dictionary<string, int>? globalSeen = null,
         int? maxDepth = null,
         bool failOnReadError = false)
     {
+        string fullAssemblyPath = Path.GetFullPath(assemblyPath);
         var bindingPolicies = new Dictionary<string, IAssemblyBindingPolicy>(
             OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal);
         IAssemblyBindingPolicy bindingPolicy =
             ReferenceTreeBindingPolicyFor(assemblyPath, bindingPolicies);
+        var visitedPaths = new HashSet<string>(
+            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal)
+        {
+            fullAssemblyPath
+        };
         return BuildTransitiveReferences(
             references,
             bindingPolicy,
             bindingPolicies,
+            Path.GetDirectoryName(fullAssemblyPath)
+                ?? throw new InvalidOperationException(
+                    "The assembly path has no containing directory."),
             visited,
+            visitedPaths,
             logger,
             depth,
             deduplicate,
-            globalSeen,
+            new Dictionary<AssemblyReferenceTraversalKey, int>(
+                AssemblyReferenceTraversalKeyComparer.Instance),
             maxDepth,
             failOnReadError);
     }
@@ -771,24 +783,20 @@ internal static class LibraryMetadataService
         IReadOnlyList<AssemblyReferenceIdentity> references,
         IAssemblyBindingPolicy bindingPolicy,
         Dictionary<string, IAssemblyBindingPolicy> bindingPolicies,
+        string bindingScope,
         HashSet<string> visited,
+        HashSet<string> visitedPaths,
         VerboseLogger logger,
         int depth,
         bool deduplicate,
-        Dictionary<string, int>? globalSeen,
+        Dictionary<AssemblyReferenceTraversalKey, int> globalSeen,
         int? maxDepth,
         bool failOnReadError)
     {
-        globalSeen ??= new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         List<AssemblyReferenceNode> nodes = [];
 
         foreach (var reference in references.OrderBy(r => r.Name))
         {
-            if (deduplicate && globalSeen.TryGetValue(reference.Name, out int seenDepth) && seenDepth <= depth)
-            {
-                continue;
-            }
-
             var node = new AssemblyReferenceNode
             {
                 Name = reference.Name,
@@ -796,23 +804,6 @@ internal static class LibraryMetadataService
                 PublicKeyToken = reference.PublicKeyToken,
                 Depth = depth
             };
-
-            if (visited.Contains(reference.Name))
-            {
-                if (!deduplicate)
-                {
-                    node.IsCyclic = true;
-                    nodes.Add(node);
-                }
-                continue;
-            }
-
-            if (deduplicate)
-            {
-                globalSeen[reference.Name] = depth;
-            }
-
-            visited.Add(reference.Name);
 
             AssemblyBindingSelection selection = bindingPolicy.Select(
                 new AssemblyBindingRequest(
@@ -860,6 +851,42 @@ internal static class LibraryMetadataService
                 : resolved is null
                     ? null
                     : "local";
+
+            string? resolvedPath = resolved?.Path is { } selectedPath
+                ? Path.GetFullPath(selectedPath)
+                : null;
+            bool isCyclic = resolved is not null
+                && (resolvedPath is not null
+                    ? visitedPaths.Contains(resolvedPath)
+                    : visited.Contains(resolved.Identity.Name));
+            if (isCyclic)
+            {
+                if (!deduplicate)
+                {
+                    node.IsCyclic = true;
+                    nodes.Add(node);
+                }
+                continue;
+            }
+
+            AssemblyReferenceTraversalKey traversalKey =
+                resolvedPath is not null
+                    ? AssemblyReferenceTraversalKey.ForResolvedPath(
+                        resolvedPath)
+                    : AssemblyReferenceTraversalKey.ForReference(
+                        reference,
+                        bindingScope);
+            if (deduplicate
+                && globalSeen.TryGetValue(
+                    traversalKey,
+                    out int seenDepth)
+                && seenDepth <= depth)
+            {
+                continue;
+            }
+            if (deduplicate)
+                globalSeen[traversalKey] = depth;
+
             nodes.Add(node);
 
             if (resolved != null)
@@ -872,18 +899,33 @@ internal static class LibraryMetadataService
                     if (childRefs.Count > 0
                         && (maxDepth is null || depth + 1 < maxDepth.Value))
                     {
-                        var branchVisited = deduplicate ? visited : new HashSet<string>(visited, StringComparer.OrdinalIgnoreCase);
+                        var branchVisited = new HashSet<string>(
+                            visited,
+                            StringComparer.OrdinalIgnoreCase)
+                        {
+                            resolved.Identity.Name
+                        };
+                        var branchVisitedPaths = new HashSet<string>(
+                            visitedPaths,
+                            visitedPaths.Comparer);
+                        if (resolvedPath is not null)
+                            branchVisitedPaths.Add(resolvedPath);
                         IAssemblyBindingPolicy childBindingPolicy =
-                            resolved.Path is { } resolvedPath
+                            resolved.Path is { } childPath
                                 ? ReferenceTreeBindingPolicyFor(
-                                    resolvedPath,
+                                    childPath,
                                     bindingPolicies)
                                 : bindingPolicy;
                         var childNodes = BuildTransitiveReferences(
                             childRefs,
                             childBindingPolicy,
                             bindingPolicies,
+                            resolvedPath is not null
+                                ? Path.GetDirectoryName(resolvedPath)
+                                    ?? bindingScope
+                                : bindingScope,
                             branchVisited,
+                            branchVisitedPaths,
                             logger,
                             depth + 1,
                             deduplicate,
@@ -923,6 +965,92 @@ internal static class LibraryMetadataService
         }
 
         return nodes;
+    }
+
+    private readonly record struct AssemblyReferenceTraversalKey(
+        string? ResolvedPath,
+        AssemblyReferenceIdentity? Reference,
+        string? BindingScope)
+    {
+        public static AssemblyReferenceTraversalKey ForResolvedPath(
+            string resolvedPath) =>
+            new(resolvedPath, null, null);
+
+        public static AssemblyReferenceTraversalKey ForReference(
+            AssemblyReferenceIdentity reference,
+            string bindingScope) =>
+            new(null, reference, bindingScope);
+    }
+
+    private sealed class AssemblyReferenceTraversalKeyComparer
+        : IEqualityComparer<AssemblyReferenceTraversalKey>
+    {
+        private static readonly StringComparer PathComparer =
+            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+
+        public static AssemblyReferenceTraversalKeyComparer Instance
+        {
+            get;
+        } = new();
+
+        public bool Equals(
+            AssemblyReferenceTraversalKey x,
+            AssemblyReferenceTraversalKey y)
+        {
+            if (x.ResolvedPath is not null
+                || y.ResolvedPath is not null)
+            {
+                return x.ResolvedPath is not null
+                    && y.ResolvedPath is not null
+                    && PathComparer.Equals(
+                        x.ResolvedPath,
+                        y.ResolvedPath);
+            }
+
+            return x.Reference is { } xReference
+                && y.Reference is { } yReference
+                && PathComparer.Equals(
+                    x.BindingScope,
+                    y.BindingScope)
+                && StringComparer.OrdinalIgnoreCase.Equals(
+                    xReference.Name,
+                    yReference.Name)
+                && EqualityComparer<Version?>.Default.Equals(
+                    xReference.Version,
+                    yReference.Version)
+                && StringComparer.OrdinalIgnoreCase.Equals(
+                    xReference.Culture,
+                    yReference.Culture)
+                && StringComparer.OrdinalIgnoreCase.Equals(
+                    xReference.PublicKeyToken,
+                    yReference.PublicKeyToken);
+        }
+
+        public int GetHashCode(AssemblyReferenceTraversalKey value)
+        {
+            var hash = new HashCode();
+            if (value.ResolvedPath is not null)
+            {
+                hash.Add(value.ResolvedPath, PathComparer);
+            }
+            else if (value.Reference is { } reference)
+            {
+                hash.Add(value.BindingScope, PathComparer);
+                hash.Add(
+                    reference.Name,
+                    StringComparer.OrdinalIgnoreCase);
+                hash.Add(reference.Version);
+                hash.Add(
+                    reference.Culture,
+                    StringComparer.OrdinalIgnoreCase);
+                hash.Add(
+                    reference.PublicKeyToken,
+                    StringComparer.OrdinalIgnoreCase);
+            }
+            return hash.ToHashCode();
+        }
     }
 
     private static IdentifierConfusionAuditFailureKind

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -729,6 +729,23 @@ internal static class LibraryMetadataService
         {
             fullAssemblyPath
         };
+        if (deduplicate)
+        {
+            return BuildDeduplicatedTransitiveReferences(
+                references,
+                bindingPolicy,
+                bindingPolicies,
+                Path.GetDirectoryName(fullAssemblyPath)
+                    ?? throw new InvalidOperationException(
+                        "The assembly path has no containing directory."),
+                visited,
+                visitedPaths,
+                logger,
+                depth,
+                maxDepth,
+                failOnReadError);
+        }
+
         return BuildTransitiveReferences(
             references,
             bindingPolicy,
@@ -740,9 +757,6 @@ internal static class LibraryMetadataService
             visitedPaths,
             logger,
             depth,
-            deduplicate,
-            new Dictionary<AssemblyReferenceTraversalKey, int>(
-                AssemblyReferenceTraversalKeyComparer.Instance),
             maxDepth,
             failOnReadError);
     }
@@ -776,6 +790,224 @@ internal static class LibraryMetadataService
         return created;
     }
 
+    private sealed record DeduplicatedReferenceNode(
+        AssemblyReferenceNode Value)
+    {
+        public List<DeduplicatedReferenceNode> Children { get; } = [];
+    }
+
+    private readonly record struct PendingAssemblyReference(
+        AssemblyReferenceIdentity Reference,
+        IAssemblyBindingPolicy BindingPolicy,
+        string BindingScope,
+        int Depth,
+        DeduplicatedReferenceNode? Parent);
+
+    private static List<AssemblyReferenceNode>
+        BuildDeduplicatedTransitiveReferences(
+            IReadOnlyList<AssemblyReferenceIdentity> references,
+            IAssemblyBindingPolicy bindingPolicy,
+            Dictionary<string, IAssemblyBindingPolicy> bindingPolicies,
+            string bindingScope,
+            HashSet<string> visited,
+            HashSet<string> visitedPaths,
+            VerboseLogger logger,
+            int depth,
+            int? maxDepth,
+            bool failOnReadError)
+    {
+        List<DeduplicatedReferenceNode> roots = [];
+        var seen = new HashSet<AssemblyReferenceTraversalKey>(
+            AssemblyReferenceTraversalKeyComparer.Instance);
+        var pending = new Queue<PendingAssemblyReference>(
+            references
+                .OrderBy(reference => reference.Name)
+                .Select(
+                    reference =>
+                        new PendingAssemblyReference(
+                            reference,
+                            bindingPolicy,
+                            bindingScope,
+                            depth,
+                            Parent: null)));
+
+        while (pending.Count > 0)
+        {
+            PendingAssemblyReference next = pending.Dequeue();
+            AssemblyReferenceIdentity reference = next.Reference;
+            var node = new AssemblyReferenceNode
+            {
+                Name = reference.Name,
+                Version = reference.Version?.ToString() ?? "",
+                PublicKeyToken = reference.PublicKeyToken,
+                Depth = next.Depth,
+            };
+
+            AssemblyBindingSelection selection =
+                next.BindingPolicy.Select(
+                    new AssemblyBindingRequest(
+                        AssemblyBindingTarget.Reference(reference),
+                        AssemblyBindingOrigin.Global(),
+                        AssemblyResolutionScope.Any));
+            ResolvedAssemblyReference? resolved =
+                (selection as AssemblyBindingSelection.Selected)
+                    ?.Assembly;
+            if (selection is AssemblyBindingSelection.Unavailable
+                unavailable)
+            {
+                node.ResolutionFailure =
+                    AssemblyReferenceResolutionFailure.Unavailable;
+                IdentifierConfusionAuditFailureKind failure =
+                    ClassifyIdentifierConfusionBindingFailure(
+                        unavailable.Failure);
+                if (failOnReadError)
+                {
+                    throw new IdentifierConfusionReferenceTraversalException(
+                        failure);
+                }
+                logger.LogWarning(
+                    "Could not inspect a resolved assembly reference: "
+                    + IdentifierConfusionAudit.DescribeFailure(failure));
+            }
+            else if (selection is AssemblyBindingSelection.Rejected
+                rejected)
+            {
+                node.ResolutionFailure =
+                    AssemblyReferenceResolutionFailure.Rejected;
+                IdentifierConfusionAuditFailureKind failure =
+                    ClassifyIdentifierConfusionBindingFailure(
+                        rejected.Failure);
+                if (failOnReadError)
+                {
+                    throw new IdentifierConfusionReferenceTraversalException(
+                        failure);
+                }
+                logger.LogWarning(
+                    "Could not inspect a resolved assembly reference: "
+                    + IdentifierConfusionAudit.DescribeFailure(failure));
+            }
+
+            node.Path = resolved?.Path;
+            node.ResolvedFrom =
+                resolved?.Provenance
+                    is AssemblyResolutionProvenance.PlatformAsset
+                    ? "platform"
+                    : resolved is null
+                        ? null
+                        : "local";
+
+            string? resolvedPath =
+                resolved?.Path is { } selectedPath
+                    ? Path.GetFullPath(selectedPath)
+                    : null;
+            bool isRootCycle = resolved is not null
+                && (resolvedPath is not null
+                    ? visitedPaths.Contains(resolvedPath)
+                    : visited.Contains(resolved.Identity.Name));
+            if (isRootCycle)
+                continue;
+
+            AssemblyReferenceTraversalKey traversalKey =
+                resolvedPath is not null
+                    ? AssemblyReferenceTraversalKey.ForResolvedPath(
+                        resolvedPath)
+                    : AssemblyReferenceTraversalKey.ForReference(
+                        reference,
+                        next.BindingScope);
+            if (!seen.Add(traversalKey))
+                continue;
+
+            var treeNode = new DeduplicatedReferenceNode(node);
+            if (next.Parent is null)
+                roots.Add(treeNode);
+            else
+                next.Parent.Children.Add(treeNode);
+
+            if (resolved is null)
+                continue;
+
+            try
+            {
+                var (childReferences, company) =
+                    AssemblyInspector
+                        .ExtractReferenceIdentitiesAndCompany(
+                            resolved);
+                node.Company = company;
+                if (childReferences.Count == 0
+                    || (maxDepth is not null
+                        && next.Depth + 1 >= maxDepth.Value))
+                {
+                    continue;
+                }
+
+                IAssemblyBindingPolicy childBindingPolicy =
+                    resolved.Path is { } childPath
+                        ? ReferenceTreeBindingPolicyFor(
+                            childPath,
+                            bindingPolicies)
+                        : next.BindingPolicy;
+                string childBindingScope =
+                    resolvedPath is not null
+                        ? Path.GetDirectoryName(resolvedPath)
+                            ?? next.BindingScope
+                        : next.BindingScope;
+                foreach (AssemblyReferenceIdentity childReference in
+                    childReferences.OrderBy(
+                        childReference =>
+                            childReference.Name))
+                {
+                    pending.Enqueue(
+                        new PendingAssemblyReference(
+                            childReference,
+                            childBindingPolicy,
+                            childBindingScope,
+                            next.Depth + 1,
+                            treeNode));
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (IdentifierConfusionReferenceTraversalException)
+            {
+                throw;
+            }
+            catch (Exception ex) when (
+                failOnReadError
+                || ex is IOException
+                    or UnauthorizedAccessException
+                    or BadImageFormatException)
+            {
+                if (failOnReadError)
+                {
+                    throw new IdentifierConfusionReferenceTraversalException(
+                        ClassifyIdentifierConfusionReferenceFailure(ex),
+                        ex);
+                }
+
+                logger.LogWarning(
+                    "Could not inspect a resolved assembly reference: "
+                    + IdentifierConfusionAudit.DescribeFailure(
+                        ClassifyIdentifierConfusionReferenceFailure(ex)));
+            }
+        }
+
+        List<AssemblyReferenceNode> flattened = [];
+        foreach (DeduplicatedReferenceNode root in roots)
+            FlattenDeduplicatedReferenceTree(root, flattened);
+        return flattened;
+    }
+
+    private static void FlattenDeduplicatedReferenceTree(
+        DeduplicatedReferenceNode node,
+        List<AssemblyReferenceNode> flattened)
+    {
+        flattened.Add(node.Value);
+        foreach (DeduplicatedReferenceNode child in node.Children)
+            FlattenDeduplicatedReferenceTree(child, flattened);
+    }
+
     private static List<AssemblyReferenceNode> BuildTransitiveReferences(
         IReadOnlyList<AssemblyReferenceIdentity> references,
         IAssemblyBindingPolicy bindingPolicy,
@@ -785,8 +1017,6 @@ internal static class LibraryMetadataService
         HashSet<string> visitedPaths,
         VerboseLogger logger,
         int depth,
-        bool deduplicate,
-        Dictionary<AssemblyReferenceTraversalKey, int> globalSeen,
         int? maxDepth,
         bool failOnReadError)
     {
@@ -858,31 +1088,10 @@ internal static class LibraryMetadataService
                     : visited.Contains(resolved.Identity.Name));
             if (isCyclic)
             {
-                if (!deduplicate)
-                {
-                    node.IsCyclic = true;
-                    nodes.Add(node);
-                }
+                node.IsCyclic = true;
+                nodes.Add(node);
                 continue;
             }
-
-            AssemblyReferenceTraversalKey traversalKey =
-                resolvedPath is not null
-                    ? AssemblyReferenceTraversalKey.ForResolvedPath(
-                        resolvedPath)
-                    : AssemblyReferenceTraversalKey.ForReference(
-                        reference,
-                        bindingScope);
-            if (deduplicate
-                && globalSeen.TryGetValue(
-                    traversalKey,
-                    out int seenDepth)
-                && seenDepth <= depth)
-            {
-                continue;
-            }
-            if (deduplicate)
-                globalSeen[traversalKey] = depth;
 
             nodes.Add(node);
 
@@ -925,8 +1134,6 @@ internal static class LibraryMetadataService
                             branchVisitedPaths,
                             logger,
                             depth + 1,
-                            deduplicate,
-                            globalSeen,
                             maxDepth,
                             failOnReadError);
                         nodes.AddRange(childNodes);

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -1221,7 +1221,7 @@ internal static class LibraryMetadataService
                 && PathComparer.Equals(
                     x.BindingScope,
                     y.BindingScope)
-                && StringComparer.OrdinalIgnoreCase.Equals(
+                && StringComparer.Ordinal.Equals(
                     xReference.Name,
                     yReference.Name)
                 && EqualityComparer<Version?>.Default.Equals(
@@ -1247,7 +1247,7 @@ internal static class LibraryMetadataService
                 hash.Add(value.BindingScope, PathComparer);
                 hash.Add(
                     reference.Name,
-                    StringComparer.OrdinalIgnoreCase);
+                    StringComparer.Ordinal);
                 hash.Add(reference.Version);
                 hash.Add(
                     reference.Culture,

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -719,16 +719,13 @@ internal static class LibraryMetadataService
         bool failOnReadError = false)
     {
         string fullAssemblyPath = Path.GetFullPath(assemblyPath);
+        StringComparer pathComparer = ReferenceTreePathComparer(
+            OperatingSystem.IsWindows());
         var bindingPolicies = new Dictionary<string, IAssemblyBindingPolicy>(
-            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
-                ? StringComparer.OrdinalIgnoreCase
-                : StringComparer.Ordinal);
+            pathComparer);
         IAssemblyBindingPolicy bindingPolicy =
             ReferenceTreeBindingPolicyFor(assemblyPath, bindingPolicies);
-        var visitedPaths = new HashSet<string>(
-            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
-                ? StringComparer.OrdinalIgnoreCase
-                : StringComparer.Ordinal)
+        var visitedPaths = new HashSet<string>(pathComparer)
         {
             fullAssemblyPath
         };
@@ -967,6 +964,11 @@ internal static class LibraryMetadataService
         return nodes;
     }
 
+    internal static StringComparer ReferenceTreePathComparer(bool isWindows) =>
+        isWindows
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+
     private readonly record struct AssemblyReferenceTraversalKey(
         string? ResolvedPath,
         AssemblyReferenceIdentity? Reference,
@@ -986,9 +988,7 @@ internal static class LibraryMetadataService
         : IEqualityComparer<AssemblyReferenceTraversalKey>
     {
         private static readonly StringComparer PathComparer =
-            OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
-                ? StringComparer.OrdinalIgnoreCase
-                : StringComparer.Ordinal;
+            ReferenceTreePathComparer(OperatingSystem.IsWindows());
 
         public static AssemblyReferenceTraversalKeyComparer Instance
         {

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -332,6 +332,22 @@ internal static class LibraryMetadataService
                 }
             }
 
+            if ((needsAuditSignals
+                    || options.CollectIdentifierConfusionReferenceTree)
+                && inspection.AssemblyReferenceInspection
+                    is FindingInspection<AssemblyReference>.Failed)
+            {
+                IdentifierConfusionAuditFailureKind failure =
+                    inspection.AssemblyReferenceFailureKind
+                    ?? IdentifierConfusionAuditFailureKind.InspectionFailed;
+                inspection.IdentifierConfusionFailure = failure;
+                if (options.CollectIdentifierConfusionReferenceTree)
+                {
+                    throw new IdentifierConfusionReferenceTraversalException(
+                        failure);
+                }
+            }
+
             // The query produces the flat direct-reference currency. Tree traversal remains a
             // path-owning CLI projection over that result.
             if (collectReferenceTree
@@ -876,13 +892,14 @@ internal static class LibraryMetadataService
                     if (failOnReadError)
                     {
                         throw new IdentifierConfusionReferenceTraversalException(
-                            reference.Name,
-                            resolved.Path ?? string.Empty,
+                            ClassifyIdentifierConfusionReferenceFailure(ex),
                             ex);
                     }
 
                     logger.LogWarning(
-                        "A resolved assembly reference could not be read; its children were omitted.");
+                        "Could not inspect a resolved assembly reference: "
+                        + IdentifierConfusionAudit.DescribeFailure(
+                            ClassifyIdentifierConfusionReferenceFailure(ex)));
                 }
             }
         }
@@ -890,25 +907,38 @@ internal static class LibraryMetadataService
         return nodes;
     }
 
+    private static IdentifierConfusionAuditFailureKind
+        ClassifyIdentifierConfusionReferenceFailure(Exception exception) =>
+        exception switch
+        {
+            BadImageFormatException
+                or ArgumentOutOfRangeException
+                or OverflowException =>
+                IdentifierConfusionAuditFailureKind.InvalidAssemblyMetadata,
+            IOException
+                or UnauthorizedAccessException
+                or NotSupportedException
+                or ObjectDisposedException =>
+                IdentifierConfusionAuditFailureKind.AssemblyUnreadable,
+            _ => IdentifierConfusionAuditFailureKind.InspectionFailed,
+        };
+
     internal sealed class IdentifierConfusionReferenceTraversalException
         : InvalidOperationException
     {
         public IdentifierConfusionReferenceTraversalException(
-            string referenceName,
-            string resolvedPath,
-            Exception innerException)
+            IdentifierConfusionAuditFailureKind failureKind,
+            Exception? innerException = null)
             : base(
-                $"Failed to inspect resolved assembly reference "
-                + $"'{referenceName}' at '{resolvedPath}': {innerException.Message}",
+                "Identifier audit could not inspect assembly references: "
+                + IdentifierConfusionAudit.DescribeFailure(failureKind)
+                + ".",
                 innerException)
         {
-            ReferenceName = referenceName;
-            FailureKind = innerException.GetType().Name;
+            FailureKind = failureKind;
         }
 
-        public string ReferenceName { get; }
-
-        public string FailureKind { get; }
+        public IdentifierConfusionAuditFailureKind FailureKind { get; }
     }
 
     /// <summary>
@@ -1878,6 +1908,7 @@ internal static class LibraryMetadataService
         {
             case AssemblyReferencesResult.Available available:
                 inspection.AssemblyReferenceIdentities = available.Identities;
+                inspection.AssemblyReferenceFailureKind = null;
                 if (inspection.AssemblyInfo is not null)
                 {
                     inspection.AssemblyInfo.References = available.References.IsEmpty
@@ -1893,6 +1924,9 @@ internal static class LibraryMetadataService
             case AssemblyReferencesResult.Failed failed:
                 logger.LogWarning(
                     $"Error reading assembly references of {path}: {failed.Error.Message}");
+                inspection.AssemblyReferenceFailureKind =
+                    ClassifyIdentifierConfusionReferenceFailure(
+                        failed.Error);
                 inspection.AssemblyReferenceInspection =
                     FailedInspection<AssemblyReference>(
                         path,

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -821,19 +821,37 @@ internal static class LibraryMetadataService
                     AssemblyResolutionScope.Any));
             ResolvedAssemblyReference? resolved =
                 (selection as AssemblyBindingSelection.Selected)?.Assembly;
-            if (selection is AssemblyBindingSelection.Unavailable)
+            if (selection is AssemblyBindingSelection.Unavailable unavailable)
             {
                 node.ResolutionFailure =
                     AssemblyReferenceResolutionFailure.Unavailable;
+                IdentifierConfusionAuditFailureKind failure =
+                    ClassifyIdentifierConfusionBindingFailure(
+                        unavailable.Failure);
+                if (failOnReadError)
+                {
+                    throw new IdentifierConfusionReferenceTraversalException(
+                        failure);
+                }
                 logger.LogWarning(
-                    "An assembly reference could not be resolved because a candidate was unavailable.");
+                    "Could not inspect a resolved assembly reference: "
+                    + IdentifierConfusionAudit.DescribeFailure(failure));
             }
-            else if (selection is AssemblyBindingSelection.Rejected)
+            else if (selection is AssemblyBindingSelection.Rejected rejected)
             {
                 node.ResolutionFailure =
                     AssemblyReferenceResolutionFailure.Rejected;
+                IdentifierConfusionAuditFailureKind failure =
+                    ClassifyIdentifierConfusionBindingFailure(
+                        rejected.Failure);
+                if (failOnReadError)
+                {
+                    throw new IdentifierConfusionReferenceTraversalException(
+                        failure);
+                }
                 logger.LogWarning(
-                    "An assembly reference could not be resolved because binding was rejected.");
+                    "Could not inspect a resolved assembly reference: "
+                    + IdentifierConfusionAudit.DescribeFailure(failure));
             }
 
             node.Path = resolved?.Path;
@@ -906,6 +924,20 @@ internal static class LibraryMetadataService
 
         return nodes;
     }
+
+    private static IdentifierConfusionAuditFailureKind
+        ClassifyIdentifierConfusionBindingFailure(
+            AssemblyBindingFailure failure) =>
+        failure.CandidateFailureKind switch
+        {
+            CandidateOpenFailureKind.InvalidImage =>
+                IdentifierConfusionAuditFailureKind.InvalidAssemblyMetadata,
+            CandidateOpenFailureKind.Unreadable =>
+                IdentifierConfusionAuditFailureKind.AssemblyUnreadable,
+            CandidateOpenFailureKind.ResourceBudget =>
+                IdentifierConfusionAuditFailureKind.InspectionFailed,
+            _ => IdentifierConfusionAuditFailureKind.InspectionFailed,
+        };
 
     private static IdentifierConfusionAuditFailureKind
         ClassifyIdentifierConfusionReferenceFailure(Exception exception) =>

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -351,6 +351,24 @@ internal static class LibraryMetadataService
                     maxDepth: options.ReferenceTreeDepth);
             }
 
+            if (options.CollectIdentifierConfusionReferenceTree
+                && inspection.AssemblyInfo?.References is { } auditReferences)
+            {
+                var sourceDir = Path.GetDirectoryName(path);
+                var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                visited.Add(
+                    inspection.AssemblyInfo.AssemblyName
+                    ?? Path.GetFileNameWithoutExtension(path));
+
+                inspection.IdentifierConfusionTransitiveReferences =
+                    BuildTransitiveReferences(
+                        auditReferences,
+                        sourceDir,
+                        visited,
+                        logger,
+                        deduplicate: true);
+            }
+
             inspection.FileSize = pdbContext.FileSize;
             inspection.LastModified = pdbContext.LastWriteTimeUtc;
 

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -360,13 +360,14 @@ internal static class LibraryMetadataService
                     inspection.AssemblyInfo.AssemblyName
                     ?? Path.GetFileNameWithoutExtension(path));
 
-                inspection.IdentifierConfusionTransitiveReferences =
+                inspection.IdentifierConfusionReferenceClosure =
                     BuildTransitiveReferences(
                         auditReferences,
                         sourceDir,
                         visited,
                         logger,
-                        deduplicate: true);
+                        deduplicate: true,
+                        failOnReadError: true);
             }
 
             inspection.FileSize = pdbContext.FileSize;
@@ -437,6 +438,10 @@ internal static class LibraryMetadataService
             throw;
         }
         catch (CostDeclarationException)
+        {
+            throw;
+        }
+        catch (IdentifierConfusionReferenceTraversalException)
         {
             throw;
         }
@@ -696,7 +701,8 @@ internal static class LibraryMetadataService
         int depth = 0,
         bool deduplicate = false,
         Dictionary<string, int>? globalSeen = null,
-        int? maxDepth = null)
+        int? maxDepth = null,
+        bool failOnReadError = false)
     {
         var bindingPolicies = new Dictionary<string, IAssemblyBindingPolicy>(
             OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
@@ -713,7 +719,8 @@ internal static class LibraryMetadataService
             depth,
             deduplicate,
             globalSeen,
-            maxDepth);
+            maxDepth,
+            failOnReadError);
     }
 
     private static IAssemblyBindingPolicy ReferenceTreeBindingPolicyFor(
@@ -754,7 +761,8 @@ internal static class LibraryMetadataService
         int depth,
         bool deduplicate,
         Dictionary<string, int>? globalSeen,
-        int? maxDepth)
+        int? maxDepth,
+        bool failOnReadError)
     {
         globalSeen ??= new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         List<AssemblyReferenceNode> nodes = [];
@@ -847,15 +855,33 @@ internal static class LibraryMetadataService
                             depth + 1,
                             deduplicate,
                             globalSeen,
-                            maxDepth);
+                            maxDepth,
+                            failOnReadError);
                         nodes.AddRange(childNodes);
                     }
                 }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (IdentifierConfusionReferenceTraversalException)
+                {
+                    throw;
+                }
                 catch (Exception ex) when (
-                    ex is IOException
+                    failOnReadError
+                    || ex is IOException
                         or UnauthorizedAccessException
                         or BadImageFormatException)
                 {
+                    if (failOnReadError)
+                    {
+                        throw new IdentifierConfusionReferenceTraversalException(
+                            $"Failed to inspect resolved assembly reference "
+                            + $"'{reference.Name}' at '{resolved.Path}': {ex.Message}",
+                            ex);
+                    }
+
                     logger.LogWarning(
                         "A resolved assembly reference could not be read; its children were omitted.");
                 }
@@ -863,6 +889,17 @@ internal static class LibraryMetadataService
         }
 
         return nodes;
+    }
+
+    private sealed class IdentifierConfusionReferenceTraversalException
+        : InvalidOperationException
+    {
+        public IdentifierConfusionReferenceTraversalException(
+            string message,
+            Exception innerException)
+            : base(message, innerException)
+        {
+        }
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -352,9 +352,8 @@ internal static class LibraryMetadataService
             }
 
             if (options.CollectIdentifierConfusionReferenceTree
-                && inspection.AssemblyInfo?.References is { } auditReferences)
+                && inspection.AssemblyReferenceIdentities is { Count: > 0 } auditReferences)
             {
-                var sourceDir = Path.GetDirectoryName(path);
                 var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 visited.Add(
                     inspection.AssemblyInfo.AssemblyName
@@ -363,7 +362,7 @@ internal static class LibraryMetadataService
                 inspection.IdentifierConfusionReferenceClosure =
                     BuildTransitiveReferences(
                         auditReferences,
-                        sourceDir,
+                        path,
                         visited,
                         logger,
                         deduplicate: true,
@@ -877,8 +876,8 @@ internal static class LibraryMetadataService
                     if (failOnReadError)
                     {
                         throw new IdentifierConfusionReferenceTraversalException(
-                            $"Failed to inspect resolved assembly reference "
-                            + $"'{reference.Name}' at '{resolved.Path}': {ex.Message}",
+                            reference.Name,
+                            resolved.Path ?? string.Empty,
                             ex);
                     }
 
@@ -891,15 +890,25 @@ internal static class LibraryMetadataService
         return nodes;
     }
 
-    private sealed class IdentifierConfusionReferenceTraversalException
+    internal sealed class IdentifierConfusionReferenceTraversalException
         : InvalidOperationException
     {
         public IdentifierConfusionReferenceTraversalException(
-            string message,
+            string referenceName,
+            string resolvedPath,
             Exception innerException)
-            : base(message, innerException)
+            : base(
+                $"Failed to inspect resolved assembly reference "
+                + $"'{referenceName}' at '{resolvedPath}': {innerException.Message}",
+                innerException)
         {
+            ReferenceName = referenceName;
+            FailureKind = innerException.GetType().Name;
         }
+
+        public string ReferenceName { get; }
+
+        public string FailureKind { get; }
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -341,11 +341,6 @@ internal static class LibraryMetadataService
                     inspection.AssemblyReferenceFailureKind
                     ?? IdentifierConfusionAuditFailureKind.InspectionFailed;
                 inspection.IdentifierConfusionFailure = failure;
-                if (options.CollectIdentifierConfusionReferenceTree)
-                {
-                    throw new IdentifierConfusionReferenceTraversalException(
-                        failure);
-                }
             }
 
             // The query produces the flat direct-reference currency. Tree traversal remains a
@@ -375,14 +370,23 @@ internal static class LibraryMetadataService
                     inspection.AssemblyInfo.AssemblyName
                     ?? Path.GetFileNameWithoutExtension(path));
 
-                inspection.IdentifierConfusionReferenceClosure =
-                    BuildTransitiveReferences(
-                        auditReferences,
-                        path,
-                        visited,
-                        logger,
-                        deduplicate: true,
-                        failOnReadError: true);
+                try
+                {
+                    inspection.IdentifierConfusionReferenceClosure =
+                        BuildTransitiveReferences(
+                            auditReferences,
+                            path,
+                            visited,
+                            logger,
+                            deduplicate: true,
+                            failOnReadError: true);
+                }
+                catch (
+                    IdentifierConfusionReferenceTraversalException ex)
+                {
+                    inspection.IdentifierConfusionFailure =
+                        ex.FailureKind;
+                }
             }
 
             inspection.FileSize = pdbContext.FileSize;

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -27,6 +27,7 @@ internal static class PackageInspector
         bool forceLatest = false,
         Verbosity verbosity = Verbosity.Minimal,
         bool fetchMetadata = false,
+        bool requireIdentifierMetadata = false,
         NuGetSourceOptions? sourceOptions = null)
     {
         string extractPath = resolution.ExtractPath;
@@ -62,7 +63,10 @@ internal static class PackageInspector
                         logger.Log,
                         forceLatest,
                         metadataSourceOptions);
-                    ApplyMetadata(cached, metadata);
+                    ApplyMetadata(
+                        cached,
+                        metadata,
+                        requireIdentifierMetadata);
                 }
                 return cached;
             }
@@ -180,7 +184,10 @@ internal static class PackageInspector
                 logger.Log,
                 forceLatest,
                 metadataSourceOptions);
-            ApplyMetadata(result, metadata);
+            ApplyMetadata(
+                result,
+                metadata,
+                requireIdentifierMetadata);
         }
 
         return result;
@@ -318,7 +325,10 @@ internal static class PackageInspector
         return PackagePdbSource.Other;
     }
 
-    private static void ApplyMetadata(InspectionResult result, PackageMetadata metadata)
+    private static void ApplyMetadata(
+        InspectionResult result,
+        PackageMetadata metadata,
+        bool requireIdentifierMetadata)
     {
         result.Published = metadata.Published;
         result.TotalDownloads = metadata.TotalDownloads;
@@ -329,6 +339,12 @@ internal static class PackageInspector
         result.Owners = metadata.Owners;
         result.Deprecation = metadata.Deprecation;
         result.Vulnerabilities = metadata.Vulnerabilities;
+        result.IdentifierConfusionFailure =
+            requireIdentifierMetadata
+            && !metadata.DeprecationMetadataAvailable
+                ? IdentifierConfusionAuditFailureKind
+                    .PackageMetadataUnavailable
+                : null;
     }
 
     private static void PopulateLibraryFiles(string extractPath, InspectionResult result)

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -345,6 +345,10 @@ internal static class PackageInspector
                 ? IdentifierConfusionAuditFailureKind
                     .PackageMetadataUnavailable
                 : null;
+        result.IdentifierConfusionRegistryScopeLimited =
+            requireIdentifierMetadata
+            && metadata.DeprecationMetadataAvailable
+            && !metadata.DeprecationMetadataSupported;
     }
 
     private static void PopulateLibraryFiles(string extractPath, InspectionResult result)

--- a/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
+++ b/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
@@ -108,17 +108,23 @@ internal static class IdentifierConfusionAudit
             }
         }
 
+        HashSet<string>? directReferenceNames = includeTransitiveReferences
+            && assembly.References is { } directReferences
+                ? new HashSet<string>(
+                    directReferences.Select(reference => reference.Name),
+                    StringComparer.OrdinalIgnoreCase)
+                : null;
         if (includeTransitiveReferences
-            && model.IdentifierConfusionTransitiveReferences is { } transitiveReferences)
+            && model.IdentifierConfusionReferenceClosure is { } transitiveReferences)
         {
             for (int index = 0; index < transitiveReferences.Count; index++)
             {
-                if (transitiveReferences[index].Depth == 0)
+                if (directReferenceNames?.Contains(transitiveReferences[index].Name) == true)
                     continue;
 
                 Add(
                     cases,
-                    $"{nameof(model.AssemblyInfo)}.{nameof(assembly.TransitiveReferences)}[{index}]."
+                    $"{nameof(model.IdentifierConfusionReferenceClosure)}[{index}]."
                         + nameof(AssemblyReferenceNode.Name),
                     "Assembly name",
                     transitiveReferences[index].Name);

--- a/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
+++ b/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
@@ -1,0 +1,178 @@
+using System.Globalization;
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Models;
+
+internal readonly record struct IdentifierConfusionCase(
+    string Location,
+    string Kind,
+    IdentifierConfusion Confusion);
+
+internal static class IdentifierConfusionAudit
+{
+    public static IReadOnlyList<IdentifierConfusionCase> InspectPackage(InspectionResult model)
+    {
+        List<IdentifierConfusionCase> cases = [];
+        Add(cases, nameof(model.PackageName), "Package ID", model.PackageName);
+
+        if (model.Deprecation?.AlternatePackageId is { } alternatePackageId)
+        {
+            Add(
+                cases,
+                $"{nameof(model.Deprecation)}.{nameof(model.Deprecation.AlternatePackageId)}",
+                "Package ID",
+                alternatePackageId);
+        }
+
+        if (model.DependencyGroups is { } groups)
+        {
+            for (int groupIndex = 0; groupIndex < groups.Count; groupIndex++)
+            {
+                for (int dependencyIndex = 0;
+                    dependencyIndex < groups[groupIndex].Dependencies.Count;
+                    dependencyIndex++)
+                {
+                    PackageDependency dependency = groups[groupIndex].Dependencies[dependencyIndex];
+                    Add(
+                        cases,
+                        $"{nameof(model.DependencyGroups)}[{groupIndex}]."
+                            + $"{nameof(DependencyGroup.Dependencies)}[{dependencyIndex}]."
+                            + nameof(dependency.Id),
+                        "Package ID",
+                        dependency.Id);
+                }
+            }
+        }
+
+        if (model.RuntimeDependencies is { } runtimeDependencies)
+        {
+            for (int index = 0; index < runtimeDependencies.Count; index++)
+            {
+                Add(
+                    cases,
+                    $"{nameof(model.RuntimeDependencies)}[{index}].{nameof(PackageDependency.Id)}",
+                    "Package ID",
+                    runtimeDependencies[index].Id);
+            }
+        }
+
+        if (model.RuntimeIdentifierPackages is { } runtimePackages)
+        {
+            for (int index = 0; index < runtimePackages.Count; index++)
+            {
+                Add(
+                    cases,
+                    $"{nameof(model.RuntimeIdentifierPackages)}[{index}]."
+                        + nameof(RidPackageReference.PackageId),
+                    "Package ID",
+                    runtimePackages[index].PackageId);
+            }
+        }
+
+        return cases;
+    }
+
+    public static IReadOnlyList<IdentifierConfusionCase> InspectLibrary(LibraryInspection model)
+    {
+        List<IdentifierConfusionCase> cases = [];
+        if (model.AssemblyInfo is not { } assembly)
+            return cases;
+
+        Add(
+            cases,
+            $"{nameof(model.AssemblyInfo)}.{nameof(assembly.AssemblyName)}",
+            "Assembly name",
+            assembly.AssemblyName);
+
+        if (assembly.References is { } references)
+        {
+            for (int index = 0; index < references.Count; index++)
+            {
+                Add(
+                    cases,
+                    $"{nameof(model.AssemblyInfo)}.{nameof(assembly.References)}[{index}].Name",
+                    "Assembly name",
+                    references[index].Name);
+            }
+        }
+
+        if (assembly.TransitiveReferences is { } transitiveReferences)
+        {
+            for (int index = 0; index < transitiveReferences.Count; index++)
+            {
+                Add(
+                    cases,
+                    $"{nameof(model.AssemblyInfo)}.{nameof(assembly.TransitiveReferences)}[{index}]."
+                        + nameof(AssemblyReferenceNode.Name),
+                    "Assembly name",
+                    transitiveReferences[index].Name);
+            }
+        }
+
+        return cases;
+    }
+
+    public static (string Value, string Evidence) Summarize(
+        IReadOnlyList<IdentifierConfusionCase> cases,
+        string scope)
+    {
+        if (cases.Count == 0)
+            return ("None", $"all inspected {scope} use ASCII characters");
+
+        int homoglyphs = cases.Count(value =>
+            (value.Confusion.Concerns & IdentifierConcern.ReservedPrefixHomoglyph) != 0);
+        string evidence = $"{cases.Count.ToString(CultureInfo.InvariantCulture)} non-ASCII "
+            + $"{(cases.Count == 1 ? "identifier" : "identifiers")}";
+        if (homoglyphs > 0)
+        {
+            string prefixes = string.Join(
+                ", ",
+                cases
+                    .Select(value => value.Confusion.ReservedPrefixMatch?.ReservedPrefix)
+                    .Where(static value => value is not null)
+                    .Distinct(StringComparer.Ordinal)
+                    .Order(StringComparer.Ordinal));
+            evidence += $"; {homoglyphs.ToString(CultureInfo.InvariantCulture)} reserved-prefix "
+                + $"{(homoglyphs == 1 ? "homoglyph" : "homoglyphs")}";
+            if (prefixes.Length > 0)
+                evidence += $" ({prefixes})";
+        }
+
+        return ("Detected", evidence);
+    }
+
+    public static string DescribeConcern(IdentifierConfusion confusion)
+        => confusion.ReservedPrefixMatch is null
+            ? "non-ASCII characters"
+            : "non-ASCII characters; reserved-prefix homoglyph";
+
+    public static string? DescribeSimilarity(IdentifierConfusion confusion)
+        => confusion.ReservedPrefixMatch is { } match
+            ? (match.Similarity * 100).ToString("F0", CultureInfo.InvariantCulture) + "%"
+            : null;
+
+    public static string DescribeCharacters(IdentifierConfusion confusion)
+    {
+        Dictionary<int, char> mappings = confusion.ReservedPrefixMatch?.Homoglyphs
+            .ToDictionary(static value => value.CodePoint, static value => value.LooksLike)
+            ?? [];
+        return string.Join(
+            ", ",
+            confusion.NonAsciiCodePoints.Select(codePoint =>
+                mappings.TryGetValue(codePoint, out char looksLike)
+                    ? $"U+{codePoint:X4}→{char.ToUpperInvariant(looksLike)}"
+                    : $"U+{codePoint:X4}"));
+    }
+
+    private static void Add(
+        List<IdentifierConfusionCase> cases,
+        string location,
+        string kind,
+        string? value)
+    {
+        if (IdentifierConfusionDetector.Inspect(value) is { } confusion)
+            cases.Add(new IdentifierConfusionCase(location, kind, confusion));
+    }
+}

--- a/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
+++ b/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
@@ -10,8 +10,31 @@ internal readonly record struct IdentifierConfusionCase(
     string Kind,
     IdentifierConfusion Confusion);
 
+internal enum IdentifierConfusionAuditFailureKind
+{
+    InvalidAssemblyMetadata,
+    AssemblyUnreadable,
+    InspectionFailed,
+}
+
 internal static class IdentifierConfusionAudit
 {
+    public static string DescribeFailure(
+        IdentifierConfusionAuditFailureKind failure) =>
+        failure switch
+        {
+            IdentifierConfusionAuditFailureKind.InvalidAssemblyMetadata =>
+                "invalid assembly metadata",
+            IdentifierConfusionAuditFailureKind.AssemblyUnreadable =>
+                "assembly could not be read",
+            IdentifierConfusionAuditFailureKind.InspectionFailed =>
+                "assembly inspection failed",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(failure),
+                failure,
+                null),
+        };
+
     public static IReadOnlyList<IdentifierConfusionCase> InspectPackage(InspectionResult model)
     {
         List<IdentifierConfusionCase> cases = [];

--- a/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
+++ b/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
@@ -74,7 +74,17 @@ internal static class IdentifierConfusionAudit
         return cases;
     }
 
-    public static IReadOnlyList<IdentifierConfusionCase> InspectLibrary(LibraryInspection model)
+    public static IReadOnlyList<IdentifierConfusionCase> InspectLibrarySummary(
+        LibraryInspection model)
+        => InspectLibrary(model, includeTransitiveReferences: false);
+
+    public static IReadOnlyList<IdentifierConfusionCase> InspectLibrary(
+        LibraryInspection model)
+        => InspectLibrary(model, includeTransitiveReferences: true);
+
+    private static IReadOnlyList<IdentifierConfusionCase> InspectLibrary(
+        LibraryInspection model,
+        bool includeTransitiveReferences)
     {
         List<IdentifierConfusionCase> cases = [];
         if (model.AssemblyInfo is not { } assembly)
@@ -98,10 +108,14 @@ internal static class IdentifierConfusionAudit
             }
         }
 
-        if (assembly.TransitiveReferences is { } transitiveReferences)
+        if (includeTransitiveReferences
+            && model.IdentifierConfusionTransitiveReferences is { } transitiveReferences)
         {
             for (int index = 0; index < transitiveReferences.Count; index++)
             {
+                if (transitiveReferences[index].Depth == 0)
+                    continue;
+
                 Add(
                     cases,
                     $"{nameof(model.AssemblyInfo)}.{nameof(assembly.TransitiveReferences)}[{index}]."

--- a/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
+++ b/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
@@ -138,7 +138,7 @@ internal static class IdentifierConfusionAudit
             && assembly.References is { } directReferences
                 ? new HashSet<string>(
                     directReferences.Select(reference => reference.Name),
-                    StringComparer.OrdinalIgnoreCase)
+                    StringComparer.Ordinal)
                 : null;
         if (includeTransitiveReferences
             && model.IdentifierConfusionReferenceClosure is { } transitiveReferences)

--- a/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
+++ b/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
@@ -15,6 +15,7 @@ internal enum IdentifierConfusionAuditFailureKind
     InvalidAssemblyMetadata,
     AssemblyUnreadable,
     InspectionFailed,
+    PackageMetadataUnavailable,
 }
 
 internal static class IdentifierConfusionAudit
@@ -29,6 +30,8 @@ internal static class IdentifierConfusionAudit
                 "assembly could not be read",
             IdentifierConfusionAuditFailureKind.InspectionFailed =>
                 "assembly inspection failed",
+            IdentifierConfusionAuditFailureKind.PackageMetadataUnavailable =>
+                "package registry metadata unavailable",
             _ => throw new ArgumentOutOfRangeException(
                 nameof(failure),
                 failure,

--- a/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
+++ b/src/dotnet-inspect/Models/IdentifierConfusionAudit.cs
@@ -202,6 +202,7 @@ internal static class IdentifierConfusionAudit
     public static string DescribeCharacters(IdentifierConfusion confusion)
     {
         Dictionary<int, char> mappings = confusion.ReservedPrefixMatch?.Homoglyphs
+            .DistinctBy(static value => value.CodePoint)
             .ToDictionary(static value => value.CodePoint, static value => value.LooksLike)
             ?? [];
         return string.Join(

--- a/src/dotnet-inspect/Models/InspectionResult.cs
+++ b/src/dotnet-inspect/Models/InspectionResult.cs
@@ -83,6 +83,13 @@ public class InspectionResult
     internal IdentifierConfusionAuditFailureKind?
         IdentifierConfusionFailure { get; set; }
 
+    [JsonIgnore]
+    internal bool IdentifierConfusionRegistryScopeLimited
+    {
+        get;
+        set;
+    }
+
     /// <summary>
     /// Known security vulnerabilities for this package version.
     /// </summary>

--- a/src/dotnet-inspect/Models/InspectionResult.cs
+++ b/src/dotnet-inspect/Models/InspectionResult.cs
@@ -79,6 +79,10 @@ public class InspectionResult
     /// </summary>
     public PackageDeprecation? Deprecation { get; set; }
 
+    [JsonIgnore]
+    internal IdentifierConfusionAuditFailureKind?
+        IdentifierConfusionFailure { get; set; }
+
     /// <summary>
     /// Known security vulnerabilities for this package version.
     /// </summary>

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -286,6 +286,13 @@ public class LibraryInspection
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public AssemblyInfo? AssemblyInfo { get; set; }
 
+    [JsonIgnore]
+    internal List<AssemblyReferenceNode>? IdentifierConfusionTransitiveReferences
+    {
+        get;
+        set;
+    }
+
     private FindingInspection<AssemblyReference>? _assemblyReferenceInspection;
 
     [JsonIgnore]

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -293,6 +293,20 @@ public class LibraryInspection
         set;
     }
 
+    [JsonIgnore]
+    internal IdentifierConfusionAuditFailureKind? IdentifierConfusionFailure
+    {
+        get;
+        set;
+    }
+
+    [JsonIgnore]
+    internal IdentifierConfusionAuditFailureKind? AssemblyReferenceFailureKind
+    {
+        get;
+        set;
+    }
+
     private FindingInspection<AssemblyReference>? _assemblyReferenceInspection;
 
     [JsonIgnore]

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -287,7 +287,7 @@ public class LibraryInspection
     public AssemblyInfo? AssemblyInfo { get; set; }
 
     [JsonIgnore]
-    internal List<AssemblyReferenceNode>? IdentifierConfusionTransitiveReferences
+    internal List<AssemblyReferenceNode>? IdentifierConfusionReferenceClosure
     {
         get;
         set;

--- a/src/dotnet-inspect/Models/PackageInspectionText.cs
+++ b/src/dotnet-inspect/Models/PackageInspectionText.cs
@@ -12,40 +12,46 @@ internal sealed class PackageInspectionText
 {
     private readonly List<PackageFile>? _packageFileSource;
     private List<PackageFileText>? _packageFiles;
+    private List<PackageTextConcernCase>? _packageFileConcernCases;
     private readonly TextConcern _concerns;
+    private readonly IReadOnlyList<PackageTextConcernCase> _concernCases;
 
     public PackageInspectionText(InspectionResult data)
     {
         var collector = new Collector();
 
-        PackageName = collector.Field(data.PackageName);
-        ManifestVersion = collector.OptionalField(data.ManifestVersion);
-        Version = collector.Field(data.Version);
-        Source = collector.OptionalField(data.Source);
-        Description = collector.Existing(data.Description);
-        Authors = collector.OptionalField(data.Authors);
-        License = collector.OptionalField(data.License);
-        LicenseUrl = collector.OptionalField(data.LicenseUrl);
-        Repository = collector.OptionalField(data.Repository);
-        RepositoryType = collector.OptionalField(data.RepositoryType);
-        RepositoryCommit = collector.OptionalField(data.RepositoryCommit);
-        Owners = collector.Fields(data.Owners);
+        PackageName = collector.Field(data.PackageName, nameof(data.PackageName));
+        ManifestVersion = collector.OptionalField(data.ManifestVersion, nameof(data.ManifestVersion));
+        Version = collector.Field(data.Version, nameof(data.Version));
+        Source = collector.OptionalField(data.Source, nameof(data.Source));
+        Description = collector.Existing(data.Description, nameof(data.Description));
+        Authors = collector.OptionalField(data.Authors, nameof(data.Authors));
+        License = collector.OptionalField(data.License, nameof(data.License));
+        LicenseUrl = collector.OptionalField(data.LicenseUrl, nameof(data.LicenseUrl));
+        Repository = collector.OptionalField(data.Repository, nameof(data.Repository));
+        RepositoryType = collector.OptionalField(data.RepositoryType, nameof(data.RepositoryType));
+        RepositoryCommit = collector.OptionalField(data.RepositoryCommit, nameof(data.RepositoryCommit));
+        Owners = collector.Fields(data.Owners, nameof(data.Owners));
         Deprecation = data.Deprecation is { } deprecation
-            ? CreateDeprecation(deprecation, collector)
+            ? CreateDeprecation(deprecation, collector, nameof(data.Deprecation))
             : null;
         Vulnerabilities = data.Vulnerabilities?
-            .Select(value => new PackageVulnerabilityText(
-                collector.Field(value.Severity),
-                collector.OptionalField(value.CveId),
-                collector.OptionalField(value.Summary),
-                collector.OptionalField(value.AdvisoryUrl),
-                collector.OptionalField(value.GhsaId)))
+            .Select((value, index) =>
+            {
+                string location = $"{nameof(data.Vulnerabilities)}[{index}]";
+                return new PackageVulnerabilityText(
+                    collector.Field(value.Severity, $"{location}.{nameof(value.Severity)}"),
+                    collector.OptionalField(value.CveId, $"{location}.{nameof(value.CveId)}"),
+                    collector.OptionalField(value.Summary, $"{location}.{nameof(value.Summary)}"),
+                    collector.OptionalField(value.AdvisoryUrl, $"{location}.{nameof(value.AdvisoryUrl)}"),
+                    collector.OptionalField(value.GhsaId, $"{location}.{nameof(value.GhsaId)}"));
+            })
             .ToList();
-        ReadmeFile = collector.OptionalField(data.ReadmeFile);
-        PackageReadmeFile = collector.OptionalField(data.PackageReadmeFile);
-        PackageTypes = collector.Fields(data.PackageTypes);
-        ContentDirectories = collector.Fields(data.ContentDirectories);
-        TargetFrameworks = collector.Fields(data.TargetFrameworks);
+        ReadmeFile = collector.OptionalField(data.ReadmeFile, nameof(data.ReadmeFile));
+        PackageReadmeFile = collector.OptionalField(data.PackageReadmeFile, nameof(data.PackageReadmeFile));
+        PackageTypes = collector.Fields(data.PackageTypes, nameof(data.PackageTypes));
+        ContentDirectories = collector.Fields(data.ContentDirectories, nameof(data.ContentDirectories));
+        TargetFrameworks = collector.Fields(data.TargetFrameworks, nameof(data.TargetFrameworks));
         OrderedTargetFrameworks = data.TargetFrameworks is { } targetFrameworks
             && TargetFrameworks is { } containedTargetFrameworks
             ? TfmSelector.OrderByTfmPriorityDescending(
@@ -57,20 +63,27 @@ internal sealed class PackageInspectionText
         HighestTfm = OrderedTargetFrameworks is { Count: > 0 } orderedTargetFrameworks
             ? orderedTargetFrameworks[0]
             : null;
-        SupportedRids = collector.Fields(data.SupportedRids);
-        ToolFormat = collector.OptionalField(data.ToolFormat);
-        ToolCommands = collector.Fields(data.ToolCommands);
+        SupportedRids = collector.Fields(data.SupportedRids, nameof(data.SupportedRids));
+        ToolFormat = collector.OptionalField(data.ToolFormat, nameof(data.ToolFormat));
+        ToolCommands = collector.Fields(data.ToolCommands, nameof(data.ToolCommands));
         RuntimeIdentifierPackages = data.RuntimeIdentifierPackages?
-            .Select(value => new RidPackageReferenceText(
-                collector.Field(value.RuntimeIdentifier),
-                collector.Field(value.PackageId),
-                value.Exists))
+            .Select((value, index) =>
+            {
+                string location = $"{nameof(data.RuntimeIdentifierPackages)}[{index}]";
+                return new RidPackageReferenceText(
+                    collector.Field(value.RuntimeIdentifier, $"{location}.{nameof(value.RuntimeIdentifier)}"),
+                    collector.Field(value.PackageId, $"{location}.{nameof(value.PackageId)}"),
+                    value.Exists);
+            })
             .ToList();
-        RuntimeTargetRid = collector.OptionalField(data.RuntimeTargetRid);
-        NativeFiles = collector.Fields(data.NativeFiles);
-        LibraryFiles = collector.Fields(data.LibraryFiles);
+        RuntimeTargetRid = collector.OptionalField(data.RuntimeTargetRid, nameof(data.RuntimeTargetRid));
+        NativeFiles = collector.Fields(data.NativeFiles, nameof(data.NativeFiles));
+        LibraryFiles = collector.Fields(data.LibraryFiles, nameof(data.LibraryFiles));
         DependencyGroups = data.DependencyGroups?
-            .Select(value => CreateDependencyGroup(value, collector))
+            .Select((value, index) => CreateDependencyGroup(
+                value,
+                collector,
+                $"{nameof(data.DependencyGroups)}[{index}]"))
             .ToList();
         FlatDependencies = data.DependencyGroups is { } groups
             && DependencyGroups is { } containedGroups
@@ -88,21 +101,28 @@ internal sealed class PackageInspectionText
                 .ToList()
             : null;
         RuntimeDependencies = data.RuntimeDependencies?
-            .Select(value => CreateDependency(value, collector))
+            .Select((value, index) => CreateDependency(
+                value,
+                collector,
+                $"{nameof(data.RuntimeDependencies)}[{index}]"))
             .ToList();
         Files = data.Files?
-            .Select(value => new PackageFileText(
-                collector.Field(value.Path),
+            .Select((value, index) => new PackageFileText(
+                collector.Field(value.Path, $"{nameof(data.Files)}[{index}].{nameof(value.Path)}"),
                 value.Size,
                 value.IsReadme,
                 value.IsAgents))
             .ToList();
         _packageFileSource = data.PackageFiles;
         SourceFiles = data.SourceFiles?
-            .Select(value => new PackageSourceFileText(
-                collector.Field(value.Library),
-                collector.Field(value.Type),
-                collector.OptionalField(value.Url)))
+            .Select((value, index) =>
+            {
+                string location = $"{nameof(data.SourceFiles)}[{index}]";
+                return new PackageSourceFileText(
+                    collector.Field(value.Library, $"{location}.{nameof(value.Library)}"),
+                    collector.Field(value.Type, $"{location}.{nameof(value.Type)}"),
+                    collector.OptionalField(value.Url, $"{location}.{nameof(value.Url)}"));
+            })
             .ToList();
         SourceAvailability = data.SourceAvailability is { } availability
             ? new PackageSourceAvailabilityText(
@@ -112,13 +132,22 @@ internal sealed class PackageInspectionText
                 availability.AccessibleSourceFiles,
                 availability.EmbeddedSourceFiles,
                 availability.MissingFiles?
-                    .Select(value => CreateSourceLinkFile(value, collector))
+                    .Select((value, index) => CreateSourceLinkFile(
+                        value,
+                        collector,
+                        $"{nameof(data.SourceAvailability)}.{nameof(availability.MissingFiles)}[{index}]"))
                     .ToList(),
                 availability.UnavailableLibraries?
-                    .Select(value => CreateSourceLinkIssue(value, collector))
+                    .Select((value, index) => CreateSourceLinkIssue(
+                        value,
+                        collector,
+                        $"{nameof(data.SourceAvailability)}.{nameof(availability.UnavailableLibraries)}[{index}]"))
                     .ToList(),
                 availability.FailedLibraries?
-                    .Select(value => CreateSourceLinkIssue(value, collector))
+                    .Select((value, index) => CreateSourceLinkIssue(
+                        value,
+                        collector,
+                        $"{nameof(data.SourceAvailability)}.{nameof(availability.FailedLibraries)}[{index}]"))
                     .ToList())
             : null;
         SourceIntegrity = data.SourceIntegrity is { } integrity
@@ -130,33 +159,53 @@ internal sealed class PackageInspectionText
                 integrity.LineEndingNormalized,
                 integrity.Unverifiable,
                 integrity.MismatchedFiles?
-                    .Select(value => CreateSourceLinkFile(value, collector))
+                    .Select((value, index) => CreateSourceLinkFile(
+                        value,
+                        collector,
+                        $"{nameof(data.SourceIntegrity)}.{nameof(integrity.MismatchedFiles)}[{index}]"))
                     .ToList(),
                 integrity.UnavailableLibraries?
-                    .Select(value => CreateSourceLinkIssue(value, collector))
+                    .Select((value, index) => CreateSourceLinkIssue(
+                        value,
+                        collector,
+                        $"{nameof(data.SourceIntegrity)}.{nameof(integrity.UnavailableLibraries)}[{index}]"))
                     .ToList(),
                 integrity.FailedLibraries?
-                    .Select(value => CreateSourceLinkIssue(value, collector))
+                    .Select((value, index) => CreateSourceLinkIssue(
+                        value,
+                        collector,
+                        $"{nameof(data.SourceIntegrity)}.{nameof(integrity.FailedLibraries)}[{index}]"))
                     .ToList())
             : null;
         SignatureResult = data.SignatureResult is { } signature
             ? new PackageSignatureText(
-                collector.OptionalField(signature.Publisher),
+                collector.OptionalField(
+                    signature.Publisher,
+                    $"{nameof(data.SignatureResult)}.{nameof(signature.Publisher)}"),
                 signature.AuthorVerified,
                 signature.RepositoryVerified,
-                collector.OptionalField(signature.Repository),
-                collector.OptionalField(signature.StatusMessage),
+                collector.OptionalField(
+                    signature.Repository,
+                    $"{nameof(data.SignatureResult)}.{nameof(signature.Repository)}"),
+                collector.OptionalField(
+                    signature.StatusMessage,
+                    $"{nameof(data.SignatureResult)}.{nameof(signature.StatusMessage)}"),
                 signature.IsUnsigned)
             : null;
         AuditSignals = data.AuditSignals?
-            .Select(value => new PackageAuditSignalText(
-                collector.Field(value.Area),
-                collector.Field(value.Signal),
-                collector.Field(value.Value),
-                collector.Field(value.Evidence)))
+            .Select((value, index) =>
+            {
+                string location = $"{nameof(data.AuditSignals)}[{index}]";
+                return new PackageAuditSignalText(
+                    collector.Field(value.Area, $"{location}.{nameof(value.Area)}"),
+                    collector.Field(value.Signal, $"{location}.{nameof(value.Signal)}"),
+                    collector.Field(value.Value, $"{location}.{nameof(value.Value)}"),
+                    collector.Field(value.Evidence, $"{location}.{nameof(value.Evidence)}"));
+            })
             .ToList();
 
         _concerns = collector.Concerns;
+        _concernCases = collector.ConcernCases;
     }
 
     public InertString PackageName { get; }
@@ -193,9 +242,7 @@ internal sealed class PackageInspectionText
     public List<PackageFileText>? Files { get; }
     public List<PackageFileText>? PackageFiles => _packageFileSource is null
         ? null
-        : _packageFiles ??= _packageFileSource
-            .Select(CreatePackageFileText)
-            .ToList();
+        : _packageFiles ??= ProjectPackageFiles();
     public List<PackageSourceFileText>? SourceFiles { get; }
     public PackageSourceAvailabilityText? SourceAvailability { get; }
     public PackageSourceIntegrityText? SourceIntegrity { get; }
@@ -208,6 +255,16 @@ internal sealed class PackageInspectionText
             static (concerns, value) => concerns | value.Path.Concerns)
             ?? TextConcern.None);
     public bool RequiredContainment => Concerns != TextConcern.None;
+    public IReadOnlyList<PackageTextConcernCase> ConcernCases
+    {
+        get
+        {
+            _ = PackageFiles;
+            return _packageFileConcernCases is { Count: > 0 } packageFileCases
+                ? _concernCases.Concat(packageFileCases).ToArray()
+                : _concernCases;
+        }
+    }
 
     public List<PackageFileText>? SelectPackageFiles(Func<PackageFile, bool> predicate)
     {
@@ -236,13 +293,40 @@ internal sealed class PackageInspectionText
             value.IsReadme,
             value.IsAgents);
 
+    private List<PackageFileText> ProjectPackageFiles()
+    {
+        List<PackageFileText> files = new(_packageFileSource!.Count);
+        List<PackageTextConcernCase> cases = [];
+        for (int index = 0; index < _packageFileSource.Count; index++)
+        {
+            PackageFileText file = CreatePackageFileText(_packageFileSource[index]);
+            files.Add(file);
+            if (file.Path.Concerns != TextConcern.None)
+            {
+                cases.Add(new PackageTextConcernCase(
+                    $"{nameof(InspectionResult.PackageFiles)}[{index}].{nameof(PackageFile.Path)}",
+                    file.Path.Concerns));
+            }
+        }
+
+        _packageFileConcernCases = cases;
+        return files;
+    }
+
     private static PackageDeprecationText CreateDeprecation(
         PackageDeprecation value,
-        Collector collector)
+        Collector collector,
+        string location)
     {
-        List<InertString>? reasons = collector.Fields(value.Reasons);
-        InertString? message = collector.OptionalField(value.Message);
-        InertString? alternatePackageId = collector.OptionalField(value.AlternatePackageId);
+        List<InertString>? reasons = collector.Fields(
+            value.Reasons,
+            $"{location}.{nameof(value.Reasons)}");
+        InertString? message = collector.OptionalField(
+            value.Message,
+            $"{location}.{nameof(value.Message)}");
+        InertString? alternatePackageId = collector.OptionalField(
+            value.AlternatePackageId,
+            $"{location}.{nameof(value.AlternatePackageId)}");
         List<InertString> parts = [];
 
         if (reasons is { Count: > 0 })
@@ -254,54 +338,109 @@ internal sealed class PackageInspectionText
 
         InertString summary = parts.Count > 0
             ? collector.Compose(InertString.Join(" - ", TextPolicy.Field, parts))
-            : collector.Field("Deprecated");
+            : new InertString(TextPolicy.Field, "Deprecated");
 
         return new PackageDeprecationText(reasons, message, alternatePackageId, summary);
     }
 
     private static PackageDependencyGroupText CreateDependencyGroup(
         DependencyGroup value,
-        Collector collector)
+        Collector collector,
+        string location)
         => new(
-            collector.Field(value.TargetFramework),
-            value.Dependencies.Select(dependency => CreateDependency(dependency, collector)).ToList(),
+            collector.Field(
+                value.TargetFramework,
+                $"{location}.{nameof(value.TargetFramework)}"),
+            value.Dependencies.Select((dependency, index) => CreateDependency(
+                dependency,
+                collector,
+                $"{location}.{nameof(value.Dependencies)}[{index}]")).ToList(),
             value.IsImplicitManifestGroup);
 
     private static PackageDependencyText CreateDependency(
         PackageDependency value,
-        Collector collector)
-        => new(collector.Field(value.Id), collector.Field(value.Version));
+        Collector collector,
+        string location)
+        => new(
+            collector.Field(value.Id, $"{location}.{nameof(value.Id)}"),
+            collector.Field(value.Version, $"{location}.{nameof(value.Version)}"));
 
     private static PackageSourceLinkFileText CreateSourceLinkFile(
         PackageSourceLinkFile value,
-        Collector collector)
-        => new(collector.Field(value.Library), collector.Field(value.Path));
+        Collector collector,
+        string location)
+        => new(
+            collector.Field(value.Library, $"{location}.{nameof(value.Library)}"),
+            collector.Field(value.Path, $"{location}.{nameof(value.Path)}"));
 
     private static PackageSourceLinkIssueText CreateSourceLinkIssue(
         PackageSourceLinkIssue value,
-        Collector collector)
-        => new(collector.Field(value.Library), collector.Field(value.Reason));
+        Collector collector,
+        string location)
+        => new(
+            collector.Field(value.Library, $"{location}.{nameof(value.Library)}"),
+            collector.Field(value.Reason, $"{location}.{nameof(value.Reason)}"));
 
     internal sealed class Collector
     {
+        private readonly List<PackageTextConcernCase> _concernCases = [];
+
         public TextConcern Concerns { get; private set; }
+        public IReadOnlyList<PackageTextConcernCase> ConcernCases => _concernCases;
 
-        public InertString Field(string value)
-            => Compose(new InertString(TextPolicy.Field, value));
+        public InertString Field(string value, string location)
+            => Track(new InertString(TextPolicy.Field, value), location);
 
-        public InertString? OptionalField(string? value)
-            => value is null ? null : Field(value);
+        public InertString? OptionalField(string? value, string location)
+            => value is null ? null : Field(value, location);
 
-        public InertString? Existing(InertString? value)
-            => value is { } existing ? Compose(existing) : null;
+        public InertString? Existing(InertString? value, string location)
+            => value is { } existing ? Track(existing, location) : null;
 
-        public List<InertString>? Fields(List<string>? values)
-            => values?.Select(Field).ToList();
+        public List<InertString>? Fields(List<string>? values, string location)
+            => values?
+                .Select((value, index) => Field(value, $"{location}[{index}]"))
+                .ToList();
+
+        private InertString Track(InertString value, string location)
+        {
+            Compose(value);
+            if (value.Concerns != TextConcern.None)
+                _concernCases.Add(new PackageTextConcernCase(location, value.Concerns));
+            return value;
+        }
 
         public InertString Compose(InertString value)
         {
             Concerns |= value.Concerns;
             return value;
+        }
+    }
+}
+
+internal readonly record struct PackageTextConcernCase(
+    string Location,
+    TextConcern Concerns);
+
+internal static class TextConcernDisplay
+{
+    public static string Describe(TextConcern concerns)
+    {
+        if (concerns == TextConcern.None)
+            return "no concerning scalars found";
+
+        List<string> kinds = [];
+        AddKind(TextConcern.Control, "control (Cc)");
+        AddKind(TextConcern.Format, "format/bidi (Cf)");
+        AddKind(TextConcern.Surrogate, "unpaired surrogate (Cs)");
+        AddKind(TextConcern.LineSeparator, "line separator (Zl)");
+        AddKind(TextConcern.ParagraphSeparator, "paragraph separator (Zp)");
+        return string.Join(", ", kinds);
+
+        void AddKind(TextConcern kind, string description)
+        {
+            if ((concerns & kind) != TextConcern.None)
+                kinds.Add(description);
         }
     }
 }

--- a/src/dotnet-inspect/Models/PackageInspectionText.cs
+++ b/src/dotnet-inspect/Models/PackageInspectionText.cs
@@ -12,7 +12,7 @@ internal sealed class PackageInspectionText
 {
     private readonly List<PackageFile>? _packageFileSource;
     private List<PackageFileText>? _packageFiles;
-    private readonly bool _requiredContainment;
+    private readonly TextConcern _concerns;
 
     public PackageInspectionText(InspectionResult data)
     {
@@ -156,7 +156,7 @@ internal sealed class PackageInspectionText
                 collector.Field(value.Evidence)))
             .ToList();
 
-        _requiredContainment = collector.RequiredContainment;
+        _concerns = collector.Concerns;
     }
 
     public InertString PackageName { get; }
@@ -201,9 +201,13 @@ internal sealed class PackageInspectionText
     public PackageSourceIntegrityText? SourceIntegrity { get; }
     public PackageSignatureText? SignatureResult { get; }
     public List<PackageAuditSignalText>? AuditSignals { get; }
-    public bool RequiredContainment =>
-        _requiredContainment
-        || PackageFiles?.Any(value => value.Path.RequiredContainment) == true;
+    public TextConcern Concerns =>
+        _concerns
+        | (PackageFiles?.Aggregate(
+            TextConcern.None,
+            static (concerns, value) => concerns | value.Path.Concerns)
+            ?? TextConcern.None);
+    public bool RequiredContainment => Concerns != TextConcern.None;
 
     public List<PackageFileText>? SelectPackageFiles(Func<PackageFile, bool> predicate)
     {
@@ -280,7 +284,7 @@ internal sealed class PackageInspectionText
 
     internal sealed class Collector
     {
-        public bool RequiredContainment { get; private set; }
+        public TextConcern Concerns { get; private set; }
 
         public InertString Field(string value)
             => Compose(new InertString(TextPolicy.Field, value));
@@ -296,7 +300,7 @@ internal sealed class PackageInspectionText
 
         public InertString Compose(InertString value)
         {
-            RequiredContainment |= value.RequiredContainment;
+            Concerns |= value.Concerns;
             return value;
         }
     }

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -35,6 +35,13 @@ public record LibraryOptions : IProjectionOptions
     internal bool CollectReferenceTree { get; init; }
 
     /// <summary>
+    /// Internal execution demand for the identifier audit's resolved transitive scope.
+    /// Kept separate from the References projection so selecting the audit cannot change
+    /// unrelated Signals rows.
+    /// </summary>
+    internal bool CollectIdentifierConfusionReferenceTree { get; init; }
+
+    /// <summary>
     /// Maximum reference-tree depth, where 1 includes direct references only.
     /// Null traverses the complete resolvable graph.
     /// </summary>

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -100,6 +100,7 @@ public static class LibrarySections
                 SourceLinkDiscoverable)
             .Add<Symbols>()
             .Add<Signals>(HasAssemblyInfo)
+            .Add<IdentifierConfusion>()
             .Add<Switches>(SwitchesQuery.Definition)
             .Add<IntegrationOpportunities>(
                 AssemblyContextIntegrationOpportunitiesQuery.Definition)
@@ -159,6 +160,7 @@ public static class LibrarySections
                 SectionNames.NonNormalizedPaths,
                 SectionNames.SourceLinkDiagnostics,
                 SectionNames.Signals,
+                SectionNames.IdentifierConfusion,
                 SectionNames.Symbols)
             .AddCategory(SectionCategoryNames.Performance,
                 [.. PerformanceKinds.Sections, SectionNames.ArrayPoolEscapes, SectionNames.TopLeverage])
@@ -455,6 +457,17 @@ public static class LibrarySections
         public static string? ScannerKey => ScannerAuditSignals;
         public static bool CanRender(LibraryInspection model)
             => model.AuditSignals is { Count: > 0 };
+    }
+
+    public sealed class IdentifierConfusion : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.IdentifierConfusion;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
+        public static string? ScannerKey => null;
+        public static bool CanRender(LibraryInspection model)
+            => IdentifierConfusionAudit.InspectLibrary(model).Count > 0;
     }
 
     public sealed class Switches : ISectionDescriptor<LibraryInspection>

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -100,7 +100,7 @@ public static class LibrarySections
                 SourceLinkDiscoverable)
             .Add<Symbols>()
             .Add<Signals>(HasAssemblyInfo)
-            .Add<IdentifierConfusion>()
+            .Add<IdentifierConfusion>(AssemblyReferencesQuery.Definition)
             .Add<Switches>(SwitchesQuery.Definition)
             .Add<IntegrationOpportunities>(
                 AssemblyContextIntegrationOpportunitiesQuery.Definition)
@@ -462,9 +462,10 @@ public static class LibrarySections
     public sealed class IdentifierConfusion : ISectionDescriptor<LibraryInspection>
     {
         public static string Name => SectionNames.IdentifierConfusion;
-        public static bool IsExpensive => false;
+        public static bool IsExpensive => true;
         public static bool ExplicitOnly => true;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
+        public static SectionCost Cost => SectionCost.Unbounded;
         public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model)
             => IdentifierConfusionAudit.InspectLibrary(model).Count > 0;

--- a/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
@@ -186,6 +186,8 @@ public static class PackageSectionDescriptors
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
+        // Alternate-package IDs require bounded registry metadata acquisition.
+        public static SectionCost Cost => SectionCost.Moderated;
         public static string? ScannerKey => null;
         public static bool CanRender(InspectionResult model)
             => IdentifierConfusionAudit.InspectPackage(model).Count > 0;

--- a/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
@@ -50,6 +50,7 @@ public static class PackageSectionDescriptors
             .Add<PackageReadme>()
             .Add<Signals>()
             .Add<AuditArtifactText>()
+            .Add<AuditIdentifierConfusion>()
             .Add<Statistics>()
             .Add<TargetFrameworks>()
             .Add<NuspecFiles>()
@@ -98,6 +99,7 @@ public static class PackageSectionDescriptors
                 SectionCategoryNames.Audit,
                 PackageSections.Signals,
                 PackageSections.AuditArtifactText,
+                PackageSections.AuditIdentifierConfusion,
                 PackageSections.Signature,
                 PackageSections.Vulnerabilities,
                 PackageSections.SourceLinkAvailability,
@@ -176,6 +178,17 @@ public static class PackageSectionDescriptors
         public static string? ScannerKey => null;
         public static bool CanRender(InspectionResult model)
             => new PackageInspectionText(model).ConcernCases.Count > 0;
+    }
+
+    public sealed class AuditIdentifierConfusion : ISectionDescriptor<InspectionResult>
+    {
+        public static string Name => PackageSections.AuditIdentifierConfusion;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static SectionSizeClass SizeClass => SectionSizeClass.Informative;
+        public static string? ScannerKey => null;
+        public static bool CanRender(InspectionResult model)
+            => IdentifierConfusionAudit.InspectPackage(model).Count > 0;
     }
 
     // ===== Network-bound sections =====

--- a/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
@@ -49,6 +49,7 @@ public static class PackageSectionDescriptors
             .Add<PackageInfo>()
             .Add<PackageReadme>()
             .Add<Signals>()
+            .Add<AuditArtifactText>()
             .Add<Statistics>()
             .Add<TargetFrameworks>()
             .Add<NuspecFiles>()
@@ -96,6 +97,7 @@ public static class PackageSectionDescriptors
             .AddCategory(
                 SectionCategoryNames.Audit,
                 PackageSections.Signals,
+                PackageSections.AuditArtifactText,
                 PackageSections.Signature,
                 PackageSections.Vulnerabilities,
                 PackageSections.SourceLinkAvailability,
@@ -157,6 +159,23 @@ public static class PackageSectionDescriptors
         public static SectionCost Cost => SectionCost.Moderated;
         public static string? ScannerKey => null;
         public static bool CanRender(InspectionResult model) => true;
+    }
+
+    /// <summary>
+    /// One content-free row per artifact-derived package field that required visual
+    /// containment. Package file paths make the possible row count track package size,
+    /// so the section is available only through an exact or category selection.
+    /// </summary>
+    public sealed class AuditArtifactText : ISectionDescriptor<InspectionResult>
+    {
+        public static string Name => PackageSections.AuditArtifactText;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static SectionSizeClass SizeClass => SectionSizeClass.Verbose;
+        public static SectionCost Cost => SectionCost.Unbounded;
+        public static string? ScannerKey => null;
+        public static bool CanRender(InspectionResult model)
+            => new PackageInspectionText(model).ConcernCases.Count > 0;
     }
 
     // ===== Network-bound sections =====

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -278,6 +278,9 @@ public static class SectionNames
     /// <summary>Section summarizing high-value audit answers across the assembly.</summary>
     public const string Signals = "Signals";
 
+    /// <summary>Section listing non-ASCII identifiers and reserved-prefix homoglyphs.</summary>
+    public const string IdentifierConfusion = "Audit: Identifier Confusion";
+
     /// <summary>Section for AppContext feature switches.</summary>
     public const string Switches = "Switches";
 

--- a/src/dotnet-inspect/Views/IdentifierConfusionRow.cs
+++ b/src/dotnet-inspect/Views/IdentifierConfusionRow.cs
@@ -1,0 +1,43 @@
+using DotnetInspector.Models;
+using InertText;
+using Markout;
+
+namespace DotnetInspector.Views;
+
+[MarkoutSerializable]
+public sealed record IdentifierConfusionRow(
+    [property: MarkoutIgnore] InertString LocationText,
+    [property: MarkoutIgnore] InertString KindText,
+    [property: MarkoutIgnore] InertString ConcernText,
+    [property: MarkoutIgnore] InertString? ReservedPrefixText,
+    [property: MarkoutIgnore] InertString? SimilarityText,
+    [property: MarkoutIgnore] InertString CharactersText)
+{
+    public string Location => LocationText.ToString();
+    public string Kind => KindText.ToString();
+    public string Concern => ConcernText.ToString();
+    [MarkoutPropertyName("Reserved Prefix")]
+    public string? ReservedPrefix => PackageViewText.Render(ReservedPrefixText);
+    public string? Similarity => PackageViewText.Render(SimilarityText);
+    public string Characters => CharactersText.ToString();
+}
+
+internal static class IdentifierConfusionRows
+{
+    public static List<IdentifierConfusionRow> Create(
+        IReadOnlyList<IdentifierConfusionCase> cases)
+        => cases.Select(value => new IdentifierConfusionRow(
+                Field(value.Location),
+                Field(value.Kind),
+                Field(IdentifierConfusionAudit.DescribeConcern(value.Confusion)),
+                value.Confusion.ReservedPrefixMatch is { } match
+                    ? Field(match.ReservedPrefix)
+                    : null,
+                IdentifierConfusionAudit.DescribeSimilarity(value.Confusion) is { } similarity
+                    ? Field(similarity)
+                    : null,
+                Field(IdentifierConfusionAudit.DescribeCharacters(value.Confusion))))
+            .ToList();
+
+    private static InertString Field(string value) => new(TextPolicy.Field, value);
+}

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -130,6 +130,16 @@ public class InspectionResultView
             new InertString(TextPolicy.Field, TextConcernDisplay.Describe(value.Concerns))))
         .ToList();
 
+    [MarkoutIgnore]
+    public bool HasIdentifierConfusion =>
+        IdentifierConfusionAudit.InspectPackage(_data).Count > 0;
+
+    [MarkoutSection(
+        Name = PackageSections.AuditIdentifierConfusion,
+        ShowWhenProperty = nameof(HasIdentifierConfusion))]
+    public List<IdentifierConfusionRow> IdentifierConfusion =>
+        IdentifierConfusionRows.Create(IdentifierConfusionAudit.InspectPackage(_data));
+
     [MarkoutSection(Name = PackageSections.Signature)]
     public SigningSection? SigningSectionData => Text.SignatureResult is { } signature
         ? new SigningSection(
@@ -957,6 +967,7 @@ public sealed record PackageSourceIntegritySection(
 [MarkoutContext(typeof(AuditSignalRow))]
 [MarkoutContext(typeof(PackageAuditSignalRow))]
 [MarkoutContext(typeof(PackageTextConcernRow))]
+[MarkoutContext(typeof(IdentifierConfusionRow))]
 [MarkoutContext(typeof(InspectionFailureRow))]
 [MarkoutContext(typeof(SwitchRow))]
 [MarkoutContext(typeof(IntegrationOpportunityRow))]

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -118,6 +118,18 @@ public class InspectionResultView
             signal.Evidence))
         .ToList();
 
+    [MarkoutIgnore]
+    public bool HasArtifactTextConcerns => Text.ConcernCases.Count > 0;
+
+    [MarkoutSection(
+        Name = PackageSections.AuditArtifactText,
+        ShowWhenProperty = nameof(HasArtifactTextConcerns))]
+    public List<PackageTextConcernRow> ArtifactTextConcerns => Text.ConcernCases
+        .Select(value => new PackageTextConcernRow(
+            new InertString(TextPolicy.Field, value.Location),
+            new InertString(TextPolicy.Field, TextConcernDisplay.Describe(value.Concerns))))
+        .ToList();
+
     [MarkoutSection(Name = PackageSections.Signature)]
     public SigningSection? SigningSectionData => Text.SignatureResult is { } signature
         ? new SigningSection(
@@ -828,6 +840,15 @@ public sealed record PackageAuditSignalRow(
 }
 
 [MarkoutSerializable]
+public sealed record PackageTextConcernRow(
+    [property: MarkoutIgnore] InertString LocationText,
+    [property: MarkoutIgnore] InertString ConcernsText)
+{
+    public string Location => LocationText.ToString();
+    public string Concerns => ConcernsText.ToString();
+}
+
+[MarkoutSerializable]
 public record PackageSourceLinkFileRow(
     [property: MarkoutIgnore] InertString LibraryText,
     [property: MarkoutIgnore] InertString FileText,
@@ -935,6 +956,7 @@ public sealed record PackageSourceIntegritySection(
 [MarkoutContext(typeof(TypeForwarderRow))]
 [MarkoutContext(typeof(AuditSignalRow))]
 [MarkoutContext(typeof(PackageAuditSignalRow))]
+[MarkoutContext(typeof(PackageTextConcernRow))]
 [MarkoutContext(typeof(InspectionFailureRow))]
 [MarkoutContext(typeof(SwitchRow))]
 [MarkoutContext(typeof(IntegrationOpportunityRow))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -271,6 +271,16 @@ public class LibraryInspectionView
         _data.AuditSignals?.Select(s => new AuditSignalRow(s.Area, s.Signal, s.Value, s.Evidence)).ToList();
 
     [MarkoutIgnore]
+    public bool HasIdentifierConfusion =>
+        IdentifierConfusionAudit.InspectLibrary(_data).Count > 0;
+
+    [MarkoutSection(
+        Name = SectionNames.IdentifierConfusion,
+        ShowWhenProperty = nameof(HasIdentifierConfusion))]
+    public List<IdentifierConfusionRow> IdentifierConfusion =>
+        IdentifierConfusionRows.Create(IdentifierConfusionAudit.InspectLibrary(_data));
+
+    [MarkoutIgnore]
     public bool HasSwitches => _data.SwitchInspection.HasFindings();
 
     [MarkoutSection(Name = "Switches", ShowWhenProperty = nameof(HasSwitches))]

--- a/src/dotnet-inspect/Views/PackageSections.cs
+++ b/src/dotnet-inspect/Views/PackageSections.cs
@@ -10,6 +10,7 @@ public static class PackageSections
     public const string PackageInfo = "Package Info";
     public const string Signals = "Signals";
     public const string AuditArtifactText = "Audit: Artifact Text";
+    public const string AuditIdentifierConfusion = "Audit: Identifier Confusion";
     public const string Statistics = "Statistics";
     public const string TargetFrameworks = "Target Frameworks";
     // The package file family. These read as natural noun phrases rather than

--- a/src/dotnet-inspect/Views/PackageSections.cs
+++ b/src/dotnet-inspect/Views/PackageSections.cs
@@ -9,6 +9,7 @@ public static class PackageSections
     public const string Summary = "Summary";
     public const string PackageInfo = "Package Info";
     public const string Signals = "Signals";
+    public const string AuditArtifactText = "Audit: Artifact Text";
     public const string Statistics = "Statistics";
     public const string TargetFrameworks = "Target Frameworks";
     // The package file family. These read as natural noun phrases rather than

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -141,10 +141,11 @@
   listing package-model field locations and concern kinds without echoing
   artifact values.
 - Adds an `Identifier confusion` Signal for package IDs, dependency IDs,
-  assembly names, and assembly references. Explicit package and library audit
-  sections report content-free locations, classifications, similarity, and
-  code points, including bounded Greek/Cyrillic homoglyph checks for `System`,
-  `Microsoft`, and `Azure`.
+  assembly names, and direct assembly references. Explicit package and library
+  audit sections report content-free locations, classifications, similarity,
+  and code points, including bounded Greek/Cyrillic homoglyph checks for
+  `System`, `Microsoft`, and `Azure`; the explicit library audit additionally
+  resolves the transitive reference closure.
 - **Breaking:** removes the hidden `--oneline` compatibility alias and
   `DOTNET_INSPECT_FORMAT=oneline`/`one-line`; use `--table`.
 - Builds Native AOT packages with `OptimizationPreference=Speed`, worth a

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -140,6 +140,11 @@
 - Adds the explicit `Audit: Artifact Text` package section under `@Audit`,
   listing package-model field locations and concern kinds without echoing
   artifact values.
+- Adds an `Identifier confusion` Signal for package IDs, dependency IDs,
+  assembly names, and assembly references. Explicit package and library audit
+  sections report content-free locations, classifications, similarity, and
+  code points, including bounded Greek/Cyrillic homoglyph checks for `System`,
+  `Microsoft`, and `Azure`.
 - **Breaking:** removes the hidden `--oneline` compatibility alias and
   `DOTNET_INSPECT_FORMAT=oneline`/`one-line`; use `--table`.
 - Builds Native AOT packages with `OptimizationPreference=Speed`, worth a

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -137,6 +137,9 @@
   `Artifact text containment`, with category-only evidence for control,
   format/bidi, unpaired-surrogate, line-separator, and paragraph-separator
   concerns. Literal backslashes do not trigger the concern.
+- Adds the explicit `Audit: Artifact Text` package section under `@Audit`,
+  listing package-model field locations and concern kinds without echoing
+  artifact values.
 - **Breaking:** removes the hidden `--oneline` compatibility alias and
   `DOTNET_INSPECT_FORMAT=oneline`/`one-line`; use `--table`.
 - Builds Native AOT packages with `OptimizationPreference=Speed`, worth a

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -133,6 +133,10 @@
   cannot impersonate tool headings or tables. Package projections expose
   aggregate containment evidence while explicit document payloads remain
   byte-preserving (#3679, #3772).
+- Reports that package aggregate in `Signals` as
+  `Artifact text containment`, with category-only evidence for control,
+  format/bidi, unpaired-surrogate, line-separator, and paragraph-separator
+  concerns. Literal backslashes do not trigger the concern.
 - **Breaking:** removes the hidden `--oneline` compatibility alias and
   `DOTNET_INSPECT_FORMAT=oneline`/`one-line`; use `--table`.
 - Builds Native AOT packages with `OptimizationPreference=Speed`, worth a
@@ -158,7 +162,6 @@
 - Adds Rung 7 `Performance Triage` shapes: `async-state-machine` (reported as
   amortized off-loop) and `materialize-in-loop` (loop-invariant
   `ToArray`/`ToList`), plus nested-type triage drilldown (#1948, #1889).
-
 ### Output and projections
 
 - Adds JSON array projection output and scalar URL/path shape projections,

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -171,6 +171,7 @@
 - Adds Rung 7 `Performance Triage` shapes: `async-state-machine` (reported as
   amortized off-loop) and `materialize-in-loop` (loop-invariant
   `ToArray`/`ToList`), plus nested-type triage drilldown (#1948, #1889).
+
 ### Output and projections
 
 - Adds JSON array projection output and scalar URL/path shape projections,


### PR DESCRIPTION
## Summary

- reports package artifact-text containment as category-only Signals evidence and an explicit content-free audit section
- reports non-ASCII package and assembly identifiers, with bounded high-confidence homoglyph classification for `System`, `Microsoft`, and `Azure` prefixes
- preserves the separation between rendering containment and identifier review while carrying concern provenance through `InertString` composition, bounding, and persistence

## Stack

Slice 2 of 2. Parent: #3831.

Residual: broader CLI trust/refusal flags remain in #3463; library-wide artifact-text containment remains deferred until the library presentation model carries `InertString` across its complete text surface.

## Boundary

Signal and audit output exposes counts, model locations, Unicode categories, matched prefixes, similarity, and code points, but never repeats artifact text or identifier values. The homoglyph catalog is deliberately bounded rather than a complete Unicode confusables implementation.

## Validation

Current-head CI and adversarial review are pending. At the user's direction, the fixed-head adversarial review starts immediately in parallel with CI; its result applies only to `432b685c3a8ac753cc5d0c1bc6612796ba9f0a66` and does not substitute for green CI.