### PR TITLE
Strengthen decompiler raise review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,8 @@ change ready to merge.
 | Call-graph projection | `docs/design/call-graph-projection.md` |
 | Shared IL/control-flow substrate | `docs/design/instruction-substrate.md`, plus the consuming subsystem's docs |
 | IL round-trip tests | `tests/DotnetInspector.ILRoundtrip.Tests/README.md` |
-| Decompiler behavior or harnesses | `docs/decompiler-correctness-pipeline.md` |
+| Decompiler raising, structuring, typing, or printer behavior | `docs/decompiler-correctness-pipeline.md`, then `docs/decompiler-raise-discipline.md` |
+| Decompiler harness-only behavior | `docs/decompiler-correctness-pipeline.md`, then the owning harness README |
 | Skills | `taste/skill-guidance.md` |
 | Stacked PRs and restacking | `docs/stacked-prs.md` |
 | Release and publishing | `docs/release-workflow.md` |

--- a/docs/decompiler-raise-discipline.md
+++ b/docs/decompiler-raise-discipline.md
@@ -62,7 +62,7 @@ cross-document node correspondence, generate the full-body structural review
 introduced by #4092 from one `CSharpStructuralComparison` and paste its
 Before/After caret overlays and structural rows verbatim.
 
-#4092 currently supplies the comparison and presentation consumer, not a
+PR #4092 currently supplies the comparison and presentation consumer, not a
 producer that maps base-render C# node ids to head-render C# node ids. Until
 such a producer exists, record `Not generated — no product correspondence
 issuer` and retain the standalone Before and After bodies. Never hand-place

--- a/docs/decompiler-raise-discipline.md
+++ b/docs/decompiler-raise-discipline.md
@@ -7,6 +7,81 @@ itself lives in [value-typed-emission.md](design/value-typed-emission.md) and
 [inverse-architecture.md](design/inverse-architecture.md); this note is how to
 work inside it without re-buying the lessons.
 
+## Raise acceptance contract
+
+A raise is a proof-backed replacement, not merely a pattern that produced
+better C# for one method. Before implementation, write down four proof
+obligations:
+
+1. **Lowering shell:** name the source construct, compiler, build configuration,
+   and exact IL/IR shape being recognized. Keep at least one compiler-produced
+   fixture or pinned real witness; a hand-built graph alone cannot establish
+   that the claimed lowering exists.
+2. **Consumed ownership:** identify every block, node, temporary, label, and
+   storage location the rewrite removes or reinterprets. Prove that no
+   unconsumed edge or use reaches into that region. Scope body-local facts to
+   their nearest function, but inspect globally visible storage across nested
+   functions.
+3. **Control-flow contract:** when the raise consumes or alters control flow,
+   preserve successor identity and multiplicity, exits, exception boundaries,
+   and the owners of `Break`, `Continue`, and `Leave`. Otherwise state why this
+   obligation does not apply. A model-agreement check proves two models
+   describe the same edges; it does not prove that the proposed C# replacement
+   preserves their meaning.
+4. **Replacement contract:** show that the emitted C# binds, preserves
+   observable behavior, and has an independently measured compile-back outcome.
+   If exact IL fidelity is not available, name the missing evidence rather than
+   treating valid-looking output as proof.
+
+Every unsupported or ambiguous obligation is a decline boundary. Leave that
+shape honestly lowered; do not infer ownership from block order, equal text,
+coordinates, node ids from another document, or a convenient fallthrough.
+The PR contract records these four obligations plus the explicit decline
+boundary and a concrete observation that would falsify the raise.
+
+### Fixture family
+
+Each behavior-changing raise needs a fixture family, not one happy-path test:
+
+- a compiler-produced positive that pins the real lowering;
+- the smallest accepted boundary shape;
+- a still-flat negative for each proof obligation the matcher relies on;
+- nested-function, external-entry, successor-multiplicity, and structured
+  transfer negatives when those domains are reachable;
+- a pinned real witness whose Before and After bodies are reviewed.
+
+Synthetic fixtures are appropriate for adversarial states a compiler will not
+emit. They complement rather than replace the compiler-produced positive.
+Assert the IR invariant on accepted and declined results.
+
+### Review evidence
+
+For the real witness, acquire exact base/head `AnnotatedSourceDocument` values
+with `-S "Annotated Source Document"`. When a product owner can also issue real
+cross-document node correspondence, generate the full-body structural review
+introduced by #4092 from one `CSharpStructuralComparison` and paste its
+Before/After caret overlays and structural rows verbatim.
+
+#4092 currently supplies the comparison and presentation consumer, not a
+producer that maps base-render C# node ids to head-render C# node ids. Until
+such a producer exists, record `Not generated — no product correspondence
+issuer` and retain the standalone Before and After bodies. Never hand-place
+carets or recover correspondence from equal ids, coordinates, text, labels, or
+display order merely to satisfy the template.
+
+The structural review explains *what changed*; it is not a correctness oracle.
+Keep the independent validity, correctness, compile-back fidelity, and exact
+revision verdicts beside it. The current correspondence-producer gap does not
+change an otherwise supported raise verdict; it changes only which
+presentation artifact is honest. Do not manufacture a persuasive substitute in
+the harness.
+
+Render A/B and corpus evidence remain population checks. Report stable
+changed-method loss/gain identities and classify every changed method; aggregate
+improvements cannot offset one newly invalid or behavior-changing method. The
+PR template at [templates/decompiler-pr.md](templates/decompiler-pr.md) is the
+required review shape.
+
 ## Evidence
 
 - **Render-text A/B is standing evidence for any raise/printer-affecting PR.**

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -5,9 +5,10 @@ Use this for decompiler PRs that affect raising, structuring, validity,
 fidelity, or corpus behavior. Delete sections that do not apply. Keep generated
 tables generated; do not re-key metric rows by hand.
 
