### PR TITLE
Preserve caller-scope output contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,9 @@ target. Bare `-S` returns high-value, fixed-length, network-free base sections.
 A single `type Type` uses `Type Info`, a type listing uses `API Info`, broad
 `member Type` summaries use `Method Groups`, `member Type -m Name` uses
 `Methods` overload rows, and a selected `member Type.Member:N` uses `Signature`.
+For a dotted `member Type.Member` target, metadata lookup first determines
+whether the final segment belongs to the type or implies a member, then
+discovery reports the matching pipeline.
 Lists for `-S`, `--columns`, and `--fields` accept commas or semicolons.
 Package and library expose authored categories rather than a computed `@All`;
 workflow categories such as `@Source` and `@Audit` expand to focused section

--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -111,6 +111,12 @@ performance, metadata, SourceLink, and other domains together.
 Commands not yet migrated may retain their existing discovery behavior. New
 work should follow the reference model rather than copy a legacy command.
 
+Structural discovery normally avoids target inspection. Dotted
+`member Type.Member` arguments are the exception because the last dot may also
+belong to a namespace-qualified or nested type. The command resolves that
+boundary against metadata first, then reports the structural schema of the
+resulting broad-member or overload-inventory pipeline.
+
 ## Network and source capabilities
 
 Package acquisition and symbol/source acquisition are separate.

--- a/src/CSharpText/FqnParser.cs
+++ b/src/CSharpText/FqnParser.cs
@@ -129,14 +129,37 @@ public static class FqnParser
         if (angleIdx <= 0)
             return typeName;
 
-        var closeIdx = typeName.LastIndexOf('>');
-        if (closeIdx <= angleIdx)
-            return typeName;
+        var normalized = new System.Text.StringBuilder(typeName.Length);
+        var segmentStart = 0;
+        while (angleIdx > 0)
+        {
+            var closeIdx = FindMatchingAngleBracket(typeName, angleIdx);
+            if (closeIdx < 0)
+                return typeName;
 
-        var baseName = typeName[..angleIdx];
-        int arity = CountTypeParameters(typeName.AsSpan((angleIdx + 1)..closeIdx));
-        var suffix = closeIdx + 1 < typeName.Length ? typeName[(closeIdx + 1)..] : "";
-        return $"{baseName}`{arity}{suffix}";
+            normalized.Append(typeName, segmentStart, angleIdx - segmentStart);
+            normalized.Append('`');
+            normalized.Append(CountTypeParameters(typeName.AsSpan((angleIdx + 1)..closeIdx)));
+            segmentStart = closeIdx + 1;
+            angleIdx = typeName.IndexOf('<', segmentStart);
+        }
+
+        normalized.Append(typeName, segmentStart, typeName.Length - segmentStart);
+        return normalized.ToString();
+    }
+
+    private static int FindMatchingAngleBracket(string value, int openIndex)
+    {
+        var depth = 0;
+        for (var i = openIndex; i < value.Length; i++)
+        {
+            if (value[i] == '<')
+                depth++;
+            else if (value[i] == '>' && --depth == 0)
+                return i;
+        }
+
+        return -1;
     }
 
     /// <summary>
@@ -151,6 +174,19 @@ public static class FqnParser
             var closeIdx = memberName.LastIndexOf('>');
             if (closeIdx > angleIdx && closeIdx == memberName.Length - 1)
                 memberName = memberName[..angleIdx];
+        }
+        else
+        {
+            var backtickIdx = memberName.LastIndexOf('`');
+            if (backtickIdx > 0
+                && backtickIdx < memberName.Length - 1
+                && memberName.AsSpan((backtickIdx + 1)..).IndexOfAnyExceptInRange('0', '9') < 0
+                && int.TryParse(
+                    memberName.AsSpan((backtickIdx + 1)..),
+                    System.Globalization.NumberStyles.None,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out _))
+                memberName = memberName[..backtickIdx];
         }
 
         return NormalizeOperatorOrSpecialMemberName(memberName);

--- a/src/ILInspector.Metadata/MemberTargetResolver.cs
+++ b/src/ILInspector.Metadata/MemberTargetResolver.cs
@@ -110,6 +110,15 @@ public sealed record MemberTargetSelector(
 
     static int? TryGetGenericArity(string value)
     {
+        var backtick = value.LastIndexOf('`');
+        if (backtick > 0
+            && int.TryParse(
+                value.AsSpan((backtick + 1)..),
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var metadataArity))
+            return metadataArity;
+
         var angleStart = value.IndexOf('<');
         if (angleStart <= 0)
             return null;

--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -328,14 +328,28 @@ public static class TypeMatcher
             };
         }
 
-        // Exact match via Matches (handles namespace prefix, generic arity, case-insensitive)
-        // When pattern has generic notation (e.g., Option<T>), prefer matching arity
-        var patternArity = GetPatternArity(pattern);
+        // Exact match via Matches (handles namespace prefix, generic arity, case-insensitive).
         var matches = list.Where(c => Matches(c, pattern)).ToList();
 
         if (matches.Count > 0)
         {
+            // Preserve every nested segment's arity before falling back to the legacy
+            // single-arity preference below. Otherwise Outer`1.Inner`2 and
+            // Outer`1.Inner`3 both compare only as Outer`1 and the first sibling wins.
+            var normalizedPattern = NormalizeForLookup(pattern);
+            var exactNormalizedMatch = matches.FirstOrDefault(candidate =>
+            {
+                var normalizedCandidate = NormalizeForLookup(candidate);
+                return normalizedCandidate.Equals(
+                           normalizedPattern,
+                           StringComparison.OrdinalIgnoreCase)
+                       || EndsWithDottedSuffix(normalizedCandidate, normalizedPattern);
+            });
+            if (exactNormalizedMatch != null)
+                return new LookupResult(exactNormalizedMatch, []);
+
             // If pattern specified arity (e.g., Option<T>), prefer candidate with matching arity
+            var patternArity = GetPatternArity(pattern);
             if (patternArity >= 0)
             {
                 var arityMatch = matches.FirstOrDefault(c => GetGenericArity(c) == patternArity);
@@ -343,7 +357,6 @@ public static class TypeMatcher
                     return new LookupResult(arityMatch, []);
             }
 
-            var normalizedPattern = FqnParser.NormalizeTypeName(pattern);
             var exactSimpleNameMatch = matches.FirstOrDefault(c =>
                 GetGenericArity(GetSimpleName(c)) == 0
                 && GetSimpleName(c).Equals(normalizedPattern, StringComparison.OrdinalIgnoreCase));

--- a/src/dotnet-inspect.Tests/ApiTypeLookupServiceTests.cs
+++ b/src/dotnet-inspect.Tests/ApiTypeLookupServiceTests.cs
@@ -62,6 +62,62 @@ public class ApiTypeLookupServiceTests
     }
 
     [Fact]
+    public void LookupType_GenericContainingTypeAndGenericMember_PeelsTrailingMember()
+    {
+        var api = new ApiSurface
+        {
+            Types =
+            [
+                new ApiType
+                {
+                    Namespace = "System.Collections.Generic",
+                    Name = "List`1",
+                    Members = [new ApiMember { Name = "ConvertAll", Kind = "method" }]
+                }
+            ]
+        };
+
+        var result = ApiTypeLookupService.LookupType(
+            api,
+            "System.Collections.Generic.List<T>.ConvertAll<TOutput>");
+
+        Assert.True(result.Found);
+        Assert.Equal("System.Collections.Generic.List`1", result.Match);
+        Assert.Equal("ConvertAll<TOutput>", result.ImpliedMember);
+    }
+
+    [Theory]
+    [InlineData("Dictionary<TKey, TValue>", "System.Collections.Generic.Dictionary`2")]
+    [InlineData(
+        "Dictionary<TKey, TValue>.KeyCollection",
+        "System.Collections.Generic.Dictionary`2.KeyCollection")]
+    [InlineData("Outer<T>.Inner<U>", "Example.Outer`1.Inner`1")]
+    public void LookupType_ExactGenericType_DoesNotPeelTrailingSegment(
+        string query,
+        string expected)
+    {
+        var api = new ApiSurface
+        {
+            Types =
+            [
+                new ApiType { Namespace = "System.Collections.Generic", Name = "Dictionary`2" },
+                new ApiType
+                {
+                    Namespace = "System.Collections.Generic",
+                    Name = "Dictionary`2.KeyCollection"
+                },
+                new ApiType { Namespace = "Example", Name = "Outer`1.Inner`1" }
+            ]
+        };
+
+        var result = ApiTypeLookupService.LookupType(api, query);
+
+        Assert.True(result.Found);
+        Assert.Equal(expected, result.Match);
+        Assert.Null(result.ImpliedMember);
+    }
+
+    [Fact]
     public void LookupType_SimpleTypeMember_PeelsTrailingMember()
     {
         var api = CreateSurface();

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -8975,6 +8975,56 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_PreResolvedAnnotatedSourceDocumentJson_IgnoresStaleSelector()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(CommandCaretGestureFixture).FullName!,
+                AssemblyPath = TestAssemblyPath,
+                MemberFilter = [nameof(CommandCaretGestureFixture.Pump)],
+                OverloadIndex = 1,
+                Select = [SectionNames.Methods],
+                IncludeSections = [SectionNames.AnnotatedSourceDocument],
+                JsonOutput = true,
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        using var document = JsonDocument.Parse(result.Output);
+        Assert.True(document.RootElement.TryGetProperty("text", out _));
+        Assert.False(document.RootElement.TryGetProperty("name", out _));
+    }
+
+    [Fact]
+    public async Task Member_PreResolvedAnnotatedSourceDocumentJson_RejectsAuthoritativeComposition()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(CommandCaretGestureFixture).FullName!,
+                AssemblyPath = TestAssemblyPath,
+                MemberFilter = [nameof(CommandCaretGestureFixture.Pump)],
+                OverloadIndex = 1,
+                Select = [SectionNames.Methods],
+                IncludeSections =
+                [
+                    SectionNames.AnnotatedSourceDocument,
+                    SectionNames.Signature
+                ],
+                JsonOutput = true,
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(
+            $"section '{SectionNames.AnnotatedSourceDocument}' must be the only selected section under --json.",
+            result.Error);
+    }
+
+    [Fact]
     public async Task Member_AnnotatedSourceDocument_UsesTheSyntaxThePrinterSelected()
     {
         await AssertNodeKind(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4999,6 +4999,217 @@ public partial class CommandExecutionTests
         Assert.NotEmpty(sections);
     }
 
+    [Fact]
+    public async Task Member_DottedOverloadInventory_BareSelectUsesActualPipeline()
+    {
+        var dotted = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializer.Serialize",
+            "--platform", "System.Text.Json",
+            "-S", "--tips", "q");
+        var explicitMember = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializer",
+            "--platform", "System.Text.Json",
+            "-m", "Serialize", "-S", "--tips", "q");
+
+        Assert.Equal(0, dotted.Exit);
+        Assert.Equal(explicitMember.Exit, dotted.Exit);
+        Assert.Equal(explicitMember.Output, dotted.Output);
+        Assert.Contains("## Methods", dotted.Output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("--count")]
+    [InlineData("--tsv")]
+    public async Task Member_DottedOverloadInventory_GlobCardinalityUsesActualPipeline(
+        string format)
+    {
+        var dotted = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializer.Serialize",
+            "--platform", "System.Text.Json",
+            "-S", "Member*", format, "--tips", "q");
+        var explicitMember = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializer",
+            "--platform", "System.Text.Json",
+            "-m", "Serialize", "-S", "Member*", format, "--tips", "q");
+
+        Assert.Equal(0, dotted.Exit);
+        Assert.Equal(explicitMember.Exit, dotted.Exit);
+        Assert.Equal(explicitMember.Output, dotted.Output);
+        Assert.Equal(explicitMember.Error, dotted.Error);
+        Assert.NotEqual(string.Empty, dotted.Output.Trim());
+    }
+
+    [Fact]
+    public async Task Member_DottedOverloadInventory_MultiSectionGlobFailsActualCardinality()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.String.Clone", "--platform", "System.Runtime",
+            "-S", "Call*", "--count", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Equal(string.Empty, output.Trim());
+        Assert.Contains(CountOutput.SingleSectionRequiredMessage, error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Member_DottedOverloadInventory_AcceptsOverloadOnlySection()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.String.Clone", "--platform", "System.Runtime",
+            "-S", SectionNames.SourceLocations, "--count", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal("1", output.Trim());
+        Assert.Equal(string.Empty, error);
+    }
+
+    [Fact]
+    public async Task Member_DottedOverloadInventory_SchemaUsesActualPipeline()
+    {
+        var broadOnly = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializer.Serialize",
+            "--platform", "System.Text.Json",
+            "-D", SectionNames.MethodGroups, "--schema", "--count", "--tips", "q");
+        var sourceLocations = await RunAppAsync(
+            "member", "System.Text.Json.JsonSerializer.Serialize",
+            "--platform", "System.Text.Json",
+            "-D", SectionNames.SourceLocations, "--schema", "--count", "--tips", "q");
+
+        Assert.Equal(1, broadOnly.Exit);
+        Assert.Equal(string.Empty, broadOnly.Output.Trim());
+        Assert.Contains($"Section '{SectionNames.MethodGroups}' not found.", broadOnly.Error, StringComparison.Ordinal);
+        Assert.Equal(0, sourceLocations.Exit);
+        Assert.NotEqual(string.Empty, sourceLocations.Output.Trim());
+    }
+
+    [Fact]
+    public async Task Member_DottedStructuralSchema_IgnoresSelectLikeExplicitMemberForm()
+    {
+        var dotted = await RunAppAsync(
+            "member", "System.String.Clone", "--platform", "System.Runtime",
+            "-D", "--schema", "-S", "Bogus", "--tips", "q");
+        var explicitMember = await RunAppAsync(
+            "member", "System.String", "--platform", "System.Runtime",
+            "-m", "Clone", "-D", "--schema", "-S", "Bogus", "--tips", "q");
+
+        Assert.Equal(0, dotted.Exit);
+        Assert.Equal(explicitMember.Exit, dotted.Exit);
+        Assert.Equal(explicitMember.Output, dotted.Output);
+        Assert.Equal(explicitMember.Error, dotted.Error);
+        Assert.DoesNotContain("Bogus", dotted.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Member_AutoSelectedDetail_PreservesAdvertisedInventorySections()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.String.Clone", "--platform", "System.Runtime",
+            "-S", SectionNames.Methods, "-S", SectionNames.Signature, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains($"## {SectionNames.Methods}", output);
+        Assert.Contains($"## {SectionNames.Signature}", output);
+    }
+
+    [Fact]
+    public async Task Member_DuplicateAllSelectors_AreIdempotent()
+    {
+        var single = await RunAppAsync(
+            "member", "System.String.Clone", "--platform", "System.Runtime",
+            "-S", SelectResolver.AllSelector, "--tips", "q");
+        var duplicate = await RunAppAsync(
+            "member", "System.String.Clone", "--platform", "System.Runtime",
+            "-S", SelectResolver.AllSelector, "-S", SelectResolver.AllSelector, "--tips", "q");
+
+        Assert.Equal(single.Exit, duplicate.Exit);
+        Assert.Equal(single.Output, duplicate.Output);
+        Assert.Equal(single.Error, duplicate.Error);
+    }
+
+    [Fact]
+    public async Task Member_AutoSelectedDetail_RendersRequestedTypeShapeSection()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Collections.Generic.List<T>.TrimExcess",
+            "--platform", "System.Collections",
+            "-S", SectionNames.TypeParameters, "-S", SectionNames.Signature, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains($"## {SectionNames.TypeParameters}", output);
+        Assert.Contains($"## {SectionNames.Signature}", output);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("--table")]
+    [InlineData("--tsv")]
+    [InlineData("--jsonl")]
+    [InlineData("--json")]
+    public async Task Member_InapplicableBodySection_CountReportsNoDataAfterAutoSelection(
+        string? ignoredFormat)
+    {
+        List<string> args =
+        [
+            "member", "System.String.Empty", "--platform", "System.Runtime",
+            "-S", SectionNames.IL, "--count", "--tips", "q"
+        ];
+        if (ignoredFormat is not null)
+            args.Add(ignoredFormat);
+
+        var (exit, output, error) = await RunAppAsync([.. args]);
+
+        Assert.Equal(0, exit);
+        Assert.Equal("0", output.Trim());
+        Assert.Contains(
+            $"section '{SectionNames.IL}' has no data",
+            error,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Member_DottedLookup_ReportsTreeFormatConflictBeforeLookup()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "Missing.Type.Member", "--platform", "System.Runtime",
+            "-S", SectionNames.CallGraph, "--tree", "--json", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Equal(string.Empty, output.Trim());
+        Assert.Contains(
+            "--tree is a standalone output format and cannot combine with another output format.",
+            error,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("not found", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Member_DottedLookup_ReportsSelectorlessCountErrorBeforeLookup()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "Missing.Type.Member", "--platform", "System.Runtime",
+            "--count", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Equal(string.Empty, output.Trim());
+        Assert.Contains(CountOutput.SingleSectionRequiredMessage, error, StringComparison.Ordinal);
+        Assert.DoesNotContain("not found", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Type_TypeInfo_ProjectsSynthesizedFactTableColumns()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "System.String", "--platform", "System.Runtime",
+            "-S", SectionNames.TypeInfo, "--tsv", "--columns", "Field", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.StartsWith("field\n", output, StringComparison.Ordinal);
+        Assert.Contains("\nType\n", output, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error);
+    }
+
     private static List<string> SectionHeadings(string output) =>
         [.. output.Split('\n')
             .Select(line => line.TrimEnd('\r'))
@@ -17499,11 +17710,65 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_DottedImpliedMemberWithDistinctGenericSelector_IsRejected()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.MemoryExtensions.Contains",
+            "--platform", "System.Memory",
+            "-m", "AsSpan<T>", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("requires exactly one member name", error);
+    }
+
+    [Fact]
+    public async Task Member_DottedImpliedMemberWithConflictingGenericArity_IsRejected()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member",
+            $"{typeof(MemberGenericSelectorFixture).FullName!}.GenericChoice<T>",
+            "--library", TestAssemblyPath,
+            "-m", "GenericChoice<T1,T2>", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("cannot combine different generic arities", error);
+    }
+
+    [Fact]
+    public async Task Member_DottedImpliedMemberWithMatchingGenericArity_Resolves()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member",
+            $"{typeof(MemberGenericSelectorFixture).FullName!}.GenericChoice<T>",
+            "--library", TestAssemblyPath,
+            "-m", "GenericChoice<TValue>", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("GenericChoice<T>", output);
+        Assert.DoesNotContain("GenericChoice(string value)", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Member_GenericContainingTypeAndGenericMethod_ResolvesTheMember()
     {
         var (exit, output, error) = await RunAppAsync(
             "member", "System.Collections.Generic.List<T>.ConvertAll<TOutput>",
             "--platform", "System.Collections",
+            "-S", "Signature", "--count", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal("1", output.Trim());
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_SourcelessGenericContainingTypeAndGenericMethod_ResolvesTheMember()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Collections.Generic.List<T>.ConvertAll<TOutput>",
             "-S", "Signature", "--count", "--tips", "q");
 
         Assert.Equal(0, exit);

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -13316,29 +13316,30 @@ public partial class CommandExecutionTests
     [Fact]
     public async Task LibraryCommand_IlOffsetsFile_PrefersExactOperationIdentity()
     {
-        static (int Token, int Offset) Coordinate(Type type, string methodName, byte opcode)
+        static (int Token, int Offset) Coordinate(Type type, string methodName, ILOpCode opcode)
         {
             var method = type.GetMethod(
                 methodName,
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)!;
-            var il = method.GetMethodBody()!.GetILAsByteArray()!;
-            var offset = Array.IndexOf(il, opcode);
-            Assert.True(offset >= 0, $"opcode 0x{opcode:X2} not found in {methodName}");
-            return (method.MetadataToken, offset);
+            var instruction = InstructionDecoder
+                .Decode(method.GetMethodBody()!.GetILAsByteArray()!)
+                .FirstOrDefault(candidate => candidate.OpCode == opcode);
+            Assert.NotNull(instruction);
+            return (method.MetadataToken, instruction.Offset);
         }
 
         var (allSignalsToken, virtualCallOffset) = Coordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.AllSignals),
-            0x6F);
+            ILOpCode.Callvirt);
         var (_, allocationOffset) = Coordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.AllSignals),
-            0x8D);
+            ILOpCode.Newarr);
         var (unsafeToken, unsafeCallOffset) = Coordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.UnsafeAs),
