### PR TITLE
Extract focused optimization recognizer analyses

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -721,7 +721,12 @@ Research overlay bridge, and the application layer:
   optimization-shape classification, lazy memoized reaching-definitions use,
   and allocation metadata projection. It reuses allocation discovery and the
   allocation analysis's Layer-1 query methods rather than opening another
-  allocation or decode path. Its separate traversal may repeat member and type
+  allocation or decode path. The collector coordinates the ordered opportunity
+  traversal and delegates focused evidence classification to
+  `ArrayEscapeAnalysis`, `LoopInvariantMaterializerAnalysis`,
+  `StackGuardFallbackAnalysis`, and `StringConcatAccumulationAnalysis`; those
+  recognizers do not emit or reorder opportunities. Its separate traversal may
+  repeat member and type
   resolution, and lazily requests its own reaching-definitions result through
   `IOptimizationOpportunityResolver`; the producer does not own the metadata
   reader, generic scope, or raw IL. The assembly reader retains PE/body

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -263,7 +263,13 @@ and `OptimizationOpportunityAnalysis` reuses the former plus the query methods
 That service owns the per-method optimization instruction walk, shape
 classification, lazy memoized reaching-definitions use, and allocation metadata
 projection without opening another allocation or decode path. Its traversal may
-repeat member and type resolution, and its reaching-definitions result is
+repeat member and type resolution. It retains opportunity ordering and deferred
+state while delegating array/span/materializer flow,
+StackGuard-fallback classification, and string-concat accumulation evidence to
+focused recognizers. Those recognizers consume the canonical context and
+factual resolver but do not emit opportunities or own another top-level body
+traversal. They may perform focused sub-scans around one candidate. The
+reaching-definitions result is
 memoized within one collection rather than shared with allocation analysis.
 Those reader- and raw-IL-dependent facts arrive through
 `IOptimizationOpportunityResolver`; the producer does not own the metadata

--- a/src/ILInspector.Analysis.Tests/OptimizationOpportunityAnalysisTests.cs
+++ b/src/ILInspector.Analysis.Tests/OptimizationOpportunityAnalysisTests.cs
@@ -7,6 +7,7 @@ public sealed class OptimizationOpportunityAnalysisTests
     const int BitConverterToken = 0x0A000001;
     const int EnumeratorToken = 0x0A000002;
     const int SpanToArrayToken = 0x0A000003;
+    const int MaterializerToken = 0x0A000004;
 
     static readonly TypeRef s_int =
         TypeRef.CoreLib("System", "Int32");
@@ -80,6 +81,30 @@ public sealed class OptimizationOpportunityAnalysisTests
 
         Assert.Single(unrelated);
         Assert.Equal(0, unrelatedResolver.ReachingDefinitionsCalls);
+
+        byte[] outsideLoopMaterializerIl =
+        [
+            0x28, 0x04, 0x00, 0x00, 0x0A,
+            0x26,
+            0x2A,
+        ];
+        var outsideLoopMaterializerContext =
+            Context(outsideLoopMaterializerIl);
+        var outsideLoopMaterializerResolver =
+            new Resolver(outsideLoopMaterializerIl);
+
+        var outsideLoopMaterializer =
+            OptimizationOpportunityAnalysis.Collect(
+                outsideLoopMaterializerContext,
+                [],
+                new MethodAllocationAnalysis(
+                    outsideLoopMaterializerContext),
+                outsideLoopMaterializerResolver);
+
+        Assert.Empty(outsideLoopMaterializer);
+        Assert.Equal(
+            0,
+            outsideLoopMaterializerResolver.ReachingDefinitionsCalls);
 
         byte[] spanCopiesIl =
         [
@@ -220,6 +245,25 @@ public sealed class OptimizationOpportunityAnalysisTests
                     MemberKind.Method)
                 {
                     HasThis = true,
+                },
+                MaterializerToken => new MemberRef(
+                    TypeRef.Definition(
+                        "System.Linq",
+                        "System.Linq",
+                        "Enumerable"),
+                    "ToArray",
+                    [
+                        TypeRef.GenericInstance(
+                            TypeRef.CoreLib(
+                                "System.Collections.Generic",
+                                "IEnumerable`1"),
+                            [s_int]),
+                    ],
+                    TypeRef.SzArray(s_int),
+                    MemberKind.Method)
+                {
+                    GenericArity = 1,
+                    TypeArguments = [s_int],
                 },
                 _ => MemberRef.Unsupported(
                     "member token"),

