### PR TITLE
Prefer exact IL coordinate evidence

### DIFF
--- a/docs/workflows/debugging/il-coordinate-artifacts.md
+++ b/docs/workflows/debugging/il-coordinate-artifacts.md
@@ -132,10 +132,6 @@ return-address
 return address
 ```
 
-> **Known issue:** #3922 — derived evidence currently labels the exact call IL
-> offset as `cost` instead of `callsite`. The intended callsite assertion above
-> remains in place.
-
 ## 2. Collect a crash dump, normalize frames, and explain them
 
 > Goal: Show the end-to-end agent workflow: run an app, collect a crash dump,
@@ -306,10 +302,6 @@ allocation
 ```expect-not
 Performance Triage
 ```
-
-> **Known issue:** #3922 — the exact allocation offset is currently derived as
-> a return address for the preceding call. The intended `allocation` assertion
-> above remains in place.
 
 ## 4. Explain analyzer or CI artifact coordinates
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -11181,6 +11181,68 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_IlOffsetsFile_PrefersExactOperationIdentity()
+    {
+        static (int Token, int Offset) Coordinate(Type type, string methodName, byte opcode)
+        {
+            var method = type.GetMethod(
+                methodName,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)!;
+            var il = method.GetMethodBody()!.GetILAsByteArray()!;
+            var offset = Array.IndexOf(il, opcode);
+            Assert.True(offset >= 0, $"opcode 0x{opcode:X2} not found in {methodName}");
+            return (method.MetadataToken, offset);
+        }
+
+        var (allSignalsToken, virtualCallOffset) = Coordinate(
+            typeof(SemanticFactsFixture),
+            nameof(SemanticFactsFixture.AllSignals),
+            0x6F);
+        var (_, allocationOffset) = Coordinate(
+            typeof(SemanticFactsFixture),
+            nameof(SemanticFactsFixture.AllSignals),
+            0x8D);
+        var (unsafeToken, unsafeCallOffset) = Coordinate(
+            typeof(SemanticFactsFixture),
+            nameof(SemanticFactsFixture.UnsafeAs),
+            0x28);
+
+        var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
+        await File.WriteAllLinesAsync(
+            path,
+            [
+                $"hot-virtual-call 0x{allSignalsToken:X8}+0x{virtualCallOffset:X}",
+                $"allocation 0x{allSignalsToken:X8}+0x{allocationOffset:X}",
+                $"unsafe-call 0x{unsafeToken:X8}+0x{unsafeCallOffset:X}"
+            ],
+            TestContext.Current.CancellationToken);
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "library", TestAssemblyPath, "--il-offsets", path, "--json", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            using var document = JsonDocument.Parse(output);
+            var rows = document.RootElement.GetProperty("rows").EnumerateArray().ToArray();
+
+            var callsite = Assert.Single(rows, row => row.GetProperty("label").GetString() == "hot-virtual-call");
+            Assert.Equal("callsite", callsite.GetProperty("meaning").GetString());
+            Assert.Contains("virtual dispatch", callsite.GetProperty("evidence").GetString());
+
+            var allocation = Assert.Single(rows, row => row.GetProperty("label").GetString() == "allocation");
+            Assert.Equal("allocation", allocation.GetProperty("meaning").GetString());
+
+            var safety = Assert.Single(rows, row => row.GetProperty("label").GetString() == "unsafe-call");
+            Assert.Equal("safety", safety.GetProperty("meaning").GetString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task LibraryCommand_IlOffsetsFile_RejectsBadCoordinateLine()
     {
         var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -1007,8 +1007,8 @@ public class LibraryCommand
 
     private static (string Meaning, string Evidence) ExplainILCoordinate(ILOffsetProjection result)
     {
-        if (result.ReturnAddressContext is { } returnAddress)
-            return ("return address", $"call at {returnAddress.CallOffset} to {returnAddress.Callee}");
+        // A batch row has one primary meaning: exact operation identity wins over derived
+        // correspondence, while semantic facts can still provide the most useful evidence text.
         if (result.AllocationContext is { Count: > 0 } allocations)
         {
             var allocation = allocations[0];
@@ -1019,13 +1019,20 @@ public class LibraryCommand
             var safety = safetyFacts[0];
             return ("safety", $"{safety.SafetyKind} {safety.Operation}".Trim());
         }
+        if (result.CallsiteContext is { } callsite)
+        {
+            var evidence = result.CostContext is { Count: > 0 } callCosts
+                ? $"{callCosts[0].CostKind} {callCosts[0].Operation}".Trim()
+                : $"{callsite.Opcode} {callsite.Callee}";
+            return ("callsite", evidence);
+        }
         if (result.CostContext is { Count: > 0 } costFacts)
         {
             var cost = costFacts[0];
             return ("cost", $"{cost.CostKind} {cost.Operation}".Trim());
         }
-        if (result.CallsiteContext is { } callsite)
-            return ("callsite", $"{callsite.Opcode} {callsite.Callee}");
+        if (result.ReturnAddressContext is { } returnAddress)
+            return ("return address", $"call at {returnAddress.CallOffset} to {returnAddress.Callee}");
         if (result.ExceptionContext is { Count: > 0 } exceptions)
             return ("exception", string.Join(", ", exceptions.Select(e => $"{e.Context} {e.Clause}".Trim())));
         if (result.InstructionContext is { } instruction)


### PR DESCRIPTION
Sparse IL-coordinate summaries now preserve the exact operation at the named offset. Exact allocation, safety, and callsite identity wins over derived cost or return-address correspondence, while semantic detail remains available as evidence.

## Before and after

The same compiler-produced `AllSignals` coordinates previously rendered as:

```text
Label             IL Offset  Meaning         Evidence
hot-virtual-call  IL_0001    cost            virtual dispatch System.Collections.Generic.ICollection<int>.get_Count()
alloc-sample      IL_0006    return address  call at IL_0001 to System.Collections.Generic.ICollection<int>::get_Count()
```

The exact-head NativeAOT workflow now renders:

```text
Label             IL Offset  Meaning     Evidence
hot-virtual-call  IL_0001    callsite    virtual dispatch System.Collections.Generic.ICollection<int>.get_Count()
alloc-sample      IL_0006    allocation  array int[]
```

A genuine debugger return address remains unchanged:

```text
Label           IL Offset  Meaning         Evidence
return-address  IL_0007    return address  call at IL_0002 to System.Collections.Generic.IList<int>::get_Item(int)
```

## Why this is better

**Before was worse** because the primary `Meaning` could describe incidental context instead of the instruction at the requested coordinate. The exact virtual call was reduced to one analysis interpretation (`cost`), and the exact `newarr` was mislabeled from its positional coincidence with the preceding call. Agents and scripts could therefore misclassify an allocation as a stack-frame return address.

**After is better** because the row separates concerns: `Meaning` identifies the exact operation at the coordinate, while `Evidence` preserves useful semantic interpretation such as virtual dispatch. Derived return-address correspondence is selected only when no stronger exact operation identity exists. Exact safety classifications remain more specific than generic call identity.

The regression test uses compiler-produced fixture IL to pin the overlapping contexts for a virtual call, its following allocation, and an unsafe call. The resolved #3922 notes are removed from the coordinate-artifact workflow.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- Focused IL-coordinate command tests — 3 passed
- NativeAOT `osx-arm64` publish, version `0.17.0+525f7e7`, flavor `NativeAOT; .NET 11.0`
- `docs/workflows/debugging/il-coordinate-artifacts.md` — 6 passed, 0 failed, 0 skipped
- `npx markdownlint-cli docs/workflows/debugging/il-coordinate-artifacts.md`
- Current-head `ci-required` — passed
- GPT-5.6 Sol and Claude Opus 5 fixed-head reviews — clean

Local full CLI execution completed 3,493 tests successfully; 18 unrelated package/version/source tests failed because the configured NuGet feed could not resolve their packages. Current-head CI passed the full-suite gate.

Closes #3922