-            0x28);
+            ILOpCode.Call);
 
         var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
         await File.WriteAllLinesAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2029,6 +2029,32 @@ public partial class CommandExecutionTests
         Assert.Contains("| Source | Platform |", factOutput, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("System.Collections.Frozen.FrozenDictionary`2.AlternateLookup`1")]
+    [InlineData("System.Collections.Frozen.FrozenDictionary<TKey,TValue>.AlternateLookup<TAlternateKey>")]
+    public async Task BareNestedGenericPlatformType_RoutesToWholeType(string typeName)
+    {
+        var (exit, output, error) = await RunAppAsync(typeName, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("System.Collections.Frozen.FrozenDictionary", output);
+        Assert.Contains("AlternateLookup", output);
+    }
+
+    [Fact]
+    public async Task BareForwardedNestedGenericPlatformType_RoutesToDeclaringType()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.Collections.Generic.List`1.Enumerator",
+            "--markdown", "-v", "m", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains(".Enumerator", output);
+        Assert.Contains("Kind: struct", output);
+    }
+
     /// <summary>
     /// A dotted prefix that does not resolve to a type enters the preamble looking like a single
     /// type -- so its sections are validated against the single-type pipeline -- but renders a
@@ -3741,6 +3767,20 @@ public partial class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains("public void Run(", output);
+    }
+
+    [Fact]
+    public async Task BareQualifiedAspNetCoreGenericMember_RoutesAcrossPlatformFrameworks()
+    {
+        SkipUnlessAspNetCoreAvailable();
+
+        var (exit, output, error) = await RunAppAsync(
+            "member", "Microsoft.AspNetCore.Components.EventCallback<T>.InvokeAsync",
+            "-S", "Methods", "--count", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.True(int.Parse(output.Trim(), CultureInfo.InvariantCulture) > 0);
+        Assert.Empty(error);
     }
 
     [Fact]
@@ -8944,18 +8984,170 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Member_BareNameCallerScope_AmbiguousOverloadReportsSelectorHint()
+    public async Task Member_BareNameCallerScope_AggregatesAmbiguousOverloads()
     {
         var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
         var (exit, output, error) = await RunAppAsync(
             "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
             nameof(MemberCallsFixture.Overloaded), "--bin", testDirectory, "--tips", "q");
 
-        Assert.Equal(1, exit);
-        Assert.Empty(output);
-        Assert.Contains("section 'Callers' requires a single selected overload", error);
-        Assert.Contains("Overloaded~<digest>", error);
-        Assert.Contains("Overloaded:1 through Overloaded:2", error);
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            2,
+            output.Split(
+                nameof(MemberCallsFixture.CallsOverloaded),
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("## Callers", output);
+        Assert.Contains($"# {typeof(MemberCallsFixture).FullName}", output);
+        Assert.Empty(error);
+        Assert.DoesNotContain("requires a single selected overload", error);
+    }
+
+    [Fact]
+    public async Task Member_BareNameCallerScope_EmptyAggregateRendersEmptyState()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallsFixture.UnusedOverloaded), "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Callers", output);
+        Assert.Contains("No callers found", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_BarePropertyNameCallerScope_AggregatesAccessorOverloads()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberPropertyCallsFixture).FullName!, "--library", TestAssemblyPath,
+            "Item", "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            2,
+            output.Split(
+                nameof(MemberPropertyCallsFixture.CallsIndexers),
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("## Callers", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_BareSelectSingleOverloadCallerScope_DoesNotAnalyzeOtherMembers()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallGraphFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallGraphFixture.NoCalls), "--bin", testDirectory,
+            "-S", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Callers", output);
+        Assert.Contains("No callers found", output);
+        Assert.DoesNotContain(nameof(MemberCallGraphFixture.LoopHeavyCall), output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_MultipleNamesCallerScope_AnalyzesOnlySelectedMembers()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallGraphFixture).FullName!, "--library", TestAssemblyPath,
+            "-m", nameof(MemberCallGraphFixture.Mid),
+            "-m", nameof(MemberCallGraphFixture.NoCalls),
+            "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Callers", output);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), output);
+        Assert.DoesNotContain(nameof(MemberCallGraphFixture.LoopHeavyCall), output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_AbstractMethodFamilyCallerScope_IncludesAbstractOverloads()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberAbstractCallsFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberAbstractCallsFixture.Mixed), "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            2,
+            output.Split(
+                nameof(MemberAbstractCallsFixture.CallsMixed),
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("## Callers", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_AbstractPropertyFamilyCallerScope_IncludesAbstractAccessors()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberAbstractPropertyCallsFixture).FullName!,
+            "--library", TestAssemblyPath,
+            "Item", "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            2,
+            output.Split(
+                nameof(MemberAbstractPropertyCallsFixture.CallsIndexers),
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("## Callers", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_FilteredSolePropertyCallerScope_DoesNotReintroduceItsAccessors()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberOnlyPropertyCallsFixture).FullName!,
+            "--library", TestAssemblyPath,
+            "Solo", "-k", "method", "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("## Callers", output);
+        Assert.DoesNotContain(nameof(MemberOnlyPropertyCallerFixture.CallsSolo), output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_ForwardedTypeCallerScope_UsesImplementationAssembly()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.String", "IndexOf", "--platform", "System.Runtime",
+            "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Callers", output);
+        Assert.Contains("| `System.", output);
+        Assert.DoesNotContain("No callers found", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_DocumentJsonWithCallerScope_PreservesOverloadInventory()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallsFixture.Overloaded), "--bin", testDirectory,
+            "--json", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        Assert.Equal(2, document.RootElement.GetProperty("members").GetArrayLength());
     }
 
     [Fact]
