### PR TITLE
Move Union Types to typed query

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -54,7 +54,7 @@ the ownership boundaries below, not the project count.
 `DotnetInspector.Queries` and the optional
 `DotnetInspector.ResearchQueries` companion now implement metadata-image,
 direct-reference, extension-method, custom-attribute, manifest-resource,
-type-forwarder, SourceLink audit, API-comparison, Analysis body-signal
+type-forwarder, union-type, SourceLink audit, API-comparison, Analysis body-signal
 comparison, Implementation comparison, assembly-context Integrations,
 implementation relationships, type/member search, extension reachability, and
 progressive member call-graph slices. The API-comparison seam retains
@@ -67,13 +67,13 @@ evidence over workspace-owned immutable snapshots; call graphs retain one
 catalog generation for both traversal directions. These queries return typed
 results without choosing a renderer or output format.
 The library CLI executes metadata-image, direct assembly-reference,
-extension-method, custom-attribute, manifest-resource, and type-forwarder
-queries through a typed, content-shaped registry over a host-owned
+extension-method, custom-attribute, manifest-resource, type-forwarder, and
+union-type queries through a typed, content-shaped registry over a host-owned
 `AssemblyInspectionSession`. The `References`, `Extension Methods`,
-`Custom Attributes`, `Resources`, `Type Forwarders`, and `Library Info`
-sections bind to concrete query definitions rather than string scanner keys,
-and the CLI and package convenience route lower section selection into that
-same registry. Library and package SourceLink sections
+`Custom Attributes`, `Resources`, `Type Forwarders`, `Union Types`, and
+`Library Info` sections bind to concrete query definitions rather than string
+scanner keys, and the CLI and package convenience route lower section
+selection into that same registry. Library and package SourceLink sections
 execute a shared document prerequisite plus availability or integrity query
 over a host-owned `SourceLinkService`. The library CLI and package
 `--all-libraries` route focused Integrations demand through the first workspace
@@ -265,7 +265,7 @@ consumer's convenience.
 ## Current migration state
 
 Metadata-image, direct-reference, extension-method, custom-attribute,
-manifest-resource, type-forwarder, SourceLink, API-comparison, Analysis
+manifest-resource, type-forwarder, union-type, SourceLink, API-comparison, Analysis
 body-signal comparison, Implementation comparison, and assembly-context
 Integrations inspection are the first vertical L1 canaries:
 
@@ -289,6 +289,9 @@ Integrations inspection are the first vertical L1 canaries:
 - `TypeForwardersQuery` returns metadata-ordered immutable forwarder facts
   shared by `Library Info` and `Type Forwarders`. The CLI adds path-based
   Finding provenance and compatibility projections after query execution.
+- `UnionTypesQuery` returns deeply immutable, metadata-ordered union facts for
+  `Union Types`. The CLI adds path-based Finding provenance and contains exact
+  metadata identity at the presentation row boundary.
 - `SourceLinkDocumentsQuery` may acquire one matching portable PDB and returns
   the typed source-document Finding inspection.
 - `SourceAvailabilityQuery` and `SourceIntegrityQuery` consume that prerequisite
@@ -317,10 +320,10 @@ Integrations inspection are the first vertical L1 canaries:
   immutable participant snapshots. The entire `@Integrations` section family
   is query-owned; the CLI retains only command hosting and projection.
 - Metadata sections, `References`, `Library Info`, `Extension Methods`,
-  `Custom Attributes`, `Resources`, `Type Forwarders`, and the diff `Changes`,
-  `Analysis Diff`, and `Implementation Diff` sections bind to query definitions
-  by object identity. A section may bind multiple definitions; diagnostic names
-  are never lookup keys.
+  `Custom Attributes`, `Resources`, `Type Forwarders`, `Union Types`, and the
+  diff `Changes`, `Analysis Diff`, and `Implementation Diff` sections bind to
+  query definitions by object identity. A section may bind multiple
+  definitions; diagnostic names are never lookup keys.
 - An executor can read only its declared transitive prerequisite results. A
   hidden dependency therefore fails whether or not another requested query
   happened to populate the shared run, and cannot understate cost.
@@ -371,8 +374,9 @@ establishes the L1 project and structural pattern, but the remaining facets and
 the L2 project split still need migration.
 
 The structural fix is completing L1. Outside the metadata, direct-reference,