--- a/src/ILInspector.Analysis.Tests/OptimizationRecognizerAnalysisTests.cs
+++ b/src/ILInspector.Analysis.Tests/OptimizationRecognizerAnalysisTests.cs
@@ -1,0 +1,242 @@
+using ILInspector.Instructions;
+
+namespace ILInspector.Analysis.Tests;
+
+public sealed class OptimizationRecognizerAnalysisTests
+{
+    const int StackGuardToken = 0x0A000001;
+
+    static readonly TypeRef s_bool =
+        TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef s_void =
+        TypeRef.CoreLib("System", "Void");
+
+    [Fact]
+    public void StackGuardFallbackRecognizesDirectAndStoredInvertedConditions()
+    {
+        byte[] directIl =
+        [
+            0x28, 0x01, 0x00, 0x00, 0x0A,
+            0x2D, 0x05,
+            0x73, 0x02, 0x00, 0x00, 0x0A,
+            0x2A,
+        ];
+        byte[] storedInvertedIl =
+        [
+            0x28, 0x01, 0x00, 0x00, 0x0A,
+            0x16,
+            0xFE, 0x01,
+            0x0A,
+            0x06,
+            0x2C, 0x05,
+            0x73, 0x02, 0x00, 0x00, 0x0A,
+            0x2A,
+        ];
+        var resolver = new Resolver();
+
+        Assert.True(StackGuardFallbackAnalysis.IsFallbackAllocation(
+            Context(directIl),
+            allocationOffset: 7,
+            resolver));
+        Assert.True(StackGuardFallbackAnalysis.IsFallbackAllocation(
+            Context(storedInvertedIl),
+            allocationOffset: 12,
+            resolver));
+        Assert.False(StackGuardFallbackAnalysis.IsFallbackAllocation(
+            Context(directIl),
+            allocationOffset: 7,
+            new Resolver(resolveStackGuard: false)));
+    }
+
+    [Fact]
+    public void ArrayFlowDistinguishesLocalUseFromEscape()
+    {
+        byte[] localIl =
+        [
+            0x17,
+            0x8D, 0x04, 0x00, 0x00, 0x01,
+            0x0A,
+            0x06,
+            0x8E,
+            0x26,
+            0x2A,
+        ];
+        byte[] escapingIl =
+        [
+            0x17,
+            0x8D, 0x04, 0x00, 0x00, 0x01,
+            0x0A,
+            0x06,
+            0x2A,
+        ];
+
+        Assert.True(
+            ArrayEscapeAnalysis.ArrayProvablyStaysLocal(
+                Context(localIl),
+                ReachingDefinitions.Analyze(localIl, argumentSlotCount: 0),
+                positionAfterNewarr: 6));
+        Assert.False(
+            ArrayEscapeAnalysis.ArrayProvablyStaysLocal(
+                Context(escapingIl),
+                ReachingDefinitions.Analyze(
+                    escapingIl,
+                    argumentSlotCount: 0),
+                positionAfterNewarr: 6));
+    }
+
+    [Fact]
+    public void SpanToArrayFlowDistinguishesLocalUseFromEscape()
+    {
+        byte[] localIl =
+        [
+            0x28, 0x02, 0x00, 0x00, 0x0A,
+            0x0A,
+            0x06,
+            0x8E,
+            0x26,
+            0x2A,
+        ];
+        byte[] escapingIl =
+        [
+            0x28, 0x02, 0x00, 0x00, 0x0A,
+            0x2A,
+        ];
+
+        Assert.False(
+            ArrayEscapeAnalysis.SpanToArrayResultEscapes(
+                Context(localIl),
+                ReachingDefinitions.Analyze(localIl, argumentSlotCount: 0),
+                positionAfterCall: 5));
+        Assert.True(
+            ArrayEscapeAnalysis.SpanToArrayResultEscapes(
+                Context(escapingIl),
+                ReachingDefinitions.Analyze(
+                    escapingIl,
+                    argumentSlotCount: 0),
+                positionAfterCall: 5));
+    }
+
+    [Fact]
+    public void MaterializerFlowRequiresSourceDefinedOutsideLoop()
+    {
+        byte[] il =
+        [
+            0x02,
+            0x28, 0x02, 0x00, 0x00, 0x0A,
+            0x26,
+            0x2A,
+        ];
+
+        Assert.True(
+            LoopInvariantMaterializerAnalysis.TryGetLoopInvariantSource(
+                Context(il, [(1, 6)]),
+                ReachingDefinitions.Analyze(
+                    il,
+                    argumentSlotCount: 1),
+                callOffset: 1,
+                out var evidence));
+        Assert.Equal("arg0", evidence);
+        Assert.False(
+            LoopInvariantMaterializerAnalysis.TryGetLoopInvariantSource(
+                Context(il),
+                ReachingDefinitions.Analyze(
+                    il,
+                    argumentSlotCount: 1),
+                callOffset: 1,
+                out _));
+    }
+
+    [Fact]
+    public void StringConcatAccumulationRequiresStoredSourceArgument()
+    {
+        byte[] accumulatingIl =
+        [
+            0x06,
+            0x72, 0x01, 0x00, 0x00, 0x70,
+            0x28, 0x02, 0x00, 0x00, 0x0A,
+            0x0A,
+            0x2A,
+        ];
+        byte[] unrelatedStoreIl =
+        [
+            0x06,
+            0x72, 0x01, 0x00, 0x00, 0x70,
+            0x28, 0x02, 0x00, 0x00, 0x0A,
+            0x0B,
+            0x2A,
+        ];
+        var resolver = new Resolver();
+
+        Assert.True(StringConcatAccumulationAnalysis.AccumulatesIntoSource(
+            Context(accumulatingIl),
+            concatOffset: 6,
+            storeOffset: 11,
+            concatArgumentCount: 2,
+            resolver));
+        Assert.False(StringConcatAccumulationAnalysis.AccumulatesIntoSource(
+            Context(unrelatedStoreIl),
+            concatOffset: 6,
+            storeOffset: 11,
+            concatArgumentCount: 2,
+            resolver));
+    }
+
+    static MethodBodyAnalysisContext Context(
+        byte[] il,
+        IReadOnlyList<(int Start, int End)>? loopRegions = null)
+    {
+        var instructions = MethodInstructions.Decode(
+            il,
+            il.Length,
+            []);
+        Assert.True(instructions.IsComplete);
+        return new MethodBodyAnalysisContext(
+            new MethodIdentity(
+                "Fixture",
+                Guid.Empty,
+                TypeRef.Definition(
+                    "Fixture",
+                    "Fixtures",
+                    "Caller"),
+                "M",
+                [],
+                s_void,
+                MetadataToken: 0x06000001,
+                IsStatic: true),
+            instructions,
+            [],
+            loopRegions ?? [],
+            []);
+    }
+
+    sealed class Resolver(bool resolveStackGuard = true)
+        : IOptimizationOpportunityResolver
+    {
+        public MemberRef ResolveMember(int token)
+            => resolveStackGuard && token == StackGuardToken
+                ? new MemberRef(
+                    TypeRef.Definition(
+                        "Fixture",
+                        "Fixtures",
+                        "StackGuard"),
+                    "TryEnterOnCurrentStack",
+                    [],
+                    s_bool,
+                    MemberKind.Method)
+                : MemberRef.Unsupported("member token");
+
+        public TypeRef ResolveType(int token)
+            => throw new NotSupportedException();
+
+        public bool IsAllocatingValueTypeBox(
+            int operandToken,
+            TypeRef boxed)
+            => throw new NotSupportedException();
+
+        public bool IsAsyncStateMachineType(TypeRef? type)
+            => throw new NotSupportedException();
+
+        public ReachingDefinitionsResult AnalyzeReachingDefinitions()
+            => throw new NotSupportedException();
+    }
+}