@@ -17653,6 +17845,19 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_OverflowingGenericArity_DoesNotBroadenSelection()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.String", "ToString`999999999999999999999:1",
+            "--platform", "System.Private.CoreLib",
+            "-S", SectionNames.Signature, "--count", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("No members matched filter", error);
+    }
+
+    [Fact]
     public async Task Member_GenericMethodSelector_MemberIndexSelectorRoundTrips()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -17713,9 +17918,8 @@ public partial class CommandExecutionTests
     public async Task Member_DottedImpliedMemberWithDistinctGenericSelector_IsRejected()
     {
         var (exit, output, error) = await RunAppAsync(
-            "member", "System.MemoryExtensions.Contains",
-            "--platform", "System.Memory",
-            "-m", "AsSpan<T>", "--tips", "q");
+            "member", "System.MemoryExtensions.Contains", "--platform", "System.Memory",
+            "-m", "AsSpan<T>", "-S", "Methods", "--count", "--tips", "q");
 
         Assert.Equal(1, exit);
         Assert.Empty(output);

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -17448,6 +17448,31 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_GenericContainingTypeAndGenericMethod_ResolvesTheMember()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Collections.Generic.List<T>.ConvertAll<TOutput>",
+            "--platform", "System.Collections",
+            "-S", "Signature", "--count", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal("1", output.Trim());
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_SourcelessGenericShiftOperator_ResolvesTheMember()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Numerics.Vector<T>.operator<<",
+            "-S", SectionNames.Signature, "--count", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal("1", output.Trim());
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Member_GenericTypeName_DoesNotAdmitMemberDetailSections()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -425,6 +425,22 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    public async Task CallerScope_ImplicitCallers_DoesNotRequireOneOverload()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallsFixture).FullName!,
+            AssemblyPath = typeof(MemberCallsFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallsFixture.Overloaded)],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallsFixture).Assembly.Location)!],
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("requires a single selected overload", result.Error);
+    }
+
+    [Fact]
     public async Task CallerScope_DoesNotAcquireScopeForNonGraphSelection()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -2,12 +2,189 @@ using DotnetInspector.Commands;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Sections;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Tests;
 
 [Collection("Console")]
 public class MemberCallGraphSectionTests
 {
+    [Fact]
+    public async Task PreResolvedSection_OverridesStaleRawSelector()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            Select = [SectionNames.Methods],
+            IncludeSections = [SectionNames.Signature],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("1", result.Output.Trim());
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public async Task EmptyPreResolvedSection_DoesNotResolveStaleRawSelector()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            Select = [SectionNames.Methods],
+            IncludeSections = [],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(CountOutput.SingleSectionRequiredMessage, result.Error);
+    }
+
+    [Fact]
+    public async Task EmptyPreResolvedSection_ValidatesBeforeAcquisition()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = "Missing.Type.Member",
+            AssemblyPath = Path.Combine(Path.GetTempPath(), "missing-member-selection.dll"),
+            Select = [SectionNames.Methods],
+            IncludeSections = [],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(CountOutput.SingleSectionRequiredMessage, result.Error);
+        Assert.DoesNotContain("not found", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task EmptyPreResolvedSection_SelectsNoDefaultSections()
+    {
+        var options = new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Detailed,
+        };
+
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(options));
+        var type = new ApiType
+        {
+            Name = "Fixture",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = nameof(MemberCallGraphFixture.RootCall),
+                    Kind = "method",
+                    MetadataToken = 0x06000001
+                }
+            ]
+        };
+        var resolvedOptions = options with { MemberSectionsPreResolved = true };
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("## ", result.Output);
+        Assert.Empty(ApiCommand.GetRequestedMemberSections(type, resolvedOptions));
+        Assert.Empty(
+            ApiOutputFormatter.BuildTypeWriterOptions(type, resolvedOptions).IncludeSections!);
+        Assert.Empty(
+            ApiMemberSectionPipelines.Create(resolvedOptions).GetDiscoverableSections(
+                type,
+                resolvedOptions.IncludeSections,
+                explicitInclude: true));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task EmptyPreResolvedSection_SelectsNoDefaultTabularRows(
+        bool tsv,
+        bool jsonl)
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallGraphFixture).FullName!,
+                AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+                IncludeSections = [],
+                Tabular = true,
+                Tsv = tsv,
+                Jsonl = jsonl,
+                TipLevel = TipLevel.Quiet,
+                Verbosity = Verbosity.Detailed
+            }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.Output.Trim());
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public async Task PreResolvedDetailSection_IgnoresStaleAllSelectorDuringAutoSelection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            Select = [SelectResolver.AllSelector],
+            IncludeSections = [SectionNames.Signature],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("1", result.Output.Trim());
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public void PreResolvedDetailSections_IgnoreStaleAllSelectorDuringFormatting()
+    {
+        var type = new ApiType
+        {
+            Name = "Fixture",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = nameof(MemberCallGraphFixture.RootCall),
+                    Kind = "method",
+                    MetadataToken = 0x06000001,
+                    Signature = "public void RootCall()"
+                }
+            ]
+        };
+        var options = new MemberOptions
+        {
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            OverloadIndex = 1,
+            Select = [SelectResolver.AllSelector],
+            IncludeSections = [SectionNames.Signature, SectionNames.CallGraph],
+            MemberSectionsPreResolved = true,
+        };
+
+        var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, options);
+
+        Assert.Equal(
+            [SectionNames.Summary, SectionNames.Signature, SectionNames.CallGraph],
+            writerOptions.IncludeSections);
+    }
+
     [Fact]
     public async Task CallGraphSection_RendersEdgeTableByDefault()
     {

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -366,6 +366,214 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    public async Task CallerScope_DoesNotInvalidateCallGraphCount()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.CallGraph],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(int.TryParse(result.Output.Trim(), out var count));
+        Assert.True(count > 0, "fixture must produce a non-empty graph");
+    }
+
+    [Fact]
+    public async Task CallerScope_DoesNotInvalidateCallGraphTabularOutput()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.CallGraph],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Tabular = true,
+            Tsv = true,
+            TabularExplicitlySet = true,
+            FormatExplicitlySet = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.StartsWith("from\t", result.Output, StringComparison.Ordinal);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), result.Output);
+    }
+
+    [Fact]
+    public async Task CallerScope_WithTabularOutputAndNoSelection_StillSelectsCallers()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.Inner)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Tabular = true,
+            Tsv = true,
+            TabularExplicitlySet = true,
+            FormatExplicitlySet = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.StartsWith("caller\t", result.Output, StringComparison.Ordinal);
+        Assert.Contains(nameof(MemberCallGraphFixture.Mid), result.Output);
+    }
+
+    [Fact]
+    public async Task CallerScope_DoesNotAcquireScopeForNonGraphSelection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            OverloadIndex = 1,
+            IncludeSections = [SectionNames.Signature],
+            CallerScopeDirectories = ["/definitely/not/a/caller/scope"],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("1", result.Output.Trim());
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public async Task CallerScope_DoesNotAcquireScopeForIneffectiveGraphSelection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.Data)],
+            OverloadIndex = 1,
+            IncludeSections = [SectionNames.Callers],
+            CallerScopeDirectories = ["/definitely/not/a/caller/scope"],
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("Directory not found", result.Error);
+    }
+
+    [Fact]
+    public async Task CallerScope_PreservesBroadBodyIndexSections()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.CalledTypes],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(int.TryParse(result.Output.Trim(), out var count));
+        Assert.True(count > 0, "fixture must produce called-type evidence");
+    }
+
+    [Fact]
+    public async Task CallerScope_PreservesSingleSectionValueValidation()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.Calls],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Columns = ["Callee"],
+            Value = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("section 'Calls' does not expose value values.", result.Error);
+        Assert.DoesNotContain("--value requires -S/--select to match exactly one section.", result.Error);
+    }
+
+    [Fact]
+    public async Task CallerScope_DoesNotInjectUnsupportedCallersIntoBroadPipeline()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = nameof(MemberCallGraphFixture),
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.MethodGroups],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Method Groups", result.Output);
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public async Task CallGraphTree_WithCallerScope_RendersTheSelectedGraph()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            IncludeSections = [SectionNames.CallGraph],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Tree = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), result.Output);
+        Assert.Contains("├─", result.Output);
+    }
+
+    [Fact]
+    public async Task CallGraphMermaid_WithCallerScope_RendersTheSelectedGraph()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            IncludeSections = [SectionNames.CallGraph],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            MermaidOutput = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("graph TD", result.Output);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), result.Output);
+    }
+
+    [Fact]
+    public async Task EnvironmentMermaidFallback_WithCallerScope_RendersCallers()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            MermaidOutput = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Callers", result.Output);
+        Assert.DoesNotContain("graph TD", result.Output);
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
     public async Task CallGraphSection_RendersEdgeTableByDefault()
     {
         var result = await RunCallGraphAsync(
@@ -995,6 +1203,8 @@ public class MemberCallGraphSectionTests
 
 public static class MemberCallGraphFixture
 {
+    public static int Data;
+
     public static void RootCall() => Mid();
 
     public static void Mid() => Inner();

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -120,6 +120,24 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    public async Task PipelineIndependentMultiSectionSelection_ValidatesBeforeAcquisition()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = "Missing.Type.Member",
+            AssemblyPath = Path.Combine(Path.GetTempPath(), "missing-member-selection.dll"),
+            Select = [SectionNames.DecompiledSource, SectionNames.OriginalSource],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(CountOutput.SingleSectionRequiredMessage, result.Error);
+        Assert.DoesNotContain("not found", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task EmptyPreResolvedSection_SelectsNoDefaultSections()
     {
         var options = new MemberOptions
@@ -274,6 +292,77 @@ public class MemberCallGraphSectionTests
         Assert.Equal(0, result.ExitCode);
         Assert.NotEqual(string.Empty, result.Output.Trim());
         Assert.Empty(result.Error);
+    }
+
+    [Theory]
+    [InlineData("count")]
+    [InlineData("table")]
+    [InlineData("tsv")]
+    [InlineData("jsonl")]
+    [InlineData("tree")]
+    [InlineData("mermaid")]
+    public async Task AutoSelectedDetail_WithCallerScope_ValidatesTheAuthoredSelection(
+        string format)
+    {
+        var options = new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            IncludeSections =
+            [
+                format is "tree" or "mermaid"
+                    ? SectionNames.CallGraph
+                    : SectionNames.Signature
+            ],
+            CallerScopeDirectories =
+            [
+                Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!
+            ],
+            Count = format == "count",
+            Tabular = format is "table" or "tsv" or "jsonl",
+            Tsv = format == "tsv",
+            Jsonl = format == "jsonl",
+            TabularExplicitlySet = format is "table" or "tsv" or "jsonl",
+            FormatExplicitlySet = format is "table" or "tsv" or "jsonl",
+            Tree = format == "tree",
+            MermaidOutput = format == "mermaid",
+            TipLevel = TipLevel.Quiet,
+        };
+
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotEqual(string.Empty, result.Output.Trim());
+        Assert.DoesNotContain("Error:", result.Error);
+        if (format is "table" or "tsv" or "jsonl")
+        {
+            Assert.Contains("signature", result.Output, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("caller", result.Output, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task ImplicitCallers_DoesNotInvalidateAuthoredInventorySection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallGraphFixture).FullName!,
+                AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+                MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+                IncludeSections = [SectionNames.MemberIndex],
+                CallerScopeDirectories =
+                [
+                    Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!
+                ],
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Contains($"## {SectionNames.MemberIndex}", result.Output);
+        Assert.Contains($"## {SectionNames.Callers}", result.Output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -10,6 +10,60 @@ namespace DotnetInspector.Tests;
 public class MemberCallGraphSectionTests
 {
     [Fact]
+    public async Task PreResolvedBroadSection_IsRejectedAfterDottedLookupSelectsOverloadInventory()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.MethodGroups],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains($"Select value '{SectionNames.MethodGroups}' not found.", result.Error);
+    }
+
+    [Fact]
+    public async Task PreResolvedDottedStructuralDiscovery_UsesTheLookupSelectedPipeline()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.MethodGroups],
+            Discover = [SectionNames.MethodGroups],
+            Schema = true,
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains($"Section '{SectionNames.MethodGroups}' not found.", result.Error);
+    }
+
+    [Fact]
+    public async Task PreResolvedDottedSection_WithRawSelector_UsesTheLookupSelectedPipeline()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            Select = [SectionNames.Methods],
+            IncludeSections = [SectionNames.Signature],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("1", result.Output.Trim());
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
     public async Task PreResolvedSection_OverridesStaleRawSelector()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
@@ -183,6 +237,43 @@ public class MemberCallGraphSectionTests
         Assert.Equal(
             [SectionNames.Summary, SectionNames.Signature, SectionNames.CallGraph],
             writerOptions.IncludeSections);
+    }
+
+    [Fact]
+    public async Task OverloadInventory_CallGraphSchema_IsQueryable()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            Discover = [SectionNames.CallGraph],
+            Schema = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Fanout", result.Output);
+        Assert.Contains("Fanin", result.Output);
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public async Task AutoSelectedDetail_EffectiveDiscoveryIncludesInventorySection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallGraphFixture).FullName!,
+                AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+                MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+                IncludeSections = [SectionNames.Methods, SectionNames.Signature],
+                Discover = [SectionNames.Methods],
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotEqual(string.Empty, result.Output.Trim());
+        Assert.Empty(result.Error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
@@ -1,6 +1,8 @@
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 using DotnetInspector.Sections;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Tests;
 
@@ -60,6 +62,53 @@ public class MemberCallsSectionTests
         Assert.Contains("Calls\tsection", result.Output);
     }
 
+    [Fact]
+    public void EmptyImplicitCallerTokenScope_DoesNotResolveSolePropertyAccessor()
+    {
+        var type = SolePropertyType();
+        var options = ImplicitCallerOptions();
+
+        var methods = ApiOutputFormatter.ResolveBodyMethods(
+            type, new HashSet<string> { SectionNames.Callers }, options);
+
+        Assert.Empty(methods);
+    }
+
+    [Fact]
+    public void EmptyImplicitCallerTokenScope_DoesNotMakeCallersEffective()
+    {
+        var type = SolePropertyType();
+        var options = ImplicitCallerOptions();
+
+        Assert.False(ApiMemberSectionPipelines.ShouldAggregateImplicitCallers(type, options));
+    }
+
+    static ApiType SolePropertyType()
+        => new()
+        {
+            Namespace = "Samples",
+            Name = "Properties",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Solo",
+                    Kind = "property",
+                    ReturnType = "int",
+                    GetterToken = 0x06000001
+                }
+            ]
+        };
+
+    static MemberOptions ImplicitCallerOptions()
+        => new()
+        {
+            CallerScopeSectionImplicitlySelected = true,
+            IncludeSections = [SectionNames.Callers],
+            ImplicitCallerMemberTokens = new HashSet<int>()
+        };
+
     static Task<(int ExitCode, string Output, string Error)> RunMemberCallsAsync(string memberName, bool tsv = false, bool discover = false, int? overloadIndex = null)
         => ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
@@ -109,6 +158,20 @@ public static class MemberCallsFixture
         Console.WriteLine(value);
     }
 
+    public static void CallsOverloaded()
+    {
+        Overloaded(1);
+        Overloaded("value");
+    }
+
+    public static void UnusedOverloaded(int value)
+    {
+    }
+
+    public static void UnusedOverloaded(string value)
+    {
+    }
+
     // Non-public member: only selectable under --all. Regression coverage for #1323,
     // where the body-load path counted overloads public-only and so reported "no IL body"
     // for a method that the Calls/IL index reads fine.
@@ -117,4 +180,51 @@ public static class MemberCallsFixture
         Console.WriteLine(value);
         return value + 1;
     }
+}
+
+public sealed class MemberPropertyCallsFixture
+{
+    public int this[int index] => index;
+    public int this[string key] => key.Length;
+
+    public static void CallsIndexers()
+    {
+        var fixture = new MemberPropertyCallsFixture();
+        _ = fixture[1];
+        _ = fixture["one"];
+    }
+}
+
+public abstract class MemberAbstractCallsFixture
+{
+    public abstract void Mixed(int value);
+    public void Mixed(string value) { }
+
+    public static void CallsMixed(MemberAbstractCallsFixture fixture)
+    {
+        fixture.Mixed(1);
+        fixture.Mixed("one");
+    }
+}
+
+public abstract class MemberAbstractPropertyCallsFixture
+{
+    public abstract int this[int index] { get; }
+    public abstract int this[string key] { get; }
+
+    public static void CallsIndexers(MemberAbstractPropertyCallsFixture fixture)
+    {
+        _ = fixture[1];
+        _ = fixture["one"];
+    }
+}
+
+public static class MemberOnlyPropertyCallsFixture
+{
+    public static int Solo => 1;
+}
+
+public static class MemberOnlyPropertyCallerFixture
+{
+    public static int CallsSolo() => MemberOnlyPropertyCallsFixture.Solo;
 }

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -828,6 +828,47 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
+    public async Task GenericArityWithMultipleMemberNames_IsRejected()
+    {
+        var (root, opts, cmdArgs) = CreateTestCommand();
+        var parseResult = root.Parse(
+            ["member", "MemoryExtensions", "--platform", "System.Memory",
+             "-m", "AsSpan`1", "-m", "Contains"]);
+        Assert.Empty(parseResult.Errors);
+
+        var result = await MemberOptionsParser.ParseAsync(parseResult, opts, cmdArgs);
+
+        var error = Assert.IsType<MemberOptionsParser.VersionError>(result);
+        Assert.Contains("requires exactly one member name", error.Error.Message);
+    }
+
+    [Fact]
+    public async Task ConflictingGenericAritiesForOneMemberName_AreRejected()
+    {
+        var (root, opts, cmdArgs) = CreateTestCommand();
+        var parseResult = root.Parse(
+            ["member", "MemoryExtensions", "--platform", "System.Memory",
+             "-m", "AsSpan`1", "-m", "AsSpan`2"]);
+        Assert.Empty(parseResult.Errors);
+
+        var result = await MemberOptionsParser.ParseAsync(parseResult, opts, cmdArgs);
+
+        var error = Assert.IsType<MemberOptionsParser.VersionError>(result);
+        Assert.Contains("cannot combine different generic arities", error.Error.Message);
+    }
+
+    [Fact]
+    public async Task RepeatedMatchingGenericAritiesForOneMemberName_AreAccepted()
+    {
+        var options = await ParseSuccessAsync(
+            "member", "MemoryExtensions", "--platform", "System.Memory",
+            "-m", "AsSpan`1", "-m", "AsSpan<T>");
+
+        Assert.Equal(["AsSpan"], options.MemberFilter);
+        Assert.Equal(1, options.MemberGenericArity);
+    }
+
+    [Fact]
     public async Task DigestShorthand_SetsMemberDigest()
     {
         var options = await ParseSuccessAsync("member", "JsonSerializer", "--package", "System.Text.Json", "-m", "Deserialize~abc123");

--- a/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
@@ -293,7 +293,7 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsDottedSyntax()
     {
         var members = new[] { "JsonSerializer.Deserialize", "GetValue" };
-        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, genericArityConflict, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Equal("JsonSerializer", typeFilter);
         Assert.Equal("Deserialize", members[0]);
@@ -301,6 +301,7 @@ public class SharedParsersTests
         Assert.Null(overloadIndex);
         Assert.Null(memberDigest);
         Assert.Null(genericArity);
+        Assert.False(genericArityConflict);
         Assert.Empty(kindFilter);
     }
 
@@ -308,13 +309,14 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsOverloadShorthand()
     {
         var members = new[] { "GetValue:2" };
-        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, genericArityConflict, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Null(typeFilter);
         Assert.Equal("GetValue", members[0]);
         Assert.Equal(2, overloadIndex);
         Assert.Null(memberDigest);
         Assert.Null(genericArity);
+        Assert.False(genericArityConflict);
         Assert.Empty(kindFilter);
     }
 
@@ -322,13 +324,14 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsBoth()
     {
         var members = new[] { "JsonSerializer.Deserialize:1" };
-        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, genericArityConflict, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Equal("JsonSerializer", typeFilter);
         Assert.Equal("Deserialize", members[0]);
         Assert.Equal(1, overloadIndex);
         Assert.Null(memberDigest);
         Assert.Null(genericArity);
+        Assert.False(genericArityConflict);
         Assert.Empty(kindFilter);
     }
 
@@ -336,13 +339,14 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsKindQualifiedSelector()
     {
         var members = new[] { "explicit:System.IConvertible.ToBoolean:1" };
-        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, genericArityConflict, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Null(typeFilter);
         Assert.Equal("System.IConvertible.ToBoolean", members[0]);
         Assert.Equal(1, overloadIndex);
         Assert.Null(memberDigest);
         Assert.Null(genericArity);
+        Assert.False(genericArityConflict);
         Assert.Contains("explicit-interface-implementation", kindFilter);
     }
 
@@ -350,13 +354,14 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsDottedKindQualifiedSelector()
     {
         var members = new[] { "DateTime.operator:op_Addition:1" };
-        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, genericArityConflict, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Equal("DateTime", typeFilter);
         Assert.Equal("op_Addition", members[0]);
         Assert.Equal(1, overloadIndex);
         Assert.Null(memberDigest);
         Assert.Null(genericArity);
+        Assert.False(genericArityConflict);
         Assert.Contains("operator", kindFilter);
     }
 
@@ -364,27 +369,42 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsGenericMethodArity()
     {
         var members = new[] { "Map<T>:1" };
-        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, genericArityConflict, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Null(typeFilter);
         Assert.Equal("Map", members[0]);
         Assert.Equal(1, overloadIndex);
         Assert.Null(memberDigest);
         Assert.Equal(1, genericArity);
+        Assert.False(genericArityConflict);
         Assert.Empty(kindFilter);
+    }
+
+    [Fact]
+    public void ProcessMemberArguments_ReportsConflictingGenericArities()
+    {
+        var members = new[] { "Map`1", "Map`2" };
+
+        var (_, _, _, genericArity, genericArityConflict, _) =
+            SharedParsers.ProcessMemberArguments(members);
+
+        Assert.Equal(["Map", "Map"], members);
+        Assert.Equal(1, genericArity);
+        Assert.True(genericArityConflict);
     }
 
     [Fact]
     public void ProcessMemberArguments_ExtractsDigestSelector()
     {
         var members = new[] { "JsonSerializer.Deserialize~abc123" };
-        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, genericArityConflict, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Equal("JsonSerializer", typeFilter);
         Assert.Equal("Deserialize", members[0]);
         Assert.Null(overloadIndex);
         Assert.Equal("abc123", memberDigest);
         Assert.Null(genericArity);
+        Assert.False(genericArityConflict);
         Assert.Empty(kindFilter);
     }
 

--- a/src/dotnet-inspect.Tests/SourceResolverTests.cs
+++ b/src/dotnet-inspect.Tests/SourceResolverTests.cs
@@ -66,6 +66,66 @@ public class SourceResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsync_BareNestedGenericType_ResolvesWholePlatformType()
+    {
+        const string typeName =
+            "System.Collections.Frozen.FrozenDictionary`2.AlternateLookup`1";
+
+        var source = await SourceResolver.ResolveAsync(
+            [typeName], explicitPackage: null, explicitAssembly: null, explicitPlatform: null,
+            NoSourceKeys, verbose: false);
+
+        Assert.Equal("System.Collections.Immutable", source.PlatformAssembly);
+        Assert.Equal(typeName, source.TypeName);
+        Assert.Null(source.PackagePath);
+        Assert.Null(source.AssemblyPath);
+    }
+
+    [Theory]
+    [InlineData("Nope`1.Nada`2")]
+    [InlineData("Nope<T>.Nada<A,B>")]
+    public async Task ResolveAsync_UnknownNestedGenericType_ReportsPlatformMiss(string typeName)
+    {
+        var source = await SourceResolver.ResolveAsync(
+            [typeName], explicitPackage: null, explicitAssembly: null, explicitPlatform: null,
+            NoSourceKeys, verbose: false);
+
+        Assert.True(source.VersionError);
+        Assert.Contains("looks like a type name", source.VersionErrorMessage);
+        Assert.Contains("Specify the source", source.VersionErrorMessage);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_GenericMemberOnKnownContainingType_FallsThroughForMemberPeeling()
+    {
+        const string target =
+            "System.Collections.Generic.List<T>.ConvertAll<TOutput>";
+
+        var source = await SourceResolver.ResolveAsync(
+            [target], explicitPackage: null, explicitAssembly: null, explicitPlatform: null,
+            NoSourceKeys, verbose: false);
+
+        Assert.False(source.VersionError);
+        Assert.Equal("System.Collections.Generic.List`1.ConvertAll`1", source.PackagePath);
+        Assert.Null(source.TypeName);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_GenericMemberOnPackageShapedContainingType_FallsThroughForMemberPeeling()
+    {
+        const string target =
+            "Newtonsoft.Json.Linq.JEnumerable<T>.GetEnumerator";
+
+        var source = await SourceResolver.ResolveAsync(
+            [target], explicitPackage: null, explicitAssembly: null, explicitPlatform: null,
+            NoSourceKeys, verbose: false);
+
+        Assert.False(source.VersionError);
+        Assert.Equal("Newtonsoft.Json.Linq.JEnumerable`1.GetEnumerator", source.PackagePath);
+        Assert.Null(source.TypeName);
+    }
+
+    [Fact]
     public async Task ResolveAsync_UnknownBareName_KeepsPackageFallback()
     {
         SkipIfCoreLibUnavailable();

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using CSharpText;
 using DotnetInspector.Commands;
 using DotnetInspector.Core;
 using DotnetInspector.Inspectors;
@@ -238,6 +239,16 @@ public static class RouterCommandDefinition
             }
 
             var allowPlatformPrefixFallback = PlatformResolver.IsPlatformCandidate(target);
+            if (TryResolveExactGenericPlatformType(target) is not null)
+            {
+                return
+                [
+                    "type",
+                    target,
+                    .. tail
+                ];
+            }
+
             string? platformLookupFailure = null;
             var memberSplit = SharedParsers.TrySplitQualifiedTypeMember(
                 target,
@@ -386,6 +397,27 @@ public static class RouterCommandDefinition
             return error == null
                    && assemblyPath != null
                    && PlatformResolver.HasType(assemblyPath, probe.Remainder);
+        }
+
+        private static PlatformTypeLookupOutcome.Resolved? TryResolveExactGenericPlatformType(
+            string target)
+        {
+            if (!target.Contains('`') && !target.Contains('<'))
+                return null;
+
+            var normalizedTarget = FqnParser.NormalizeTypeName(target).Replace('+', '.');
+            if (PlatformResolver.LookupType(target)
+                is not PlatformTypeLookupOutcome.Resolved resolved)
+                return null;
+
+            var normalizedCandidate = resolved.Candidate.Type
+                .ToMetadataFullName()
+                .Replace('+', '.');
+            return normalizedCandidate.Equals(
+                normalizedTarget,
+                StringComparison.OrdinalIgnoreCase)
+                ? resolved
+                : null;
         }
     }
 }

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -249,7 +249,7 @@ public static class MemberOptionsParser
         var ctorOnly = parseResult.GetValue(args.CtorOption);
 
         // Process dotted syntax and overload shorthand
-        var (dottedTypeFilter, shorthandIndex, memberDigest, memberGenericArity, memberKindFilter) = SharedParsers.ProcessMemberArguments(allMembers);
+        var (dottedTypeFilter, shorthandIndex, memberDigest, memberGenericArity, memberGenericArityConflict, memberKindFilter) = SharedParsers.ProcessMemberArguments(allMembers);
 
         // Use extracted type name if no explicit type was provided
         if (dottedTypeFilter != null && string.IsNullOrEmpty(typeName))
@@ -259,6 +259,10 @@ public static class MemberOptionsParser
         var (memberFilter, memberLimit) = BuildMemberFilter(allMembers, ctorOnly, out var clearShorthand);
         if (clearShorthand)
             shorthandIndex = null;
+        if (memberGenericArityConflict)
+            return new VersionError("A member selection cannot combine different generic arities.");
+        if (memberGenericArity.HasValue && memberFilter.Count != 1)
+            return new VersionError("A generic arity selector requires exactly one member name.");
 
         var kindValues = parseResult.GetValue(args.KindOption) ?? [];
         var kindFilter = SharedParsers.ParseKindFilter(kindValues);

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -263,12 +263,13 @@ public static class SharedParsers
     /// </summary>
     /// <param name="members">The member arguments to process.</param>
     /// <returns>Extracted type filter and overload index if found.</returns>
-    public static (string? DottedTypeFilter, int? OverloadIndex, string? MemberDigest, int? GenericArity, HashSet<string> KindFilter) ProcessMemberArguments(string[] members)
+    public static (string? DottedTypeFilter, int? OverloadIndex, string? MemberDigest, int? GenericArity, bool GenericArityConflict, HashSet<string> KindFilter) ProcessMemberArguments(string[] members)
     {
         string? dottedTypeFilter = null;
         int? overloadIndex = null;
         string? memberDigest = null;
         int? genericArity = null;
+        bool genericArityConflict = false;
         HashSet<string> kindFilter = [];
 
         for (int i = 0; i < members.Length; i++)
@@ -292,13 +293,18 @@ public static class SharedParsers
             if (selector.DigestPrefix is { Length: > 0 })
                 memberDigest = selector.DigestPrefix;
             if (selector.GenericArity is { } arity)
-                genericArity = arity;
+            {
+                if (genericArity is { } existingArity && existingArity != arity)
+                    genericArityConflict = true;
+                else
+                    genericArity = arity;
+            }
             if (selector.OverloadIndex is { } index)
                 overloadIndex = index;
             members[i] = selector.Name;
         }
 
-        return (dottedTypeFilter, overloadIndex, memberDigest, genericArity, kindFilter);
+        return (dottedTypeFilter, overloadIndex, memberDigest, genericArity, genericArityConflict, kindFilter);
     }
 
     public static (string Name, string? Digest) ParseDigestShorthand(string value)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -355,7 +355,8 @@ public class ApiCommand
         => options.HasCallerScope
            && options.IncludeSections is { } sections
            && (sections.Contains(SectionNames.Callers, StringComparer.OrdinalIgnoreCase)
-               && ApiMemberDetailSectionDescriptors.Callers.CanRender(type)
+               && (ApiMemberSectionPipelines.ShouldAggregateImplicitCallers(type, options)
+                   || ApiMemberDetailSectionDescriptors.Callers.CanRender(type))
                || sections.Contains(SectionNames.CallGraph, StringComparer.OrdinalIgnoreCase)
                && ApiMemberDetailSectionDescriptors.CallGraph.CanRender(type));
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -206,6 +206,9 @@ public class ApiCommand
 
     internal static (PreambleResult Result, int? Error) RunPreamble(ApiOptions options)
     {
+        if (options is MemberOptions { IncludeSections: not null } preResolvedMemberOptions)
+            options = preResolvedMemberOptions with { MemberSectionsPreResolved = true };
+
         var typePipeline = ApiTypeSectionDescriptors.CreatePipeline();
         var memberPipeline = ApiMemberSectionPipelines.Create(options);
         bool hasTypeName = !string.IsNullOrWhiteSpace(options.TypeName);
@@ -285,26 +288,29 @@ public class ApiCommand
         }
 
         // -S/--select with values: resolve as section filter for backpressure