-extension-method, custom-attribute, manifest-resource, type-forwarder, and
-SourceLink canaries, collection is still neither typed nor demand-driven:
+extension-method, custom-attribute, manifest-resource, type-forwarder,
+union-type, and SourceLink canaries, collection is still neither typed nor
+demand-driven:
 
 - Data collection **mutates a shared aggregate** rather than returning typed
   results for most scanner families, so a consumer cannot yet take those
@@ -380,7 +384,7 @@ SourceLink canaries, collection is still neither typed nor demand-driven:
 - The binding to residual collection is a **nullable string key** for the
   remaining scanner-backed sections. Metadata, `References`, `Library Info`,
   `Extension Methods`, `Custom Attributes`, `Resources`, `Type Forwarders`,
-  SourceLink, and the diff `Changes`, `Analysis Diff`, and
+  `Union Types`, SourceLink, and the diff `Changes`, `Analysis Diff`, and
   `Implementation Diff` sections use checked query-definition bindings.
 - The collection context is **path-shaped**, so a consumer without a filesystem
   cannot call the residual `LibraryMetadataService` orchestration. The

--- a/docs/design/section-pipeline.md
+++ b/docs/design/section-pipeline.md
@@ -70,15 +70,15 @@ The library catalog calls `WithoutComputedPoles`; it does not expose computed
 
 ```csharp
 registry.Add(
-    "UnionTypes",
+    "Switches",
     SectionCost.NetworkFree,
-    ctx => ctx.Model.UnionTypeInspection =
+    ctx => ctx.Model.SwitchInspection =
         ctx.Scan(
-            session => LibraryMetadataService.ScanUnionTypes(
+            session => LibraryMetadataService.ScanSwitches(
                 session,
                 ctx.AssemblyPath,
                 ctx.Logger),
-            () => LibraryMetadataService.ScanUnionTypes(
+            () => LibraryMetadataService.ScanSwitches(
                 ctx.AssemblyPath,
                 ctx.Logger)));
 ```
@@ -192,8 +192,10 @@ inspection are also typed query work. `Library Info` binds all four query
 definitions, while `Extension Methods`, `Custom Attributes`, `Resources`, and
 `Type Forwarders` each bind the definition for their detailed rows. One
 immutable result per facet therefore supplies the summary count and detailed
-rows without string scanner keys or duplicate metadata passes. A section may
-bind multiple typed queries; its effective cost is the maximum over every
+rows without string scanner keys or duplicate metadata passes. `Union Types`
+binds `UnionTypesQuery` for its detailed rows; the deeply immutable result
+preserves metadata order and exact identity until the row boundary. A section
+may bind multiple typed queries; its effective cost is the maximum over every
 query's prerequisite closure.
 
 ## Effectiveness

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -15,7 +15,7 @@ shared contracts, not dynamically loaded plugins.
 
 This document describes the target core architecture and the principles that
 govern its migration. Library metadata, direct-reference, extension-method,
-custom-attribute, manifest-resource, type-forwarder, SourceLink, and
+custom-attribute, manifest-resource, type-forwarder, union-type, SourceLink, and
 API-comparison inspection plus implementation-relationship and type/member
 search inspection are the first typed-query canaries: commands and section
 catalogs plan typed demand while queries remain independent of acquisition and
@@ -559,8 +559,9 @@ The existing `ScannerRegistry` remains an assembly-local predecessor: its
 explicit prerequisites, once-per-run resources, deterministic ordering, and
 tracing are useful foundations. `DotnetInspector.Queries` and its optional
 Research-backed companion now own typed metadata, direct-reference,
-extension-method, custom-attribute, manifest-resource, type-forwarder, SourceLink,
-API-comparison, and Analysis body-signal comparison plans. The Analysis query
+extension-method, custom-attribute, manifest-resource, type-forwarder,
+union-type, SourceLink, API-comparison, and Analysis body-signal comparison
+plans. The Analysis query
 consumes old/new `LibraryBodyIndex` collections and returns
 `ResearchComparison`; the diff CLI still owns lazy path-to-index acquisition as
 a transitional adapter. String keys, mutable CLI models, path-shaped residual

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,9 +11,10 @@ core: workspace contexts, typed query planning, acquisition and caching, shared
 identity and provenance, owner-issued correspondence, and safe presentation
 boundaries. Typed query-planning slices are implemented for library
 metadata-image, direct-reference, extension-method, custom-attribute,
