### PR TITLE
Classify commit-pinned Azure SourceLink URLs as immutable

### DIFF
--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -244,7 +244,8 @@ network requests.
   filesystem-free hosts may run without one.
 - Positive availability and integrity results are cached permanently only when
   the provenance grammar establishes an immutable commit-pinned GitHub or Azure
-  DevOps URL; unknown hosts and moving or ambiguous selectors retain a TTL.
+  DevOps URL. Other availability results retain a TTL; integrity results for
+  unknown hosts and moving or ambiguous selectors are not cached.
 - Effective-section caches may summarize what sections are renderable, but must
   be invalidated when section semantics change.
 

--- a/docs/sourcelink-exposure.md
+++ b/docs/sourcelink-exposure.md
@@ -242,6 +242,9 @@ network requests.
 - Symbol-package PDB caches are identity-keyed to avoid multi-TFM collisions.
 - Source availability and integrity queries accept an optional host cache;
   filesystem-free hosts may run without one.
+- Positive availability and integrity results are cached permanently only when
+  the provenance grammar establishes an immutable commit-pinned GitHub or Azure
+  DevOps URL; unknown hosts and moving or ambiguous selectors retain a TTL.
 - Effective-section caches may summarize what sections are renderable, but must
   be invalidated when section semantics change.
 

--- a/src/DotnetInspector.Services/SourceLinkUrls.cs
+++ b/src/DotnetInspector.Services/SourceLinkUrls.cs
@@ -1,22 +1,11 @@
-using System.Text.RegularExpressions;
-
 namespace DotnetInspector.Services;
 
 /// <summary>
 /// Classifies SourceLink URLs by mutability. Only commit-pinned (content-addressed) URLs are
 /// immutable and therefore safe to cache permanently; everything else must be re-validated.
 /// </summary>
-public static partial class SourceLinkUrls
+public static class SourceLinkUrls
 {
-    /// <summary>
-    /// Matches URLs whose path embeds a full 40-hex commit SHA, e.g.
-    /// <c>https://raw.githubusercontent.com/&lt;org&gt;/&lt;repo&gt;/&lt;40-hex-sha&gt;/...</c>.
-    /// These are content-addressed: the bytes at the URL can never change.
-    /// </summary>
-    [GeneratedRegex(
-        @"^https://raw\.githubusercontent\.com/[^/]+/[^/]+/[0-9a-fA-F]{40}/",
-        RegexOptions.IgnoreCase)]
-    private static partial Regex ImmutableUrlRegex();
-
-    public static bool IsImmutable(string url) => ImmutableUrlRegex().IsMatch(url);
+    public static bool IsImmutable(string url) =>
+        SourceLinkFetch.SourceLinkProvenance.IsImmutableContentUrl(url);
 }

--- a/src/SourceLinkFetch/SourceLinkProvenance.cs
+++ b/src/SourceLinkFetch/SourceLinkProvenance.cs
@@ -266,6 +266,21 @@ public static class SourceLinkProvenance
     }
 
     /// <summary>
+    /// Reports whether a resolved source URL names content at an immutable commit origin.
+    /// </summary>
+    /// <remarks>
+    /// This is the cache-policy view of the provenance grammar. A URL is immutable only when the
+    /// same host-specific reader that attributes its repository and revision establishes a full
+    /// commit selector. Unknown hosts, moving refs, ambiguous selectors, and malformed URLs remain
+    /// mutable. Gated by <c>SourceLinkUrlsTests</c>.
+    /// </remarks>
+    public static bool IsImmutableContentUrl(string url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+        return TryReadOrigin(url, out _, out _);
+    }
+
+    /// <summary>
     /// Converts a resolved GitHub raw-content URL into a browsable URL for the same content.
     /// </summary>
     /// <returns>

