### PR TITLE
Move primary CI lanes to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,13 @@ concurrency:
 
 jobs:
   # Detect what changed to determine which jobs to run
+  #
+  # This entry job uses the GA image deliberately. Every workflow run waits on
+  # it before path-gated jobs can be selected, so preview-image capacity must
+  # not serialize the entire PR queue. Specialized jobs below retain
+  # ubuntu-26.04 coverage without making it the scheduler for every run.
   changes:
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
       code: ${{ steps.filter.outputs.code }}
@@ -602,6 +607,10 @@ jobs:
   # most expensive leg) and to reduce queued-job contention when many agents
   # have PRs in flight at once. Release packages are built by release.yml at
   # publish time, not here.
+  #
+  # Keep the primary Linux lane on the GA image so ordinary code PRs do not
+  # compete for preview-image capacity. Path-gated specialist jobs, Deep
+  # Inspect, and release publishing continue to exercise ubuntu-26.04.
   test:
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name == 'pull_request'
@@ -609,7 +618,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-26.04
+          - os: ubuntu-24.04
             rid: linux-x64
     runs-on: ${{ matrix.os }}
     env:
@@ -1424,6 +1433,10 @@ jobs:
   # skipped, so a check that looked only at the gated jobs would see nothing but
   # `skipped` and pass a PR on which no test ran at all. `changes` reporting
   # `failure` or `skipped` is what closes that path.
+  #
+  # Like `changes`, this always-run terminal gate uses the GA image so preview
+  # capacity cannot leave an otherwise-complete PR waiting for its required
+  # status. Path-gated jobs retain ubuntu-26.04 coverage.
   ci-required:
     needs:
       - changes
@@ -1440,7 +1453,7 @@ jobs:
       - il-diff-smoke
       - pack
     if: always()
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
       # Defined once and consumed by both the self-test and the real check, so

--- a/src/dotnet-inspect.Tests/CiWorkflowTests.cs
+++ b/src/dotnet-inspect.Tests/CiWorkflowTests.cs
@@ -1,0 +1,53 @@
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Gates the CI runner split between the high-frequency GA lanes and
+/// path-gated Ubuntu preview coverage.
+/// </summary>
+public class CiWorkflowTests
+{
+    static readonly string Workflow = File.ReadAllText(
+        Path.Combine(FindRepoRoot(), ".github", "workflows", "ci.yml"));
+
+    [Fact]
+    public void PrimaryLinuxJobs_UseGeneralAvailabilityRunner()
+    {
+        Assert.Contains("runs-on: ubuntu-24.04", JobHeader("changes"));
+        Assert.Contains("- os: ubuntu-24.04", JobHeader("test"));
+        Assert.Contains("runs-on: ubuntu-24.04", JobHeader("ci-required"));
+    }
+
+    [Fact]
+    public void PathGatedJobs_RetainUbuntu2604Coverage()
+    {
+        Assert.Contains("runs-on: ubuntu-26.04", JobHeader("markdownlint"));
+        Assert.Contains("runs-on: ubuntu-26.04", JobHeader("decompiler-gates"));
+        Assert.Contains("runs-on: ubuntu-26.04", JobHeader("pack"));
+    }
+
+    static string JobHeader(string jobName)
+    {
+        int jobStart = Workflow.IndexOf($"\n  {jobName}:\n", StringComparison.Ordinal);
+        Assert.True(jobStart >= 0, $"CI workflow does not define the '{jobName}' job.");
+
+        int stepsStart = Workflow.IndexOf("\n    steps:\n", jobStart, StringComparison.Ordinal);
+        Assert.True(stepsStart > jobStart, $"CI job '{jobName}' does not define steps.");
+        return Workflow[jobStart..stepsStart];
+    }
+
+    static string FindRepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate the repository root.");
+    }
+}


### PR DESCRIPTION
Move the always-run `changes` and `ci-required` jobs plus the primary Linux test lane to the GA Ubuntu 24.04 runner. This prevents limited Ubuntu 26.04 preview capacity from serializing every PR.

Path-gated specialist jobs, Deep Inspect, and release publishing remain on Ubuntu 26.04, preserving preview-image coverage where contention is lower.

Adds a focused workflow gate for the runner split.

Validation: `dotnet run --project src/dotnet-inspect.Tests -c Release -- -class DotnetInspector.Tests.CiWorkflowTests` (2 passed). YAML parsed successfully.