-manifest-resource, type-forwarder, SourceLink, Integrations, implementation
-relationships, type/member search, extension reachability, API-comparison,
-Analysis body-signal comparison, and Implementation comparison inspection. The
+manifest-resource, type-forwarder, union-type, SourceLink, Integrations,
+implementation relationships, type/member search, extension reachability,
+API-comparison, Analysis body-signal comparison, and Implementation comparison
+inspection. The
 `diff` Changes, Analysis Diff, and Implementation Diff sections consume
 producer-owned comparison results over host-resolved surfaces, body indexes,
 and retained assembly content.
@@ -28,9 +29,10 @@ substrates, and inspection producers that will extend that space.
 - `src/DotnetInspector.Queries/` contains host-neutral typed query definitions,
   deterministic synchronous/asynchronous execution, prerequisite-aware cost,
   and content-shaped metadata, reference, extension-method, custom-attribute,
-  manifest-resource, type-forwarder, SourceLink, implementation-relationship,
-  type/member search, extension-reachability, API-comparison, and progressive
-  call-graph queries. It has no Markout, console, or filesystem-path dependency.
+  manifest-resource, type-forwarder, union-type, SourceLink,
+  implementation-relationship, type/member search, extension-reachability,
+  API-comparison, and progressive call-graph queries. It has no Markout,
+  console, or filesystem-path dependency.
 - `src/DotnetInspector.ResearchQueries/` contains the optional Research-backed
   L1 query family. It compares already-acquired Analysis body indexes and
   retained implementation assembly content, returning Research-owned results

--- a/src/DotnetInspector.Queries/UnionTypesQuery.cs
+++ b/src/DotnetInspector.Queries/UnionTypesQuery.cs
@@ -1,0 +1,39 @@
+using System.Collections.Immutable;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>Typed result of reading an assembly's discriminated-union types.</summary>
+public abstract record UnionTypesResult
+{
+    private UnionTypesResult()
+    {
+    }
+
+    /// <summary>The union types, in metadata order, which may be empty.</summary>
+    public sealed record Available(ImmutableArray<UnionTypeInfo> Unions) : UnionTypesResult;
+
+    /// <summary>The query failed while reading union types.</summary>
+    public sealed record Failed(Exception Error) : UnionTypesResult;
+}
+
+/// <summary>Reads discriminated-union types from an already-open assembly session.</summary>
+public static class UnionTypesQuery
+{
+    public static InspectionQuery<UnionTypesResult> Definition { get; } =
+        new("Union types", InspectionCost.NetworkFree);
+
+    public static UnionTypesResult Execute(AssemblyInspectionSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        try
+        {
+            return new UnionTypesResult.Available(session.UnionTypes().ToImmutableArray());
+        }
+        catch (Exception ex)
+        {
+            return new UnionTypesResult.Failed(ex);
+        }
+    }
+}

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -143,7 +143,10 @@ public sealed class AssemblyInspectionSession : IDisposable
 
     /// <summary>Discriminated-union types.</summary>
     public List<UnionTypeInfo> UnionTypes()
-        => UnionTypeScanner.Scan(_image.PEReader);
+    {
+        _image.EnsureAlive();
+        return UnionTypeScanner.Scan(_image.PEReader);
+    }
 
     /// <summary>Extension methods.</summary>
     public IEnumerable<ExtensionMethodInfo> ExtensionMethods(bool includeAll = false)

--- a/src/ILInspector.Metadata/UnionTypeScanner.cs
+++ b/src/ILInspector.Metadata/UnionTypeScanner.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -8,7 +9,7 @@ public record UnionTypeInfo(
     string TypeName,
     string Kind,
     bool ImplementsIUnion,
-    List<string> CaseTypes);
+    ImmutableArray<string> CaseTypes);
 
 /// <summary>
 /// Scans assemblies for C# union-shaped types.
@@ -36,7 +37,7 @@ public static class UnionTypeScanner
                 reader.GetFullTypeName(typeDef),
                 GetTypeKind(reader, typeDef),
                 ImplementsIUnion(reader, typeDef, context),
-                GetUnionCaseTypes(reader, typeDef).ToList()));
+                GetUnionCaseTypes(reader, typeDef).ToImmutableArray()));
         }
 
         return results;

