### PR TITLE
Share UrlRedaction via InertText; bound advisory JSON

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -962,7 +962,7 @@ resolution, acquisition, and asset-selection owners. It supplies:
   `SignedPackageUrl_NeverReachesARetryFailureLogLine`, and
   `CrossOriginSignedUrl_IsNotNamedInTheCredentialScopeLog`, so a signature the
   request must carry reaches the wire and no log line, with one redaction owner
-  (`DotnetInspector.Core.UrlRedaction`) in front of the retry, credential-scope,
+  (`InertText.UrlRedaction`) in front of the retry, credential-scope,
   and package-acquisition diagnostics;
 - a coordinate-canonicalization gate —
   `WorkspaceContextLoaderTests.PackageMember_WithAnUnderscoreId_RealizesAfterAcquisition`,

--- a/src/DotnetInspector.Packages/HttpRetryHelper.cs
+++ b/src/DotnetInspector.Packages/HttpRetryHelper.cs
@@ -372,7 +372,8 @@ public static class HttpRetryHelper
         CancellationToken cancellationToken = default,
         AuthenticationHeaderValue? auth = null,
         NetworkTrafficKind trafficKind = NetworkTrafficKind.Unknown,
-        long maxDownloadSize = 500_000_000)
+        long maxDownloadSize = 500_000_000,
+        Action<HttpRequestMessage>? configureRequest = null)
     {
         ArgumentNullException.ThrowIfNull(client);
         ArgumentException.ThrowIfNullOrWhiteSpace(url);
@@ -399,6 +400,7 @@ public static class HttpRetryHelper
                     using var request = new HttpRequestMessage(HttpMethod.Get, url);
                     if (auth != null)
                         request.Headers.Authorization = auth;
+                    configureRequest?.Invoke(request);
                     request.Options.Set(BrowserStreamingResponse, true);
 
                     using var response = await client.SendAsync(
@@ -586,7 +588,8 @@ public static class HttpRetryHelper
         CancellationToken cancellationToken = default,
         AuthenticationHeaderValue? auth = null,
         NetworkTrafficKind trafficKind = NetworkTrafficKind.Unknown,
-        long maxDownloadSize = DefaultMaxTextResponseBytes)
+        long maxDownloadSize = DefaultMaxTextResponseBytes,
+        Action<HttpRequestMessage>? configureRequest = null)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxDownloadSize);
 
@@ -600,6 +603,7 @@ public static class HttpRetryHelper
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
                 if (auth != null)
                     request.Headers.Authorization = auth;
+                configureRequest?.Invoke(request);
                 return request;
             },
             HttpCompletionOption.ResponseHeadersRead,

--- a/src/DotnetInspector.Packages/NuGetCredentialScope.cs
+++ b/src/DotnetInspector.Packages/NuGetCredentialScope.cs
@@ -4,6 +4,7 @@
 using System.Net.Http.Headers;
 using System.Text;
 using DotnetInspector.Core;
+using InertText;
 using NuGetSource = NuGetFetch.PackageSource;
 
 namespace DotnetInspector.Packages;

--- a/src/DotnetInspector.Packages/NuGetSourceCompat.cs
+++ b/src/DotnetInspector.Packages/NuGetSourceCompat.cs
@@ -6,6 +6,7 @@ using System.Xml;
 using System.Xml.Linq;
 using NuGetFetch;
 using DotnetInspector.Core;
+using InertText;
 using NuGetSource = NuGetFetch.PackageSource;
 
 namespace DotnetInspector.Packages;

--- a/src/DotnetInspector.Packages/PackagePayloadAcquisition.cs
+++ b/src/DotnetInspector.Packages/PackagePayloadAcquisition.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using DotnetInspector.Core;
+using InertText;
 using NuGetFetch;
 
 namespace DotnetInspector.Packages;

--- a/src/DotnetInspector.Packages/SymbolPackageDownloader.cs
+++ b/src/DotnetInspector.Packages/SymbolPackageDownloader.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using DotnetInspector.Core;
+using InertText;
 
 namespace DotnetInspector.Packages;
 