-Every raise PR must keep Before, After, and Fully raised. Before and After must
-each show a concrete C# example. After records this PR's output; Fully raised
-records the intended endpoint.
+Every behavior-changing raise PR must keep Raise contract, Structural review
+status, Before, After, and Fully raised. Before and After must each show a
+concrete C# example. After records this PR's output; Fully raised records the
+intended endpoint.
 
 Under Before and After, record independent verdicts on the shown C# so the
 assessment sits next to the code it judges:
@@ -70,12 +71,47 @@ For focused invalid-Full / burndown row fixes, prefer
 
 **Conclusion:** **PASS/REVIEW/BLOCKED** — {one sentence with the decisive reason}.
 
+### Raise contract
+
+<!--
+Required for behavior-changing raises. State the proof before presenting the
+output. "The tests pass" is not a lowering or ownership proof.
+
+- Source construct: the C# construct being recovered.
+- Compiler lowering: compiler/version, Release/Debug, target framework, and the
+  exact IL/IR shell recognized. Cite the compiler-produced fixture or pinned
+  real witness.
+- Consumed ownership: blocks, nodes, labels, temporaries, and storage removed
+  or reinterpreted, plus the proof that no outside edge/use reaches them.
+- Control flow: when the raise consumes or alters control flow, successor
+  identity and multiplicity, exits/EH boundaries, and ownership of
+  Break/Continue/Leave. Otherwise state why it is not applicable.
+- Replacement: independent binding, observable-behavior, and compile-back
+  evidence for the emitted C#.
+- Decline boundary: the closest plausible shapes that remain flat and the
+  adversarial tests that pin them.
+- Falsifier: the concrete observation that would disprove this raise's claim.
+-->
+
+| Obligation | Contract |
+| --- | --- |
+| Lowering shell | {source construct, compiler/configuration, and exact recognized shell} |
+| Consumed ownership | {consumed region/storage and exclusivity proof} |
+| Control flow | {successors, exits, EH, and structured-transfer ownership / not applicable and why} |
+| Replacement | {binding, observable behavior, and compile-back evidence} |
+| Decline boundary | {near misses that remain flat and their tests} |
+| Falsifier | {evidence that would make the raise unsound} |
+
 ### Structural review
 
 <!--
