### PR TITLE
Extract method call analysis

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -703,8 +703,13 @@ Research overlay bridge, and the application layer:
   `BodySignalAnalysis` consumes the context with metadata-dependent box
   classification supplied through a narrow callback.
   `MethodSafetyAnalysis` owns declaration, local, opcode, call, and unsafety
-  occurrence interpretation; call-site acquisition remains separate and
-  delegates only its safety projection.
+  occurrence interpretation.
+  `MethodCallAnalysis` owns the single instruction traversal that projects
+  direct and indirect calls, return addresses, definition tokens, call kinds,
+  opcodes, loop membership, and allocation-derived multiplicity. It receives
+  member, calli-signature, and definition-token facts through
+  `IMethodCallResolver`, appends calls and safety evidence incrementally, and
+  delegates unsafe-call/opcode policy back to `MethodSafetyAnalysis`.
   `MethodAllocationAnalysis` owns allocation interpretation for one decoded
   body: occurrence discovery, allocation-shape classification, escape
   classification, and the private path-context/confidence/post-dominance indexes
@@ -715,7 +720,7 @@ Research overlay bridge, and the application layer:
   optimization-opportunity collection query that interpretation instead of
   rebuilding it; the reader retains PE/body acquisition, the intentionally
   throwing decode path, method identity and scope creation, metadata ownership
-  and token resolution, orchestration, call-site acquisition, optimization
+  and token resolution, orchestration, optimization
   recommendations, resource/leak analysis, and result aggregation.
   `MethodInstructionFacts` owns the
   metadata-free local/argument-slot, operand, and single-branch-target grammar

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -236,6 +236,15 @@ probes reused by body-signal and allocation analysis.
 opcode and call evidence, and the pointer-stack interpretation that emits
 unsafety occurrences. The assembly reader retains calli-signature resolution
 and passes only the display detail into the producer.
+`MethodCallAnalysis` owns one instruction traversal that projects direct and
+indirect calls, return addresses, same-assembly definition tokens, call kinds,
+opcodes, loop membership, and allocation-derived multiplicity. Metadata facts
+arrive through `IMethodCallResolver`; the reader retains member and calli
+signature resolution plus MethodSpec peeling without exposing its reader or
+generic scope. The producer appends to caller-owned call and safety-evidence
+builders so results emitted before a later recoverable metadata failure survive,
+and delegates unsafe-call/opcode classification to `MethodSafetyAnalysis`
+without a second body scan.
 `MethodAllocationAnalysis` owns the allocation topic for one decoded body:
 allocation occurrence discovery, allocation-shape classification, escape
 classification, and the private path-context, path-confidence, and
@@ -257,11 +266,9 @@ The assembly reader retains, on the allocation path, exactly: PE/body
 acquisition, the intentionally throwing `InstructionDecoder.Decode` +
 `BlockGraph.Build` decode, loop-region computation for the context, method
 identity and generic-scope creation, metadata ownership and token resolution,
-per-method orchestration and recoverable-failure diagnostics, call-site
-acquisition, optimization-recommendation production, resource/leak analysis, and
+per-method orchestration and recoverable-failure diagnostics,
+optimization-recommendation production, resource/leak analysis, and
 result aggregation.
-Call-site acquisition and multiplicity remain separate; that scan delegates
-safety projection rather than owning the unsafe-type policy.
 `MethodInstructionFacts` owns the metadata-free local/argument-slot, operand,
 and single-branch-target grammar shared by safety and allocation interpretation,
 and `CompilerGeneratedNames` owns the unspeakable-name grammar shared by

