### PR TITLE
docs: lock IChatClient dual-lens graph demo

### DIFF
--- a/docs/workflows/discovery/aspire-ai-package-graph.md
+++ b/docs/workflows/discovery/aspire-ai-package-graph.md
@@ -1,57 +1,32 @@
 ---
 id: aspire-ai-package-graph
-description: Multi-hub Aspire package web (Hosting + Azure + AI spokes) with cross-package call graph
+description: Simple Aspire hosting + AI package demo (integrations, extensions web, seed call graph)
 commands: [library, package, extensions, member, type]
 areas: [packages, integrations, call-graph, extensions, aspire, ai]
 ---
 
-# Aspire + AI package graph
+# Aspire hosting + AI
 
-> First **package call-graph** demo. Aspire is not one hub package: a useful
-> graph starts from **several base packages as peers**, then hangs AI spokes
-> and the MEAI client stack off that web.
+> Simple **package hosting** demo: Aspire’s AppHost hub, AI resource packages,
+> and a seed-centric call graph into the hub. Pattern: integration census →
+> hub-type extension web → one `Add*` drill. Flex: multi-package `extensions`,
+> `Integration: Aspire`, and `Call Graph` with `--caller-package`.
 >
-> Pattern: multi-hub package set → hub-type extension web → integration census
-> → multi-package call-graph drill. Flex: multi-`--package` `extensions`,
-> `Integration:` sections, and `Call Graph` with repeated `--caller-package`.
+> Deliberately small. Expand when call-graph modes grow (seed-centric vs ad hoc
+> multi-input — #4133; cross-library body resolution — #3632).
 
-## Why not only `Aspire.Hosting`?
+## Pins
 
-`Aspire.Hosting` is necessary substrate (application model, builder, resources)
-but on its own it under-describes Aspire. Component packages and the Azure
-base carry most of the interesting surface. A single-member call graph that
-only widens into `Aspire.Hosting` also reads as hub-centric: every spoke’s
-`Add*` collapses into the same substrate edges.
+| Role | Package | Version |
+| ---- | ------- | ------- |
+| Hosting hub | `Aspire.Hosting` | 13.4.6 |
+| OpenAI hosting | `Aspire.Hosting.OpenAI` | 13.4.6 |
+| Azure OpenAI hosting | `Aspire.Hosting.Azure.CognitiveServices` | 13.4.6 |
+| GitHub Models hosting | `Aspire.Hosting.GitHub.Models` | 13.4.6 |
+| AI abstractions (optional client) | `Microsoft.Extensions.AI` | 10.9.0 |
 
-This demo therefore treats **three packages as hubs** and keeps AI packages as
-first-class peers rather than footnotes on Hosting:
-
-| Hub role | Package | Why it is a hub |
-| -------- | ------- | --------------- |
-| Application model | `Aspire.Hosting` | Builder, resources, parameters, snapshots |
-| Azure substrate | `Aspire.Hosting.Azure` | Provisioning, environment, Bicep/identity |
-| Azure OpenAI spoke-hub | `Aspire.Hosting.Azure.CognitiveServices` | AI entry that **fans into both** Hosting and Azure |
-
-AI peers on the same web (not hubs, still first-class):
-
-| Peer | Package |
-| ---- | ------- |
-| OpenAI hosting | `Aspire.Hosting.OpenAI` |
-| GitHub Models | `Aspire.Hosting.GitHub.Models` |
-
-Client plane (how apps consume models Aspire provisions):
-
-| Role | Package |
-| ---- | ------- |
-| AI abstractions | `Microsoft.Extensions.AI` |
-| OpenAI adapter | `Microsoft.Extensions.AI.OpenAI` |
-
-All Aspire pins are **13.4.6**; MEAI pins are **10.9.0**. Bump a column
-together when refreshing.
-
-Hub type for the package web: `IDistributedApplicationBuilder`.  
-Hero call-graph member: `AzureOpenAIExtensions.AddAzureOpenAI` (multi-hub
-fanout). Contrast member: `OpenAIExtensions.AddOpenAI` (Hosting-only fanout).
+Hub type: `IDistributedApplicationBuilder`.  
+Seed member: `OpenAIExtensions.AddOpenAI`.
 
 ## Preconditions
 
@@ -63,22 +38,16 @@ export DOTNET_INSPECT_ISOLATED=aspire-ai-package-graph
 dotnet-inspect cache clear
 ```
 
-Prime the cache (network once per machine/session):
-
 ```bash
 dotnet-inspect Aspire.Hosting@13.4.6 -v:q
 ```
 
 ```bash
-dotnet-inspect Aspire.Hosting.Azure@13.4.6 -v:q
+dotnet-inspect Aspire.Hosting.OpenAI@13.4.6 -v:q
 ```
 
 ```bash
 dotnet-inspect Aspire.Hosting.Azure.CognitiveServices@13.4.6 -v:q
-```
-
-```bash
-dotnet-inspect Aspire.Hosting.OpenAI@13.4.6 -v:q
 ```
 
 ```bash
@@ -89,24 +58,18 @@ dotnet-inspect Aspire.Hosting.GitHub.Models@13.4.6 -v:q
 dotnet-inspect Microsoft.Extensions.AI@10.9.0 -v:q
 ```
 
-```bash
-dotnet-inspect Microsoft.Extensions.AI.OpenAI@10.9.0 -v:q
-```
+## 1. Integration census (AI hosting packages)
 
-## 1. Hub integration census (base packages first)
+> Goal: Each package’s Aspire contract card — resources and `Add*` entry points.
 
-> Goal: Read each hub’s `Integration: Aspire` card before any spoke. This is
-> the multi-hub story: Hosting alone is thin compared with Azure’s resource
-> and builder surface.
-
-### 1a. Azure substrate hub
+### 1a. OpenAI
 
 ```prompt
-What Aspire integrations does the Azure hosting base package declare?
+What Aspire resources does Aspire.Hosting.OpenAI expose?
 ```
 
 ```bash
-dotnet-inspect library Aspire.Hosting.Azure@13.4.6 -S "Integration: Aspire" -v:n
+dotnet-inspect library Aspire.Hosting.OpenAI@13.4.6 -S "Integration: Aspire" -v:n
 ```
 
 ```expect
@@ -114,21 +77,17 @@ Integration: Aspire
 ```
 
 ```expect
-AzureEnvironmentResource
+OpenAIResource
 ```
 
 ```expect
-AddAzureEnvironment
+AddOpenAI
 ```
 
-```expect
-IAzureResource
-```
-
-### 1b. Azure OpenAI hub (AI entry on Azure)
+### 1b. Azure OpenAI and GitHub Models
 
 ```prompt
-How does Aspire model Azure OpenAI on top of the Azure substrate?
+What do the other AI hosting packages declare to Aspire?
 ```
 
 ```bash
@@ -143,24 +102,6 @@ AzureOpenAIResource
 AddAzureOpenAI
 ```
 
-### 1c. OpenAI and GitHub Models peers
-
-```prompt
-What Aspire resources do the non-Azure AI hosting packages expose?
-```
-
-```bash
-dotnet-inspect library Aspire.Hosting.OpenAI@13.4.6 -S "Integration: Aspire" -v:n
-```
-
-```expect
-OpenAIResource
-```
-
-```expect
-AddOpenAI
-```
-
 ```bash
 dotnet-inspect library Aspire.Hosting.GitHub.Models@13.4.6 -S "Integration: Aspire" -v:n
 ```
@@ -173,43 +114,24 @@ GitHubModelResource
 AddGitHubModel
 ```
 
-## 2. Package web via hub-type extensions (multi-hub)
+## 2. Package web on the hub type
 
-> Goal: One query over **all hubs and AI peers**. Contributions are labeled by
-> library — the package graph people navigate when composing an AppHost. Hosting
-> still dominates method count; Azure and AI packages supply the distinctive
-> `Add*` spokes.
+> Goal: One multi-package `extensions` query — how AI packages hang off
+> `IDistributedApplicationBuilder`.
 
-### 2a. Three hubs + AI peers on `IDistributedApplicationBuilder`
+### 2a. Hub + AI spokes
 
 ```prompt
-What Add* methods hang off IDistributedApplicationBuilder across Aspire hosting, Azure, and AI packages?
+Which AI Add* methods hang off IDistributedApplicationBuilder?
 ```
 
 ```bash
 dotnet-inspect extensions IDistributedApplicationBuilder \
   --package Aspire.Hosting@13.4.6 \
-  --package Aspire.Hosting.Azure@13.4.6 \
-  --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
   --package Aspire.Hosting.OpenAI@13.4.6 \
+  --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
   --package Aspire.Hosting.GitHub.Models@13.4.6 \
   --tfm net8.0 -v:n
-```
-
-```expect
-AddAzureEnvironment
-```
-
-```expect
-Aspire.Hosting.Azure
-```
-
-```expect
-AddAzureOpenAI
-```
-
-```expect
-Aspire.Hosting.Azure.CognitiveServices
 ```
 
 ```expect
@@ -221,109 +143,29 @@ Aspire.Hosting.OpenAI
 ```
 
 ```expect
+AddAzureOpenAI
+```
+
+```expect
 AddGitHubModel
 ```
 
-```expect
-Aspire.Hosting.GitHub.Models
-```
+## 3. Seed call graph — `AddOpenAI` into the hub
 
-## 3. Multi-hub call graph — `AddAzureOpenAI`
+> Goal: Classic seed-centric path. Focus one builder API; widen into
+> `Aspire.Hosting` so edges resolve to real hub APIs (parameters, snapshots)
+> instead of opaque externals.
 
-> Goal: Deep-drill the member that actually crosses hubs. With
-> `--caller-package` for both `Aspire.Hosting` and `Aspire.Hosting.Azure`,
-> edges resolve into **two** package groups (provisioning/environment on Azure,
-> resources/snapshots on Hosting) instead of a Hosting-only star.
-
-### 3a. Edge table across Hosting + Azure
+### 3a. Edge table
 
 ```prompt
-Show the call graph for AddAzureOpenAI with Aspire.Hosting and Aspire.Hosting.Azure in scope.
-```
-
-```bash
-dotnet-inspect member AzureOpenAIExtensions AddAzureOpenAI \
-  --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
-  --caller-package Aspire.Hosting@13.4.6 \
-  --caller-package Aspire.Hosting.Azure@13.4.6 \
-  -S "Call Graph" -v:n
-```
-
-```expect
-Call Graph
-```
-
-```expect
-AddAzureOpenAI
-```
-
-```expect
-from Aspire.Hosting.Azure
-```
-
-```expect
-AddAzureProvisioning
-```
-
-```expect
-AddAzureEnvironment
-```
-
-```expect
-from Aspire.Hosting
-```
-
-```expect
-AddResource
-```
-
-### 3b. Mermaid projection
-
-```prompt
-Render the multi-hub AddAzureOpenAI call graph as Mermaid.
-```
-
-```bash
-dotnet-inspect member AzureOpenAIExtensions AddAzureOpenAI \
-  --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
-  --caller-package Aspire.Hosting@13.4.6 \
-  --caller-package Aspire.Hosting.Azure@13.4.6 \
-  -S "Call Graph" --markdown --mermaid -v:n
-```
-
-```expect
-mermaid
-```
-
-```expect
-graph TD
-```
-
-```expect
-AddAzureOpenAI
-```
-
-```expect
-AddAzureProvisioning
-```
-
-## 4. Contrast — Hosting-only fanout (`AddOpenAI`)
-
-> Goal: Same recipe on the pure OpenAI spoke. The graph is still useful, but
-> almost every resolved edge is `from Aspire.Hosting`. That is the hub-centric
-> shape to avoid as the *only* story in the demo.
-
-### 4a. AddOpenAI into Hosting
-
-```prompt
-Show that AddOpenAI’s cross-package graph collapses into Aspire.Hosting.
+Show the call graph for AddOpenAI with Aspire.Hosting in scope.
 ```
 
 ```bash
 dotnet-inspect member OpenAIExtensions AddOpenAI \
   --package Aspire.Hosting.OpenAI@13.4.6 \
   --caller-package Aspire.Hosting@13.4.6 \
-  --caller-package Aspire.Hosting.Azure@13.4.6 \
   -S "Call Graph" -v:n
 ```
 
@@ -347,11 +189,32 @@ WithInitialState
 OpenAIResource
 ```
 
-```expect-not
-from Aspire.Hosting.Azure
+### 3b. Mermaid
+
+```prompt
+Render the AddOpenAI call graph as Mermaid.
 ```
 
-### 4b. Type surface of the OpenAI spoke
+```bash
+dotnet-inspect member OpenAIExtensions AddOpenAI \
+  --package Aspire.Hosting.OpenAI@13.4.6 \
+  --caller-package Aspire.Hosting@13.4.6 \
+  -S "Call Graph" --markdown --mermaid -v:n
+```
+
+```expect
+mermaid
+```
+
+```expect
+graph TD
+```
+
+```expect
+AddOpenAI
+```
+
+### 3c. Type surface of the seed’s class
 
 ```prompt
 What fluent members does OpenAIExtensions expose?
@@ -373,12 +236,12 @@ AddModel
 WithApiKey
 ```
 
-## 5. Client-side AI stack
+## 4. Optional — client AI integrations
 
-> Goal: Pair multi-hub hosting with MEAI. Aspire hubs provision; MEAI is how
-> application code registers chat/embeddings clients.
+> Goal: Brief “apps consume models” counterpart via MEAI (not required for the
+> hosting story).
 
-### 5a. MEAI integration census
+### 4a. Microsoft.Extensions.AI
 
 ```prompt
 What AI integration points does Microsoft.Extensions.AI expose?
@@ -396,74 +259,17 @@ Integration: AI
 AddChatClient
 ```
 
-```expect
-ChatClientBuilder
-```
+## Narrative
 
-### 5b. OpenAI provider adapter
+1. **Census** — `Integration: Aspire` on each AI hosting package.
+2. **Web** — multi-package `extensions` on `IDistributedApplicationBuilder`.
+3. **Seed graph** — `AddOpenAI` + `--caller-package Aspire.Hosting`.
+4. **Optional client** — MEAI `Integration: AI`.
 
-```prompt
-How does Microsoft.Extensions.AI.OpenAI adapt OpenAI clients into MEAI?
-```
+## Later (out of scope here)
 
-```bash
-dotnet-inspect library Microsoft.Extensions.AI.OpenAI@10.9.0 -S "Integration: AI" -v:n
-```
-
-```expect
-AsIChatClient
-```
-
-```expect
-AsIEmbeddingGenerator
-```
-
-## 6. Dependency color on the Azure OpenAI hub
-
-> Goal: Show CognitiveServices is not a leaf — it depends on both hub packages
-> the call graph just traversed.
-
-### 6a. Package dependencies
-
-```prompt
-What does Aspire.Hosting.Azure.CognitiveServices depend on?
-```
-
-```bash
-dotnet-inspect package Aspire.Hosting.Azure.CognitiveServices@13.4.6 -S Dependencies -v:n
-```
-
-```expect
-Aspire.Hosting
-```
-
-```expect
-Aspire.Hosting.Azure
-```
-
-## Narrative (for presenters)
-
-1. **Hubs first** — `Aspire.Hosting` + `Aspire.Hosting.Azure` + Azure OpenAI
-   CognitiveServices as the third hub; do not open with Hosting alone.
-2. **Web** — multi-package `extensions IDistributedApplicationBuilder` labels
-   every `Add*` by library (Hosting bulk + Azure/AI distinctive spokes).
-3. **Multi-hub call graph** — `AddAzureOpenAI` with two `--caller-package`
-   values; edges cite `from Aspire.Hosting.Azure` *and* `from Aspire.Hosting`.
-4. **Contrast** — `AddOpenAI` is Hosting-star shaped; useful, but incomplete as
-   the only graph in the demo.
-5. **Client** — MEAI `Integration: AI` + `AsIChatClient` closes
-   “provision vs consume.”
-
-## Product notes (honest limits)
-
-- Today’s member call graph is **seed-centric**: one focus member, scope widened
-  by `--caller-package` / `--bin` / `--project`. It is not yet a multi-root
-  “package graph” object. The demo fakes multi-hub interest by (a) choosing a
-  seed that fans across hubs and (b) showing the extension web as the true
-  multi-package map.
-- `Aspire.Hosting.AppHost` is a real product package but a weak inspect hub
-  today (MSBuild/tasks-heavy; default library selection is easy to mis-pick).
-  Left out until library selection in the demo is bulletproof.
-- Declarative workspace/scenario registry (wasm share) is still design-only.
-- Deeper transitive multi-hop graphs: #3632. Workspace integrations roll-up:
-  #3629. Sibling **type** call-graph demo remains separate.
+- Ad hoc multi-input call graph (several packages as equal hubs) — #4133.
+- Resolve workspace `(external)` callees into defining bodies — #3632.
+- Deeper Azure substrate multi-hub walk (`AddAzureOpenAI` across
+  `Aspire.Hosting.Azure` + Hosting) — natural expansion once #4133/#3632 land.
+- Workspace integrations roll-up — #3629. Type call-graph sibling demo — separate.

--- a/docs/workflows/discovery/aspire-ai-package-graph.md
+++ b/docs/workflows/discovery/aspire-ai-package-graph.md
@@ -1,0 +1,363 @@
+---
+id: aspire-ai-package-graph
+description: Package call-graph and integration web over Aspire hosting plus AI client stack
+commands: [library, package, extensions, member, type]
+areas: [packages, integrations, call-graph, extensions, aspire, ai]
+---
+
+# Aspire + AI package graph
+
+> First **package call-graph** demo: a deep web of Aspire hosting libraries
+> that provision AI resources, paired with the Microsoft.Extensions.AI client
+> stack that consumes models. Pattern people steal: “hub type + component
+> packages + integration census + call-graph drill.” Flex: multi-package
+> `extensions`, `Integration:` sections, and cross-package `Call Graph` via
+> `--caller-package`.
+
+Pinned coordinates (bump together when refreshing the demo):
+
+| Role | Package | Version |
+| ---- | ------- | ------- |
+| Hosting hub | `Aspire.Hosting` | 13.4.6 |
+| OpenAI hosting | `Aspire.Hosting.OpenAI` | 13.4.6 |
+| Azure OpenAI hosting | `Aspire.Hosting.Azure.CognitiveServices` | 13.4.6 |
+| GitHub Models hosting | `Aspire.Hosting.GitHub.Models` | 13.4.6 |
+| AI abstractions | `Microsoft.Extensions.AI` | 10.9.0 |
+| OpenAI client adapter | `Microsoft.Extensions.AI.OpenAI` | 10.9.0 |
+
+Hub type for the package web: `IDistributedApplicationBuilder`.
+Hero member for the call-graph drill: `OpenAIExtensions.AddOpenAI`.
+
+## Preconditions
+
+```bash
+export DOTNET_INSPECT_ISOLATED=aspire-ai-package-graph
+```
+
+```bash
+dotnet-inspect cache clear
+```
+
+Prime the cache (network once per machine/session):
+
+```bash
+dotnet-inspect Aspire.Hosting@13.4.6 -v:q
+```
+
+```bash
+dotnet-inspect Aspire.Hosting.OpenAI@13.4.6 -v:q
+```
+
+```bash
+dotnet-inspect Aspire.Hosting.Azure.CognitiveServices@13.4.6 -v:q
+```
+
+```bash
+dotnet-inspect Aspire.Hosting.GitHub.Models@13.4.6 -v:q
+```
+
+```bash
+dotnet-inspect Microsoft.Extensions.AI@10.9.0 -v:q
+```
+
+```bash
+dotnet-inspect Microsoft.Extensions.AI.OpenAI@10.9.0 -v:q
+```
+
+## 1. Per-package Aspire integration census
+
+> Goal: See how each AI hosting package declares itself to Aspire (resources
+> and builder entry points) without reading source.
+
+### 1a. OpenAI hosting
+
+```prompt
+What Aspire resources and builders does Aspire.Hosting.OpenAI expose?
+```
+
+```bash
+dotnet-inspect library Aspire.Hosting.OpenAI@13.4.6 -S "Integration: Aspire" -v:n
+```
+
+```expect
+Integration: Aspire
+```
+
+```expect
+OpenAIResource
+```
+
+```expect
+AddOpenAI
+```
+
+### 1b. Azure OpenAI hosting
+
+```prompt
+How does Aspire model Azure OpenAI?
+```
+
+```bash
+dotnet-inspect library Aspire.Hosting.Azure.CognitiveServices@13.4.6 -S "Integration: Aspire" -v:n
+```
+
+```expect
+AzureOpenAIResource
+```
+
+```expect
+AddAzureOpenAI
+```
+
+### 1c. GitHub Models hosting
+
+```prompt
+How do GitHub Models show up as Aspire resources?
+```
+
+```bash
+dotnet-inspect library Aspire.Hosting.GitHub.Models@13.4.6 -S "Integration: Aspire" -v:n
+```
+
+```expect
+GitHubModelResource
+```
+
+```expect
+AddGitHubModel
+```
+
+## 2. Package web via hub-type extensions
+
+> Goal: Treat `IDistributedApplicationBuilder` as the hub and list every
+> component package’s `Add*` spokes in one multi-package query. This is the
+> package graph people navigate when composing an AppHost.
+
+### 2a. Hub + three AI spokes
+
+```prompt
+What AI-related Add* methods hang off IDistributedApplicationBuilder across Aspire hosting packages?
+```
+
+```bash
+dotnet-inspect extensions IDistributedApplicationBuilder \
+  --package Aspire.Hosting@13.4.6 \
+  --package Aspire.Hosting.OpenAI@13.4.6 \
+  --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
+  --package Aspire.Hosting.GitHub.Models@13.4.6 \
+  --tfm net8.0 -v:n
+```
+
+```expect
+AddOpenAI
+```
+
+```expect
+Aspire.Hosting.OpenAI
+```
+
+```expect
+AddAzureOpenAI
+```
+
+```expect
+Aspire.Hosting.Azure.CognitiveServices
+```
+
+```expect
+AddGitHubModel
+```
+
+```expect
+Aspire.Hosting.GitHub.Models
+```
+
+## 3. Type surface of the OpenAI spoke
+
+> Goal: From the package web, open the extension type and see the full fluent
+> chain (`AddOpenAI`, `AddModel`, `WithApiKey`, …) — the type-scoped companion
+> to the package graph (not the type call-graph demo).
+
+### 3a. OpenAIExtensions members
+
+```prompt
+What members does OpenAIExtensions expose on the OpenAI Aspire package?
+```
+
+```bash
+dotnet-inspect type OpenAIExtensions --package Aspire.Hosting.OpenAI@13.4.6 -v:n
+```
+
+```expect
+AddOpenAI
+```
+
+```expect
+AddModel
+```
+
+```expect
+WithApiKey
+```
+
+```expect
+OpenAIResource
+```
+
+## 4. Package call graph — AddOpenAI into Aspire.Hosting
+
+> Goal: Deep-drill one spoke: follow `AddOpenAI` into the hosting hub so
+> external edges resolve as real Aspire.Hosting APIs (parameters, snapshots,
+> annotations) rather than opaque `(external)` stubs.
+
+### 4a. Edge table with caller-package scope
+
+```prompt
+Show the call graph for AddOpenAI with Aspire.Hosting on the caller/callee scope.
+```
+
+```bash
+dotnet-inspect member OpenAIExtensions AddOpenAI \
+  --package Aspire.Hosting.OpenAI@13.4.6 \
+  --caller-package Aspire.Hosting@13.4.6 \
+  -S "Call Graph" -v:n
+```
+
+```expect
+Call Graph
+```
+
+```expect
+AddOpenAI
+```
+
+```expect
+from Aspire.Hosting
+```
+
+```expect
+WithInitialState
+```
+
+```expect
+OpenAIResource
+```
+
+### 4b. Mermaid projection (Markdown)
+
+```prompt
+Render the AddOpenAI call graph as Mermaid.
+```
+
+```bash
+dotnet-inspect member OpenAIExtensions AddOpenAI \
+  --package Aspire.Hosting.OpenAI@13.4.6 \
+  --caller-package Aspire.Hosting@13.4.6 \
+  -S "Call Graph" --markdown --mermaid -v:n
+```
+
+```expect
+mermaid
+```
+
+```expect
+graph TD
+```
+
+```expect
+AddOpenAI
+```
+
+```expect
+OpenAIResource
+```
+
+## 5. Client-side AI stack (how apps talk to models)
+
+> Goal: Pair hosting with the MEAI client surface. Aspire provisions resources;
+> Microsoft.Extensions.AI is how application code registers chat/embeddings
+> clients — including the OpenAI adapter.
+
+### 5a. MEAI integration census
+
+```prompt
+What AI integration points does Microsoft.Extensions.AI expose?
+```
+
+```bash
+dotnet-inspect library Microsoft.Extensions.AI@10.9.0 -S "Integration: AI" -v:n
+```
+
+```expect
+Integration: AI
+```
+
+```expect
+AddChatClient
+```
+
+```expect
+ChatClientBuilder
+```
+
+### 5b. OpenAI provider adapter
+
+```prompt
+How does Microsoft.Extensions.AI.OpenAI adapt OpenAI clients into MEAI?
+```
+
+```bash
+dotnet-inspect library Microsoft.Extensions.AI.OpenAI@10.9.0 -S "Integration: AI" -v:n
+```
+
+```expect
+AsIChatClient
+```
+
+```expect
+AsIEmbeddingGenerator
+```
+
+## 6. Optional dependency color
+
+> Goal: Show that the OpenAI hosting package is not a leaf — it depends on the
+> hub and pulls ecosystem packages (including MCP) worth a follow-on demo.
+
+### 6a. OpenAI hosting dependencies
+
+```prompt
+What does Aspire.Hosting.OpenAI depend on?
+```
+
+```bash
+dotnet-inspect package Aspire.Hosting.OpenAI@13.4.6 -S Dependencies -v:n
+```
+
+```expect
+Aspire.Hosting
+```
+
+```expect
+ModelContextProtocol
+```
+
+## Narrative (for presenters)
+
+1. **Census** — each AI hosting package’s `Integration: Aspire` row is the
+   contract card (resource types + `Add*` entry).
+2. **Web** — multi-package `extensions IDistributedApplicationBuilder` is the
+   package graph: one hub type, many spokes, labeled by library.
+3. **Type** — open `OpenAIExtensions` for the fluent API neighborhood.
+4. **Call graph** — `AddOpenAI` + `--caller-package Aspire.Hosting` is the
+   package call-graph flex: edges cross the package boundary into real hub
+   APIs (`WithInitialState`, parameters, snapshots).
+5. **Client** — MEAI `Integration: AI` + OpenAI `AsIChatClient` is the app
+   half of “Aspire provisions; MEAI consumes.”
+
+Non-goals for this demo (tracked separately):
+
+- Declarative workspace/scenario registry (wasm share packet) — design only
+  until productized.
+- True transitive multi-hop call graph beyond current session bounds (#3632).
+- Workspace-wide integrations roll-up (#3629).
+- Type call-graph demo (sibling of this package demo).

--- a/docs/workflows/discovery/aspire-ai-package-graph.md
+++ b/docs/workflows/discovery/aspire-ai-package-graph.md
@@ -264,6 +264,43 @@ relationship type.
 Issue numbers above are GitHub issues (4133, 3632, 3629, 3630); link them in
 the PR body when filing the two new trackers.
 
+## Thesis — type and package at once
+
+Call-graph demos are most powerful when **type and package are simultaneous
+lenses on one member-centric graph**, not two separate tools:
+
+| Direction | Start | Travel | Land |
+| --------- | ----- | ------ | ---- |
+| Type outward | A type (or its members) | Call edges + characteristics | Packages, integrations, providers |
+| Package inward | A package set | Call / extends / integration arcs | Types and APIs that matter |
+
+**Arcs are to the graph what carets are to AnnotatedSourceDocument:** the
+visual hook that carries the rest of the tool’s richness (integration kind,
+package boundary, loop, alloc, findings) without changing the underlying
+identity. Members stay the substrate (#4139); arcs and node marks are the
+descriptive plane; viewers filter layers.
+
+Same envelope both ways — seed or ad hoc mode (#4133) only changes how the
+subgraph is chosen, not whether type and package can co-appear.
+
+```mermaid
+flowchart LR
+  subgraph typeLens["Type lens"]
+    T["IChatClient / OpenAIExtensions"]
+  end
+  subgraph pkgLens["Package lens"]
+    P1["MEAI.OpenAI"]
+    P2["Bedrock.MEAI"]
+    P3["Aspire.Hosting.OpenAI"]
+  end
+  T -->|AsIChatClient Integration: AI| P1
+  T -->|AsIChatClient Integration: AI| P2
+  P3 -->|AddOpenAI Integration: Aspire| T
+```
+
+Demo A/C lean package→type; Demo B leans type/member→package. Ideal shareable
+views show **both** group labels and typed arcs in one diagram.
+
 ## Validation posture
 
 - **Target Mermaid** in this file is normative for product direction; it is not

--- a/docs/workflows/discovery/aspire-ai-package-graph.md
+++ b/docs/workflows/discovery/aspire-ai-package-graph.md
@@ -1,21 +1,21 @@
 ---
 id: aspire-ai-package-graph
-description: Simple Aspire hosting + AI package demo (integrations, extensions web, seed call graph)
-commands: [library, package, extensions, member, type]
-areas: [packages, integrations, call-graph, extensions, aspire, ai]
+description: Target demos — Aspire hosting web, multi-provider AI client graph, annotated arcs
+commands: [library, package, extensions, member, callgraph]
+areas: [packages, integrations, call-graph, extensions, aspire, ai, demos]
+status: target
 ---
 
-# Aspire hosting + AI
+# Aspire + AI graphs (target demos)
 
-> Simple **package hosting** demo: Aspire’s AppHost hub, AI resource packages,
-> and a seed-centric call graph into the hub. Pattern: integration census →
-> hub-type extension web → one `Add*` drill. Flex: multi-package `extensions`,
-> `Integration: Aspire`, and `Call Graph` with `--caller-package`.
+> **These are demos we want**, not a claim that every step is product-complete
+> today. Each scenario states what works now vs what is blocked. Tracking
+> issues own the gaps; this file owns the experience we are aiming at.
 >
-> Deliberately small. Expand when call-graph modes grow (seed-centric vs ad hoc
-> multi-input — #4133; cross-library body resolution — #3632).
+> Framing: useful patterns equal tool flex. Graphs should answer composition
+> questions with **readable arcs**, not only dense member stars.
 
-## Pins
+## Pins (when exercising live slices)
 
 | Role | Package | Version |
 | ---- | ------- | ------- |
@@ -23,107 +23,78 @@ areas: [packages, integrations, call-graph, extensions, aspire, ai]
 | OpenAI hosting | `Aspire.Hosting.OpenAI` | 13.4.6 |
 | Azure OpenAI hosting | `Aspire.Hosting.Azure.CognitiveServices` | 13.4.6 |
 | GitHub Models hosting | `Aspire.Hosting.GitHub.Models` | 13.4.6 |
-| AI abstractions (optional client) | `Microsoft.Extensions.AI` | 10.9.0 |
+| MEAI abstractions | `Microsoft.Extensions.AI.Abstractions` | 10.9.0 |
+| MEAI | `Microsoft.Extensions.AI` | 10.9.0 |
+| OpenAI to MEAI | `Microsoft.Extensions.AI.OpenAI` | 10.9.0 |
+| OpenAI SDK | `OpenAI` | 2.12.0 |
+| Azure OpenAI SDK | `Azure.AI.OpenAI` | 2.1.0 |
+| Bedrock to MEAI | `AWSSDK.Extensions.Bedrock.MEAI` | 4.0.101.8 |
 
-Hub type: `IDistributedApplicationBuilder`.  
-Seed member: `OpenAIExtensions.AddOpenAI`.
+## Arc annotations (design intent)
 
-## Preconditions
+Graphs are only compelling when **edges carry meaning**. Target annotation
+layers (orthogonal; progressive disclosure picks which render):
 
-```bash
-export DOTNET_INSPECT_ISOLATED=aspire-ai-package-graph
+| Layer | Example arc label | Applies to |
+| ----- | ----------------- | ---------- |
+| Relationship kind | `extends`, `calls`, `implements`, `references` | All graph modes |
+| API / member | `AddOpenAI`, `AsIChatClient` | Package web, call graph |
+| Integration category | `Integration: Aspire`, `Integration: AI` | Package and integration webs |
+| Call facts | `loop`, `virtual`, `external-resolved` | Call graph (partially today) |
+| Boundary | `package: Aspire.Hosting` / group id | Multi-package graphs |
+
+### Mermaid support
+
+**Yes.** Flowchart edges take labels:
+
+```mermaid
+flowchart LR
+  A -->|AddOpenAI| B
+  C -->|calls loop| D
+  E -->|Integration: AI AsIChatClient| F
 ```
 
-```bash
-dotnet-inspect cache clear
+Forms: `A -->|label| B` and `A -- label --> B`. GitHub PR Markdown renders
+label text on the arc. Optional `linkStyle` is chrome; **label text is the
+contract**.
+
+### Product today vs target
+
+| Concern | Today | Target |
+| ------- | ----- | ------ |
+| Call-graph edge label | Mostly loop (`GraphEdge.Label = LoopLabel`); member names on nodes | Selectable edge fields: kind, loop, integration, package boundary |
+| Package / extensions web | Table of methods (no graph sink) | Graph: hub type to package; arc = method + integration |
+| Multi-input ad hoc graph | Seed-centric only (see #4133) | Ad hoc mode unions inputs; arcs keep provenance |
+| Node signals (`--fields`) | Alloc/throw on nodes | Keep; do not force all facts onto arcs |
+
+Tracking issues are listed in [Gap index](#gap-index).
+
+## Demo A — Aspire hosting package web
+
+**Question:** How do AI hosting packages hang off the AppHost builder?
+
+### A — Target experience
+
+```text
+dotnet-inspect graph extensions IDistributedApplicationBuilder \
+  --package Aspire.Hosting@13.4.6 \
+  --package Aspire.Hosting.OpenAI@13.4.6 \
+  --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
+  --package Aspire.Hosting.GitHub.Models@13.4.6 \
+  --tfm net8.0 \
+  --mermaid
 ```
 
-```bash
-dotnet-inspect Aspire.Hosting@13.4.6 -v:q
+```mermaid
+flowchart LR
+  hub["IDistributedApplicationBuilder"]
+  hub -->|AddOpenAI Integration: Aspire| oai["Aspire.Hosting.OpenAI"]
+  hub -->|AddAzureOpenAI Integration: Aspire| az["Aspire.Hosting.Azure.CognitiveServices"]
+  hub -->|AddGitHubModel Integration: Aspire| gh["Aspire.Hosting.GitHub.Models"]
+  hub -->|AddProject| host["Aspire.Hosting"]
 ```
 
-```bash
-dotnet-inspect Aspire.Hosting.OpenAI@13.4.6 -v:q
-```
-
-```bash
-dotnet-inspect Aspire.Hosting.Azure.CognitiveServices@13.4.6 -v:q
-```
-
-```bash
-dotnet-inspect Aspire.Hosting.GitHub.Models@13.4.6 -v:q
-```
-
-```bash
-dotnet-inspect Microsoft.Extensions.AI@10.9.0 -v:q
-```
-
-## 1. Integration census (AI hosting packages)
-
-> Goal: Each package’s Aspire contract card — resources and `Add*` entry points.
-
-### 1a. OpenAI
-
-```prompt
-What Aspire resources does Aspire.Hosting.OpenAI expose?
-```
-
-```bash
-dotnet-inspect library Aspire.Hosting.OpenAI@13.4.6 -S "Integration: Aspire" -v:n
-```
-
-```expect
-Integration: Aspire
-```
-
-```expect
-OpenAIResource
-```
-
-```expect
-AddOpenAI
-```
-
-### 1b. Azure OpenAI and GitHub Models
-
-```prompt
-What do the other AI hosting packages declare to Aspire?
-```
-
-```bash
-dotnet-inspect library Aspire.Hosting.Azure.CognitiveServices@13.4.6 -S "Integration: Aspire" -v:n
-```
-
-```expect
-AzureOpenAIResource
-```
-
-```expect
-AddAzureOpenAI
-```
-
-```bash
-dotnet-inspect library Aspire.Hosting.GitHub.Models@13.4.6 -S "Integration: Aspire" -v:n
-```
-
-```expect
-GitHubModelResource
-```
-
-```expect
-AddGitHubModel
-```
-
-## 2. Package web on the hub type
-
-> Goal: One multi-package `extensions` query — how AI packages hang off
-> `IDistributedApplicationBuilder`.
-
-### 2a. Hub + AI spokes
-
-```prompt
-Which AI Add* methods hang off IDistributedApplicationBuilder?
-```
+### A — Works now (partial)
 
 ```bash
 dotnet-inspect extensions IDistributedApplicationBuilder \
@@ -134,66 +105,41 @@ dotnet-inspect extensions IDistributedApplicationBuilder \
   --tfm net8.0 -v:n
 ```
 
-```expect
-AddOpenAI
-```
-
-```expect
-Aspire.Hosting.OpenAI
-```
-
-```expect
-AddAzureOpenAI
-```
-
-```expect
-AddGitHubModel
-```
-
-## 3. Seed call graph — `AddOpenAI` into the hub
-
-> Goal: Classic seed-centric path. Focus one builder API; widen into
-> `Aspire.Hosting` so edges resolve to real hub APIs (parameters, snapshots)
-> instead of opaque externals.
-
-### 3a. Edge table
-
-```prompt
-Show the call graph for AddOpenAI with Aspire.Hosting in scope.
-```
-
 ```bash
+dotnet-inspect library Aspire.Hosting.OpenAI@13.4.6 -S "Integration: Aspire" -v:n
+```
+
+Table plus per-library integration census. No graph sink; no integration on
+arcs (integrations are a separate section).
+
+**Blocked on:** package-web graph projection; arc annotation model; optional
+command shape (`graph` / `extensions --mermaid`).
+
+## Demo B — Seed call graph into the hosting hub
+
+**Question:** What does `AddOpenAI` do inside Aspire once the hub is in scope?
+
+### B — Target experience
+
+```text
 dotnet-inspect member OpenAIExtensions AddOpenAI \
   --package Aspire.Hosting.OpenAI@13.4.6 \
   --caller-package Aspire.Hosting@13.4.6 \
-  -S "Call Graph" -v:n
+  -S "Call Graph" --mermaid \
+  --edge-fields kind,package
 ```
 
-```expect
-Call Graph
+```mermaid
+flowchart TD
+  seed["AddOpenAI focus"]
+  seed -->|calls package:OpenAI| res["OpenAIResource ctor"]
+  seed -->|calls package:Hosting| param["AddParameter ParameterResource"]
+  seed -->|calls package:Hosting| init["WithInitialState OpenAIResource"]
+  init -->|calls package:Hosting| ann["WithAnnotation"]
+  seed -->|calls package:Hosting| oninit["OnInitializeResource"]
 ```
 
-```expect
-AddOpenAI
-```
-
-```expect
-from Aspire.Hosting
-```
-
-```expect
-WithInitialState
-```
-
-```expect
-OpenAIResource
-```
-
-### 3b. Mermaid
-
-```prompt
-Render the AddOpenAI call graph as Mermaid.
-```
+### B — Works now (partial)
 
 ```bash
 dotnet-inspect member OpenAIExtensions AddOpenAI \
@@ -202,74 +148,126 @@ dotnet-inspect member OpenAIExtensions AddOpenAI \
   -S "Call Graph" --markdown --mermaid -v:n
 ```
 
-```expect
-mermaid
+Seed-centric call graph with Hosting resolution; groups appear in node text /
+`from_group`. Edge labels are not rich package or integration annotations.
+
+**Blocked on:** richer arc annotations; #3632 for deeper external
+resolution. Does **not** reach MEAI, Azure.AI.OpenAI, or Bedrock (no refs from
+the hosting package).
+
+## Demo C — Multi-provider AI client graph (MEAI hub)
+
+**Question:** How do OpenAI, Azure OpenAI, and Bedrock meet at `IChatClient`?
+
+This is the compelling **cross-ecosystem** story. It is **not** `AddOpenAI`
+widened with client packages — hosting does not call them.
+
+### C — Target experience (ad hoc / multi-seed)
+
+```text
+dotnet-inspect callgraph \
+  --package Microsoft.Extensions.AI.Abstractions@10.9.0 \
+  --package Microsoft.Extensions.AI.OpenAI@10.9.0 \
+  --package OpenAI@2.12.0 \
+  --package Azure.AI.OpenAI@2.1.0 \
+  --package AWSSDK.Extensions.Bedrock.MEAI@4.0.101.8 \
+  --seed OpenAIClientExtensions.AsIChatClient \
+  --seed AmazonBedrockRuntimeExtensions.AsIChatClient \
+  --focus-type Microsoft.Extensions.AI.IChatClient \
+  --mermaid
 ```
 
-```expect
-graph TD
+```mermaid
+flowchart TB
+  ichat["IChatClient MEAI.Abstractions"]
+  oai["OpenAI ChatClient OpenAI SDK"]
+  az["AzureOpenAIClient Azure.AI.OpenAI"]
+  br["IAmazonBedrockRuntime AWSSDK"]
+  oai -->|AsIChatClient Integration: AI| ichat
+  br -->|AsIChatClient Integration: AI| ichat
+  az -.->|opportunity MEAI adapter| ichat
+  az -->|references| oai
 ```
 
-```expect
-AddOpenAI
-```
+### C — Works now (partial, seed-centric only)
 
-### 3c. Type surface of the seed’s class
-
-```prompt
-What fluent members does OpenAIExtensions expose?
+```bash
+dotnet-inspect library Microsoft.Extensions.AI.OpenAI@10.9.0 -S "Integration: AI" -v:n
 ```
 
 ```bash
-dotnet-inspect type OpenAIExtensions --package Aspire.Hosting.OpenAI@13.4.6 -v:n
-```
-
-```expect
-AddOpenAI
-```
-
-```expect
-AddModel
-```
-
-```expect
-WithApiKey
-```
-
-## 4. Optional — client AI integrations
-
-> Goal: Brief “apps consume models” counterpart via MEAI (not required for the
-> hosting story).
-
-### 4a. Microsoft.Extensions.AI
-
-```prompt
-What AI integration points does Microsoft.Extensions.AI expose?
+dotnet-inspect library AWSSDK.Extensions.Bedrock.MEAI@4.0.101.8 -S "Integration: AI" -v:n
 ```
 
 ```bash
-dotnet-inspect library Microsoft.Extensions.AI@10.9.0 -S "Integration: AI" -v:n
+dotnet-inspect member OpenAIClientExtensions AsIChatClient:3 \
+  --package Microsoft.Extensions.AI.OpenAI@10.9.0 \
+  --caller-package Microsoft.Extensions.AI.Abstractions@10.9.0 \
+  --caller-package OpenAI@2.12.0 \
+  -S "Call Graph" -v:n
 ```
 
-```expect
-Integration: AI
+```bash
+dotnet-inspect member AmazonBedrockRuntimeExtensions AsIChatClient:1 \
+  --package AWSSDK.Extensions.Bedrock.MEAI@4.0.101.8 \
+  --caller-package Microsoft.Extensions.AI.Abstractions@10.9.0 \
+  -S "Call Graph" -v:n
 ```
 
-```expect
-AddChatClient
+Each adapter is a separate seed graph into MEAI.Abstractions or the provider
+SDK. No single multi-seed diagram. Azure shows Integration Opportunities toward
+MEAI rather than a hard `AsIChatClient` edge in-package.
+
+**Blocked on:** #4133 ad hoc multi-input mode; arc annotations
+(integration on edges); optional touchpoints (#3630) for reference-only
+Azure to OpenAI edges; #3632 where bodies cross packages.
+
+## Demo D — Two-plane story (hosting provision and client consume)
+
+**Question:** End-to-end narrative in one shareable view.
+
+```mermaid
+flowchart TB
+  subgraph hosting["AppHost plane"]
+    builder["IDistributedApplicationBuilder"]
+    builder -->|AddOpenAI Aspire| oaiH["Aspire.Hosting.OpenAI"]
+  end
+  subgraph client["App plane"]
+    ichat["IChatClient"]
+    openaiSdk["OpenAI / Azure.AI.OpenAI"]
+    bedrock["Bedrock runtime"]
+    openaiSdk -->|AsIChatClient AI| ichat
+    bedrock -->|AsIChatClient AI| ichat
+  end
+  oaiH -.->|provisions resources for| openaiSdk
 ```
 
-## Narrative
+**Works now:** tell the story with Demo A/B partial plus Demo C partial as
+separate commands.
 
-1. **Census** — `Integration: Aspire` on each AI hosting package.
-2. **Web** — multi-package `extensions` on `IDistributedApplicationBuilder`.
-3. **Seed graph** — `AddOpenAI` + `--caller-package Aspire.Hosting`.
-4. **Optional client** — MEAI `Integration: AI`.
+**Blocked on:** workspace scenario composition, ad hoc graph, annotated arcs.
+Dashed "provisions for" is narrative unless modeled as a first-class
+relationship type.
 
-## Later (out of scope here)
+## Gap index
 
-- Ad hoc multi-input call graph (several packages as equal hubs) — #4133.
-- Resolve workspace `(external)` callees into defining bodies — #3632.
-- Deeper Azure substrate multi-hub walk (`AddAzureOpenAI` across
-  `Aspire.Hosting.Azure` + Hosting) — natural expansion once #4133/#3632 land.
-- Workspace integrations roll-up — #3629. Type call-graph sibling demo — separate.
+| Gap | Demo | Tracking |
+| --- | ---- | -------- |
+| Seed vs ad hoc call-graph modes | C, D | #4133 |
+| Transitive cross-library body resolution | B, C | #3632 |
+| Package-web / extensions as graph sink | A | #4139 (envelope) + package-web producer |
+| Graph arc annotation model | A-D | #4139 |
+| Workspace integrations roll-up | A, C | #3629 |
+| Reference touchpoints (non-call edges) | C | #3630 |
+| Declarative scenario / wasm multi-package share | D | workspace-definitions / wasm |
+
+Issue numbers above are GitHub issues (4133, 3632, 3629, 3630); link them in
+the PR body when filing the two new trackers.
+
+## Validation posture
+
+- **Target Mermaid** in this file is normative for product direction; it is not
+  an expect block until the command exists.
+- **Works now** commands may gain expect blocks in follow-ups once stabilized.
+- Do not weaken product call-graph contracts to fake multi-provider edges from
+  `AddOpenAI`; wrong seed is a demo bug.

--- a/docs/workflows/discovery/aspire-ai-package-graph.md
+++ b/docs/workflows/discovery/aspire-ai-package-graph.md
@@ -1,32 +1,57 @@
 ---
 id: aspire-ai-package-graph
-description: Package call-graph and integration web over Aspire hosting plus AI client stack
+description: Multi-hub Aspire package web (Hosting + Azure + AI spokes) with cross-package call graph
 commands: [library, package, extensions, member, type]
 areas: [packages, integrations, call-graph, extensions, aspire, ai]
 ---
 
 # Aspire + AI package graph
 
-> First **package call-graph** demo: a deep web of Aspire hosting libraries
-> that provision AI resources, paired with the Microsoft.Extensions.AI client
-> stack that consumes models. Pattern people steal: “hub type + component
-> packages + integration census + call-graph drill.” Flex: multi-package
-> `extensions`, `Integration:` sections, and cross-package `Call Graph` via
-> `--caller-package`.
+> First **package call-graph** demo. Aspire is not one hub package: a useful
+> graph starts from **several base packages as peers**, then hangs AI spokes
+> and the MEAI client stack off that web.
+>
+> Pattern: multi-hub package set → hub-type extension web → integration census
+> → multi-package call-graph drill. Flex: multi-`--package` `extensions`,
+> `Integration:` sections, and `Call Graph` with repeated `--caller-package`.
 
-Pinned coordinates (bump together when refreshing the demo):
+## Why not only `Aspire.Hosting`?
 
-| Role | Package | Version |
-| ---- | ------- | ------- |
-| Hosting hub | `Aspire.Hosting` | 13.4.6 |
-| OpenAI hosting | `Aspire.Hosting.OpenAI` | 13.4.6 |
-| Azure OpenAI hosting | `Aspire.Hosting.Azure.CognitiveServices` | 13.4.6 |
-| GitHub Models hosting | `Aspire.Hosting.GitHub.Models` | 13.4.6 |
-| AI abstractions | `Microsoft.Extensions.AI` | 10.9.0 |
-| OpenAI client adapter | `Microsoft.Extensions.AI.OpenAI` | 10.9.0 |
+`Aspire.Hosting` is necessary substrate (application model, builder, resources)
+but on its own it under-describes Aspire. Component packages and the Azure
+base carry most of the interesting surface. A single-member call graph that
+only widens into `Aspire.Hosting` also reads as hub-centric: every spoke’s
+`Add*` collapses into the same substrate edges.
 
-Hub type for the package web: `IDistributedApplicationBuilder`.
-Hero member for the call-graph drill: `OpenAIExtensions.AddOpenAI`.
+This demo therefore treats **three packages as hubs** and keeps AI packages as
+first-class peers rather than footnotes on Hosting:
+
+| Hub role | Package | Why it is a hub |
+| -------- | ------- | --------------- |
+| Application model | `Aspire.Hosting` | Builder, resources, parameters, snapshots |
+| Azure substrate | `Aspire.Hosting.Azure` | Provisioning, environment, Bicep/identity |
+| Azure OpenAI spoke-hub | `Aspire.Hosting.Azure.CognitiveServices` | AI entry that **fans into both** Hosting and Azure |
+
+AI peers on the same web (not hubs, still first-class):
+
+| Peer | Package |
+| ---- | ------- |
+| OpenAI hosting | `Aspire.Hosting.OpenAI` |
+| GitHub Models | `Aspire.Hosting.GitHub.Models` |
+
+Client plane (how apps consume models Aspire provisions):
+
+| Role | Package |
+| ---- | ------- |
+| AI abstractions | `Microsoft.Extensions.AI` |
+| OpenAI adapter | `Microsoft.Extensions.AI.OpenAI` |
+
+All Aspire pins are **13.4.6**; MEAI pins are **10.9.0**. Bump a column
+together when refreshing.
+
+Hub type for the package web: `IDistributedApplicationBuilder`.  
+Hero call-graph member: `AzureOpenAIExtensions.AddAzureOpenAI` (multi-hub
+fanout). Contrast member: `OpenAIExtensions.AddOpenAI` (Hosting-only fanout).
 
 ## Preconditions
 
@@ -45,11 +70,15 @@ dotnet-inspect Aspire.Hosting@13.4.6 -v:q
 ```
 
 ```bash
-dotnet-inspect Aspire.Hosting.OpenAI@13.4.6 -v:q
+dotnet-inspect Aspire.Hosting.Azure@13.4.6 -v:q
 ```
 
 ```bash
 dotnet-inspect Aspire.Hosting.Azure.CognitiveServices@13.4.6 -v:q
+```
+
+```bash
+dotnet-inspect Aspire.Hosting.OpenAI@13.4.6 -v:q
 ```
 
 ```bash
@@ -64,19 +93,20 @@ dotnet-inspect Microsoft.Extensions.AI@10.9.0 -v:q
 dotnet-inspect Microsoft.Extensions.AI.OpenAI@10.9.0 -v:q
 ```
 
-## 1. Per-package Aspire integration census
+## 1. Hub integration census (base packages first)
 
-> Goal: See how each AI hosting package declares itself to Aspire (resources
-> and builder entry points) without reading source.
+> Goal: Read each hub’s `Integration: Aspire` card before any spoke. This is
+> the multi-hub story: Hosting alone is thin compared with Azure’s resource
+> and builder surface.
 
-### 1a. OpenAI hosting
+### 1a. Azure substrate hub
 
 ```prompt
-What Aspire resources and builders does Aspire.Hosting.OpenAI expose?
+What Aspire integrations does the Azure hosting base package declare?
 ```
 
 ```bash
-dotnet-inspect library Aspire.Hosting.OpenAI@13.4.6 -S "Integration: Aspire" -v:n
+dotnet-inspect library Aspire.Hosting.Azure@13.4.6 -S "Integration: Aspire" -v:n
 ```
 
 ```expect
@@ -84,17 +114,21 @@ Integration: Aspire
 ```
 
 ```expect
-OpenAIResource
+AzureEnvironmentResource
 ```
 
 ```expect
-AddOpenAI
+AddAzureEnvironment
 ```
 
-### 1b. Azure OpenAI hosting
+```expect
+IAzureResource
+```
+
+### 1b. Azure OpenAI hub (AI entry on Azure)
 
 ```prompt
-How does Aspire model Azure OpenAI?
+How does Aspire model Azure OpenAI on top of the Azure substrate?
 ```
 
 ```bash
@@ -109,10 +143,22 @@ AzureOpenAIResource
 AddAzureOpenAI
 ```
 
-### 1c. GitHub Models hosting
+### 1c. OpenAI and GitHub Models peers
 
 ```prompt
-How do GitHub Models show up as Aspire resources?
+What Aspire resources do the non-Azure AI hosting packages expose?
+```
+
+```bash
+dotnet-inspect library Aspire.Hosting.OpenAI@13.4.6 -S "Integration: Aspire" -v:n
+```
+
+```expect
+OpenAIResource
+```
+
+```expect
+AddOpenAI
 ```
 
 ```bash
@@ -127,33 +173,35 @@ GitHubModelResource
 AddGitHubModel
 ```
 
-## 2. Package web via hub-type extensions
+## 2. Package web via hub-type extensions (multi-hub)
 
-> Goal: Treat `IDistributedApplicationBuilder` as the hub and list every
-> component package’s `Add*` spokes in one multi-package query. This is the
-> package graph people navigate when composing an AppHost.
+> Goal: One query over **all hubs and AI peers**. Contributions are labeled by
+> library — the package graph people navigate when composing an AppHost. Hosting
+> still dominates method count; Azure and AI packages supply the distinctive
+> `Add*` spokes.
 
-### 2a. Hub + three AI spokes
+### 2a. Three hubs + AI peers on `IDistributedApplicationBuilder`
 
 ```prompt
-What AI-related Add* methods hang off IDistributedApplicationBuilder across Aspire hosting packages?
+What Add* methods hang off IDistributedApplicationBuilder across Aspire hosting, Azure, and AI packages?
 ```
 
 ```bash
 dotnet-inspect extensions IDistributedApplicationBuilder \
   --package Aspire.Hosting@13.4.6 \
-  --package Aspire.Hosting.OpenAI@13.4.6 \
+  --package Aspire.Hosting.Azure@13.4.6 \
   --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
+  --package Aspire.Hosting.OpenAI@13.4.6 \
   --package Aspire.Hosting.GitHub.Models@13.4.6 \
   --tfm net8.0 -v:n
 ```
 
 ```expect
-AddOpenAI
+AddAzureEnvironment
 ```
 
 ```expect
-Aspire.Hosting.OpenAI
+Aspire.Hosting.Azure
 ```
 
 ```expect
@@ -165,6 +213,14 @@ Aspire.Hosting.Azure.CognitiveServices
 ```
 
 ```expect
+AddOpenAI
+```
+
+```expect
+Aspire.Hosting.OpenAI
+```
+
+```expect
 AddGitHubModel
 ```
 
@@ -172,54 +228,102 @@ AddGitHubModel
 Aspire.Hosting.GitHub.Models
 ```
 
-## 3. Type surface of the OpenAI spoke
+## 3. Multi-hub call graph — `AddAzureOpenAI`
 
-> Goal: From the package web, open the extension type and see the full fluent
-> chain (`AddOpenAI`, `AddModel`, `WithApiKey`, …) — the type-scoped companion
-> to the package graph (not the type call-graph demo).
+> Goal: Deep-drill the member that actually crosses hubs. With
+> `--caller-package` for both `Aspire.Hosting` and `Aspire.Hosting.Azure`,
+> edges resolve into **two** package groups (provisioning/environment on Azure,
+> resources/snapshots on Hosting) instead of a Hosting-only star.
 
-### 3a. OpenAIExtensions members
+### 3a. Edge table across Hosting + Azure
 
 ```prompt
-What members does OpenAIExtensions expose on the OpenAI Aspire package?
+Show the call graph for AddAzureOpenAI with Aspire.Hosting and Aspire.Hosting.Azure in scope.
 ```
 
 ```bash
-dotnet-inspect type OpenAIExtensions --package Aspire.Hosting.OpenAI@13.4.6 -v:n
+dotnet-inspect member AzureOpenAIExtensions AddAzureOpenAI \
+  --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
+  --caller-package Aspire.Hosting@13.4.6 \
+  --caller-package Aspire.Hosting.Azure@13.4.6 \
+  -S "Call Graph" -v:n
 ```
 
 ```expect
-AddOpenAI
+Call Graph
 ```
 
 ```expect
-AddModel
+AddAzureOpenAI
 ```
 
 ```expect
-WithApiKey
+from Aspire.Hosting.Azure
 ```
 
 ```expect
-OpenAIResource
+AddAzureProvisioning
 ```
 
-## 4. Package call graph — AddOpenAI into Aspire.Hosting
+```expect
+AddAzureEnvironment
+```
 
-> Goal: Deep-drill one spoke: follow `AddOpenAI` into the hosting hub so
-> external edges resolve as real Aspire.Hosting APIs (parameters, snapshots,
-> annotations) rather than opaque `(external)` stubs.
+```expect
+from Aspire.Hosting
+```
 
-### 4a. Edge table with caller-package scope
+```expect
+AddResource
+```
+
+### 3b. Mermaid projection
 
 ```prompt
-Show the call graph for AddOpenAI with Aspire.Hosting on the caller/callee scope.
+Render the multi-hub AddAzureOpenAI call graph as Mermaid.
+```
+
+```bash
+dotnet-inspect member AzureOpenAIExtensions AddAzureOpenAI \
+  --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
+  --caller-package Aspire.Hosting@13.4.6 \
+  --caller-package Aspire.Hosting.Azure@13.4.6 \
+  -S "Call Graph" --markdown --mermaid -v:n
+```
+
+```expect
+mermaid
+```
+
+```expect
+graph TD
+```
+
+```expect
+AddAzureOpenAI
+```
+
+```expect
+AddAzureProvisioning
+```
+
+## 4. Contrast — Hosting-only fanout (`AddOpenAI`)
+
+> Goal: Same recipe on the pure OpenAI spoke. The graph is still useful, but
+> almost every resolved edge is `from Aspire.Hosting`. That is the hub-centric
+> shape to avoid as the *only* story in the demo.
+
+### 4a. AddOpenAI into Hosting
+
+```prompt
+Show that AddOpenAI’s cross-package graph collapses into Aspire.Hosting.
 ```
 
 ```bash
 dotnet-inspect member OpenAIExtensions AddOpenAI \
   --package Aspire.Hosting.OpenAI@13.4.6 \
   --caller-package Aspire.Hosting@13.4.6 \
+  --caller-package Aspire.Hosting.Azure@13.4.6 \
   -S "Call Graph" -v:n
 ```
 
@@ -243,25 +347,18 @@ WithInitialState
 OpenAIResource
 ```
 
-### 4b. Mermaid projection (Markdown)
+```expect-not
+from Aspire.Hosting.Azure
+```
+
+### 4b. Type surface of the OpenAI spoke
 
 ```prompt
-Render the AddOpenAI call graph as Mermaid.
+What fluent members does OpenAIExtensions expose?
 ```
 
 ```bash
-dotnet-inspect member OpenAIExtensions AddOpenAI \
-  --package Aspire.Hosting.OpenAI@13.4.6 \
-  --caller-package Aspire.Hosting@13.4.6 \
-  -S "Call Graph" --markdown --mermaid -v:n
-```
-
-```expect
-mermaid
-```
-
-```expect
-graph TD
+dotnet-inspect type OpenAIExtensions --package Aspire.Hosting.OpenAI@13.4.6 -v:n
 ```
 
 ```expect
@@ -269,14 +366,17 @@ AddOpenAI
 ```
 
 ```expect
-OpenAIResource
+AddModel
 ```
 
-## 5. Client-side AI stack (how apps talk to models)
+```expect
+WithApiKey
+```
 
-> Goal: Pair hosting with the MEAI client surface. Aspire provisions resources;
-> Microsoft.Extensions.AI is how application code registers chat/embeddings
-> clients — including the OpenAI adapter.
+## 5. Client-side AI stack
+
+> Goal: Pair multi-hub hosting with MEAI. Aspire hubs provision; MEAI is how
+> application code registers chat/embeddings clients.
 
 ### 5a. MEAI integration census
 
@@ -318,19 +418,19 @@ AsIChatClient
 AsIEmbeddingGenerator
 ```
 
-## 6. Optional dependency color
+## 6. Dependency color on the Azure OpenAI hub
 
-> Goal: Show that the OpenAI hosting package is not a leaf — it depends on the
-> hub and pulls ecosystem packages (including MCP) worth a follow-on demo.
+> Goal: Show CognitiveServices is not a leaf — it depends on both hub packages
+> the call graph just traversed.
 
-### 6a. OpenAI hosting dependencies
+### 6a. Package dependencies
 
 ```prompt
-What does Aspire.Hosting.OpenAI depend on?
+What does Aspire.Hosting.Azure.CognitiveServices depend on?
 ```
 
 ```bash
-dotnet-inspect package Aspire.Hosting.OpenAI@13.4.6 -S Dependencies -v:n
+dotnet-inspect package Aspire.Hosting.Azure.CognitiveServices@13.4.6 -S Dependencies -v:n
 ```
 
 ```expect
@@ -338,26 +438,32 @@ Aspire.Hosting
 ```
 
 ```expect
-ModelContextProtocol
+Aspire.Hosting.Azure
 ```
 
 ## Narrative (for presenters)
 
-1. **Census** — each AI hosting package’s `Integration: Aspire` row is the
-   contract card (resource types + `Add*` entry).
-2. **Web** — multi-package `extensions IDistributedApplicationBuilder` is the
-   package graph: one hub type, many spokes, labeled by library.
-3. **Type** — open `OpenAIExtensions` for the fluent API neighborhood.
-4. **Call graph** — `AddOpenAI` + `--caller-package Aspire.Hosting` is the
-   package call-graph flex: edges cross the package boundary into real hub
-   APIs (`WithInitialState`, parameters, snapshots).
-5. **Client** — MEAI `Integration: AI` + OpenAI `AsIChatClient` is the app
-   half of “Aspire provisions; MEAI consumes.”
+1. **Hubs first** — `Aspire.Hosting` + `Aspire.Hosting.Azure` + Azure OpenAI
+   CognitiveServices as the third hub; do not open with Hosting alone.
+2. **Web** — multi-package `extensions IDistributedApplicationBuilder` labels
+   every `Add*` by library (Hosting bulk + Azure/AI distinctive spokes).
+3. **Multi-hub call graph** — `AddAzureOpenAI` with two `--caller-package`
+   values; edges cite `from Aspire.Hosting.Azure` *and* `from Aspire.Hosting`.
+4. **Contrast** — `AddOpenAI` is Hosting-star shaped; useful, but incomplete as
+   the only graph in the demo.
+5. **Client** — MEAI `Integration: AI` + `AsIChatClient` closes
+   “provision vs consume.”
 
-Non-goals for this demo (tracked separately):
+## Product notes (honest limits)
 
-- Declarative workspace/scenario registry (wasm share packet) — design only
-  until productized.
-- True transitive multi-hop call graph beyond current session bounds (#3632).
-- Workspace-wide integrations roll-up (#3629).
-- Type call-graph demo (sibling of this package demo).
+- Today’s member call graph is **seed-centric**: one focus member, scope widened
+  by `--caller-package` / `--bin` / `--project`. It is not yet a multi-root
+  “package graph” object. The demo fakes multi-hub interest by (a) choosing a
+  seed that fans across hubs and (b) showing the extension web as the true
+  multi-package map.
+- `Aspire.Hosting.AppHost` is a real product package but a weak inspect hub
+  today (MSBuild/tasks-heavy; default library selection is easy to mis-pick).
+  Left out until library selection in the demo is bulletproof.
+- Declarative workspace/scenario registry (wasm share) is still design-only.
+- Deeper transitive multi-hop graphs: #3632. Workspace integrations roll-up:
+  #3629. Sibling **type** call-graph demo remains separate.

--- a/docs/workflows/discovery/aspire-ai-package-graph.md
+++ b/docs/workflows/discovery/aspire-ai-package-graph.md
@@ -1,211 +1,188 @@
 ---
-id: aspire-ai-package-graph
-description: Target demos — Aspire hosting web, multi-provider AI client graph, annotated arcs
-commands: [library, package, extensions, member, callgraph]
-areas: [packages, integrations, call-graph, extensions, aspire, ai, demos]
-status: target
+id: ichatclient-dual-lens-graph
+description: Locked demo — IChatClient type↔package dual lens with integration arcs
+commands: [type, library, member, extensions, implements, find]
+areas: [call-graph, packages, integrations, ai, demos]
+status: locked-demo
 ---
 
-# Aspire + AI graphs (target demos)
+# Locked demo: `IChatClient` dual lens
 
-> **These are demos we want**, not a claim that every step is product-complete
-> today. Each scenario states what works now vs what is blocked. Tracking
-> issues own the gaps; this file owns the experience we are aiming at.
+> **One demo.** Start from a **type** and read **packages**; start from
+> **packages** and land on the **type**. Same member-centric world; arcs carry
+> integration richness the way AnnotatedSource carets carry facts.
 >
-> Framing: useful patterns equal tool flex. Graphs should answer composition
-> questions with **readable arcs**, not only dense member stars.
+> Status: **locked narrative + pins + works-now path.** Full single-diagram
+> product experience is target (characteristics #4139, ad hoc mode #4133).
 
-## Pins (when exercising live slices)
+## Why this demo
+
+| Need | Choice |
+| ---- | ------ |
+| Dual lens | Type `IChatClient` ↔ provider packages |
+| Arc richness | `Integration: AI`, `AsIChatClient`, package boundary |
+| Real ecosystems | OpenAI, Bedrock, Azure opportunity — not one vendor |
+| Honest substrate | Members/adapters underneath; no fake edges from Aspire hosting |
+| Tool flex | `type`, `implements`, `library -S Integration`, `member` CG, later one graph |
+
+Aspire AppHost `AddOpenAI` is a **sibling** story (provisioning plane), not this
+lock. See [Related demos](#related-demos-not-locked).
+
+## Pins (freeze together)
 
 | Role | Package | Version |
 | ---- | ------- | ------- |
-| Hosting hub | `Aspire.Hosting` | 13.4.6 |
-| OpenAI hosting | `Aspire.Hosting.OpenAI` | 13.4.6 |
-| Azure OpenAI hosting | `Aspire.Hosting.Azure.CognitiveServices` | 13.4.6 |
-| GitHub Models hosting | `Aspire.Hosting.GitHub.Models` | 13.4.6 |
-| MEAI abstractions | `Microsoft.Extensions.AI.Abstractions` | 10.9.0 |
-| MEAI | `Microsoft.Extensions.AI` | 10.9.0 |
-| OpenAI to MEAI | `Microsoft.Extensions.AI.OpenAI` | 10.9.0 |
+| Hub type owner | `Microsoft.Extensions.AI.Abstractions` | 10.9.0 |
+| MEAI helpers | `Microsoft.Extensions.AI` | 10.9.0 |
+| OpenAI adapter | `Microsoft.Extensions.AI.OpenAI` | 10.9.0 |
 | OpenAI SDK | `OpenAI` | 2.12.0 |
-| Azure OpenAI SDK | `Azure.AI.OpenAI` | 2.1.0 |
-| Bedrock to MEAI | `AWSSDK.Extensions.Bedrock.MEAI` | 4.0.101.8 |
+| Bedrock adapter | `AWSSDK.Extensions.Bedrock.MEAI` | 4.0.101.8 |
+| Azure SDK (opportunity / refs) | `Azure.AI.OpenAI` | 2.1.0 |
 
-## Arc annotations (design intent)
+**Hub type:** `Microsoft.Extensions.AI.IChatClient`  
+**Hero arcs (target spelling):** `AsIChatClient` · `Integration: AI`  
+**Hero seeds (works-now CG):**
 
-Graphs are only compelling when **edges carry meaning**. Target annotation
-layers (orthogonal; progressive disclosure picks which render):
+- `OpenAIClientExtensions.AsIChatClient` (ChatClient overload)
+- `AmazonBedrockRuntimeExtensions.AsIChatClient`
 
-| Layer | Example arc label | Applies to |
-| ----- | ----------------- | ---------- |
-| Relationship kind | `extends`, `calls`, `implements`, `references` | All graph modes |
-| API / member | `AddOpenAI`, `AsIChatClient` | Package web, call graph |
-| Integration category | `Integration: Aspire`, `Integration: AI` | Package and integration webs |
-| Call facts | `loop`, `virtual`, `external-resolved` | Call graph (partially today) |
-| Boundary | `package: Aspire.Hosting` / group id | Multi-package graphs |
+## Target experience (one shareable graph)
 
-### Mermaid support
-
-**Yes.** Flowchart edges take labels:
-
-```mermaid
-flowchart LR
-  A -->|AddOpenAI| B
-  C -->|calls loop| D
-  E -->|Integration: AI AsIChatClient| F
-```
-
-Forms: `A -->|label| B` and `A -- label --> B`. GitHub PR Markdown renders
-label text on the arc. Optional `linkStyle` is chrome; **label text is the
-contract**.
-
-### Product today vs target
-
-| Concern | Today | Target |
-| ------- | ----- | ------ |
-| Call-graph edge label | Mostly loop (`GraphEdge.Label = LoopLabel`); member names on nodes | Selectable edge fields: kind, loop, integration, package boundary |
-| Package / extensions web | Table of methods (no graph sink) | Graph: hub type to package; arc = method + integration |
-| Multi-input ad hoc graph | Seed-centric only (see #4133) | Ad hoc mode unions inputs; arcs keep provenance |
-| Node signals (`--fields`) | Alloc/throw on nodes | Keep; do not force all facts onto arcs |
-
-Tracking issues are listed in [Gap index](#gap-index).
-
-## Demo A — Aspire hosting package web
-
-**Question:** How do AI hosting packages hang off the AppHost builder?
-
-### A — Target experience
-
-```text
-dotnet-inspect graph extensions IDistributedApplicationBuilder \
-  --package Aspire.Hosting@13.4.6 \
-  --package Aspire.Hosting.OpenAI@13.4.6 \
-  --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
-  --package Aspire.Hosting.GitHub.Models@13.4.6 \
-  --tfm net8.0 \
-  --mermaid
-```
-
-```mermaid
-flowchart LR
-  hub["IDistributedApplicationBuilder"]
-  hub -->|AddOpenAI Integration: Aspire| oai["Aspire.Hosting.OpenAI"]
-  hub -->|AddAzureOpenAI Integration: Aspire| az["Aspire.Hosting.Azure.CognitiveServices"]
-  hub -->|AddGitHubModel Integration: Aspire| gh["Aspire.Hosting.GitHub.Models"]
-  hub -->|AddProject| host["Aspire.Hosting"]
-```
-
-### A — Works now (partial)
-
-```bash
-dotnet-inspect extensions IDistributedApplicationBuilder \
-  --package Aspire.Hosting@13.4.6 \
-  --package Aspire.Hosting.OpenAI@13.4.6 \
-  --package Aspire.Hosting.Azure.CognitiveServices@13.4.6 \
-  --package Aspire.Hosting.GitHub.Models@13.4.6 \
-  --tfm net8.0 -v:n
-```
-
-```bash
-dotnet-inspect library Aspire.Hosting.OpenAI@13.4.6 -S "Integration: Aspire" -v:n
-```
-
-Table plus per-library integration census. No graph sink; no integration on
-arcs (integrations are a separate section).
-
-**Blocked on:** package-web graph projection; arc annotation model; optional
-command shape (`graph` / `extensions --mermaid`).
-
-## Demo B — Seed call graph into the hosting hub
-
-**Question:** What does `AddOpenAI` do inside Aspire once the hub is in scope?
-
-### B — Target experience
-
-```text
-dotnet-inspect member OpenAIExtensions AddOpenAI \
-  --package Aspire.Hosting.OpenAI@13.4.6 \
-  --caller-package Aspire.Hosting@13.4.6 \
-  -S "Call Graph" --mermaid \
-  --edge-fields kind,package
-```
-
-```mermaid
-flowchart TD
-  seed["AddOpenAI focus"]
-  seed -->|calls package:OpenAI| res["OpenAIResource ctor"]
-  seed -->|calls package:Hosting| param["AddParameter ParameterResource"]
-  seed -->|calls package:Hosting| init["WithInitialState OpenAIResource"]
-  init -->|calls package:Hosting| ann["WithAnnotation"]
-  seed -->|calls package:Hosting| oninit["OnInitializeResource"]
-```
-
-### B — Works now (partial)
-
-```bash
-dotnet-inspect member OpenAIExtensions AddOpenAI \
-  --package Aspire.Hosting.OpenAI@13.4.6 \
-  --caller-package Aspire.Hosting@13.4.6 \
-  -S "Call Graph" --markdown --mermaid -v:n
-```
-
-Seed-centric call graph with Hosting resolution; groups appear in node text /
-`from_group`. Edge labels are not rich package or integration annotations.
-
-**Blocked on:** richer arc annotations; #3632 for deeper external
-resolution. Does **not** reach MEAI, Azure.AI.OpenAI, or Bedrock (no refs from
-the hosting package).
-
-## Demo C — Multi-provider AI client graph (MEAI hub)
-
-**Question:** How do OpenAI, Azure OpenAI, and Bedrock meet at `IChatClient`?
-
-This is the compelling **cross-ecosystem** story. It is **not** `AddOpenAI`
-widened with client packages — hosting does not call them.
-
-### C — Target experience (ad hoc / multi-seed)
-
-```text
-dotnet-inspect callgraph \
-  --package Microsoft.Extensions.AI.Abstractions@10.9.0 \
-  --package Microsoft.Extensions.AI.OpenAI@10.9.0 \
-  --package OpenAI@2.12.0 \
-  --package Azure.AI.OpenAI@2.1.0 \
-  --package AWSSDK.Extensions.Bedrock.MEAI@4.0.101.8 \
-  --seed OpenAIClientExtensions.AsIChatClient \
-  --seed AmazonBedrockRuntimeExtensions.AsIChatClient \
-  --focus-type Microsoft.Extensions.AI.IChatClient \
-  --mermaid
-```
+What we want the product to emit (normative Mermaid — not an expect block yet):
 
 ```mermaid
 flowchart TB
-  ichat["IChatClient MEAI.Abstractions"]
-  oai["OpenAI ChatClient OpenAI SDK"]
-  az["AzureOpenAIClient Azure.AI.OpenAI"]
-  br["IAmazonBedrockRuntime AWSSDK"]
-  oai -->|AsIChatClient Integration: AI| ichat
-  br -->|AsIChatClient Integration: AI| ichat
-  az -.->|opportunity MEAI adapter| ichat
-  az -->|references| oai
+  T["IChatClient · type lens<br/>MEAI.Abstractions"]
+  P_oai["Microsoft.Extensions.AI.OpenAI"]
+  P_br["AWSSDK.Extensions.Bedrock.MEAI"]
+  P_az["Azure.AI.OpenAI"]
+  S_oai["OpenAI · SDK"]
+  S_br["AWSSDK.BedrockRuntime"]
+  T ---|package group| P_oai
+  T ---|package group| P_br
+  S_oai -->|AsIChatClient · Integration: AI| T
+  S_br -->|AsIChatClient · Integration: AI| T
+  P_oai -.->|owns adapter| S_oai
+  P_br -.->|owns adapter| S_br
+  P_az -->|references| S_oai
+  P_az -.->|Integration opportunity · MEAI| T
 ```
 
-### C — Works now (partial, seed-centric only)
+**Read both ways:**
+
+- **Type outward** — from `IChatClient`, packages and providers that adapt into it.  
+- **Package inward** — from OpenAI/Bedrock/Azure packages, the type that unifies clients.
+
+Arcs hold tool richness (integration kind, relationship, boundary). Nodes stay
+member/type identity; package is group + characteristic (#4139).
+
+## Works now (rehearsal path)
+
+Run in order. This is the locked **manual dual-lens** until one command exists.
+
+### Preconditions
 
 ```bash
-dotnet-inspect library Microsoft.Extensions.AI.OpenAI@10.9.0 -S "Integration: AI" -v:n
+export DOTNET_INSPECT_ISOLATED=ichatclient-dual-lens
+dotnet-inspect cache clear
+dotnet-inspect Microsoft.Extensions.AI.Abstractions@10.9.0 -v:q
+dotnet-inspect Microsoft.Extensions.AI@10.9.0 -v:q
+dotnet-inspect Microsoft.Extensions.AI.OpenAI@10.9.0 -v:q
+dotnet-inspect OpenAI@2.12.0 -v:q
+dotnet-inspect AWSSDK.Extensions.Bedrock.MEAI@4.0.101.8 -v:q
+dotnet-inspect Azure.AI.OpenAI@2.1.0 -v:q
+```
+
+### 1. Type lens — hub type
+
+```bash
+dotnet-inspect type IChatClient \
+  --package Microsoft.Extensions.AI.Abstractions@10.9.0 -v:n
+```
+
+```expect
+IChatClient
+```
+
+```expect
+GetResponseAsync
+```
+
+```expect
+Microsoft.Extensions.AI.Abstractions
+```
+
+### 2. Package lens — integration census on adapters
+
+```bash
+dotnet-inspect library Microsoft.Extensions.AI.OpenAI@10.9.0 \
+  -S "Integration: AI" -v:n
+```
+
+```expect
+Integration: AI
+```
+
+```expect
+AsIChatClient
 ```
 
 ```bash
-dotnet-inspect library AWSSDK.Extensions.Bedrock.MEAI@4.0.101.8 -S "Integration: AI" -v:n
+dotnet-inspect library AWSSDK.Extensions.Bedrock.MEAI@4.0.101.8 \
+  -S "Integration: AI" -v:n
 ```
+
+```expect
+AsIChatClient
+```
+
+```bash
+dotnet-inspect library Azure.AI.OpenAI@2.1.0 \
+  -S "Integration: Opportunities" -v:n
+```
+
+```expect
+Microsoft.Extensions.AI
+```
+
+### 3. Type outward — extensions on the hub (MEAI surface)
+
+```bash
+dotnet-inspect extensions IChatClient \
+  --package Microsoft.Extensions.AI.Abstractions@10.9.0 \
+  --package Microsoft.Extensions.AI@10.9.0 \
+  --tfm net10.0 -v:n
+```
+
+```expect
+IChatClient
+```
+
+```expect
+GetResponseAsync
+```
+
+### 4. Package inward — seed CG on adapter arcs
+
+OpenAI adapter into MEAI abstractions + SDK:
 
 ```bash
 dotnet-inspect member OpenAIClientExtensions AsIChatClient:3 \
   --package Microsoft.Extensions.AI.OpenAI@10.9.0 \
   --caller-package Microsoft.Extensions.AI.Abstractions@10.9.0 \
   --caller-package OpenAI@2.12.0 \
-  -S "Call Graph" -v:n
+  -S "Call Graph" --markdown --mermaid -v:n
 ```
+
+```expect
+AsIChatClient
+```
+
+```expect
+Call Graph
+```
+
+Bedrock adapter:
 
 ```bash
 dotnet-inspect member AmazonBedrockRuntimeExtensions AsIChatClient:1 \
@@ -214,97 +191,50 @@ dotnet-inspect member AmazonBedrockRuntimeExtensions AsIChatClient:1 \
   -S "Call Graph" -v:n
 ```
 
-Each adapter is a separate seed graph into MEAI.Abstractions or the provider
-SDK. No single multi-seed diagram. Azure shows Integration Opportunities toward
-MEAI rather than a hard `AsIChatClient` edge in-package.
-
-**Blocked on:** #4133 ad hoc multi-input mode; arc annotations
-(integration on edges); optional touchpoints (#3630) for reference-only
-Azure to OpenAI edges; #3632 where bodies cross packages.
-
-## Demo D — Two-plane story (hosting provision and client consume)
-
-**Question:** End-to-end narrative in one shareable view.
-
-```mermaid
-flowchart TB
-  subgraph hosting["AppHost plane"]
-    builder["IDistributedApplicationBuilder"]
-    builder -->|AddOpenAI Aspire| oaiH["Aspire.Hosting.OpenAI"]
-  end
-  subgraph client["App plane"]
-    ichat["IChatClient"]
-    openaiSdk["OpenAI / Azure.AI.OpenAI"]
-    bedrock["Bedrock runtime"]
-    openaiSdk -->|AsIChatClient AI| ichat
-    bedrock -->|AsIChatClient AI| ichat
-  end
-  oaiH -.->|provisions resources for| openaiSdk
+```expect
+AsIChatClient
 ```
 
-**Works now:** tell the story with Demo A/B partial plus Demo C partial as
-separate commands.
-
-**Blocked on:** workspace scenario composition, ad hoc graph, annotated arcs.
-Dashed "provisions for" is narrative unless modeled as a first-class
-relationship type.
-
-## Gap index
-
-| Gap | Demo | Tracking |
-| --- | ---- | -------- |
-| Seed vs ad hoc call-graph modes | C, D | #4133 |
-| Transitive cross-library body resolution | B, C | #3632 |
-| Package-web / extensions as graph sink | A | #4139 (envelope) + package-web producer |
-| Graph arc annotation model | A-D | #4139 |
-| Workspace integrations roll-up | A, C | #3629 |
-| Reference touchpoints (non-call edges) | C | #3630 |
-| Declarative scenario / wasm multi-package share | D | workspace-definitions / wasm |
-
-Issue numbers above are GitHub issues (4133, 3632, 3629, 3630); link them in
-the PR body when filing the two new trackers.
-
-## Thesis — type and package at once
-
-Call-graph demos are most powerful when **type and package are simultaneous
-lenses on one member-centric graph**, not two separate tools:
-
-| Direction | Start | Travel | Land |
-| --------- | ----- | ------ | ---- |
-| Type outward | A type (or its members) | Call edges + characteristics | Packages, integrations, providers |
-| Package inward | A package set | Call / extends / integration arcs | Types and APIs that matter |
-
-**Arcs are to the graph what carets are to AnnotatedSourceDocument:** the
-visual hook that carries the rest of the tool’s richness (integration kind,
-package boundary, loop, alloc, findings) without changing the underlying
-identity. Members stay the substrate (#4139); arcs and node marks are the
-descriptive plane; viewers filter layers.
-
-Same envelope both ways — seed or ad hoc mode (#4133) only changes how the
-subgraph is chosen, not whether type and package can co-appear.
-
-```mermaid
-flowchart LR
-  subgraph typeLens["Type lens"]
-    T["IChatClient / OpenAIExtensions"]
-  end
-  subgraph pkgLens["Package lens"]
-    P1["MEAI.OpenAI"]
-    P2["Bedrock.MEAI"]
-    P3["Aspire.Hosting.OpenAI"]
-  end
-  T -->|AsIChatClient Integration: AI| P1
-  T -->|AsIChatClient Integration: AI| P2
-  P3 -->|AddOpenAI Integration: Aspire| T
+```expect
+Call Graph
 ```
 
-Demo A/C lean package→type; Demo B leans type/member→package. Ideal shareable
-views show **both** group labels and typed arcs in one diagram.
+### 5. Presenter stitch (until ad hoc graph exists)
+
+1. Show **type** card (`IChatClient`).  
+2. Show **two package** integration cards (OpenAI + Bedrock `AsIChatClient`).  
+3. Show **one** seed Mermaid (OpenAI `AsIChatClient`) — package names on nodes via
+   `from` / groups.  
+4. Say the missing product step: **one diagram, both lenses, integration on arcs**
+   (#4133 + #4139).
+
+## Product gaps (this demo only)
+
+| Gap | Issue |
+| --- | ----- |
+| One multi-input / multi-seed graph | #4133 |
+| Arc + node characteristics (integration, package on edges) | #4139 |
+| Deeper external body resolution | #3632 |
+| Workspace integrations roll-up across the pin set | #3629 |
+| Reference edge Azure→OpenAI as first-class arc | #3630 |
+
+## Non-goals for this lock
+
+- Aspire.Hosting `AddOpenAI` as the center (wrong refs for MEAI/Bedrock).  
+- Claiming implementors table lists all provider clients (many adapters are
+  factory/`As*` shaped, not public `implements IChatClient` on the SDK type).  
+- Shipping expect blocks against target Mermaid before commands exist.
+
+## Related demos (not locked)
+
+- Aspire hosting package web + `AddOpenAI` seed CG (AppHost plane).  
+- Two-plane “provision vs consume” once this demo and hosting demo both exist.  
+- Type CG rollup / package CG aggregation lenses generally (#4139).
 
 ## Validation posture
 
-- **Target Mermaid** in this file is normative for product direction; it is not
-  an expect block until the command exists.
-- **Works now** commands may gain expect blocks in follow-ups once stabilized.
-- Do not weaken product call-graph contracts to fake multi-provider edges from
-  `AddOpenAI`; wrong seed is a demo bug.
+- **Locked** means: pins, narrative, dual-lens read, and works-now command
+  sequence will not churn without an explicit demo revision.  
+- **Target Mermaid** is directional.  
+- **Works-now** expects may be tightened in a follow-up once CI workflow
+  runners are attached.


### PR DESCRIPTION
## Summary

Locks **one** workspace demo: **`IChatClient` type↔package dual lens**.

- **Type outward** — hub `Microsoft.Extensions.AI.IChatClient`
- **Package inward** — MEAI.OpenAI, Bedrock.MEAI, Azure.AI.OpenAI opportunity
- **Arcs** — `AsIChatClient` · `Integration: AI` (AnnotatedSource carets analogue)
- **Works-now** — ordered CLI path with expect strings (smoked)
- **Target** — one shareable Mermaid when #4133 + #4139 land

Workflow: `docs/workflows/discovery/aspire-ai-package-graph.md`

Aspire hosting / `AddOpenAI` remains a **related** demo, not the lock.

## Demo (target)

```mermaid
flowchart TB
  T["IChatClient · type lens<br/>MEAI.Abstractions"]
  P_oai["Microsoft.Extensions.AI.OpenAI"]
  P_br["AWSSDK.Extensions.Bedrock.MEAI"]
  P_az["Azure.AI.OpenAI"]
  S_oai["OpenAI · SDK"]
  S_br["AWSSDK.BedrockRuntime"]
  T ---|package group| P_oai
  T ---|package group| P_br
  S_oai -->|AsIChatClient · Integration: AI| T
  S_br -->|AsIChatClient · Integration: AI| T
  P_oai -.->|owns adapter| S_oai
  P_br -.->|owns adapter| S_br
  P_az -->|references| S_oai
  P_az -.->|Integration opportunity · MEAI| T
```

## Pins

| Package | Version |
| --- | --- |
| Microsoft.Extensions.AI.Abstractions | 10.9.0 |
| Microsoft.Extensions.AI | 10.9.0 |
| Microsoft.Extensions.AI.OpenAI | 10.9.0 |
| OpenAI | 2.12.0 |
| AWSSDK.Extensions.Bedrock.MEAI | 4.0.101.8 |
| Azure.AI.OpenAI | 2.1.0 |

## Gaps

| Gap | Issue |
| --- | --- |
| Multi-seed / ad hoc graph | #4133 |
| Arc + node characteristics | #4139 |
| External bodies | #3632 |
| Integrations roll-up | #3629 |
| Touchpoints | #3630 |

## Validation

Docs-only. Local smoke of locked expect strings (Release tool): type, library Integration AI/Opportunities, extensions, OpenAI + Bedrock `AsIChatClient` call graphs — all green. `markdownlint` clean.

## Non-action

No product CG implementation in this PR. No Aspire hosting lock.