--- a/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
+++ b/src/dotnet-inspect.Tests/LibraryFindingConsumerTests.cs
@@ -20,16 +20,56 @@ namespace DotnetInspector.Tests;
 public class LibraryFindingConsumerTests
 {
     [Fact]
-    public void UnionScanner_RetainsMetadataFindingInspection()
+    public void UnionTypesQueryProjection_RetainsMetadataFindingInspection()
     {
-        var inspection = LibraryMetadataService.ScanUnionTypes(
-            typeof(SampleDiscoveredUnion).Assembly.Location,
-            new VerboseLogger(enabled: false));
+        string path = typeof(SampleDiscoveredUnion).Assembly.Location;
+        using var session = AssemblyInspectionSession.Open(path);
+        var inspection = new LibraryInspection();
+
+        LibraryMetadataService.ApplyUnionTypesResult(
+            path,
+            inspection,
+            new VerboseLogger(enabled: false),
+            UnionTypesQuery.Execute(session));
 
         var finding = Assert.Single(
-            inspection.Findings(),
+            inspection.UnionTypeInspection.Findings(),
             finding => finding.Payload.TypeName == typeof(SampleDiscoveredUnion).FullName);
         Assert.Same(MetadataFindings.UnionTypeDescriptor, finding.Descriptor);
+    }
+
+    [Fact]
+    public void UnionTypesQueryProjection_PreservesIdentityUntilInertViewBoundary()
+    {
+        const string TypeName = "Sample.\u200B\u001b[31mForged";
+        const string Kind = "str\U000E0074uct";
+        const string CaseType = "Sample.Case\nError: forged";
+        var inspection = new LibraryInspection();
+
+        LibraryMetadataService.ApplyUnionTypesResult(
+            "hostile.dll",
+            inspection,
+            new VerboseLogger(enabled: false),
+            new UnionTypesResult.Available(
+                ImmutableArray.Create(
+                    new UnionTypeInfo(TypeName, Kind, true, [CaseType]))));
+
+        UnionTypeInfo payload = Assert.Single(
+            inspection.UnionTypeInspection.Findings()).Payload;
+        UnionTypeRow row = Assert.Single(
+            new LibraryInspectionView(inspection).UnionTypesSection!);
+
+        Assert.Equal(TypeName, payload.TypeName);
+        Assert.Equal(Kind, payload.Kind);
+        Assert.Equal([CaseType], payload.CaseTypes);
+        Assert.NotEqual(TypeName, row.Type);
+        Assert.NotEqual(Kind, row.Kind);
+        Assert.NotEqual(CaseType, row.Cases);
+        Assert.True(InertString.IsPermitted(TextPolicy.Field, row.Type));
+        Assert.True(InertString.IsPermitted(TextPolicy.Field, row.Kind));
+        Assert.True(InertString.IsPermitted(TextPolicy.Field, row.Cases));
+        Assert.DoesNotContain("\u200B", row.Type, StringComparison.Ordinal);
+        Assert.DoesNotContain("\U000E0074", row.Kind, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -284,7 +324,6 @@ public class LibraryFindingConsumerTests
         var logger = new VerboseLogger(enabled: false);
         var inspection = new LibraryInspection
         {
-            UnionTypeInspection = LibraryMetadataService.ScanUnionTypes(missingPath, logger),
             SwitchInspection = LibraryMetadataService.ScanSwitches(missingPath, logger),
         };
 
@@ -313,6 +352,12 @@ public class LibraryFindingConsumerTests
             logger,
             new TypeForwardersResult.Failed(
                 new FileNotFoundException("Type forwarder input was not found.", missingPath)));
+        LibraryMetadataService.ApplyUnionTypesResult(
+            missingPath,
+            inspection,
+            logger,
+            new UnionTypesResult.Failed(
+                new FileNotFoundException("Union type input was not found.", missingPath)));
 
         AssertFailure(inspection.ClassifiedMethodInspection, MetadataFindings.ClassifiedMethodDescriptor);
         AssertFailure(inspection.ExtensionMemberInspection, MetadataFindings.ExtensionMemberDescriptor);

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1520,6 +1520,19 @@ public class SectionPipelineTests
         Assert.Equal([TypeForwardersQuery.Definition], queries);
     }
 
+    [Fact]
+    public void LibraryPipeline_TargetedUnionTypes_OnlyRequiresItsQuery()
+    {
+        var pipeline = LibrarySections.CreatePipeline();
+        var include = new HashSet<string> { "Union Types" };
+
+        var scanners = pipeline.GetRequiredScanners(Verbosity.Minimal, include);
+        var queries = pipeline.GetRequiredQueries(Verbosity.Minimal, include);
+
+        Assert.Empty(scanners);
+        Assert.Equal([UnionTypesQuery.Definition], queries);
+    }
+
     // ===== Scanner registry tests =====
 
     [Fact]
@@ -1628,6 +1641,7 @@ public class SectionPipelineTests
                 SourceAvailabilityQuery.Definition,
                 SourceIntegrityQuery.Definition,
                 TypeForwardersQuery.Definition,
+                UnionTypesQuery.Definition,
             ],
             pipeline.DeclaredQueries.OrderBy(q => q.Name, StringComparer.Ordinal));
     }