-        var selectResult = SelectResolver.ResolveSelectAsSections(
-            options.Select,
-            knownSections,
-            bareSelectSections,
-            singleTypeMode ? memberPipeline.GetCategoryMap() : typePipeline.GetCategoryMap(),
-            selectDefault: options.SelectDefault);
-        if (ShouldDeferSelectToListing(options, singleTypeMode, selectResult, typePipeline))
+        if (options.IncludeSections is null)
         {
-            // `-D` advertised these names and `-S` rejected them, on the same command line: the
-            // preamble was answering for the single-type pipeline while the render is a listing.
-            // Hold the rejection rather than resolving it here, because which pipeline is right is
-            // not known until the type lookup runs.
-            options = options with { SelectDeferredToListing = true };
-        }
-        else
-        {
-            if (SelectOutput.WriteUnresolved(selectResult))
-                return (null!, 1);
-            if (selectResult.Sections != null)
-                options = options with { IncludeSections = selectResult.Sections };
+            var selectResult = SelectResolver.ResolveSelectAsSections(
+                options.Select,
+                knownSections,
+                bareSelectSections,
+                singleTypeMode ? memberPipeline.GetCategoryMap() : typePipeline.GetCategoryMap(),
+                selectDefault: options.SelectDefault);
+            if (ShouldDeferSelectToListing(options, singleTypeMode, selectResult, typePipeline))
+            {
+                // `-D` advertised these names and `-S` rejected them, on the same command line: the
+                // preamble was answering for the single-type pipeline while the render is a listing.
+                // Hold the rejection rather than resolving it here, because which pipeline is right is
+                // not known until the type lookup runs.
+                options = options with { SelectDeferredToListing = true };
+            }
+            else
+            {
+                if (SelectOutput.WriteUnresolved(selectResult))
+                    return (null!, 1);
+                if (selectResult.Sections != null)
+                    options = options with { IncludeSections = selectResult.Sections };
+            }
         }
 
         // A deferred select has no IncludeSections yet, and the preamble cannot know whether a