--- a/src/ILInspector.Analysis.Tests/MethodCallAnalysisTests.cs
+++ b/src/ILInspector.Analysis.Tests/MethodCallAnalysisTests.cs
@@ -1,0 +1,424 @@
+using System.Collections.Immutable;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Analysis.Tests;
+
+public sealed class MethodCallAnalysisTests
+{
+    const int FirstToken = 0x0A000001;
+    const int SecondToken = 0x0A000002;
+    const int SignatureToken = 0x11000001;
+
+    static readonly TypeRef s_void =
+        TypeRef.CoreLib("System", "Void");
+
+    [Fact]
+    public void ProjectsCallKindsAndCoordinatesInInstructionOrder()
+    {
+        byte[] il =
+        [
+            0x28, 0x01, 0x00, 0x00, 0x0A,
+            0x6F, 0x02, 0x00, 0x00, 0x0A,
+            0x73, 0x01, 0x00, 0x00, 0x0A,
+            0xFE, 0x06, 0x02, 0x00, 0x00, 0x0A,
+            0xFE, 0x07, 0x01, 0x00, 0x00, 0x0A,
+            0x29, 0x01, 0x00, 0x00, 0x11,
+            0x2A,
+        ];
+        var context = Context(il, [(5, 21)]);
+        var calls = ImmutableArray.CreateBuilder<DirectCall>();
+        var evidence = ImmutableArray.CreateBuilder<UnsafeEvidence>();
+
+        MethodCallAnalysis.Collect(
+            context,
+            new Resolver(),
+            offset => offset switch
+            {
+                0 => AllocationMultiplicity.Once,
+                5 => AllocationMultiplicity.Conditional,
+                10 => AllocationMultiplicity.Loop,
+                15 => AllocationMultiplicity.Unknown,
+                21 => AllocationMultiplicity.Once,
+                _ => AllocationMultiplicity.Conditional,
+            },
+            calls,
+            evidence,
+            includeIndirectOpcodes: false);
+
+        Assert.Collection(
+            calls,
+            call => AssertCall(
+                call,
+                0,
+                5,
+                FirstToken,
+                0x06000001,
+                CallKind.Call,
+                "call"),
+            call => AssertCall(
+                call,
+                5,
+                10,
+                SecondToken,
+                0x06000002,
+                CallKind.CallVirtual,
+                "callvirt"),
+            call => AssertCall(
+                call,
+                10,
+                15,
+                FirstToken,
+                0x06000001,
+                CallKind.NewObject,
+                "newobj"),
+            call => AssertCall(
+                call,
+                15,
+                21,
+                SecondToken,
+                0x06000002,
+                CallKind.LoadFunction,
+                "ldftn"),
+            call => AssertCall(
+                call,
+                21,
+                27,
+                FirstToken,
+                0x06000001,
+                CallKind.LoadVirtualFunction,
+                "ldvirtftn"),
+            call => AssertCall(
+                call,
+                27,
+                32,
+                SignatureToken,
+                SignatureToken,
+                CallKind.CallIndirect,
+                "calli"));
+        Assert.Collection(
+            calls,
+            call => AssertCallContext(
+                call,
+                inLoop: false,
+                AllocationMultiplicity.Once),
+            call => AssertCallContext(
+                call,
+                inLoop: true,
+                AllocationMultiplicity.Conditional),
+            call => AssertCallContext(
+                call,
+                inLoop: true,
+                AllocationMultiplicity.Loop),
+            call => AssertCallContext(
+                call,
+                inLoop: true,
+                AllocationMultiplicity.Unknown),
+            call => AssertCallContext(
+                call,
+                inLoop: true,
+                AllocationMultiplicity.Once),
+            call => AssertCallContext(
+                call,
+                inLoop: false,
+                AllocationMultiplicity.Conditional));
+        Assert.Single(
+            evidence,
+            item => item.Kind == "calli"
+                && item.ILOffset == 27);
+    }
+
+    [Fact]
+    public void DelegatesUnsafeCallAndOperationEvidenceInBodyOrder()
+    {
+        byte[] il =
+        [
+            0x28, 0x01, 0x00, 0x00, 0x0A,
+            0x4A,
+            0x29, 0x01, 0x00, 0x00, 0x11,
+            0x2A,
+        ];
+        var calls = ImmutableArray.CreateBuilder<DirectCall>();
+        var evidence = ImmutableArray.CreateBuilder<UnsafeEvidence>();
+
+        MethodCallAnalysis.Collect(
+            Context(il),
+            new Resolver(unsafeMember: true),
+            _ => AllocationMultiplicity.Once,
+            calls,
+            evidence,
+            includeIndirectOpcodes: true);
+
+        Assert.Collection(
+            evidence,
+            item =>
+            {
+                Assert.Equal("Unsafe call", item.Reason);
+                Assert.Equal(0, item.ILOffset);
+            },
+            item =>
+            {
+                Assert.Equal("Unsafe operation", item.Reason);
+                Assert.Equal(5, item.ILOffset);
+            },
+            item =>
+            {
+                Assert.Equal("calli", item.Kind);
+                Assert.Equal(6, item.ILOffset);
+            });
+    }
+
+    [Fact]
+    public void SuppressesIndirectOpcodesWithoutSuppressingOtherUnsafeOperations()
+    {
+        byte[] il =
+        [
+            0xFE, 0x0F,
+            0x4A,
+            0x29, 0x01, 0x00, 0x00, 0x11,
+            0x2A,
+        ];
+        var calls = ImmutableArray.CreateBuilder<DirectCall>();
+        var evidence = ImmutableArray.CreateBuilder<UnsafeEvidence>();
+
+        MethodCallAnalysis.Collect(
+            Context(il),
+            new Resolver(),
+            _ => AllocationMultiplicity.Once,
+            calls,
+            evidence,
+            includeIndirectOpcodes: false);
+
+        Assert.Collection(
+            evidence,
+            item =>
+            {
+                Assert.Equal("localloc", item.Detail);
+                Assert.Equal(0, item.ILOffset);
+            },
+            item =>
+            {
+                Assert.Equal("calli", item.Kind);
+                Assert.Equal(3, item.ILOffset);
+            });
+    }
+
+    [Fact]
+    public void DirectCallDependenciesCompleteBeforeResultsAreAppended()
+    {
+        var calls = ImmutableArray.CreateBuilder<DirectCall>();
+        var evidence = ImmutableArray.CreateBuilder<UnsafeEvidence>();
+        var events = new List<string>();
+
+        Assert.Throws<BadImageFormatException>(() =>
+            MethodCallAnalysis.Collect(
+                Context([0x28, 0x01, 0x00, 0x00, 0x0A, 0x2A]),
+                new Resolver(
+                    unsafeMember: true,
+                    throwOnDefinition: true,
+                    events: events),
+                _ =>
+                {
+                    events.Add("multiplicity");
+                    return AllocationMultiplicity.Once;
+                },
+                calls,
+                evidence,
+                includeIndirectOpcodes: false));
+
+        Assert.Equal(["member", "definition"], events);
+        Assert.Empty(calls);
+        Assert.Empty(evidence);
+
+        events.Clear();
+        Assert.Throws<InvalidOperationException>(() =>
+            MethodCallAnalysis.Collect(
+                Context([0x28, 0x01, 0x00, 0x00, 0x0A, 0x2A]),
+                new Resolver(unsafeMember: true, events: events),
+                _ =>
+                {
+                    events.Add("multiplicity");
+                    throw new InvalidOperationException(
+                        "Multiplicity unavailable.");
+                },
+                calls,
+                evidence,
+                includeIndirectOpcodes: false));
+
+        Assert.Equal(
+            ["member", "definition", "multiplicity"],
+            events);
+        Assert.Empty(calls);
+        Assert.Empty(evidence);
+    }
+
+    [Fact]
+    public void IndirectCallResolutionCompletesBeforeResultsAreAppended()
+    {
+        var calls = ImmutableArray.CreateBuilder<DirectCall>();
+        var evidence = ImmutableArray.CreateBuilder<UnsafeEvidence>();
+        bool multiplicityRequested = false;
+
+        Assert.Throws<BadImageFormatException>(() =>
+            MethodCallAnalysis.Collect(
+                Context([0x29, 0x01, 0x00, 0x00, 0x11, 0x2A]),
+                new Resolver(throwOnIndirectCall: true),
+                _ =>
+                {
+                    multiplicityRequested = true;
+                    return AllocationMultiplicity.Once;
+                },
+                calls,
+                evidence,
+                includeIndirectOpcodes: false));
+
+        Assert.False(multiplicityRequested);
+        Assert.Empty(calls);
+        Assert.Empty(evidence);
+    }
+
+    [Fact]
+    public void ResultsBeforeLaterResolutionFailureArePreserved()
+    {
+        byte[] il =
+        [
+            0x28, 0x01, 0x00, 0x00, 0x0A,
+            0x28, 0x02, 0x00, 0x00, 0x0A,
+            0x2A,
+        ];
+        var calls = ImmutableArray.CreateBuilder<DirectCall>();
+        var evidence = ImmutableArray.CreateBuilder<UnsafeEvidence>();
+
+        Assert.Throws<BadImageFormatException>(() =>
+            MethodCallAnalysis.Collect(
+                Context(il),
+                new Resolver(
+                    unsafeMember: true,
+                    throwOnSecondMember: true),
+                _ => AllocationMultiplicity.Once,
+                calls,
+                evidence,
+                includeIndirectOpcodes: false));
+
+        var call = Assert.Single(calls);
+        Assert.Equal(FirstToken, call.OperandToken);
+        var item = Assert.Single(evidence);
+        Assert.Equal("Unsafe call", item.Reason);
+        Assert.Equal(0, item.ILOffset);
+    }
+
+    static void AssertCall(
+        DirectCall call,
+        int offset,
+        int returnAddress,
+        int operandToken,
+        int definitionToken,
+        CallKind kind,
+        string opcode)
+    {
+        Assert.Equal(offset, call.ILOffset);
+        Assert.Equal(returnAddress, call.ReturnAddress);
+        Assert.Equal(operandToken, call.OperandToken);
+        Assert.Equal(definitionToken, call.CalleeDefinitionToken);
+        Assert.Equal(kind, call.Kind);
+        Assert.Equal(opcode, call.Opcode);
+    }
+
+    static void AssertCallContext(
+        DirectCall call,
+        bool inLoop,
+        AllocationMultiplicity multiplicity)
+    {
+        Assert.Equal(inLoop, call.InLoop);
+        Assert.Equal(multiplicity, call.Multiplicity);
+    }
+
+    static MethodBodyAnalysisContext Context(
+        byte[] il,
+        IReadOnlyList<(int Start, int End)>? loopRegions = null)
+    {
+        var instructions = MethodInstructions.Decode(
+            il,
+            il.Length,
+            []);
+        Assert.True(instructions.IsComplete);
+        return new MethodBodyAnalysisContext(
+            Method(),
+            instructions,
+            [],
+            loopRegions ?? [],
+            []);
+    }
+
+    static MethodIdentity Method()
+        => new(
+            "Fixture",
+            Guid.Empty,
+            TypeRef.Definition(
+                "Fixture",
+                "Fixtures",
+                "Caller"),
+            "M",
+            [],
+            s_void,
+            MetadataToken: 0x06000001,
+            IsStatic: true);
+
+    sealed class Resolver(
+        bool unsafeMember = false,
+        bool throwOnSecondMember = false,
+        bool throwOnDefinition = false,
+        bool throwOnIndirectCall = false,
+        List<string>? events = null)
+        : IMethodCallResolver
+    {
+        public MemberRef ResolveMember(int token)
+        {
+            events?.Add("member");
+            if (throwOnSecondMember && token == SecondToken)
+                throw new BadImageFormatException(
+                    "Malformed member token.");
+            return new MemberRef(
+                TypeRef.Definition(
+                    "Fixture",
+                    "Fixtures",
+                    "Target"),
+                "Target",
+                unsafeMember
+                    ? [TypeRef.Pointer(
+                        TypeRef.CoreLib(
+                            "System",
+                            "Int32"))]
+                    : [],
+                s_void,
+                MemberKind.Method);
+        }
+
+        public MemberRef ResolveIndirectCall(int signatureToken)
+        {
+            if (throwOnIndirectCall)
+                throw new BadImageFormatException(
+                    "Malformed standalone signature.");
+            return new(
+                    TypeRef.Unsupported("function pointer"),
+                    "calli",
+                    [],
+                    s_void,
+                    MemberKind.FunctionPointer);
+        }
+
+        public int DefinitionToken(int operandToken)
+        {
+            events?.Add("definition");
+            if (throwOnDefinition)
+                throw new BadImageFormatException(
+                    "Malformed definition token.");
+            return operandToken switch
+            {
+                FirstToken => 0x06000001,
+                SecondToken => 0x06000002,
+                _ => operandToken,
+            };
+        }
+    }
+}