@@ -2327,6 +2341,150 @@ public class SectionPipelineTests
             model.TypeForwarderInspection!.Value);
         Assert.Null(model.TypeForwarders);
         Assert.Equal("Type Forwarders", Assert.Single(model.InspectionFailures!).Section);
+    }
+
+    [Fact]
+    public void UnionTypesQuery_ReturnsMetadataOrderedUnionsFromBorrowedContent()
+    {
+        using var session = AssemblyInspectionSession.Open(
+            typeof(SampleDiscoveredUnion).Assembly.Location);
+
+        var result = Assert.IsType<UnionTypesResult.Available>(
+            UnionTypesQuery.Execute(session));
+
+        Assert.Contains(
+            result.Unions,
+            union => union.TypeName == typeof(SampleDiscoveredUnion).FullName);
+        Assert.Equal(
+            session.UnionTypes().Select(union =>
+                (union.TypeName,
+                    union.Kind,
+                    union.ImplementsIUnion,
+                    Cases: string.Join('\n', union.CaseTypes))),
+            result.Unions.Select(union =>
+                (union.TypeName,
+                    union.Kind,
+                    union.ImplementsIUnion,
+                    Cases: string.Join('\n', union.CaseTypes))));
+    }
+
+    [Fact]
+    public void UnionTypesQuery_UsesTheCommandsOpenImage()
+    {
+        string missingPath = Path.Combine(
+            Path.GetTempPath(),
+            $"missing-{Guid.NewGuid():N}.dll");
+        using var metadataContext = PdbContext.Open(
+            typeof(SampleDiscoveredUnion).Assembly.Location);
+        using var context = new ScannerContext
+        {
+            AssemblyPath = missingPath,
+            Model = new LibraryInspection(),
+            Logger = new Output.VerboseLogger(false),
+            MetadataContext = metadataContext,
+        };
+
+        InspectionQueryResults results = LibrarySections.CreateQueryRegistry().Run(
+            [UnionTypesQuery.Definition],
+            context);
+        var unions = Assert.IsType<UnionTypesResult.Available>(
+            results.Get(UnionTypesQuery.Definition));
+
+        Assert.Contains(
+            unions.Unions,
+            union => union.TypeName == typeof(SampleDiscoveredUnion).FullName);
+        Assert.Equal(1, context.SharedScanCount);
+    }
+
+    [Fact]
+    public void UnionTypesQuery_OpenFailureRemainsTyped()
+    {
+        string missingPath = Path.Combine(
+            Path.GetTempPath(),
+            $"missing-{Guid.NewGuid():N}.dll");
+        using var context = new ScannerContext
+        {
+            AssemblyPath = missingPath,
+            Model = new LibraryInspection(),
+            Logger = new Output.VerboseLogger(false),
+        };
+
+        InspectionQueryResults results = LibrarySections.CreateQueryRegistry().Run(
+            [UnionTypesQuery.Definition],
+            context);
+        var failure = Assert.IsType<UnionTypesResult.Failed>(
+            results.Get(UnionTypesQuery.Definition));
+
+        Assert.IsType<FileNotFoundException>(failure.Error);
+        Assert.Equal(0, context.SharedScanCount);
+    }
+
+    [Fact]
+    public void UnionTypesQuery_DisposedBorrowedSessionRemainsTyped()
+    {
+        using var lender = PdbContext.Open(
+            typeof(SampleDiscoveredUnion).Assembly.Location);
+        var session = AssemblyInspectionSession.Borrow(lender);
+        session.Dispose();
+
+        var failure = Assert.IsType<UnionTypesResult.Failed>(
+            UnionTypesQuery.Execute(session));
+
+        Assert.IsType<ObjectDisposedException>(failure.Error);
+    }
+
+    [Fact]
+    public void UnionTypesQuery_RetainedImageFailureDoesNotReopenPath()
+    {
+        using var metadataContext = PdbContext.Open(
+            typeof(LibraryInspection).Assembly.Location);
+        string reopenCanary = typeof(SampleDiscoveredUnion).Assembly.Location;
+        using (var canarySession = AssemblyInspectionSession.Open(reopenCanary))
+        {
+            Assert.Contains(
+                canarySession.UnionTypes(),
+                union => union.TypeName == typeof(SampleDiscoveredUnion).FullName);
+        }
+
+        using var context = new ScannerContext
+        {
+            AssemblyPath = reopenCanary,
+            Model = new LibraryInspection(),
+            Logger = new Output.VerboseLogger(false),
+            MetadataContext = metadataContext,
+        };
+        metadataContext.Dispose();
+
+        InspectionQueryResults results = LibrarySections.CreateQueryRegistry().Run(
+            [UnionTypesQuery.Definition],
+            context);
+        var failure = Assert.IsType<UnionTypesResult.Failed>(
+            results.Get(UnionTypesQuery.Definition));
+
+        Assert.IsType<ObjectDisposedException>(failure.Error);
+        Assert.Equal(0, context.SharedScanCount);
+    }
+
+    [Fact]
+    public void UnionTypesQuery_FailureRemainsTypedAndProjectsFindingFailure()
+    {
+        var session = AssemblyInspectionSession.Open(
+            typeof(SectionPipelineTests).Assembly.Location);
+        session.Dispose();
+        var model = new LibraryInspection();
+
+        var result = Assert.IsType<UnionTypesResult.Failed>(
+            UnionTypesQuery.Execute(session));
+        LibraryMetadataService.ApplyUnionTypesResult(
+            "disposed.dll",
+            model,
+            new Output.VerboseLogger(false),
+            result);
+
+        Assert.IsType<FindingInspection<UnionTypeInfo>.Failed>(
+            model.UnionTypeInspection!.Value);
+        Assert.Null(model.UnionTypes);
+        Assert.Equal("Union Types", Assert.Single(model.InspectionFailures!).Section);
     }
 
     [Fact]