@@ -577,8 +583,15 @@ public class ApiCommand
     {
         if (options.IncludeSections is not { Count: > 0 })
             return;
-        if (SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
-            || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
+        var sectionsPreResolved = options is MemberOptions { MemberSectionsPreResolved: true };
+        if (SelectResolver.IsActiveInfoSelector(
+                options.SelectDefault,
+                options.IncludeSections,
+                sectionsPreResolved)
+            || SelectResolver.IsActiveAllSelector(
+                options.Select,
+                options.IncludeSections,
+                sectionsPreResolved))
             return;
 
         var filtered = BuildFilteredTypeForSections(type, options);
@@ -785,8 +798,13 @@ public class ApiCommand
     internal static HashSet<string> GetRequestedMemberSections(ApiType type, ApiOptions options)
     {
         var pipeline = ApiMemberSectionPipelines.Create(options);
+        var explicitInclude = options is MemberOptions { MemberSectionsPreResolved: true };
         var sections = new HashSet<string>(
-            pipeline.GetEffectiveSections(type, options.Verbosity, options.IncludeSections),
+            pipeline.GetEffectiveSections(
+                type,
+                options.Verbosity,
+                options.IncludeSections,
+                explicitInclude: explicitInclude),
             StringComparer.OrdinalIgnoreCase);
         if (options.Discover is { Length: > 0 } discover)
         {
@@ -1619,12 +1637,18 @@ public class ApiCommand
             }
             else
             {
-                if (SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
+                if (SelectResolver.IsActiveAllSelector(
+                    options.Select,
+                    options.IncludeSections,
+                    options is MemberOptions { MemberSectionsPreResolved: true }))
                 {
                     var pipeline = ApiMemberSectionPipelines.Create(options);
                     writerOptions.SectionOrder = pipeline.GetAllSelectorSections(type);
                 }
-                else if (SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections))
+                else if (SelectResolver.IsActiveInfoSelector(
+                    options.SelectDefault,
+                    options.IncludeSections,
+                    options is MemberOptions { MemberSectionsPreResolved: true }))
                 {
                     var pipeline = ApiMemberSectionPipelines.Create(options);
                     writerOptions.SectionOrder = pipeline.InfoSectionNames;
@@ -2025,7 +2049,10 @@ public class ApiCommand
     {
         var fullSchema = GetTypeDocumentSchema(options);
         var filteredType = BuildFilteredTypeForSections(apiType, options);
-        var effective = memberPipeline.GetDiscoverableSections(filteredType, options.IncludeSections);
+        var effective = memberPipeline.GetDiscoverableSections(
+            filteredType,
+            options.IncludeSections,
+            explicitInclude: options is MemberOptions { MemberSectionsPreResolved: true });
         effective = DiscoverOutput.RestrictToSchemaSections(effective, fullSchema);
         var unprobed = memberPipeline.GetUnprobedSections();
         var bareDiscover = options.Discover is null or { Length: 0 };
@@ -2434,7 +2461,9 @@ public class ApiCommand
                 .ToList();
 
         // -S/--select scopes JSON to the requested sections, mirroring the markdown view.
-        if (options.IncludeSections is { Count: > 0 } sections)
+        if (options.IncludeSections is { } sections
+            && (sections.Count > 0
+                || options is MemberOptions { MemberSectionsPreResolved: true }))
         {
             outputType = ProjectTypeToSections(type, members, sections);
         }
@@ -2487,7 +2516,8 @@ public class ApiCommand
            && !IsProjectionRequested(options)
            && options.IncludeSections is { Count: 1 } sections
            && sections.Contains(SectionNames.AnnotatedSourceDocument)
-           && HasOnlyExplicitAnnotatedSourceDocumentSelectors(options);
+           && (options is MemberOptions { MemberSectionsPreResolved: true }
+               || HasOnlyExplicitAnnotatedSourceDocumentSelectors(options));
 
     private static bool IsInvalidAnnotatedSourceDocumentJsonSelection(ApiOptions options)
         => options.JsonOutput
@@ -2495,9 +2525,11 @@ public class ApiCommand
            && !IsProjectionRequested(options)
            && options.IncludeSections is { Count: > 0 } sections
            && sections.Contains(SectionNames.AnnotatedSourceDocument)
-           && options.Select?.Any(IsExplicitAnnotatedSourceDocumentSelector) == true
-           && (sections.Count != 1
-               || !HasOnlyExplicitAnnotatedSourceDocumentSelectors(options));
+           && (options is MemberOptions { MemberSectionsPreResolved: true }
+               ? sections.Count != 1
+               : options.Select?.Any(IsExplicitAnnotatedSourceDocumentSelector) == true
+                 && (sections.Count != 1
+                     || !HasOnlyExplicitAnnotatedSourceDocumentSelectors(options)));
 
     private static bool HasOnlyExplicitAnnotatedSourceDocumentSelectors(ApiOptions options)
         => options.Select is { Length: > 0 } selectors

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -320,6 +320,8 @@ public class ApiCommand
         if (!options.HasCallerScope
             || options.Tree
             || IsStandaloneMermaid(options)
+            || options.JsonOutput
+            && options.IncludeSections is not { Count: > 0 }
             || !options.CallerScopeSectionImplicitlySelected
             && options.IncludeSections is not null
             && UsesSingleSectionOutput(options)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -127,6 +127,210 @@ public class ApiCommand
         return listingOptions;
     }
 
+    /// <summary>
+    /// Resolves a dotted member request against the pipeline selected by metadata lookup, then
+    /// runs every selection-dependent validation that the preamble deferred.
+    /// </summary>
+    internal static MemberOptions? ReresolveSectionsForMemberLookup(MemberOptions options)
+    {
+        var pipeline = ApiMemberSectionPipelines.Create(options);
+        var usesFixedOverview = ApiMemberSectionPipelines.UsesDetailPipeline(options);
+        var bareSelectSections = usesFixedOverview
+            ? pipeline.FixedOverviewSectionNames
+            : pipeline.InfoSectionNames;
+
+        if (options.IncludeSections is null
+            && usesFixedOverview
+            && HasNoBareSelectOverview(options, bareSelectSections))
+        {
+            CommandError.Write(
+                "this view publishes no bare -S overview sections.",
+                "Use -S <Section> to select one, -D to discover what is available, or -S @All for everything.");
+            return null;
+        }
+
+        MemberOptions? resolved;
+        if (options.IncludeSections is not null)
+        {
+            resolved = RevalidateResolvedMemberSections(options, pipeline);
+        }
+        else
+        {
+            var selectResult = SelectResolver.ResolveSelectAsSections(
+                options.Select,
+                pipeline.SelectableSectionNames,
+                bareSelectSections,
+                pipeline.GetCategoryMap(),
+                selectDefault: options.SelectDefault);
+            if (SelectOutput.WriteUnresolved(selectResult))
+                return null;
+
+            resolved = selectResult.Sections != null
+                ? options with { IncludeSections = selectResult.Sections }
+                : options;
+        }
+
+        if (resolved is null)
+            return null;
+
+        resolved = resolved with
+        {
+            MemberPipelineDeferredToLookup = false,
+            MemberSelectionDeferredToLookup = false
+        };
+
+        return ValidateResolvedMemberSelection(resolved, pipeline);
+    }
+
+    private static MemberOptions? ValidateResolvedMemberSelection(
+        MemberOptions resolved,
+        SectionPipeline<ApiType> pipeline)
+    {
+        if (resolved.Discover == null && resolved.Count
+            && !CountOutput.ValidateSingleSection(resolved.IncludeSections))
+        {
+            return null;
+        }
+
+        var shapeCount = ShapeProjectionOutput.ActiveShapeCount(
+            resolved.Value, resolved.Urls, resolved.Paths);
+        if (shapeCount == 1 && resolved.Discover == null)
+        {
+            var optionName = resolved.Value ? "--value" : resolved.Urls ? "--urls" : "--paths";
+            if (!ShapeProjectionOutput.ValidateSingleSection(resolved.IncludeSections, optionName))
+                return null;
+        }
+
+        if (resolved.Print && resolved.Discover == null
+            && !ValidateApiPrintSelection(resolved.IncludeSections))
+        {
+            return null;
+        }
+
+        if (!OutputFormatResolver.ValidateSingleSectionForTabular(
+                resolved.TabularExplicitlySet, resolved.IncludeSections))
+        {
+            return null;
+        }
+
+        if (resolved.Discover is null)
+        {
+            resolved = NormalizeMemberGraphFormat(resolved, resolved.IncludeSections);
+            if (!ValidateMemberGraphFormat(resolved, resolved.IncludeSections))
+                return null;
+        }
+
+        if (resolved.IncludeSections is { Count: > 0 })
+        {
+            var requiredVerbosity = pipeline.GetRequiredVerbosity(resolved.IncludeSections);
+            if (requiredVerbosity > resolved.Verbosity)
+                resolved = resolved with { Verbosity = requiredVerbosity };
+        }
+
+        if (!resolved.Count)
+        {
+            OutputFormatResolver.WarnIfTabularDetailMismatch(
+                resolved.Tabular, resolved.Verbosity, resolved.IncludeSections);
+        }
+
+        return resolved;
+    }
+
+    internal static MemberOptions? FinalizeResolvedMemberSelection(
+        MemberOptions options,
+        SectionPipeline<ApiType> pipeline)
+    {
+        var resolved = options with
+        {
+            MemberPipelineDeferredToLookup = false,
+            MemberSelectionDeferredToLookup = false
+        };
+        return ValidateResolvedMemberSelection(resolved, pipeline);
+    }
+
+    /// <summary>
+    /// Revalidates a programmatically supplied section set after member lookup has selected the
+    /// broad, overload-inventory, or detail pipeline.
+    /// </summary>
+    internal static MemberOptions? RevalidateResolvedMemberSections(
+        MemberOptions options,
+        SectionPipeline<ApiType> pipeline)
+    {
+        if (options.IncludeSections is not { Count: > 0 } includeSections)
+            return options;
+
+        var result = SelectResolver.ResolveSelectAsSections(
+            includeSections.ToArray(),
+            pipeline.SelectableSectionNames,
+            pipeline.InfoSectionNames,
+            pipeline.GetCategoryMap(),
+            selectDefault: false);
+        if (SelectOutput.WriteErrors(result.Unresolved))
+            return null;
+
+        return result.Sections is not null
+            ? options with { IncludeSections = result.Sections }
+            : options;
+    }
+
+    private static HashSet<string>? ResolvePipelineIndependentMemberSections(
+        MemberOptions options)
+    {
+        SectionPipeline<ApiType>[] pipelines =
+        [
+            ApiMemberSectionDescriptors.CreatePipeline(),
+            ApiMemberOverloadSectionDescriptors.CreatePipeline(),
+            ApiMemberDetailSectionDescriptors.CreatePipeline()
+        ];
+
+        HashSet<string>? resolvedSections = null;
+        for (var i = 0; i < pipelines.Length; i++)
+        {
+            var pipeline = pipelines[i];
+            var bareSelectSections = i == pipelines.Length - 1
+                ? pipeline.FixedOverviewSectionNames
+                : pipeline.InfoSectionNames;
+            var result = SelectResolver.ResolveSelectAsSections(
+                options.Select,
+                pipeline.SelectableSectionNames,
+                bareSelectSections,
+                pipeline.GetCategoryMap(),
+                selectDefault: options.SelectDefault);
+            if (result.HasError || result.Sections is null)
+                return null;
+            if (resolvedSections is null)
+            {
+                resolvedSections = result.Sections;
+                continue;
+            }
+            if (!resolvedSections.SetEquals(result.Sections))
+                return null;
+        }
+
+        return resolvedSections;
+    }
+
+    internal static int ExecuteStructuralTypeDiscovery(
+        ApiOptions options,
+        SectionPipeline<ApiType> memberPipeline)
+    {
+        var schema = RestrictSchemaToSections(
+            GetTypeDocumentSchema(options),
+            memberPipeline.SelectableSectionNames);
+        schema = ToQueryableSchema(schema, options);
+        return DiscoverOutput.Execute(
+            options.Discover,
+            schema,
+            tree: options.Tree,
+            json: options.JsonOutput,
+            tsv: options.Tsv,
+            jsonl: options.Jsonl,
+            markdown: !options.Tabular && !options.JsonOutput,
+            sectionCostAnnotations: memberPipeline.GetCostAnnotations(),
+            sectionCategories: memberPipeline.GetCategoryMap(),
+            projection: options);
+    }
+
     // ===== Shared Preamble =====
 
     /// <summary>
@@ -207,7 +411,9 @@ public class ApiCommand
     internal static (PreambleResult Result, int? Error) RunPreamble(ApiOptions options)
     {
         if (options is MemberOptions { IncludeSections: not null } preResolvedMemberOptions)
+        {
             options = preResolvedMemberOptions with { MemberSectionsPreResolved = true };
+        }
 
         var typePipeline = ApiTypeSectionDescriptors.CreatePipeline();
         var memberPipeline = ApiMemberSectionPipelines.Create(options);
@@ -215,35 +421,38 @@ public class ApiCommand
         bool typeNameIsGlob = hasTypeName && (options.TypeName!.Contains('*') || options.TypeName!.Contains('?'));
         bool singleTypeMode = options is MemberOptions || (hasTypeName && !typeNameIsGlob);
         var knownSections = singleTypeMode ? memberPipeline.SelectableSectionNames : typePipeline.SelectableSectionNames;
-        if (options is MemberOptions memberOptions
-            && memberOptions.MemberFilter.Count == 0
-            && MightPeelDottedGenericMemberSelector(memberOptions.TypeName))
+        var memberPipelineRequiresLookup = options is MemberOptions
         {
-            knownSections = knownSections
-                .Concat(ApiMemberDetailSectionDescriptors.CreatePipeline().SelectableSectionNames)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
+            MemberFilter.Count: 0,
+            TypeName: { } memberTypeName
+        } && FqnParser.LastTopLevelDot(memberTypeName) > 0;
+        var deferMemberSelection = memberPipelineRequiresLookup
+            && options.IncludeSections is null
+            && (options.Select is not null
+                || options.SelectDefault);
+        if (options is MemberOptions memberOptions && memberPipelineRequiresLookup)
+        {
+            options = memberOptions with
+            {
+                MemberPipelineDeferredToLookup = true,
+                MemberSelectionDeferredToLookup = deferMemberSelection
+            };
         }
 
-        // Discovery mode: -D/--discover lists effective sections (resolves source) by
-        // default; --schema opts out to the cheap, offline static schema listing.
-        if (options.Discover != null && !options.EffectiveDiscovery)
+        // Discovery mode: -D/--discover lists effective sections (resolves source) by default;
+        // --schema normally opts out to the cheap, offline static schema listing. A dotted member
+        // target is the exception: metadata lookup must first distinguish a namespace-qualified
+        // type from Type.Member so structural discovery reports the pipeline that actually applies.
+        if (options.Discover != null && !options.EffectiveDiscovery && !memberPipelineRequiresLookup)
         {
-            var schema = singleTypeMode
-                ? GetTypeDocumentSchema(options)
-                : ApiViewContext.Default.GetSchemaInfo<CliApiSurface>()!.ToDocumentSchema();
-
-            // Restrict plain discovery to columns/sections queryable under the active options.
             if (singleTypeMode)
-            {
-                schema = RestrictSchemaToSections(schema, knownSections);
-                schema = ToQueryableSchema(schema, options);
-            }
+                return (null!, ExecuteStructuralTypeDiscovery(options, memberPipeline));
 
+            var schema = ApiViewContext.Default.GetSchemaInfo<CliApiSurface>()!.ToDocumentSchema();
             return (null!, DiscoverOutput.Execute(options.Discover, schema,
                 tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.Tabular && !options.JsonOutput,
-                sectionCostAnnotations: singleTypeMode ? memberPipeline.GetCostAnnotations() : null,
-                sectionCategories: singleTypeMode ? memberPipeline.GetCategoryMap() : typePipeline.GetCategoryMap(),
+                sectionCostAnnotations: null,
+                sectionCategories: typePipeline.GetCategoryMap(),
                 projection: options));
         }
 
@@ -279,7 +488,10 @@ public class ApiCommand
         // that as "no filter at all" and falls through to the verbosity ladder -- turning a request
         // for a bounded overview into the widest output the command has, with the scanner
         // backpressure -S exists to apply switched off.
-        if (usesFixedOverview && HasNoBareSelectOverview(options, bareSelectSections))
+        if (options.IncludeSections is null
+            && !deferMemberSelection
+            && usesFixedOverview
+            && HasNoBareSelectOverview(options, bareSelectSections))
         {
             CommandError.Write(
                 "this view publishes no bare -S overview sections.",
@@ -288,28 +500,40 @@ public class ApiCommand
         }
 
         // -S/--select with values: resolve as section filter for backpressure
-        if (options.IncludeSections is null)
+        if (!deferMemberSelection)
         {
-            var selectResult = SelectResolver.ResolveSelectAsSections(
-                options.Select,
-                knownSections,
-                bareSelectSections,
-                singleTypeMode ? memberPipeline.GetCategoryMap() : typePipeline.GetCategoryMap(),
-                selectDefault: options.SelectDefault);
-            if (ShouldDeferSelectToListing(options, singleTypeMode, selectResult, typePipeline))
+            if (options is MemberOptions { IncludeSections: not null } preResolved)
             {
-                // `-D` advertised these names and `-S` rejected them, on the same command line: the
-                // preamble was answering for the single-type pipeline while the render is a listing.
-                // Hold the rejection rather than resolving it here, because which pipeline is right is
-                // not known until the type lookup runs.
-                options = options with { SelectDeferredToListing = true };
+                if (!preResolved.MemberPipelineDeferredToLookup)
+                {
+                    if (RevalidateResolvedMemberSections(preResolved, memberPipeline) is not { } revalidated)
+                        return (null!, 1);
+                    options = revalidated;
+                }
             }
             else
             {
-                if (SelectOutput.WriteUnresolved(selectResult))
-                    return (null!, 1);
-                if (selectResult.Sections != null)
-                    options = options with { IncludeSections = selectResult.Sections };
+                var selectResult = SelectResolver.ResolveSelectAsSections(
+                    options.Select,
+                    knownSections,
+                    bareSelectSections,
+                    singleTypeMode ? memberPipeline.GetCategoryMap() : typePipeline.GetCategoryMap(),
+                    selectDefault: options.SelectDefault);
+                if (ShouldDeferSelectToListing(options, singleTypeMode, selectResult, typePipeline))
+                {
+                    // `-D` advertised these names and `-S` rejected them, on the same command line: the
+                    // preamble was answering for the single-type pipeline while the render is a listing.
+                    // Hold the rejection rather than resolving it here, because which pipeline is right is
+                    // not known until the type lookup runs.
+                    options = options with { SelectDeferredToListing = true };
+                }
+                else
+                {
+                    if (SelectOutput.WriteUnresolved(selectResult))
+                        return (null!, 1);
+                    if (selectResult.Sections != null)
+                        options = options with { IncludeSections = selectResult.Sections };
+                }
             }
         }
 
@@ -318,8 +542,15 @@ public class ApiCommand
         // down: judging the empty set reports a requirement to narrow -S that is neither true nor
         // actionable, and judging the listing's sections preempts the single-type view's own, more
         // accurate rejection. ReresolveSectionsForListing re-runs them once the pipeline is known.
-        var selectionSections = options.SelectDeferredToListing ? null : options.IncludeSections;
-        if (options.Discover == null && options.Count && !options.SelectDeferredToListing
+        var selectionDeferred = options.SelectDeferredToListing
+            || options is MemberOptions { MemberSelectionDeferredToLookup: true };
+        var selectionSections = selectionDeferred
+            ? options is MemberOptions { MemberSelectionDeferredToLookup: true } deferredMember
+                ? ResolvePipelineIndependentMemberSections(deferredMember)
+                : null
+            : options.IncludeSections;
+        var selectionValidationDeferred = selectionDeferred && selectionSections is null;
+        if (options.Discover == null && options.Count && !selectionValidationDeferred
             && !CountOutput.ValidateSingleSection(selectionSections))
             return (null!, 1);
 
@@ -335,7 +566,7 @@ public class ApiCommand
             var optionName = options.Value ? "--value" : options.Urls ? "--urls" : "--paths";
             // Discovery renders its own payload and refuses the shape projections itself with
             // an accurate reason; demanding -S first reports a requirement that is not the problem.
-            if (options.Discover == null && !options.SelectDeferredToListing
+            if (options.Discover == null && !selectionValidationDeferred
                 && !ShapeProjectionOutput.ValidateSingleSection(selectionSections, optionName))
                 return (null!, 1);
             if (options.Count || options.Print)
@@ -362,7 +593,7 @@ public class ApiCommand
             return (null!, 1);
         }
 
-        if (options.Print && options.Discover == null && !options.SelectDeferredToListing
+        if (options.Print && options.Discover == null && !selectionValidationDeferred
             && !ValidateApiPrintSelection(selectionSections))
             return (null!, 1);
 
@@ -378,21 +609,26 @@ public class ApiCommand
             return (null!, 1);
         }
 
-        if (!options.SelectDeferredToListing
+        if (!selectionValidationDeferred
             && !OutputFormatResolver.ValidateSingleSectionForTabular(options.TabularExplicitlySet, selectionSections))
             return (null!, 1);
 
-        if (options is MemberOptions memberFormat
-            && options.Discover is null)
+        if (options is MemberOptions memberFormat && options.Discover is null)
         {
-            memberFormat = NormalizeMemberGraphFormat(memberFormat, selectionSections);
-            options = memberFormat;
-            if (!ValidateMemberGraphFormat(memberFormat, selectionSections))
+            if (!ValidateMemberGraphFormatConflict(memberFormat))
                 return (null!, 1);
+
+            if (!selectionValidationDeferred)
+            {
+                memberFormat = NormalizeMemberGraphFormat(memberFormat, selectionSections);
+                options = memberFormat;
+                if (!ValidateMemberGraphFormat(memberFormat, selectionSections))
+                    return (null!, 1);
+            }
         }
 
         // Auto-promote verbosity when -S targets specific sections
-        if (options.IncludeSections is { Count: > 0 })
+        if (!selectionDeferred && options.IncludeSections is { Count: > 0 })
         {
             var typeVerbosity = typePipeline.GetRequiredVerbosity(options.IncludeSections);
             var memberVerbosity = memberPipeline.GetRequiredVerbosity(options.IncludeSections);
@@ -402,7 +638,7 @@ public class ApiCommand
         }
 
         // Warn if tabular output is combined with detailed verbosity without section selector
-        if (!options.Count)
+        if (!options.Count && !selectionDeferred)
             OutputFormatResolver.WarnIfTabularDetailMismatch(options.Tabular, options.Verbosity, options.IncludeSections);
 
         // Resolve the tool-owned .dotnet-inspectconfig once per invocation at the
@@ -453,13 +689,6 @@ public class ApiCommand
     {
         if (options.Tree)
         {
-            if (options.FormatFlagExplicitlySet)
-            {
-                CommandError.Write(
-                    "--tree is a standalone output format and cannot combine with another output format.");
-                return false;
-            }
-
             if (sections is not { Count: 1 }
                 || !sections.Contains(SectionNames.CallGraph, StringComparer.OrdinalIgnoreCase))
             {
@@ -493,6 +722,16 @@ public class ApiCommand
         return true;
     }
 
+    private static bool ValidateMemberGraphFormatConflict(MemberOptions options)
+    {
+        if (!options.Tree || !options.FormatFlagExplicitlySet)
+            return true;
+
+        CommandError.Write(
+            "--tree is a standalone output format and cannot combine with another output format.");
+        return false;
+    }
+
     private static MemberOptions NormalizeMemberGraphFormat(
         MemberOptions options,
         IReadOnlyCollection<string>? sections)
@@ -518,18 +757,6 @@ public class ApiCommand
             return options with { MermaidOutput = false };
 
         return options;
-    }
-
-    static bool MightPeelDottedGenericMemberSelector(string? typeName)
-    {
-        if (string.IsNullOrWhiteSpace(typeName))
-            return false;
-
-        var lastDot = FqnParser.LastTopLevelDot(typeName);
-        if (lastDot <= 0 || lastDot == typeName.Length - 1)
-            return false;
-
-        return MemberTargetSelector.Parse(typeName[(lastDot + 1)..]).GenericArity.HasValue;
     }
 
     private static bool ValidateApiPrintSelection(HashSet<string>? includeSections)
@@ -682,14 +909,19 @@ public class ApiCommand
         // those schema entries because the type pipeline exposes whole-type code sections.
         var detailSchema = MergeSchemas(schema,
             ApiViewContext.Default.GetSchemaInfo<MemberCodeView>()!.ToDocumentSchema());
-        if (!ApiMemberSectionPipelines.UsesDetailPipeline(options))
+        var usesDetailPipeline = ApiMemberSectionPipelines.UsesDetailPipeline(options);
+        var usesOverloadInventoryPipeline = ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options);
+        if (!usesDetailPipeline && !usesOverloadInventoryPipeline)
             return detailSchema;
-        if (detailSchema.GetSection(SectionNames.Calls) == null)
-            detailSchema.Add(SectionNames.Calls, "column", "IL Offset", "Opcode", "Call Kind", "Callee", "Operand Token", "Return Address");
-        if (detailSchema.GetSection(SectionNames.Callers) == null)
-            detailSchema.Add(SectionNames.Callers, "column", "Caller", "IL Offset", "Opcode", "Call Kind", "Operand Token", "Return Address");
-        if (detailSchema.GetSection(SectionNames.UnsafeOperations) == null)
-            detailSchema.Add(SectionNames.UnsafeOperations, "column", "Reason", "Detail", "Kind", "IL", "Token");
+        if (usesDetailPipeline)
+        {
+            if (detailSchema.GetSection(SectionNames.Calls) == null)
+                detailSchema.Add(SectionNames.Calls, "column", "IL Offset", "Opcode", "Call Kind", "Callee", "Operand Token", "Return Address");
+            if (detailSchema.GetSection(SectionNames.Callers) == null)
+                detailSchema.Add(SectionNames.Callers, "column", "Caller", "IL Offset", "Opcode", "Call Kind", "Operand Token", "Return Address");
+            if (detailSchema.GetSection(SectionNames.UnsafeOperations) == null)
+                detailSchema.Add(SectionNames.UnsafeOperations, "column", "Reason", "Detail", "Kind", "IL", "Token");
+        }
         // One bidirectional section, so one field list: the union of what the outbound and inbound
         // halves each used to declare separately.
         detailSchema.Add(SectionNames.CallGraph, "field",
@@ -806,6 +1038,17 @@ public class ApiCommand
                 options.IncludeSections,
                 explicitInclude: explicitInclude),
             StringComparer.OrdinalIgnoreCase);
+        if (options is MemberOptions { AutoSelectedSingleOverload: true })
+        {
+            sections.UnionWith(
+                ApiMemberOverloadSectionDescriptors.CreatePipeline().GetEffectiveSections(
+                    type,
+                    options.Verbosity,
+                    options.IncludeSections,
+                    explicitInclude: explicitInclude));
+        }
+        if (ApiMemberSectionPipelines.ShouldAggregateImplicitCallers(type, options))
+            sections.Add(SectionNames.Callers);
         if (options.Discover is { Length: > 0 } discover)
         {
             var resolved = SelectResolver.ResolveSelectAsSections(
@@ -1323,49 +1566,57 @@ public class ApiCommand
 
         if (fullSerializer && view.EnumValues == null && view.EnumValuesWithDocs == null)
         {
-            if (options is MemberOptions { OverloadIndex: not null })
+            var selectedOverload = options is MemberOptions { OverloadIndex: not null };
+            var autoSelectedOverload =
+                options is MemberOptions { AutoSelectedSingleOverload: true };
+            if (selectedOverload)
             {
                 ApiOutputFormatter.PopulateMemberSignature(view, type, options);
             }
-            else if (options is MemberOptions { CtorOnly: true } && options.Verbosity >= Verbosity.Normal
-                && type.Members.Any(m => m.Kind == "constructor"))
+            if (!selectedOverload || autoSelectedOverload)
             {
-                ApiOutputFormatter.PopulateConstructorOverloads(view, type, options);
-            }
-            else
-            {
-                var renderMemberGroups = ApiOutputFormatter.ShouldRenderMemberGroups(options);
-                var renderMemberRows = ApiOutputFormatter.ShouldRenderMemberRows(options);
-                var renderSupplementalRows = ApiOutputFormatter.ShouldRenderSupplementalMemberRows(options);
-                if (renderMemberGroups)
+                if (!selectedOverload
+                    && options is MemberOptions { CtorOnly: true }
+                    && options.Verbosity >= Verbosity.Normal
+                    && type.Members.Any(m => m.Kind == "constructor"))
                 {
-                    methodGroupsView ??= new MethodGroupsView();
-                    eventsView ??= new EventsView();
-                    ApiOutputFormatter.PopulateMemberSummarySections(
-                        view, methodGroupsView, eventsView, type, options, methodGroupsOnly: renderMemberRows);
+                    ApiOutputFormatter.PopulateConstructorOverloads(view, type, options);
                 }
-                if (renderMemberRows || renderSupplementalRows)
+                else
                 {
-                    methodsView ??= new MethodsView();
-                    operatorsView ??= new OperatorsView();
-                    explicitInterfaceImplementationsView ??= new ExplicitInterfaceImplementationsView();
-                    extensionMethodsView ??= new ExtensionMethodsView();
-                    eventsView ??= new EventsView();
-                    ApiOutputFormatter.PopulateMemberSections(
-                        view,
-                        methodsView,
-                        operatorsView,
-                        explicitInterfaceImplementationsView,
-                        extensionMethodsView,
-                        eventsView,
-                        type,
-                        options,
-                        renderSupplementalRows ? ApiOutputFormatter.SupplementalMemberKinds : null);
-                }
-                if (ShouldRenderMemberIndex(options))
-                {
-                    memberIndexView ??= new MemberIndexView();
-                    ApiOutputFormatter.PopulateMemberIndex(memberIndexView, type, options);
+                    var renderMemberGroups = ApiOutputFormatter.ShouldRenderMemberGroups(options);
+                    var renderMemberRows = ApiOutputFormatter.ShouldRenderMemberRows(options);
+                    var renderSupplementalRows = ApiOutputFormatter.ShouldRenderSupplementalMemberRows(options);
+                    if (renderMemberGroups)
+                    {
+                        methodGroupsView ??= new MethodGroupsView();
+                        eventsView ??= new EventsView();
+                        ApiOutputFormatter.PopulateMemberSummarySections(
+                            view, methodGroupsView, eventsView, type, options, methodGroupsOnly: renderMemberRows);
+                    }
+                    if (renderMemberRows || renderSupplementalRows)
+                    {
+                        methodsView ??= new MethodsView();
+                        operatorsView ??= new OperatorsView();
+                        explicitInterfaceImplementationsView ??= new ExplicitInterfaceImplementationsView();
+                        extensionMethodsView ??= new ExtensionMethodsView();
+                        eventsView ??= new EventsView();
+                        ApiOutputFormatter.PopulateMemberSections(
+                            view,
+                            methodsView,
+                            operatorsView,
+                            explicitInterfaceImplementationsView,
+                            extensionMethodsView,
+                            eventsView,
+                            type,
+                            options,
+                            renderSupplementalRows ? ApiOutputFormatter.SupplementalMemberKinds : null);
+                    }
+                    if (ShouldRenderMemberIndex(options))
+                    {
+                        memberIndexView ??= new MemberIndexView();
+                        ApiOutputFormatter.PopulateMemberIndex(memberIndexView, type, options);
+                    }
                 }
             }
 
@@ -2005,6 +2256,49 @@ public class ApiCommand
         return DiscoverOutput.WithoutColumn(schema, "Select");
     }
 
+    internal static bool ValidateTypeProjection(
+        DocumentSchema schema,
+        IReadOnlyCollection<string> sectionNames,
+        string[]? fields,
+        string[]? columns)
+    {
+        if (!ProjectionDiagnostics.ValidateProjection(
+                schema, sectionNames, fields, columns: null))
+        {
+            return false;
+        }
+
+        if (columns is not { Length: > 0 })
+            return true;
+
+        var columnSchema = new DocumentSchema();
+        foreach (var name in sectionNames)
+        {
+            var section = schema.GetSection(name);
+            if (section is null)
+                continue;
+
+            if (TypeFieldLayoutSections.Contains(name))
+            {
+                columnSchema.Add(name, "column", ["Field", "Value"]);
+            }
+            else if (section.Items.Length > 0)
+            {
+                columnSchema.Add(
+                    name,
+                    section.ItemKind,
+                    section.Items.Select(item => item.Name).ToArray());
+            }
+            else
+            {
+                columnSchema.AddSection(name);
+            }
+        }
+
+        return ProjectionDiagnostics.ValidateProjection(
+            columnSchema, sectionNames, fields: null, columns);
+    }
+
     /// <summary>
     /// Executes effective discovery (<c>-D</c>) for a single type. Shared by the
     /// type and member commands so both paths apply identical queryability filtering:
@@ -2047,7 +2341,12 @@ public class ApiCommand
         ApiType apiType, SectionPipeline<ApiType> memberPipeline, ApiOptions options,
         TypeAcquisitionContext? acquisition = null)
     {
-        var fullSchema = GetTypeDocumentSchema(options);
+        if (options is MemberOptions { AutoSelectedSingleOverload: true })
+            memberPipeline = ApiMemberOverloadSectionDescriptors.CreatePipeline();
+
+        var fullSchema = RestrictSchemaToSections(
+            GetTypeDocumentSchema(options),
+            memberPipeline.SelectableSectionNames);
         var filteredType = BuildFilteredTypeForSections(apiType, options);
         var effective = memberPipeline.GetDiscoverableSections(
             filteredType,
@@ -2196,9 +2495,13 @@ public class ApiCommand
 
         if (view.EnumValues == null && view.EnumValuesWithDocs == null)
         {
-            if (renderOptions is MemberOptions { OverloadIndex: not null })
+            var selectedOverload =
+                renderOptions is MemberOptions { OverloadIndex: not null };
+            var autoSelectedOverload =
+                renderOptions is MemberOptions { AutoSelectedSingleOverload: true };
+            if (selectedOverload)
                 ApiOutputFormatter.PopulateMemberSignature(view, type, renderOptions);
-            else
+            if (!selectedOverload || autoSelectedOverload)
             {
                 var renderMemberGroups = ApiOutputFormatter.ShouldRenderMemberGroups(renderOptions);
                 var renderMemberRows = ApiOutputFormatter.ShouldRenderMemberRows(renderOptions);

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -178,6 +178,7 @@ public class ApiCommand
             MemberPipelineDeferredToLookup = false,
             MemberSelectionDeferredToLookup = false
         };
+        resolved = IncludeCallerScopeSection(resolved, pipeline);
 
         return ValidateResolvedMemberSelection(resolved, pipeline);
     }
@@ -240,11 +241,13 @@ public class ApiCommand
         MemberOptions options,
         SectionPipeline<ApiType> pipeline)
     {
-        var resolved = options with
-        {
-            MemberPipelineDeferredToLookup = false,
-            MemberSelectionDeferredToLookup = false
-        };
+        var resolved = IncludeCallerScopeSection(
+            options with
+            {
+                MemberPipelineDeferredToLookup = false,
+                MemberSelectionDeferredToLookup = false
+            },
+            pipeline);
         return ValidateResolvedMemberSelection(resolved, pipeline);
     }
 
@@ -309,6 +312,53 @@ public class ApiCommand
 
         return resolvedSections;
     }
+
+    private static MemberOptions IncludeCallerScopeSection(
+        MemberOptions options,
+        SectionPipeline<ApiType> pipeline)
+    {
+        if (!options.HasCallerScope
+            || options.Tree
+            || IsStandaloneMermaid(options)
+            || options.IncludeSections is not null
+            && UsesSingleSectionOutput(options)
+            || !pipeline.SelectableSectionNames.Contains(
+                SectionNames.Callers,
+                StringComparer.OrdinalIgnoreCase))
+            return options;
+        if (options.IncludeSections?.Contains(SectionNames.Callers) == true)
+            return options;
+
+        var includeSections = options.IncludeSections is { Count: > 0 } existing
+            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        includeSections.Add(SectionNames.Callers);
+        return options with { IncludeSections = includeSections };
+    }
+
+    private static bool UsesSingleSectionOutput(MemberOptions options)
+        => options.Discover is null
+           && (options.Count
+               || options.Print
+               || options.TabularExplicitlySet
+               || ShapeProjectionOutput.ActiveShapeCount(
+                   options.Value,
+                   options.Urls,
+                   options.Paths) > 0);
+
+    internal static bool RequiresCallerScopeResolution(MemberOptions options, ApiType type)
+        => options.HasCallerScope
+           && options.IncludeSections is { } sections
+           && (sections.Contains(SectionNames.Callers, StringComparer.OrdinalIgnoreCase)
+               && ApiMemberDetailSectionDescriptors.Callers.CanRender(type)
+               || sections.Contains(SectionNames.CallGraph, StringComparer.OrdinalIgnoreCase)
+               && ApiMemberDetailSectionDescriptors.CallGraph.CanRender(type));
+
+    private static bool IsStandaloneMermaid(MemberOptions options)
+        => options.MermaidOutput
+           && (options.FormatFlagExplicitlySet
+               || options.IncludeSections is { Count: 1 } sections
+               && sections.Contains(SectionNames.CallGraph, StringComparer.OrdinalIgnoreCase));
 
     internal static int ExecuteStructuralTypeDiscovery(
         ApiOptions options,
@@ -429,7 +479,8 @@ public class ApiCommand
         var deferMemberSelection = memberPipelineRequiresLookup
             && options.IncludeSections is null
             && (options.Select is not null
-                || options.SelectDefault);
+                || options.SelectDefault
+                || options is MemberOptions { HasCallerScope: true });
         if (options is MemberOptions memberOptions && memberPipelineRequiresLookup)
         {
             options = memberOptions with
@@ -535,6 +586,12 @@ public class ApiCommand
                         options = options with { IncludeSections = selectResult.Sections };
                 }
             }
+        }
+
+        if (options is MemberOptions callerScopeOptions
+            && !callerScopeOptions.MemberPipelineDeferredToLookup)
+        {
+            options = IncludeCallerScopeSection(callerScopeOptions, memberPipeline);
         }
 
         // A deferred select has no IncludeSections yet, and the preamble cannot know whether a

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -320,7 +320,8 @@ public class ApiCommand
         if (!options.HasCallerScope
             || options.Tree
             || IsStandaloneMermaid(options)
-            || options.IncludeSections is not null
+            || !options.CallerScopeSectionImplicitlySelected
+            && options.IncludeSections is not null
             && UsesSingleSectionOutput(options)
             || !pipeline.SelectableSectionNames.Contains(
                 SectionNames.Callers,
@@ -333,7 +334,11 @@ public class ApiCommand
             ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
             : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         includeSections.Add(SectionNames.Callers);
-        return options with { IncludeSections = includeSections };
+        return options with
+        {
+            IncludeSections = includeSections,
+            CallerScopeSectionImplicitlySelected = true
+        };
     }
 
     private static bool UsesSingleSectionOutput(MemberOptions options)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1630,7 +1630,7 @@ public class ApiCommand
                 && (mo4.OverloadIndex.HasValue || mo4.HasCallerScope))
             {
                 var requestedSections = GetRequestedMemberSections(type, mo4);
-                var methods = ApiOutputFormatter.ResolveBodyMethods(type, requestedSections);
+                var methods = ApiOutputFormatter.ResolveBodyMethods(type, requestedSections, mo4);
                 if (methods.Count > 0)
                 {
                     var analysisInspection = new ApiMemberAnalysisInspection(
@@ -2545,7 +2545,7 @@ public class ApiCommand
                 && (memberOptions.OverloadIndex.HasValue || memberOptions.HasCallerScope))
             {
                 var requestedSections = GetRequestedMemberSections(type, memberOptions);
-                var methods = ApiOutputFormatter.ResolveBodyMethods(type, requestedSections);
+                var methods = ApiOutputFormatter.ResolveBodyMethods(type, requestedSections, memberOptions);
                 if (methods.Count > 0)
                 {
                     var analysisInspection = new ApiMemberAnalysisInspection(

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -182,7 +182,9 @@ public static class MemberCommand
             MemberOptions effectiveOptions = options;
             if (!options.DocsExplicitlySet && options.Verbosity >= Verbosity.Normal)
                 effectiveOptions = options with { ShowDocs = true };
-            var authoredSelection = effectiveOptions;
+            var authoredSelection = effectiveOptions.CallerScopeSectionImplicitlySelected
+                ? ExcludeCallersSection(effectiveOptions)
+                : effectiveOptions;
 
             // Keep member-name lookups as overload inventories. Only auto-select the lone
             // overload when the user explicitly asks for a selected-overload detail section.
@@ -623,6 +625,15 @@ public static class MemberCommand
         }
 
         return members;
+    }
+
+    private static MemberOptions ExcludeCallersSection(MemberOptions options)
+    {
+        var includeSections = options.IncludeSections is { } existing
+            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
+            : [];
+        includeSections.Remove(SectionNames.Callers);
+        return options with { IncludeSections = includeSections };
     }
 
     private static readonly string[] SingleOverloadSectionNames =

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -496,8 +496,9 @@ public static class MemberCommand
         if (options.IncludeSections is not { Count: > 0 } includeSections)
             return false;
         // Bare -S carries no selector value, so it cannot be recognized by inspecting Select.
-        if ((options.SelectDefault && options.Select is null)
-            || IsPureSelector(options.Select, SelectResolver.AllSelector))
+        if (!options.MemberSectionsPreResolved
+            && ((options.SelectDefault && options.Select is null)
+                || IsPureSelector(options.Select, SelectResolver.AllSelector)))
             return false;
 
         sections = SingleOverloadSectionNames

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -182,8 +182,11 @@ public static class MemberCommand
             MemberOptions effectiveOptions = options;
             if (!options.DocsExplicitlySet && options.Verbosity >= Verbosity.Normal)
                 effectiveOptions = options with { ShowDocs = true };
-            var callersImplicitlySelected = ShouldImplicitlySelectCallers(effectiveOptions);
+            var callersImplicitlySelected = effectiveOptions.IncludeSections is { Count: > 0 }
+                && ShouldImplicitlySelectCallers(effectiveOptions);
             if (callersImplicitlySelected)
+                effectiveOptions = IncludeCallersSection(effectiveOptions);
+            else if (effectiveOptions.HasCallerScope)
                 effectiveOptions = IncludeCallersSection(effectiveOptions);
             var authoredSelection = callersImplicitlySelected
                 ? ExcludeCallersSection(effectiveOptions)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -280,6 +280,21 @@ public static class MemberCommand
                 }
             }
 
+            if (effectiveOptions is
+                {
+                    CallerScopeSectionImplicitlySelected: true,
+                    OverloadIndex: null
+                })
+            {
+                effectiveOptions = effectiveOptions with
+                {
+                    ImplicitCallerMemberTokens = GetImplicitCallerMembers(apiType, effectiveOptions)
+                        .Where(ApiMemberSectionDescriptors.IsBodyBacked)
+                        .SelectMany(member => BodyMethodTokens(apiType, member))
+                        .ToHashSet()
+                };
+            }
+
             if (effectiveOptions.OverloadIndex is null
                 && string.IsNullOrWhiteSpace(effectiveOptions.MemberDigest)
                 && effectiveOptions.MemberGenericArity.HasValue
@@ -397,11 +412,12 @@ public static class MemberCommand
 
             // For caller-scope queries without a specific overload, ensure DllPath is set so we can
             // open the member's own assembly index for aggregated callers across all overloads.
+            var callerTargetAssembly = apiType.SourceAssemblyPath ?? apiDllPath;
             if (effectiveOptions.HasCallerScope
                 && effectiveOptions.DllPath == null
-                && apiDllPath != null)
+                && callerTargetAssembly != null)
             {
-                effectiveOptions = effectiveOptions with { DllPath = apiDllPath };
+                effectiveOptions = effectiveOptions with { DllPath = callerTargetAssembly };
             }
 
             // Expand --bin/--directory, --project, and --caller-package into assemblies
@@ -626,6 +642,44 @@ public static class MemberCommand
            && (options.FormatFlagExplicitlySet
                || options.IncludeSections is { Count: 1 } sections
                && sections.Contains(SectionNames.CallGraph));
+
+    private static IEnumerable<int> BodyMethodTokens(
+        ApiType type,
+        ApiMember member)
+    {
+        if (ApiMemberSectionDescriptors.IsMethodLike(member))
+        {
+            if (member.MetadataToken is { } token)
+                yield return token;
+            yield break;
+        }
+
+        if (!ApiMemberSectionDescriptors.HasAccessorTokens(member))
+            yield break;
+
+        foreach (var accessor in ApiOutputFormatter.AccessorMethods(member, type))
+        {
+            if (accessor.MetadataToken is { } token)
+                yield return token;
+        }
+    }
+
+    private static IEnumerable<ApiMember> GetImplicitCallerMembers(
+        ApiType type,
+        MemberOptions options)
+    {
+        IEnumerable<ApiMember> members = ApiOutputFormatter
+            .GroupMembersByKind(type, options.MemberFilter, options.UnsafeOnly, options.KindFilter)
+            .SelectMany(group => group.Value);
+        if (options.MemberGenericArity.HasValue && options.MemberFilter.Count == 1)
+        {
+            var memberName = options.MemberFilter.First();
+            var arityCandidates = GetCandidateMembers(type, options, memberName).ToHashSet();
+            members = members.Where(arityCandidates.Contains);
+        }
+
+        return members;
+    }
 
     private static readonly string[] SingleOverloadSectionNames =
     [

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -182,11 +182,8 @@ public static class MemberCommand
             MemberOptions effectiveOptions = options;
             if (!options.DocsExplicitlySet && options.Verbosity >= Verbosity.Normal)
                 effectiveOptions = options with { ShowDocs = true };
-            var callersImplicitlySelected = effectiveOptions.IncludeSections is { Count: > 0 }
-                && ShouldImplicitlySelectCallers(effectiveOptions);
+            var callersImplicitlySelected = ShouldImplicitlySelectCallers(effectiveOptions);
             if (callersImplicitlySelected)
-                effectiveOptions = IncludeCallersSection(effectiveOptions);
-            else if (effectiveOptions.HasCallerScope)
                 effectiveOptions = IncludeCallersSection(effectiveOptions);
             var authoredSelection = callersImplicitlySelected
                 ? ExcludeCallersSection(effectiveOptions)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -182,12 +182,7 @@ public static class MemberCommand
             MemberOptions effectiveOptions = options;
             if (!options.DocsExplicitlySet && options.Verbosity >= Verbosity.Normal)
                 effectiveOptions = options with { ShowDocs = true };
-            var callersImplicitlySelected = ShouldImplicitlySelectCallers(effectiveOptions);
-            if (callersImplicitlySelected)
-                effectiveOptions = IncludeCallersSection(effectiveOptions);
-            var authoredSelection = callersImplicitlySelected
-                ? ExcludeCallersSection(effectiveOptions)
-                : effectiveOptions;
+            var authoredSelection = effectiveOptions;
 
             // Keep member-name lookups as overload inventories. Only auto-select the lone
             // overload when the user explicitly asks for a selected-overload detail section.
@@ -219,9 +214,7 @@ public static class MemberCommand
                             detailPipeline)
                         is not { } detailOptions)
                         return 1;
-                    effectiveOptions = callersImplicitlySelected
-                        ? IncludeCallersSection(detailOptions)
-                        : detailOptions;
+                    effectiveOptions = detailOptions;
                 }
             }
 
@@ -420,7 +413,7 @@ public static class MemberCommand
             // Expand --bin/--directory, --project, and --caller-package into assemblies
             // for cross-assembly callers and Call Graph traversal, in addition to the
             // selected member's own assembly.
-            if (effectiveOptions.HasCallerScope)
+            if (ApiCommand.RequiresCallerScopeResolution(effectiveOptions, apiType))
             {
                 var ownAssembly = effectiveOptions.DllPath ?? runtimeAssemblyPath ?? apiDllPath;
                 callerScopeAssemblySet = await CallerScopeResolver.ResolveAsync(
@@ -593,52 +586,6 @@ public static class MemberCommand
             .ToList();
         return sections.Count > 0;
     }
-
-    private static MemberOptions IncludeCallersSection(MemberOptions options)
-    {
-        var includeSections = options.IncludeSections is { Count: > 0 } existing
-            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
-            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        includeSections.Add(SectionNames.Callers);
-        return options with
-        {
-            IncludeSections = includeSections,
-            CallerScopeSectionImplicitlySelected = true
-        };
-    }
-
-    private static MemberOptions ExcludeCallersSection(MemberOptions options)
-    {
-        var includeSections = options.IncludeSections is { } existing
-            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
-            : [];
-        includeSections.Remove(SectionNames.Callers);
-        return options with { IncludeSections = includeSections };
-    }
-
-    private static bool ShouldImplicitlySelectCallers(MemberOptions options)
-        => options.HasCallerScope
-           && options.IncludeSections?.Contains(SectionNames.Callers) != true
-           && (!options.JsonOutput || options.IncludeSections is { Count: > 0 })
-           && !options.Tree
-           && !IsStandaloneMermaid(options)
-           && (options.IncludeSections is null || !UsesSingleSectionOutput(options));
-
-    private static bool UsesSingleSectionOutput(MemberOptions options)
-        => options.Discover is null
-           && (options.Count
-               || options.Print
-               || options.TabularExplicitlySet
-               || ShapeProjectionOutput.ActiveShapeCount(
-                   options.Value,
-                   options.Urls,
-                   options.Paths) > 0);
-
-    private static bool IsStandaloneMermaid(MemberOptions options)
-        => options.MermaidOutput
-           && (options.FormatFlagExplicitlySet
-               || options.IncludeSections is { Count: 1 } sections
-               && sections.Contains(SectionNames.CallGraph));
 
     private static IEnumerable<int> BodyMethodTokens(
         ApiType type,

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -96,26 +96,57 @@ public static class MemberCommand
                 {
                     impliedSelector.Name
                 };
+                if (options.MemberGenericArity is { } explicitArity
+                    && impliedSelector.GenericArity is { } impliedArity
+                    && explicitArity != impliedArity)
+                {
+                    CommandError.Write("A member selection cannot combine different generic arities.");
+                    return 1;
+                }
+
+                var mergedArity = options.MemberGenericArity ?? impliedSelector.GenericArity;
+                if (mergedArity.HasValue && mergedFilter.Count != 1)
+                {
+                    CommandError.Write("A generic arity selector requires exactly one member name.");
+                    return 1;
+                }
+
                 options = options with
                 {
                     MemberFilter = mergedFilter,
-                    MemberGenericArity = options.MemberGenericArity ?? impliedSelector.GenericArity
+                    MemberGenericArity = mergedArity
                 };
             }
-            else if (options.MemberFilter.Count == 0 && options.Select is { Length: > 0 })
+
+            memberPipeline = ApiMemberSectionPipelines.Create(options);
+
+            // Structural discovery ignores -S. Once lookup has identified the actual member
+            // pipeline, report that schema directly just as the non-dotted path does.
+            if (options.Discover is not null && !options.EffectiveDiscovery)
             {
-                var actualPipeline = ApiMemberSectionPipelines.Create(options);
-                var actualSelect = SelectResolver.ResolveSelectAsSections(
-                    options.Select,
-                    actualPipeline.SelectableSectionNames,
-                    actualPipeline.InfoSectionNames,
-                    actualPipeline.GetCategoryMap(),
-                    selectDefault: options.SelectDefault);
-                if (SelectOutput.WriteUnresolved(actualSelect))
-                    return 1;
-                if (actualSelect.Sections != null)
-                    options = options with { IncludeSections = actualSelect.Sections };
+                return ApiCommand.ExecuteStructuralTypeDiscovery(options, memberPipeline);
             }
+
+            if (options.MemberSelectionDeferredToLookup)
+            {
+                if (ApiCommand.ReresolveSectionsForMemberLookup(options) is not { } resolved)
+                    return 1;
+                options = resolved;
+                memberPipeline = ApiMemberSectionPipelines.Create(options);
+            }
+            else if (ApiCommand.RevalidateResolvedMemberSections(options, memberPipeline) is { } revalidated)
+            {
+                options = revalidated;
+                if (options.MemberPipelineDeferredToLookup)
+                {
+                    if (ApiCommand.FinalizeResolvedMemberSelection(options, memberPipeline)
+                        is not { } finalized)
+                        return 1;
+                    options = finalized;
+                }
+            }
+            else
+                return 1;
 
             // Check each member filter before producing output
             if (options.MemberFilter.Count > 0)
@@ -151,8 +182,12 @@ public static class MemberCommand
             MemberOptions effectiveOptions = options;
             if (!options.DocsExplicitlySet && options.Verbosity >= Verbosity.Normal)
                 effectiveOptions = options with { ShowDocs = true };
-            if (effectiveOptions.HasCallerScope)
+            var callersImplicitlySelected = ShouldImplicitlySelectCallers(effectiveOptions);
+            if (callersImplicitlySelected)
                 effectiveOptions = IncludeCallersSection(effectiveOptions);
+            var authoredSelection = callersImplicitlySelected
+                ? ExcludeCallersSection(effectiveOptions)
+                : effectiveOptions;
 
             // Keep member-name lookups as overload inventories. Only auto-select the lone
             // overload when the user explicitly asks for a selected-overload detail section.
@@ -165,7 +200,29 @@ public static class MemberCommand
                 var autoMemberName = effectiveOptions.MemberFilter.First();
                 var autoOverloads = GetCandidateMembers(apiType, effectiveOptions, autoMemberName);
                 if (autoOverloads.Count == 1)
-                    effectiveOptions = effectiveOptions with { OverloadIndex = 1 };
+                {
+                    var inventoryPipeline = ApiMemberSectionPipelines.Create(authoredSelection);
+                    if (ApiCommand.RevalidateResolvedMemberSections(
+                            authoredSelection,
+                            inventoryPipeline)
+                        is not { } inventorySections)
+                        return 1;
+
+                    inventorySections = inventorySections with
+                    {
+                        OverloadIndex = 1,
+                        AutoSelectedSingleOverload = true
+                    };
+                    var detailPipeline = ApiMemberSectionPipelines.Create(inventorySections);
+                    if (ApiCommand.FinalizeResolvedMemberSelection(
+                            inventorySections,
+                            detailPipeline)
+                        is not { } detailOptions)
+                        return 1;
+                    effectiveOptions = callersImplicitlySelected
+                        ? IncludeCallersSection(detailOptions)
+                        : detailOptions;
+                }
             }
 
             if (effectiveOptions.OverloadIndex.HasValue
@@ -205,7 +262,7 @@ public static class MemberCommand
             }
 
             if (effectiveOptions.OverloadIndex is null
-                && TryGetSelectedSingleOverloadSections(effectiveOptions, out var singleOverloadSections))
+                && TryGetSelectedSingleOverloadSections(authoredSelection, out var singleOverloadSections))
             {
                 var memberName = effectiveOptions.MemberFilter.First();
                 var overloads = GetCandidateMembers(apiType, effectiveOptions, memberName);
@@ -337,7 +394,9 @@ public static class MemberCommand
 
             // For caller-scope queries without a specific overload, ensure DllPath is set so we can
             // open the member's own assembly index for aggregated callers across all overloads.
-            if (effectiveOptions.HasCallerScope && effectiveOptions.DllPath == null && apiDllPath != null)
+            if (effectiveOptions.HasCallerScope
+                && effectiveOptions.DllPath == null
+                && apiDllPath != null)
             {
                 effectiveOptions = effectiveOptions with { DllPath = apiDllPath };
             }
@@ -357,12 +416,9 @@ public static class MemberCommand
                     context.HttpClient,
                     logger);
 
-                // Supplying a caller scope is an explicit request for the Callers section, so it
-                // renders (with an empty-state note when nothing matches) even at low verbosity.
                 effectiveOptions = effectiveOptions with
                 {
-                    CallerScopeAssemblies = callerScopeAssemblySet.Assemblies,
-                    IncludeSections = IncludeCallersSection(effectiveOptions).IncludeSections
+                    CallerScopeAssemblies = callerScopeAssemblySet.Assemblies
                 };
             }
 
@@ -381,13 +437,28 @@ public static class MemberCommand
                 var schema = ApiCommand.ToQueryableSchema(
                     ApiCommand.GetTypeDocumentSchema(effectiveOptions),
                     effectiveOptions);
-                if (!ProjectionDiagnostics.ValidateProjection(schema, projectionSections, effectiveOptions.Fields, effectiveOptions.Columns))
+                if (!ApiCommand.ValidateTypeProjection(
+                        schema,
+                        projectionSections,
+                        effectiveOptions.Fields,
+                        effectiveOptions.Columns))
                     return 1;
             }
 
             var writeExitCode = await ApiCommand.WriteTypeOutputAsync(apiType, foundIn, packageName, packageVersion, apiSource, selectedTfm, effectiveOptions);
             if (writeExitCode != 0)
                 return writeExitCode;
+
+            if ((effectiveOptions.Count
+                 || !effectiveOptions.Tabular
+                 && !effectiveOptions.JsonOutput)
+                && apiType.Members is [{ Kind: "field" }])
+            {
+                ApiCommand.WarnEmptySelectedSections(
+                    apiType,
+                    effectiveOptions,
+                    ApiMemberSectionPipelines.Create(effectiveOptions));
+            }
 
             if (!effectiveOptions.FormatExplicitlySet && !effectiveOptions.IsRawOutput && effectiveOptions.OverloadIndex == null)
             {
@@ -513,8 +584,45 @@ public static class MemberCommand
             ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
             : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         includeSections.Add(SectionNames.Callers);
+        return options with
+        {
+            IncludeSections = includeSections,
+            CallerScopeSectionImplicitlySelected = true
+        };
+    }
+
+    private static MemberOptions ExcludeCallersSection(MemberOptions options)
+    {
+        var includeSections = options.IncludeSections is { } existing
+            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
+            : [];
+        includeSections.Remove(SectionNames.Callers);
         return options with { IncludeSections = includeSections };
     }
+
+    private static bool ShouldImplicitlySelectCallers(MemberOptions options)
+        => options.HasCallerScope
+           && options.IncludeSections?.Contains(SectionNames.Callers) != true
+           && (!options.JsonOutput || options.IncludeSections is { Count: > 0 })
+           && !options.Tree
+           && !IsStandaloneMermaid(options)
+           && (options.IncludeSections is null || !UsesSingleSectionOutput(options));
+
+    private static bool UsesSingleSectionOutput(MemberOptions options)
+        => options.Discover is null
+           && (options.Count
+               || options.Print
+               || options.TabularExplicitlySet
+               || ShapeProjectionOutput.ActiveShapeCount(
+                   options.Value,
+                   options.Urls,
+                   options.Paths) > 0);
+
+    private static bool IsStandaloneMermaid(MemberOptions options)
+        => options.MermaidOutput
+           && (options.FormatFlagExplicitlySet
+               || options.IncludeSections is { Count: 1 } sections
+               && sections.Contains(SectionNames.CallGraph));
 
     private static readonly string[] SingleOverloadSectionNames =
     [
@@ -542,7 +650,8 @@ public static class MemberCommand
     ];
 
     private static bool IsPureSelector(string[]? select, string name) =>
-        select is { Length: 1 } && select[0].Equals(name, StringComparison.OrdinalIgnoreCase);
+        select is { Length: > 0 }
+        && select.All(selector => selector.Equals(name, StringComparison.OrdinalIgnoreCase));
 
     private static List<ApiMember> GetCandidateMembers(ApiType apiType, MemberOptions options, string memberName)
         => GetTargetCandidates(apiType, options, memberName)

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -276,7 +276,11 @@ public static class TypeCommand
                     if (tabularProjection && effectiveOptions.IncludeSections is { Count: > 0 })
                     {
                         var projSchema = ApiCommand.GetTypeDocumentSchema(effectiveOptions);
-                        if (!ProjectionDiagnostics.ValidateProjection(projSchema, effectiveOptions.IncludeSections, effectiveOptions.Fields, effectiveOptions.Columns))
+                        if (!ApiCommand.ValidateTypeProjection(
+                                projSchema,
+                                effectiveOptions.IncludeSections,
+                                effectiveOptions.Fields,
+                                effectiveOptions.Columns))
                             return 1;
                     }
 

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -285,11 +285,39 @@ public record TypeOptions : ApiOptions
 public record MemberOptions : ApiOptions
 {
     /// <summary>
+    /// True when a dotted type argument may resolve either as a namespace-qualified type or as
+    /// <c>Type.Member</c>. The member pipeline, selection, and structural discovery stay deferred
+    /// until metadata lookup determines which context is real.
+    /// </summary>
+    public bool MemberPipelineDeferredToLookup { get; init; }
+
+    /// <summary>
+    /// True when raw section selectors must also wait for the member pipeline selected by lookup.
+    /// Pre-resolved <see cref="ApiOptions.IncludeSections"/> still validate argument-only contracts
+    /// in the preamble, then use <see cref="MemberPipelineDeferredToLookup"/> for post-lookup
+    /// pipeline validation.
+    /// </summary>
+    public bool MemberSelectionDeferredToLookup { get; init; }
+
+    /// <summary>
     /// True when <see cref="ApiOptions.IncludeSections"/> was supplied before the command
     /// preamble. Retained raw selectors are provenance only and must not override that set or
     /// control later member-pipeline transitions.
     /// </summary>
     public bool MemberSectionsPreResolved { get; init; }
+
+    /// <summary>
+    /// True when a member-name inventory contained one overload and the command selected it to
+    /// produce requested detail evidence. The authored command remains an overload-inventory
+    /// query, so its advertised inventory sections stay valid alongside detail sections.
+    /// </summary>
+    internal bool AutoSelectedSingleOverload { get; init; }
+
+    /// <summary>
+    /// True when caller-scope resolution, rather than an authored selector, added Callers to
+    /// <see cref="ApiOptions.IncludeSections"/>.
+    /// </summary>
+    internal bool CallerScopeSectionImplicitlySelected { get; init; }
 
     public bool CtorOnly { get; init; }
     public int? OverloadIndex { get; init; }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -319,6 +319,12 @@ public record MemberOptions : ApiOptions
     /// </summary>
     internal bool CallerScopeSectionImplicitlySelected { get; init; }
 
+    /// <summary>
+    /// Method definition tokens for the overload family targeted by an implicit Callers
+    /// selection. Null keeps the ordinary selected-member body scope.
+    /// </summary>
+    internal IReadOnlySet<int>? ImplicitCallerMemberTokens { get; init; }
+
     public bool CtorOnly { get; init; }
     public int? OverloadIndex { get; init; }
     public string? MemberDigest { get; init; }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -284,6 +284,13 @@ public record TypeOptions : ApiOptions
 /// </summary>
 public record MemberOptions : ApiOptions
 {
+    /// <summary>
+    /// True when <see cref="ApiOptions.IncludeSections"/> was supplied before the command
+    /// preamble. Retained raw selectors are provenance only and must not override that set or
+    /// control later member-pipeline transitions.
+    /// </summary>
+    public bool MemberSectionsPreResolved { get; init; }
+
     public bool CtorOnly { get; init; }
     public int? OverloadIndex { get; init; }
     public string? MemberDigest { get; init; }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -196,9 +196,17 @@ public static class ApiOutputFormatter
         var effectiveVerbosity = options.Verbosity;
 
         var pipeline = ApiMemberSectionPipelines.Create(options);
-        var selectAll = SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
+        var sectionsPreResolved = options is MemberOptions { MemberSectionsPreResolved: true };
+        var selectAll = SelectResolver.IsActiveAllSelector(
+            options.Select,
+            options.IncludeSections,
+            sectionsPreResolved);
         var includeSections = pipeline.ComputeIncludeSections(
-            type, effectiveVerbosity, options.IncludeSections, selectAll);
+            type,
+            effectiveVerbosity,
+            options.IncludeSections,
+            selectAll,
+            explicitInclude: sectionsPreResolved);
         if (ShouldRenderMemberDetailContext(options) && includeSections is { Count: > 0 }
             && !includeSections.Contains(SectionNames.Summary))
             includeSections = [SectionNames.Summary, .. includeSections];
@@ -214,8 +222,14 @@ public static class ApiOutputFormatter
     internal static bool ShouldRenderMemberDetailContext(ApiOptions options) =>
         options is MemberOptions { OverloadIndex: not null }
         && options.IncludeSections is { Count: > 0 }
-        && !SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections)
-        && !SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
+        && !SelectResolver.IsActiveAllSelector(
+            options.Select,
+            options.IncludeSections,
+            options is MemberOptions { MemberSectionsPreResolved: true })
+        && !SelectResolver.IsActiveInfoSelector(
+            options.SelectDefault,
+            options.IncludeSections,
+            options is MemberOptions { MemberSectionsPreResolved: true })
         && !options.Count
         && !options.JsonOutput
         && !options.Tabular;
@@ -238,7 +252,10 @@ public static class ApiOutputFormatter
         options.Verbosity != Verbosity.Minimal
         || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options)
         || SectionRequested(options.IncludeSections, SectionNames.Methods)
-        || (!SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
+        || (!SelectResolver.IsActiveInfoSelector(
+                options.SelectDefault,
+                options.IncludeSections,
+                options is MemberOptions { MemberSectionsPreResolved: true })
             && (SectionRequested(options.IncludeSections, SectionNames.Operators)
                 || SectionRequested(options.IncludeSections, SectionNames.ExplicitInterfaceImplementations)
                 || SectionRequested(options.IncludeSections, SectionNames.ExtensionMethods)))
@@ -258,7 +275,10 @@ public static class ApiOutputFormatter
         options.Verbosity == Verbosity.Minimal
         && !ShouldRenderMemberRows(options)
         && (options.IncludeSections is null
-            || SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections));
+            || SelectResolver.IsActiveInfoSelector(
+                options.SelectDefault,
+                options.IncludeSections,
+                options is MemberOptions { MemberSectionsPreResolved: true }));
 
     /// <summary>
     /// True when the type-listing tabular view must project the fixed fact table rather than type
@@ -280,6 +300,12 @@ public static class ApiOutputFormatter
 
     internal static bool ShouldRenderSectionedTabularView(ApiType type, ApiOptions options)
     {
+        if (options is MemberOptions
+            {
+                MemberSectionsPreResolved: true,
+                IncludeSections.Count: 0
+            })
+            return true;
         if (options.IncludeSections is { Count: 1 })
             return true;
         if (!ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options))

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -207,6 +207,21 @@ public static class ApiOutputFormatter
             options.IncludeSections,
             selectAll,
             explicitInclude: sectionsPreResolved);