--- a/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
+++ b/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
@@ -619,7 +619,12 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
                 result.Signals = signals;
                 result.HasSignals = true;
             }
-            ScanBody(context, allocationAnalysis, scope, calls, evidence,
+            MethodCallAnalysis.Collect(
+                context,
+                new CallResolver(this, scope),
+                offset => allocationAnalysis.MultiplicityAt(offset),
+                calls,
+                evidence,
                 includeIndirectOpcodes: hasUnsafeApiMember || hasUnsafeSignature || hasUnsafeLocals);
         }
         catch (Exception ex) when (IsRecoverableMethodFailure(ex))
@@ -1107,6 +1112,27 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
                 il,
                 ArgumentSlotCount(caller),
                 exceptionRegions);
+    }
+
+    // Metadata-dependent call-site facts for one method. MethodCallAnalysis owns
+    // the body traversal and projection while this resolver retains reader/scope
+    // ownership and the established malformed-metadata behavior.
+    sealed class CallResolver(
+        LibraryBodyAnalysisBuilder owner,
+        GenericScope scope)
+        : IMethodCallResolver
+    {
+        public MemberRef ResolveMember(int token)
+            => MemberResolver.ResolveMethod(
+                owner._reader,
+                MetadataTokens.EntityHandle(token),
+                scope);
+
+        public MemberRef ResolveIndirectCall(int signatureToken)
+            => owner.ResolveCalliMember(signatureToken, scope);
+
+        public int DefinitionToken(int operandToken)
+            => owner.PeelToDefinitionToken(operandToken);
     }
 
     // A value-type `newobj` whose operand is an unresolvable external TypeRef is still