@@ -3836,8 +3994,6 @@ public class SectionPipelineTests
         [
             // remains from ScanInfoCounts's fan-out
             LibrarySections.ScannerClassifiedMethods,
-            // workspace-backed library inspection must not reopen its package path
-            LibrarySections.ScannerUnionTypes,
             LibrarySections.ScannerSwitches,
             // was PopulateLibraryAudit running ScanClassifiedMethods on its own session
             LibrarySections.ScannerAuditSignals,
@@ -3988,6 +4144,7 @@ public class SectionPipelineTests
                 MetadataImageQuery.Definition,
                 ResourcesQuery.Definition,
                 TypeForwardersQuery.Definition,
+                UnionTypesQuery.Definition,
             ],
             requested.OrderBy(query => query.Name, StringComparer.Ordinal));
 
@@ -4408,7 +4565,6 @@ public class SectionPipelineTests
     private static readonly string[] SharedSessionScannerKeys =
     [
         LibrarySections.ScannerClassifiedMethods,
-        LibrarySections.ScannerUnionTypes,
         LibrarySections.ScannerSwitches,
         LibrarySections.ScannerAuditSignals,
     ];

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -297,8 +297,12 @@ internal static class LibraryMetadataService
                         inspection,
                         logger,
                         TypeForwardersQuery.Execute(session));
+                    ApplyUnionTypesResult(
+                        path,
+                        inspection,
+                        logger,
+                        UnionTypesQuery.Execute(session));
                     inspection.Apply(ScanClassifiedMethods(session, path, logger));
-                    inspection.UnionTypeInspection = ScanUnionTypes(session, path, logger);
                 }
 
                 catch (Exception ex)
@@ -1639,42 +1643,6 @@ internal static class LibraryMetadataService
         }
     }
 