-For a changed rendered body, this generated artifact is the preferred review
-shape. Produce it from two C# AnnotatedSourceDocument revisions plus
-owner-issued node correspondence:
+For a changed rendered body, first acquire both exact revisions with:
+
+dotnet-inspect member {Type} {MethodSelector} {scope} \
+  -S "Annotated Source Document"
+
+When a product owner can issue real cross-document node correspondence, produce
+the generated artifact from those two C# AnnotatedSourceDocument revisions:
 
 dotnet run --project tools/DecompilerHarness -c Release -- \
   --structural-review /tmp/comparison.json
@@ -83,16 +119,26 @@ dotnet run --project tools/DecompilerHarness -c Release -- \
 Paste the output verbatim. Its complete Before/After blocks and rich structural
 diff consume one CSharpStructuralComparison; do not manually place carets or
 reconstruct rows. Node ids are document-local. Correspondence must come from
-the owner that produced the revisions, never equal ids, coordinates, selected
-text, or labels. Fidelity and retained IL notes are independent evidence, not
+an explicit product owner, never equal ids, coordinates, selected text, labels,
+or display order. Fidelity and retained IL notes are independent evidence, not
 claims inferred from the C# transition.
+
+#4092 currently consumes comparison input but no product component maps
+base-render C# node ids to head-render C# node ids. When no correspondence
+issuer exists, write exactly:
+
+Not generated — no product correspondence issuer
+
+Do not fabricate comparison JSON. This current presentation gap does not by
+itself change the raise verdict; independent validity, correctness, fidelity,
+and corpus evidence still decide it.
 
 When this artifact is present, delete the duplicate code fences in the
 standalone Before and After sections below, but retain their validity,
 correctness, fidelity, taste, and commit verdicts.
 -->
 
-{generated full-body Before/After carets and rich structural diff}
+Structural review status: {generated artifact / Not generated — no product correspondence issuer}
 
 ### Benchmark target
 
@@ -206,13 +252,20 @@ counts can rise even while some previously-passing test starts failing.
 | --- | --- | --- |
 | Product build | Pass | Pass |
 | Focused tests | `{test class}`: {n} passed | `{test class}`: {n} passed |
+| Compiler-produced positive | `{fixture}` remains flat | `{fixture}` raises |
+| Adversarial declines | `{negative fixtures}` remain flat | `{negative fixtures}` remain flat |
 | Decompiler fast suite | {total}, {failed} failed | {total}, {failed} failed |
 | Reduced fixture validity | Pass / not applicable | Pass / not applicable |
 | Reduced fixture fidelity | Pass / not currently checkable | Pass / not currently checkable |
+| Structural review | Base document acquired | Generated comparison attached / Not generated — no product correspondence issuer |
 | Real witness | `{Type::Method}` broken / not applicable | `{Type::Method}` fixed / not applicable |
 
 If Baseline shows any failures, name them and confirm they are unchanged by
 this PR (same tests, same reason) rather than omitting them.
+
+For render A/B or corpus deltas, list stable changed-method identities and
+classify every loss/gain. Do not use a net count to offset a newly invalid,
+behavior-changing, or unexplained method.
 
 ## Decompiler quality
 


### PR DESCRIPTION
## Summary

- defines a proof-backed acceptance contract for behavior-changing decompiler raises
- requires compiler-produced positives, proof-specific adversarial declines, and a pinned real witness
- separates structural explanation from validity, correctness, compile-back fidelity, and corpus evidence
- documents that #4092 currently consumes cross-document correspondence but does not produce it, preventing agents from fabricating mappings
- upgrades the decompiler PR template to surface every obligation and stable changed-method evidence

## Validation

- `npx markdownlint-cli AGENTS.md docs/decompiler-raise-discipline.md docs/templates/decompiler-pr.md`