@@ -2313,97 +2339,6 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
         }
         return true;
     }
-
-
-    void ScanBody(
-        MethodBodyAnalysisContext context,
-        MethodAllocationAnalysis allocationAnalysis,
-        GenericScope callerScope,
-        ImmutableArray<DirectCall>.Builder calls,
-        ImmutableArray<UnsafeEvidence>.Builder unsafeEvidence,
-        bool includeIndirectOpcodes)
-    {
-        var caller = context.Method;
-        foreach (var instruction in context.Instructions.Instructions)
-        {
-            int offset = instruction.Offset;
-            var opcode = instruction.OpCode;
-            switch (opcode)
-            {
-                case ILOpCode.Call:
-                case ILOpCode.Callvirt:
-                case ILOpCode.Newobj:
-                case ILOpCode.Ldftn:
-                case ILOpCode.Ldvirtftn:
-                {
-                    int token = MethodInstructionFacts.OperandInt32(instruction);
-                    var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
-                    bool inLoop = context.IsInLoopRegion(offset);
-                    calls.Add(new DirectCall(
-                        caller,
-                        callee,
-                        offset,
-                        token,
-                        PeelToDefinitionToken(token),
-                        ToCallKind(opcode),
-                        inLoop)
-                    {
-                        Opcode = FormatCallOpcode(opcode),
-                        ReturnAddress = instruction.NextOffset,
-                        Multiplicity =
-                            allocationAnalysis.MultiplicityAt(offset),
-                    });
-                    if (MethodSafetyAnalysis.InspectCall(
-                            caller,
-                            callee,
-                            ToCallKind(opcode),
-                            offset,
-                            token)
-                        is { } callEvidence)
-                    {
-                        unsafeEvidence.Add(callEvidence);
-                    }
-                    break;
-                }
-                case ILOpCode.Calli:
-                {
-                    int token = MethodInstructionFacts.OperandInt32(instruction);
-                    calls.Add(new DirectCall(
-                        caller,
-                        ResolveCalliMember(token, callerScope),
-                        offset,
-                        token,
-                        token,
-                        CallKind.CallIndirect,
-                        context.IsInLoopRegion(offset))
-                    {
-                        Opcode = FormatCallOpcode(opcode),
-                        ReturnAddress = instruction.NextOffset,
-                        Multiplicity =
-                            allocationAnalysis.MultiplicityAt(offset),
-                    });
-                    unsafeEvidence.Add(
-                        MethodSafetyAnalysis.CallIndirect(
-                            caller,
-                            offset,
-                            token));
-                    break;
-                }
-                default:
-                    if (MethodSafetyAnalysis.InspectOperation(
-                            caller,
-                            opcode,
-                            offset,
-                            includeIndirectOpcodes)
-                        is { } operationEvidence)
-                    {
-                        unsafeEvidence.Add(operationEvidence);
-                    }
-                    break;
-            }
-        }
-    }
-
     MemberRef ResolveCalliMember(int token, GenericScope scope)
     {
         try
@@ -2503,25 +2438,6 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
         int tick = name.IndexOf('`');
         return tick < 0 ? name : name[..tick];
     }