-    internal static FindingInspection<UnionTypeInfo> ScanUnionTypes(
-        string path,
-        VerboseLogger logger)
-    {
-        try
-        {
-            using var session = AssemblyInspectionSession.Open(path);
-            return ScanUnionTypes(session, path, logger);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning($"Error scanning union types in {path}: {ex.Message}");
-            return FailedInspection<UnionTypeInfo>(
-                path, MetadataFindings.UnionTypeDescriptor, ex);
-        }
-    }
-
-    internal static FindingInspection<UnionTypeInfo> ScanUnionTypes(
-        AssemblyInspectionSession session,
-        string path,
-        VerboseLogger logger)
-    {
-        try
-        {
-            return MetadataFindings.InspectUnionTypes(
-                session.UnionTypes(),
-                FindingSubjectFor(path));
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning($"Error scanning union types in {path}: {ex.Message}");
-            return FailedInspection<UnionTypeInfo>(
-                path, MetadataFindings.UnionTypeDescriptor, ex);
-        }
-    }
-
     private static void ApplyQueryResults(
         string path,
         LibraryInspection inspection,
@@ -1727,6 +1695,13 @@ internal static class LibraryMetadataService
                 out TypeForwardersResult? typeForwarders))
         {
             ApplyTypeForwardersResult(path, inspection, logger, typeForwarders);
+        }
+
+        if (results.TryGet(
+                UnionTypesQuery.Definition,
+                out UnionTypesResult? unionTypes))
+        {
+            ApplyUnionTypesResult(path, inspection, logger, unionTypes);
         }
 
         if (results.TryGet(
@@ -1982,6 +1957,37 @@ internal static class LibraryMetadataService
             default:
                 throw new InvalidOperationException(
                     $"Unknown type-forwarders result '{result.GetType().Name}'.");
+        }
+    }
+
+    internal static void ApplyUnionTypesResult(
+        string path,
+        LibraryInspection inspection,
+        VerboseLogger logger,
+        UnionTypesResult result)
+    {
+        switch (result)
+        {
+            case UnionTypesResult.Available available:
+                inspection.UnionTypeInspection =
+                    MetadataFindings.InspectUnionTypes(
+                        available.Unions,
+                        FindingSubjectFor(path));
+                break;
+
+            case UnionTypesResult.Failed failed:
+                logger.LogWarning(
+                    $"Error scanning union types in {path}: {failed.Error.Message}");
+                inspection.UnionTypeInspection =
+                    FailedInspection<UnionTypeInfo>(
+                        path,
+                        MetadataFindings.UnionTypeDescriptor,
+                        failed.Error);
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown union-types result '{result.GetType().Name}'.");
         }
     }
 

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -21,7 +21,6 @@ public static class LibrarySections
     // Every key here must be registered in CreateScannerRegistry and declared by at least one
     // section. Gate: SectionPipelineTests.LibraryScannerRegistry_RegistrationMatchesDeclaration.
     public const string ScannerClassifiedMethods = "ClassifiedMethods";
-    public const string ScannerUnionTypes = "UnionTypes";
     public const string ScannerInfoCounts = "InfoCounts";
     public const string ScannerAuditSignals = "AuditSignals";
     public const string ScannerSwitches = "Switches";
@@ -136,7 +135,7 @@ public static class LibrarySections
             .Add<AsyncMethods>()
             .Add<Resources>(ResourcesQuery.Definition)
             .Add<CustomAttributes>(CustomAttributesQuery.Definition)
-            .Add<UnionTypes>()
+            .Add<UnionTypes>(UnionTypesQuery.Definition)
             .Add<TypeForwarders>(TypeForwardersQuery.Definition)
             .Add<NonNormalizedPaths>()
             .AddMetadataLens()
@@ -191,10 +190,6 @@ public static class LibrarySections
                 ctx.Model.Apply(ctx.Scan(
                     session => LibraryMetadataService.ScanClassifiedMethods(session, ctx.AssemblyPath, ctx.Logger),
                     () => LibraryMetadataService.ScanClassifiedMethods(ctx.AssemblyPath, ctx.Logger))))
-            .Add(ScannerUnionTypes, SectionCost.NetworkFree, ctx =>
-                ctx.Model.UnionTypeInspection = ctx.Scan(
-                    session => LibraryMetadataService.ScanUnionTypes(session, ctx.AssemblyPath, ctx.Logger),
-                    () => LibraryMetadataService.ScanUnionTypes(ctx.AssemblyPath, ctx.Logger)))
             .AddBundle(
                 ScannerInfoCounts,
                 ScannerClassifiedMethods)