--- a/src/dotnet-inspect.Tests/SourceLinkUrlsTests.cs
+++ b/src/dotnet-inspect.Tests/SourceLinkUrlsTests.cs
@@ -4,18 +4,38 @@ namespace DotnetInspector.Tests;
 
 public class SourceLinkUrlsTests
 {
+    private const string Sha = "4370ea16341331f045fa9b89cc46e03aed27195c";
+
     [Theory]
-    [InlineData("https://raw.githubusercontent.com/dotnet/dotnet/4370ea16341331f045fa9b89cc46e03aed27195c/src/a.cs")]
+    [InlineData($"https://raw.githubusercontent.com/dotnet/dotnet/{Sha}/src/a.cs")]
     [InlineData("https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json/0123456789abcdefABCDEF0123456789abcdef01/Src/b.cs")]
-    public void CommitPinnedUrls_AreImmutable(string url) =>
+    public void CommitPinnedGitHubUrls_AreImmutable(string url) =>
         Assert.True(SourceLinkUrls.IsImmutable(url));
 
     [Theory]
-    [InlineData("https://raw.githubusercontent.com/dotnet/dotnet/main/src/a.cs")]            // branch, not sha
-    [InlineData("https://raw.githubusercontent.com/dotnet/dotnet/v1.2.3/src/a.cs")]          // tag, not sha
-    [InlineData("https://raw.githubusercontent.com/dotnet/dotnet/abc123/src/a.cs")]          // short sha
-    [InlineData("https://example.com/dotnet/dotnet/4370ea16341331f045fa9b89cc46e03aed27195c/a.cs")] // other host
-    [InlineData("http://raw.githubusercontent.com/dotnet/dotnet/4370ea16341331f045fa9b89cc46e03aed27195c/a.cs")] // http
-    public void NonCommitPinnedUrls_AreMutable(string url) =>
+    [InlineData($"https://dev.azure.com/org/project/_apis/git/repositories/repo/items?api-version=1.0&versionType=commit&version={Sha}&path=/src/a.cs")]
+    [InlineData($"https://account.visualstudio.com/project/_apis/git/repositories/repo/items?api-version=1.0&versionType=commit&version={Sha}&path=/src/a.cs")]
+    [InlineData($"https://account.visualstudio.com/DefaultCollection/project/_apis/git/repositories/repo/items?api-version=1.0&versionType=commit&version={Sha}&path=/src/a.cs")]
+    public void CommitPinnedAzureDevOpsUrls_AreImmutable(string url) =>
+        Assert.True(SourceLinkUrls.IsImmutable(url));
+
+    [Theory]
+    [InlineData("https://raw.githubusercontent.com/dotnet/dotnet/main/src/a.cs")]
+    [InlineData("https://raw.githubusercontent.com/dotnet/dotnet/v1.2.3/src/a.cs")]
+    [InlineData("https://raw.githubusercontent.com/dotnet/dotnet/abc123/src/a.cs")]
+    public void MovingOrAmbiguousGitHubRefs_AreMutable(string url) =>
+        Assert.False(SourceLinkUrls.IsImmutable(url));
+
+    [Theory]
+    [InlineData($"https://dev.azure.com/org/project/_apis/git/repositories/repo/items?api-version=1.0&versionType=branch&version={Sha}&path=/src/a.cs")]
+    [InlineData("https://dev.azure.com/org/project/_apis/git/repositories/repo/items?api-version=1.0&versionType=commit&version=abc123&path=/src/a.cs")]
+    [InlineData($"https://dev.azure.com/org/project/_apis/git/repositories/repo/items?api-version=1.0&versionType=commit&version={Sha}&versionOptions=previousChange&path=/src/a.cs")]
+    public void MovingOrAmbiguousAzureDevOpsSelectors_AreMutable(string url) =>
+        Assert.False(SourceLinkUrls.IsImmutable(url));
+
+    [Theory]
+    [InlineData($"https://example.com/dotnet/dotnet/{Sha}/a.cs")]
+    [InlineData($"http://raw.githubusercontent.com/dotnet/dotnet/{Sha}/a.cs")]
+    public void CommitLikeUrlsOutsideKnownHttpsGrammars_AreMutable(string url) =>
         Assert.False(SourceLinkUrls.IsImmutable(url));
 }

--- a/tests/ILInspector.Metadata.Tests/SourceLinkProvenanceTests.cs
+++ b/tests/ILInspector.Metadata.Tests/SourceLinkProvenanceTests.cs
@@ -2271,11 +2271,11 @@ public class SourceLinkProvenanceTests
     /// reader fails here rather than being quietly tolerated.
     /// </para>
     /// <para>
-    /// Three entries are legitimate and stay. <c>LocalRepoSourceAcquisition</c> maps an
-    /// already-attributed URL onto a local git object, <c>SourceLinkUrls</c> classifies a URL as
-    /// content-addressed for caching, and <c>GitHubUrlResolver</c> builds a raw URL from a
-    /// github.com one. All three parse rather than match text, and none of them decides where
-    /// source came from. Comment text is ignored: naming the host in prose is not reading it.
+    /// Two non-attributing readers are legitimate and stay. <c>LocalRepoSourceAcquisition</c>
+    /// maps an already-attributed URL onto a local git object, and <c>GitHubUrlResolver</c> builds
+    /// a raw URL from a github.com one. Both parse rather than match text, and neither decides
+    /// where source came from. Comment text is ignored: naming the host in prose is not reading
+    /// it.
     /// </para>
     /// </remarks>
     [Fact]
@@ -2294,7 +2294,6 @@ public class SourceLinkProvenanceTests
             [
                 "DotnetInspector.Services/GitHubUrlResolver.cs",
                 "DotnetInspector.Services/LocalRepoSourceAcquisition.cs",
-                "DotnetInspector.Services/SourceLinkUrls.cs",
                 "SourceLinkFetch/SourceLinkProvenance.cs",
             ],
             readers);


### PR DESCRIPTION
Commit-pinned Azure DevOps SourceLink URLs now receive the same permanent positive-result cache policy as commit-pinned GitHub URLs. The cache classifier delegates to the canonical provenance grammar, so unknown hosts, moving refs, ambiguous selectors, malformed URLs, non-HTTPS URLs, and non-default ports remain conservative: availability entries are TTL-bound and mutable integrity results are not cached.

The change also separates positive and close-negative classifier cases by their actual refusal rule and updates the provenance-owner set gate now that `SourceLinkUrls` no longer parses a host itself.

Validation at head `c1730778cf61452062b7fa38a6560fae0261e877`:
- `dotnet build dotnet-inspect.slnx -c Release`
- Full CLI suite: 3528 passed, 4 platform skips
- `DotnetInspector.Services.Tests`: 416 passed
- `ILInspector.Metadata.Tests`: 1358 passed
- `SourceLinkUrlsTests`: 13 passed
- `markdownlint` and `git diff --check`

Closes #3597