-
-    static string FormatCallOpcode(ILOpCode opcode) => opcode switch
-    {
-        ILOpCode.Callvirt => "callvirt",
-        ILOpCode.Newobj => "newobj",
-        ILOpCode.Ldftn => "ldftn",
-        ILOpCode.Ldvirtftn => "ldvirtftn",
-        ILOpCode.Calli => "calli",
-        _ => "call",
-    };
-
-    static CallKind ToCallKind(ILOpCode opcode) => opcode switch
-    {
-        ILOpCode.Call => CallKind.Call,
-        ILOpCode.Callvirt => CallKind.CallVirtual,
-        ILOpCode.Newobj => CallKind.NewObject,
-        ILOpCode.Ldftn => CallKind.LoadFunction,
-        _ => CallKind.LoadVirtualFunction,
-    };
 
     GenericScope CreateScope(TypeDefinition typeDef, MethodDefinition methodDef)
         => new(GenericParameterNames(typeDef.GetGenericParameters()), GenericParameterNames(methodDef.GetGenericParameters()));

--- a/src/ILInspector.Analysis/MethodCallAnalysis.cs
+++ b/src/ILInspector.Analysis/MethodCallAnalysis.cs
@@ -1,0 +1,140 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Metadata-dependent call-site facts supplied by the assembly reader without
+/// exposing its reader or generic decoding scope.
+/// </summary>
+internal interface IMethodCallResolver
+{
+    MemberRef ResolveMember(int token);
+
+    MemberRef ResolveIndirectCall(int signatureToken);
+
+    int DefinitionToken(int operandToken);
+}
+
+/// <summary>
+/// Projects direct and indirect call sites from one shared decoded method body.
+/// Safety policy remains owned by <see cref="MethodSafetyAnalysis"/> and is
+/// delegated within the same instruction traversal.
+/// </summary>
+internal static class MethodCallAnalysis
+{
+    /// <summary>
+    /// Appends results incrementally so calls and safety evidence emitted before
+    /// a later recoverable metadata failure remain visible to the method-level
+    /// diagnostic gate.
+    /// </summary>
+    internal static void Collect(
+        MethodBodyAnalysisContext context,
+        IMethodCallResolver resolver,
+        Func<int, AllocationMultiplicity> multiplicityAt,
+        ImmutableArray<DirectCall>.Builder calls,
+        ImmutableArray<UnsafeEvidence>.Builder unsafeEvidence,
+        bool includeIndirectOpcodes)
+    {
+        var caller = context.Method;
+        foreach (var instruction in context.Instructions.Instructions)
+        {
+            int offset = instruction.Offset;
+            var opcode = instruction.OpCode;
+            switch (opcode)
+            {
+                case ILOpCode.Call:
+                case ILOpCode.Callvirt:
+                case ILOpCode.Newobj:
+                case ILOpCode.Ldftn:
+                case ILOpCode.Ldvirtftn:
+                {
+                    int token =
+                        MethodInstructionFacts.OperandInt32(instruction);
+                    var callee = resolver.ResolveMember(token);
+                    var kind = ToCallKind(opcode);
+                    calls.Add(new DirectCall(
+                        caller,
+                        callee,
+                        offset,
+                        token,
+                        resolver.DefinitionToken(token),
+                        kind,
+                        context.IsInLoopRegion(offset))
+                    {
+                        Opcode = FormatCallOpcode(opcode),
+                        ReturnAddress = instruction.NextOffset,
+                        Multiplicity = multiplicityAt(offset),
+                    });
+                    if (MethodSafetyAnalysis.InspectCall(
+                            caller,
+                            callee,
+                            kind,
+                            offset,
+                            token)
+                        is { } callEvidence)
+                    {
+                        unsafeEvidence.Add(callEvidence);
+                    }
+                    break;
+                }
+                case ILOpCode.Calli:
+                {
+                    int token =
+                        MethodInstructionFacts.OperandInt32(instruction);
+                    calls.Add(new DirectCall(
+                        caller,
+                        resolver.ResolveIndirectCall(token),
+                        offset,
+                        token,
+                        token,
+                        CallKind.CallIndirect,
+                        context.IsInLoopRegion(offset))
+                    {
+                        Opcode = FormatCallOpcode(opcode),
+                        ReturnAddress = instruction.NextOffset,
+                        Multiplicity = multiplicityAt(offset),
+                    });
+                    unsafeEvidence.Add(
+                        MethodSafetyAnalysis.CallIndirect(
+                            caller,
+                            offset,
+                            token));
+                    break;
+                }
+                default:
+                    if (MethodSafetyAnalysis.InspectOperation(
+                            caller,
+                            opcode,
+                            offset,
+                            includeIndirectOpcodes)
+                        is { } operationEvidence)
+                    {
+                        unsafeEvidence.Add(operationEvidence);
+                    }
+                    break;
+            }
+        }
+    }
+
+    static string FormatCallOpcode(ILOpCode opcode) => opcode switch
+    {
+        ILOpCode.Callvirt => "callvirt",
+        ILOpCode.Newobj => "newobj",
+        ILOpCode.Ldftn => "ldftn",
+        ILOpCode.Ldvirtftn => "ldvirtftn",
+        ILOpCode.Calli => "calli",
+        _ => "call",
+    };
+
+    static CallKind ToCallKind(ILOpCode opcode) => opcode switch
+    {
+        ILOpCode.Call => CallKind.Call,
+        ILOpCode.Callvirt => CallKind.CallVirtual,
+        ILOpCode.Newobj => CallKind.NewObject,
+        ILOpCode.Ldftn => CallKind.LoadFunction,
+        _ => CallKind.LoadVirtualFunction,
+    };
+}