@@ -305,6 +300,10 @@ public static class LibrarySections
                 ctx.Query(
                     TypeForwardersQuery.Execute,
                     ex => new TypeForwardersResult.Failed(ex)))
+            .Add(UnionTypesQuery.Definition, ctx =>
+                ctx.Query(
+                    UnionTypesQuery.Execute,
+                    ex => new UnionTypesResult.Failed(ex)))
             .AddSourceLinkQueries(RequireSourceLinkContext);
     }
 
@@ -838,7 +837,7 @@ public static class LibrarySections
     {
         public static string Name => SectionNames.UnionTypes;
         public static bool IsExpensive => false;
-        public static string? ScannerKey => ScannerUnionTypes;
+        public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model)
             => model.UnionTypeInspection.CanRenderWithPresence(model.HasUnionTypes);
     }

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -1824,17 +1824,23 @@ public record UnionTypeRow(
     string IUnion,
     string Cases)
 {
-    /// <inheritdoc cref="LibraryViewText"/>
-    public string Type { get; init; } = LibraryViewText.Contain(Type);
+    /// <summary>
+    /// Crosses exact union identity into field-safe presentation text.
+    /// Gate: LibraryFindingConsumerTests.UnionTypesQueryProjection_PreservesIdentityUntilInertViewBoundary.
+    /// </summary>
+    public string Type { get; init; } =
+        new InertString(TextPolicy.Field, Type).ToString();
 
-    /// <inheritdoc cref="LibraryViewText"/>
-    public string Kind { get; init; } = LibraryViewText.Contain(Kind);
+    /// <inheritdoc cref="Type"/>
+    public string Kind { get; init; } =
+        new InertString(TextPolicy.Field, Kind).ToString();
 
     [MarkoutPropertyName("IUnion")]
     public string IUnion { get; init; } = IUnion;
 
-    /// <inheritdoc cref="LibraryViewText"/>
-    public string Cases { get; init; } = LibraryViewText.Contain(Cases);
+    /// <inheritdoc cref="Type"/>
+    public string Cases { get; init; } =
+        new InertString(TextPolicy.Field, Cases).ToString();
 }
 
 [MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.Table)]

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -562,7 +562,7 @@ internal static class CorpusSensor
             return;
 
         var unions = UnionTypeScanner.Scan(pe)
-            .Where(union => union.ImplementsIUnion && union.CaseTypes.Count > 0)
+            .Where(union => union.ImplementsIUnion && union.CaseTypes.Length > 0)
             .ToArray();
         if (unions.Length == 0)
             return;


### PR DESCRIPTION
## What

Moves Union Types off the string-keyed `ScannerRegistry` and onto a typed,
content-shaped query demanded by the detailed `Union Types` section.

- adds `UnionTypesQuery`, returning metadata-ordered immutable
  `UnionTypeInfo` facts or a typed failure;
- makes each union's case collection deeply immutable;
- executes only against a live `AssemblyInspectionSession` and never accepts
  or reopens a path;
- removes `ScannerUnionTypes` and both path/session scanner adapters;
- keeps path-based Finding provenance, warnings, compatibility JSON, ordering,
  and failure reporting in the CLI;
- preserves exact union identity through query and Finding layers, then applies
  explicit `InertString(TextPolicy.Field)` containment at `UnionTypeRow`.

## Compatibility

Markdown, JSON, and traced stdout are byte-identical to exact base
`781be8d06e12cbc1d65dbc12c06338a42d65169e` on the repository's real
union-bearing test assembly. The only intentional observable change is the
diagnostic trace: `Union Types` now attributes demand to one `Union types`
query execution instead of the `UnionTypes` scanner, while borrowing the same
command-owned metadata image.

`Library Info` does not gain union-query demand, preserving its current cost
and output. Switches, classified methods, audit signals, and unbounded IL
analyses remain on the transitional scanner registry.

## Evidence

- Release solution build passed.
- `ILInspector.Metadata.Tests`: 1,358/1,358.
- `SectionPipelineTests`, `LibraryFindingConsumerTests`, and
  `UnionTypesSectionTests`: 284/284.
- Exact-base Markdown, JSON, and traced stdout matched byte-for-byte.
- Changed Markdown passed `markdownlint`.
- `git diff --check` passed.