--- a/src/ILInspector.Analysis/ArrayEscapeAnalysis.cs
+++ b/src/ILInspector.Analysis/ArrayEscapeAnalysis.cs
@@ -1,0 +1,242 @@
+using System.Reflection.Metadata;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Analysis;
+
+internal static class ArrayEscapeAnalysis
+{
+    // Promote an array only when reaching definitions show local element/length use.
+    internal static bool ArrayProvablyStaysLocal(
+        MethodBodyAnalysisContext context,
+        ReachingDefinitionsResult reachingDefinitions,
+        int positionAfterNewarr)
+    {
+        try
+        {
+            if (!TryReadStoreLocalDefinition(
+                    context,
+                    positionAfterNewarr,
+                    out int slot,
+                    out int storeOffset)
+                || !reachingDefinitions.IsComplete)
+            {
+                return false;
+            }
+
+            var definition = reachingDefinitions.Definitions.FirstOrDefault(candidate =>
+                !candidate.IsArgument
+                && candidate.Slot == slot
+                && candidate.Offset == storeOffset);
+            if (definition is null)
+                return false;
+
+            foreach (var use in reachingDefinitions.UsesOf(definition))
+            {
+                if (use.Address
+                    || !TryPositionAfterLoadLocal(
+                        context,
+                        use.Offset,
+                        slot,
+                        out int positionAfterLoad)
+                    || ArrayLoadEscapes(context, positionAfterLoad))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or InvalidOperationException
+                or ArgumentException
+                or OverflowException)
+        {
+            return false;
+        }
+    }
+
+    // Keep the copy row only when the materialized array is consumed locally.
+    internal static bool SpanToArrayResultEscapes(
+        MethodBodyAnalysisContext context,
+        ReachingDefinitionsResult reachingDefinitions,
+        int positionAfterCall)
+    {
+        try
+        {
+            if (!reachingDefinitions.IsComplete)
+                return true;
+
+            int firstUseIndex = context.NextNonNopIndexAtOrAfter(positionAfterCall);
+            positionAfterCall = firstUseIndex < context.Instructions.Instructions.Length
+                ? context.Instructions.Instructions[firstUseIndex].Offset
+                : positionAfterCall;
+            if (TryReadStoreLocalDefinition(
+                    context,
+                    positionAfterCall,
+                    out int slot,
+                    out int storeOffset))
+            {
+                var definition = reachingDefinitions.Definitions.FirstOrDefault(candidate =>
+                    !candidate.IsArgument
+                    && candidate.Slot == slot
+                    && candidate.Offset == storeOffset);
+                if (definition is null)
+                    return true;
+
+                foreach (var use in reachingDefinitions.UsesOf(definition))
+                {
+                    if (use.Address
+                        || !TryPositionAfterLoadLocal(
+                            context,
+                            use.Offset,
+                            slot,
+                            out int positionAfterLoad)
+                        || ArrayLoadEscapes(context, positionAfterLoad))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            return ArrayLoadEscapes(context, positionAfterCall);
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or InvalidOperationException
+                or ArgumentException
+                or OverflowException
+                or IndexOutOfRangeException)
+        {
+            return true;
+        }
+    }
+
+    static bool TryReadStoreLocalDefinition(
+        MethodBodyAnalysisContext context,
+        int position,
+        out int slot,
+        out int storeOffset)
+    {
+        slot = -1;
+        storeOffset = position;
+        if (context.InstructionAt(position) is not { } instruction
+            || !MethodInstructionFacts.TryReadLocalSlot(
+                instruction,
+                out var access)
+            || !access.IsStore
+            || access.IsArgument)
+        {
+            return false;
+        }
+
+        slot = access.Slot;
+        storeOffset = instruction.Offset;
+        return true;
+    }
+
+    static bool TryPositionAfterLoadLocal(
+        MethodBodyAnalysisContext context,
+        int offset,
+        int slot,
+        out int positionAfterLoad)
+    {
+        positionAfterLoad = offset;
+        if (context.InstructionAt(offset) is not { } instruction
+            || !MethodInstructionFacts.TryReadLocalSlot(
+                instruction,
+                out var access)
+            || access.IsStore
+            || access.IsArgument
+            || access.Slot != slot)
+        {
+            return false;
+        }
+
+        positionAfterLoad = instruction.NextOffset;
+        return true;
+    }
+
+    // Track how many stack slots are pushed above the array until its first
+    // consumer; only an element access or length read at the expected depth is
+    // treated as local use.
+    static bool ArrayLoadEscapes(
+        MethodBodyAnalysisContext context,
+        int position)
+    {
+        int extra = 0;
+        for (int index = context.IndexAtOrAfter(position);
+            index < context.Instructions.Instructions.Length;
+            index++)
+        {
+            var opcode = context.Instructions.Instructions[index].OpCode;
+            switch (opcode)
+            {
+                case ILOpCode.Ldc_i4_m1
+                    or ILOpCode.Ldc_i4_0
+                    or ILOpCode.Ldc_i4_1
+                    or ILOpCode.Ldc_i4_2
+                    or ILOpCode.Ldc_i4_3
+                    or ILOpCode.Ldc_i4_4
+                    or ILOpCode.Ldc_i4_5
+                    or ILOpCode.Ldc_i4_6
+                    or ILOpCode.Ldc_i4_7
+                    or ILOpCode.Ldc_i4_8
+                    or ILOpCode.Ldnull
+                    or ILOpCode.Ldc_i4_s
+                    or ILOpCode.Ldc_i4
+                    or ILOpCode.Ldc_r4
+                    or ILOpCode.Ldc_i8
+                    or ILOpCode.Ldc_r8
+                    or ILOpCode.Ldloc_0
+                    or ILOpCode.Ldloc_1
+                    or ILOpCode.Ldloc_2
+                    or ILOpCode.Ldloc_3
+                    or ILOpCode.Ldarg_0
+                    or ILOpCode.Ldarg_1
+                    or ILOpCode.Ldarg_2
+                    or ILOpCode.Ldarg_3
+                    or ILOpCode.Ldloc_s
+                    or ILOpCode.Ldloca_s
+                    or ILOpCode.Ldarg_s
+                    or ILOpCode.Ldarga_s:
+                    extra++;
+                    break;
+                case ILOpCode.Ldlen:
+                    return extra != 0;
+                case ILOpCode.Ldelem
+                    or ILOpCode.Ldelem_i
+                    or ILOpCode.Ldelem_i1
+                    or ILOpCode.Ldelem_i2
+                    or ILOpCode.Ldelem_i4
+                    or ILOpCode.Ldelem_i8
+                    or ILOpCode.Ldelem_r4
+                    or ILOpCode.Ldelem_r8
+                    or ILOpCode.Ldelem_u1
+                    or ILOpCode.Ldelem_u2
+                    or ILOpCode.Ldelem_u4
+                    or ILOpCode.Ldelem_ref:
+                    return extra != 1;
+                case ILOpCode.Stelem
+                    or ILOpCode.Stelem_i
+                    or ILOpCode.Stelem_i1
+                    or ILOpCode.Stelem_i2
+                    or ILOpCode.Stelem_i4
+                    or ILOpCode.Stelem_i8
+                    or ILOpCode.Stelem_r4
+                    or ILOpCode.Stelem_r8
+                    or ILOpCode.Stelem_ref:
+                    return extra != 2;
+                default:
+                    // Calls, returns, stores, aliases, and ambiguous stack
+                    // shapes are all treated as escapes.
+                    return true;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/ILInspector.Analysis/LoopInvariantMaterializerAnalysis.cs
+++ b/src/ILInspector.Analysis/LoopInvariantMaterializerAnalysis.cs
@@ -1,0 +1,95 @@
+using System.Reflection.Metadata;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Analysis;
+
+internal static class LoopInvariantMaterializerAnalysis
+{
+    internal static bool TryGetLoopInvariantSource(
+        MethodBodyAnalysisContext context,
+        ReachingDefinitionsResult reachingDefinitions,
+        int callOffset,
+        out string evidence)
+    {
+        evidence = "";
+        if (!TryGetContainingLoop(
+                callOffset,
+                context.LoopRegions,
+                out var loop)
+            || !reachingDefinitions.IsComplete
+            || !TryFindPreviousInstruction(
+                context,
+                callOffset,
+                out var loadInstruction)
+            || !MethodInstructionFacts.TryReadLocalSlot(
+                loadInstruction,
+                out var access)
+            || access.IsStore)
+        {
+            return false;
+        }
+
+        var use = reachingDefinitions.Uses.FirstOrDefault(candidate =>
+            candidate.Offset == loadInstruction.Offset
+            && candidate.IsArgument == access.IsArgument
+            && candidate.Slot == access.Slot);
+        if (use is null
+            || use.Address
+            || use.ReachingDefinitions.Length == 0
+            || reachingDefinitions.Uses.Any(candidate =>
+                candidate.Address
+                && candidate.IsArgument == access.IsArgument
+                && candidate.Slot == access.Slot
+                && candidate.Offset >= loop.Start
+                && candidate.Offset <= loop.End)
+            || use.ReachingDefinitions.Any(definition =>
+                definition.Offset >= loop.Start
+                && definition.Offset <= loop.End))
+        {
+            return false;
+        }
+
+        evidence = access.IsArgument
+            ? $"arg{access.Slot}"
+            : $"V_{access.Slot}";
+        return true;
+    }
+
+    static bool TryGetContainingLoop(
+        int offset,
+        IReadOnlyList<(int Start, int End)> loopRegions,
+        out (int Start, int End) loop)
+    {
+        loop = default;
+        var found = false;
+        foreach (var region in loopRegions)
+        {
+            if (offset < region.Start || offset > region.End)
+                continue;
+            if (!found || region.End - region.Start < loop.End - loop.Start)
+                loop = region;
+            found = true;
+        }
+
+        return found;
+    }
+
+    static bool TryFindPreviousInstruction(
+        MethodBodyAnalysisContext context,
+        int targetOffset,
+        out DecodedInstruction previousInstruction)
+    {
+        previousInstruction = default!;
+        foreach (var instruction in context.Instructions.Instructions)
+        {
+            if (instruction.Offset >= targetOffset)
+                break;
+            if (instruction.OpCode == ILOpCode.Nop)
+                continue;
+            previousInstruction = instruction;
+        }
+
+        return previousInstruction is not null;
+    }
+}

--- a/src/ILInspector.Analysis/OptimizationOpportunityAnalysis.Collect.cs
+++ b/src/ILInspector.Analysis/OptimizationOpportunityAnalysis.Collect.cs
@@ -118,7 +118,10 @@ internal static partial class OptimizationOpportunityAnalysis
                         // array provably stays local AND its element type is stackalloc-
                         // eligible (an unmanaged primitive); otherwise keep the
                         // non-committal shape.
-                        bool local = ArrayProvablyStaysLocal(context, GetReachingDefinitions(), instruction.NextOffset)
+                        bool local = ArrayEscapeAnalysis.ArrayProvablyStaysLocal(
+                                context,
+                                GetReachingDefinitions(),
+                                instruction.NextOffset)
                             && IsStackallocEligibleElement(resolver.ResolveType(elementToken));
                         opportunities.Add(local
                             ? new OptimizationOpportunity(
@@ -182,7 +185,10 @@ internal static partial class OptimizationOpportunityAnalysis
                         {
                             var inLoop = context.IsInLoopRegion(offset);
                             bool iteratesInLoop = allocationAnalysis.MultiplicityAt(offset) == AllocationMultiplicity.Loop;
-                            bool stackGuardFallback = IsStackGuardFallbackAllocation(context, offset, resolver);
+                            bool stackGuardFallback = StackGuardFallbackAnalysis.IsFallbackAllocation(
+                                context,
+                                offset,
+                                resolver);
                             pendingDelegateOpportunityIndex = opportunities.Count;
                             opportunities.Add(new OptimizationOpportunity(
                                 caller,
@@ -261,7 +267,10 @@ internal static partial class OptimizationOpportunityAnalysis
                     }
                     else if (IsSpanToArrayCopy(callee, out var copyReceiver))
                     {
-                        if (!SpanToArrayResultEscapes(context, GetReachingDefinitions(), instruction.NextOffset))
+                        if (!ArrayEscapeAnalysis.SpanToArrayResultEscapes(
+                                context,
+                                GetReachingDefinitions(),
+                                instruction.NextOffset))
                         {
                             opportunities.Add(new OptimizationOpportunity(
                                 caller,
@@ -275,8 +284,12 @@ internal static partial class OptimizationOpportunityAnalysis
                         }
                     }
                     else if (RepeatedScanAnalysis.IsLinqMaterializer(callee, out var materializeOp)
-                        && TryGetContainingLoop(offset, context.LoopRegions, out var materializeLoop)
-                        && LinqMaterializerSourceIsLoopInvariant(context, GetReachingDefinitions(), offset, materializeLoop, out var sourceEvidence))
+                        && context.IsInLoopRegion(offset)
+                        && LoopInvariantMaterializerAnalysis.TryGetLoopInvariantSource(
+                            context,
+                            GetReachingDefinitions(),
+                            offset,
+                            out var sourceEvidence))
                     {
                         opportunities.Add(new OptimizationOpportunity(
                             caller,
@@ -305,7 +318,12 @@ internal static partial class OptimizationOpportunityAnalysis
                             "Quadratic only if the scanned sequence grows with the loop; a small or constant sequence is fine."));
                     }
                     else if (RepeatedScanAnalysis.IsStringConcat(callee) && context.IsInLoopRegion(offset)
-                        && ConcatAccumulatesIntoSource(context, offset, instruction.NextOffset, callee.ParameterTypes.Length, resolver))
+                        && StringConcatAccumulationAnalysis.AccumulatesIntoSource(
+                            context,
+                            offset,
+                            instruction.NextOffset,
+                            callee.ParameterTypes.Length,
+                            resolver))
                     {
                         // `s += …` inside a loop lowers to String.Concat(s, …) stored back to
                         // the same local/parameter. Each iteration copies the whole growing
@@ -525,108 +543,6 @@ internal static partial class OptimizationOpportunityAnalysis
         => target.Kind != MemberKind.Unsupported
            && CompilerGeneratedNames.IsDisplayClass(target.DeclaringType);
 
-    static bool IsStackGuardFallbackAllocation(MethodBodyAnalysisContext context, int allocationOffset, IOptimizationOpportunityResolver resolver)
-    {
-        const int NoStackGuardCondition = 0;
-        const int DirectResult = 1;
-        const int DirectStored = 2;
-        const int DirectLoaded = 3;
-        const int ZeroAfterDirect = 4;
-        const int InvertedResult = 5;
-        const int InvertedStored = 6;
-        const int InvertedLoaded = 7;
-
-        try
-        {
-            int conditionState = NoStackGuardCondition;
-            int conditionSlot = -1;
-            foreach (var instruction in context.Instructions.Instructions)
-            {
-                if (instruction.Offset >= allocationOffset)
-                    break;
-                int offset = instruction.Offset;
-                var opcode = instruction.OpCode;
-                if (opcode is ILOpCode.Call or ILOpCode.Callvirt)
-                {
-                    int token = MethodInstructionFacts.OperandInt32(instruction);
-                    var call = resolver.ResolveMember(token);
-                    conditionState = call.Name == "TryEnterOnCurrentStack"
-                        ? DirectResult
-                        : NoStackGuardCondition;
-                    conditionSlot = -1;
-                    continue;
-                }
-                if (opcode == ILOpCode.Ldc_i4_0 && conditionState == DirectResult)
-                {
-                    conditionState = ZeroAfterDirect;
-                    continue;
-                }
-                if (opcode == ILOpCode.Ceq && conditionState == ZeroAfterDirect)
-                {
-                    conditionState = InvertedResult;
-                    continue;
-                }
-                if (MethodInstructionFacts.TryReadLocalSlot(
-                        instruction,
-                        out var access))
-                {
-                    if (!access.IsArgument && access.IsStore && conditionState is DirectResult or DirectLoaded or InvertedResult or InvertedLoaded)
-                    {
-                        conditionSlot = access.Slot;
-                        conditionState = conditionState is DirectResult or DirectLoaded ? DirectStored : InvertedStored;
-                        continue;
-                    }
-                    if (!access.IsArgument && !access.IsStore && access.Slot == conditionSlot)
-                    {
-                        if (conditionState == DirectStored)
-                        {
-                            conditionState = DirectLoaded;
-                            continue;
-                        }
-                        if (conditionState == InvertedStored)
-                        {
-                            conditionState = InvertedLoaded;
-                            continue;
-                        }
-                    }
-                    conditionState = NoStackGuardCondition;
-                    conditionSlot = -1;
-                    continue;
-                }
-                if (opcode is ILOpCode.Brtrue or ILOpCode.Brtrue_s or ILOpCode.Brfalse or ILOpCode.Brfalse_s)
-                {
-                    if (MethodInstructionFacts.TrySingleBranchTarget(instruction, out int branchTarget)
-                        && branchTarget > allocationOffset
-                        && BranchSkipsStackGuardFallback(opcode, conditionState))
-                    {
-                        return true;
-                    }
-                    conditionState = NoStackGuardCondition;
-                    conditionSlot = -1;
-                    continue;
-                }
-                if (opcode == ILOpCode.Nop)
-                    continue;
-
-                conditionState = NoStackGuardCondition;
-                conditionSlot = -1;
-            }
-            return false;
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException)
-        {
-            return false;
-        }
-
-        static bool BranchSkipsStackGuardFallback(ILOpCode opcode, int conditionState)
-            => opcode switch
-            {
-                ILOpCode.Brtrue or ILOpCode.Brtrue_s => conditionState is DirectResult or DirectLoaded,
-                ILOpCode.Brfalse or ILOpCode.Brfalse_s => conditionState is InvertedResult or InvertedLoaded,
-                _ => false,
-            };
-    }
-
     // Opcodes that consume a boxed value in a way that makes it escape (so the box is a
     // real heap allocation): stored into a reference array, passed to a call/ctor, written
     // to a field, or returned. Local round-trips (unbox/unbox.any/isinst/castclass/pop) are
@@ -646,248 +562,6 @@ internal static partial class OptimizationOpportunityAnalysis
                or "Int64" or "UInt64" or "Single" or "Double"
                or "IntPtr" or "UIntPtr";
 
-    // Conservative, sound local-escape check for a freshly created array. Returns true
-    // only when the array is stored straight into a local (`newarr; stloc.X`) whose every
-    // load is an in-place element access / length read — never returned, stored to a
-    // field, address-taken, or passed to a call. Any shape we cannot prove local returns
-    // false (keep the non-committal `small-array`), so a false positive is impossible.
-    static bool ArrayProvablyStaysLocal(MethodBodyAnalysisContext context, ReachingDefinitionsResult reachingDefinitions, int positionAfterNewarr)
-    {
-        try
-        {
-            if (!TryReadStoreLocalDefinition(context, positionAfterNewarr, out int slot, out int storeOffset))
-                return false;
-            if (!reachingDefinitions.IsComplete)
-                return false;
-            var definition = reachingDefinitions.Definitions.FirstOrDefault(d =>
-                !d.IsArgument && d.Slot == slot && d.Offset == storeOffset);
-            if (definition is null)
-                return false;
-
-            foreach (var use in reachingDefinitions.UsesOf(definition))
-            {
-                if (use.Address)
-                    return false;
-                if (!TryPositionAfterLoadLocal(context, use.Offset, slot, out int positionAfterLoad)
-                    || ArrayLoadEscapes(context, positionAfterLoad))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
-        {
-            return false;
-        }
-    }
-
-    // If the next instruction stores to a local, returns its slot and IL offset.
-    static bool TryReadStoreLocalDefinition(MethodBodyAnalysisContext context, int position, out int slot, out int storeOffset)
-    {
-        slot = -1;
-        storeOffset = position;
-        if (context.InstructionAt(position) is not { } instruction
-            || !MethodInstructionFacts.TryReadLocalSlot(
-                instruction,
-                out var access)
-            || !access.IsStore
-            || access.IsArgument)
-        {
-            return false;
-        }
-        slot = access.Slot;
-        storeOffset = instruction.Offset;
-        return true;
-    }
-
-    static bool TryPositionAfterLoadLocal(MethodBodyAnalysisContext context, int offset, int slot, out int positionAfterLoad)
-    {
-        positionAfterLoad = offset;
-        if (context.InstructionAt(offset) is not { } instruction
-            || !MethodInstructionFacts.TryReadLocalSlot(
-                instruction,
-                out var access)
-            || access.IsStore
-            || access.IsArgument
-            || access.Slot != slot)
-        {
-            return false;
-        }
-        positionAfterLoad = instruction.NextOffset;
-        return true;
-    }
-
-    static bool SpanToArrayResultEscapes(MethodBodyAnalysisContext context, ReachingDefinitionsResult reachingDefinitions, int positionAfterCall)
-    {
-        try
-        {
-            if (!reachingDefinitions.IsComplete)
-                return true;
-
-            int firstUseIndex = context.NextNonNopIndexAtOrAfter(positionAfterCall);
-            positionAfterCall = firstUseIndex < context.Instructions.Instructions.Length
-                ? context.Instructions.Instructions[firstUseIndex].Offset
-                : positionAfterCall;
-            if (TryReadStoreLocalDefinition(context, positionAfterCall, out int slot, out int storeOffset))
-            {
-                var definition = reachingDefinitions.Definitions.FirstOrDefault(d =>
-                    !d.IsArgument && d.Slot == slot && d.Offset == storeOffset);
-                if (definition is null)
-                    return true;
-
-                foreach (var use in reachingDefinitions.UsesOf(definition))
-                {
-                    if (use.Address)
-                        return true;
-                    if (!TryPositionAfterLoadLocal(context, use.Offset, slot, out int positionAfterLoad)
-                        || ArrayLoadEscapes(context, positionAfterLoad))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            return ArrayLoadEscapes(context, positionAfterCall);
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException)
-        {
-            return true;
-        }
-    }
-
-    static bool TryGetContainingLoop(int offset, IReadOnlyList<(int Start, int End)> loopRegions, out (int Start, int End) loop)
-    {
-        loop = default;
-        var found = false;
-        foreach (var region in loopRegions)
-        {
-            if (offset < region.Start || offset > region.End)
-                continue;
-            if (!found || region.End - region.Start < loop.End - loop.Start)
-                loop = region;
-            found = true;
-        }
-        return found;
-    }
-
-    static bool LinqMaterializerSourceIsLoopInvariant(
-        MethodBodyAnalysisContext context,
-        ReachingDefinitionsResult reachingDefinitions,
-        int callOffset,
-        (int Start, int End) loop,
-        out string evidence)
-    {
-        evidence = "";
-        if (!reachingDefinitions.IsComplete)
-            return false;
-        if (!TryFindPreviousInstruction(context, callOffset, out var loadInstruction))
-            return false;
-        if (!MethodInstructionFacts.TryReadLocalSlot(
-                loadInstruction,
-                out var access)
-            || access.IsStore)
-        {
-            return false;
-        }
-
-        var use = reachingDefinitions.Uses.FirstOrDefault(candidate =>
-            candidate.Offset == loadInstruction.Offset
-            && candidate.IsArgument == access.IsArgument
-            && candidate.Slot == access.Slot);
-        if (use is null || use.Address || use.ReachingDefinitions.Length == 0)
-            return false;
-        if (reachingDefinitions.Uses.Any(candidate =>
-            candidate.Address
-            && candidate.IsArgument == access.IsArgument
-            && candidate.Slot == access.Slot
-            && candidate.Offset >= loop.Start
-            && candidate.Offset <= loop.End))
-        {
-            return false;
-        }
-        foreach (var definition in use.ReachingDefinitions)
-        {
-            if (definition.Offset >= loop.Start && definition.Offset <= loop.End)
-                return false;
-        }
-
-        evidence = access.IsArgument ? $"arg{access.Slot}" : $"V_{access.Slot}";
-        return true;
-    }
-
-    static bool TryFindPreviousInstruction(MethodBodyAnalysisContext context, int targetOffset, out DecodedInstruction previousInstruction)
-    {
-        previousInstruction = default!;
-        foreach (var instruction in context.Instructions.Instructions)
-        {
-            if (instruction.Offset >= targetOffset)
-                break;
-            if (instruction.OpCode == ILOpCode.Nop)
-                continue;
-            previousInstruction = instruction;
-        }
-        return previousInstruction is not null;
-    }
-
-    // Given the array reference freshly loaded onto the stack, decide whether this use
-    // keeps it local. Walks forward tracking how many extra slots sit above the array;
-    // an element access / length read that consumes the array at the right depth is local,
-    // anything else (return, store, call argument, ambiguous stack shape) is an escape.
-    static bool ArrayLoadEscapes(MethodBodyAnalysisContext context, int position)
-    {
-        int extra = 0; // stack slots pushed above the array reference
-        for (int index = context.IndexAtOrAfter(position); index < context.Instructions.Instructions.Length; index++)
-        {
-            var opcode = context.Instructions.Instructions[index].OpCode;
-            switch (opcode)
-            {
-                // Simple single pushes (indices, values) layered above the array.
-                case ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2
-                    or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6
-                    or ILOpCode.Ldc_i4_7 or ILOpCode.Ldc_i4_8 or ILOpCode.Ldnull:
-                    extra++;
-                    break;
-                case ILOpCode.Ldc_i4_s:
-                    extra++;
-                    break;
-                case ILOpCode.Ldc_i4 or ILOpCode.Ldc_r4:
-                    extra++;
-                    break;
-                case ILOpCode.Ldc_i8 or ILOpCode.Ldc_r8:
-                    extra++;
-                    break;
-                case ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
-                    or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3:
-                    extra++;
-                    break;
-                case ILOpCode.Ldloc_s or ILOpCode.Ldloca_s or ILOpCode.Ldarg_s or ILOpCode.Ldarga_s:
-                    extra++;
-                    break;
-                // Length read: pops the array. Local only when the array is on top.
-                case ILOpCode.Ldlen:
-                    return extra != 0;
-                // Element read: pops index + array. Local when exactly the index is above.
-                case ILOpCode.Ldelem or ILOpCode.Ldelem_i or ILOpCode.Ldelem_i1 or ILOpCode.Ldelem_i2
-                    or ILOpCode.Ldelem_i4 or ILOpCode.Ldelem_i8 or ILOpCode.Ldelem_r4 or ILOpCode.Ldelem_r8
-                    or ILOpCode.Ldelem_u1 or ILOpCode.Ldelem_u2 or ILOpCode.Ldelem_u4 or ILOpCode.Ldelem_ref:
-                    return extra != 1;
-                // Element store: pops value + index + array. Local when index+value are above.
-                case ILOpCode.Stelem or ILOpCode.Stelem_i or ILOpCode.Stelem_i1 or ILOpCode.Stelem_i2
-                    or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8 or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8
-                    or ILOpCode.Stelem_ref:
-                    return extra != 2;
-                default:
-                    // Anything else consuming the array (ret, stfld, call, box, element
-                    // address, dup-aliasing, branch) is treated as an escape.
-                    return true;
-            }
-        }
-        return true;
-    }
     static bool IsBitConverterGetBytes(MemberRef member)
         => member.Kind != MemberKind.Unsupported
             && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "BitConverter")
@@ -930,163 +604,5 @@ internal static partial class OptimizationOpportunityAnalysis
         int tick = name.IndexOf('`');
         return tick < 0 ? name : name[..tick];
     }
-
-    // True when the String.Concat at `concatOffset` — whose result is stored by the
-    // instruction at `storeOffset` — accumulates into one of its own arguments, i.e.
-    // `s = String.Concat(s, …)` (the `s += …` lowering). Each iteration copies the whole
-    // growing accumulator: the canonical O(n^2) StringBuilder anti-pattern.
-    static bool ConcatAccumulatesIntoSource(MethodBodyAnalysisContext context, int concatOffset, int storeOffset, int concatArgCount, IOptimizationOpportunityResolver resolver)
-    {
-        const int ArgSlotBias = 1 << 20;
-        try
-        {
-            if (concatOffset < 0 || concatArgCount <= 0)
-                return false;
-            if (context.InstructionAt(storeOffset) is not { } storeInstruction
-                || !MethodInstructionFacts.TryReadLocalSlot(
-                    storeInstruction,
-                    out var storeAccess)
-                || !storeAccess.IsStore)
-            {
-                return false;
-            }
-            int storeKey = (storeAccess.IsArgument ? ArgSlotBias : 0) | storeAccess.Slot;
-
-            int blockStart = 0;
-            foreach (var instruction in context.Instructions.Instructions)
-            {
-                if (instruction.Offset >= concatOffset)
-                    break;
-                bool isLocal =
-                    MethodInstructionFacts.TryReadLocalSlot(
-                        instruction,
-                        out var access);
-                if (instruction.NextOffset <= concatOffset
-                    && ((isLocal && access.IsStore) || EndsConcatArgumentBlock(instruction.OpCode)))
-                {
-                    blockStart = instruction.NextOffset;
-                }
-            }
-
-            var stack = new List<bool>();
-            for (int i = context.IndexAtOrAfter(blockStart); i < context.Instructions.Instructions.Length; i++)
-            {
-                var instruction = context.Instructions.Instructions[i];
-                if (instruction.Offset >= concatOffset)
-                    break;
-                if (MethodInstructionFacts.TryReadLocalSlot(
-                        instruction,
-                        out var access))
-                {
-                    if (access.IsStore)
-                        return false; // a store starts a new block; model desync -> bail
-                    int key = (access.IsArgument ? ArgSlotBias : 0) | access.Slot;
-                    stack.Add(key == storeKey);
-                    continue;
-                }
-                if (!ApplyConcatBlockStackEffect(instruction, stack, resolver))
-                    return false; // unmodeled opcode or stack underflow -> conservative bail
-            }
-
-            if (stack.Count < concatArgCount)
-                return false;
-            for (int i = stack.Count - concatArgCount; i < stack.Count; i++)
-                if (stack[i])
-                    return true;
-            return false;
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
-        {
-            return false;
-        }
-    }
-
-    static bool ApplyConcatBlockStackEffect(DecodedInstruction instruction, List<bool> stack, IOptimizationOpportunityResolver resolver)
-    {
-        switch (instruction.OpCode)
-        {
-            case ILOpCode.Nop:
-                return true;
-            case ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2
-                or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6
-                or ILOpCode.Ldc_i4_7 or ILOpCode.Ldc_i4_8 or ILOpCode.Ldnull
-                or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4 or ILOpCode.Ldc_r4 or ILOpCode.Ldstr
-                or ILOpCode.Ldsfld or ILOpCode.Ldsflda or ILOpCode.Ldtoken or ILOpCode.Ldftn
-                or ILOpCode.Sizeof or ILOpCode.Ldc_i8 or ILOpCode.Ldc_r8
-                or ILOpCode.Ldloca_s or ILOpCode.Ldarga_s or ILOpCode.Ldloca or ILOpCode.Ldarga:
-                stack.Add(false);
-                return true;
-            case ILOpCode.Conv_i1 or ILOpCode.Conv_i2 or ILOpCode.Conv_i4 or ILOpCode.Conv_i8
-                or ILOpCode.Conv_r4 or ILOpCode.Conv_r8 or ILOpCode.Conv_u4 or ILOpCode.Conv_u8
-                or ILOpCode.Conv_u2 or ILOpCode.Conv_u1 or ILOpCode.Conv_i or ILOpCode.Conv_u
-                or ILOpCode.Conv_r_un or ILOpCode.Neg or ILOpCode.Not or ILOpCode.Ldlen
-                or ILOpCode.Ldind_i1 or ILOpCode.Ldind_u1 or ILOpCode.Ldind_i2 or ILOpCode.Ldind_u2
-                or ILOpCode.Ldind_i4 or ILOpCode.Ldind_u4 or ILOpCode.Ldind_i8 or ILOpCode.Ldind_i
-                or ILOpCode.Ldind_r4 or ILOpCode.Ldind_r8 or ILOpCode.Ldind_ref
-                or ILOpCode.Ldfld or ILOpCode.Ldflda or ILOpCode.Ldobj or ILOpCode.Castclass
-                or ILOpCode.Isinst or ILOpCode.Unbox or ILOpCode.Unbox_any or ILOpCode.Box:
-                return Pop(stack, 1) && Push(stack);
-            case ILOpCode.Add or ILOpCode.Sub or ILOpCode.Mul or ILOpCode.Div or ILOpCode.Div_un
-                or ILOpCode.Rem or ILOpCode.Rem_un or ILOpCode.And or ILOpCode.Or or ILOpCode.Xor
-                or ILOpCode.Shl or ILOpCode.Shr or ILOpCode.Shr_un or ILOpCode.Ceq or ILOpCode.Cgt
-                or ILOpCode.Cgt_un or ILOpCode.Clt or ILOpCode.Clt_un or ILOpCode.Ldelem_i1
-                or ILOpCode.Ldelem_u1 or ILOpCode.Ldelem_i2 or ILOpCode.Ldelem_u2 or ILOpCode.Ldelem_i4
-                or ILOpCode.Ldelem_u4 or ILOpCode.Ldelem_i8 or ILOpCode.Ldelem_i or ILOpCode.Ldelem_r4
-                or ILOpCode.Ldelem_r8 or ILOpCode.Ldelem_ref or ILOpCode.Ldelem or ILOpCode.Ldelema:
-                return Pop(stack, 2) && Push(stack);
-            case ILOpCode.Dup:
-                if (stack.Count == 0)
-                    return false;
-                stack.Add(stack[^1]);
-                return true;
-            case ILOpCode.Pop:
-                return Pop(stack, 1);
-            case ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj:
-            {
-                int token = MethodInstructionFacts.OperandInt32(instruction);
-                var callee = resolver.ResolveMember(token);
-                if (callee.Kind == MemberKind.Unsupported)
-                    return false;
-                int pops = callee.ParameterTypes.Length + (instruction.OpCode != ILOpCode.Newobj && callee.HasThis ? 1 : 0);
-                if (!Pop(stack, pops))
-                    return false;
-                if (instruction.OpCode == ILOpCode.Newobj || callee.ReturnType.Name != "Void")
-                    stack.Add(false);
-                return true;
-            }
-            default:
-                return false; // unmodeled opcode -> bail (no false positive)
-        }
-    }
-
-    static bool Pop(List<bool> stack, int count)
-    {
-        if (stack.Count < count)
-            return false;
-        stack.RemoveRange(stack.Count - count, count);
-        return true;
-    }
-
-    static bool Push(List<bool> stack)
-    {
-        stack.Add(false);
-        return true;
-    }
-
-    static bool EndsConcatArgumentBlock(ILOpCode opcode)
-        => opcode is ILOpCode.Stfld or ILOpCode.Stsfld or ILOpCode.Stobj
-            or ILOpCode.Stelem or ILOpCode.Stelem_i or ILOpCode.Stelem_i1 or ILOpCode.Stelem_i2
-            or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8 or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8
-            or ILOpCode.Stelem_ref or ILOpCode.Stind_i or ILOpCode.Stind_i1 or ILOpCode.Stind_i2
-            or ILOpCode.Stind_i4 or ILOpCode.Stind_i8 or ILOpCode.Stind_r4 or ILOpCode.Stind_r8
-            or ILOpCode.Stind_ref
-            or ILOpCode.Ret or ILOpCode.Throw or ILOpCode.Rethrow or ILOpCode.Leave or ILOpCode.Leave_s
-            or ILOpCode.Br or ILOpCode.Br_s or ILOpCode.Brtrue or ILOpCode.Brtrue_s
-            or ILOpCode.Brfalse or ILOpCode.Brfalse_s or ILOpCode.Beq or ILOpCode.Beq_s
-            or ILOpCode.Bne_un or ILOpCode.Bne_un_s or ILOpCode.Bge or ILOpCode.Bge_s
-            or ILOpCode.Bgt or ILOpCode.Bgt_s or ILOpCode.Ble or ILOpCode.Ble_s
-            or ILOpCode.Blt or ILOpCode.Blt_s or ILOpCode.Bge_un or ILOpCode.Bge_un_s
-            or ILOpCode.Bgt_un or ILOpCode.Bgt_un_s or ILOpCode.Ble_un or ILOpCode.Ble_un_s
-            or ILOpCode.Blt_un or ILOpCode.Blt_un_s or ILOpCode.Switch;
 
 }

--- a/src/ILInspector.Analysis/StackGuardFallbackAnalysis.cs
+++ b/src/ILInspector.Analysis/StackGuardFallbackAnalysis.cs
@@ -1,0 +1,142 @@
+using System.Reflection.Metadata;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Analysis;
+
+internal static class StackGuardFallbackAnalysis
+{
+    internal static bool IsFallbackAllocation(
+        MethodBodyAnalysisContext context,
+        int allocationOffset,
+        IOptimizationOpportunityResolver resolver)
+    {
+        const int NoStackGuardCondition = 0;
+        const int DirectResult = 1;
+        const int DirectStored = 2;
+        const int DirectLoaded = 3;
+        const int ZeroAfterDirect = 4;
+        const int InvertedResult = 5;
+        const int InvertedStored = 6;
+        const int InvertedLoaded = 7;
+
+        try
+        {
+            int conditionState = NoStackGuardCondition;
+            int conditionSlot = -1;
+            foreach (var instruction in context.Instructions.Instructions)
+            {
+                if (instruction.Offset >= allocationOffset)
+                    break;
+
+                var opcode = instruction.OpCode;
+                if (opcode is ILOpCode.Call or ILOpCode.Callvirt)
+                {
+                    int token = MethodInstructionFacts.OperandInt32(instruction);
+                    var call = resolver.ResolveMember(token);
+                    conditionState = call.Name == "TryEnterOnCurrentStack"
+                        ? DirectResult
+                        : NoStackGuardCondition;
+                    conditionSlot = -1;
+                    continue;
+                }
+                if (opcode == ILOpCode.Ldc_i4_0
+                    && conditionState == DirectResult)
+                {
+                    conditionState = ZeroAfterDirect;
+                    continue;
+                }
+                if (opcode == ILOpCode.Ceq
+                    && conditionState == ZeroAfterDirect)
+                {
+                    conditionState = InvertedResult;
+                    continue;
+                }
+                if (MethodInstructionFacts.TryReadLocalSlot(
+                        instruction,
+                        out var access))
+                {
+                    if (!access.IsArgument
+                        && access.IsStore
+                        && conditionState is DirectResult
+                            or DirectLoaded
+                            or InvertedResult
+                            or InvertedLoaded)
+                    {
+                        conditionSlot = access.Slot;
+                        conditionState = conditionState is DirectResult
+                            or DirectLoaded
+                                ? DirectStored
+                                : InvertedStored;
+                        continue;
+                    }
+                    if (!access.IsArgument
+                        && !access.IsStore
+                        && access.Slot == conditionSlot)
+                    {
+                        if (conditionState == DirectStored)
+                        {
+                            conditionState = DirectLoaded;
+                            continue;
+                        }
+                        if (conditionState == InvertedStored)
+                        {
+                            conditionState = InvertedLoaded;
+                            continue;
+                        }
+                    }
+
+                    conditionState = NoStackGuardCondition;
+                    conditionSlot = -1;
+                    continue;
+                }
+                if (opcode is ILOpCode.Brtrue
+                    or ILOpCode.Brtrue_s
+                    or ILOpCode.Brfalse
+                    or ILOpCode.Brfalse_s)
+                {
+                    if (MethodInstructionFacts.TrySingleBranchTarget(
+                            instruction,
+                            out int branchTarget)
+                        && branchTarget > allocationOffset
+                        && BranchSkipsFallback(opcode, conditionState))
+                    {
+                        return true;
+                    }
+
+                    conditionState = NoStackGuardCondition;
+                    conditionSlot = -1;
+                    continue;
+                }
+                if (opcode == ILOpCode.Nop)
+                    continue;
+
+                conditionState = NoStackGuardCondition;
+                conditionSlot = -1;
+            }
+
+            return false;
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or InvalidOperationException
+                or ArgumentException
+                or OverflowException
+                or IndexOutOfRangeException)
+        {
+            return false;
+        }
+
+        static bool BranchSkipsFallback(
+            ILOpCode opcode,
+            int conditionState)
+            => opcode switch
+            {
+                ILOpCode.Brtrue or ILOpCode.Brtrue_s =>
+                    conditionState is DirectResult or DirectLoaded,
+                ILOpCode.Brfalse or ILOpCode.Brfalse_s =>
+                    conditionState is InvertedResult or InvertedLoaded,
+                _ => false,
+            };
+    }
+}

--- a/src/ILInspector.Analysis/StringConcatAccumulationAnalysis.cs
+++ b/src/ILInspector.Analysis/StringConcatAccumulationAnalysis.cs
@@ -1,0 +1,305 @@
+using System.Reflection.Metadata;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Analysis;
+
+internal static class StringConcatAccumulationAnalysis
+{
+    const int ArgumentSlotBias = 1 << 20;
+
+    // Track whether the stored accumulator reaches a Concat argument with an
+    // abstract boolean stack over the argument-producing block.
+    internal static bool AccumulatesIntoSource(
+        MethodBodyAnalysisContext context,
+        int concatOffset,
+        int storeOffset,
+        int concatArgumentCount,
+        IOptimizationOpportunityResolver resolver)
+    {
+        try
+        {
+            if (concatOffset < 0
+                || concatArgumentCount <= 0
+                || context.InstructionAt(storeOffset) is not { } storeInstruction
+                || !MethodInstructionFacts.TryReadLocalSlot(
+                    storeInstruction,
+                    out var storeAccess)
+                || !storeAccess.IsStore)
+            {
+                return false;
+            }
+
+            int storeKey = SlotKey(storeAccess);
+            int blockStart = 0;
+            foreach (var instruction in context.Instructions.Instructions)
+            {
+                if (instruction.Offset >= concatOffset)
+                    break;
+                bool isLocal = MethodInstructionFacts.TryReadLocalSlot(
+                    instruction,
+                    out var access);
+                if (instruction.NextOffset <= concatOffset
+                    && ((isLocal && access.IsStore)
+                        || EndsArgumentBlock(instruction.OpCode)))
+                {
+                    blockStart = instruction.NextOffset;
+                }
+            }
+
+            var stack = new List<bool>();
+            for (int index = context.IndexAtOrAfter(blockStart);
+                index < context.Instructions.Instructions.Length;
+                index++)
+            {
+                var instruction = context.Instructions.Instructions[index];
+                if (instruction.Offset >= concatOffset)
+                    break;
+                if (MethodInstructionFacts.TryReadLocalSlot(
+                        instruction,
+                        out var access))
+                {
+                    // A store starts a new block; model desynchronization is
+                    // not evidence of accumulation.
+                    if (access.IsStore)
+                        return false;
+                    stack.Add(SlotKey(access) == storeKey);
+                    continue;
+                }
+                // Unmodeled opcodes and stack underflow are not evidence.
+                if (!ApplyStackEffect(instruction, stack, resolver))
+                    return false;
+            }
+
+            if (stack.Count < concatArgumentCount)
+                return false;
+            for (int index = stack.Count - concatArgumentCount;
+                index < stack.Count;
+                index++)
+            {
+                if (stack[index])
+                    return true;
+            }
+
+            return false;
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or InvalidOperationException
+                or ArgumentException
+                or OverflowException)
+        {
+            return false;
+        }
+    }
+
+    static int SlotKey(LocalSlotAccess access)
+        => (access.IsArgument ? ArgumentSlotBias : 0) | access.Slot;
+
+    static bool ApplyStackEffect(
+        DecodedInstruction instruction,
+        List<bool> stack,
+        IOptimizationOpportunityResolver resolver)
+    {
+        switch (instruction.OpCode)
+        {
+            case ILOpCode.Nop:
+                return true;
+            case ILOpCode.Ldc_i4_m1
+                or ILOpCode.Ldc_i4_0
+                or ILOpCode.Ldc_i4_1
+                or ILOpCode.Ldc_i4_2
+                or ILOpCode.Ldc_i4_3
+                or ILOpCode.Ldc_i4_4
+                or ILOpCode.Ldc_i4_5
+                or ILOpCode.Ldc_i4_6
+                or ILOpCode.Ldc_i4_7
+                or ILOpCode.Ldc_i4_8
+                or ILOpCode.Ldnull
+                or ILOpCode.Ldc_i4_s
+                or ILOpCode.Ldc_i4
+                or ILOpCode.Ldc_r4
+                or ILOpCode.Ldstr
+                or ILOpCode.Ldsfld
+                or ILOpCode.Ldsflda
+                or ILOpCode.Ldtoken
+                or ILOpCode.Ldftn
+                or ILOpCode.Sizeof
+                or ILOpCode.Ldc_i8
+                or ILOpCode.Ldc_r8
+                or ILOpCode.Ldloca_s
+                or ILOpCode.Ldarga_s
+                or ILOpCode.Ldloca
+                or ILOpCode.Ldarga:
+                stack.Add(false);
+                return true;
+            case ILOpCode.Conv_i1
+                or ILOpCode.Conv_i2
+                or ILOpCode.Conv_i4
+                or ILOpCode.Conv_i8
+                or ILOpCode.Conv_r4
+                or ILOpCode.Conv_r8
+                or ILOpCode.Conv_u4
+                or ILOpCode.Conv_u8
+                or ILOpCode.Conv_u2
+                or ILOpCode.Conv_u1
+                or ILOpCode.Conv_i
+                or ILOpCode.Conv_u
+                or ILOpCode.Conv_r_un
+                or ILOpCode.Neg
+                or ILOpCode.Not
+                or ILOpCode.Ldlen
+                or ILOpCode.Ldind_i1
+                or ILOpCode.Ldind_u1
+                or ILOpCode.Ldind_i2
+                or ILOpCode.Ldind_u2
+                or ILOpCode.Ldind_i4
+                or ILOpCode.Ldind_u4
+                or ILOpCode.Ldind_i8
+                or ILOpCode.Ldind_i
+                or ILOpCode.Ldind_r4
+                or ILOpCode.Ldind_r8
+                or ILOpCode.Ldind_ref
+                or ILOpCode.Ldfld
+                or ILOpCode.Ldflda
+                or ILOpCode.Ldobj
+                or ILOpCode.Castclass
+                or ILOpCode.Isinst
+                or ILOpCode.Unbox
+                or ILOpCode.Unbox_any
+                or ILOpCode.Box:
+                return Pop(stack, 1) && Push(stack);
+            case ILOpCode.Add
+                or ILOpCode.Sub
+                or ILOpCode.Mul
+                or ILOpCode.Div
+                or ILOpCode.Div_un
+                or ILOpCode.Rem
+                or ILOpCode.Rem_un
+                or ILOpCode.And
+                or ILOpCode.Or
+                or ILOpCode.Xor
+                or ILOpCode.Shl
+                or ILOpCode.Shr
+                or ILOpCode.Shr_un
+                or ILOpCode.Ceq
+                or ILOpCode.Cgt
+                or ILOpCode.Cgt_un
+                or ILOpCode.Clt
+                or ILOpCode.Clt_un
+                or ILOpCode.Ldelem_i1
+                or ILOpCode.Ldelem_u1
+                or ILOpCode.Ldelem_i2
+                or ILOpCode.Ldelem_u2
+                or ILOpCode.Ldelem_i4
+                or ILOpCode.Ldelem_u4
+                or ILOpCode.Ldelem_i8
+                or ILOpCode.Ldelem_i
+                or ILOpCode.Ldelem_r4
+                or ILOpCode.Ldelem_r8
+                or ILOpCode.Ldelem_ref
+                or ILOpCode.Ldelem
+                or ILOpCode.Ldelema:
+                return Pop(stack, 2) && Push(stack);
+            case ILOpCode.Dup:
+                if (stack.Count == 0)
+                    return false;
+                stack.Add(stack[^1]);
+                return true;
+            case ILOpCode.Pop:
+                return Pop(stack, 1);
+            case ILOpCode.Call
+                or ILOpCode.Callvirt
+                or ILOpCode.Newobj:
+            {
+                int token = MethodInstructionFacts.OperandInt32(instruction);
+                var callee = resolver.ResolveMember(token);
+                if (callee.Kind == MemberKind.Unsupported)
+                    return false;
+                int pops = callee.ParameterTypes.Length
+                    + (instruction.OpCode != ILOpCode.Newobj && callee.HasThis
+                        ? 1
+                        : 0);
+                if (!Pop(stack, pops))
+                    return false;
+                if (instruction.OpCode == ILOpCode.Newobj
+                    || callee.ReturnType.Name != "Void")
+                {
+                    stack.Add(false);
+                }
+                return true;
+            }
+            default:
+                // An unmodeled opcode cannot establish accumulation.
+                return false;
+        }
+    }
+
+    static bool Pop(List<bool> stack, int count)
+    {
+        if (stack.Count < count)
+            return false;
+        stack.RemoveRange(stack.Count - count, count);
+        return true;
+    }
+
+    static bool Push(List<bool> stack)
+    {
+        stack.Add(false);
+        return true;
+    }
+
+    static bool EndsArgumentBlock(ILOpCode opcode)
+        => opcode is ILOpCode.Stfld
+            or ILOpCode.Stsfld
+            or ILOpCode.Stobj
+            or ILOpCode.Stelem
+            or ILOpCode.Stelem_i
+            or ILOpCode.Stelem_i1
+            or ILOpCode.Stelem_i2
+            or ILOpCode.Stelem_i4
+            or ILOpCode.Stelem_i8
+            or ILOpCode.Stelem_r4
+            or ILOpCode.Stelem_r8
+            or ILOpCode.Stelem_ref
+            or ILOpCode.Stind_i
+            or ILOpCode.Stind_i1
+            or ILOpCode.Stind_i2
+            or ILOpCode.Stind_i4
+            or ILOpCode.Stind_i8
+            or ILOpCode.Stind_r4
+            or ILOpCode.Stind_r8
+            or ILOpCode.Stind_ref
+            or ILOpCode.Ret
+            or ILOpCode.Throw
+            or ILOpCode.Rethrow
+            or ILOpCode.Leave
+            or ILOpCode.Leave_s
+            or ILOpCode.Br
+            or ILOpCode.Br_s
+            or ILOpCode.Brtrue
+            or ILOpCode.Brtrue_s
+            or ILOpCode.Brfalse
+            or ILOpCode.Brfalse_s
+            or ILOpCode.Beq
+            or ILOpCode.Beq_s
+            or ILOpCode.Bne_un
+            or ILOpCode.Bne_un_s
+            or ILOpCode.Bge
+            or ILOpCode.Bge_s
+            or ILOpCode.Bgt
+            or ILOpCode.Bgt_s
+            or ILOpCode.Ble
+            or ILOpCode.Ble_s
+            or ILOpCode.Blt
+            or ILOpCode.Blt_s
+            or ILOpCode.Bge_un
+            or ILOpCode.Bge_un_s
+            or ILOpCode.Bgt_un
+            or ILOpCode.Bgt_un_s
+            or ILOpCode.Ble_un
+            or ILOpCode.Ble_un_s
+            or ILOpCode.Blt_un
+            or ILOpCode.Blt_un_s
+            or ILOpCode.Switch;
+}


### PR DESCRIPTION
## Summary

- keep `OptimizationOpportunityAnalysis` as the sole ordered opportunity coordinator while extracting array escape, loop-invariant materializer, StackGuard fallback, and string-concat accumulation evidence into focused services
- preserve deferred collector state, resolver ordering, lazy memoized reaching definitions, and existing opportunity emission/metadata behavior
- add direct positive and close-negative service coverage, including an out-of-loop materializer gate that proves reaching definitions remain lazy

## Compatibility

This is an internal, behavior-preserving ownership change. It does not alter public models, output shapes, opportunity ordering, recognizer policy, metadata contracts, or acquisition/decode paths. Focused recognizers may perform their existing candidate-local sub-scans but do not own another top-level body traversal or emit opportunities.

## Validation

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore` — 627 passed
- `npx markdownlint-cli docs/architecture.md docs/design/method-body-inspection.md`
- `git diff --check origin/main...HEAD`

Frozen candidate base: `94b87a33ee622acfcba053cea5b72288635c48ff`
Frozen candidate head: `0f31549e7b0bb45056817ee8675a96ea7841aaf8`