### PR DESCRIPTION
## Summary

- move direct and indirect call-site projection into `MethodCallAnalysis` behind the narrow metadata-dependent `IMethodCallResolver`
- preserve one canonical instruction traversal by delegating unsafe call/opcode policy to `MethodSafetyAnalysis` while reusing allocation-owned multiplicity
- append calls and safety evidence incrementally so results emitted before a later recoverable metadata failure remain visible to the existing method diagnostic path

## Evidence

- 619 Analysis tests pass in Release
- full Release solution build succeeds
- Analysis corpus gate reports 0 regressions; the two established baseline drifts (`ILInspector.Decompiler.dll` 45→47 and `Newtonsoft.Json.dll` 3→4 for `scan-method-in-loop-call`) remain unchanged
- changed Markdown passes `markdownlint`

## Compatibility and boundaries

`LibraryBodyIndex` remains the compatibility facade. The extraction preserves call ordering, opcode/kind mapping, return addresses, loop membership, same-assembly MethodSpec peeling, calli signature handling, allocation-derived multiplicity, and unsafe-evidence ordering. `LibraryBodyAnalysisBuilder` retains PE/body acquisition, throwing decode and CFG construction, metadata/generic-scope ownership, calli/member resolution, per-method diagnostics, optimization and resource analysis, and aggregation. No second decode, CFG build, metadata traversal, or instruction scan is introduced.