+        if (options is MemberOptions { AutoSelectedSingleOverload: true })
+        {
+            includeSections ??= [];
+            includeSections.UnionWith(
+                ApiMemberOverloadSectionDescriptors.CreatePipeline().GetEffectiveSections(
+                    type,
+                    effectiveVerbosity,
+                    options.IncludeSections,
+                    explicitInclude: sectionsPreResolved));
+        }
+        if (ApiMemberSectionPipelines.ShouldAggregateImplicitCallers(type, options))
+        {
+            includeSections ??= [];
+            includeSections.Add(SectionNames.Callers);
+        }
         if (ShouldRenderMemberDetailContext(options) && includeSections is { Count: > 0 }
             && !includeSections.Contains(SectionNames.Summary))
             includeSections = [SectionNames.Summary, .. includeSections];
@@ -463,7 +478,9 @@ public static class ApiOutputFormatter
 
         // Type parameters table (pipeline controls visibility via IncludeSections)
         List<TypeParameterRow>? typeParameterRows = null;
-        if (!memberFilterActive && type.TypeParameters.Count > 0)
+        if ((!memberFilterActive
+             || SectionRequested(options.IncludeSections, SectionNames.TypeParameters))
+            && type.TypeParameters.Count > 0)
         {
             typeParameterRows = type.TypeParameters
                 .Select(tp => new TypeParameterRow { Parameter = tp.DisplayName, Constraints = ConstraintSummary(type.TypeParameters, tp) })
@@ -472,7 +489,9 @@ public static class ApiOutputFormatter
 
         // Interfaces (pipeline controls visibility via IncludeSections)
         List<InterfaceRow>? interfaceRows = null;
-        if (!memberFilterActive && type.Interfaces.Count > 0)
+        if ((!memberFilterActive
+             || SectionRequested(options.IncludeSections, SectionNames.Interfaces))
+            && type.Interfaces.Count > 0)
         {
             interfaceRows = projection.Interfaces
                 .Select(i => new InterfaceRow { Interface = CSharpIdentifier.ContainRenderedText(i) })
@@ -481,7 +500,9 @@ public static class ApiOutputFormatter
 
         // Baseclass (pipeline controls visibility via IncludeSections; filtered for trivial bases)
         List<BaseclassRow>? baseclassRows = null;
-        if (!memberFilterActive && baseType != null)
+        if ((!memberFilterActive
+             || SectionRequested(options.IncludeSections, SectionNames.Baseclass))
+            && baseType != null)
         {
             baseclassRows = [new BaseclassRow { Type = baseType }];
         }
@@ -1412,7 +1433,9 @@ public static class ApiOutputFormatter
     /// overload-index selector (<c>Prop:1</c>/<c>Prop:2</c>) addresses. A field carries
     /// no accessor token and yields no body methods, so its body sections stay N/A.
     /// </summary>
-    internal static List<ApiMember> ResolveBodyMethods(ApiType type, IReadOnlySet<string> requestedSections)
+    internal static List<ApiMember> ResolveBodyMethods(
+        ApiType type,
+        IReadOnlySet<string> requestedSections)
     {
         bool includeAbstract = requestedSections.Contains(SectionNames.UnsafeOperations);
         var methods = type.Members

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1435,14 +1435,39 @@ public static class ApiOutputFormatter
     /// </summary>
     internal static List<ApiMember> ResolveBodyMethods(
         ApiType type,
-        IReadOnlySet<string> requestedSections)
+        IReadOnlySet<string> requestedSections,
+        ApiOptions? options = null)
     {
         bool includeAbstract = requestedSections.Contains(SectionNames.UnsafeOperations);
-        var methods = type.Members
-            .Where(m => ApiMemberSectionDescriptors.IsMethodLike(m) && (!m.IsAbstract || includeAbstract))
-            .ToList();
+        var implicitCallerTokens = (options as MemberOptions)?.ImplicitCallerMemberTokens;
+        List<ApiMember> methods;
+        if (implicitCallerTokens is { } tokens)
+        {
+            methods = type.Members
+                .Where(ApiMemberSectionDescriptors.IsMethodLike)
+                .Where(member => member.MetadataToken is { } token && tokens.Contains(token))
+                .ToList();
+            var methodTokens = methods
+                .Select(member => member.MetadataToken)
+                .OfType<int>()
+                .ToHashSet();
+            methods.AddRange(type.Members
+                .Where(ApiMemberSectionDescriptors.HasAccessorTokens)
+                .SelectMany(member => AccessorMethods(member, type))
+                .Where(member => member.MetadataToken is { } token
+                    && tokens.Contains(token)
+                    && methodTokens.Add(token)));
+        }
+        else
+        {
+            methods = type.Members
+                .Where(m => ApiMemberSectionDescriptors.IsMethodLike(m)
+                    && (!m.IsAbstract || includeAbstract))
+                .ToList();
+        }
 
-        if (methods.Count == 0
+        if (implicitCallerTokens is null
+            && methods.Count == 0
             && type.Members is [{ } single]
             && ApiMemberSectionDescriptors.HasAccessorTokens(single))
         {

--- a/src/dotnet-inspect/Output/SelectResolver.cs
+++ b/src/dotnet-inspect/Output/SelectResolver.cs
@@ -103,12 +103,24 @@ public static class SelectResolver
     public static bool IsActiveAllSelector(string[]? select, HashSet<string>? includeSections)
         => IsAllSelector(select) && includeSections is { Count: > 1 };
 
+    public static bool IsActiveAllSelector(
+        string[]? select,
+        HashSet<string>? includeSections,
+        bool sectionsPreResolved)
+        => !sectionsPreResolved && IsActiveAllSelector(select, includeSections);
+
     /// <summary>
     /// Whether the default preset is in effect and actually resolved to something. The preset is
     /// reached only through bare <c>-S</c>; it has no selector spelling.
     /// </summary>
     public static bool IsActiveInfoSelector(bool selectDefault, HashSet<string>? includeSections)
         => selectDefault && includeSections is { Count: > 0 };
+
+    public static bool IsActiveInfoSelector(
+        bool selectDefault,
+        HashSet<string>? includeSections,
+        bool sectionsPreResolved)
+        => !sectionsPreResolved && IsActiveInfoSelector(selectDefault, includeSections);
 
     internal static bool TryResolveCategory(
         string value,

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -566,10 +566,22 @@ public static class ApiMemberSectionPipelines
     public static bool UsesOverloadInventoryPipeline(ApiOptions options)
         => options is MemberOptions
            {
-              OverloadIndex: null,
               MemberDigest: null,
               MemberFilter.Count: > 0
-           };
+           } member
+           && (member.OverloadIndex is null || member.AutoSelectedSingleOverload);
+
+    internal static bool ShouldAggregateImplicitCallers(
+        ApiType type,
+        ApiOptions options)
+        => options is MemberOptions
+           {
+               CallerScopeSectionImplicitlySelected: true
+           }
+           && options.IncludeSections?.Contains(
+               SectionNames.Callers,
+               StringComparer.OrdinalIgnoreCase) == true
+           && type.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -577,11 +577,13 @@ public static class ApiMemberSectionPipelines
         => options is MemberOptions
            {
                CallerScopeSectionImplicitlySelected: true
-           }
+           } memberOptions
            && options.IncludeSections?.Contains(
                SectionNames.Callers,
                StringComparer.OrdinalIgnoreCase) == true
-           && type.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
+           && (memberOptions.ImplicitCallerMemberTokens is { } tokens
+               ? tokens.Count > 0
+               : type.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked));
 }
 
 /// <summary>

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -572,13 +572,13 @@ public sealed class SectionPipeline<TModel>
     /// filtered by verbosity and <c>-S</c>.
     /// </summary>
     public List<string> GetEffectiveSections(TModel model, Verbosity verbosity,
-        HashSet<string>? include = null, bool fixedOverview = false)
+        HashSet<string>? include = null, bool fixedOverview = false, bool explicitInclude = false)
     {
         List<string> result = [];
         for (int i = 0; i < _entries.Count; i++)
         {
             var entry = _entries[i];
-            if (!IsRequested(entry, i, verbosity, include, fixedOverview))
+            if (!IsRequested(entry, i, verbosity, include, fixedOverview, explicitInclude))
                 continue;
             if (entry.CanRender(model))
                 result.Add(entry.Name);
@@ -649,14 +649,18 @@ public sealed class SectionPipeline<TModel>
     /// structural applicability; they merely skip render probing so discovery never opens a
     /// whole-assembly index. Registration order is preserved.
     /// </summary>
-    public List<string> GetDiscoverableSections(TModel model, HashSet<string>? include = null)
+    public List<string> GetDiscoverableSections(
+        TModel model,
+        HashSet<string>? include = null,
+        bool explicitInclude = false)
     {
         List<string> result = [];
         foreach (var entry in _entries)
         {
             if (!IsSelectable(entry))
                 continue;
-            if (include is { Count: > 0 } && !include.Contains(entry.Name))
+            if ((explicitInclude || include is { Count: > 0 })
+                && include?.Contains(entry.Name) != true)
                 continue;
             if (entry.IsApplicable(model))
                 result.Add(entry.Name);
@@ -754,11 +758,12 @@ public sealed class SectionPipeline<TModel>
     /// all sections should be rendered (no filtering needed).
     /// </summary>
     public HashSet<string>? ComputeIncludeSections(TModel model, Verbosity verbosity,
-        HashSet<string>? include = null, bool allSelector = false, bool fixedOverview = false)
+        HashSet<string>? include = null, bool allSelector = false, bool fixedOverview = false,
+        bool explicitInclude = false)
     {
         var effective = allSelector
             ? GetAllSelectorSections(model)
-            : GetEffectiveSections(model, verbosity, include, fixedOverview);
+            : GetEffectiveSections(model, verbosity, include, fixedOverview, explicitInclude);
 
         if (allSelector)
             return [.. effective];
@@ -959,11 +964,11 @@ public sealed class SectionPipeline<TModel>
     }
 
     private bool IsRequested(SectionEntry<TModel> entry, int index, Verbosity verbosity,
-        HashSet<string>? include, bool fixedOverview = false)
+        HashSet<string>? include, bool fixedOverview = false, bool explicitInclude = false)
     {
         // Explicit include overrides verbosity (and is the only way to select ExplicitOnly sections)
-        if (include is { Count: > 0 })
-            return include.Contains(entry.Name);
+        if (explicitInclude || include is { Count: > 0 })
+            return include?.Contains(entry.Name) == true;
 
         // Not explicitly included: ExplicitOnly sections are never auto-selected by verbosity.
         // In the curated model this covers coordinate-gated sections (IL context) only; the old

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -414,26 +414,31 @@ public static class SourceResolver
             // Detect bare type names (e.g., "Dictionary`2", "List`1") passed without a source.
             // Backticks never appear in package names — they're .NET generic arity notation.
             // Try to auto-resolve the containing library from platform ref assemblies.
-            // Exception: if the value also contains a dot after the backtick, it might be
-            // a Type.Member pattern (e.g., "List`1.IndexOf:3"), so skip this check and let
-            // MemberOptionsParser handle the splitting.
+            // A dot after a backtick may be either a nested generic type or Type.Member.
+            // Resolve the whole value first so an exact nested type keeps its identity;
+            // only a miss falls through to MemberOptionsParser for member peeling.
             if (packagePath != null && typeName == null && packagePath.Contains('`'))
             {
-                // Check if this might be Type.Member (has a dot after the type part)
-                bool mightBeTypeDotMember = packagePath.LastIndexOf('.') > packagePath.LastIndexOf('`');
-                
-                if (!mightBeTypeDotMember)
+                var lastDot = packagePath.LastIndexOf('.');
+                var containingTypeLookup = lastDot > 0
+                    ? PlatformResolver.LookupType(packagePath[..lastDot])
+                    : null;
+                bool mightBeTypeDotMember =
+                    containingTypeLookup is PlatformTypeLookupOutcome.Resolved
+                        or PlatformTypeLookupOutcome.Ambiguous
+                    || lastDot > packagePath.LastIndexOf('`');
+                PlatformTypeLookupOutcome lookup =
+                    PlatformResolver.LookupType(packagePath);
+                if (lookup is PlatformTypeLookupOutcome.Resolved resolved)
                 {
-                    PlatformTypeLookupOutcome lookup =
-                        PlatformResolver.LookupType(packagePath);
-                    if (lookup is PlatformTypeLookupOutcome.Resolved resolved)
-                    {
-                        typeName = packagePath;
-                        packagePath = null;
-                        platformAssembly =
-                            resolved.Candidate.Assembly.Identity.Name;
-                    }
-                    else if (lookup is PlatformTypeLookupOutcome.Missing)
+                    typeName = packagePath;
+                    packagePath = null;
+                    platformAssembly =
+                        resolved.Candidate.Assembly.Identity.Name;
+                }
+                else if (!mightBeTypeDotMember)
+                {
+                    if (lookup is PlatformTypeLookupOutcome.Missing)
                     {
                         // Convert backtick notation back to C#-style for display
                         var displayName = MetadataTypeNameFormatter.FormatGenericTypeName(packagePath);

--- a/tests/CSharpText.Tests/FqnParserTests.cs
+++ b/tests/CSharpText.Tests/FqnParserTests.cs
@@ -219,6 +219,14 @@ public class FqnParserTests
         Assert.Equal("System.Collections.Generic.List`1", result.TypeName);
     }
 
+    [Fact]
+    public void NormalizeMemberName_OverflowingMetadataArityPreservesMalformedSuffix()
+    {
+        const string malformed = "ToString`999999999999999999999";
+
+        Assert.Equal(malformed, FqnParser.NormalizeMemberName(malformed));
+    }
+
     // ── ParseMemberFilter tests ──────────────────────────────────────────
 
     [Theory]

--- a/tests/CSharpText.Tests/GenericTypeNameTests.cs
+++ b/tests/CSharpText.Tests/GenericTypeNameTests.cs
@@ -44,6 +44,19 @@ public class GenericTypeNameTests
     }
 
     [Theory]
+    [InlineData("List<T>.ConvertAll<TOutput>", "List`1.ConvertAll`1")]
+    [InlineData("Dictionary<TKey, TValue>.KeyCollection", "Dictionary`2.KeyCollection")]
+    [InlineData("Outer<T>.Inner<U>", "Outer`1.Inner`1")]
+    public void ConvertGenericTypeName_MultipleGenericSegments_NormalizesEachSegment(
+        string input,
+        string expected)
+    {
+        var result = FqnParser.NormalizeTypeName(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
     [InlineData("IEnumerable<T>", "IEnumerable`1")]
     [InlineData("ICollection<T>", "ICollection`1")]
     [InlineData("IList<T>", "IList`1")]

--- a/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
@@ -7,6 +7,7 @@ public class MemberTargetResolverTests
     [InlineData("Name:2", "Name", 2, null, null, null)]
     [InlineData("Name~abc123", "Name", null, "abc123", null, null)]
     [InlineData("M<T>", "M", null, null, null, 1)]
+    [InlineData("M`1", "M", null, null, null, 1)]
     [InlineData("M<TKey,TValue>:3", "M", 3, null, null, 2)]
     [InlineData(".ctor", ".ctor", null, null, null, null)]
     [InlineData(".cctor", ".cctor", null, null, null, null)]

--- a/tests/ILInspector.Metadata.Tests/TypeMatcherTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeMatcherTests.cs
@@ -157,4 +157,21 @@ public class TypeMatcherTests
         Assert.NotNull(result.Match);
         Assert.Equal("System.Action`2", result.Match);
     }
+
+    [Fact]
+    public void Lookup_prefers_exact_nested_segment_arities()
+    {
+        var candidates = new[]
+        {
+            "Example.ShiftedSiblingOuter`1.Inner`2",
+            "Example.ShiftedSiblingOuter`1.Inner`3"
+        };
+
+        var result = TypeMatcher.Lookup(
+            candidates,
+            "Example.ShiftedSiblingOuter<T>.Inner<A,B,C>");
+
+        Assert.Equal("Example.ShiftedSiblingOuter`1.Inner`3", result.Match);
+        Assert.Empty(result.Suggestions);
+    }
 }


### PR DESCRIPTION
## Summary

Make caller scope an input to the resolved member pipeline without changing the requested output shape. `Callers` is injected only where the pipeline publishes it and only when the selected format permits a companion section.

External directories, projects, and packages are acquired only when effective `Callers` or `Call Graph` output can render. Local assembly setup remains available to broad body-index sections, and count, TSV, value, tree, and Mermaid retain their cardinality contracts.

## Stack

Slice 2 of 3. This PR targets `feature/member-selection-resolution` in #4108.

Residual work:

- Slice 3: explicit broad-member `Member Info` census in #4038.

This slice intentionally adds no new section or census rendering.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `source eng/activate-iltools.sh --mdv && dotnet run --project src/dotnet-inspect.Tests -c Release --no-build`
- 3,554 CLI tests passed; 4 platform-specific tests skipped
- 46 focused member call-graph and caller-scope tests passed