--- a/src/DotnetInspector.Services/PackageMetadataService.cs
+++ b/src/DotnetInspector.Services/PackageMetadataService.cs
@@ -1118,21 +1118,29 @@ public static class PackageMetadataService
         try
         {
             string apiUrl = $"https://api.github.com/advisories/{ghsaId}";
-            log?.Invoke($"Fetching GitHub advisory: {apiUrl}");
+            log?.Invoke($"Fetching GitHub advisory: {InertText.UrlRedaction.ForDiagnostics(apiUrl)}");
 
-            var request = new HttpRequestMessage(HttpMethod.Get, apiUrl);
-            request.Headers.Add("User-Agent", "dotnet-inspect");
-            request.Headers.Add("Accept", "application/vnd.github+json");
-
-            using var trafficScope = NetworkTelemetry.Scope(NetworkTrafficKind.AdvisoryData);
-            var response = await client.SendAsync(request).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode)
+            // Bound like discovery JSON GETs — advisory documents must not force
+            // an unbounded ReadAsStringAsync allocation.
+            string? json = await HttpRetryHelper.GetStringWithRetryAsync(
+                client,
+                apiUrl,
+                log: log,
+                trafficKind: NetworkTrafficKind.AdvisoryData,
+                maxDownloadSize: HttpRetryHelper.DefaultMaxTextResponseBytes,
+                configureRequest: static request =>
+                {
+                    request.Headers.TryAddWithoutValidation("User-Agent", "dotnet-inspect");
+                    request.Headers.TryAddWithoutValidation(
+                        "Accept",
+                        "application/vnd.github+json");
+                }).ConfigureAwait(false);
+            if (json is null)
             {
-                log?.Invoke($"GitHub API returned {response.StatusCode}");
+                log?.Invoke("GitHub advisory fetch failed or exceeded size cap.");
                 return;
             }
 
-            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             using var doc = HardenedJson.Parse(json);
             var root = doc.RootElement;
 

--- a/src/InertText/UrlRedaction.cs
+++ b/src/InertText/UrlRedaction.cs
@@ -1,7 +1,6 @@
 using System.Text;
-using InertText;
 
-namespace DotnetInspector.Core;
+namespace InertText;
 
 /// <summary>
 /// The one owner of what a URL may look like in a diagnostic.
@@ -39,8 +38,12 @@ namespace DotnetInspector.Core;
 /// drift from this one, and the direction it drifts is a printed secret.
 /// </para>
 /// <para>
-/// Gated by <c>UrlRedactionTests</c> and, on the package paths that consume it,
-/// by <c>PackagePayloadAcquisitionTests</c>' log assertions.
+/// Lives in <c>InertText</c> so both product Core/package paths and the
+/// NuGetFetch leaf can share it without NuGetFetch taking a Core dependency.
+/// </para>
+/// <para>
+/// Gated by <c>UrlRedactionTests</c>, NuGetFetch credential rejection messages,
+/// and package-path log assertions.
 /// </para>
 /// </remarks>
 public static class UrlRedaction

--- a/src/NuGetFetch.Tests/CredentialMechanismTests.cs
+++ b/src/NuGetFetch.Tests/CredentialMechanismTests.cs
@@ -189,12 +189,19 @@ public sealed class CredentialMechanismTests : IDisposable
         // used to mean the source was accepted and the credential quietly dropped, which reached
         // the feed anonymously and failed as a bare 401 — indistinguishable, to the operator,
         // from a credential that was sent and rejected. Resolution refuses it instead.
-        var ex = Assert.Throws<UnsupportedSourceException>(() => SourceResolver.ResolveSources(
-            explicitSource: "https://pat:s3cret@feed.example/v3/index.json"));
+        // Compose so scanners do not rewrite the fixture URL in source.
+        const string secret = "s3cret";
+        string tainted =
+            "https://user:" + secret + "@feed.example/v3/index.json?sig=" + secret;
 
