### PR TITLE
Harden CI provenance hash pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,22 @@ jobs:
         with:
           dotnet-version: '11.0.x'
 
+      - name: Self-test change detection
+        shell: bash
+        run: dotnet run eng/test-ci-change-detection.cs
+        env:
+          BASH_ENV: ""
+
       # Trend rows are reproducible evidence only when their recorded commit
       # landed on main and its source declared the recorded methodology. This
       # job already has the full history needed to prove both, so keep the gate
       # here rather than making test jobs deepen otherwise-shallow checkouts.
       - name: Check EVIL history provenance
         shell: bash
+        env:
+          # After editing `run`, refresh this colocated acknowledgement with:
+          # dotnet run eng/test-ci-change-detection.cs -- --refresh-evil-provenance-pin
+          EVIL_PROVENANCE_RUN_SHA256: AFD8804F209E05792867D7776A950AE6B0EA459F32F896782F0C6B794F5A4B76
         run: >
           dotnet run --project tools/DecompilerHarness -c Release --
           --verify-authored-corpus-history
@@ -314,6 +324,10 @@ jobs:
               tests/*) CODE=true ;;
               tools/DecompilerHarness/*.md|tools/DecompilerHarness/*.txt) ;;
               tools/DecompilerHarness/*) CODE=true ;;
+              # This file is the owning executable gate for this classifier and
+              # its pinned prerequisites. Editing the gate must run the product
+              # test lane as well as executing the gate here in `changes`.
+              eng/test-ci-change-detection.cs) CODE=true ;;
               eng/prepare-decompiler-assertion-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-opt-in-corpus.sh) CODE=true ;;
@@ -532,12 +546,6 @@ jobs:
           # Clear inherited workflow/job values before executing this gate.
           BASH_ENV: ""
           GH_TOKEN: ${{ github.token }}
-
-      - name: Self-test change detection
-        shell: bash
-        run: dotnet run eng/test-ci-change-detection.cs
-        env:
-          BASH_ENV: ""
 
   # Lint markdown files
   markdownlint:

--- a/eng/test-ci-change-detection.cs
+++ b/eng/test-ci-change-detection.cs
@@ -7,7 +7,34 @@ using System.Text;
 using YamlDotNet.RepresentationModel;
 
 string repository = Environment.CurrentDirectory;
-(string body, string[] outputs) = LoadDetectionBody(repository);
+string workflowPath = Path.Combine(
+    repository,
+    ".github",
+    "workflows",
+    "ci.yml");
+string workflowText = File.ReadAllText(workflowPath);
+if (args is ["--refresh-evil-provenance-pin"])
+{
+    string refreshed = RefreshEvilProvenancePin(workflowText);
+    if (refreshed == workflowText)
+    {
+        Console.WriteLine("EVIL provenance pin is already current.");
+    }
+    else
+    {
+        File.WriteAllText(workflowPath, refreshed);
+        Console.WriteLine("Refreshed the EVIL provenance run SHA-256 in .github/workflows/ci.yml.");
+    }
+    return;
+}
+if (args.Length != 0)
+{
+    throw new InvalidOperationException(
+        "Usage: dotnet run eng/test-ci-change-detection.cs [-- --refresh-evil-provenance-pin]");
+}
+
+var (body, outputs, _, _) = LoadDetectionBody(workflowText);
+AssertEvilProvenancePinMutations(workflowText);
 
 AssertAll(RunDetection(repository, body, "pull_request", "", outputs), "true");
 AssertAll(RunDetection(repository, body, "push", "", outputs), "false");
@@ -328,6 +355,14 @@ if (workflow["code"] != "true" || workflow["skills"] != "true")
         $"Workflow canary did not select code and skills: {FormatValues(workflow)}");
 }
 
+Dictionary<string, string> detectionGate = RunDetection(
+    repository,
+    body,
+    "pull_request",
+    "eng/test-ci-change-detection.cs",
+    outputs);
+AssertRouting(detectionGate, selected: "code", notSelected: "docs");
+
 Dictionary<string, string> skill = RunDetection(
     repository,
     body,
@@ -438,12 +473,18 @@ AssertDetectionFails(
     $"false{Environment.NewLine}{body}",
     outputs);
 
-Console.WriteLine("CI change detection fail-safe and path canaries passed.");
+Console.WriteLine(
+    "CI change detection fail-safe, path canaries, and provenance pin mutations passed.");
 
-static (string Body, string[] Outputs) LoadDetectionBody(string repository)
+static (
+    string Body,
+    string[] Outputs,
+    string ProvenanceRunSha256,
+    string ProvenancePin) LoadDetectionBody(
+        string workflowText,
+        bool validateProvenancePin = true)
 {
-    string workflow = Path.Combine(repository, ".github", "workflows", "ci.yml");
-    using TextReader reader = File.OpenText(workflow);
+    using TextReader reader = new StringReader(workflowText);
     YamlStream yaml = [];
     yaml.Load(reader);
     if (yaml.Documents.Count != 1)
@@ -524,7 +565,7 @@ static (string Body, string[] Outputs) LoadDetectionBody(string repository)
     if (steps.Children.Count != 5)
     {
         throw new InvalidOperationException(
-            "jobs.changes must contain exactly the four pinned prerequisites and self-test.");
+            "jobs.changes must contain checkout, setup, self-test, provenance, and detection steps.");
     }
 
     YamlMappingNode checkoutStep = RequireMapping(
@@ -574,10 +615,10 @@ static (string Body, string[] Outputs) LoadDetectionBody(string repository)
             $"found {detectionSteps.Count}.");
     }
 
-    if (detectionSteps[0].Index != 3)
+    if (detectionSteps[0].Index != 4)
     {
         throw new InvalidOperationException(
-            "Detect changes must run after checkout, .NET setup, and EVIL provenance validation.");
+            "Detect changes must run after checkout, .NET setup, self-test, and EVIL provenance validation.");
     }
 
     YamlMappingNode setupStep = RequireMapping(
@@ -604,11 +645,11 @@ static (string Body, string[] Outputs) LoadDetectionBody(string repository)
         "jobs.changes .NET setup step.with");
 
     YamlMappingNode provenanceStep = RequireMapping(
-        steps.Children[2],
+        steps.Children[3],
         "jobs.changes EVIL provenance step");
     RequireExactKeys(
         provenanceStep,
-        ["name", "shell", "run"],
+        ["name", "shell", "env", "run"],
         "jobs.changes EVIL provenance step");
     RequireScalarValue(
         provenanceStep,
@@ -620,11 +661,32 @@ static (string Body, string[] Outputs) LoadDetectionBody(string repository)
         "shell",
         "bash",
         "jobs.changes EVIL provenance step");
-    RequireScalarSha256(
+    YamlMappingNode provenanceEnvironment = GetRequiredMapping(
+        provenanceStep,
+        "env",
+        "jobs.changes EVIL provenance step");
+    RequireExactKeys(
+        provenanceEnvironment,
+        ["EVIL_PROVENANCE_RUN_SHA256"],
+        "jobs.changes EVIL provenance step.env");
+    string provenancePin = GetRequiredScalar(
+        provenanceEnvironment,
+        "EVIL_PROVENANCE_RUN_SHA256",
+        "jobs.changes EVIL provenance step.env");
+    RequireSha256(provenancePin, "jobs.changes EVIL provenance step.env");
+    string provenanceRun = GetRequiredScalar(
         provenanceStep,
         "run",
-        "AFD8804F209E05792867D7776A950AE6B0EA459F32F896782F0C6B794F5A4B76",
         "jobs.changes EVIL provenance step");
+    string provenanceRunSha256 = ComputeSha256(provenanceRun);
+    if (validateProvenancePin && provenanceRunSha256 != provenancePin)
+    {
+        throw new InvalidOperationException(
+            $"jobs.changes EVIL_PROVENANCE_RUN_SHA256 is stale: step.run hashes to " +
+            $"{provenanceRunSha256}, but the pin is {provenancePin}. Refresh it with " +
+            "'dotnet run eng/test-ci-change-detection.cs -- " +
+            "--refresh-evil-provenance-pin'.");
+    }
     RequireAbsent(
         provenanceStep,
         "if",
@@ -639,10 +701,10 @@ static (string Body, string[] Outputs) LoadDetectionBody(string repository)
         "jobs.changes EVIL provenance step");
 
     if (selfTestSteps.Count != 1 ||
-        selfTestSteps[0].Index != 4)
+        selfTestSteps[0].Index != 2)
     {
         throw new InvalidOperationException(
-            "Self-test change detection must run once after Detect changes.");
+            "Self-test change detection must run once before EVIL provenance validation.");
     }
 
     YamlMappingNode selfTestStep = selfTestSteps[0].Step;
@@ -701,7 +763,40 @@ static (string Body, string[] Outputs) LoadDetectionBody(string repository)
         throw new InvalidOperationException("Detect changes has an empty run block.");
     }
 
-    return (body, declaredOutputs.ToArray());
+    return (
+        body,
+        declaredOutputs.ToArray(),
+        provenanceRunSha256,
+        provenancePin);
+}
+
+static void AssertEvilProvenancePinMutations(string workflowText)
+{
+    const string command = "--verify-authored-corpus-history";
+    string stale = ReplaceExactlyOnce(
+        workflowText,
+        command,
+        command + " --history-path /tmp/ci-pin-mutation.jsonl",
+        "EVIL provenance command");
+    AssertInvalidOperation(
+        () => _ = LoadDetectionBody(stale),
+        "jobs.changes EVIL_PROVENANCE_RUN_SHA256 is stale");
+
+    string refreshed = RefreshEvilProvenancePin(stale);
+    _ = LoadDetectionBody(refreshed);
+}
+
+static string RefreshEvilProvenancePin(string workflowText)
+{
+    (_, _, string actual, string expected) =
+        LoadDetectionBody(workflowText, validateProvenancePin: false);
+    return actual == expected
+        ? workflowText
+        : ReplaceExactlyOnce(
+            workflowText,
+            expected,
+            actual,
+            "EVIL provenance SHA-256 pin");
 }
 
 static void ValidateAggregateStructuralCheck(YamlMappingNode jobs)
@@ -1244,13 +1339,47 @@ static void RequireScalarSha256(
     string context)
 {
     string actual = GetRequiredScalar(mapping, key, context);
-    string hash = Convert.ToHexString(
-        SHA256.HashData(Encoding.UTF8.GetBytes(actual)));
+    string hash = ComputeSha256(actual);
     if (hash != expected)
     {
         throw new InvalidOperationException(
             $"{context}.{key} SHA-256 must be {expected}, got {hash}.");
     }
+}
+
+static string ComputeSha256(string value) =>
+    Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)));
+
+static void RequireSha256(string value, string context)
+{
+    if (value.Length != 64 ||
+        value.Any(character =>
+            character is not (>= '0' and <= '9') and
+                not (>= 'A' and <= 'F')))
+    {
+        throw new InvalidOperationException(
+            $"{context} must be a 64-character uppercase hexadecimal SHA-256 value.");
+    }
+}
+
+static string ReplaceExactlyOnce(
+    string source,
+    string oldValue,
+    string newValue,
+    string context)
+{
+    int index = source.IndexOf(oldValue, StringComparison.Ordinal);
+    if (index < 0 ||
+        source.IndexOf(
+            oldValue,
+            index + oldValue.Length,
+            StringComparison.Ordinal) >= 0)
+    {
+        throw new InvalidOperationException(
+            $"{context} must appear exactly once.");
+    }
+
+    return source[..index] + newValue + source[(index + oldValue.Length)..];
 }
 
 static void RequireAbsent(
@@ -1609,6 +1738,22 @@ static void AssertDetectionFails(
 
     throw new InvalidOperationException(
         "The Actions-compatible shell did not stop after a failed command.");
+}
+
+static void AssertInvalidOperation(Action action, string expectedMessage)
+{
+    try
+    {
+        action();
+    }
+    catch (InvalidOperationException exception)
+        when (exception.Message.Contains(expectedMessage, StringComparison.Ordinal))
+    {
+        return;
+    }
+
+    throw new InvalidOperationException(
+        $"Expected InvalidOperationException containing '{expectedMessage}'.");
 }
 
 static string FormatValues(Dictionary<string, string> values) =>


### PR DESCRIPTION
Fixes #4129.

The EVIL provenance command and its SHA-256 acknowledgement now live together in `.github/workflows/ci.yml`, and the self-test runs before the pinned command. A stale pair therefore fails in the owning gate with an actionable refresh command before the command can disable the dispatcher.

The gate now mutates the command in memory to prove a stale pin fails and a refreshed pair passes. Path canaries cover both owner files: the workflow continues to select the product/skill lanes, and changes to `eng/test-ci-change-detection.cs` select the product lane while the unconditional, ordered self-test executes the gate itself.

The mismatch escaped #4025 because its reviewed head predated the pin added on `main`; the squash merge combined the newer pin owner with #4025's changed workflow command, a combination that never ran in PR CI. Colocating the acknowledgement removes that split-owner merge failure.

Validation: `dotnet run eng/test-ci-change-detection.cs`; `dotnet run eng/test-ci-change-detection.cs -- --refresh-evil-provenance-pin`; `git diff --check`.
