### PR TITLE
Extract merged-slot compiler fixtures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5952,27 +5952,6 @@ public static class EnumCastSamples
         => new[] { (System.StringComparison)4, System.StringComparison.OrdinalIgnoreCase };
 }
 
-// Issue #1767: a value produced at a stack slot (the object-merged `cond ? null
-// : value` ternary) and consumed at a control-flow merge where the slot is typed
-// `string` (a field store) must share ONE local name. Keying slot names on
-// (slot, type) split them into `object S_1` (store) and `string S_1_1` (load),
-// so the consumer read an unassigned local (CS0165) and the value was dropped.
-public static class MergedSlotStrU
-{
-    public static bool IsNullOrEmpty(string s) => s == null || s.Length == 0;
-}
-
-public class MergedSlotProbe
-{
-    private string? _fmt;
-
-    public string? MergedFormat
-    {
-        get => _fmt;
-        set => _fmt = MergedSlotStrU.IsNullOrEmpty(value!) ? null : value;
-    }
-}
-
 // Issue: a user-defined operator with `in`/`ref` parameters is called with the
 // operands' addresses (ldarga/ldloca). The operator must spell as `a != b`, not
 // `(ref a) != (ref b)` — the latter is CS1525 "Invalid expression term 'ref'".

--- a/src/ILInspector.Decompiler.Tests/MergedSlotNamingSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/MergedSlotNamingSamples.cs
@@ -1,0 +1,22 @@
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #1767: a value produced at a stack slot (the object-merged `cond ? null
+// : value` ternary) and consumed at a control-flow merge where the slot is typed
+// `string` (a field store) must share ONE local name. Keying slot names on
+// (slot, type) split them into `object S_1` (store) and `string S_1_1` (load),
+// so the consumer read an unassigned local (CS0165) and the value was dropped.
+public static class MergedSlotStrU
+{
+    public static bool IsNullOrEmpty(string s) => s == null || s.Length == 0;
+}
+
+public class MergedSlotProbe
+{
+    private string? _fmt;
+
+    public string? MergedFormat
+    {
+        get => _fmt;
+        set => _fmt = MergedSlotStrU.IsNullOrEmpty(value!) ? null : value;
+    }
+}


### PR DESCRIPTION
## Summary

Moves `MergedSlotStrU` and `MergedSlotProbe` unchanged from the catch-all `CfgSampleClass.cs` fixture into feature-focused `MergedSlotNamingSamples.cs`.

This keeps the compiler fixture next to its sole behavioral owner, `MergedSlotNamingTests`, while preserving declaration order and emitted behavior. The source move intentionally changes PDB document provenance; rendered method inventory and bodies remain identical.

## Evidence

- Release solution build succeeded at integrated head `68ad634c0`.
- `MergedSlotNamingTests`: 1 passed.
- Decompiler fast gate: 4,908 total, 0 failed, 8 expected privilege-dependent skips.
- Stable-path render A/B: 19,982 methods evaluated; 0 changed, 0 added, 0 removed.
- Integrated `main` tip `fdbd1a683`; its delta from the prior frozen base is solely the CI self-test hash repair in `eng/test-ci-change-detection.cs`.

Related to #3913. Leaves #3913 open for the remaining fixture groups.