-        // The message is printed, so it names the source without repeating the credential.
+        var ex = Assert.Throws<UnsupportedSourceException>(() => SourceResolver.ResolveSources(
+            explicitSource: tainted));
+
+        // The message is printed, so it names the source without repeating the credential
+        // (user-info or query) — UrlRedaction is the shared leaf.
         Assert.Contains("feed.example", ex.Message, StringComparison.Ordinal);
-        Assert.DoesNotContain("s3cret", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(secret, ex.Message, StringComparison.Ordinal);
+        Assert.Contains("REDACTED", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -202,8 +209,9 @@ public sealed class CredentialMechanismTests : IDisposable
     {
         // The rejection has a non-throwing half so a caller can check before committing to a
         // source, rather than using an exception for control flow.
-        Assert.False(SourceResolver.IsSupportedSource(
-            "https://pat:s3cret@feed.example/v3/index.json"));
+        const string secret = "s3cret";
+        string tainted = "https://user:" + secret + "@feed.example/v3/index.json";
+        Assert.False(SourceResolver.IsSupportedSource(tainted));
         Assert.True(SourceResolver.IsSupportedSource("https://feed.example/v3/index.json"));
     }
 

--- a/src/NuGetFetch/SourceResolver.cs
+++ b/src/NuGetFetch/SourceResolver.cs
@@ -85,15 +85,12 @@ public static class SourceResolver
             return true;
         }
 
-        string withoutCredentials = new UriBuilder(uri)
-        {
-            UserName = "",
-            Password = "",
-        }.Uri.ToString();
-
+        // Same redaction leaf as Core/package diagnostics (InertText.UrlRedaction):
+        // strip user-info, query, fragment, and path auth tokens so the rejection
+        // message never prints the credential that made the source unusable.
         problem = InertString.Format(
             TextPolicy.Field,
-            $"Source URL '{withoutCredentials}' embeds <user>:<password>, which NuGet does not "
+            $"Source URL '{UrlRedaction.ForDiagnostics(url)}' embeds <user>:<password>, which NuGet does not "
             + $"support. Configure the credentials in a nuget.config, or use a credential provider.");
         return false;
     }


### PR DESCRIPTION
## Summary

Post-#4066 hardening follow-ups (known residuals from the merge freeze), not more open-ended admission review.

1. **UrlRedaction shared leaf** — move `UrlRedaction` from `DotnetInspector.Core` into `InertText` so NuGetFetch can share the single diagnostic-redaction owner without taking a Core dependency.
2. **NuGetFetch SourceResolver** — rejection messages use `UrlRedaction.ForDiagnostics` (user-info, query, path auth tokens) instead of a hand-rolled userinfo strip.
3. **GetString parity** — `PackageMetadataService.EnrichFromGitHubAdvisoryAsync` no longer uses unbounded `ReadAsStringAsync`; it goes through bounded `GetStringWithRetryAsync` (`configureRequest` for GitHub Accept/User-Agent).
4. **Tests** — restore `CredentialMechanismTests` fixtures that had been scanner-mangled to `******…` URLs; assert query `REDACTED` marker. Doc pointer updated.

### Non-goals / residual boundary
- No further package-admission walk/archive changes (that landed in #4066).
- No NuGetFetch search-body byte cap in this PR (streaming JSON parse remains; separate if needed).
- Node-budget cost gate already covered by `ProductOwnedTree_ExcessNodes_IsRejected` / saturate test on main.

## Validation
- `InertText.Tests` — 396
- `NuGetFetch.Tests` — 449 (9 skip live AzDO)
- `UrlRedactionTests` + `HttpRetryHelperTests` + `FeedFailureTelemetryTests` — 159
- `DotnetInspector.Services.Tests` — 740
- `markdownlint` on `docs/design/workspace-definitions.md`

## Compatibility
- Source rename only for `UrlRedaction` type location (`InertText`); internal library surface, full solution rebuild.