### PR TITLE
Drive ReturnToSender from product member surfaces

### DIFF
--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -81,6 +81,23 @@ compiler-produced target gate for this boundary.
 the same resolver to reach closure member-surface planning; target
 classification alone is not sufficient.
 
+ReturnToSender must retain a reconstructed base slot only when its typed
+signature, static shape, generic arity, and generic-parameter positions match
+the override; it must resolve an external explicit event through the frozen
+compilation closure before naming its qualified event and base interface; it
+must let closure growth settle before treating an implicit-interface diagnostic
+as final; and it must decline an implicit interface target when the exact
+declaring interface member (including a specialized same-assembly
+property/event accessor) is absent from the product-produced surface. The gates
+are
+`CompileBackTargets_PreservesGenericOverrideWithRenamedTypeParameterWhenBaseSlotIsEmitted`,
+`CompileBackTargets_FullRoundTripsExternalExplicitInterfaceEvent`, and
+`CompileBackTargets_FullRoundTripsReconstructedGenericImplicitInterfaceGetter`;
+`CompileBackTargets_SameAssemblyImplicitInterfaceWithoutReconstructedMemberDeclines`
+remains the missing-member decline gate.
+`CompileBackTargets_UnrelatedExternalInterfaceDoesNotDeclineLocalSlot` pins the
+close non-matching interface boundary.
+
 An assembly-bound Portable PDB does not supply the missing attribution identity.
 When present and recognized, its checksum can authenticate a mapped document's
 content, but a `#line` directive in another, potentially unsupplied compilation

--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -379,7 +379,8 @@ public sealed class TypeShellProducerTests
             ReturnType: "bool",
             TypeParameters: [],
             BodyKind: CSharpShellBodyKind.TargetBody,
-            Body: "return true;"));
+            Body: "return true;",
+            CSharpOperatorDeclaration: true));
         var inequality = CSharpMemberShellProducer.BuildPolicy(new CSharpMemberShellSpec(
             Name: "op_Inequality",
             Kind: CSharpShellMemberKind.Operator,
@@ -392,9 +393,12 @@ public sealed class TypeShellProducerTests
             ReturnType: "bool",
             TypeParameters: [],
             BodyKind: CSharpShellBodyKind.Throw,
-            Body: null));
+            Body: null,
+            CSharpOperatorDeclaration: true));
 
         Assert.Equal("operator", equality.Member.Kind);
+        Assert.True(equality.Member.CSharpOperatorDeclaration);
+        Assert.True(inequality.Member.CSharpOperatorDeclaration);
         var type = new ApiType
         {
             Name = "Row",
@@ -413,6 +417,36 @@ public sealed class TypeShellProducerTests
             "public static bool operator !=(Row left, Row right)",
             Assert.Single(result.Units).Source,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MemberShellProducer_PreservesNegativeTypedOperatorProof()
+    {
+        var policy = CSharpMemberShellProducer.BuildPolicy(new CSharpMemberShellSpec(
+            Name: "op_Increment",
+            Kind: CSharpShellMemberKind.Operator,
+            IsStatic: true,
+            Parameters: [new CSharpShellParameter("value", "Counter")],
+            ReturnType: "string",
+            TypeParameters: [],
+            BodyKind: CSharpShellBodyKind.Throw,
+            Body: null,
+            CSharpOperatorDeclaration: false));
+
+        Assert.False(policy.Member.CSharpOperatorDeclaration);
+        var type = new ApiType
+        {
+            Name = "Counter",
+            Kind = "class",
+            Members = [policy.Member],
+        };
+        var result = new CSharpTypePrinter().Print(new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides: [policy]));
+        string source = Assert.Single(result.Units).Source;
+
+        Assert.Contains("string op_Increment(Counter value)", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("operator ++", source, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -197,6 +197,54 @@ public sealed class TypeShellProducerTests
     }
 
     [Fact]
+    public void MemberShellProducer_PreservesCustomIndexerMetadataName()
+    {
+        var policy = CSharpMemberShellProducer.BuildPolicy(new CSharpMemberShellSpec(
+            Name: "Custom",
+            Kind: CSharpShellMemberKind.PropertySet,
+            IsStatic: false,
+            Parameters: [new CSharpShellParameter("index", "int")],
+            ReturnType: "int",
+            TypeParameters: [],
+            BodyKind: CSharpShellBodyKind.TargetBody,
+            Body: "return;",
+            Attributes: ["Contoso.NotIndexerName"]));
+
+        Assert.Contains("Contoso.NotIndexerName", policy.Member.Attributes);
+        Assert.Contains(
+            "System.Runtime.CompilerServices.IndexerNameAttribute(\"Custom\")",
+            policy.Member.Attributes);
+
+        var ordinary = CSharpMemberShellProducer.BuildPolicy(new CSharpMemberShellSpec(
+            Name: "Item",
+            Kind: CSharpShellMemberKind.PropertyGet,
+            IsStatic: false,
+            Parameters: [new CSharpShellParameter("index", "int")],
+            ReturnType: "int",
+            TypeParameters: [],
+            BodyKind: CSharpShellBodyKind.Throw,
+            Body: null));
+        var explicitImplementation = CSharpMemberShellProducer.BuildPolicy(
+            new CSharpMemberShellSpec(
+                Name: "Custom",
+                Kind: CSharpShellMemberKind.PropertyGet,
+                IsStatic: false,
+                Parameters: [new CSharpShellParameter("index", "int")],
+                ReturnType: "int",
+                TypeParameters: [],
+                BodyKind: CSharpShellBodyKind.Throw,
+                Body: null,
+                ExplicitInterfaceMemberName: "IValues.Custom"));
+
+        Assert.DoesNotContain(
+            ordinary.Member.Attributes,
+            attribute => attribute.Contains("IndexerName", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            explicitImplementation.Member.Attributes,
+            attribute => attribute.Contains("IndexerName", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void MemberShellProducer_ComposesExplicitInterfaceEventWithSiblingBody()
     {
         var policy = CSharpMemberShellProducer.BuildPolicy(new CSharpMemberShellSpec(

--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -208,7 +208,8 @@ public sealed class TypeShellProducerTests
             TypeParameters: [],
             BodyKind: CSharpShellBodyKind.TargetBody,
             Body: "return;",
-            Attributes: ["Contoso.NotIndexerName"]));
+            Attributes: ["Contoso.NotIndexerName"],
+            MetadataName: "Custom"));
 
         Assert.Contains("Contoso.NotIndexerName", policy.Member.Attributes);
         Assert.Contains(
@@ -234,7 +235,8 @@ public sealed class TypeShellProducerTests
                 TypeParameters: [],
                 BodyKind: CSharpShellBodyKind.Throw,
                 Body: null,
-                ExplicitInterfaceMemberName: "IValues.Custom"));
+                ExplicitInterfaceMemberName: "IValues.Custom",
+                MetadataName: "Custom"));
 
         Assert.DoesNotContain(
             ordinary.Member.Attributes,
@@ -242,6 +244,21 @@ public sealed class TypeShellProducerTests
         Assert.DoesNotContain(
             explicitImplementation.Member.Attributes,
             attribute => attribute.Contains("IndexerName", StringComparison.Ordinal));
+
+        var keyword = CSharpMemberShellProducer.BuildPolicy(new CSharpMemberShellSpec(
+            Name: "@class",
+            Kind: CSharpShellMemberKind.PropertyGet,
+            IsStatic: false,
+            Parameters: [new CSharpShellParameter("index", "int")],
+            ReturnType: "int",
+            TypeParameters: [],
+            BodyKind: CSharpShellBodyKind.Throw,
+            Body: null,
+            MetadataName: "class"));
+
+        Assert.Contains(
+            "System.Runtime.CompilerServices.IndexerNameAttribute(\"class\")",
+            keyword.Member.Attributes);
     }
 
     [Fact]

--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -415,6 +415,36 @@ public sealed class TypeShellProducerTests
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void MemberShellProducer_PreservesFinalizerDeclaratorWhenDestructorSyntaxIsSuppressed()
+    {
+        var policy = CSharpMemberShellProducer.BuildPolicy(new CSharpMemberShellSpec(
+            Name: "Finalize",
+            Kind: CSharpShellMemberKind.Finalizer,
+            IsStatic: false,
+            Parameters: [],
+            ReturnType: "void",
+            TypeParameters: [],
+            BodyKind: CSharpShellBodyKind.TargetBody,
+            Body: "return;",
+            SuppressDestructorSyntax: true));
+
+        Assert.Equal("void Finalize()", policy.Member.Signature);
+        var type = new ApiType
+        {
+            Name = "Target",
+            Kind = "class",
+            Members = [policy.Member],
+        };
+        var result = new CSharpTypePrinter().Print(new CSharpTypePrintRequest(
+            type,
+            memberPolicyOverrides: [policy]));
+        string source = Assert.Single(result.Units).Source;
+
+        Assert.Contains("void Finalize()", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("~Target()", source, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(CSharpShellMemberKind.Method, "Run")]
     [InlineData(CSharpShellMemberKind.Method, " IRunner.Run")]

--- a/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
+++ b/src/ILInspector.CSharp.Tests/TypeShellProducerTests.cs
@@ -445,7 +445,9 @@ public sealed class TypeShellProducerTests
             TypeParameters: [],
             BodyKind: CSharpShellBodyKind.TargetBody,
             Body: "return true;",
-            CSharpOperatorDeclaration: true));
+            CSharpOperatorDeclaration: true,
+            OperatorPairingKey: "pairing-key",
+            HasOperatorPairingKey: true));
         var inequality = CSharpMemberShellProducer.BuildPolicy(new CSharpMemberShellSpec(
             Name: "op_Inequality",
             Kind: CSharpShellMemberKind.Operator,
@@ -459,11 +461,17 @@ public sealed class TypeShellProducerTests
             TypeParameters: [],
             BodyKind: CSharpShellBodyKind.Throw,
             Body: null,
-            CSharpOperatorDeclaration: true));
+            CSharpOperatorDeclaration: true,
+            OperatorPairingKey: "pairing-key",
+            HasOperatorPairingKey: true));
 
         Assert.Equal("operator", equality.Member.Kind);
         Assert.True(equality.Member.CSharpOperatorDeclaration);
         Assert.True(inequality.Member.CSharpOperatorDeclaration);
+        Assert.True(equality.Member.HasOperatorPairingKey);
+        Assert.Equal("pairing-key", equality.Member.OperatorPairingKey);
+        Assert.True(inequality.Member.HasOperatorPairingKey);
+        Assert.Equal("pairing-key", inequality.Member.OperatorPairingKey);
         var type = new ApiType
         {
             Name = "Row",

--- a/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
+++ b/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
@@ -343,6 +343,9 @@ public static class CSharpMemberShellProducer
 
     static string? DeclarationSignature(CSharpMemberShellSpec spec)
     {
+        if (spec.Kind == CSharpShellMemberKind.Finalizer)
+            return $"{spec.ReturnType ?? "void"} {spec.Name}()";
+
         if (spec.Kind != CSharpShellMemberKind.Method
             || spec.ExplicitInterfaceMemberName is null)
         {

--- a/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
+++ b/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
@@ -87,6 +87,8 @@ public sealed record CSharpMemberShellSpec(
     int? RemoverToken = null,
     bool SuppressDestructorSyntax = false,
     bool? CSharpOperatorDeclaration = null,
+    string? OperatorPairingKey = null,
+    bool HasOperatorPairingKey = false,
     string? MetadataName = null);
 
 /// <summary>
@@ -292,6 +294,8 @@ public static class CSharpMemberShellProducer
             IsAsync = spec.IsAsync,
             IsExtension = spec.IsExtension,
             CSharpOperatorDeclaration = spec.CSharpOperatorDeclaration,
+            OperatorPairingKey = spec.OperatorPairingKey,
+            HasOperatorPairingKey = spec.HasOperatorPairingKey,
             IsConst = spec.Kind == CSharpShellMemberKind.Field
                 && spec.BodyKind == CSharpShellBodyKind.TargetBody,
             MetadataToken = spec.MetadataToken,

--- a/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
+++ b/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
@@ -10,6 +10,7 @@ public enum CSharpShellMemberKind
     EventAdd,
     EventRemove,
     Constructor,
+    Finalizer,
     Method,
     Operator,
     Field,
@@ -83,7 +84,8 @@ public sealed record CSharpMemberShellSpec(
     int? GetterToken = null,
     int? SetterToken = null,
     int? AdderToken = null,
-    int? RemoverToken = null);
+    int? RemoverToken = null,
+    bool SuppressDestructorSyntax = false);
 
 /// <summary>
 /// Composes product-owned C# member models and body policies from a neutral shell
@@ -194,7 +196,12 @@ public static class CSharpMemberShellProducer
                     CSharpBodyPolicy.Full,
                     TargetBlockBody(RequiredBody(spec), initializer)),
             CSharpShellBodyKind.TargetBody
-                => new(member, CSharpBodyPolicy.Full, TargetBlockBody(RequiredBody(spec))),
+                => new(
+                    member,
+                    CSharpBodyPolicy.Full,
+                    TargetBlockBody(
+                        RequiredBody(spec),
+                        suppressDestructorSyntax: spec.SuppressDestructorSyntax)),
             CSharpShellBodyKind.TargetGetterWithSetter
                 or CSharpShellBodyKind.TargetGetterWithInitSetter
                 => new(
@@ -256,6 +263,7 @@ public static class CSharpMemberShellProducer
                     CSharpShellMemberKind.PropertyGet or CSharpShellMemberKind.PropertySet => "property",
                     CSharpShellMemberKind.EventAdd or CSharpShellMemberKind.EventRemove => "event",
                     CSharpShellMemberKind.Constructor => "constructor",
+                    CSharpShellMemberKind.Finalizer => "finalizer",
                     CSharpShellMemberKind.Method => "method",
                     CSharpShellMemberKind.Operator => "operator",
                     CSharpShellMemberKind.Field => "field",
@@ -269,6 +277,7 @@ public static class CSharpMemberShellProducer
             IsVirtual = spec.IsVirtual,
             IsOverride = spec.IsOverride,
             IsSealed = spec.IsSealed,
+            IsFinalizer = spec.Kind == CSharpShellMemberKind.Finalizer,
             Accessibility = spec.Accessibility switch
             {
                 CSharpShellAccessibility.Public => "public",
@@ -611,8 +620,13 @@ public static class CSharpMemberShellProducer
 
     static CSharpBlockBody TargetBlockBody(
         string source,
-        CSharpConstructorInitializer? constructorInitializer = null)
-        => new(source, constructorInitializer) { IsReplacementTarget = true };
+        CSharpConstructorInitializer? constructorInitializer = null,
+        bool suppressDestructorSyntax = false)
+        => new(source, constructorInitializer)
+        {
+            IsReplacementTarget = true,
+            SuppressDestructorSyntax = suppressDestructorSyntax,
+        };
 
     static CSharpAccessorBody TargetAccessorBody(string source)
         => CSharpAccessorBody.Block(source) with { IsReplacementTarget = true };

--- a/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
+++ b/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
@@ -286,7 +286,7 @@ public static class CSharpMemberShellProducer
                 _ => throw new NotSupportedException(
                     $"Unsupported C# shell accessibility '{spec.Accessibility}'."),
             },
-            Attributes = spec.Attributes?.ToList() ?? [],
+            Attributes = MemberAttributes(spec, isProperty, isExplicitInterface),
             IsUnsafe = spec.RequiresUnsafeModifier || RequiresUnsafe(spec),
             IsAsync = spec.IsAsync,
             IsExtension = spec.IsExtension,
@@ -341,6 +341,37 @@ public static class CSharpMemberShellProducer
         }
 
         return member;
+    }
+
+    static List<string> MemberAttributes(
+        CSharpMemberShellSpec spec,
+        bool isProperty,
+        bool isExplicitInterface)
+    {
+        var attributes = spec.Attributes?.ToList() ?? [];
+        if (isProperty
+            && spec.Parameters.Count > 0
+            && !isExplicitInterface
+            && spec.Name != "Item"
+            && CSharpIdentifier.IsIdentifierLike(spec.Name)
+            && !attributes.Any(IsIndexerNameAttribute))
+        {
+            attributes.Add(
+                $"System.Runtime.CompilerServices.IndexerNameAttribute(\"{spec.Name}\")");
+        }
+
+        return attributes;
+    }
+
+    static bool IsIndexerNameAttribute(string attribute)
+    {
+        int argumentStart = attribute.IndexOf('(');
+        string name = (argumentStart < 0 ? attribute : attribute[..argumentStart]).Trim();
+        if (name.StartsWith("global::", StringComparison.Ordinal))
+            name = name["global::".Length..];
+        return name is "IndexerName" or "IndexerNameAttribute"
+            or "System.Runtime.CompilerServices.IndexerName"
+            or "System.Runtime.CompilerServices.IndexerNameAttribute";
     }
 
     static string? DeclarationSignature(CSharpMemberShellSpec spec)

--- a/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
+++ b/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
@@ -85,7 +85,8 @@ public sealed record CSharpMemberShellSpec(
     int? SetterToken = null,
     int? AdderToken = null,
     int? RemoverToken = null,
-    bool SuppressDestructorSyntax = false);
+    bool SuppressDestructorSyntax = false,
+    bool? CSharpOperatorDeclaration = null);
 
 /// <summary>
 /// Composes product-owned C# member models and body policies from a neutral shell
@@ -289,6 +290,7 @@ public static class CSharpMemberShellProducer
             IsUnsafe = spec.RequiresUnsafeModifier || RequiresUnsafe(spec),
             IsAsync = spec.IsAsync,
             IsExtension = spec.IsExtension,
+            CSharpOperatorDeclaration = spec.CSharpOperatorDeclaration,
             IsConst = spec.Kind == CSharpShellMemberKind.Field
                 && spec.BodyKind == CSharpShellBodyKind.TargetBody,
             MetadataToken = spec.MetadataToken,

--- a/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
+++ b/src/ILInspector.CSharp/CSharpMemberShellProducer.cs
@@ -86,7 +86,8 @@ public sealed record CSharpMemberShellSpec(
     int? AdderToken = null,
     int? RemoverToken = null,
     bool SuppressDestructorSyntax = false,
-    bool? CSharpOperatorDeclaration = null);
+    bool? CSharpOperatorDeclaration = null,
+    string? MetadataName = null);
 
 /// <summary>
 /// Composes product-owned C# member models and body policies from a neutral shell
@@ -349,15 +350,16 @@ public static class CSharpMemberShellProducer
         bool isExplicitInterface)
     {
         var attributes = spec.Attributes?.ToList() ?? [];
+        string metadataName = spec.MetadataName ?? spec.Name;
         if (isProperty
             && spec.Parameters.Count > 0
             && !isExplicitInterface
-            && spec.Name != "Item"
-            && CSharpIdentifier.IsIdentifierLike(spec.Name)
+            && metadataName != "Item"
+            && CSharpIdentifier.IsIdentifierLike(metadataName)
             && !attributes.Any(IsIndexerNameAttribute))
         {
             attributes.Add(
-                $"System.Runtime.CompilerServices.IndexerNameAttribute(\"{spec.Name}\")");
+                $"System.Runtime.CompilerServices.IndexerNameAttribute(\"{metadataName}\")");
         }
 
         return attributes;

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -298,6 +298,189 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullUsesInheritedInterfaceImplementation()
+    {
+        var assemblyPath = CompileFixture("""
+            public class BaseHolder
+            {
+                public virtual int GetHashCode(object value) => 42;
+            }
+
+            public sealed class Holder :
+                BaseHolder,
+                System.Collections.IEqualityComparer
+            {
+                bool System.Collections.IEqualityComparer.Equals(
+                    object left,
+                    object right) =>
+                    ((System.Collections.IEqualityComparer)this).GetHashCode(left) == 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Holder",
+                    "System.Collections.IEqualityComparer.Equals",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.DoesNotContain(
+                "int System.Collections.IEqualityComparer.GetHashCode(",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.Equal(
+                42,
+                InvokeDonorComparer(
+                    Assert.IsType<byte[]>(result.DonorPe),
+                    comparer => comparer.GetHashCode(new object())));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullPreservesImplicitInterfaceOverrideSlot()
+    {
+        var assemblyPath = CompileFixture("""
+            public class BaseHolder
+            {
+                public virtual int GetHashCode(object value) => 1;
+            }
+
+            public static class Helper
+            {
+                public static bool Check(BaseHolder holder, object value) =>
+                    holder.GetHashCode(value) == 2;
+            }
+
+            public sealed class Holder :
+                BaseHolder,
+                System.Collections.IEqualityComparer
+            {
+                bool System.Collections.IEqualityComparer.Equals(
+                    object left,
+                    object right) =>
+                    Helper.Check(this, left);
+
+                public override int GetHashCode(object value) => 2;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Holder",
+                    "System.Collections.IEqualityComparer.Equals",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains(
+                "public override int GetHashCode(object value)",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.True(InvokeDonorComparer(
+                Assert.IsType<byte[]>(result.DonorPe),
+                comparer => comparer.Equals(new object(), new object())));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullKeepsDerivedShellOfAbstractBaseBuildable()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class BaseNode
+            {
+                public int Target() => 42;
+                public abstract int Render();
+            }
+
+            public sealed class DerivedNode : BaseNode
+            {
+                public override int Render() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("BaseNode", "Target", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(
+                "public virtual int Render() { throw null; }",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "abstract-base-member-stubbed");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_OperatorSurfaceDoesNotExpandAbstractHierarchy()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class BaseNode
+            {
+                public abstract int Render();
+
+                public static explicit operator int(BaseNode value) => 42;
+            }
+
+            public sealed class DerivedNode : BaseNode
+            {
+                public override int Render() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("BaseNode", "op_Explicit", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Selected));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.DoesNotContain("Render", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_FullKeepsExplicitOverloadedIndexersDistinct()
     {
         var assemblyPath = CompileFixture("""
@@ -5605,15 +5788,8 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackFirstPropertyGetter_FallsBackToCompileBackFloorForAttributeShellStall()
+    public void CompileBackFirstPropertyGetter_RepairsAbstractBaseMemberShell()
     {
-        // Issue #2527: base-class reconstruction restores same-assembly base classes,
-        // so the old dropped-base attribute stall no longer occurs. A concrete shell
-        // that inherits an abstract member it does not itself consume still cannot
-        // satisfy that obligation (CS0534) — the growth loop does not synthesize
-        // abstract/interface member implementations. The shell stalls with a complete
-        // payload; the compile-back floor (which compiles the decompiled member
-        // against the full original assembly) rescues it.
         var assemblyPath = CompileFixture("""
             public abstract class Shape
             {
@@ -5631,18 +5807,12 @@ public class ReturnToSenderPrototypeTests
         {
             var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
 
-            Assert.True(result.UsedCompileBackFloor, result.Detail);
-            Assert.NotNull(result.CompileBackFloor);
-            Assert.True(
-                result.Status is FidelityCheck.CompileBackStatus.Exact
-                    or FidelityCheck.CompileBackStatus.OpcodeDiff
-                    or FidelityCheck.CompileBackStatus.OperandDiff,
-                result.Detail);
-            Assert.Equal(result.CompileBackFloor.Status, result.Status);
-            Assert.Contains("compile-back-floor", result.Detail);
-            Assert.Contains("CS0534", result.Detail);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "abstract-base-member-stubbed");
             Assert.Contains("Corners", result.TargetBody);
-            Assert.Contains("Corners", result.Source);
             Assert.NotNull(result.MemberAnchor);
         }
         finally
@@ -5655,34 +5825,27 @@ public class ReturnToSenderPrototypeTests
     public void CorpusParity_DoesNotApplyCompileBackFloorToRtsFailure()
     {
         var assemblyPath = CompileFixture("""
-            public abstract class Shape
+            public sealed class Holder
             {
-                protected abstract int Corners();
-            }
-
-            public sealed class Triangle : Shape
-            {
-                protected override int Corners() => 3;
-
-                public int First => Corners();
+                public int Compute() => 1;
             }
             """);
         try
         {
-            var target = new ReturnToSender.RequestedTarget("Triangle", "get_First", 0);
-            var floored = Assert.Single(ReturnToSender.CompileBackTargets(assemblyPath, [target]));
-            Assert.True(floored.UsedCompileBackFloor, floored.Detail);
-            var reference = Assert.IsType<FidelityCheck.CompileBackResult>(floored.CompileBackFloor);
-
-            var native = Assert.Single(ReturnToSender.CompileBackTargets(
+            var target = new ReturnToSender.RequestedTarget("Holder", "Compute", 0);
+            var reference = Assert.Single(
+                FidelityCheck.Evaluate(assemblyPath),
+                row => row.Type == "Holder" && row.Method == "Compute");
+            var exact = Assert.Single(ReturnToSender.CompileBackTargets(
                 assemblyPath,
                 [target],
                 applyCompileBackFloor: false));
-            Assert.False(native.UsedCompileBackFloor);
-            Assert.True(
-                native.Status is FidelityCheck.CompileBackStatus.RecompileFail
-                    or FidelityCheck.CompileBackStatus.ContextFail,
-                $"{native.Status}: {native.Detail}");
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, exact.Status);
+            var native = exact with
+            {
+                Status = FidelityCheck.CompileBackStatus.RecompileFail,
+                Detail = "synthetic native RTS failure",
+            };
 
             var aligned = CorpusSensor.AlignReturnToSenderResultsForTesting([reference], [native]);
             var parity = CorpusSensor.SummarizeReturnToSenderParityForTesting([reference], aligned);
@@ -12255,6 +12418,27 @@ public class ReturnToSenderPrototypeTests
             File.Exists(dllPath),
             $"ilasm did not produce an assembly:{Environment.NewLine}{stdout}{Environment.NewLine}{stderr}");
         return dllPath;
+    }
+
+    static TResult InvokeDonorComparer<TResult>(
+        byte[] assemblyBytes,
+        Func<System.Collections.IEqualityComparer, TResult> action)
+    {
+        var context = new System.Runtime.Loader.AssemblyLoadContext(
+            $"rts-donor-{Guid.NewGuid():N}",
+            isCollectible: true);
+        try
+        {
+            using var stream = new MemoryStream(assemblyBytes, writable: false);
+            var assembly = context.LoadFromStream(stream);
+            var holder = (System.Collections.IEqualityComparer)Activator.CreateInstance(
+                assembly.GetType("Holder", throwOnError: true)!)!;
+            return action(holder);
+        }
+        finally
+        {
+            context.Unload();
+        }
     }
 
     static string CompileFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -629,6 +629,52 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_TargetOwnedOperatorDependencyIncludesRequiredPair()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Counter
+            {
+                public static bool operator ==(Counter left, Counter right) => true;
+                public static bool operator !=(Counter left, Counter right) => false;
+
+                public bool Self() => this == this;
+                public bool Same => this == this;
+
+                public override bool Equals(object value) => value is Counter;
+                public override int GetHashCode() => 0;
+            }
+            """);
+        try
+        {
+            var method = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Counter", "Self", 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Selected));
+            var property = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Counter", "get_Same", 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Selected));
+
+            Assert.All(
+                [method, property],
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.False(result.UsedCompileBackFloor, result.Detail);
+                    Assert.Contains("operator ==", result.Source, StringComparison.Ordinal);
+                    Assert.Contains("operator !=", result.Source, StringComparison.Ordinal);
+                    Assert.DoesNotContain("op_Equality", result.Source, StringComparison.Ordinal);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_KeepsOverrideWhenReconstructedBaseEmitsInternalSlot()
     {
         var assemblyPath = CompileFixture("""
@@ -904,6 +950,103 @@ public class ReturnToSenderPrototypeTests
             Assert.Contains("override int Value", result.Source, StringComparison.Ordinal);
             Assert.Contains("virtual event", result.Source, StringComparison.Ordinal);
             Assert.Contains("override event", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DropsOverridesWhoseSlotsExistOnlyOnDroppedAncestor()
+    {
+        var assemblyPath = CompileFixture("""
+            public class GenericBase<T>
+            {
+                public virtual int Read() => 1;
+                public virtual int Value => 1;
+                public virtual event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+
+            public class MiddleNode : GenericBase<int>
+            {
+            }
+
+            public sealed class LeafNode : MiddleNode
+            {
+                public override int Read() => 3;
+                public override int Value => 3;
+                public override event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+
+                public int Target(System.Action handler)
+                {
+                    Changed += handler;
+                    return Read() + Value;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("LeafNode", "Target", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.DoesNotContain("override int Read()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("override int Value", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("override event", result.Source, StringComparison.Ordinal);
+            Assert.Contains(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "override-slot-unavailable");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExternalImplicitInterfaceTargetDeclinesNatively()
+    {
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            "public interface IProbe { int Read(); }",
+            directory: fixtureDir,
+            assemblyName: "contracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class Probe : IProbe
+            {
+                public int Read() => 42;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(
+                "external-implicit-interface-not-reconstructed",
+                result.Detail,
+                StringComparison.Ordinal);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -746,6 +746,172 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PrimaryTargetsPreserveSealedOverrideSlots()
+    {
+        var assemblyPath = CompileFixture("""
+            public class BaseNode
+            {
+                public virtual int Read() => 1;
+                public virtual int Value => 1;
+                public virtual event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+
+            public class LeafNode : BaseNode
+            {
+                public sealed override int Read() => 2;
+                public sealed override int Value => 2;
+                public sealed override event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+            """);
+        try
+        {
+            var method = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("LeafNode", "Read", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+            var property = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("LeafNode", "get_Value", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+            var @event = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("LeafNode", "add_Changed", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.All(
+                [method, property, @event],
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.False(result.UsedCompileBackFloor, result.Detail);
+                });
+            Assert.Contains("sealed override int Read()", method.Source, StringComparison.Ordinal);
+            Assert.Contains("sealed override int Value", property.Source, StringComparison.Ordinal);
+            Assert.Contains("sealed override event", @event.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PrimaryExternalOverrideDeclinesVisibly()
+    {
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            "public class ExternalBase { public virtual string Describe() => \"base\"; }",
+            directory: fixtureDir,
+            assemblyName: "contracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class Impl : ExternalBase
+            {
+                public override string Describe() => "impl";
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Impl", "Describe", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(
+                "target-override-slot-unavailable",
+                result.Detail,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DemotedMiddleSlotsRemainVirtualForDerivedOverrides()
+    {
+        var assemblyPath = CompileFixture("""
+            public class GenericBase<T>
+            {
+                public virtual int Ping() => 1;
+                public virtual int Value => 1;
+                public virtual event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+
+            public class MiddleNode : GenericBase<int>
+            {
+                public override int Ping() => 2;
+                public override int Value => 2;
+                public override event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+
+            public sealed class LeafNode : MiddleNode
+            {
+                public override int Ping() => 3;
+                public override int Value => 3;
+                public override event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+
+                public int Target(System.Action handler)
+                {
+                    Changed += handler;
+                    return Ping() + Value;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("LeafNode", "Target", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("virtual int Ping()", result.Source, StringComparison.Ordinal);
+            Assert.Contains("override int Ping()", result.Source, StringComparison.Ordinal);
+            Assert.Contains("virtual int Value", result.Source, StringComparison.Ordinal);
+            Assert.Contains("override int Value", result.Source, StringComparison.Ordinal);
+            Assert.Contains("virtual event", result.Source, StringComparison.Ordinal);
+            Assert.Contains("override event", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RepairsAbstractBasePropertyShell()
     {
         var assemblyPath = CompileFixture("""
@@ -10458,7 +10624,7 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackTargets_DoesNotMarkUserBaseOverrideWithoutBaseShell()
+    public void CompileBackTargets_DemotesUserOverrideWhenBaseSlotIsUnavailable()
     {
         var assemblyPath = CompileFixture("""
             public abstract class BaseNode
@@ -10478,7 +10644,8 @@ public class ReturnToSenderPrototypeTests
                 [new ReturnToSender.RequestedTarget("DerivedNode", "Describe", 0)]));
 
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-            Assert.Contains("public string Describe()", result.Source);
+            Assert.True(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("public virtual string Describe()", result.Source);
             Assert.DoesNotContain("override string Describe", result.Source);
         }
         finally

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -215,12 +215,12 @@ public class ReturnToSenderPrototypeTests
         var assemblyPath = CompileFixture("""
             using System.Collections;
 
-            public sealed class Holder : IEqualityComparer
+            public class Holder : IEqualityComparer
             {
                 bool IEqualityComparer.Equals(object left, object right) =>
                     ReferenceEquals(left, right);
 
-                public int GetHashCode(object value) => 42;
+                public virtual int GetHashCode(object value) => 42;
             }
             """);
         try
@@ -243,11 +243,51 @@ public class ReturnToSenderPrototypeTests
                 result.Source,
                 StringComparison.Ordinal);
             Assert.Contains(
-                "public int GetHashCode(object value)",
+                "public virtual int GetHashCode(object value)",
                 result.Source,
                 StringComparison.Ordinal);
             Assert.DoesNotContain(
                 "System.Collections.IEqualityComparer.GetHashCode",
+                result.Source,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullKeepsAbstractInterfaceImplementationAbstract()
+    {
+        var assemblyPath = CompileFixture("""
+            using System.Collections;
+
+            public abstract class Holder : IEqualityComparer
+            {
+                bool IEqualityComparer.Equals(object left, object right) =>
+                    ReferenceEquals(left, right);
+
+                public abstract int GetHashCode(object value);
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Holder",
+                    "System.Collections.IEqualityComparer.Equals",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains(
+                "public abstract int GetHashCode(object value);",
                 result.Source,
                 StringComparison.Ordinal);
         }
@@ -3357,6 +3397,64 @@ public class ReturnToSenderPrototypeTests
             // interface's full required surface is satisfied.
             Assert.Contains("IConvertible.GetTypeCode(", result.Source, StringComparison.Ordinal);
             Assert.DoesNotContain("System_IConvertible_ToBoolean", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExternalImplicitKeywordMethodDoesNotDuplicate()
+    {
+        var fixtureDir = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            """
+            namespace RtsKeyword;
+
+            public interface IProbe
+            {
+                void Run();
+                int @class();
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "RtsKeywordContracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class Holder : RtsKeyword.IProbe
+            {
+                void RtsKeyword.IProbe.Run()
+                {
+                    _ = @class();
+                }
+
+                public int @class() => 42;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Holder",
+                    "RtsKeyword.IProbe.Run",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Equal(
+                1,
+                result.Source.Split("public int @class()", StringSplitOptions.None).Length - 1);
         }
         finally
         {
@@ -9010,6 +9108,48 @@ public class ReturnToSenderPrototypeTests
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Contains("IndexerName", result.Source, StringComparison.Ordinal);
             Assert.Contains("public int this[int index]", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Theory]
+    [InlineData("get_class")]
+    [InlineData("set_class")]
+    public void CompileBackTargets_RoundTripsKeywordNamedIndexer(string methodName)
+    {
+        var assemblyPath = CompileFixture("""
+            using System.Runtime.CompilerServices;
+
+            public sealed class Holder
+            {
+                private int _value;
+
+                [IndexerName("class")]
+                public int this[int index]
+                {
+                    get => _value + index;
+                    set { _value = value; }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", methodName, 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Selected));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains(
+                "IndexerNameAttribute(\"class\")",
+                result.Source,
+                StringComparison.Ordinal);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -10103,6 +10103,249 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ClusterPreservesNestedGenericIncrementDecrementOperators()
+    {
+        var assemblyPath = CompileNestedGenericIncrementDecrementFixture();
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Selected));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            var counter = Assert.Single(
+                result.Plan.Types,
+                type => type.Type.MetadataFullName == "Outer`1.Counter");
+            Assert.Single(counter.Members, member =>
+                member.Name == "op_Increment"
+                && member.IsOperator
+                && member.SourceFacts.Any(
+                    fact => fact.Id == "typed-closure-method"
+                        && fact.Detail == "op_Increment"));
+            Assert.Single(counter.Members, member =>
+                member.Name == "op_Decrement"
+                && member.IsOperator
+                && member.SourceFacts.Any(
+                    fact => fact.Id == "typed-closure-method"
+                        && fact.Detail == "op_Decrement"));
+            Assert.Contains("operator ++", result.Source, StringComparison.Ordinal);
+            Assert.Contains("operator --", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "operator-not-representable");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullRepresentsNestedGenericIncrementDecrementOperators()
+    {
+        var assemblyPath = CompileNestedGenericIncrementDecrementFixture();
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(
+                result.BodyComplete,
+                string.Join(
+                    Environment.NewLine,
+                    result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+            Assert.Single(
+                result.FullBodies,
+                body => body.Member.EndsWith(".op_Increment", StringComparison.Ordinal)
+                    && body.Status == MemberBodyProductionStatus.Complete);
+            Assert.Single(
+                result.FullBodies,
+                body => body.Member.EndsWith(".op_Decrement", StringComparison.Ordinal)
+                    && body.Status == MemberBodyProductionStatus.Complete);
+            Assert.Contains("operator ++", result.Source, StringComparison.Ordinal);
+            Assert.Contains("operator --", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason is "operator-not-representable"
+                    or "declaration-not-represented");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ClusterPreservesDerivedReturnIncrementDecrementTargets()
+    {
+        var assemblyPath = CompileDerivedReturnIncrementDecrementFixture();
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Counter", "op_Increment", 0),
+                    new ReturnToSender.RequestedTarget("Counter", "op_Decrement", 0),
+                ],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Selected);
+
+            Assert.Collection(
+                results,
+                increment => AssertDerivedReturnOperator(
+                    increment,
+                    "op_Increment",
+                    "IncrementedCounter operator ++"),
+                decrement => AssertDerivedReturnOperator(
+                    decrement,
+                    "op_Decrement",
+                    "DecrementedCounter operator --"));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+
+        static void AssertDerivedReturnOperator(
+            ReturnToSender.Result result,
+            string methodName,
+            string declaration)
+        {
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            var counter = Assert.Single(result.Plan.Types, type => type.Name == "Counter");
+            Assert.Contains(
+                counter.Members,
+                member => member.Name == methodName && member.IsOperator);
+            var member = Assert.Single(
+                result.Plan.PrintRequests.SelectMany(request => request.Members),
+                member => member.Name == methodName);
+            Assert.True(member.CSharpOperatorDeclaration);
+            Assert.Contains(declaration, result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "operator-not-representable");
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullRepresentsDerivedReturnIncrementDecrementOperators()
+    {
+        var assemblyPath = CompileDerivedReturnIncrementDecrementFixture();
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(
+                result.BodyComplete,
+                string.Join(
+                    Environment.NewLine,
+                    result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+            Assert.Single(
+                result.FullBodies,
+                body => body.Member == "Counter.op_Increment"
+                    && body.Status == MemberBodyProductionStatus.Complete);
+            Assert.Single(
+                result.FullBodies,
+                body => body.Member == "Counter.op_Decrement"
+                    && body.Status == MemberBodyProductionStatus.Complete);
+            Assert.Contains(
+                "IncrementedCounter operator ++",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "DecrementedCounter operator --",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason is "operator-not-representable"
+                    or "declaration-not-represented");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_UnrepresentableIncrementDecrementTargetsStayRawMethods()
+    {
+        var assemblyPath = EmitUnrepresentableIncrementDecrementFixture();
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Poison", "op_Increment", 0),
+                    new ReturnToSender.RequestedTarget("Poison", "op_Decrement", 0),
+                ],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Selected);
+
+            Assert.Collection(
+                results,
+                increment => AssertUnrepresentableOperator(
+                    increment,
+                    "op_Increment",
+                    "operator ++"),
+                decrement => AssertUnrepresentableOperator(
+                    decrement,
+                    "op_Decrement",
+                    "operator --"));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+
+        static void AssertUnrepresentableOperator(
+            ReturnToSender.Result result,
+            string methodName,
+            string operatorDeclaration)
+        {
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            var poison = Assert.Single(result.Plan.Types, type => type.Name == "Poison");
+            var requirement = Assert.Single(
+                poison.Members,
+                member => member.Name == methodName);
+            Assert.False(requirement.IsOperator);
+            var member = Assert.Single(
+                result.Plan.PrintRequests.SelectMany(request => request.Members),
+                member => member.Name == methodName);
+            Assert.False(member.CSharpOperatorDeclaration);
+            Assert.Contains($"string {methodName}(Poison value)", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(operatorDeclaration, result.Source, StringComparison.Ordinal);
+            Assert.Contains(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "operator-not-representable"
+                    && diagnostic.Detail.Contains(methodName, StringComparison.Ordinal));
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_PreservesCheckedBinaryOperatorSibling()
     {
         var assemblyPath = CompileFixture("""
@@ -11692,6 +11935,91 @@ public class ReturnToSenderPrototypeTests
 
         var emit = compilation.Emit(path);
         Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return path;
+    }
+
+    static string CompileNestedGenericIncrementDecrementFixture()
+        => CompileFixture("""
+            public class Outer<T>
+            {
+                public sealed class Counter
+                {
+                    public int Value;
+
+                    public Counter(int value)
+                    {
+                        Value = value;
+                    }
+
+                    public static Outer<T>.Counter operator ++(Counter value)
+                        => new Outer<T>.Counter(value.Value + 1);
+
+                    public static Outer<T>.Counter operator --(Counter value)
+                        => new Outer<T>.Counter(value.Value - 1);
+                }
+            }
+
+            public static class Target
+            {
+                public static Outer<int>.Counter Run(Outer<int>.Counter value)
+                {
+                    value++;
+                    value--;
+                    return value;
+                }
+            }
+            """);
+
+    static string CompileDerivedReturnIncrementDecrementFixture()
+        => CompileFixture("""
+            public class Counter
+            {
+                public static IncrementedCounter operator ++(Counter value)
+                    => new IncrementedCounter();
+
+                public static DecrementedCounter operator --(Counter value)
+                    => new DecrementedCounter();
+            }
+
+            public sealed class IncrementedCounter : Counter;
+
+            public sealed class DecrementedCounter : Counter;
+
+            public static class Target
+            {
+                public static int Run() => 42;
+            }
+            """);
+
+    static string EmitUnrepresentableIncrementDecrementFixture()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-unrepresentable-increment-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "fixture.dll");
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new AssemblyName("fixture"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("fixture");
+
+        var poison = module.DefineType("Poison", TypeAttributes.Public | TypeAttributes.Class);
+        foreach (string methodName in new[] { "op_Increment", "op_Decrement" })
+        {
+            var method = poison.DefineMethod(
+                methodName,
+                MethodAttributes.Public | MethodAttributes.Static
+                    | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+                typeof(string),
+                [poison]);
+            method.DefineParameter(1, ParameterAttributes.None, "value");
+            var il = method.GetILGenerator();
+            il.Emit(System.Reflection.Emit.OpCodes.Ldnull);
+            il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        }
+        poison.CreateType();
+
+        assembly.Save(path);
         return path;
     }
 

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -210,6 +210,98 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullKeepsPublicInterfaceImplementationPublic()
+    {
+        var assemblyPath = CompileFixture("""
+            using System.Collections;
+
+            public sealed class Holder : IEqualityComparer
+            {
+                bool IEqualityComparer.Equals(object left, object right) =>
+                    ReferenceEquals(left, right);
+
+                public int GetHashCode(object value) => 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Holder",
+                    "System.Collections.IEqualityComparer.Equals",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains(
+                "bool System.Collections.IEqualityComparer.Equals(",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "public int GetHashCode(object value)",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "System.Collections.IEqualityComparer.GetHashCode",
+                result.Source,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullKeepsExplicitOverloadedIndexersDistinct()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface IValues
+            {
+                int this[int index] { get; }
+                int this[string index] { get; }
+            }
+
+            public sealed class Holder : IValues
+            {
+                int IValues.this[int index] => 1;
+                int IValues.this[string index] => 2;
+            }
+
+            public static class Target
+            {
+                public static int Run() => 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains("int IValues.this[int index]", result.Source, StringComparison.Ordinal);
+            Assert.Contains("int IValues.this[string index]", result.Source, StringComparison.Ordinal);
+            Assert.Contains("return 1;", result.Source, StringComparison.Ordinal);
+            Assert.Contains("return 2;", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_PreservesStandaloneAccessorPrefixedMethods()
     {
         var assemblyPath = CompileFixture("""
@@ -8882,6 +8974,42 @@ public class ReturnToSenderPrototypeTests
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
             Assert.Contains("public int this[int index]", result.Source);
             Assert.Contains("set", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RoundTripsCustomNamedIndexerSetter()
+    {
+        var assemblyPath = CompileFixture("""
+            using System.Runtime.CompilerServices;
+
+            public sealed class Holder
+            {
+                private int _value;
+
+                [IndexerName("Custom")]
+                public int this[int index]
+                {
+                    set { _value = index + value; }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "set_Custom", 0)],
+                false));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("IndexerName", result.Source, StringComparison.Ordinal);
+            Assert.Contains("public int this[int index]", result.Source, StringComparison.Ordinal);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -348,6 +348,108 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_GenericBaseInterfaceImplementationDeclinesVisibly()
+    {
+        var assemblyPath = CompileFixture("""
+            public class BaseHolder<T>
+            {
+                public virtual int GetHashCode(T value) => 42;
+            }
+
+            public sealed class Holder :
+                BaseHolder<object>,
+                System.Collections.IEqualityComparer
+            {
+                bool System.Collections.IEqualityComparer.Equals(
+                    object left,
+                    object right) =>
+                    ((System.Collections.IEqualityComparer)this).GetHashCode(left) == 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Holder",
+                    "System.Collections.IEqualityComparer.Equals",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, result.Status);
+            Assert.Contains(
+                "external-interface-base-not-reconstructed",
+                result.Detail,
+                StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(
+                "System_Collections_IEqualityComparer_Equals",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                ": System.Collections.IEqualityComparer",
+                result.Source,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_GenericTargetInheritedInterfaceImplementationDeclinesVisibly()
+    {
+        var assemblyPath = CompileFixture("""
+            public class BaseHolder
+            {
+                public virtual int GetHashCode(object value) => 42;
+            }
+
+            public sealed class Holder<T> :
+                BaseHolder,
+                System.Collections.IEqualityComparer
+            {
+                bool System.Collections.IEqualityComparer.Equals(
+                    object left,
+                    object right) =>
+                    ((System.Collections.IEqualityComparer)this).GetHashCode(left) == 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "Holder`1",
+                    "System.Collections.IEqualityComparer.Equals",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, result.Status);
+            Assert.Contains(
+                "external-interface-base-not-reconstructed",
+                result.Detail,
+                StringComparison.Ordinal);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(
+                "System_Collections_IEqualityComparer_Equals",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                ": System.Collections.IEqualityComparer",
+                result.Source,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_FullPreservesImplicitInterfaceOverrideSlot()
     {
         var assemblyPath = CompileFixture("""
@@ -473,6 +575,297 @@ public class ReturnToSenderPrototypeTests
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.False(result.UsedCompileBackFloor, result.Detail);
             Assert.DoesNotContain("Render", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ConsumedOperatorDoesNotExpandDeclaringTypeSurface()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class CounterBase
+            {
+                public abstract string Render();
+            }
+
+            public sealed class Counter : CounterBase
+            {
+                public int Value;
+
+                public Counter(int value) => Value = value;
+
+                public override string Render() => Value.ToString();
+
+                public static Counter operator ++(Counter value) =>
+                    new Counter(value.Value + 1);
+            }
+
+            public static class Holder
+            {
+                public static Counter Increment(Counter value) => value++;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "Increment", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Selected));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.DoesNotContain("Render", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_KeepsOverrideWhenReconstructedBaseEmitsInternalSlot()
+    {
+        var assemblyPath = CompileFixture("""
+            public class BaseNode
+            {
+                internal virtual int Render() => 1;
+            }
+
+            public sealed class DerivedNode : BaseNode
+            {
+                internal override int Render() => 2;
+
+                public int Target() => Render();
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("DerivedNode", "Target", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("virtual int Render()", result.Source, StringComparison.Ordinal);
+            Assert.Contains("override int Render()", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DropsOverrideWhenExternalBaseIsNotReconstructed()
+    {
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            "public class ExternalBase { public virtual string Describe() => \"base\"; }",
+            directory: fixtureDir,
+            assemblyName: "contracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class Impl : ExternalBase
+            {
+                public override string Describe() => "impl";
+
+                public string Target() => Describe();
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Impl", "Target", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("string Describe()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("override string Describe()", result.Source, StringComparison.Ordinal);
+            Assert.Contains(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "override-slot-unavailable");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DropsOverrideWhenGenericBaseSlotIsNotEmitted()
+    {
+        var assemblyPath = CompileFixture("""
+            public class BaseNode
+            {
+                public virtual T Echo<T>(T value) => value;
+            }
+
+            public sealed class DerivedNode : BaseNode
+            {
+                public override T Echo<T>(T value) => value;
+
+                public int Target() => Echo(42);
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("DerivedNode", "Target", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("T Echo<T>(T value)", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("override T Echo<T>", result.Source, StringComparison.Ordinal);
+            Assert.Contains(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "override-slot-unavailable");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RepairsAbstractBasePropertyShell()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class Shape
+            {
+                public abstract int Corners { get; }
+            }
+
+            public sealed class Triangle : Shape
+            {
+                public override int Corners => 3;
+
+                public int First => Corners;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Triangle", "get_First", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("virtual int Corners", result.Source, StringComparison.Ordinal);
+            Assert.Contains("override int Corners", result.Source, StringComparison.Ordinal);
+            Assert.Contains(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "abstract-base-member-stubbed"
+                    && diagnostic.Detail.Contains("Corners", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesReconstructedEventOverrideSlot()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Publisher
+            {
+                public virtual event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+
+            public sealed class ConcretePublisher : Publisher
+            {
+                public override event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+
+                public void Target(System.Action handler) => Changed += handler;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("ConcretePublisher", "Target", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("virtual event", result.Source, StringComparison.Ordinal);
+            Assert.Contains("override event", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RepairsAbstractBaseEventShell()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class Publisher
+            {
+                public abstract event System.Action Changed;
+
+                public void Target(System.Action handler) => Changed += handler;
+            }
+
+            public sealed class ConcretePublisher : Publisher
+            {
+                public override event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Publisher", "Target", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("virtual event", result.Source, StringComparison.Ordinal);
+            Assert.Contains(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "abstract-base-member-stubbed"
+                    && diagnostic.Detail.Contains("Changed", StringComparison.Ordinal));
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1454,10 +1454,10 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
-    // The closure member surface classifies operators without a relationship resolver, so an
-    // operator whose signature names a type outside the assembly is unclassifiable. Both the
-    // unclassifiable and the proven-negative case emit a raw method, but only the proven one
-    // may claim the member is not representable.
+    // The closure member surface classifies operators through a cross-assembly relationship
+    // resolver, so classification is unavailable exactly when a signature type cannot be
+    // resolved at all. Both the unclassifiable and the proven-negative case emit a raw
+    // method, but only the proven one may claim the member is not representable.
     [Fact]
     public void CompileBackTargets_UnknownOperatorClassificationUsesUnknownReason()
     {
@@ -1490,26 +1490,40 @@ public class ReturnToSenderPrototypeTests
             assemblyName: "local");
         try
         {
-            // `All` reconstructs Wallet as a closure root with its member surface, which is
-            // where the surface's operator classification is consumed.
-            var external = Assert.Single(ReturnToSender.CompileBackTargets(
+            // Close negative: the conversion target resolves, so the operator is classified,
+            // representable, and reports nothing. `All` reconstructs Wallet as a closure root
+            // with its member surface, which is where the classification is consumed.
+            var resolved = Assert.Single(ReturnToSender.CompileBackTargets(
+                externalPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.DoesNotContain(
+                resolved.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason is "operator-representability-unknown"
+                    or "operator-not-representable");
+
+            File.Delete(contractsPath);
+
+            var unavailable = Assert.Single(ReturnToSender.CompileBackTargets(
                 externalPath,
                 [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
                 RoundTripScope.All,
                 RoundTripBodyPolicy.Full));
 
             Assert.Contains(
-                external.Plan.Diagnostics,
+                unavailable.Plan.Diagnostics,
                 diagnostic => diagnostic.Reason == "operator-representability-unknown"
                     && diagnostic.Layer == "member surface"
                     && diagnostic.Detail.Contains("op_Implicit", StringComparison.Ordinal));
             Assert.DoesNotContain(
-                external.Plan.Diagnostics,
+                unavailable.Plan.Diagnostics,
                 diagnostic => diagnostic.Reason == "operator-not-representable"
                     && diagnostic.Detail.Contains("op_Implicit", StringComparison.Ordinal));
 
             // Close negative: the same operator with an in-assembly conversion target is
-            // classified, representable, and reports nothing.
+            // classified without consulting any reference, and reports nothing.
             var local = Assert.Single(ReturnToSender.CompileBackTargets(
                 localPath,
                 [new ReturnToSender.RequestedTarget("Target", "Run", 0)],

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1262,6 +1262,271 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    // An external interface whose definition cannot be read leaves the question "does this
+    // interface declare the target?" unanswered. Reporting the unanswered case as "no" made
+    // a dropped `: IProbe` base-list entry round-trip as a clean Exact even though the
+    // target's final/newslot slot exists only because of that interface.
+    [Fact]
+    public void CompileBackTargets_UnavailableExternalImplicitInterfaceReportsUnknownEvidence()
+    {
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            "public interface IProbe { int Read(); }",
+            directory: fixtureDir,
+            assemblyName: "contracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class Probe : IProbe
+            {
+                public int Read() => 42;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            // Close negative: the definition is readable, so the omission is proven and
+            // keeps the proven reason.
+            var resolved = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, resolved.Status);
+            Assert.Contains(
+                resolved.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-not-reconstructed");
+            Assert.DoesNotContain(
+                resolved.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-evidence-unavailable");
+
+            File.Delete(contractsPath);
+
+            var unavailable = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, unavailable.Status);
+            Assert.Contains(
+                "implicit-interface-evidence-unavailable",
+                unavailable.Detail,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                unavailable.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-evidence-unavailable"
+                    && diagnostic.Layer == "type identity"
+                    && diagnostic.Detail.Contains("Probe::Read", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    // A constructed generic interface nested in another type is referenced through a
+    // TypeSpec whose root TypeRef is scoped to its enclosing TypeRef, not to an assembly
+    // reference. That reference cannot be resolved to a definition here, so the interface's
+    // members are never read: the base-list entry disappears and, before the tri-state
+    // evidence, nothing said so.
+    [Fact]
+    public void CompileBackTargets_NestedExternalConstructedInterfaceReportsUnknownEvidence()
+    {
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            """
+            public interface IOuter
+            {
+                public interface IInner<T>
+                {
+                    int Read();
+                }
+            }
+
+            public interface ITopLevel<T>
+            {
+                int Read();
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "contracts");
+        var nestedPath = CompileFixture(
+            """
+            public sealed class Probe : IOuter.IInner<int>
+            {
+                public int Read() => 42;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "nested",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        var topLevelPath = CompileFixture(
+            """
+            public sealed class Probe : ITopLevel<int>
+            {
+                public int Read() => 42;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "toplevel",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var nested = Assert.Single(ReturnToSender.CompileBackTargets(
+                nestedPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, nested.Status);
+            Assert.DoesNotContain("IInner", nested.Source, StringComparison.Ordinal);
+            Assert.Contains(
+                nested.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-evidence-unavailable"
+                    && diagnostic.Layer == "type identity");
+
+            // Close negative: the same constructed generic shape at top level resolves, so
+            // the omission stays a proven fact rather than an unavailable one.
+            var topLevel = Assert.Single(ReturnToSender.CompileBackTargets(
+                topLevelPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, topLevel.Status);
+            Assert.Contains(
+                topLevel.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-not-reconstructed");
+            Assert.DoesNotContain(
+                topLevel.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-evidence-unavailable");
+        }
+        finally
+        {
+            DeleteFixture(nestedPath);
+        }
+    }
+
+    // The interface an explicit event accessor implements is named by the accessor's own
+    // canonical metadata name, not by MethodImpl table order. `Probe` carries two
+    // `.override` rows on one accessor and emits the wrong one first, so first-row selection
+    // reconstructs the event as `IB.Changed` and silently moves the member to another
+    // interface's slot.
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void CompileBackTargets_ExplicitEventUsesCanonicalDeclarationNotTableOrder()
+    {
+        var ilasm = TryLocateIlasm();
+        if (ilasm is null)
+        {
+            Assert.Skip("ilasm not available; skipping hand-authored IL explicit-event regression.");
+            return;
+        }
+
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var assemblyPath = AssembleIlFixture(ilasm, MultiOverrideEventIl, directory, "eventoverride");
+        try
+        {
+            var shared = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "IA.add_Changed", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Contains("IA.Changed", shared.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IB.Changed", shared.Source, StringComparison.Ordinal);
+
+            // Close negative: one `.override` row for the same canonical name selects the
+            // same interface and is unaffected by the tie-break.
+            var single = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Solo", "IA.add_Changed", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Contains("IA.Changed", single.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("IB.Changed", single.Source, StringComparison.Ordinal);
+            Assert.True(
+                shared.Status == single.Status,
+                $"shared {shared.Status}: {shared.Detail}{Environment.NewLine}"
+                    + $"single {single.Status}: {single.Detail}");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    // The closure member surface classifies operators without a relationship resolver, so an
+    // operator whose signature names a type outside the assembly is unclassifiable. Both the
+    // unclassifiable and the proven-negative case emit a raw method, but only the proven one
+    // may claim the member is not representable.
+    [Fact]
+    public void CompileBackTargets_UnknownOperatorClassificationUsesUnknownReason()
+    {
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            "public sealed class Money { }",
+            directory: fixtureDir,
+            assemblyName: "contracts");
+        const string WalletSource = """
+            public sealed class Wallet
+            {
+                public static implicit operator Money(Wallet value) => new Money();
+
+                public static Wallet Create() => new Wallet();
+            }
+
+            public static class Target
+            {
+                public static object Run() => Wallet.Create();
+            }
+            """;
+        var externalPath = CompileFixture(
+            WalletSource,
+            directory: fixtureDir,
+            assemblyName: "external",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        var localPath = CompileFixture(
+            "public sealed class Money { }" + Environment.NewLine + WalletSource,
+            directory: fixtureDir,
+            assemblyName: "local");
+        try
+        {
+            // `All` reconstructs Wallet as a closure root with its member surface, which is
+            // where the surface's operator classification is consumed.
+            var external = Assert.Single(ReturnToSender.CompileBackTargets(
+                externalPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Contains(
+                external.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "operator-representability-unknown"
+                    && diagnostic.Layer == "member surface"
+                    && diagnostic.Detail.Contains("op_Implicit", StringComparison.Ordinal));
+            Assert.DoesNotContain(
+                external.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "operator-not-representable"
+                    && diagnostic.Detail.Contains("op_Implicit", StringComparison.Ordinal));
+
+            // Close negative: the same operator with an in-assembly conversion target is
+            // classified, representable, and reports nothing.
+            var local = Assert.Single(ReturnToSender.CompileBackTargets(
+                localPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.DoesNotContain(
+                local.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason is "operator-representability-unknown"
+                    or "operator-not-representable");
+        }
+        finally
+        {
+            DeleteFixture(externalPath);
+        }
+    }
+
     [Fact]
     public void CompileBackTargets_ExternalImplicitInterfaceAccessorsDeclineNatively()
     {
@@ -13288,6 +13553,104 @@ public class ReturnToSenderPrototypeTests
         pe.Serialize(image);
         return image.ToArray();
     }
+
+    // Hand-authored IL exercising MethodImpl table order against canonical declaration
+    // identity: two interfaces declare the same event shape, and `Probe` satisfies both with
+    // one pair of accessors whose canonical metadata names spell `IA`. The `.override` rows
+    // are emitted IB-first, so table order disagrees with the accessor's own name. `Solo` is
+    // the single-row control. Assembled with ilasm because C# cannot emit one accessor
+    // carrying overrides for two interfaces.
+    const string MultiOverrideEventIl = """
+        .assembly extern System.Runtime { .ver 0:0:0:0 }
+        .assembly eventoverride { }
+        .module eventoverride.dll
+
+        .class interface public abstract auto ansi IA
+        {
+          .method public hidebysig newslot specialname abstract virtual
+              instance void add_Changed(class [System.Runtime]System.Action 'value') cil managed {}
+          .method public hidebysig newslot specialname abstract virtual
+              instance void remove_Changed(class [System.Runtime]System.Action 'value') cil managed {}
+          .event [System.Runtime]System.Action Changed
+          {
+            .addon instance void IA::add_Changed(class [System.Runtime]System.Action)
+            .removeon instance void IA::remove_Changed(class [System.Runtime]System.Action)
+          }
+        }
+
+        .class interface public abstract auto ansi IB
+        {
+          .method public hidebysig newslot specialname abstract virtual
+              instance void add_Changed(class [System.Runtime]System.Action 'value') cil managed {}
+          .method public hidebysig newslot specialname abstract virtual
+              instance void remove_Changed(class [System.Runtime]System.Action 'value') cil managed {}
+          .event [System.Runtime]System.Action Changed
+          {
+            .addon instance void IB::add_Changed(class [System.Runtime]System.Action)
+            .removeon instance void IB::remove_Changed(class [System.Runtime]System.Action)
+          }
+        }
+
+        .class public auto ansi sealed beforefieldinit Probe
+            extends [System.Runtime]System.Object
+            implements IA, IB
+        {
+          .method private hidebysig newslot specialname virtual final
+              instance void 'IA.add_Changed'(class [System.Runtime]System.Action 'value') cil managed
+          {
+            .override IB::add_Changed
+            .override IA::add_Changed
+            ret
+          }
+          .method private hidebysig newslot specialname virtual final
+              instance void 'IA.remove_Changed'(class [System.Runtime]System.Action 'value') cil managed
+          {
+            .override IB::remove_Changed
+            .override IA::remove_Changed
+            ret
+          }
+          .event [System.Runtime]System.Action 'IA.Changed'
+          {
+            .addon instance void Probe::'IA.add_Changed'(class [System.Runtime]System.Action)
+            .removeon instance void Probe::'IA.remove_Changed'(class [System.Runtime]System.Action)
+          }
+          .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+          {
+            ldarg.0
+            call instance void [System.Runtime]System.Object::.ctor()
+            ret
+          }
+        }
+
+        .class public auto ansi sealed beforefieldinit Solo
+            extends [System.Runtime]System.Object
+            implements IA
+        {
+          .method private hidebysig newslot specialname virtual final
+              instance void 'IA.add_Changed'(class [System.Runtime]System.Action 'value') cil managed
+          {
+            .override IA::add_Changed
+            ret
+          }
+          .method private hidebysig newslot specialname virtual final
+              instance void 'IA.remove_Changed'(class [System.Runtime]System.Action 'value') cil managed
+          {
+            .override IA::remove_Changed
+            ret
+          }
+          .event [System.Runtime]System.Action 'IA.Changed'
+          {
+            .addon instance void Solo::'IA.add_Changed'(class [System.Runtime]System.Action)
+            .removeon instance void Solo::'IA.remove_Changed'(class [System.Runtime]System.Action)
+          }
+          .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+          {
+            ldarg.0
+            call instance void [System.Runtime]System.Object::.ctor()
+            ret
+          }
+        }
+        """;
 
     // Hand-authored IL exercising the shadowing-sibling regression: a class with a clean
     // explicit-interface metadata name for System.Collections.IEnumerable.GetEnumerator plus

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -957,7 +957,7 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackTargets_UsesSignatureToDisambiguateDottedTypeTarget()
+    public void CompileBackTargets_UsesCanonicalSignatureToDisambiguateDottedTypeTarget()
     {
         var assemblyPath = EmitTypeNameCollisionFixture();
         try
@@ -968,7 +968,7 @@ public class ReturnToSenderPrototypeTests
                     "N.C",
                     "SignatureShared",
                     Overload: 0,
-                    Signature: "`0(int)")]));
+                    Signature: CanonicalMethodSignature("int SignatureShared(int value);"))]));
 
             Assert.Contains("int SignatureShared(int", result.Source, StringComparison.Ordinal);
             Assert.DoesNotContain("int SignatureShared(string", result.Source, StringComparison.Ordinal);

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -147,7 +147,7 @@ public class ReturnToSenderPrototypeTests
         var assemblyPath = CompileFixture("""
             public sealed class Target
             {
-                public int Run() => 42;
+                public int Run() => this.Extra();
             }
 
             public static class TargetExtensions
@@ -163,7 +163,10 @@ public class ReturnToSenderPrototypeTests
 
             var target = Assert.Single(result.Plan.Types, type => type.Name == "Target");
             Assert.DoesNotContain(target.Members, member => member.Name == "Extra");
-            Assert.DoesNotContain("int Extra(", result.Source, StringComparison.Ordinal);
+            var extensions = Assert.Single(result.Plan.Types, type => type.Name == "TargetExtensions");
+            Assert.Contains(extensions.Members, member => member.Name == "Extra" && member.IsExtension);
+            Assert.Contains("static class TargetExtensions", result.Source, StringComparison.Ordinal);
+            Assert.Contains("int Extra(this Target target)", result.Source, StringComparison.Ordinal);
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
         }
         finally
@@ -608,7 +611,7 @@ public class ReturnToSenderPrototypeTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void CompileBackTargets_UnrepresentableOperatorDoesNotBreakUnrelatedTarget(
+    public void CompileBackTargets_ReconstructsUnrepresentableOperatorAsRawClosureMethod(
         bool staticZeroParameter)
     {
         var assemblyPath = EmitUnrepresentableOperatorFixture(staticZeroParameter);
@@ -617,7 +620,7 @@ public class ReturnToSenderPrototypeTests
             var result = Assert.Single(ReturnToSender.CompileBackTargets(
                 assemblyPath,
                 [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
-                RoundTripScope.All,
+                RoundTripScope.Cluster,
                 RoundTripBodyPolicy.Full));
 
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
@@ -625,12 +628,13 @@ public class ReturnToSenderPrototypeTests
             Assert.Contains(
                 result.FullBodies,
                 body => body.Member == "Poison.op_Addition"
-                    && body.Status != MemberBodyProductionStatus.Complete);
-            Assert.False(result.BodyComplete);
+                    && body.Status == MemberBodyProductionStatus.Complete);
+            Assert.Contains("op_Addition(", result.Source, StringComparison.Ordinal);
             Assert.Contains(
                 result.Plan.Diagnostics,
                 diagnostic => diagnostic.Reason == "operator-not-representable"
-                    && diagnostic.Detail.Contains("op_Addition", StringComparison.Ordinal));
+                    && diagnostic.Detail.Contains("op_Addition", StringComparison.Ordinal)
+                    && diagnostic.Detail.Contains("not representable", StringComparison.Ordinal));
         }
         finally
         {
@@ -671,8 +675,11 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
-    [Fact]
-    public void CompileBackTargets_SuppressedFinalizerKeepsItsDeclarator()
+    [Theory]
+    [InlineData(RoundTripBodyPolicy.Selected)]
+    [InlineData(RoundTripBodyPolicy.Full)]
+    public void CompileBackTargets_SuppressedFinalizerKeepsItsDeclarator(
+        RoundTripBodyPolicy bodyPolicy)
     {
         var assemblyPath = EmitNonDestructorFinalizerFixture();
         try
@@ -681,7 +688,7 @@ public class ReturnToSenderPrototypeTests
                 assemblyPath,
                 [new ReturnToSender.RequestedTarget("Target", "Finalize", 0)],
                 RoundTripScope.Cluster,
-                RoundTripBodyPolicy.Selected));
+                bodyPolicy));
 
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
             Assert.False(result.UsedCompileBackFloor, result.Detail);
@@ -10335,7 +10342,7 @@ public class ReturnToSenderPrototypeTests
             var member = Assert.Single(
                 result.Plan.PrintRequests.SelectMany(request => request.Members),
                 member => member.Name == methodName);
-            Assert.False(member.CSharpOperatorDeclaration);
+            Assert.Null(member.CSharpOperatorDeclaration);
             Assert.Contains($"string {methodName}(Poison value)", result.Source, StringComparison.Ordinal);
             Assert.DoesNotContain(operatorDeclaration, result.Source, StringComparison.Ordinal);
             Assert.Contains(
@@ -10386,10 +10393,10 @@ public class ReturnToSenderPrototypeTests
             var addition = Assert.Single(number.Members, member => member.Name == "op_Addition");
             Assert.Contains(
                 addition.SourceFacts,
-                fact => fact.Id == "operator-pair-sibling" && fact.Detail == "op_Addition");
+                fact => fact.Id == "closure-method" && fact.Detail == "op_Addition");
             Assert.DoesNotContain(
                 addition.SourceFacts,
-                fact => fact.Id == "typed-closure-method");
+                fact => fact.Id == "operator-pair-sibling");
         }
         finally
         {
@@ -10563,7 +10570,7 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackTargets_EmitsSignatureMatchedEqualityOperatorPairSibling()
+    public void CompileBackTargets_EmitsProductEqualityOperatorSurface()
     {
         var assemblyPath = CompileFixture("""
             public sealed class Row
@@ -10585,7 +10592,8 @@ public class ReturnToSenderPrototypeTests
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
             Assert.Contains("operator ==(Row left, string right)", result.Source);
             Assert.Contains("operator !=(Row left, string right)", result.Source);
-            Assert.DoesNotContain("operator !=(Row left, Row right)", result.Source);
+            Assert.Contains("operator ==(Row left, Row right)", result.Source);
+            Assert.Contains("operator !=(Row left, Row right)", result.Source);
         }
         finally
         {
@@ -12314,20 +12322,8 @@ public class ReturnToSenderPrototypeTests
             typeof(object).Assembly);
         var module = assembly.DefineDynamicModule("fixture");
 
-        var target = module.DefineType(
-            "Target",
-            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
-        var run = target.DefineMethod(
-            "Run",
-            MethodAttributes.Public | MethodAttributes.Static,
-            typeof(int),
-            Type.EmptyTypes);
-        var runIl = run.GetILGenerator();
-        runIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, 42);
-        runIl.Emit(System.Reflection.Emit.OpCodes.Ret);
-        target.CreateType();
-
         var poison = module.DefineType("Poison", TypeAttributes.Public | TypeAttributes.Class);
+        var constructor = poison.DefineDefaultConstructor(MethodAttributes.Public);
         var op = poison.DefineMethod(
             "op_Addition",
             staticZeroParameter
@@ -12340,6 +12336,29 @@ public class ReturnToSenderPrototypeTests
         opIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_0);
         opIl.Emit(System.Reflection.Emit.OpCodes.Ret);
         poison.CreateType();
+
+        var target = module.DefineType(
+            "Target",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var run = target.DefineMethod(
+            "Run",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(int),
+            Type.EmptyTypes);
+        var runIl = run.GetILGenerator();
+        if (staticZeroParameter)
+        {
+            runIl.Emit(System.Reflection.Emit.OpCodes.Call, op);
+        }
+        else
+        {
+            runIl.Emit(System.Reflection.Emit.OpCodes.Newobj, constructor);
+            runIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_1);
+            runIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_2);
+            runIl.Emit(System.Reflection.Emit.OpCodes.Call, op);
+        }
+        runIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        target.CreateType();
 
         assembly.Save(path);
         return path;

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1044,7 +1044,7 @@ public class ReturnToSenderPrototypeTests
             Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, result.Status);
             Assert.False(result.UsedCompileBackFloor, result.Detail);
             Assert.Contains(
-                "external-implicit-interface-not-reconstructed",
+                "implicit-interface-not-reconstructed",
                 result.Detail,
                 StringComparison.Ordinal);
         }
@@ -1052,6 +1052,147 @@ public class ReturnToSenderPrototypeTests
         {
             DeleteFixture(assemblyPath);
         }
+    }
+
+    [Fact]
+    public void CompileBackTargets_UnrelatedExternalInterfaceDoesNotDeclineLocalSlot()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface ILocal
+            {
+                int Read();
+            }
+
+            public sealed class Probe : ILocal, System.IDisposable
+            {
+                public int Read() => 42;
+                public void Dispose() { }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.DoesNotContain(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-not-reconstructed");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_GenericLocalInterfaceDeclineUsesNeutralReason()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface ILocal<T>
+            {
+                T Read();
+            }
+
+            public sealed class Probe : ILocal<int>
+            {
+                public int Read() => 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, result.Status);
+            Assert.Contains(
+                "implicit-interface-not-reconstructed",
+                result.Detail,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("external-", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExternalImplicitInterfaceAccessorsDeclineNatively()
+    {
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            """
+            public interface IProbe
+            {
+                int Count { get; }
+                int Value { set; }
+                event System.Action Changed;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "contracts");
+        var assemblyPath = CompileFixture(
+            """
+            public sealed class Probe : IProbe
+            {
+                public int Count => 42;
+                public int Value { set { } }
+                public event System.Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            foreach (string methodName in new[] { "get_Count", "set_Value", "add_Changed", "remove_Changed" })
+            {
+                var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget("Probe", methodName, 0)],
+                    applyCompileBackFloor: false));
+
+                Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, result.Status);
+                Assert.False(result.UsedCompileBackFloor, result.Detail);
+                Assert.Contains(
+                    "implicit-interface-not-reconstructed",
+                    result.Detail,
+                    StringComparison.Ordinal);
+            }
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RealPrintedRangeMapAccessorDeclinesNatively()
+    {
+        var result = Assert.Single(ReturnToSender.CompileBackTargets(
+            typeof(PrintedRangeMap).Assembly.Location,
+            [new ReturnToSender.RequestedTarget(
+                "ILInspector.Decompiler.Pipeline.PrintedRangeMap",
+                "get_Count",
+                0)],
+            applyCompileBackFloor: false));
+
+        Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, result.Status);
+        Assert.False(result.UsedCompileBackFloor, result.Detail);
+        Assert.Contains(
+            "implicit-interface-not-reconstructed",
+            result.Detail,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -142,6 +142,840 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DoesNotRehomeExtensionMethodsOntoExtendedType()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Target
+            {
+                public int Run() => 42;
+            }
+
+            public static class TargetExtensions
+            {
+                public static int Extra(this Target target) => target.Run();
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)]));
+
+            var target = Assert.Single(result.Plan.Types, type => type.Name == "Target");
+            Assert.DoesNotContain(target.Members, member => member.Name == "Extra");
+            Assert.DoesNotContain("int Extra(", result.Source, StringComparison.Ordinal);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesStandaloneAccessorPrefixedMethods()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Target
+            {
+                public int get_Value() => 7;
+                public int op_Custom() => 2;
+                public void op_AdditionAssignment(int value) { }
+                public int Helper()
+                {
+                    op_AdditionAssignment(1);
+                    return get_Value() + op_Custom();
+                }
+                public int Run() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            var target = Assert.Single(result.Plan.Types, type => type.Name == "Target");
+            Assert.Contains(target.Members, member => member.Name == "get_Value");
+            Assert.Contains(target.Members, member => member.Name == "op_Custom");
+            Assert.Contains(target.Members, member => member.Name == "op_AdditionAssignment");
+            Assert.Contains(
+                "void op_AdditionAssignment(int value)",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "operator +=",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ReconstructsInstanceAssignmentOperatorCalls()
+    {
+        var assemblyPath = CompileFixture("""
+            public struct Vec
+            {
+                public int X;
+
+                public void operator +=(Vec other)
+                {
+                    X += other.X;
+                }
+
+                public void operator ++()
+                {
+                    X++;
+                }
+            }
+
+            public sealed class Target
+            {
+                public int Run(Vec other)
+                {
+                    var value = new Vec();
+                    value += other;
+                    value++;
+                    return value.X;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains("void operator +=(Vec other)", result.Source, StringComparison.Ordinal);
+            Assert.Contains("void operator ++()", result.Source, StringComparison.Ordinal);
+            Assert.Contains("+= other;", result.Source, StringComparison.Ordinal);
+            Assert.Contains("++;", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(".op_AdditionAssignment(", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(".op_IncrementAssignment(", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ReconstructsCheckedInstanceAssignmentOperatorCalls()
+    {
+        var assemblyPath = CompileFixture("""
+            public struct Vec
+            {
+                public int X;
+
+                public void operator +=(Vec other)
+                {
+                    X += other.X;
+                }
+
+                public void operator checked +=(Vec other)
+                {
+                    X = checked(X + other.X);
+                }
+
+                public void operator ++()
+                {
+                    X++;
+                }
+
+                public void operator checked ++()
+                {
+                    X = checked(X + 1);
+                }
+            }
+
+            public sealed class Target
+            {
+                public int Run(Vec other)
+                {
+                    var value = new Vec();
+                    checked
+                    {
+                        value += other;
+                        value++;
+                    }
+                    return value.X;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains("void operator checked +=(Vec other)", result.Source, StringComparison.Ordinal);
+            Assert.Contains("void operator checked ++()", result.Source, StringComparison.Ordinal);
+            Assert.Contains("checked {", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(".op_CheckedAdditionAssignment(", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(".op_CheckedIncrementAssignment(", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ReconstructsCrossAssemblyInstanceAssignmentOperators()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        string operatorsPath = CompileFixture(
+            """
+            public struct ExternalVec
+            {
+                public int X;
+
+                public void operator +=(ExternalVec other)
+                {
+                    X += other.X;
+                }
+
+                public void operator checked +=(ExternalVec other)
+                {
+                    X = checked(X + other.X);
+                }
+            }
+            """,
+            directory: directory,
+            assemblyName: "ExternalOperators");
+        string assemblyPath = CompileFixture(
+            """
+            public sealed class Target
+            {
+                public int Run(ExternalVec other)
+                {
+                    var value = new ExternalVec();
+                    value += other;
+                    checked
+                    {
+                        value += other;
+                    }
+                    return value.X;
+                }
+            }
+            """,
+            directory: directory,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(operatorsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("+= other;", result.Source, StringComparison.Ordinal);
+            Assert.Contains("checked {", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(".op_AdditionAssignment(", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(".op_CheckedAdditionAssignment(", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ResolvesGenericTypeSpecOperatorByDefinitionSignature()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        string operatorsPath = CompileFixture(
+            """
+            public struct GenericVec<T>
+            {
+                public int X;
+
+                private void op_AdditionAssignment(T value)
+                {
+                    X = 1;
+                }
+
+                public void operator +=(int value)
+                {
+                    X += value;
+                }
+            }
+            """,
+            directory: directory,
+            assemblyName: "GenericExternalOperators");
+        string assemblyPath = CompileFixture(
+            """
+            public sealed class Target
+            {
+                public int Run(int amount)
+                {
+                    var value = new GenericVec<int>();
+                    value += amount;
+                    return value.X;
+                }
+            }
+            """,
+            directory: directory,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(operatorsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("+= amount;", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(".op_AdditionAssignment(", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PinsInstanceAssignmentOperatorRhsOverload()
+    {
+        var assemblyPath = CompileFixture("""
+            public struct Vec
+            {
+                public int X;
+
+                public void operator +=(object? value)
+                {
+                    X = 1;
+                }
+
+                public void operator +=(string? value)
+                {
+                    X = 2;
+                }
+            }
+
+            public sealed class Target
+            {
+                public int Run()
+                {
+                    var value = new Vec();
+                    value += (object?)null;
+                    return value.X;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("+= (object)null;", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesNestedUncheckedOperatorInsideCheckedAssignment()
+    {
+        var assemblyPath = CompileFixture("""
+            public struct Vec
+            {
+                public int X;
+
+                public static Vec operator +(Vec left, Vec right)
+                    => new() { X = left.X + right.X };
+
+                public static Vec operator checked +(Vec left, Vec right)
+                    => new() { X = checked(left.X + right.X + 1) };
+
+                public void operator +=(Vec other)
+                {
+                    X += other.X;
+                }
+
+                public void operator checked +=(Vec other)
+                {
+                    X = checked(X + other.X);
+                }
+            }
+
+            public sealed class Target
+            {
+                public int Run(Vec left, Vec right)
+                {
+                    var value = new Vec();
+                    checked
+                    {
+                        value += unchecked(left + right);
+                    }
+                    return value.X;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains(
+                "+= unchecked(left + right);",
+                result.Source,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullPreservesFinalizerIdentity()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Target
+            {
+                ~Target()
+                {
+                    System.GC.KeepAlive(this);
+                }
+
+                public int Run() => 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains("~Target()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("void Finalize()", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FinalizerTargetPreservesFinalizerIdentity()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Target
+            {
+                ~Target()
+                {
+                    System.GC.KeepAlive(this);
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Finalize", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains("~Target()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("void Finalize()", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DoesNotBorrowNonGenericOverloadTokenForGenericRequirement()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Target
+            {
+                public int Run() => M<int>(1);
+
+                public static int M<T>(int value) => value;
+
+                public static int M(int value) => value + 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains("M<T>(int value)", result.Source, StringComparison.Ordinal);
+            Assert.Contains("M(int value)", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CreateMemberSurfaceIndex_DefersDuplicateNameFailureUntilLookup()
+    {
+        var duplicateName = Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create("Sample", ["Duplicate"])).Name;
+        var uniqueName = Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create("Sample", ["Unique"])).Name;
+        var surface = new ApiSurface
+        {
+            Types =
+            [
+                new ApiType { DefinitionName = duplicateName, Name = "Duplicate" },
+                new ApiType { DefinitionName = duplicateName, Name = "Duplicate" },
+                new ApiType { DefinitionName = uniqueName, Name = "Unique" },
+            ],
+        };
+
+        var index = CompileBackSourceComposer.CreateMemberSurfaceIndex(surface);
+
+        Assert.True(index.TryGetValue(uniqueName, out var unique));
+        Assert.Equal("Unique", unique.Name);
+        Assert.Throws<InvalidOperationException>(
+            () => index.TryGetValue(duplicateName, out _));
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesUnownedSpecialNameAccessorMethod()
+    {
+        var assemblyPath = EmitUnownedSpecialNameAccessorFixture();
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            var target = Assert.Single(result.Plan.Types, type => type.Name == "Target");
+            Assert.Contains(target.Members, member => member.Name == "get_Value");
+            var semantics = Assert.Single(result.Plan.Types, type => type.Name == "SemanticsFixture");
+            Assert.Contains(semantics.Members, member => member.Name == "OtherProperty");
+            Assert.Contains(semantics.Members, member => member.Name == "RaiseChanged");
+            Assert.Contains(semantics.Members, member => member.Name == "OtherEvent");
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullBackfillsRequiredOperatorToken()
+    {
+        var assemblyPath = CompileFixture("""
+            public readonly struct Number
+            {
+                public Number(int value) => Value = value;
+                public int Value { get; }
+                public static Number operator +(Number left, Number right) =>
+                    new(left.Value + right.Value);
+            }
+
+            public static class Target
+            {
+                public static int Run() => (new Number(1) + new Number(2)).Value;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            var body = Assert.Single(result.FullBodies, candidate =>
+                candidate.Member == "Number.op_Addition");
+            Assert.Equal(MemberBodyProductionStatus.Complete, body.Status);
+            Assert.DoesNotContain("throw null", result.Source, StringComparison.Ordinal);
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullBackfillsExactOverloadTokens()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Worker
+            {
+                public int Convert(int value) => value + 1;
+                public int Convert(string value) => value.Length;
+                public int Run() => Convert("value");
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Worker", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains("Convert(int value)", result.Source, StringComparison.Ordinal);
+            Assert.Contains("Convert(string value)", result.Source, StringComparison.Ordinal);
+            Assert.Equal(
+                2,
+                result.FullBodies.Count(body => body.Member == "Worker.Convert"
+                    && body.Status == MemberBodyProductionStatus.Complete));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_AllFullMaterializesUnrelatedOperators()
+    {
+        var assemblyPath = CompileFixture("""
+            public readonly struct Number
+            {
+                public Number(int value) => Value = value;
+                public int Value { get; }
+                public static Number operator +(Number left, Number right) =>
+                    new(left.Value + right.Value);
+            }
+
+            public static class Target
+            {
+                public static int Run() => 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains("operator +", result.Source, StringComparison.Ordinal);
+            Assert.Contains(
+                result.FullBodies,
+                body => body.Member == "Number.op_Addition"
+                    && body.Status == MemberBodyProductionStatus.Complete);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_DistinguishesDottedAndNestedTypeNames()
+    {
+        var assemblyPath = EmitTypeNameCollisionFixture();
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("N.C", "Top", 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Source.Contains("int Top()", StringComparison.Ordinal),
+                $"{result.Status}: {result.Detail}");
+            Assert.DoesNotContain("int Nested()", result.Source, StringComparison.Ordinal);
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RejectsAmbiguousDottedTypeTarget()
+    {
+        var assemblyPath = EmitTypeNameCollisionFixture();
+        try
+        {
+            var exception = Assert.Throws<AmbiguousMatchException>(() =>
+                ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget("N.C", "Shared", 0)]));
+
+            Assert.Contains("ambiguous", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_UsesSignatureToDisambiguateDottedTypeTarget()
+    {
+        var assemblyPath = EmitTypeNameCollisionFixture();
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "N.C",
+                    "SignatureShared",
+                    Overload: 0,
+                    Signature: "`0(int)")]));
+
+            Assert.Contains("int SignatureShared(int", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("int SignatureShared(string", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Theory]
+    [InlineData("`0(string)")]
+    [InlineData("() -> corelib:System.String")]
+    public void CompileBackTargets_FallsBackToOrdinalWhenSignatureDoesNotResolve(
+        string signature)
+    {
+        var assemblyPath = EmitTypeNameCollisionFixture();
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "N.C",
+                    "Top",
+                    Overload: 0,
+                    Signature: signature)]));
+
+            Assert.Contains("int Top()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("int Nested()", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Theory]
+    [InlineData("`0(bool)")]
+    [InlineData("(corelib:System.Boolean) -> corelib:System.Int32")]
+    public void CompileBackTargets_PreservesAmbiguityWhenSignatureDoesNotResolve(
+        string signature)
+    {
+        var assemblyPath = EmitTypeNameCollisionFixture();
+        try
+        {
+            Assert.Throws<AmbiguousMatchException>(() =>
+                ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget(
+                        "N.C",
+                        "SignatureShared",
+                        Overload: 0,
+                        Signature: signature)]));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ContainsMalformedBodyDuringSignatureDiscovery()
+    {
+        var assemblyPath = EmitTypeNameCollisionFixture();
+        try
+        {
+            CorruptMethodBody(assemblyPath, "N.C", "Shared");
+
+            Assert.Throws<AmbiguousMatchException>(() =>
+                ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget(
+                        "N.C",
+                        "Shared",
+                        Overload: 0,
+                        Signature: "() -> corelib:System.String")]));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_FullRejectsMultiplePrimaryTargets()
     {
         var exception = Assert.Throws<NotSupportedException>(() => ReturnToSender.CompileBackTargets(
@@ -7484,7 +8318,14 @@ public class ReturnToSenderPrototypeTests
             Overload: overload,
             SignatureText: "",
             ClosureRoots: new HashSet<TypeDefinitionHandle> { typeHandle },
-            ClosureFacts: new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>());
+            ClosureFacts: new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>())
+        {
+            MemberSurfaceByDefinitionName = CompileBackSourceComposer.CreateMemberSurfaceIndex(
+                ApiSurfaceExtractor.Extract(
+                    reader,
+                    includeAll: true,
+                    includeCompilerGenerated: true)),
+        };
         ReturnToSenderSourceIndex? sourceIndex;
         if (useRawSourceIndex)
         {
@@ -10775,6 +11616,170 @@ public class ReturnToSenderPrototypeTests
         var emit = compilation.Emit(path);
         Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
         return path;
+    }
+
+    static string EmitUnownedSpecialNameAccessorFixture()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-special-name-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "fixture.dll");
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new AssemblyName("fixture"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("fixture");
+        var type = module.DefineType(
+            "Target",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var accessorLikeMethod = type.DefineMethod(
+            "get_Value",
+            MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var accessorIl = accessorLikeMethod.GetILGenerator();
+        accessorIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_7);
+        accessorIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var run = type.DefineMethod(
+            "Run",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(int),
+            Type.EmptyTypes);
+        var runIl = run.GetILGenerator();
+        runIl.Emit(System.Reflection.Emit.OpCodes.Call, accessorLikeMethod);
+        runIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        type.CreateType();
+
+        var semanticsType = module.DefineType(
+            "SemanticsFixture",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var getter = semanticsType.DefineMethod(
+            "get_Value",
+            MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        getter.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ldc_I4_1);
+        getter.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+        var otherProperty = DefineVoidMethod(semanticsType, "OtherProperty", Type.EmptyTypes);
+        var property = semanticsType.DefineProperty(
+            "Value",
+            PropertyAttributes.None,
+            typeof(int),
+            null);
+        property.SetGetMethod(getter);
+        property.AddOtherMethod(otherProperty);
+        var adder = DefineVoidMethod(semanticsType, "add_Changed", [typeof(Action)]);
+        var remover = DefineVoidMethod(semanticsType, "remove_Changed", [typeof(Action)]);
+        var raiser = DefineVoidMethod(semanticsType, "RaiseChanged", Type.EmptyTypes);
+        var otherEvent = DefineVoidMethod(semanticsType, "OtherEvent", Type.EmptyTypes);
+        var @event = semanticsType.DefineEvent(
+            "Changed",
+            EventAttributes.None,
+            typeof(Action));
+        @event.SetAddOnMethod(adder);
+        @event.SetRemoveOnMethod(remover);
+        @event.SetRaiseMethod(raiser);
+        @event.AddOtherMethod(otherEvent);
+        semanticsType.CreateType();
+
+        assembly.Save(path);
+        return path;
+
+        static System.Reflection.Emit.MethodBuilder DefineVoidMethod(
+            System.Reflection.Emit.TypeBuilder type,
+            string name,
+            Type[] parameters)
+        {
+            var method = type.DefineMethod(
+                name,
+                MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.SpecialName,
+                typeof(void),
+                parameters);
+            method.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+            return method;
+        }
+    }
+
+    static string EmitTypeNameCollisionFixture()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-type-name-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "fixture.dll");
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new AssemblyName("fixture"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("fixture");
+
+        var outer = module.DefineType("N", TypeAttributes.Public | TypeAttributes.Class);
+        var nested = outer.DefineNestedType("C", TypeAttributes.NestedPublic | TypeAttributes.Class);
+        DefineConstantMethod(nested, "Nested", 2);
+        DefineConstantMethod(nested, "Shared", 3);
+        DefineConstantMethod(nested, "SignatureShared", 6, typeof(string));
+        nested.CreateType();
+        outer.CreateType();
+
+        var dotted = module.DefineType("N.C", TypeAttributes.Public | TypeAttributes.Class);
+        DefineConstantMethod(dotted, "Top", 1);
+        DefineConstantMethod(dotted, "Shared", 4);
+        DefineConstantMethod(dotted, "SignatureShared", 7, typeof(int));
+        dotted.CreateType();
+
+        var target = module.DefineType(
+            "Target",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        DefineConstantMethod(target, "Run", 5);
+        target.CreateType();
+
+        assembly.Save(path);
+        return path;
+
+        static void DefineConstantMethod(
+            System.Reflection.Emit.TypeBuilder type,
+            string name,
+            int value,
+            params Type[] parameterTypes)
+        {
+            var method = type.DefineMethod(
+                name,
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(int),
+                parameterTypes);
+            var il = method.GetILGenerator();
+            il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, value);
+            il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        }
+    }
+
+    static void CorruptMethodBody(
+        string assemblyPath,
+        string typeName,
+        string methodName)
+    {
+        var image = File.ReadAllBytes(assemblyPath);
+        using var pe = new PEReader(new MemoryStream(image, writable: false));
+        var reader = pe.GetMetadataReader();
+        var typeHandle = Assert.Single(
+            reader.TypeDefinitions,
+            handle =>
+            {
+                var definition = reader.GetTypeDefinition(handle);
+                return reader.GetFullTypeName(definition) == typeName
+                    && definition.GetDeclaringType().IsNil
+                    && definition.GetMethods().Any(methodHandle =>
+                        reader.GetString(reader.GetMethodDefinition(methodHandle).Name) == methodName);
+            });
+        var methodHandle = Assert.Single(
+            reader.GetTypeDefinition(typeHandle).GetMethods(),
+            handle => reader.GetString(reader.GetMethodDefinition(handle).Name) == methodName);
+        int rva = reader.GetMethodDefinition(methodHandle).RelativeVirtualAddress;
+        var section = pe.PEHeaders.SectionHeaders.Single(section =>
+            rva >= section.VirtualAddress
+            && rva < section.VirtualAddress + Math.Max(section.VirtualSize, section.SizeOfRawData));
+        int bodyOffset = section.PointerToRawData + rva - section.VirtualAddress;
+        image[bodyOffset] = 0;
+        File.WriteAllBytes(assemblyPath, image);
     }
 
     static void DeleteFixture(string assemblyPath)

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -605,6 +605,39 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CompileBackTargets_UnrepresentableOperatorDoesNotBreakUnrelatedTarget(
+        bool staticZeroParameter)
+    {
+        var assemblyPath = EmitUnrepresentableOperatorFixture(staticZeroParameter);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Run", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.DoesNotContain("operator +", result.Source, StringComparison.Ordinal);
+            Assert.Contains(
+                result.FullBodies,
+                body => body.Member == "Poison.op_Addition"
+                    && body.Status != MemberBodyProductionStatus.Complete);
+            Assert.False(result.BodyComplete);
+            Assert.Contains(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "operator-not-representable"
+                    && diagnostic.Detail.Contains("op_Addition", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     [Fact]
     public void CompileBackTargets_FinalizerTargetPreservesFinalizerIdentity()
     {
@@ -631,6 +664,29 @@ public class ReturnToSenderPrototypeTests
             Assert.True(result.BodyComplete, result.Detail);
             Assert.Contains("~Target()", result.Source, StringComparison.Ordinal);
             Assert.DoesNotContain("void Finalize()", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_SuppressedFinalizerKeepsItsDeclarator()
+    {
+        var assemblyPath = EmitNonDestructorFinalizerFixture();
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Target", "Finalize", 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Selected));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains("void Finalize()", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("void\n", result.Source, StringComparison.Ordinal);
         }
         finally
         {
@@ -872,6 +928,27 @@ public class ReturnToSenderPrototypeTests
                     [new ReturnToSender.RequestedTarget("N.C", "Shared", 0)]));
 
             Assert.Contains("ambiguous", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RejectsDuplicatePhysicalTypeDefinitions()
+    {
+        var assemblyPath = EmitDuplicateTypeDefinitionFixture();
+        try
+        {
+            var exception = Assert.Throws<AmbiguousMatchException>(() =>
+                ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    [new ReturnToSender.RequestedTarget("N.C", ".ctor", 0)],
+                    RoundTripScope.Cluster,
+                    RoundTripBodyPolicy.Selected));
+
+            Assert.Contains("multiple TypeDef rows", exception.Message, StringComparison.Ordinal);
         }
         finally
         {
@@ -11780,6 +11857,197 @@ public class ReturnToSenderPrototypeTests
         int bodyOffset = section.PointerToRawData + rva - section.VirtualAddress;
         image[bodyOffset] = 0;
         File.WriteAllBytes(assemblyPath, image);
+    }
+
+    static string EmitDuplicateTypeDefinitionFixture()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-duplicate-typedef-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "fixture.dll");
+
+        var metadata = new MetadataBuilder();
+        metadata.AddAssembly(
+            metadata.GetOrAddString("fixture"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            AssemblyHashAlgorithm.Sha1);
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("fixture.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        var corlib = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Runtime"),
+            new Version(11, 0, 0, 0),
+            default,
+            metadata.GetOrAddBlob(
+                new byte[] { 0xB0, 0x3F, 0x5F, 0x7F, 0x11, 0xD5, 0x0A, 0x3A }),
+            default,
+            default);
+        var systemObject = metadata.AddTypeReference(
+            corlib,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+
+        var constructorSignature = new BlobBuilder();
+        new BlobEncoder(constructorSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(0, returnType => returnType.Void(), _ => { });
+        var constructorSignatureHandle = metadata.GetOrAddBlob(constructorSignature);
+        var objectConstructor = metadata.AddMemberReference(
+            systemObject,
+            metadata.GetOrAddString(".ctor"),
+            constructorSignatureHandle);
+        var intSignature = new BlobBuilder();
+        new BlobEncoder(intSignature)
+            .MethodSignature()
+            .Parameters(0, returnType => returnType.Type().Int32(), _ => { });
+        var intSignatureHandle = metadata.GetOrAddBlob(intSignature);
+
+        var methodBodies = new BlobBuilder();
+        var bodies = new MethodBodyStreamEncoder(methodBodies);
+        var decoyBody = new InstructionEncoder(new BlobBuilder());
+        decoyBody.LoadConstantI4(7);
+        decoyBody.OpCode(ILOpCode.Ret);
+        var decoy = metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Decoy"),
+            intSignatureHandle,
+            bodies.AddMethodBody(decoyBody),
+            default);
+        var constructorBody = new InstructionEncoder(new BlobBuilder());
+        constructorBody.OpCode(ILOpCode.Ldarg_0);
+        constructorBody.Call(objectConstructor);
+        constructorBody.OpCode(ILOpCode.Ret);
+        var constructor = metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.HideBySig
+                | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString(".ctor"),
+            constructorSignatureHandle,
+            bodies.AddMethodBody(constructorBody),
+            default);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            decoy);
+        var first = metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.BeforeFieldInit,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("C"),
+            systemObject,
+            MetadataTokens.FieldDefinitionHandle(1),
+            decoy);
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.BeforeFieldInit,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("C"),
+            systemObject,
+            MetadataTokens.FieldDefinitionHandle(1),
+            constructor);
+        var marker = metadata.AddTypeDefinition(
+            TypeAttributes.NestedPublic | TypeAttributes.Class | TypeAttributes.BeforeFieldInit,
+            default,
+            metadata.GetOrAddString("MarkerFromRowA"),
+            systemObject,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(3));
+        metadata.AddNestedType(marker, first);
+
+        var peBuilder = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata),
+            methodBodies);
+        var image = new BlobBuilder();
+        peBuilder.Serialize(image);
+        File.WriteAllBytes(path, image.ToArray());
+        return path;
+    }
+
+    static string EmitUnrepresentableOperatorFixture(bool staticZeroParameter)
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-unrepresentable-operator-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "fixture.dll");
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new AssemblyName("fixture"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("fixture");
+
+        var target = module.DefineType(
+            "Target",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var run = target.DefineMethod(
+            "Run",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(int),
+            Type.EmptyTypes);
+        var runIl = run.GetILGenerator();
+        runIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, 42);
+        runIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        target.CreateType();
+
+        var poison = module.DefineType("Poison", TypeAttributes.Public | TypeAttributes.Class);
+        var op = poison.DefineMethod(
+            "op_Addition",
+            staticZeroParameter
+                ? MethodAttributes.Public | MethodAttributes.Static
+                    | MethodAttributes.SpecialName | MethodAttributes.HideBySig
+                : MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            typeof(int),
+            staticZeroParameter ? Type.EmptyTypes : [typeof(int), typeof(int)]);
+        var opIl = op.GetILGenerator();
+        opIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_0);
+        opIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        poison.CreateType();
+
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitNonDestructorFinalizerFixture()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-suppressed-finalizer-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "fixture.dll");
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new AssemblyName("fixture"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("fixture");
+
+        var type = module.DefineType("Target", TypeAttributes.Public | TypeAttributes.Class);
+        var cleanup = type.DefineMethod(
+            "Cleanup",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(void),
+            Type.EmptyTypes);
+        cleanup.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+        var finalizer = type.DefineMethod(
+            "Finalize",
+            MethodAttributes.Family | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            typeof(void),
+            Type.EmptyTypes);
+        var finalizerIl = finalizer.GetILGenerator();
+        finalizerIl.Emit(System.Reflection.Emit.OpCodes.Call, cleanup);
+        finalizerIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        type.CreateType();
+
+        assembly.Save(path);
+        return path;
     }
 
     static void DeleteFixture(string assemblyPath)

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -176,6 +176,40 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullMatchesOverloadedIndexerByExactSignature()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Holder
+            {
+                public int this[int index] => 1;
+                public int this[string index] => 2;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Holder", "get_Item", 1)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains("this[int index]", result.Source, StringComparison.Ordinal);
+            Assert.Contains("this[string index]", result.Source, StringComparison.Ordinal);
+            Assert.Contains("return 1;", result.Source, StringComparison.Ordinal);
+            Assert.Contains("return 2;", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_PreservesStandaloneAccessorPrefixedMethods()
     {
         var assemblyPath = CompileFixture("""
@@ -635,6 +669,42 @@ public class ReturnToSenderPrototypeTests
                 diagnostic => diagnostic.Reason == "operator-not-representable"
                     && diagnostic.Detail.Contains("op_Addition", StringComparison.Ordinal)
                     && diagnostic.Detail.Contains("not representable", StringComparison.Ordinal));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CompileBackTargets_FullKeepsUnpairedOperatorsAsOneRawMethod(
+        bool checkedAddition)
+    {
+        var assemblyPath = EmitUnpairedOperatorFixture(checkedAddition);
+        string methodName = checkedAddition ? "op_CheckedAddition" : "op_Equality";
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Number", methodName, 0)],
+                RoundTripScope.Cluster,
+                RoundTripBodyPolicy.Full));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.True(result.BodyComplete, result.Detail);
+            Assert.Contains(methodName, result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("operator ==", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain("operator checked +", result.Source, StringComparison.Ordinal);
+            Assert.Single(
+                result.Plan.Types
+                    .Single(type => type.Name == "Number")
+                    .Members,
+                member => member.Name == methodName);
         }
         finally
         {
@@ -12360,6 +12430,38 @@ public class ReturnToSenderPrototypeTests
         runIl.Emit(System.Reflection.Emit.OpCodes.Ret);
         target.CreateType();
 
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitUnpairedOperatorFixture(bool checkedAddition)
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-unpaired-operator-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "fixture.dll");
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new AssemblyName("fixture"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("fixture");
+        var number = module.DefineType(
+            "Number",
+            TypeAttributes.Public | TypeAttributes.Class);
+        number.DefineDefaultConstructor(MethodAttributes.Public);
+        var method = number.DefineMethod(
+            checkedAddition ? "op_CheckedAddition" : "op_Equality",
+            MethodAttributes.Public | MethodAttributes.Static
+                | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            checkedAddition ? number : typeof(bool),
+            [number, number]);
+        var il = method.GetILGenerator();
+        if (checkedAddition)
+            il.Emit(System.Reflection.Emit.OpCodes.Ldarg_0);
+        else
+            il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        number.CreateType();
         assembly.Save(path);
         return path;
     }

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -754,19 +754,24 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackTargets_DropsOverrideWhenGenericBaseSlotIsNotEmitted()
+    public void CompileBackTargets_PreservesGenericOverrideWithRenamedTypeParameterWhenBaseSlotIsEmitted()
     {
         var assemblyPath = CompileFixture("""
             public class BaseNode
             {
-                public virtual T Echo<T>(T value) => value;
+                public virtual string Echo<T>(T value) => "base";
             }
 
             public sealed class DerivedNode : BaseNode
             {
-                public override T Echo<T>(T value) => value;
+                public override string Echo<U>(U value) => "derived";
 
-                public int Target() => Echo(42);
+                public string Target() => DispatchProbe.Run(this);
+            }
+
+            public static class DispatchProbe
+            {
+                public static string Run(BaseNode value) => value.Echo(42);
             }
             """);
         try
@@ -777,13 +782,14 @@ public class ReturnToSenderPrototypeTests
                 RoundTripScope.All,
                 RoundTripBodyPolicy.Full));
 
-            Assert.NotEqual(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
             Assert.False(result.UsedCompileBackFloor, result.Detail);
-            Assert.Contains("T Echo<T>(T value)", result.Source, StringComparison.Ordinal);
-            Assert.DoesNotContain("override T Echo<T>", result.Source, StringComparison.Ordinal);
-            Assert.Contains(
-                result.Plan.Diagnostics,
-                diagnostic => diagnostic.Reason == "override-slot-unavailable");
+            Assert.Contains("string Echo<T>(T value)", result.Source, StringComparison.Ordinal);
+            Assert.Contains("override string Echo<U>(U value)", result.Source, StringComparison.Ordinal);
+            Assert.Equal(
+                "derived",
+                InvokeDonorGenericOverride(
+                    Assert.IsType<byte[]>(result.DonorPe)));
         }
         finally
         {
@@ -1055,7 +1061,7 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackTargets_UnrelatedExternalInterfaceDoesNotDeclineLocalSlot()
+    public void CompileBackTargets_SameAssemblyImplicitInterfaceWithoutReconstructedMemberDeclines()
     {
         var assemblyPath = CompileFixture("""
             public interface ILocal
@@ -1063,7 +1069,141 @@ public class ReturnToSenderPrototypeTests
                 int Read();
             }
 
-            public sealed class Probe : ILocal, System.IDisposable
+            public sealed class Probe : ILocal
+            {
+                public int Read() => 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                applyCompileBackFloor: false));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(
+                "implicit-interface-not-reconstructed",
+                result.Detail,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullRoundTripsReconstructedGenericImplicitInterfaceMethod()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface IProbe<T>
+            {
+                T Read();
+            }
+
+            public sealed class Probe : IProbe<int>
+            {
+                public int Read() => 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.DoesNotContain(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-not-reconstructed");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullRoundTripsReconstructedGenericImplicitInterfaceGetter()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface IProbe<T>
+            {
+                T Value { get; }
+            }
+
+            public sealed class Probe : IProbe<int>
+            {
+                public int Value => 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "get_Value", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.DoesNotContain(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-not-reconstructed");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullRoundTripsReconstructedImplicitInterfaceEventAccessor()
+    {
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public interface IProbe
+            {
+                event Action Changed;
+            }
+
+            public sealed class Probe : IProbe
+            {
+                public event Action Changed
+                {
+                    add { }
+                    remove { }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "add_Changed", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.DoesNotContain(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-not-reconstructed");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_UnrelatedExternalInterfaceDoesNotDeclineLocalSlot()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Probe : System.IDisposable
             {
                 public int Read() => 42;
                 public void Dispose() { }
@@ -3430,6 +3570,263 @@ public class ReturnToSenderPrototypeTests
                     StringComparison.Ordinal),
                 result.Source);
             Assert.DoesNotContain("System_Collections_IEnumerable_GetEnumerator", result.Source, StringComparison.Ordinal);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullRoundTripsExternalExplicitInterfaceEvent()
+    {
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            """
+            using System;
+
+            namespace Contracts;
+
+            public interface IEvents
+            {
+                event Action Changed;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "contracts");
+        var assemblyPath = CompileFixture(
+            """
+            using System;
+
+            public sealed class EventSource : Contracts.IEvents
+            {
+                private Action? _changed;
+
+                event Action Contracts.IEvents.Changed
+                {
+                    add { _changed += value; }
+                    remove { _changed -= value; }
+                }
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "EventSource",
+                    "Contracts.IEvents.add_Changed",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.True(
+                result.BodyComplete,
+                string.Join(
+                    Environment.NewLine,
+                    result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
+            Assert.True(
+                result.Source.Contains(
+                    "class EventSource : Contracts.IEvents",
+                    StringComparison.Ordinal)
+                || result.Source.Contains(
+                    "class EventSource : IEvents",
+                    StringComparison.Ordinal),
+                result.Source);
+            Assert.True(
+                result.Source.Contains(
+                    "event Action Contracts.IEvents.Changed",
+                    StringComparison.Ordinal)
+                || result.Source.Contains(
+                    "event Action IEvents.Changed",
+                    StringComparison.Ordinal),
+                result.Source);
+            var sourceMember = Assert.Single(
+                Assert.Single(
+                    result.Plan.Types,
+                    type => type.Type.MetadataFullName == "EventSource").Members,
+                member => member.MetadataName == "Contracts.IEvents.Changed");
+            Assert.Equal("Contracts.IEvents.Changed", sourceMember.ExplicitInterfaceMemberName);
+            Assert.Contains(
+                Assert.Single(result.Plan.Types, type => type.Type.MetadataFullName == "EventSource")
+                    .ExternalInterfaces,
+                interfaceName => interfaceName == "Contracts.IEvents");
+            Assert.Equal(
+                MemberBodyProductionStatus.Complete,
+                Assert.Single(
+                    result.FullBodies,
+                    body => body.Member == "EventSource.Contracts.IEvents.add_Changed").Status);
+            Assert.Equal(
+                MemberBodyProductionStatus.Complete,
+                Assert.Single(
+                    result.FullBodies,
+                    body => body.Member.EndsWith(
+                        ".remove_Contracts.IEvents.Changed",
+                        StringComparison.Ordinal)).Status);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_ExternalExplicitInterfaceEventSkipsNonmatchingMethodImpl()
+    {
+        var ilasm = TryLocateIlasm();
+        if (ilasm is null)
+        {
+            Assert.Skip("ilasm not available; skipping external event MethodImpl regression.");
+            return;
+        }
+
+        var fixtureDir = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            """
+            using System;
+
+            namespace Contracts;
+
+            public interface IEvents
+            {
+                event Action Changed;
+            }
+
+            public interface IOther
+            {
+                event Action Changed;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "contracts");
+        var assemblyPath = AssembleIlFixture(
+            ilasm,
+            """
+            .assembly extern System.Runtime { .ver 0:0:0:0 }
+            .assembly extern contracts { }
+            .assembly fixture { }
+            .module fixture.dll
+
+            .class public auto ansi sealed beforefieldinit EventSource
+                extends [System.Runtime]System.Object
+                implements [contracts]Contracts.IEvents, [contracts]Contracts.IOther
+            {
+              .method private final hidebysig newslot specialname virtual
+                  instance void 'Contracts.IEvents.add_Changed'(class [System.Runtime]System.Action) cil managed
+              {
+                .override method instance void [contracts]Contracts.IOther::add_Changed(class [System.Runtime]System.Action)
+                .override method instance void [contracts]Contracts.IEvents::add_Changed(class [System.Runtime]System.Action)
+                ret
+              }
+              .method private final hidebysig newslot specialname virtual
+                  instance void 'Contracts.IEvents.remove_Changed'(class [System.Runtime]System.Action) cil managed
+              {
+                .override method instance void [contracts]Contracts.IOther::remove_Changed(class [System.Runtime]System.Action)
+                .override method instance void [contracts]Contracts.IEvents::remove_Changed(class [System.Runtime]System.Action)
+                ret
+              }
+              .event [System.Runtime]System.Action 'Contracts.IEvents.Changed'
+              {
+                .addon instance void EventSource::'Contracts.IEvents.add_Changed'(class [System.Runtime]System.Action)
+                .removeon instance void EventSource::'Contracts.IEvents.remove_Changed'(class [System.Runtime]System.Action)
+              }
+              .method public hidebysig specialname rtspecialname instance void .ctor() cil managed
+              {
+                ldarg.0
+                call instance void [System.Runtime]System.Object::.ctor()
+                ret
+              }
+            }
+            """,
+            fixtureDir,
+            "fixture");
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "EventSource",
+                    "Contracts.IEvents.add_Changed",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.False(result.UsedCompileBackFloor, result.Detail);
+            Assert.Contains(
+                "event Action Contracts.IEvents.Changed",
+                result.Source,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            TryDeleteDirectory(fixtureDir);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullKeepsPlainEventWithSameSimpleNameAsExplicitEvent()
+    {
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public interface IEvents
+            {
+                event Action Changed;
+            }
+
+            public sealed class EventSource : IEvents
+            {
+                private Action _explicitChanged;
+                private Action _plainChanged;
+
+                event Action IEvents.Changed
+                {
+                    add { _explicitChanged += value; }
+                    remove { _explicitChanged -= value; }
+                }
+
+                public event Action Changed
+                {
+                    add { _plainChanged += value; }
+                    remove { _plainChanged -= value; }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "EventSource",
+                    "IEvents.add_Changed",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(
+                "event Action IEvents.Changed",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "public event Action Changed",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                Assert.Single(
+                    result.Plan.Types,
+                    type => type.Type.MetadataFullName == "EventSource").Members,
+                member => member.MetadataName == "IEvents.Changed");
+            Assert.Contains(
+                Assert.Single(
+                    result.Plan.Types,
+                    type => type.Type.MetadataFullName == "EventSource").Members,
+                member => member.MetadataName == "Changed");
         }
         finally
         {
@@ -12506,13 +12903,8 @@ public class ReturnToSenderPrototypeTests
     [Fact]
     public void CompileBackTargets_FullExplicitInterfaceEventTargetDoesNotDoubleDeclare()
     {
-        // Issue #3007 follow-up (PR #3075 review): the Full member surface folds events by the
-        // sanitized full metadata name ("IBaseEvents.Changed") while an explicit-interface event
-        // target requirement carries the stripped identity ("Changed"). Enabling the surface for
-        // such a target missed the fold and appended a SECOND `event Action IBaseEvents.Changed`
-        // with a `throw null` accessor (CS8646/CS0102) while still reporting BodyComplete=true — a
-        // double-declaration false success. Declining the surface for explicit-interface targets
-        // restores the pre-#3007 single-accessor shape and the honest incomplete floor.
+        // The Full surface identifies events by their raw metadata name. An explicit event target
+        // therefore folds into its surface event rather than appending a second declaration.
         var assemblyPath = CompileFixture("""
             using System;
 
@@ -12547,10 +12939,7 @@ public class ReturnToSenderPrototypeTests
                 $"Expected a single explicit-interface event declaration, found {declarations}.{Environment.NewLine}{result.Source}");
             Assert.DoesNotContain("throw null", result.Source, StringComparison.Ordinal);
 
-            // The sibling remover and the constructor are not represented under the declined
-            // surface, so BodyComplete is honestly false rather than an inflated double-declaration
-            // success (coherent explicit-interface reconstruction is out of #3007's scope).
-            Assert.False(
+            Assert.True(
                 result.BodyComplete,
                 string.Join(Environment.NewLine, result.FullBodies.Select(body => $"{body.Member}: {body.Status}: {body.Failure}")));
         }
@@ -13278,6 +13667,28 @@ public class ReturnToSenderPrototypeTests
             var holder = (System.Collections.IEqualityComparer)Activator.CreateInstance(
                 assembly.GetType("Holder", throwOnError: true)!)!;
             return action(holder);
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    static string InvokeDonorGenericOverride(byte[] assemblyBytes)
+    {
+        var context = new System.Runtime.Loader.AssemblyLoadContext(
+            $"rts-donor-{Guid.NewGuid():N}",
+            isCollectible: true);
+        try
+        {
+            using var stream = new MemoryStream(assemblyBytes, writable: false);
+            var assembly = context.LoadFromStream(stream);
+            var derived = Activator.CreateInstance(
+                assembly.GetType("DerivedNode", throwOnError: true)!)!;
+            return Assert.IsType<string>(assembly
+                .GetType("DispatchProbe", throwOnError: true)!
+                .GetMethod("Run")!
+                .Invoke(null, [derived]));
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1061,6 +1061,74 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_ValueTypeImplicitInterfaceMethodsAndAccessorsDeclineWhenOmitted()
+    {
+        var fixtureDir = Path.Combine(
+            Path.GetTempPath(),
+            $"return-to-sender-{Guid.NewGuid():N}");
+        var contractsPath = CompileFixture(
+            """
+            using System;
+
+            public interface IProbe
+            {
+                int Read();
+                int Value { get; }
+                event Action Changed;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "contracts");
+        var assemblyPath = CompileFixture(
+            """
+            using System;
+
+            public struct Probe : IProbe
+            {
+                public int Read() => 42;
+                public int Value => 42;
+                public event Action Changed;
+            }
+            """,
+            directory: fixtureDir,
+            assemblyName: "fixture",
+            additionalReferences: [MetadataReference.CreateFromFile(contractsPath)]);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Probe", "Read", 0),
+                    new ReturnToSender.RequestedTarget("Probe", "get_Value", 0),
+                    new ReturnToSender.RequestedTarget("Probe", "add_Changed", 0),
+                ],
+                applyCompileBackFloor: false);
+
+            Assert.Collection(
+                results,
+                method =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, method.Status);
+                    Assert.Contains("implicit-interface-not-reconstructed", method.Detail, StringComparison.Ordinal);
+                },
+                property =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, property.Status);
+                    Assert.Contains("implicit-interface-not-reconstructed", property.Detail, StringComparison.Ordinal);
+                },
+                @event =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.ContextFail, @event.Status);
+                    Assert.Contains("implicit-interface-not-reconstructed", @event.Detail, StringComparison.Ordinal);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_SameAssemblyImplicitInterfaceWithoutReconstructedMemberDeclines()
     {
         var assemblyPath = CompileFixture("""
@@ -1095,6 +1163,102 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_FullRoundTripsSameAssemblyImplicitInterfaceEdge()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface ILocal
+            {
+                int Read();
+            }
+
+            public sealed class Probe : ILocal
+            {
+                public int Read() => 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(
+                "public sealed class Probe : ILocal",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-not-reconstructed");
+            Assert.NotNull(result.DonorPe);
+            using var donorPe = new PEReader(new MemoryStream((byte[])result.DonorPe!));
+            var donorReader = donorPe.GetMetadataReader();
+            var probe = Assert.Single(
+                donorReader.TypeDefinitions,
+                handle => donorReader.GetString(donorReader.GetTypeDefinition(handle).Name) == "Probe");
+            Assert.Contains(
+                donorReader.GetTypeDefinition(probe).GetInterfaceImplementations(),
+                handle => donorReader.GetInterfaceImplementation(handle).Interface.Kind
+                    == HandleKind.TypeDefinition);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullRoundTripsInheritedSameAssemblyInterfacePath()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface IBase
+            {
+                int Read();
+            }
+
+            public interface IDerived : IBase
+            {
+            }
+
+            public sealed class Probe : IDerived
+            {
+                public int Read() => 42;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Probe", "Read", 0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public sealed class Probe : IDerived", result.Source, StringComparison.Ordinal);
+            Assert.Contains("public interface IDerived : IBase", result.Source, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                result.Plan.Diagnostics,
+                diagnostic => diagnostic.Reason == "implicit-interface-not-reconstructed");
+            Assert.NotNull(result.DonorPe);
+            using var donorPe = new PEReader(new MemoryStream((byte[])result.DonorPe!));
+            var donorReader = donorPe.GetMetadataReader();
+            var derived = Assert.Single(
+                donorReader.TypeDefinitions,
+                handle => donorReader.GetString(donorReader.GetTypeDefinition(handle).Name) == "IDerived");
+            Assert.Contains(
+                donorReader.GetTypeDefinition(derived).GetInterfaceImplementations(),
+                handle => donorReader.GetInterfaceImplementation(handle).Interface.Kind
+                    == HandleKind.TypeDefinition);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_FullRoundTripsReconstructedGenericImplicitInterfaceMethod()
     {
         var assemblyPath = CompileFixture("""
@@ -1117,9 +1281,93 @@ public class ReturnToSenderPrototypeTests
                 RoundTripBodyPolicy.Full));
 
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(
+                "public sealed class Probe : IProbe<int>",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.NotNull(result.DonorPe);
+            using (var donorPe = new PEReader(new MemoryStream((byte[])result.DonorPe!)))
+            {
+                var donorReader = donorPe.GetMetadataReader();
+                var probe = Assert.Single(
+                    donorReader.TypeDefinitions,
+                    handle => donorReader.GetString(donorReader.GetTypeDefinition(handle).Name) == "Probe");
+                Assert.Contains(
+                    donorReader.GetTypeDefinition(probe).GetInterfaceImplementations(),
+                    handle => donorReader.GetInterfaceImplementation(handle).Interface.Kind
+                        == HandleKind.TypeSpecification);
+            }
             Assert.DoesNotContain(
                 result.Plan.Diagnostics,
                 diagnostic => diagnostic.Reason == "implicit-interface-not-reconstructed");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_FullRoundTripsImplicitStaticAbstractInterfaceMethod()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface IParseable
+            {
+                static abstract int Parse(string text);
+            }
+
+            public sealed class ImplicitStaticFixture : IParseable
+            {
+                public static int Parse(string text) => text.Length;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget(
+                    "ImplicitStaticFixture",
+                    "Parse",
+                    0)],
+                RoundTripScope.All,
+                RoundTripBodyPolicy.Full));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(
+                "public sealed class ImplicitStaticFixture : IParseable",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "public static int Parse(string text)",
+                result.Source,
+                StringComparison.Ordinal);
+            Assert.True(
+                result.Plan.Diagnostics.All(diagnostic => diagnostic.Reason != "implicit-interface-not-reconstructed"),
+                $"{result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.NotNull(result.DonorPe);
+            using var donorPe = new PEReader(new MemoryStream((byte[])result.DonorPe!));
+            var donorReader = donorPe.GetMetadataReader();
+            var targetType = Assert.Single(
+                donorReader.TypeDefinitions,
+                handle => donorReader.GetString(donorReader.GetTypeDefinition(handle).Name)
+                    == "ImplicitStaticFixture");
+            var targetMethod = Assert.Single(
+                donorReader.GetTypeDefinition(targetType).GetMethods(),
+                handle => donorReader.GetString(donorReader.GetMethodDefinition(handle).Name)
+                    == "Parse");
+            Assert.Contains(
+                donorReader.GetTypeDefinition(targetType).GetMethodImplementations(),
+                handle =>
+                {
+                    var implementation = donorReader.GetMethodImplementation(handle);
+                    return implementation.MethodBody == targetMethod
+                        && implementation.MethodDeclaration.Kind == HandleKind.MethodDefinition
+                        && donorReader.GetString(
+                            donorReader.GetTypeDefinition(
+                                donorReader.GetMethodDefinition(
+                                    (MethodDefinitionHandle)implementation.MethodDeclaration)
+                                    .GetDeclaringType()).Name) == "IParseable";
+                });
         }
         finally
         {
@@ -6098,6 +6346,30 @@ public class ReturnToSenderPrototypeTests
             Assert.False(result.UsedCompileBackFloor, result.Detail);
             Assert.Contains("static int IParseable.Parse(string text)", result.Source, StringComparison.Ordinal);
             Assert.DoesNotContain("IParseable_Parse", result.Source, StringComparison.Ordinal);
+            Assert.NotNull(result.DonorPe);
+            using var donorPe = new PEReader(new MemoryStream((byte[])result.DonorPe!));
+            var donorReader = donorPe.GetMetadataReader();
+            var targetType = Assert.Single(
+                donorReader.TypeDefinitions,
+                handle => donorReader.GetString(donorReader.GetTypeDefinition(handle).Name)
+                    == "ExplicitStaticFixture");
+            var targetMethod = Assert.Single(
+                donorReader.GetTypeDefinition(targetType).GetMethods(),
+                handle => donorReader.GetString(donorReader.GetMethodDefinition(handle).Name)
+                    == "IParseable.Parse");
+            Assert.Contains(
+                donorReader.GetTypeDefinition(targetType).GetMethodImplementations(),
+                handle =>
+                {
+                    var implementation = donorReader.GetMethodImplementation(handle);
+                    return implementation.MethodBody == targetMethod
+                        && implementation.MethodDeclaration.Kind == HandleKind.MethodDefinition
+                        && donorReader.GetString(
+                            donorReader.GetTypeDefinition(
+                                donorReader.GetMethodDefinition(
+                                    (MethodDefinitionHandle)implementation.MethodDeclaration)
+                                    .GetDeclaringType()).Name) == "IParseable";
+                });
         }
         finally
         {
@@ -12453,8 +12725,14 @@ public class ReturnToSenderPrototypeTests
                 },
                 typedEquals =>
                 {
-                    Assert.True(
-                        typedEquals.Status == FidelityCheck.CompileBackStatus.OperandDiff,
+                    Assert.Equal(
+                        FidelityCheck.CompileBackStatus.ContextFail,
+                        typedEquals.Status);
+                    Assert.Contains(
+                        typedEquals.Plan.Diagnostics,
+                        diagnostic => diagnostic.Reason == "implicit-interface-not-reconstructed");
+                    Assert.False(
+                        typedEquals.Status == FidelityCheck.CompileBackStatus.Exact,
                         $"{typedEquals.Status}: {typedEquals.Detail}{Environment.NewLine}{typedEquals.Source}");
                     Assert.Contains("public bool Equals(Row other)", typedEquals.Source);
                     Assert.Contains("public string Name;", typedEquals.Source);

--- a/src/ILInspector.Decompiler.Tests/ValidDifferentFaultIsolationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidDifferentFaultIsolationTests.cs
@@ -495,7 +495,14 @@ public sealed class ValidDifferentFaultIsolationTests
                 Overload: 0,
                 SignatureText: "",
                 ClosureRoots: new HashSet<TypeDefinitionHandle> { typeHandle },
-                ClosureFacts: new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>());
+                ClosureFacts: new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>())
+            {
+                MemberSurfaceByDefinitionName = CompileBackSourceComposer.CreateMemberSurfaceIndex(
+                    ApiSurfaceExtractor.Extract(
+                        reader,
+                        includeAll: true,
+                        includeCompilerGenerated: true)),
+            };
             var sourceIndex = ReturnToSenderSourceIndex.FromCorrelatedMembers(
                 [
                     new ReturnToSenderSourceMember(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -300,7 +300,8 @@ public static class ApiSurfaceExtractor
         MetadataReader reader,
         bool includeAll = false,
         bool typesOnly = false,
-        bool includeCompilerGenerated = false)
+        bool includeCompilerGenerated = false,
+        IOperatorTypeRelationshipResolver? operatorRelationshipResolver = null)
         => Extract(
             reader,
             includeAll
@@ -309,7 +310,8 @@ public static class ApiSurfaceExtractor
             typesOnly,
             includeCompilerGenerated,
             budget: null,
-            constraintResolution: null);
+            constraintResolution: null,
+            operatorRelationshipResolver);
 
     /// <summary>
     /// Extracts one API surface at an explicit scope.
@@ -515,7 +517,8 @@ public static class ApiSurfaceExtractor
         bool typesOnly,
         bool includeCompilerGenerated,
         ExtractionBudget? budget,
-        TypeParameterConstraintResolution? constraintResolution)
+        TypeParameterConstraintResolution? constraintResolution,
+        IOperatorTypeRelationshipResolver? operatorRelationshipResolver = null)
     {
         if (!Enum.IsDefined(scope))
             throw new ArgumentOutOfRangeException(nameof(scope));
@@ -1163,7 +1166,8 @@ public static class ApiSurfaceExtractor
                             ?? OperatorMetadata
                                 .ClassifyCSharpOperatorDeclaration(
                                     reader,
-                                    method)
+                                    method,
+                                    operatorRelationshipResolver)
                         : null;
                 bool hasOperatorPairingIdentity = isOperator
                     && (OperatorNames.RequiredOperatorSibling(methodName) is not null

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -653,6 +653,7 @@ static class ReturnToSender
             {
                 RequiresAsyncModifier = finalRequest.TargetBody.RequiresAsyncModifier,
                 RequiresUnsafeModifier = finalRequest.TargetBody.RequiresUnsafeModifier,
+                SuppressDestructorSyntax = finalRequest.TargetBody.SuppressDestructorSyntax,
             });
         return RoundTripRequest.Create(
             RoundTripArtifactIdentity.FromFile(assemblyPath, "return-to-sender"),

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -460,14 +460,13 @@ static class ReturnToSender
         using var metadata = CorpusMetadata.Create([assemblyPath]);
         using var source = MetadataSource.Open(assemblyPath, context: metadata);
         var sourceIndex = ReturnToSenderSourceIndex.TryCreate(assemblyPath);
-        var memberSurface = ApiSurfaceExtractor.Extract(
-            reader,
-            includeAll: true,
-            includeCompilerGenerated: true);
-        var memberSurfaceIndex = CompileBackSourceComposer.CreateMemberSurfaceIndex(memberSurface);
-        var memberAnchors = MemberAnchorsByMethodToken(memberSurface);
         CompilationClosure compilationClosure =
             CreateCompilationClosure(assemblyPath);
+        var memberSurface = ExtractMemberSurface(
+            reader,
+            compilationClosure);
+        var memberSurfaceIndex = CompileBackSourceComposer.CreateMemberSurfaceIndex(memberSurface);
+        var memberAnchors = MemberAnchorsByMethodToken(memberSurface);
 
         foreach (var typeHandle in reader.TypeDefinitions)
         {
@@ -768,14 +767,13 @@ static class ReturnToSender
         var reader = pe.GetMetadataReader();
         using var metadata = CorpusMetadata.Create([assemblyPath]);
         using var source = MetadataSource.Open(assemblyPath, context: metadata);
-        var memberSurface = ApiSurfaceExtractor.Extract(
-            reader,
-            includeAll: true,
-            includeCompilerGenerated: true);
-        var memberSurfaceIndex = CompileBackSourceComposer.CreateMemberSurfaceIndex(memberSurface);
-        var memberAnchors = MemberAnchorsByMethodToken(memberSurface);
         compilationClosure ??=
             CreateCompilationClosure(assemblyPath);
+        var memberSurface = ExtractMemberSurface(
+            reader,
+            compilationClosure);
+        var memberSurfaceIndex = CompileBackSourceComposer.CreateMemberSurfaceIndex(memberSurface);
+        var memberAnchors = MemberAnchorsByMethodToken(memberSurface);
         var typeHandles = reader.TypeDefinitions
             .Select(handle => (Handle: handle, Definition: reader.GetTypeDefinition(handle)))
             .Where(item => reader.GetFullTypeName(item.Definition) is { } fullName
@@ -2370,6 +2368,24 @@ static class ReturnToSender
             resolver,
             targetAssembly,
             CompilationReferences(resolver).ToArray());
+    }
+
+    static ApiSurface ExtractMemberSurface(
+        MetadataReader reader,
+        CompilationClosure compilationClosure)
+    {
+        using var metadataContext = new MetadataContext(
+            (IAssemblyReferenceResolver)compilationClosure.Resolver);
+        var typeResolver = new CrossAssemblyTypeResolver(
+            reader,
+            compilationClosure.TargetAssembly,
+            metadataContext);
+        return ApiSurfaceExtractor.Extract(
+            reader,
+            includeAll: true,
+            includeCompilerGenerated: true,
+            operatorRelationshipResolver:
+                typeResolver.CreateOperatorRelationshipResolver());
     }
 
     static IEnumerable<MetadataReference> CompilationReferences(

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -460,7 +460,12 @@ static class ReturnToSender
         using var metadata = CorpusMetadata.Create([assemblyPath]);
         using var source = MetadataSource.Open(assemblyPath, context: metadata);
         var sourceIndex = ReturnToSenderSourceIndex.TryCreate(assemblyPath);
-        var memberAnchors = MemberAnchorsByMethodToken(pe);
+        var memberSurface = ApiSurfaceExtractor.Extract(
+            reader,
+            includeAll: true,
+            includeCompilerGenerated: true);
+        var memberSurfaceIndex = CompileBackSourceComposer.CreateMemberSurfaceIndex(memberSurface);
+        var memberAnchors = MemberAnchorsByMethodToken(memberSurface);
         CompilationClosure compilationClosure =
             CreateCompilationClosure(assemblyPath);
 
@@ -514,7 +519,8 @@ static class ReturnToSender
                     propertyHandle,
                     accessors.Getter,
                     MemberAnchorFor(memberAnchors, accessors.Getter),
-                    sourceIndex));
+                    sourceIndex,
+                    memberSurfaceIndex));
                 if (results.Count >= maxTargets)
                     return applyCompileBackFloor ? ApplyCompileBackFloor(assemblyPath, results) : results;
             }
@@ -761,28 +767,67 @@ static class ReturnToSender
         var reader = pe.GetMetadataReader();
         using var metadata = CorpusMetadata.Create([assemblyPath]);
         using var source = MetadataSource.Open(assemblyPath, context: metadata);
-        var memberAnchors = MemberAnchorsByMethodToken(pe);
+        var memberSurface = ApiSurfaceExtractor.Extract(
+            reader,
+            includeAll: true,
+            includeCompilerGenerated: true);
+        var memberSurfaceIndex = CompileBackSourceComposer.CreateMemberSurfaceIndex(memberSurface);
+        var memberAnchors = MemberAnchorsByMethodToken(memberSurface);
         compilationClosure ??=
             CreateCompilationClosure(assemblyPath);
         var typeHandles = reader.TypeDefinitions
             .Select(handle => (Handle: handle, Definition: reader.GetTypeDefinition(handle)))
             .Where(item => reader.GetFullTypeName(item.Definition) is { } fullName
                 && fullName.Length != 0)
-            .ToDictionary(item => reader.GetFullTypeName(item.Definition), item => item.Handle, StringComparer.Ordinal);
+            .GroupBy(
+                item => reader.GetFullTypeName(item.Definition),
+                StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(item => item.Handle).ToArray(),
+                StringComparer.Ordinal);
 
         foreach (var target in targets)
         {
-            if (!typeHandles.TryGetValue(target.Type, out var typeHandle))
+            if (!typeHandles.TryGetValue(target.Type, out var candidates))
                 continue;
 
-            var typeDef = reader.GetTypeDefinition(typeHandle);
-            string typeName = reader.GetString(typeDef.Name);
-            if (typeName == "<Module>"
-                || typeName.Contains('<', StringComparison.Ordinal)
-                || !IsSupportedTargetType(source, typeHandle))
+            var matchingTypes = candidates
+                .Where(handle =>
+                {
+                    var definition = reader.GetTypeDefinition(handle);
+                    string name = reader.GetString(definition.Name);
+                    return name != "<Module>"
+                        && !name.Contains('<', StringComparison.Ordinal)
+                        && IsSupportedTargetType(source, handle);
+                })
+                .Where(handle => TryFindMethod(
+                    reader,
+                    reader.GetTypeDefinition(handle),
+                    target) is not null)
+                .ToArray();
+            if (matchingTypes.Length > 1 && target.Signature is { } signature)
             {
-                continue;
+                var exactSignatureMatches = matchingTypes
+                    .Where(handle => TryFindMethodBySignature(
+                        reader,
+                        reader.GetTypeDefinition(handle),
+                        target.Method,
+                        signature) is not null)
+                    .ToArray();
+                if (exactSignatureMatches.Length != 0)
+                    matchingTypes = exactSignatureMatches;
             }
+            if (matchingTypes.Length > 1)
+            {
+                throw new AmbiguousMatchException(
+                    $"Target '{target.Type}.{target.Method}' is ambiguous across {matchingTypes.Length} metadata types.");
+            }
+            if (matchingTypes.Length == 0)
+                continue;
+
+            var typeHandle = matchingTypes[0];
+            var typeDef = reader.GetTypeDefinition(typeHandle);
 
             if (TryFindPropertyGetter(reader, typeDef, target) is { } propertyTarget)
             {
@@ -797,6 +842,7 @@ static class ReturnToSender
                     propertyTarget.Getter,
                     MemberAnchorFor(memberAnchors, propertyTarget.Getter),
                     sourceIndex,
+                    memberSurfaceIndex,
                     scope,
                     bodyPolicy));
                 continue;
@@ -815,6 +861,7 @@ static class ReturnToSender
                     setterTarget.Setter,
                     MemberAnchorFor(memberAnchors, setterTarget.Setter),
                     sourceIndex,
+                    memberSurfaceIndex,
                     scope,
                     bodyPolicy));
                 continue;
@@ -833,6 +880,7 @@ static class ReturnToSender
                     eventTarget.Accessor,
                     MemberAnchorFor(memberAnchors, eventTarget.Accessor),
                     sourceIndex,
+                    memberSurfaceIndex,
                     scope,
                     bodyPolicy));
                 continue;
@@ -850,6 +898,7 @@ static class ReturnToSender
                     methodHandle,
                     MemberAnchorFor(memberAnchors, methodHandle),
                     sourceIndex,
+                    memberSurfaceIndex,
                     scope,
                     bodyPolicy));
             }
@@ -1227,12 +1276,26 @@ static class ReturnToSender
         MethodDefinitionHandle getterHandle,
         MemberAnchor? memberAnchor,
         ReturnToSenderSourceIndex? sourceIndex,
+        CompileBackMemberSurfaceIndex memberSurface,
         RoundTripScope scope = RoundTripScope.Cluster,
         RoundTripBodyPolicy bodyPolicy = RoundTripBodyPolicy.Selected)
     {
         try
         {
-            return CompileBackPropertyGetter(assemblyPath, compilationClosure, pe, reader, source, typeHandle, propertyHandle, getterHandle, memberAnchor, sourceIndex, scope, bodyPolicy);
+            return CompileBackPropertyGetter(
+                assemblyPath,
+                compilationClosure,
+                pe,
+                reader,
+                source,
+                typeHandle,
+                propertyHandle,
+                getterHandle,
+                memberAnchor,
+                sourceIndex,
+                memberSurface,
+                scope,
+                bodyPolicy);
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
@@ -1250,12 +1313,25 @@ static class ReturnToSender
         MethodDefinitionHandle methodHandle,
         MemberAnchor? memberAnchor,
         ReturnToSenderSourceIndex? sourceIndex,
+        CompileBackMemberSurfaceIndex memberSurface,
         RoundTripScope scope = RoundTripScope.Cluster,
         RoundTripBodyPolicy bodyPolicy = RoundTripBodyPolicy.Selected)
     {
         try
         {
-            return CompileBackMethod(assemblyPath, compilationClosure, pe, reader, source, typeHandle, methodHandle, memberAnchor, sourceIndex, scope, bodyPolicy);
+            return CompileBackMethod(
+                assemblyPath,
+                compilationClosure,
+                pe,
+                reader,
+                source,
+                typeHandle,
+                methodHandle,
+                memberAnchor,
+                sourceIndex,
+                memberSurface,
+                scope,
+                bodyPolicy);
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
@@ -1274,6 +1350,7 @@ static class ReturnToSender
         MethodDefinitionHandle accessorHandle,
         MemberAnchor? memberAnchor,
         ReturnToSenderSourceIndex? sourceIndex,
+        CompileBackMemberSurfaceIndex memberSurface,
         RoundTripScope scope = RoundTripScope.Cluster,
         RoundTripBodyPolicy bodyPolicy = RoundTripBodyPolicy.Selected)
     {
@@ -1290,6 +1367,7 @@ static class ReturnToSender
                 accessorHandle,
                 memberAnchor,
                 sourceIndex,
+                memberSurface,
                 scope,
                 bodyPolicy);
         }
@@ -1316,12 +1394,26 @@ static class ReturnToSender
         MethodDefinitionHandle setterHandle,
         MemberAnchor? memberAnchor,
         ReturnToSenderSourceIndex? sourceIndex,
+        CompileBackMemberSurfaceIndex memberSurface,
         RoundTripScope scope = RoundTripScope.Cluster,
         RoundTripBodyPolicy bodyPolicy = RoundTripBodyPolicy.Selected)
     {
         try
         {
-            return CompileBackPropertySetter(assemblyPath, compilationClosure, pe, reader, source, typeHandle, propertyHandle, setterHandle, memberAnchor, sourceIndex, scope, bodyPolicy);
+            return CompileBackPropertySetter(
+                assemblyPath,
+                compilationClosure,
+                pe,
+                reader,
+                source,
+                typeHandle,
+                propertyHandle,
+                setterHandle,
+                memberAnchor,
+                sourceIndex,
+                memberSurface,
+                scope,
+                bodyPolicy);
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
@@ -1340,6 +1432,7 @@ static class ReturnToSender
         MethodDefinitionHandle getterHandle,
         MemberAnchor? memberAnchor,
         ReturnToSenderSourceIndex? sourceIndex,
+        CompileBackMemberSurfaceIndex memberSurface,
         RoundTripScope scope,
         RoundTripBodyPolicy bodyPolicy)
     {
@@ -1387,6 +1480,7 @@ static class ReturnToSender
             {
                 BodyPolicy = bodyPolicy,
                 BodySource = source,
+                MemberSurfaceByDefinitionName = memberSurface,
             },
             scope: scope,
             bodyPolicy: bodyPolicy);
@@ -1402,6 +1496,7 @@ static class ReturnToSender
         MethodDefinitionHandle methodHandle,
         MemberAnchor? memberAnchor,
         ReturnToSenderSourceIndex? sourceIndex,
+        CompileBackMemberSurfaceIndex memberSurface,
         RoundTripScope scope,
         RoundTripBodyPolicy bodyPolicy)
     {
@@ -1448,6 +1543,7 @@ static class ReturnToSender
             {
                 BodyPolicy = bodyPolicy,
                 BodySource = source,
+                MemberSurfaceByDefinitionName = memberSurface,
             },
             scope: scope,
             bodyPolicy: bodyPolicy);
@@ -1464,6 +1560,7 @@ static class ReturnToSender
         MethodDefinitionHandle accessorHandle,
         MemberAnchor? memberAnchor,
         ReturnToSenderSourceIndex? sourceIndex,
+        CompileBackMemberSurfaceIndex memberSurface,
         RoundTripScope scope,
         RoundTripBodyPolicy bodyPolicy)
     {
@@ -1543,6 +1640,7 @@ static class ReturnToSender
             {
                 BodyPolicy = bodyPolicy,
                 BodySource = source,
+                MemberSurfaceByDefinitionName = memberSurface,
             },
             siblingMethodName is not null && siblingOriginalOps is not null
                 ? (siblingMethodName, siblingOriginalOps)
@@ -1562,6 +1660,7 @@ static class ReturnToSender
         MethodDefinitionHandle setterHandle,
         MemberAnchor? memberAnchor,
         ReturnToSenderSourceIndex? sourceIndex,
+        CompileBackMemberSurfaceIndex memberSurface,
         RoundTripScope scope,
         RoundTripBodyPolicy bodyPolicy)
     {
@@ -1609,6 +1708,7 @@ static class ReturnToSender
             {
                 BodyPolicy = bodyPolicy,
                 BodySource = source,
+                MemberSurfaceByDefinitionName = memberSurface,
             },
             scope: scope,
             bodyPolicy: bodyPolicy);
@@ -2007,8 +2107,10 @@ static class ReturnToSender
     }
 
     static IReadOnlyDictionary<int, MemberAnchor> MemberAnchorsByMethodToken(PEReader pe)
+        => MemberAnchorsByMethodToken(ApiSurfaceExtractor.Extract(pe, includeAll: true));
+
+    static IReadOnlyDictionary<int, MemberAnchor> MemberAnchorsByMethodToken(ApiSurface surface)
     {
-        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: true);
         var result = new Dictionary<int, MemberAnchor>();
         foreach (var type in surface.Types)
         {

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1776,25 +1776,6 @@ static class ReturnToSender
         }
 
         var firstArtifact = Compose();
-        if (firstArtifact.Plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } initialIdentityDiagnostic)
-        {
-            return new Result(
-                firstArtifact.Plan,
-                firstArtifact.Source,
-                FidelityCheck.CompileBackStatus.ContextFail,
-                originalOpcodes,
-                "",
-                $"{initialIdentityDiagnostic.Reason}: {initialIdentityDiagnostic.Detail}",
-                TargetBody: targetBody.Source,
-                MemberAnchor: memberAnchor,
-                Decisions: targetBody.Decisions)
-            {
-                FinalRequest = firstArtifact.Request,
-                BodyPolicy = bodyPolicy,
-                FullBodies = firstArtifact.FullBodies,
-            };
-        }
-
         bool firstArtifactPending = true;
         CompileBackPlanningDiagnostic? identityFailure = null;
         var compilationResult = RoundTripCompilationEngine.Compile(
@@ -1813,12 +1794,6 @@ static class ReturnToSender
             compileOptions,
             grow: (artifact, errors, semanticModel) =>
             {
-                if (artifact.Plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identity)
-                {
-                    identityFailure = identity;
-                    return RoundTripGrowthResult.Stop("type-identity");
-                }
-
                 var growth = AddClosureRoots(
                     errors,
                     semanticModel,
@@ -1828,16 +1803,22 @@ static class ReturnToSender
                     closureRoots,
                     closureFacts);
                 int effectiveRootCount = EffectiveClosureRootCount(artifact, closureRoots);
-                string? reason = effectiveRootCount > maxRoots
-                    ? "closure-root-budget"
-                    : !growth.Grew
-                        ? ClosureDiagnosticEvidence.FailureReason(
+                if (effectiveRootCount > maxRoots)
+                    return RoundTripGrowthResult.Stop("closure-root-budget");
+                if (growth.Grew)
+                    return RoundTripGrowthResult.Continue;
+
+                if (artifact.Plan.Diagnostics.FirstOrDefault(
+                        diagnostic => diagnostic.Layer == "type identity") is { } identity)
+                {
+                    identityFailure = identity;
+                    return RoundTripGrowthResult.Stop("type-identity");
+                }
+
+                return RoundTripGrowthResult.Stop(
+                    ClosureDiagnosticEvidence.FailureReason(
                         "closure-stalled",
-                            growth.UnextractedDiagnosticIds)
-                        : null;
-                return reason is null
-                    ? RoundTripGrowthResult.Continue
-                    : RoundTripGrowthResult.Stop(reason);
+                        growth.UnextractedDiagnosticIds));
             },
             new RoundTripCompilationOptions
             {

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1850,6 +1850,28 @@ static class ReturnToSender
         var sourceResult = compilationResult.Artifact;
         var plan = sourceResult.Plan;
         string unit = sourceResult.Source;
+        if (compilationResult.Succeeded
+            && compilationResult.PeImage is not null
+            && plan.Diagnostics.FirstOrDefault(
+                diagnostic => diagnostic.Layer == "type identity") is { } finalIdentityDiagnostic)
+        {
+            return new Result(
+                plan,
+                unit,
+                FidelityCheck.CompileBackStatus.ContextFail,
+                originalOpcodes,
+                "",
+                $"{finalIdentityDiagnostic.Reason}: {finalIdentityDiagnostic.Detail}",
+                TargetBody: targetBody.Source,
+                MemberAnchor: memberAnchor,
+                Decisions: targetBody.Decisions)
+            {
+                FinalRequest = sourceResult.Request,
+                Compilation = compilationResult.Provenance,
+                BodyPolicy = bodyPolicy,
+                FullBodies = sourceResult.FullBodies,
+            };
+        }
         if (!compilationResult.Succeeded || compilationResult.PeImage is null)
         {
             if (identityFailure is { } identityDiagnostic)

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -402,6 +402,7 @@ public sealed record CompileBackTypeRequirement(
     public CompileBackTypeKind Kind => RequiredKind;
     public IReadOnlyList<CompileBackMemberRequirement> Members => RequiredMembers;
     public bool IncludeMemberSurface { get; init; }
+    public bool IncludeOperatorSurface { get; init; }
     public IReadOnlyList<string> ExternalInterfaces { get; init; } = [];
 }
 
@@ -463,7 +464,11 @@ internal sealed record ExplicitInterfaceEventInfo(
 internal sealed record ExternalExplicitInterfaceMethodInfo(
     string InterfaceDisplayName,
     string ExplicitInterfaceMemberName,
-    IReadOnlyList<CompileBackMemberRequirement> AdditionalInterfaceStubs);
+    IReadOnlyList<ExternalInterfaceMemberRequirement> AdditionalInterfaceMembers);
+
+internal sealed record ExternalInterfaceMemberRequirement(
+    TypeDefinitionHandle DeclaringType,
+    CompileBackMemberRequirement Member);
 
 internal sealed record ExternalInterfaceReferenceInfo(
     string MetadataFullName,
@@ -1679,13 +1684,13 @@ public static class CompileBackSourceComposer
 
             // Naming the interface in the base list forces the reconstructed type to satisfy
             // its ENTIRE required surface (CS0535). The target method reconstructs the matched
-            // member with its real body; every OTHER required member is synthesized here as a
-            // `throw null` explicit-interface stub. If any such member cannot be spelled as
-            // valid, bindable C# (a member name that does not round-trip, or a signature type
-            // SignatureDecoder renders unbindably), decline the WHOLE engagement and keep the
-            // sanitized ContextFail floor rather than emit a partial surface (CS0535) or an
-            // unbindable stub (CS0246 = RecompileFail).
-            var additionalInterfaceStubs = new List<CompileBackMemberRequirement>(requiredMethods.Count - 1);
+            // member with its real body. Preserve a matching local or inherited public
+            // implementation when one exists; otherwise synthesize a `throw null`
+            // explicit-interface stub. If any member cannot be spelled as valid, bindable C#,
+            // decline the whole engagement rather than emit a partial surface.
+            var additionalInterfaceMembers = new List<ExternalInterfaceMemberRequirement>(
+                requiredMethods.Count - 1);
+            var targetTypeHandle = targetMethodDefinition.GetDeclaringType();
             for (int index = 0; index < requiredMethods.Count; index++)
             {
                 if (index == matchIndex)
@@ -1695,9 +1700,9 @@ public static class CompileBackSourceComposer
                     return null;
                 var implicitImplementation = FindImplicitInterfaceMethod(
                     reader,
-                    targetMethodDefinition.GetDeclaringType(),
+                    targetTypeHandle,
                     requiredMethod);
-                var stub = implicitImplementation.IsNil
+                var member = implicitImplementation.IsNil
                     ? SynthesizeExternalInterfaceStub(
                         interfaceReference.DisplayFullName,
                         requiredMethod)
@@ -1705,9 +1710,13 @@ public static class CompileBackSourceComposer
                         reader,
                         targetMethodDefinition.GetDeclaringType(),
                         implicitImplementation);
-                if (stub is null)
+                if (member is null)
                     return null;
-                additionalInterfaceStubs.Add(stub);
+                additionalInterfaceMembers.Add(new ExternalInterfaceMemberRequirement(
+                    implicitImplementation.IsNil
+                        ? targetTypeHandle
+                        : reader.GetMethodDefinition(implicitImplementation).GetDeclaringType(),
+                    member));
             }
 
             string explicitInterfaceMemberName =
@@ -1715,7 +1724,7 @@ public static class CompileBackSourceComposer
             return new ExternalExplicitInterfaceMethodInfo(
                 interfaceReference.DisplayFullName,
                 explicitInterfaceMemberName,
-                additionalInterfaceStubs);
+                additionalInterfaceMembers);
         }
 
         return null;
@@ -1726,47 +1735,59 @@ public static class CompileBackSourceComposer
         TypeDefinitionHandle targetType,
         ExternalInterfaceRequiredMethod requiredMethod)
     {
-        MethodDefinitionHandle match = default;
-        foreach (var methodHandle in reader.GetTypeDefinition(targetType).GetMethods())
+        TypeDefinitionHandle currentType = targetType;
+        while (!currentType.IsNil)
         {
-            var method = reader.GetMethodDefinition(methodHandle);
-            if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
-                || method.Attributes.HasFlag(MethodAttributes.Static)
-                || reader.GetString(method.Name) != requiredMethod.Name
-                || method.GetGenericParameters().Count != requiredMethod.GenericArity
-                || SignatureHasUnrepresentableDetail(reader, method))
+            MethodDefinitionHandle match = default;
+            foreach (var methodHandle in reader.GetTypeDefinition(currentType).GetMethods())
             {
-                continue;
+                var method = reader.GetMethodDefinition(methodHandle);
+                if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
+                    || method.Attributes.HasFlag(MethodAttributes.Static)
+                    || reader.GetString(method.Name) != requiredMethod.Name
+                    || method.GetGenericParameters().Count != requiredMethod.GenericArity
+                    || SignatureHasUnrepresentableDetail(reader, method))
+                {
+                    continue;
+                }
+
+                MethodSignature<string> signature;
+                try
+                {
+                    signature = method.DecodeSignature(
+                        SignatureDecoder.Instance,
+                        GenericContext.ForMethod(
+                            reader,
+                            reader.GetTypeDefinition(currentType),
+                            method));
+                }
+                catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+                {
+                    continue;
+                }
+
+                if (signature.ReturnType != requiredMethod.ReturnType
+                    || !signature.ParameterTypes.SequenceEqual(
+                        requiredMethod.ParameterTypes,
+                        StringComparer.Ordinal))
+                {
+                    continue;
+                }
+                if (!match.IsNil)
+                    return default;
+                match = methodHandle;
             }
 
-            MethodSignature<string> signature;
-            try
-            {
-                signature = method.DecodeSignature(
-                    SignatureDecoder.Instance,
-                    GenericContext.ForMethod(
-                        reader,
-                        reader.GetTypeDefinition(targetType),
-                        method));
-            }
-            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
-            {
-                continue;
-            }
-
-            if (signature.ReturnType != requiredMethod.ReturnType
-                || !signature.ParameterTypes.SequenceEqual(
-                    requiredMethod.ParameterTypes,
-                    StringComparer.Ordinal))
-            {
-                continue;
-            }
             if (!match.IsNil)
-                return default;
-            match = methodHandle;
+                return match;
+
+            var baseType = reader.GetTypeDefinition(currentType).BaseType;
+            currentType = baseType.Kind == HandleKind.TypeDefinition
+                ? (TypeDefinitionHandle)baseType
+                : default;
         }
 
-        return match;
+        return default;
     }
 
     static CompileBackMemberRequirement? ImplicitInterfaceMethodRequirement(
@@ -3120,16 +3141,16 @@ public static class CompileBackSourceComposer
                 MetadataToken: MetadataTokens.GetToken(targetMethod),
                 SuppressDestructorSyntax: suppressDestructorSyntax)
         ];
-        if (externalExplicitInterfaceMethod is { AdditionalInterfaceStubs.Count: > 0 })
+        if (externalExplicitInterfaceMethod is { AdditionalInterfaceMembers.Count: > 0 })
         {
             // Naming a multi-member external interface in the base list requires the
-            // reconstructed type to implement its full required surface (CS0535). Supply every
-            // non-target member as a `throw null` explicit-interface stub. The gate excluded the
-            // matched target member from these stubs, so none duplicates the target's own
-            // explicit implementation (CS0111), and external interface members are never closure
-            // members (they live outside the target assembly), so none collides with the record
-            // or closure surface added below.
-            targetMembers.AddRange(externalExplicitInterfaceMethod.AdditionalInterfaceStubs);
+            // reconstructed type to implement its full required surface (CS0535). Add direct
+            // implementations here; inherited implementations are attached to their declaring
+            // base requirement after the closure types have been collected.
+            targetMembers.AddRange(
+                externalExplicitInterfaceMethod.AdditionalInterfaceMembers
+                    .Where(requirement => requirement.DeclaringType == targetType)
+                    .Select(requirement => requirement.Member));
         }
         bool includeRecordSurface = false;
         if (!isConstructor && IsRecordGeneratedFieldReadHelper(reader, targetTypeDef, targetIdentity, methodName, signature, function))
@@ -3220,8 +3241,8 @@ public static class CompileBackSourceComposer
                 targetFacts)
             {
                 IncludeMemberSurface = includeRecordSurface
-                    || targetOperatorIsRepresentable
                     || targetFacts.Any(fact => fact.Id == "closure-member"),
+                IncludeOperatorSurface = targetOperatorIsRepresentable,
                 ExternalInterfaces = externalExplicitInterfaceMethod is null
                     ? []
                     : [externalExplicitInterfaceMethod.InterfaceDisplayName],
@@ -3236,6 +3257,12 @@ public static class CompileBackSourceComposer
 
             AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
         }
+        AddInheritedInterfaceMemberRequirements(
+            requirements,
+            reader,
+            targetType,
+            externalExplicitInterfaceMethod,
+            closureFacts);
 
         if (explicitInterfaceMemberName is not null)
         {
@@ -3290,6 +3317,55 @@ public static class CompileBackSourceComposer
             declarations,
             diagnostics);
         return ComposeCompilationUnit(plan);
+    }
+
+    static void AddInheritedInterfaceMemberRequirements(
+        List<CompileBackTypeRequirement> requirements,
+        MetadataReader reader,
+        TypeDefinitionHandle targetType,
+        ExternalExplicitInterfaceMethodInfo? externalInterface,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
+    {
+        if (externalInterface is null)
+            return;
+
+        foreach (var inherited in externalInterface.AdditionalInterfaceMembers.Where(
+            requirement => requirement.DeclaringType != targetType))
+        {
+            var typeDef = reader.GetTypeDefinition(inherited.DeclaringType);
+            var identity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
+            int requirementIndex = requirements.FindIndex(
+                requirement => requirement.Type == identity);
+            if (requirementIndex < 0)
+            {
+                var facts = closureFacts.TryGetValue(inherited.DeclaringType, out var foundFacts)
+                    ? foundFacts
+                    : [new CompileBackFact(
+                        "metadata",
+                        "inherited-interface-implementation",
+                        identity.FullName)];
+                requirements.Add(new CompileBackTypeRequirement(
+                    identity,
+                    ShellKind(reader, typeDef, facts),
+                    [inherited.Member],
+                    PrimaryConstructor: null,
+                    facts));
+                continue;
+            }
+
+            var requirement = requirements[requirementIndex];
+            if (requirement.RequiredMembers.Any(member =>
+                SameMemberDeclaration(member, inherited.Member)))
+            {
+                continue;
+            }
+            requirements[requirementIndex] = requirement with
+            {
+                RequiredMembers = requirement.RequiredMembers
+                    .Append(inherited.Member)
+                    .ToArray(),
+            };
+        }
     }
 
     static CompileBackSourceResult ComposeCompilationUnit(CompileBackReconstructionPlan plan)
@@ -4957,8 +5033,12 @@ public static class CompileBackSourceComposer
                 isConstructor ? null : methodDeclaration?.Signature.ReturnAttributes,
                 IsAbstract: !isConstructor && IsAbstractMethod(method),
                 IsVirtual: !isConstructor && IsVirtualMethod(method),
-                IsOverride: false,
-                IsSealed: false,
+                IsOverride: !isConstructor
+                    && !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && methodDeclaration?.IsOverride == true,
+                IsSealed: !isConstructor
+                    && !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && methodDeclaration?.IsSealed == true,
                 IsExtension: IsExtensionMethod(reader, typeDef, method),
                 IsOperator: operatorIsRepresentable,
                 MetadataToken: MetadataTokens.GetToken(methodHandle));
@@ -5012,7 +5092,9 @@ public static class CompileBackSourceComposer
                     fact.Detail));
             }
             bool includeMemberSurface = requirement.IncludeMemberSurface;
-            if (includeMemberSurface && kind != CompileBackTypeKind.Delegate)
+            bool includeOperatorSurface = requirement.IncludeOperatorSurface;
+            if ((includeMemberSurface || includeOperatorSurface)
+                && kind != CompileBackTypeKind.Delegate)
             {
                 if (surfaceByDefinitionName.TryGetValue(
                         DefinitionName(reader, handle),
@@ -5025,7 +5107,8 @@ public static class CompileBackSourceComposer
                         surface,
                         members,
                         diagnostics,
-                        relationshipResolver);
+                        relationshipResolver,
+                        operatorOnly: !includeMemberSurface);
                 }
                 else
                 {
@@ -5044,6 +5127,15 @@ public static class CompileBackSourceComposer
                     members,
                     relationshipResolver);
             }
+            bool isReconstructedBase = kind == CompileBackTypeKind.Class
+                && IsReconstructedBaseOfAnotherType(
+                    reader,
+                    requirement,
+                    requirementsByIdentity,
+                    typeDefinitions);
+            if (isReconstructedBase)
+                RepairAbstractBaseMembers(members, requirement.Type, diagnostics);
+
             // When this class is reconstructed as the base of another shell type, a
             // derived stub constructor emits an implicit `: base()`. If the class has
             // only parameterized constructors (no accessible parameterless one), that
@@ -5053,11 +5145,7 @@ public static class CompileBackSourceComposer
             if (kind == CompileBackTypeKind.Class
                 && members.Any(member => member.Kind == CompileBackMemberKind.Constructor)
                 && !members.Any(member => member.Kind == CompileBackMemberKind.Constructor && member.Parameters.Count == 0)
-                && IsReconstructedBaseOfAnotherType(
-                    reader,
-                    requirement,
-                    requirementsByIdentity,
-                    typeDefinitions))
+                && isReconstructedBase)
             {
                 members.Add(SyntheticParameterlessConstructor(requirement.Type));
             }
@@ -5524,6 +5612,40 @@ public static class CompileBackSourceComposer
                 TargetBody: null,
                 [new CompileBackFact("synthetic", "base-parameterless-constructor", typeIdentity.MetadataFullName)]);
 
+        static void RepairAbstractBaseMembers(
+            List<CompileBackMemberRequirement> members,
+            CompileBackTypeIdentity typeIdentity,
+            List<CompileBackPlanningDiagnostic> diagnostics)
+        {
+            for (int index = 0; index < members.Count; index++)
+            {
+                var member = members[index];
+                if (member.Kind != CompileBackMemberKind.Method
+                    || !member.IsAbstract
+                    || member.StubBody != CompileBackStubBodyKind.None)
+                {
+                    continue;
+                }
+
+                members[index] = member with
+                {
+                    StubBody = CompileBackStubBodyKind.Throw,
+                    IsAbstract = false,
+                    IsVirtual = !member.IsOverride,
+                    SourceFacts = member.SourceFacts
+                        .Append(new CompileBackFact(
+                            "synthetic",
+                            "abstract-base-member-body",
+                            member.Identity.Signature))
+                        .ToArray(),
+                };
+                diagnostics.Add(new CompileBackPlanningDiagnostic(
+                    "member surface",
+                    "abstract-base-member-stubbed",
+                    $"{typeIdentity.MetadataFullName}::{member.Identity.Signature}"));
+            }
+        }
+
         static IReadOnlyList<CompileBackTypeSignature> InterfaceSignatures(
             MetadataReader reader,
             TypeDefinition typeDef,
@@ -5572,7 +5694,8 @@ public static class CompileBackSourceComposer
             List<CompileBackMemberRequirement> members,
             List<CompileBackPlanningDiagnostic> diagnostics,
             IOperatorTypeRelationshipResolver? relationshipResolver,
-            bool allowUnsafeSurface = false)
+            bool allowUnsafeSurface = false,
+            bool operatorOnly = false)
         {
             if (requirement.RequiredKind == CompileBackTypeKind.Enum)
             {
@@ -5611,7 +5734,8 @@ public static class CompileBackSourceComposer
 
             allowUnsafeSurface = allowUnsafeSurface
                 || requirement.RequiredMembers.Count != 0
-                || requirement.IncludeMemberSurface;
+                || requirement.IncludeMemberSurface
+                || requirement.IncludeOperatorSurface;
             var surfaceAccessorTokens = surface.Members
                 .SelectMany(member => new[]
                 {
@@ -5627,7 +5751,8 @@ public static class CompileBackSourceComposer
             // Product surface extraction owns member discovery, accessor ownership,
             // and backing-field exclusion. RTS retains only reconstruction policy:
             // representability, unsafe gating, deduplication, and stub/full bodies.
-            foreach (var surfaceField in surface.Members.Where(member => member.Kind == "field"))
+            foreach (var surfaceField in surface.Members.Where(member =>
+                !operatorOnly && member.Kind == "field"))
             {
                 if (FindField(reader, typeDef, surfaceField.Name) is not { } fieldHandle)
                 {
@@ -5676,7 +5801,8 @@ public static class CompileBackSourceComposer
                     DeclarationSignature: fixedBufferSignature));
             }
 
-            foreach (var surfaceProperty in surface.Members.Where(member => member.Kind == "property"))
+            foreach (var surfaceProperty in surface.Members.Where(member =>
+                !operatorOnly && member.Kind == "property"))
             {
                 var propertyHandle = PropertyForAccessor(
                     reader,
@@ -5814,7 +5940,8 @@ public static class CompileBackSourceComposer
                     MetadataName: propertyName));
             }
 
-            foreach (var surfaceEvent in surface.Members.Where(member => member.Kind == "event"))
+            foreach (var surfaceEvent in surface.Members.Where(member =>
+                !operatorOnly && member.Kind == "event"))
             {
                 var eventHandle = EventForAccessor(
                     reader,
@@ -5878,7 +6005,8 @@ public static class CompileBackSourceComposer
             foreach (var surfaceMethod in surface.Members.Where(member =>
                 member.MetadataToken is not null
                 && !surfaceAccessorTokens.Contains(member.MetadataToken.Value)
-                && member.Kind != "extension-method"))
+                && member.Kind != "extension-method"
+                && (!operatorOnly || member.CSharpOperatorDeclaration == true)))
             {
                 var methodHandle = SurfaceMethodHandle(surfaceMethod.MetadataToken);
                 if (methodHandle.IsNil)
@@ -6041,8 +6169,12 @@ public static class CompileBackSourceComposer
                     isConstructor ? null : methodDeclaration?.Signature.ReturnAttributes,
                     IsAbstract: !isConstructor && IsAbstractMethod(method),
                     IsVirtual: !isConstructor && IsVirtualMethod(method),
-                    IsOverride: false,
-                    IsSealed: false,
+                    IsOverride: !isConstructor
+                        && !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                        && methodDeclaration?.IsOverride == true,
+                    IsSealed: !isConstructor
+                        && !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                        && methodDeclaration?.IsSealed == true,
                     IsExtension: surfaceMethod.IsExtension,
                     IsOperator: methodIsOperator,
                     IsFinalizer: surfaceMethod.IsFinalizer,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -856,19 +856,6 @@ public static class CompileBackSourceComposer
             method,
             relationshipResolver);
 
-    static CompileBackMemberRequirement? TryCreateRequiredOperatorSibling(
-        MetadataReader reader,
-        TypeDefinitionHandle typeHandle,
-        MethodRef method,
-        MethodDefinitionHandle excludedMethod,
-        IOperatorTypeRelationshipResolver? relationshipResolver)
-        => TypeProducer.TryCreateRequiredOperatorSibling(
-            reader,
-            typeHandle,
-            method,
-            excludedMethod,
-            relationshipResolver);
-
     public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
         MetadataReader reader,
         TypeDefinitionHandle typeHandle,
@@ -1030,20 +1017,6 @@ public static class CompileBackSourceComposer
         void AddMethodFact(MethodRef method, bool allowTargetRoot = false)
         {
             AddSingleMethodFact(method, allowTargetRoot);
-            if (method.IsOperator == MetadataFactState.Yes
-                && OperatorNames.RequiredOperatorSibling(method.Name) is { } siblingName)
-            {
-                AddMemberFact(method.DeclaringType, "method", siblingName);
-                AddMemberRequirement(
-                    method.DeclaringType,
-                    root => TryCreateRequiredOperatorSibling(
-                        reader,
-                        root,
-                        method,
-                        targetMethod,
-                        relationshipResolver),
-                    allowTargetRoot);
-            }
         }
 
         void AddSingleMethodFact(MethodRef method, bool allowTargetRoot)
@@ -1371,13 +1344,16 @@ public static class CompileBackSourceComposer
             if (requirements.Any(requirement => requirement.Type == identity))
                 return;
             var facts = closureFacts.TryGetValue(handle, out var foundFacts) ? foundFacts : [];
+            var requiredMembers = closureMemberRequirements.TryGetValue(
+                handle,
+                out var foundMembers)
+                ? foundMembers.ToArray()
+                : [];
 
             var requirement = new CompileBackTypeRequirement(
                 identity,
                 ShellKind(reader, typeDef, facts),
-                RequiredMembers: closureMemberRequirements.TryGetValue(handle, out var requiredMembers)
-                    ? requiredMembers.ToArray()
-                    : [],
+                RequiredMembers: requiredMembers,
                 PrimaryConstructor: null,
                 SourceFacts: facts.Count != 0
                     ? facts.ToArray()
@@ -1385,7 +1361,8 @@ public static class CompileBackSourceComposer
                         ? [new CompileBackFact("closure", "closure-root", identity.FullName)]
                         : [new CompileBackFact("metadata", "nested-closure-member-owner", identity.FullName)])
             {
-                IncludeMemberSurface = facts.Any(fact => fact.Id == "closure-member")
+                IncludeMemberSurface = requiredMembers.Any(member => member.IsOperator)
+                    || facts.Any(fact => fact.Id == "closure-member")
             };
             requirements.Add(requirement);
         }
@@ -2972,15 +2949,12 @@ public static class CompileBackSourceComposer
             : CompileBackTypeSignature.Display(MethodReturnType(reader, targetTypeDef, method));
         var targetParameters = MethodParameters(reader, method, signature);
         var targetTypeParameters = MethodTypeParameters(reader, method);
+        CompileBackMemberKind targetMemberKind =
+            MethodKind(reader, method, isConstructor, operatorResolver);
         bool targetHasOperatorIdentity = !isConstructor
             && IsMetadataOperator(reader, method);
-        bool targetOperatorIsRepresentable = targetHasOperatorIdentity
-            && IsRepresentableOperator(
-                reader,
-                targetTypeDef,
-                method,
-                methodName,
-                signature);
+        bool targetOperatorIsRepresentable =
+            targetMemberKind == CompileBackMemberKind.Operator;
         if (targetHasOperatorIdentity && !targetOperatorIsRepresentable)
         {
             diagnostics.Add(new CompileBackPlanningDiagnostic(
@@ -3021,8 +2995,6 @@ public static class CompileBackSourceComposer
         string? explicitInterfaceMemberName =
             sameAssemblyExplicitInterfaceMemberName
             ?? externalExplicitInterfaceMethod?.ExplicitInterfaceMemberName;
-        CompileBackMemberKind targetMemberKind =
-            MethodKind(reader, method, isConstructor, operatorResolver);
         var targetMembers = isConstructor && primaryConstructor is not null
             ? primaryConstructor.FieldInitializers.ToList()
             :
@@ -3084,19 +3056,6 @@ public static class CompileBackSourceComposer
             targetMembers.AddRange(TargetBackingFieldWriteMembers(reader, targetTypeDef, targetIdentity, function, allowStaticStores: false));
         if (function.MethodKind is IrMethodKind.StaticConstructor)
             targetMembers.AddRange(TargetBackingFieldWriteMembers(reader, targetTypeDef, targetIdentity, function, allowStaticStores: true));
-        if (!isConstructor
-            && targetMemberKind == CompileBackMemberKind.Operator
-            && RequiredOperatorSibling(
-                reader,
-                targetTypeDef,
-                targetIdentity,
-                methodName,
-                targetMethod,
-                relationshipResolver: operatorResolver)
-                is { } operatorSibling)
-        {
-            targetMembers.Add(operatorSibling);
-        }
         if (!isConstructor
             && TypedEqualsSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } typedEqualsSibling)
         {
@@ -3166,6 +3125,7 @@ public static class CompileBackSourceComposer
                 targetFacts)
             {
                 IncludeMemberSurface = includeRecordSurface
+                    || targetOperatorIsRepresentable
                     || targetFacts.Any(fact => fact.Id == "closure-member"),
                 ExternalInterfaces = externalExplicitInterfaceMethod is null
                     ? []
@@ -3413,81 +3373,13 @@ public static class CompileBackSourceComposer
     static string MethodReturnType(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
         => MetadataDeclarationQuery.GetMethodReturnType(reader, typeDef, method);
 
-    static CompileBackMemberRequirement? RequiredOperatorSibling(
-        MetadataReader reader,
-        TypeDefinition typeDef,
-        CompileBackTypeIdentity typeIdentity,
-        string methodName,
-        MethodDefinitionHandle targetMethod,
-        MethodDefinitionHandle excludedMethod = default,
-        IOperatorTypeRelationshipResolver? relationshipResolver = null)
-    {
-        var siblingName = OperatorNames.RequiredOperatorSibling(methodName);
-        if (siblingName is null)
-            return null;
-
-        foreach (var methodHandle in typeDef.GetMethods())
-        {
-            if (methodHandle == excludedMethod)
-                continue;
-
-            var method = reader.GetMethodDefinition(methodHandle);
-            if (reader.GetString(method.Name) != siblingName
-                || !IsOperatorMethod(
-                    reader,
-                    method,
-                    relationshipResolver))
-            {
-                continue;
-            }
-
-            if (!OperatorSignaturesMatch(reader, targetMethod, methodHandle))
-                continue;
-            var parameters = MethodParameters(reader, method, signature);
-            var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
-            if (!IsRepresentableOperator(
-                    reader,
-                    typeDef,
-                    method,
-                    siblingName,
-                    signature))
-            {
-                continue;
-            }
-
-            var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
-            return new CompileBackMemberRequirement(
-                new CompileBackMethodIdentity(typeIdentity.FullName, siblingName, 0, MethodSignatureText(siblingName, signature)),
-                CompileBackMemberKind.Operator,
-                method.Attributes.HasFlag(MethodAttributes.Static),
-                parameters,
-                returnType,
-                MethodTypeParameters(reader, method),
-                CompileBackStubBodyKind.Throw,
-                TargetBody: null,
-                [new CompileBackFact("metadata", "operator-pair-sibling", siblingName)],
-                MemberAttributes(reader, method.GetCustomAttributes()),
-                MethodReturnAttributes(reader, method),
-                IsAbstract: IsAbstractMethod(method),
-                IsVirtual: IsVirtualMethod(method),
-                IsOverride: false,
-                IsSealed: false,
-                IsOperator: true);
-        }
-
-        return null;
-    }
-
-    static bool OperatorSignaturesMatch(
-        MetadataReader reader,
-        MethodDefinitionHandle left,
-        MethodDefinitionHandle right)
-        => MethodStructuralSignature.BuildOperatorPairing(
-                reader,
-                reader.GetMethodDefinition(left))
-            == MethodStructuralSignature.BuildOperatorPairing(
-                reader,
-                reader.GetMethodDefinition(right));
+    static bool OperatorSignaturesMatch(MethodSignature<string> left, MethodSignature<string> right)
+        => OperatorNames.OperatorPairingTypesMatch(left.ReturnType, right.ReturnType)
+            && left.ParameterTypes.Length == right.ParameterTypes.Length
+            && left.ParameterTypes.Zip(
+                right.ParameterTypes,
+                OperatorNames.OperatorPairingTypesMatch)
+                .All(static equal => equal);
 
     static bool IsMetadataOperator(MetadataReader reader, MethodDefinition method)
         => ILInspector.Metadata.OperatorMetadata.IsMetadataOperator(reader, method);
@@ -4482,28 +4374,6 @@ public static class CompileBackSourceComposer
             return null;
         }
 
-        public static CompileBackMemberRequirement? TryCreateRequiredOperatorSibling(
-            MetadataReader reader,
-            TypeDefinitionHandle typeHandle,
-            MethodRef methodRef,
-            MethodDefinitionHandle excludedMethod,
-            IOperatorTypeRelationshipResolver? relationshipResolver)
-        {
-            var typeDef = reader.GetTypeDefinition(typeHandle);
-            if (TryFindMethod(reader, typeDef, methodRef) is not { } methodHandle)
-                return null;
-
-            var method = reader.GetMethodDefinition(methodHandle);
-            return RequiredOperatorSibling(
-                reader,
-                typeDef,
-                CompileBackTypeIdentity.FromDefinition(reader, typeDef),
-                methodRef.Name,
-                methodHandle,
-                excludedMethod,
-                relationshipResolver);
-        }
-
         public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
             MetadataReader reader,
             TypeDefinitionHandle typeHandle,
@@ -4590,6 +4460,7 @@ public static class CompileBackSourceComposer
         {
             var requests = new List<CSharpTypePrintRequest>();
             var producedRequirements = new List<CompileBackTypeRequirement>();
+            var typeDefinitions = new TypeDefinitionIndex(reader);
             var requirementsByIdentity = requirements.ToDictionary(
                 requirement => requirement.Type,
                 requirement => requirement,
@@ -4597,7 +4468,7 @@ public static class CompileBackSourceComposer
             var emittedRoots = new HashSet<TypeDefinitionHandle>();
             foreach (var requirement in requirements)
             {
-                if (FindType(reader, requirement.Type) is not { } handle)
+                if (typeDefinitions.Find(requirement.Type) is not { } handle)
                 {
                     diagnostics.Add(new CompileBackPlanningDiagnostic("type identity", "type-not-found", requirement.Type.MetadataFullName));
                     continue;
@@ -4624,6 +4495,7 @@ public static class CompileBackSourceComposer
                     rootHandle,
                     rootRequirement,
                     requirementsByIdentity,
+                    typeDefinitions,
                     surfaceByDefinitionName,
                     producedRequirements,
                     diagnostics,
@@ -4637,6 +4509,37 @@ public static class CompileBackSourceComposer
         public sealed record TypeProduction(
             IReadOnlyList<CSharpTypePrintRequest> Requests,
             IReadOnlyList<CompileBackTypeRequirement> Requirements);
+
+        sealed class TypeDefinitionIndex
+        {
+            readonly Dictionary<CompileBackTypeIdentity, TypeDefinitionHandle> _handles = [];
+            readonly HashSet<CompileBackTypeIdentity> _ambiguous = [];
+
+            public TypeDefinitionIndex(MetadataReader reader)
+            {
+                foreach (var handle in reader.TypeDefinitions)
+                {
+                    var identity = CompileBackTypeIdentity.FromDefinition(
+                        reader,
+                        reader.GetTypeDefinition(handle));
+                    if (!_handles.TryAdd(identity, handle))
+                        _ambiguous.Add(identity);
+                }
+            }
+
+            public TypeDefinitionHandle? Find(CompileBackTypeIdentity identity)
+            {
+                if (_ambiguous.Contains(identity))
+                {
+                    throw new AmbiguousMatchException(
+                        $"Product type identity '{identity.MetadataFullName}' matches multiple TypeDef rows.");
+                }
+
+                return _handles.TryGetValue(identity, out var handle)
+                    ? handle
+                    : null;
+            }
+        }
 
         internal static MetadataTypeDefinitionName DefinitionName(
             MetadataReader reader,
@@ -4814,7 +4717,13 @@ public static class CompileBackSourceComposer
                 propertyDeclaration.Signature.ReturnAttributes,
                 IsAbstract: isAbstractAccessor,
                 IsVirtual: !accessor.IsNil && propertyDeclaration.IsVirtual,
-                ExplicitInterfaceMemberName: explicitInterfaceMemberName);
+                ExplicitInterfaceMemberName: explicitInterfaceMemberName,
+                GetterToken: accessors.Getter.IsNil
+                    ? null
+                    : MetadataTokens.GetToken(accessors.Getter),
+                SetterToken: accessors.Setter.IsNil
+                    ? null
+                    : MetadataTokens.GetToken(accessors.Setter));
         }
 
         static CompileBackStubBodyKind PropertyStubBody(
@@ -4918,7 +4827,13 @@ public static class CompileBackSourceComposer
                 [new CompileBackFact("metadata", factId, accessorName)],
                 MemberAttributes(reader, eventDefinition.GetCustomAttributes()),
                 IsAbstract: isAbstract,
-                IsVirtual: IsVirtualMethod(accessor));
+                IsVirtual: IsVirtualMethod(accessor),
+                AdderToken: accessors.Adder.IsNil
+                    ? null
+                    : MetadataTokens.GetToken(accessors.Adder),
+                RemoverToken: accessors.Remover.IsNil
+                    ? null
+                    : MetadataTokens.GetToken(accessors.Remover));
         }
 
         internal static CompileBackMemberRequirement? MethodRequirement(
@@ -4980,10 +4895,22 @@ public static class CompileBackSourceComposer
                     method,
                     name,
                     signature);
-            if (hasOperatorIdentity && !operatorIsRepresentable)
-                return null;
 
             string identifierName = MemberIdentifierName(name, isConstructor);
+            IReadOnlyList<CompileBackFact> sourceFacts =
+                hasOperatorIdentity && !operatorIsRepresentable
+                    ?
+                    [
+                        new CompileBackFact("metadata", factId, name),
+                        new CompileBackFact(
+                            "metadata",
+                            "operator-raw-method",
+                            $"{MethodSignatureText(name, signature)}; C# operator declaration not representable"),
+                    ]
+                    : [new CompileBackFact(
+                        "metadata",
+                        isConstructor ? "typed-closure-constructor" : factId,
+                        name)];
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, identifierName, DeclaringOverloadIndex(reader, typeDef, methodHandle, name), MethodSignatureText(identifierName, signature)),
                 MethodKind(
@@ -4999,7 +4926,7 @@ public static class CompileBackSourceComposer
                     ? CompileBackStubBodyKind.None
                     : CompileBackStubBodyKind.Throw,
                 null,
-                [new CompileBackFact("metadata", isConstructor ? "typed-closure-constructor" : factId, name)],
+                sourceFacts,
                 isConstructor ? null : methodDeclaration?.Attributes,
                 isConstructor ? null : methodDeclaration?.Signature.ReturnAttributes,
                 IsAbstract: !isConstructor && IsAbstractMethod(method),
@@ -5007,7 +4934,8 @@ public static class CompileBackSourceComposer
                 IsOverride: false,
                 IsSealed: false,
                 IsExtension: IsExtensionMethod(reader, typeDef, method),
-                IsOperator: operatorIsRepresentable);
+                IsOperator: operatorIsRepresentable,
+                MetadataToken: MetadataTokens.GetToken(methodHandle));
         }
 
         static bool IsExtensionMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
@@ -5037,6 +4965,7 @@ public static class CompileBackSourceComposer
             TypeDefinitionHandle handle,
             CompileBackTypeRequirement requirement,
             IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity,
+            TypeDefinitionIndex typeDefinitions,
             CompileBackMemberSurfaceIndex surfaceByDefinitionName,
             List<CompileBackTypeRequirement> producedRequirements,
             List<CompileBackPlanningDiagnostic> diagnostics,
@@ -5047,6 +4976,15 @@ public static class CompileBackSourceComposer
             var members = kind == CompileBackTypeKind.Delegate
                 ? [DelegateInvokeRequirement(reader, typeDef, requirement.Type)]
                 : RequiredMemberRequirements(requirement);
+            foreach (var fact in members
+                .SelectMany(member => member.SourceFacts)
+                .Where(fact => fact.Id == "operator-raw-method"))
+            {
+                diagnostics.Add(new CompileBackPlanningDiagnostic(
+                    "member surface",
+                    "operator-not-representable",
+                    fact.Detail));
+            }
             bool includeMemberSurface = requirement.IncludeMemberSurface;
             if (includeMemberSurface && kind != CompileBackTypeKind.Delegate)
             {
@@ -5089,7 +5027,11 @@ public static class CompileBackSourceComposer
             if (kind == CompileBackTypeKind.Class
                 && members.Any(member => member.Kind == CompileBackMemberKind.Constructor)
                 && !members.Any(member => member.Kind == CompileBackMemberKind.Constructor && member.Parameters.Count == 0)
-                && IsReconstructedBaseOfAnotherType(reader, requirement, requirementsByIdentity))
+                && IsReconstructedBaseOfAnotherType(
+                    reader,
+                    requirement,
+                    requirementsByIdentity,
+                    typeDefinitions))
             {
                 members.Add(SyntheticParameterlessConstructor(requirement.Type));
             }
@@ -5119,6 +5061,7 @@ public static class CompileBackSourceComposer
                     reader,
                     typeDef,
                     requirementsByIdentity,
+                    typeDefinitions,
                     surfaceByDefinitionName,
                     includeMemberSurface,
                     producedRequirements,
@@ -5335,6 +5278,7 @@ public static class CompileBackSourceComposer
             MetadataReader reader,
             TypeDefinition typeDef,
             IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity,
+            TypeDefinitionIndex typeDefinitions,
             CompileBackMemberSurfaceIndex surfaceByDefinitionName,
             bool includeMemberSurface,
             List<CompileBackTypeRequirement> producedRequirements,
@@ -5371,6 +5315,7 @@ public static class CompileBackSourceComposer
                     nestedHandle,
                     nestedRequirement,
                     requirementsByIdentity,
+                    typeDefinitions,
                     surfaceByDefinitionName,
                     producedRequirements,
                     diagnostics,
@@ -5396,6 +5341,7 @@ public static class CompileBackSourceComposer
                             PrimaryConstructor: null,
                             SourceFacts: [new CompileBackFact("metadata", "generated-dynamic-delegate", identity.FullName)]),
                         requirementsByIdentity,
+                        typeDefinitions,
                         surfaceByDefinitionName,
                         producedRequirements,
                         diagnostics,
@@ -5436,11 +5382,12 @@ public static class CompileBackSourceComposer
         static bool IsReconstructedBaseOfAnotherType(
             MetadataReader reader,
             CompileBackTypeRequirement requirement,
-            IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity)
+            IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity,
+            TypeDefinitionIndex typeDefinitions)
         {
             foreach (var other in requirementsByIdentity.Values)
             {
-                if (FindType(reader, other.Type) is not { } otherHandle)
+                if (typeDefinitions.Find(other.Type) is not { } otherHandle)
                     continue;
                 if (TypeOrNestedDerivesFrom(reader, otherHandle, requirement.Type))
                     return true;
@@ -5605,7 +5552,13 @@ public static class CompileBackSourceComposer
             foreach (var surfaceField in surface.Members.Where(member => member.Kind == "field"))
             {
                 if (FindField(reader, typeDef, surfaceField.Name) is not { } fieldHandle)
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "field-token-unresolved",
+                        $"{requirement.Type.MetadataFullName}::{surfaceField.Name}"));
                     continue;
+                }
                 var field = reader.GetFieldDefinition(fieldHandle);
                 string fieldName = reader.GetString(field.Name);
                 if (fieldName.Contains('.', StringComparison.Ordinal))
@@ -5652,7 +5605,13 @@ public static class CompileBackSourceComposer
                     typeDef,
                     SurfaceMethodHandle(surfaceProperty.GetterToken ?? surfaceProperty.SetterToken));
                 if (propertyHandle.IsNil)
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "property-accessor-token-unresolved",
+                        $"{requirement.Type.MetadataFullName}::{surfaceProperty.Name}"));
                     continue;
+                }
                 var property = reader.GetPropertyDefinition(propertyHandle);
                 var accessors = property.GetAccessors();
 
@@ -5670,8 +5629,8 @@ public static class CompileBackSourceComposer
                     var existing = members[existingPropertyIndex];
                     members[existingPropertyIndex] = existing with
                     {
-                        GetterToken = existing.GetterToken ?? (accessors.Getter.IsNil ? null : MetadataTokens.GetToken(accessors.Getter)),
-                        SetterToken = existing.SetterToken ?? (accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter)),
+                        GetterToken = existing.GetterToken ?? surfaceProperty.GetterToken,
+                        SetterToken = existing.SetterToken ?? surfaceProperty.SetterToken,
                     };
                     continue;
                 }
@@ -5733,8 +5692,8 @@ public static class CompileBackSourceComposer
                     Accessibility: accessor.IsNil
                         ? CompileBackAccessibility.Public
                         : MethodAccessibility(accessorMethod),
-                    GetterToken: accessors.Getter.IsNil ? null : MetadataTokens.GetToken(accessors.Getter),
-                    SetterToken: accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter)));
+                    GetterToken: surfaceProperty.GetterToken,
+                    SetterToken: surfaceProperty.SetterToken));
             }
 
             foreach (var surfaceEvent in surface.Members.Where(member => member.Kind == "event"))
@@ -5744,7 +5703,13 @@ public static class CompileBackSourceComposer
                     typeDef,
                     SurfaceMethodHandle(surfaceEvent.AdderToken ?? surfaceEvent.RemoverToken));
                 if (eventHandle.IsNil)
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "event-accessor-token-unresolved",
+                        $"{requirement.Type.MetadataFullName}::{surfaceEvent.Name}"));
                     continue;
+                }
                 var eventDefinition = reader.GetEventDefinition(eventHandle);
                 var accessors = eventDefinition.GetAccessors();
 
@@ -5754,8 +5719,8 @@ public static class CompileBackSourceComposer
                 int existingEventIndex = members.FindIndex(member =>
                     member.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove
                     && member.Identity.Method == Identifier(eventName));
-                int? adderToken = accessors.Adder.IsNil ? null : MetadataTokens.GetToken(accessors.Adder);
-                int? removerToken = accessors.Remover.IsNil ? null : MetadataTokens.GetToken(accessors.Remover);
+                int? adderToken = surfaceEvent.AdderToken;
+                int? removerToken = surfaceEvent.RemoverToken;
                 if (existingEventIndex >= 0)
                 {
                     var existing = members[existingEventIndex];
@@ -5799,13 +5764,23 @@ public static class CompileBackSourceComposer
             {
                 var methodHandle = SurfaceMethodHandle(surfaceMethod.MetadataToken);
                 if (methodHandle.IsNil)
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "method-token-invalid",
+                        $"{requirement.Type.MetadataFullName}::{surfaceMethod.Name} ({surfaceMethod.MetadataToken:X8})"));
                     continue;
+                }
                 var method = reader.GetMethodDefinition(methodHandle);
                 if (CompileBackTypeIdentity.FromDefinition(
                         reader,
                         reader.GetTypeDefinition(method.GetDeclaringType()))
                     != requirement.Type)
                 {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "method-token-owner-mismatch",
+                        $"{requirement.Type.MetadataFullName}::{surfaceMethod.Name} ({surfaceMethod.MetadataToken:X8})"));
                     continue;
                 }
                 string name = reader.GetString(method.Name);
@@ -5819,29 +5794,6 @@ public static class CompileBackSourceComposer
 
                 bool isConstructor = name == ".ctor";
                 string identifierName = MemberIdentifierName(name, isConstructor);
-                var memberKind = MethodKind(
-                    reader,
-                    method,
-                    isConstructor,
-                    relationshipResolver);
-                int existingMethodIndex = members.FindIndex(member =>
-                    member.Kind == memberKind
-                    && member.Identity.Method == identifierName);
-                if (existingMethodIndex >= 0)
-                {
-                    var existing = members[existingMethodIndex];
-                    members[existingMethodIndex] = existing with
-                    {
-                        MetadataToken = existing.MetadataToken ?? MetadataTokens.GetToken(methodHandle),
-                    };
-                    continue;
-                }
-                if (!isConstructor
-                    && method.Attributes.HasFlag(
-                        MethodAttributes.SpecialName))
-                {
-                    continue;
-                }
                 if (requirement.RequiredKind == CompileBackTypeKind.Interface && method.Attributes.HasFlag(MethodAttributes.Static))
                     continue;
                 if (method.GetGenericParameters().Count != 0)
@@ -5880,25 +5832,28 @@ public static class CompileBackSourceComposer
                         && (IsPointerSignature(methodReturnType)
                             || parameters.Any(parameter => IsPointerSignature(parameter.Type.DisplayName)))))
                 {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "method-signature-not-representable",
+                        signatureIdentity));
                     continue;
                 }
                 bool methodIsStatic = method.Attributes.HasFlag(MethodAttributes.Static);
-                bool methodHasOperatorIdentity = memberKind == CompileBackMemberKind.Operator;
+                bool methodHasOperatorIdentity = !isConstructor && IsMetadataOperator(reader, method);
                 bool methodIsOperator = methodHasOperatorIdentity
-                    && IsRepresentableOperator(
-                        reader,
-                        typeDef,
-                        method,
-                        name,
-                        signature);
+                    && surfaceMethod.CSharpOperatorDeclaration == true;
                 if (methodHasOperatorIdentity && !methodIsOperator)
                 {
                     diagnostics.Add(new CompileBackPlanningDiagnostic(
                         "member surface",
                         "operator-not-representable",
-                        signatureIdentity));
-                    continue;
+                        $"{signatureIdentity}; emitted as raw method"));
                 }
+                var memberKind = isConstructor
+                    ? CompileBackMemberKind.Constructor
+                    : methodIsOperator
+                        ? CompileBackMemberKind.Operator
+                        : CompileBackMemberKind.Method;
                 string? returnTypeIdentity = isConstructor
                     ? null
                     : CompileBackTypeSignature.Display(methodReturnType).DisplayName;
@@ -5925,7 +5880,7 @@ public static class CompileBackSourceComposer
                     var existing = members[existingMethodIndex];
                     members[existingMethodIndex] = existing with
                     {
-                        MetadataToken = existing.MetadataToken ?? MetadataTokens.GetToken(methodHandle),
+                        MetadataToken = existing.MetadataToken ?? surfaceMethod.MetadataToken,
                     };
                     continue;
                 }
@@ -5960,10 +5915,11 @@ public static class CompileBackSourceComposer
                     IsVirtual: !isConstructor && IsVirtualMethod(method),
                     IsOverride: false,
                     IsSealed: false,
+                    IsExtension: surfaceMethod.IsExtension,
                     IsOperator: methodIsOperator,
                     IsFinalizer: surfaceMethod.IsFinalizer,
                     Accessibility: MethodAccessibility(method),
-                    MetadataToken: MetadataTokens.GetToken(methodHandle)));
+                    MetadataToken: surfaceMethod.MetadataToken));
             }
 
             if (requirement.RequiredKind == CompileBackTypeKind.Class

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2980,9 +2980,7 @@ public static class CompileBackSourceComposer
                 targetTypeDef,
                 method,
                 methodName,
-                signature,
-                targetParameters,
-                targetReturnType?.DisplayName);
+                signature);
         if (targetHasOperatorIdentity && !targetOperatorIsRepresentable)
         {
             diagnostics.Add(new CompileBackPlanningDiagnostic(
@@ -3354,7 +3352,10 @@ public static class CompileBackSourceComposer
             SetterToken: requirement.SetterToken,
             AdderToken: requirement.AdderToken,
             RemoverToken: requirement.RemoverToken,
-            SuppressDestructorSyntax: requirement.SuppressDestructorSyntax);
+            SuppressDestructorSyntax: requirement.SuppressDestructorSyntax,
+            CSharpOperatorDeclaration: requirement.Kind == CompileBackMemberKind.Operator
+                ? requirement.IsOperator
+                : null);
 
     static CSharpShellParameter ToShellParameter(CompileBackParameter parameter)
         => new(
@@ -3449,9 +3450,7 @@ public static class CompileBackSourceComposer
                     typeDef,
                     method,
                     siblingName,
-                    signature,
-                    parameters,
-                    returnType.DisplayName))
+                    signature))
             {
                 continue;
             }
@@ -3498,42 +3497,15 @@ public static class CompileBackSourceComposer
         TypeDefinition declaringType,
         MethodDefinition method,
         string name,
-        MethodSignature<string> signature,
-        IReadOnlyList<CompileBackParameter> parameters,
-        string? returnType)
+        MethodSignature<string> signature)
     {
-        if (returnType is null
-            || !ILInspector.Metadata.OperatorMetadata.IsCSharpOperatorDeclaration(reader, method))
-        {
-            return false;
-        }
-
-        var declaringIdentity = CompileBackTypeIdentity.FromDefinition(reader, declaringType);
-        if (name is "op_Increment" or "op_Decrement"
-            && !IsDeclaringTypeSpelling(returnType, declaringIdentity))
+        if (!ILInspector.Metadata.OperatorMetadata.IsCSharpOperatorDeclaration(reader, method))
         {
             return false;
         }
 
         return RequiredOperatorPair(name) is not { } pairName
             || HasOperatorPair(reader, declaringType, pairName, signature);
-    }
-
-    static bool IsConversionOperator(string name)
-        => name is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";
-
-    static bool IsDeclaringTypeSpelling(
-        string type,
-        CompileBackTypeIdentity declaringType)
-    {
-        string normalized = type.EndsWith('?')
-            ? type[..^1]
-            : type;
-        return normalized == declaringType.DisplayName
-            || normalized == declaringType.FullName
-            || normalized == declaringType.MetadataFullName
-            || normalized.StartsWith($"{declaringType.DisplayName}<", StringComparison.Ordinal)
-            || normalized.StartsWith($"{declaringType.FullName}<", StringComparison.Ordinal);
     }
 
     static string? RequiredOperatorPair(string name)
@@ -5007,9 +4979,7 @@ public static class CompileBackSourceComposer
                     typeDef,
                     method,
                     name,
-                    signature,
-                    parameters,
-                    CompileBackTypeSignature.Display(methodReturnType).DisplayName);
+                    signature);
             if (hasOperatorIdentity && !operatorIsRepresentable)
                 return null;
 
@@ -5920,9 +5890,7 @@ public static class CompileBackSourceComposer
                         typeDef,
                         method,
                         name,
-                        signature,
-                        parameters,
-                        CompileBackTypeSignature.Display(methodReturnType).DisplayName);
+                        signature);
                 if (methodHasOperatorIdentity && !methodIsOperator)
                 {
                     diagnostics.Add(new CompileBackPlanningDiagnostic(

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -563,6 +563,7 @@ public static class CompileBackSourceComposer
         {
             PropertyGetterArtifactRequest getter => ComposePropertyGetter(
                 request.AssemblyPath,
+                request.CompilationClosure,
                 request.Reader,
                 request.Function,
                 request.TargetType,
@@ -581,6 +582,7 @@ public static class CompileBackSourceComposer
                 operatorResolver),
             PropertySetterArtifactRequest setter => ComposePropertySetter(
                 request.AssemblyPath,
+                request.CompilationClosure,
                 request.Reader,
                 request.Function,
                 request.TargetType,
@@ -598,6 +600,7 @@ public static class CompileBackSourceComposer
                 operatorResolver),
             EventAccessorArtifactRequest eventAccessor => ComposeEventAccessor(
                 request.AssemblyPath,
+                request.CompilationClosure,
                 request.Reader,
                 request.Function,
                 request.TargetType,
@@ -1169,6 +1172,7 @@ public static class CompileBackSourceComposer
 
     internal static CompileBackSourceResult ComposePropertyGetter(
         string assemblyPath,
+        ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader reader,
         IrFunction function,
         TypeDefinitionHandle targetType,
@@ -1208,6 +1212,18 @@ public static class CompileBackSourceComposer
         };
         if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
+        if (ImplicitInterfaceTargetIsOmitted(
+                assemblyPath,
+                compilationClosure,
+                reader,
+                targetTypeDef,
+                getter))
+        {
+            diagnostics.Add(new CompileBackPlanningDiagnostic(
+                "type identity",
+                "implicit-interface-not-reconstructed",
+                $"{targetIdentity.MetadataFullName}::{reader.GetString(getter.Name)}"));
+        }
 
         var targetMembers = new List<CompileBackMemberRequirement>
         {
@@ -2689,14 +2705,16 @@ public static class CompileBackSourceComposer
 
     static ExternalInterfaceReferenceInfo? ExternalInterfaceReference(
         MetadataReader reader,
-        TypeReferenceHandle handle)
+        TypeReferenceHandle handle,
+        bool allowGenericMetadataName = false)
     {
         var typeRef = reader.GetTypeReference(handle);
         if (typeRef.ResolutionScope.Kind != HandleKind.AssemblyReference)
             return null;
 
         string metadataFullName = reader.GetFullTypeName(typeRef);
-        if (metadataFullName.Contains('`', StringComparison.Ordinal))
+        if (!allowGenericMetadataName
+            && metadataFullName.Contains('`', StringComparison.Ordinal))
             return null;
 
         return new ExternalInterfaceReferenceInfo(
@@ -2798,6 +2816,7 @@ public static class CompileBackSourceComposer
 
     internal static CompileBackSourceResult ComposePropertySetter(
         string assemblyPath,
+        ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader reader,
         IrFunction function,
         TypeDefinitionHandle targetType,
@@ -2834,6 +2853,18 @@ public static class CompileBackSourceComposer
         };
         if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
+        if (ImplicitInterfaceTargetIsOmitted(
+                assemblyPath,
+                compilationClosure,
+                reader,
+                targetTypeDef,
+                setter))
+        {
+            diagnostics.Add(new CompileBackPlanningDiagnostic(
+                "type identity",
+                "implicit-interface-not-reconstructed",
+                $"{targetIdentity.MetadataFullName}::{reader.GetString(setter.Name)}"));
+        }
 
         var indexerParameterCount = propertySignature.ParameterTypes.Length;
         var targetMembers = new List<CompileBackMemberRequirement>
@@ -2925,6 +2956,7 @@ public static class CompileBackSourceComposer
 
     internal static CompileBackSourceResult ComposeEventAccessor(
         string assemblyPath,
+        ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader reader,
         IrFunction function,
         TypeDefinitionHandle targetType,
@@ -2976,6 +3008,18 @@ public static class CompileBackSourceComposer
         };
         if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
+        if (ImplicitInterfaceTargetIsOmitted(
+                assemblyPath,
+                compilationClosure,
+                reader,
+                targetTypeDef,
+                accessor))
+        {
+            diagnostics.Add(new CompileBackPlanningDiagnostic(
+                "type identity",
+                "implicit-interface-not-reconstructed",
+                $"{targetIdentity.MetadataFullName}::{reader.GetString(accessor.Name)}"));
+        }
 
         var targetMembers = new List<CompileBackMemberRequirement>
         {
@@ -3181,11 +3225,16 @@ public static class CompileBackSourceComposer
                 "external-interface-base-not-reconstructed",
                 externalInterfaceDeclineReason));
         }
-        if (ExternalImplicitInterfaceTargetIsOmitted(reader, targetTypeDef, method))
+        if (ImplicitInterfaceTargetIsOmitted(
+                assemblyPath,
+                compilationClosure,
+                reader,
+                targetTypeDef,
+                method))
         {
             diagnostics.Add(new CompileBackPlanningDiagnostic(
                 "type identity",
-                "external-implicit-interface-not-reconstructed",
+                "implicit-interface-not-reconstructed",
                 $"{targetIdentity.MetadataFullName}::{reader.GetString(method.Name)}"));
         }
         string? explicitInterfaceMemberName =
@@ -3869,7 +3918,9 @@ public static class CompileBackSourceComposer
         => method.Attributes.HasFlag(MethodAttributes.Virtual)
             && !method.Attributes.HasFlag(MethodAttributes.NewSlot);
 
-    static bool ExternalImplicitInterfaceTargetIsOmitted(
+    static bool ImplicitInterfaceTargetIsOmitted(
+        string assemblyPath,
+        ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader reader,
         TypeDefinition typeDef,
         MethodDefinition method)
@@ -3888,8 +3939,354 @@ public static class CompileBackSourceComposer
             return false;
         }
 
-        return typeDef.GetInterfaceImplementations().Any(handle =>
-            reader.GetInterfaceImplementation(handle).Interface.Kind != HandleKind.TypeDefinition);
+        MethodSignature<string> targetSignature;
+        try
+        {
+            targetSignature = method.DecodeSignature(
+                SignatureDecoder.Instance,
+                GenericContext.ForMethod(reader, typeDef, method));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return false;
+        }
+
+        foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
+        {
+            var interfaceHandle = reader.GetInterfaceImplementation(implementationHandle).Interface;
+            if (interfaceHandle.Kind == HandleKind.TypeDefinition)
+                continue;
+            if (OmittedInterfaceDeclaresTarget(
+                    assemblyPath,
+                    compilationClosure,
+                    reader,
+                    interfaceHandle,
+                    method,
+                    targetSignature))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool OmittedInterfaceDeclaresTarget(
+        string assemblyPath,
+        ReturnToSender.CompilationClosure? compilationClosure,
+        MetadataReader reader,
+        EntityHandle interfaceHandle,
+        MethodDefinition targetMethod,
+        MethodSignature<string> targetSignature)
+    {
+        EntityHandle root = interfaceHandle;
+        bool genericInstantiation = false;
+        if (interfaceHandle.Kind == HandleKind.TypeSpecification)
+        {
+            if (!TryReadNamedTypeSpecificationRoot(
+                    reader,
+                    (TypeSpecificationHandle)interfaceHandle,
+                    out root,
+                    out genericInstantiation))
+            {
+                return false;
+            }
+        }
+
+        if (root.Kind == HandleKind.TypeDefinition)
+        {
+            var interfaceDef = reader.GetTypeDefinition((TypeDefinitionHandle)root);
+            return InterfaceDeclaresTarget(
+                reader,
+                interfaceDef,
+                targetMethod,
+                targetSignature,
+                exactSignature: !genericInstantiation);
+        }
+        if (root.Kind != HandleKind.TypeReference
+            || ExternalInterfaceReference(
+                reader,
+                (TypeReferenceHandle)root,
+                allowGenericMetadataName: true) is not { } interfaceReference)
+        {
+            return false;
+        }
+
+        return ExternalInterfaceDeclaresTarget(
+            assemblyPath,
+            compilationClosure,
+            reader,
+            interfaceReference,
+            targetMethod,
+            targetSignature,
+            exactSignature: !genericInstantiation);
+    }
+
+    static bool InterfaceDeclaresTarget(
+        MetadataReader reader,
+        TypeDefinition interfaceDef,
+        MethodDefinition targetMethod,
+        MethodSignature<string> targetSignature,
+        bool exactSignature)
+    {
+        string targetName = reader.GetString(targetMethod.Name);
+        foreach (var methodHandle in interfaceDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != targetName
+                || method.GetGenericParameters().Count != targetMethod.GetGenericParameters().Count)
+            {
+                continue;
+            }
+            MethodSignature<string> signature;
+            try
+            {
+                signature = method.DecodeSignature(
+                    SignatureDecoder.Instance,
+                    GenericContext.ForMethod(reader, interfaceDef, method));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                continue;
+            }
+            if (signature.ParameterTypes.Length != targetSignature.ParameterTypes.Length)
+                continue;
+            if (!exactSignature
+                || signature.ReturnType == targetSignature.ReturnType
+                    && signature.ParameterTypes.SequenceEqual(
+                        targetSignature.ParameterTypes,
+                        StringComparer.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        foreach (var implementationHandle in interfaceDef.GetInterfaceImplementations())
+        {
+            var inherited = reader.GetInterfaceImplementation(implementationHandle).Interface;
+            if (inherited.Kind == HandleKind.TypeDefinition
+                && InterfaceDeclaresTarget(
+                    reader,
+                    reader.GetTypeDefinition((TypeDefinitionHandle)inherited),
+                    targetMethod,
+                    targetSignature,
+                    exactSignature))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool ExternalInterfaceDeclaresTarget(
+        string assemblyPath,
+        ReturnToSender.CompilationClosure? compilationClosure,
+        MetadataReader targetReader,
+        ExternalInterfaceReferenceInfo interfaceReference,
+        MethodDefinition targetMethod,
+        MethodSignature<string> targetSignature,
+        bool exactSignature)
+    {
+        ReturnToSender.CompilationClosure closure =
+            compilationClosure
+            ?? ReturnToSender.CreateCompilationClosure(assemblyPath);
+        if (ResolveExternalTypeDefinition(
+                closure.TargetAssembly,
+                interfaceReference.AssemblyIdentity,
+                interfaceReference.MetadataFullName,
+                closure.Resolver) is not { } definition)
+        {
+            return false;
+        }
+
+        try
+        {
+            return ResolvedExternalInterfaceDeclaresTarget(
+                definition,
+                closure.Resolver,
+                targetReader.GetString(targetMethod.Name),
+                targetMethod.GetGenericParameters().Count,
+                targetSignature,
+                exactSignature,
+                []);
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException or ArgumentException or InvalidOperationException)
+        {
+            return false;
+        }
+
+        static bool ResolvedExternalInterfaceDeclaresTarget(
+            (
+                ResolvedAssemblyReference Assembly,
+                MetadataTypeDefinitionAddress Address) definition,
+            AssemblyDependencyResolver resolver,
+            string targetName,
+            int targetGenericArity,
+            MethodSignature<string> targetSignature,
+            bool exactSignature,
+            HashSet<string> visited)
+        {
+            using Stream stream = definition.Assembly.OpenRead();
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return false;
+            var reader = peReader.GetMetadataReader();
+            if (!definition.Address.TryResolve(
+                    reader,
+                    out TypeDefinitionHandle interfaceHandle))
+            {
+                return false;
+            }
+            return ExternalInterfaceDefinitionDeclaresTarget(
+                reader,
+                definition.Assembly,
+                interfaceHandle,
+                resolver,
+                targetName,
+                targetGenericArity,
+                targetSignature,
+                exactSignature,
+                visited);
+        }
+
+        static bool ExternalInterfaceDefinitionDeclaresTarget(
+            MetadataReader reader,
+            ResolvedAssemblyReference assembly,
+            TypeDefinitionHandle interfaceHandle,
+            AssemblyDependencyResolver resolver,
+            string targetName,
+            int targetGenericArity,
+            MethodSignature<string> targetSignature,
+            bool exactSignature,
+            HashSet<string> visited)
+        {
+            string visitKey =
+                $"{assembly.Identity}|{reader.GetGuid(reader.GetModuleDefinition().Mvid):D}|"
+                + $"{MetadataTokens.GetToken(interfaceHandle):X8}";
+            if (!visited.Add(visitKey))
+                return false;
+            var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+            foreach (var methodHandle in interfaceDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != targetName
+                    || method.GetGenericParameters().Count != targetGenericArity)
+                {
+                    continue;
+                }
+                MethodSignature<string> signature;
+                try
+                {
+                    signature = method.DecodeSignature(
+                        SignatureDecoder.Instance,
+                        GenericContext.ForMethod(reader, interfaceDef, method));
+                }
+                catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+                {
+                    continue;
+                }
+                if (signature.ParameterTypes.Length != targetSignature.ParameterTypes.Length)
+                    continue;
+                if (!exactSignature
+                    || signature.ReturnType == targetSignature.ReturnType
+                        && signature.ParameterTypes.SequenceEqual(
+                            targetSignature.ParameterTypes,
+                            StringComparer.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            foreach (var implementationHandle in interfaceDef.GetInterfaceImplementations())
+            {
+                EntityHandle inherited = reader.GetInterfaceImplementation(implementationHandle).Interface;
+                bool inheritedExact = exactSignature;
+                if (inherited.Kind == HandleKind.TypeSpecification)
+                {
+                    if (!TryReadNamedTypeSpecificationRoot(
+                            reader,
+                            (TypeSpecificationHandle)inherited,
+                            out inherited,
+                            out bool genericInstantiation))
+                    {
+                        continue;
+                    }
+                    inheritedExact &= !genericInstantiation;
+                }
+                if (inherited.Kind == HandleKind.TypeDefinition
+                    && ExternalInterfaceDefinitionDeclaresTarget(
+                        reader,
+                        assembly,
+                        (TypeDefinitionHandle)inherited,
+                        resolver,
+                        targetName,
+                        targetGenericArity,
+                        targetSignature,
+                        inheritedExact,
+                        visited))
+                {
+                    return true;
+                }
+                if (inherited.Kind == HandleKind.TypeReference
+                    && ExternalInterfaceReference(
+                        reader,
+                        (TypeReferenceHandle)inherited,
+                        allowGenericMetadataName: true) is { } inheritedReference
+                    && ResolveExternalTypeDefinition(
+                        assembly,
+                        inheritedReference.AssemblyIdentity,
+                        inheritedReference.MetadataFullName,
+                        resolver) is { } inheritedDefinition
+                    && ResolvedExternalInterfaceDeclaresTarget(
+                        inheritedDefinition,
+                        resolver,
+                        targetName,
+                        targetGenericArity,
+                        targetSignature,
+                        inheritedExact,
+                        visited))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    static bool TryReadNamedTypeSpecificationRoot(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        out EntityHandle root,
+        out bool genericInstantiation)
+    {
+        root = default;
+        genericInstantiation = false;
+        try
+        {
+            var blob = reader.GetBlobReader(reader.GetTypeSpecification(handle).Signature);
+            byte code = blob.ReadByte();
+            genericInstantiation = code == 0x15;
+            if (genericInstantiation)
+                code = blob.ReadByte();
+            if (code is not (0x11 or 0x12))
+                return false;
+            int encoded = blob.ReadCompressedInteger();
+            if (encoded < 0)
+                return false;
+            int row = encoded >> 2;
+            root = (encoded & 3) switch
+            {
+                0 => MetadataTokens.TypeDefinitionHandle(row),
+                1 => MetadataTokens.TypeReferenceHandle(row),
+                2 => MetadataTokens.TypeSpecificationHandle(row),
+                _ => default,
+            };
+            return !root.IsNil;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return false;
+        }
     }
 
     static bool IsProtectedMethod(MethodDefinition method)

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -5524,7 +5524,10 @@ public static class CompileBackSourceComposer
             bool hasOperatorIdentity = !isConstructor
                 && IsMetadataOperator(reader, method);
             bool operatorIsRepresentable = hasOperatorIdentity
-                && IsOperatorMethod(reader, method);
+                && IsOperatorMethod(
+                    reader,
+                    method,
+                    relationshipResolver);
 
             string identifierName = MemberIdentifierName(name, isConstructor);
             IReadOnlyList<CompileBackFact> sourceFacts =

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1271,7 +1271,8 @@ public static class CompileBackSourceComposer
                 PrimaryConstructor: null,
                 targetFacts)
             {
-                IncludeMemberSurface = targetFacts.Any(fact => fact.Id == "closure-member")
+                IncludeMemberSurface = targetFacts.Any(fact => fact.Id == "closure-member"),
+                IncludeOperatorSurface = targetMembers.Any(member => member.IsOperator),
             }
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetRoot);
@@ -2886,7 +2887,8 @@ public static class CompileBackSourceComposer
                 PrimaryConstructor: null,
                 targetFacts)
             {
-                IncludeMemberSurface = targetFacts.Any(fact => fact.Id == "closure-member")
+                IncludeMemberSurface = targetFacts.Any(fact => fact.Id == "closure-member"),
+                IncludeOperatorSurface = targetMembers.Any(member => member.IsOperator),
             }
         };
         AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
@@ -3038,7 +3040,8 @@ public static class CompileBackSourceComposer
                 // coherent explicit-interface reconstruction is out of #3007's plain-event scope.
                 IncludeMemberSurface = bodyPolicy == RoundTripBodyPolicy.Full
                     && explicitEvent is null
-                    && targetFacts.Any(fact => fact.Id == "closure-member")
+                    && targetFacts.Any(fact => fact.Id == "closure-member"),
+                IncludeOperatorSurface = targetMembers.Any(member => member.IsOperator),
             }
         };
         AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
@@ -3177,6 +3180,13 @@ public static class CompileBackSourceComposer
                 "type identity",
                 "external-interface-base-not-reconstructed",
                 externalInterfaceDeclineReason));
+        }
+        if (ExternalImplicitInterfaceTargetIsOmitted(reader, targetTypeDef, method))
+        {
+            diagnostics.Add(new CompileBackPlanningDiagnostic(
+                "type identity",
+                "external-implicit-interface-not-reconstructed",
+                $"{targetIdentity.MetadataFullName}::{reader.GetString(method.Name)}"));
         }
         string? explicitInterfaceMemberName =
             sameAssemblyExplicitInterfaceMemberName
@@ -3318,7 +3328,8 @@ public static class CompileBackSourceComposer
             {
                 IncludeMemberSurface = includeRecordSurface
                     || targetFacts.Any(fact => fact.Id == "closure-member"),
-                IncludeOperatorSurface = targetOperatorIsRepresentable,
+                IncludeOperatorSurface = targetOperatorIsRepresentable
+                    || targetMembers.Any(member => member.IsOperator),
                 ExternalInterfaces = externalExplicitInterfaceMethod is null
                     ? []
                     : [externalExplicitInterfaceMethod.InterfaceDisplayName],
@@ -3857,6 +3868,29 @@ public static class CompileBackSourceComposer
     static bool IsOverrideSlotReuse(MethodDefinition method)
         => method.Attributes.HasFlag(MethodAttributes.Virtual)
             && !method.Attributes.HasFlag(MethodAttributes.NewSlot);
+
+    static bool ExternalImplicitInterfaceTargetIsOmitted(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method)
+    {
+        if (ShellKind(reader, typeDef) != CompileBackTypeKind.Class)
+            return false;
+
+        string name = reader.GetString(method.Name);
+        if (name.Contains('.', StringComparison.Ordinal)
+            || method.Attributes.HasFlag(MethodAttributes.Static)
+            || (method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
+            || !method.Attributes.HasFlag(MethodAttributes.Virtual)
+            || !method.Attributes.HasFlag(MethodAttributes.Final)
+            || !method.Attributes.HasFlag(MethodAttributes.NewSlot))
+        {
+            return false;
+        }
+
+        return typeDef.GetInterfaceImplementations().Any(handle =>
+            reader.GetInterfaceImplementation(handle).Interface.Kind != HandleKind.TypeDefinition);
+    }
 
     static bool IsProtectedMethod(MethodDefinition method)
         => MetadataDeclarationQuery.AccessibilityKeyword(method) is "protected" or "protected internal";
@@ -5766,13 +5800,26 @@ public static class CompileBackSourceComposer
             {
                 if (!requirementsByIdentity.TryGetValue(baseIdentity, out var baseRequirement))
                     return true;
-                if ((baseRequirement.IncludeMemberSurface
-                        && member.TypeParameters.Count == 0)
-                    || baseRequirement.RequiredMembers.Any(baseMember =>
-                        (baseMember.IsVirtual || baseMember.IsAbstract || baseMember.IsOverride)
-                        && SameOverrideSlot(baseMember, member)))
+                var requiredSlot = DeclaredOverrideSlotState(
+                    baseRequirement.RequiredMembers,
+                    member);
+                if (requiredSlot == OverrideSlotState.Usable)
                 {
                     return true;
+                }
+                if (requiredSlot == OverrideSlotState.Unusable)
+                    return false;
+                if (baseRequirement.IncludeMemberSurface)
+                {
+                    var surfaceSlot = MemberSurfaceOverrideSlotState(
+                        reader,
+                        (TypeDefinitionHandle)reader.GetTypeDefinition(current).BaseType,
+                        baseRequirement,
+                        member);
+                    if (surfaceSlot == OverrideSlotState.Usable)
+                        return true;
+                    if (surfaceSlot == OverrideSlotState.Unusable)
+                        return false;
                 }
 
                 var baseType = reader.GetTypeDefinition(current).BaseType;
@@ -5782,6 +5829,95 @@ public static class CompileBackSourceComposer
             }
 
             return IsSystemObjectOverride(member);
+        }
+
+        enum OverrideSlotState
+        {
+            Missing,
+            Usable,
+            Unusable,
+        }
+
+        static OverrideSlotState MemberSurfaceOverrideSlotState(
+            MetadataReader reader,
+            TypeDefinitionHandle baseHandle,
+            CompileBackTypeRequirement baseRequirement,
+            CompileBackMemberRequirement member)
+        {
+            if (member.TypeParameters.Count != 0)
+                return OverrideSlotState.Missing;
+
+            var baseDef = reader.GetTypeDefinition(baseHandle);
+            var candidates = new List<CompileBackMemberRequirement>();
+            if (member.Kind == CompileBackMemberKind.Method)
+            {
+                foreach (var methodHandle in baseDef.GetMethods())
+                {
+                    if (MethodRequirement(
+                            reader,
+                            baseDef,
+                            baseRequirement.Type,
+                            methodHandle) is { } candidate)
+                    {
+                        candidates.Add(candidate);
+                    }
+                }
+            }
+            else if (member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet)
+            {
+                foreach (var propertyHandle in baseDef.GetProperties())
+                {
+                    var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+                    var accessor = member.Kind == CompileBackMemberKind.PropertyGet
+                        ? accessors.Getter
+                        : accessors.Setter;
+                    if (!accessor.IsNil
+                        && PropertyRequirement(
+                            reader,
+                            baseDef,
+                            baseRequirement.Type,
+                            propertyHandle,
+                            reader.GetString(reader.GetMethodDefinition(accessor).Name)) is { } candidate)
+                    {
+                        candidates.Add(candidate);
+                    }
+                }
+            }
+            else if (member.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove)
+            {
+                foreach (var eventHandle in baseDef.GetEvents())
+                {
+                    var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
+                    var accessor = member.Kind == CompileBackMemberKind.EventAdd
+                        ? accessors.Adder
+                        : accessors.Remover;
+                    if (!accessor.IsNil
+                        && EventRequirement(
+                            reader,
+                            baseDef,
+                            baseRequirement.Type,
+                            eventHandle,
+                            reader.GetString(reader.GetMethodDefinition(accessor).Name)) is { } candidate)
+                    {
+                        candidates.Add(candidate);
+                    }
+                }
+            }
+
+            return DeclaredOverrideSlotState(candidates, member);
+        }
+
+        static OverrideSlotState DeclaredOverrideSlotState(
+            IEnumerable<CompileBackMemberRequirement> candidates,
+            CompileBackMemberRequirement member)
+        {
+            var matching = candidates.Where(candidate => SameOverrideSlot(candidate, member)).ToArray();
+            if (matching.Length == 0)
+                return OverrideSlotState.Missing;
+            return matching.Any(candidate =>
+                candidate.IsVirtual || candidate.IsAbstract || candidate.IsOverride)
+                    ? OverrideSlotState.Usable
+                    : OverrideSlotState.Unusable;
         }
 
         static bool SameOverrideSlot(

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2745,11 +2745,32 @@ public static class CompileBackSourceComposer
         return $"{returnType.DisplayName} {explicitInterfaceMemberName}{typeParametersText}({parametersText})";
     }
 
+    // Which interface event an explicit accessor implements comes from the accessor's own
+    // canonical declaration identity — its explicit-interface metadata name (`IA.add_E`) —
+    // not from MethodImpl table order. One body can carry several `.override` rows, and the
+    // first row is simply whichever the producer emitted first: selecting it names the wrong
+    // interface in the reconstructed declaration and silently moves the member to a different
+    // slot. When the accessor carries no resolvable canonical name, only an unambiguous single
+    // row is usable; several rows are declined rather than guessed.
     static ExplicitInterfaceEventInfo? ExplicitInterfaceEvent(
         MetadataReader reader,
         TypeDefinition targetType,
         MethodDefinitionHandle targetAccessor)
     {
+        TypeDefinitionHandle? canonicalInterface = null;
+        string? canonicalMemberName = null;
+        if (TrySplitExplicitInterfaceMetadataName(
+                reader.GetString(reader.GetMethodDefinition(targetAccessor).Name),
+                out string interfaceMetadataName,
+                out string memberMetadataName)
+            && TypeProducer.FindType(reader, interfaceMetadataName) is { } canonicalHandle)
+        {
+            canonicalInterface = canonicalHandle;
+            canonicalMemberName = memberMetadataName;
+        }
+
+        ExplicitInterfaceEventInfo? fallback = null;
+        bool fallbackIsAmbiguous = false;
         foreach (var implementationHandle in targetType.GetMethodImplementations())
         {
             var implementation = reader.GetMethodImplementation(implementationHandle);
@@ -2763,6 +2784,7 @@ public static class CompileBackSourceComposer
             var declaration = reader.GetMethodDefinition(declarationHandle);
             var interfaceHandle = declaration.GetDeclaringType();
             var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+            ExplicitInterfaceEventInfo? candidate = null;
             foreach (var eventHandle in interfaceDef.GetEvents())
             {
                 var eventDefinition = reader.GetEventDefinition(eventHandle);
@@ -2772,15 +2794,32 @@ public static class CompileBackSourceComposer
 
                 var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
                 string eventName = Identifier(reader.GetString(eventDefinition.Name));
-                return new ExplicitInterfaceEventInfo(
+                candidate = new ExplicitInterfaceEventInfo(
                     interfaceHandle,
                     eventHandle,
                     $"{interfaceIdentity.FullName}.{eventName}",
                     reader.GetString(declaration.Name));
+                break;
             }
+
+            if (candidate is null)
+                continue;
+            if (canonicalInterface is { } expectedInterface)
+            {
+                if (interfaceHandle == expectedInterface
+                    && reader.GetString(declaration.Name) == canonicalMemberName)
+                {
+                    return candidate;
+                }
+                continue;
+            }
+            if (fallback is null)
+                fallback = candidate;
+            else
+                fallbackIsAmbiguous = true;
         }
 
-        return null;
+        return fallbackIsAmbiguous ? null : fallback;
     }
 
     static (ExternalExplicitInterfaceEventInfo? Event, string? DeclineReason)
@@ -4164,25 +4203,37 @@ public static class CompileBackSourceComposer
         MethodDefinition targetMethod,
         IReadOnlyList<CompileBackTypeRequirement> reconstructedRequirements)
     {
-        if (!ImplicitInterfaceTargetIsOmitted(
-                assemblyPath,
-                compilationClosure,
-                reader,
-                targetType,
-                targetMethod,
-                reconstructedRequirements))
-        {
+        var omission = ImplicitInterfaceTargetOmission(
+            assemblyPath,
+            compilationClosure,
+            reader,
+            targetType,
+            targetMethod,
+            reconstructedRequirements);
+        if (omission == MetadataFactState.No)
             return;
-        }
 
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetType);
-        diagnostics.Add(new CompileBackPlanningDiagnostic(
-            "type identity",
-            "implicit-interface-not-reconstructed",
-            $"{targetIdentity.MetadataFullName}::{reader.GetString(targetMethod.Name)}"));
+        AddImplicitInterfaceOmissionDiagnostic(
+            diagnostics,
+            omission,
+            $"{targetIdentity.MetadataFullName}::{reader.GetString(targetMethod.Name)}");
     }
 
-    static bool ImplicitInterfaceTargetIsOmitted(
+    // Whether an interface the reconstruction omits from the target type's base list
+    // declares the target member — i.e. whether the target is an implicit interface
+    // implementation whose declaring interface the shell no longer names.
+    //
+    // The answer is tri-state on purpose. `No` is a proven negative: every omitted
+    // interface was read and none declares this member. `Unknown` means the evidence
+    // was unavailable — an unresolvable external assembly, an undecodable signature, or
+    // an interface reference this planner cannot follow (a nested-scope TypeRef, a
+    // TypeSpec rooted in another TypeSpec). Collapsing `Unknown` into `No` is what let a
+    // dropped `: IProbe` (or `: IOuter.IInner<int>`) report a clean Exact: the member's
+    // final/newslot slot only exists because of an interface the shell never mentions,
+    // and nothing said so. Callers must decline on `Unknown` with a distinct reason
+    // rather than claim fidelity they cannot prove.
+    static MetadataFactState ImplicitInterfaceTargetOmission(
         string assemblyPath,
         ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader reader,
@@ -4191,7 +4242,7 @@ public static class CompileBackSourceComposer
         IReadOnlyList<CompileBackTypeRequirement> reconstructedRequirements)
     {
         if (ShellKind(reader, typeDef) != CompileBackTypeKind.Class)
-            return false;
+            return MetadataFactState.No;
 
         string name = reader.GetString(method.Name);
         if (name.Contains('.', StringComparison.Ordinal)
@@ -4201,7 +4252,7 @@ public static class CompileBackSourceComposer
             || !method.Attributes.HasFlag(MethodAttributes.Final)
             || !method.Attributes.HasFlag(MethodAttributes.NewSlot))
         {
-            return false;
+            return MetadataFactState.No;
         }
 
         MethodSignature<string> targetSignature;
@@ -4213,23 +4264,25 @@ public static class CompileBackSourceComposer
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
-            return false;
+            return MetadataFactState.Unknown;
         }
 
+        var omission = MetadataFactState.No;
         foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
         {
             var interfaceHandle = reader.GetInterfaceImplementation(implementationHandle).Interface;
-            if (!OmittedInterfaceDeclaresTarget(
-                    assemblyPath,
-                    compilationClosure,
-                    reader,
-                    interfaceHandle,
-                    method,
-                    targetSignature))
-            {
+            var declares = OmittedInterfaceDeclaresTarget(
+                assemblyPath,
+                compilationClosure,
+                reader,
+                interfaceHandle,
+                method,
+                targetSignature);
+            if (declares == MetadataFactState.No)
                 continue;
-            }
 
+            // A same-assembly interface the plan actually reconstructs is not omitted, so
+            // it neither proves an omission nor leaves one unproven.
             if (SameAssemblyInterfaceTargetIsReconstructed(
                     reader,
                     interfaceHandle,
@@ -4239,10 +4292,12 @@ public static class CompileBackSourceComposer
                 continue;
             }
 
-            return true;
+            omission = CombineInterfaceEvidence(omission, declares);
+            if (omission == MetadataFactState.Yes)
+                return MetadataFactState.Yes;
         }
 
-        return false;
+        return omission;
     }
 
     static bool SameAssemblyInterfaceTargetIsReconstructed(
@@ -4534,7 +4589,38 @@ public static class CompileBackSourceComposer
         return !interfaceType.IsNil;
     }
 
-    static bool OmittedInterfaceDeclaresTarget(
+    // A proven `Yes` wins outright; otherwise one unavailable answer makes the whole
+    // question unanswerable. Never let a later `No` overwrite an earlier `Unknown`.
+    static MetadataFactState CombineInterfaceEvidence(
+        MetadataFactState current,
+        MetadataFactState next)
+        => (current, next) switch
+        {
+            (MetadataFactState.Yes, _) or (_, MetadataFactState.Yes) => MetadataFactState.Yes,
+            (MetadataFactState.Unknown, _) or (_, MetadataFactState.Unknown) => MetadataFactState.Unknown,
+            _ => MetadataFactState.No,
+        };
+
+    static void AddImplicitInterfaceOmissionDiagnostic(
+        List<CompileBackPlanningDiagnostic> diagnostics,
+        MetadataFactState omission,
+        string memberIdentity)
+    {
+        string? reason = omission switch
+        {
+            MetadataFactState.Yes => "implicit-interface-not-reconstructed",
+            MetadataFactState.Unknown => "implicit-interface-evidence-unavailable",
+            _ => null,
+        };
+        if (reason is null)
+            return;
+        diagnostics.Add(new CompileBackPlanningDiagnostic(
+            "type identity",
+            reason,
+            memberIdentity));
+    }
+
+    static MetadataFactState OmittedInterfaceDeclaresTarget(
         string assemblyPath,
         ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader reader,
@@ -4552,7 +4638,7 @@ public static class CompileBackSourceComposer
                     out root,
                     out genericInstantiation))
             {
-                return false;
+                return MetadataFactState.Unknown;
             }
         }
 
@@ -4560,19 +4646,24 @@ public static class CompileBackSourceComposer
         {
             var interfaceDef = reader.GetTypeDefinition((TypeDefinitionHandle)root);
             return InterfaceDeclaresTarget(
+                assemblyPath,
+                compilationClosure,
                 reader,
                 interfaceDef,
                 targetMethod,
                 targetSignature,
                 exactSignature: !genericInstantiation);
         }
+        // A TypeSpec rooted in another TypeSpec, or a TypeRef this planner cannot turn
+        // into an assembly-qualified identity (a nested type's scope is its enclosing
+        // TypeRef, not an AssemblyRef), leaves the interface's members unread.
         if (root.Kind != HandleKind.TypeReference
             || ExternalInterfaceReference(
                 reader,
                 (TypeReferenceHandle)root,
                 allowGenericMetadataName: true) is not { } interfaceReference)
         {
-            return false;
+            return MetadataFactState.Unknown;
         }
 
         return ExternalInterfaceDeclaresTarget(
@@ -4585,13 +4676,16 @@ public static class CompileBackSourceComposer
             exactSignature: !genericInstantiation);
     }
 
-    static bool InterfaceDeclaresTarget(
+    static MetadataFactState InterfaceDeclaresTarget(
+        string assemblyPath,
+        ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader reader,
         TypeDefinition interfaceDef,
         MethodDefinition targetMethod,
         MethodSignature<string> targetSignature,
         bool exactSignature)
     {
+        var evidence = MetadataFactState.No;
         string targetName = reader.GetString(targetMethod.Name);
         foreach (var methodHandle in interfaceDef.GetMethods())
         {
@@ -4610,6 +4704,9 @@ public static class CompileBackSourceComposer
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
+                // A same-named, same-arity candidate whose signature will not decode is
+                // exactly the case that cannot be dismissed as "does not declare it".
+                evidence = MetadataFactState.Unknown;
                 continue;
             }
             if (signature.ParameterTypes.Length != targetSignature.ParameterTypes.Length)
@@ -4620,28 +4717,66 @@ public static class CompileBackSourceComposer
                         targetSignature.ParameterTypes,
                         StringComparer.Ordinal))
             {
-                return true;
+                return MetadataFactState.Yes;
             }
         }
 
         foreach (var implementationHandle in interfaceDef.GetInterfaceImplementations())
         {
             var inherited = reader.GetInterfaceImplementation(implementationHandle).Interface;
-            if (inherited.Kind == HandleKind.TypeDefinition
-                && InterfaceDeclaresTarget(
+            bool inheritedExact = exactSignature;
+            if (inherited.Kind == HandleKind.TypeSpecification)
+            {
+                if (!TryReadNamedTypeSpecificationRoot(
+                        reader,
+                        (TypeSpecificationHandle)inherited,
+                        out inherited,
+                        out bool genericInstantiation))
+                {
+                    evidence = MetadataFactState.Unknown;
+                    continue;
+                }
+                inheritedExact &= !genericInstantiation;
+            }
+            MetadataFactState inheritedEvidence;
+            if (inherited.Kind == HandleKind.TypeDefinition)
+            {
+                inheritedEvidence = InterfaceDeclaresTarget(
+                    assemblyPath,
+                    compilationClosure,
                     reader,
                     reader.GetTypeDefinition((TypeDefinitionHandle)inherited),
                     targetMethod,
                     targetSignature,
-                    exactSignature))
-            {
-                return true;
+                    inheritedExact);
             }
+            else if (inherited.Kind == HandleKind.TypeReference
+                && ExternalInterfaceReference(
+                    reader,
+                    (TypeReferenceHandle)inherited,
+                    allowGenericMetadataName: true) is { } inheritedReference)
+            {
+                inheritedEvidence = ExternalInterfaceDeclaresTarget(
+                    assemblyPath,
+                    compilationClosure,
+                    reader,
+                    inheritedReference,
+                    targetMethod,
+                    targetSignature,
+                    inheritedExact);
+            }
+            else
+            {
+                inheritedEvidence = MetadataFactState.Unknown;
+            }
+            evidence = CombineInterfaceEvidence(evidence, inheritedEvidence);
+            if (evidence == MetadataFactState.Yes)
+                return MetadataFactState.Yes;
         }
-        return false;
+        return evidence;
     }
 
-    static bool ExternalInterfaceDeclaresTarget(
+    static MetadataFactState ExternalInterfaceDeclaresTarget(
         string assemblyPath,
         ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader targetReader,
@@ -4659,7 +4794,11 @@ public static class CompileBackSourceComposer
                 interfaceReference.MetadataFullName,
                 closure.Resolver) is not { } definition)
         {
-            return false;
+            // The interface exists in metadata but its definition is unavailable, so
+            // whether it declares the target member is unknown. Reporting "does not
+            // declare it" here is what let a dropped external interface round-trip as
+            // Exact when its assembly could not be resolved.
+            return MetadataFactState.Unknown;
         }
 
         try
@@ -4675,10 +4814,10 @@ public static class CompileBackSourceComposer
         }
         catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException or ArgumentException or InvalidOperationException)
         {
-            return false;
+            return MetadataFactState.Unknown;
         }
 
-        static bool ResolvedExternalInterfaceDeclaresTarget(
+        static MetadataFactState ResolvedExternalInterfaceDeclaresTarget(
             (
                 ResolvedAssemblyReference Assembly,
                 MetadataTypeDefinitionAddress Address) definition,
@@ -4692,13 +4831,13 @@ public static class CompileBackSourceComposer
             using Stream stream = definition.Assembly.OpenRead();
             using var peReader = new PEReader(stream);
             if (!peReader.HasMetadata)
-                return false;
+                return MetadataFactState.Unknown;
             var reader = peReader.GetMetadataReader();
             if (!definition.Address.TryResolve(
                     reader,
                     out TypeDefinitionHandle interfaceHandle))
             {
-                return false;
+                return MetadataFactState.Unknown;
             }
             return ExternalInterfaceDefinitionDeclaresTarget(
                 reader,
@@ -4712,7 +4851,7 @@ public static class CompileBackSourceComposer
                 visited);
         }
 
-        static bool ExternalInterfaceDefinitionDeclaresTarget(
+        static MetadataFactState ExternalInterfaceDefinitionDeclaresTarget(
             MetadataReader reader,
             ResolvedAssemblyReference assembly,
             TypeDefinitionHandle interfaceHandle,
@@ -4726,8 +4865,11 @@ public static class CompileBackSourceComposer
             string visitKey =
                 $"{assembly.Identity}|{reader.GetGuid(reader.GetModuleDefinition().Mvid):D}|"
                 + $"{MetadataTokens.GetToken(interfaceHandle):X8}";
+            // A repeat visit contributed its own answer the first time; treating the
+            // cycle stop as `No` keeps it from masking that answer.
             if (!visited.Add(visitKey))
-                return false;
+                return MetadataFactState.No;
+            var evidence = MetadataFactState.No;
             var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
             foreach (var methodHandle in interfaceDef.GetMethods())
             {
@@ -4746,6 +4888,7 @@ public static class CompileBackSourceComposer
                 }
                 catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
                 {
+                    evidence = MetadataFactState.Unknown;
                     continue;
                 }
                 if (signature.ParameterTypes.Length != targetSignature.ParameterTypes.Length)
@@ -4756,7 +4899,7 @@ public static class CompileBackSourceComposer
                             targetSignature.ParameterTypes,
                             StringComparer.Ordinal))
                 {
-                    return true;
+                    return MetadataFactState.Yes;
                 }
             }
 
@@ -4772,12 +4915,15 @@ public static class CompileBackSourceComposer
                             out inherited,
                             out bool genericInstantiation))
                     {
+                        evidence = MetadataFactState.Unknown;
                         continue;
                     }
                     inheritedExact &= !genericInstantiation;
                 }
-                if (inherited.Kind == HandleKind.TypeDefinition
-                    && ExternalInterfaceDefinitionDeclaresTarget(
+                MetadataFactState inheritedEvidence;
+                if (inherited.Kind == HandleKind.TypeDefinition)
+                {
+                    inheritedEvidence = ExternalInterfaceDefinitionDeclaresTarget(
                         reader,
                         assembly,
                         (TypeDefinitionHandle)inherited,
@@ -4786,11 +4932,9 @@ public static class CompileBackSourceComposer
                         targetGenericArity,
                         targetSignature,
                         inheritedExact,
-                        visited))
-                {
-                    return true;
+                        visited);
                 }
-                if (inherited.Kind == HandleKind.TypeReference
+                else if (inherited.Kind == HandleKind.TypeReference
                     && ExternalInterfaceReference(
                         reader,
                         (TypeReferenceHandle)inherited,
@@ -4799,20 +4943,26 @@ public static class CompileBackSourceComposer
                         assembly,
                         inheritedReference.AssemblyIdentity,
                         inheritedReference.MetadataFullName,
-                        resolver) is { } inheritedDefinition
-                    && ResolvedExternalInterfaceDeclaresTarget(
+                        resolver) is { } inheritedDefinition)
+                {
+                    inheritedEvidence = ResolvedExternalInterfaceDeclaresTarget(
                         inheritedDefinition,
                         resolver,
                         targetName,
                         targetGenericArity,
                         targetSignature,
                         inheritedExact,
-                        visited))
-                {
-                    return true;
+                        visited);
                 }
+                else
+                {
+                    inheritedEvidence = MetadataFactState.Unknown;
+                }
+                evidence = CombineInterfaceEvidence(evidence, inheritedEvidence);
+                if (evidence == MetadataFactState.Yes)
+                    return MetadataFactState.Yes;
             }
-            return false;
+            return evidence;
         }
     }
 
@@ -7442,9 +7592,24 @@ public static class CompileBackSourceComposer
             foreach (var surfaceMethod in surface.Members.Where(member =>
                 member.MetadataToken is not null
                 && !surfaceAccessorTokens.Contains(member.MetadataToken.Value)
-                && member.Kind != "extension-method"
-                && (!operatorOnly || member.CSharpOperatorDeclaration == true)))
+                && member.Kind != "extension-method"))
             {
+                if (operatorOnly && surfaceMethod.CSharpOperatorDeclaration != true)
+                {
+                    // An operator-only surface keeps proven operators and drops everything
+                    // else. An unclassifiable operator is neither, so record that it was
+                    // dropped without evidence instead of dropping it silently.
+                    if (surfaceMethod.HasCSharpOperatorDeclarationClassification
+                        && surfaceMethod.CSharpOperatorDeclaration is null)
+                    {
+                        diagnostics.Add(new CompileBackPlanningDiagnostic(
+                            "member surface",
+                            "operator-representability-unknown",
+                            $"{requirement.Type.MetadataFullName}::{surfaceMethod.Name}; "
+                                + "C# operator classification unavailable; omitted from operator surface"));
+                    }
+                    continue;
+                }
                 var methodHandle = SurfaceMethodHandle(surfaceMethod.MetadataToken);
                 if (methodHandle.IsNil)
                 {
@@ -7528,10 +7693,21 @@ public static class CompileBackSourceComposer
                     && surfaceMethod.CSharpOperatorDeclaration == true;
                 if (methodHasOperatorIdentity && !methodIsOperator)
                 {
+                    // A null classification is unavailable evidence, not a proven negative:
+                    // the surface classifies without a relationship resolver, so an operator
+                    // whose signature names a type outside this assembly is unclassifiable.
+                    // Both cases still emit the raw method, but reporting the unproven one as
+                    // "not representable" claims a fact nothing established.
+                    bool classificationUnavailable =
+                        surfaceMethod.CSharpOperatorDeclaration is null;
                     diagnostics.Add(new CompileBackPlanningDiagnostic(
                         "member surface",
-                        "operator-not-representable",
-                        $"{signatureIdentity}; emitted as raw method"));
+                        classificationUnavailable
+                            ? "operator-representability-unknown"
+                            : "operator-not-representable",
+                        classificationUnavailable
+                            ? $"{signatureIdentity}; C# operator classification unavailable; emitted as raw method"
+                            : $"{signatureIdentity}; emitted as raw method"));
                 }
                 var memberKind = isConstructor
                     ? CompileBackMemberKind.Constructor

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2972,6 +2972,24 @@ public static class CompileBackSourceComposer
             : CompileBackTypeSignature.Display(MethodReturnType(reader, targetTypeDef, method));
         var targetParameters = MethodParameters(reader, method, signature);
         var targetTypeParameters = MethodTypeParameters(reader, method);
+        bool targetHasOperatorIdentity = !isConstructor
+            && IsMetadataOperator(method, methodName);
+        bool targetOperatorIsRepresentable = targetHasOperatorIdentity
+            && IsRepresentableOperator(
+                reader,
+                targetTypeDef,
+                method,
+                methodName,
+                signature,
+                targetParameters,
+                targetReturnType?.DisplayName);
+        if (targetHasOperatorIdentity && !targetOperatorIsRepresentable)
+        {
+            diagnostics.Add(new CompileBackPlanningDiagnostic(
+                "member surface",
+                "operator-not-representable",
+                MethodSignatureText(methodName, signature)));
+        }
         bool isFinalizer = !isConstructor
             && memberSurfaceByDefinitionName.TryGetValue(
                 TypeProducer.DefinitionName(reader, targetType),
@@ -3030,7 +3048,7 @@ public static class CompileBackSourceComposer
                 IsAsync: !isConstructor
                     && (function.RequiresAsyncBodyModifier
                         || function.IsRuntimeAsync == MetadataFactState.Yes),
-                IsOperator: !isConstructor && IsMetadataOperator(method, methodName),
+                IsOperator: targetOperatorIsRepresentable,
                 IsFinalizer: isFinalizer,
                 ConstructorInitializer: targetConstructorInitializer,
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
@@ -3424,14 +3442,27 @@ public static class CompileBackSourceComposer
 
             if (!OperatorSignaturesMatch(reader, targetMethod, methodHandle))
                 continue;
+            var parameters = MethodParameters(reader, method, signature);
+            var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
+            if (!IsRepresentableOperator(
+                    reader,
+                    typeDef,
+                    method,
+                    siblingName,
+                    signature,
+                    parameters,
+                    returnType.DisplayName))
+            {
+                continue;
+            }
 
             var signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, siblingName, 0, MethodSignatureText(siblingName, signature)),
                 CompileBackMemberKind.Operator,
                 method.Attributes.HasFlag(MethodAttributes.Static),
-                MethodParameters(reader, method, signature),
-                CompileBackTypeSignature.Display(signature.ReturnType),
+                parameters,
+                returnType,
                 MethodTypeParameters(reader, method),
                 CompileBackStubBodyKind.Throw,
                 TargetBody: null,
@@ -3463,6 +3494,159 @@ public static class CompileBackSourceComposer
         => method.Attributes.HasFlag(MethodAttributes.SpecialName)
             && method.GetGenericParameters().Count == 0
             && OperatorNames.IsOperatorMethodName(name);
+
+    static bool IsRepresentableOperator(
+        MetadataReader reader,
+        TypeDefinition declaringType,
+        MethodDefinition method,
+        string name,
+        MethodSignature<string> signature,
+        IReadOnlyList<CompileBackParameter> parameters,
+        string? returnType)
+    {
+        if (!IsMetadataOperator(method, name) || returnType is null)
+            return false;
+
+        bool isStatic = method.Attributes.HasFlag(MethodAttributes.Static);
+        bool isPublic = (method.Attributes & MethodAttributes.MemberAccessMask)
+            == MethodAttributes.Public;
+        if (OperatorNames.IsAssignmentOperatorMethodName(name))
+        {
+            return OperatorNames.IsCSharpInstanceAssignmentOperator(
+                    name,
+                    isStatic,
+                    isPublic,
+                    returnType,
+                    parameters.Count)
+                && parameters.All(parameter => parameter.Modifier is null);
+        }
+
+        int? expectedParameterCount = CSharpOperatorParameterCount(name);
+        if (!isStatic
+            || !isPublic
+            || returnType is "void" or "System.Void"
+            || expectedParameterCount is null
+            || parameters.Count != expectedParameterCount
+            || parameters.Any(parameter => parameter.Modifier is "ref" or "out"))
+        {
+            return false;
+        }
+
+        var declaringIdentity = CompileBackTypeIdentity.FromDefinition(reader, declaringType);
+        bool hasDeclaringOperand = parameters.Any(parameter =>
+            IsDeclaringTypeSpelling(parameter.Type.DisplayName, declaringIdentity));
+        if (IsConversionOperator(name))
+        {
+            if (!hasDeclaringOperand
+                && !IsDeclaringTypeSpelling(returnType, declaringIdentity))
+            {
+                return false;
+            }
+        }
+        else if (!hasDeclaringOperand)
+        {
+            return false;
+        }
+
+        if (name is "op_True" or "op_False"
+            && returnType is not ("bool" or "System.Boolean"))
+        {
+            return false;
+        }
+        if (name is "op_Increment" or "op_Decrement"
+            && !IsDeclaringTypeSpelling(returnType, declaringIdentity))
+        {
+            return false;
+        }
+
+        return RequiredOperatorPair(name) is not { } pairName
+            || HasOperatorPair(reader, declaringType, pairName, signature);
+    }
+
+    static int? CSharpOperatorParameterCount(string name)
+    {
+        if (IsConversionOperator(name))
+            return 1;
+
+        string uncheckedName = name.StartsWith("op_Checked", StringComparison.Ordinal)
+            ? $"op_{name["op_Checked".Length..]}"
+            : name;
+        return uncheckedName switch
+        {
+            "op_UnaryPlus" or "op_UnaryNegation" or "op_Increment" or "op_Decrement"
+                or "op_OnesComplement" or "op_True" or "op_False" or "op_LogicalNot" => 1,
+            "op_Addition" or "op_Subtraction" or "op_Multiply" or "op_Division"
+                or "op_Modulus" or "op_BitwiseAnd" or "op_BitwiseOr" or "op_ExclusiveOr"
+                or "op_LeftShift" or "op_RightShift" or "op_UnsignedRightShift"
+                or "op_Equality" or "op_Inequality" or "op_LessThan" or "op_GreaterThan"
+                or "op_LessThanOrEqual" or "op_GreaterThanOrEqual" => 2,
+            _ => null,
+        };
+    }
+
+    static bool IsConversionOperator(string name)
+        => name is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";
+
+    static bool IsDeclaringTypeSpelling(
+        string type,
+        CompileBackTypeIdentity declaringType)
+    {
+        string normalized = type.EndsWith('?')
+            ? type[..^1]
+            : type;
+        return normalized == declaringType.DisplayName
+            || normalized == declaringType.FullName
+            || normalized == declaringType.MetadataFullName
+            || normalized.StartsWith($"{declaringType.DisplayName}<", StringComparison.Ordinal)
+            || normalized.StartsWith($"{declaringType.FullName}<", StringComparison.Ordinal);
+    }
+
+    static string? RequiredOperatorPair(string name)
+        => name switch
+        {
+            "op_Equality" => "op_Inequality",
+            "op_Inequality" => "op_Equality",
+            "op_LessThan" => "op_GreaterThan",
+            "op_GreaterThan" => "op_LessThan",
+            "op_LessThanOrEqual" => "op_GreaterThanOrEqual",
+            "op_GreaterThanOrEqual" => "op_LessThanOrEqual",
+            "op_True" => "op_False",
+            "op_False" => "op_True",
+            _ => OperatorNames.UncheckedOperator(name),
+        };
+
+    static bool HasOperatorPair(
+        MetadataReader reader,
+        TypeDefinition declaringType,
+        string pairName,
+        MethodSignature<string> signature)
+    {
+        foreach (var methodHandle in declaringType.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != pairName
+                || !IsMetadataOperator(method, pairName))
+            {
+                continue;
+            }
+
+            try
+            {
+                var pairSignature = GuardedSignatureText.MethodText(
+                    reader,
+                    method,
+                    GenericContext.ForMethod(reader, declaringType, method));
+                if (OperatorSignaturesMatch(signature, pairSignature))
+                    return true;
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
 
     static bool IsRecordGeneratedFieldReadHelper(
         MetadataReader reader,
@@ -4880,6 +5064,19 @@ public static class CompileBackSourceComposer
             {
                 return null;
             }
+            bool hasOperatorIdentity = !isConstructor
+                && IsMetadataOperator(method, name);
+            bool operatorIsRepresentable = hasOperatorIdentity
+                && IsRepresentableOperator(
+                    reader,
+                    typeDef,
+                    method,
+                    name,
+                    signature,
+                    parameters,
+                    CompileBackTypeSignature.Display(methodReturnType).DisplayName);
+            if (hasOperatorIdentity && !operatorIsRepresentable)
+                return null;
 
             string identifierName = MemberIdentifierName(name, isConstructor);
             return new CompileBackMemberRequirement(
@@ -4905,7 +5102,7 @@ public static class CompileBackSourceComposer
                 IsOverride: false,
                 IsSealed: false,
                 IsExtension: IsExtensionMethod(reader, typeDef, method),
-                IsOperator: !isConstructor && IsMetadataOperator(method, name));
+                IsOperator: operatorIsRepresentable);
         }
 
         static bool IsExtensionMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
@@ -5781,7 +5978,24 @@ public static class CompileBackSourceComposer
                     continue;
                 }
                 bool methodIsStatic = method.Attributes.HasFlag(MethodAttributes.Static);
-                bool methodIsOperator = memberKind == CompileBackMemberKind.Operator;
+                bool methodHasOperatorIdentity = memberKind == CompileBackMemberKind.Operator;
+                bool methodIsOperator = methodHasOperatorIdentity
+                    && IsRepresentableOperator(
+                        reader,
+                        typeDef,
+                        method,
+                        name,
+                        signature,
+                        parameters,
+                        CompileBackTypeSignature.Display(methodReturnType).DisplayName);
+                if (methodHasOperatorIdentity && !methodIsOperator)
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "operator-not-representable",
+                        signatureIdentity));
+                    continue;
+                }
                 string? returnTypeIdentity = isConstructor
                     ? null
                     : CompileBackTypeSignature.Display(methodReturnType).DisplayName;
@@ -6045,14 +6259,23 @@ public static class CompileBackSourceComposer
             MetadataReader reader,
             CompileBackTypeIdentity identity)
         {
+            TypeDefinitionHandle? match = null;
             foreach (var handle in reader.TypeDefinitions)
             {
                 var typeDef = reader.GetTypeDefinition(handle);
                 if (CompileBackTypeIdentity.FromDefinition(reader, typeDef) == identity)
-                    return handle;
+                {
+                    if (match is not null)
+                    {
+                        throw new AmbiguousMatchException(
+                            $"Product type identity '{identity.MetadataFullName}' matches multiple TypeDef rows.");
+                    }
+
+                    match = handle;
+                }
             }
 
-            return null;
+            return match;
         }
 
         static bool HasParameterlessInstanceConstructor(MetadataReader reader, TypeDefinition typeDef)

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -463,6 +463,10 @@ internal sealed record ExplicitInterfaceEventInfo(
     string QualifiedName,
     string AccessorName);
 
+internal sealed record ExternalExplicitInterfaceEventInfo(
+    string InterfaceDisplayName,
+    string QualifiedName);
+
 internal sealed record ExternalExplicitInterfaceMethodInfo(
     string InterfaceDisplayName,
     string ExplicitInterfaceMemberName,
@@ -1215,19 +1219,6 @@ public static class CompileBackSourceComposer
         };
         if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
-        if (ImplicitInterfaceTargetIsOmitted(
-                assemblyPath,
-                compilationClosure,
-                reader,
-                targetTypeDef,
-                getter))
-        {
-            diagnostics.Add(new CompileBackPlanningDiagnostic(
-                "type identity",
-                "implicit-interface-not-reconstructed",
-                $"{targetIdentity.MetadataFullName}::{reader.GetString(getter.Name)}"));
-        }
-
         var targetMembers = new List<CompileBackMemberRequirement>
         {
             new CompileBackMemberRequirement(
@@ -1312,6 +1303,14 @@ public static class CompileBackSourceComposer
             memberSurfaceByDefinitionName,
             diagnostics,
             relationshipResolver);
+        AddImplicitInterfaceTargetDiagnostic(
+            diagnostics,
+            assemblyPath,
+            compilationClosure,
+            reader,
+            targetTypeDef,
+            getter,
+            production.Requirements);
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
             Usings: BuildUsings(function),
@@ -2784,6 +2783,217 @@ public static class CompileBackSourceComposer
         return null;
     }
 
+    static (ExternalExplicitInterfaceEventInfo? Event, string? DeclineReason)
+        ExternalExplicitInterfaceEvent(
+        MetadataReader reader,
+        string assemblyPath,
+        ReturnToSender.CompilationClosure? compilationClosure,
+        TypeDefinition targetType,
+        EventDefinition targetEvent,
+        MethodDefinitionHandle targetAccessor,
+        IReadOnlySet<TypeDefinitionHandle> closureRoots)
+    {
+        string metadataEventName = reader.GetString(targetEvent.Name);
+        if (!TrySplitExplicitInterfaceMetadataName(
+                metadataEventName,
+                out var interfaceMetadataName,
+                out var eventName))
+        {
+            return (null, null);
+        }
+
+        foreach (var implementationHandle in targetType.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody != targetAccessor)
+                continue;
+
+            if (implementation.MethodDeclaration.Kind != HandleKind.MemberReference)
+                continue;
+
+            var declaration = reader.GetMemberReference(
+                (MemberReferenceHandle)implementation.MethodDeclaration);
+            if (declaration.GetKind() != MemberReferenceKind.Method
+                || declaration.Parent.Kind != HandleKind.TypeReference)
+            {
+                continue;
+            }
+
+            if (ExternalInterfaceReference(
+                    reader,
+                    (TypeReferenceHandle)declaration.Parent) is not { } interfaceReference
+                || !string.Equals(
+                    interfaceReference.MetadataFullName,
+                    interfaceMetadataName,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!ExternalInterfaceNameIsRepresentable(interfaceReference.MetadataFullName)
+                || !MetadataIdentifierRoundTrips(eventName))
+            {
+                return Decline("External explicit event identity is not representable in C#.");
+            }
+            if (ExternalInterfaceSpellingShadowedByClosure(
+                    reader,
+                    targetType,
+                    closureRoots,
+                    interfaceReference.MetadataFullName))
+            {
+                return Decline("External explicit event identity is shadowed by the reconstruction closure.");
+            }
+
+            var targetAccessorDefinition = reader.GetMethodDefinition(targetAccessor);
+            if (SignatureHasUnrepresentableDetail(reader, targetAccessorDefinition))
+                return Decline("External explicit event accessor signature is not representable.");
+
+            MethodSignature<string> targetSignature;
+            MethodSignature<string> declarationSignature;
+            try
+            {
+                targetSignature = GuardedSignatureText.MethodText(
+                    reader,
+                    targetAccessorDefinition,
+                    GenericContext.ForMethod(reader, targetType, targetAccessorDefinition));
+                declarationSignature = declaration.DecodeMethodSignature(
+                    SignatureDecoder.Instance,
+                    genericContext: null);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return Decline("External explicit event accessor signature could not be decoded.");
+            }
+
+            ReturnToSender.CompilationClosure closure =
+                compilationClosure
+                ?? ReturnToSender.CreateCompilationClosure(assemblyPath);
+            if (ResolveExternalTypeDefinition(
+                    closure.TargetAssembly,
+                    interfaceReference.AssemblyIdentity,
+                    interfaceReference.MetadataFullName,
+                    closure.Resolver) is not { } definition)
+            {
+                return Decline("External explicit event interface was not resolved from the compilation closure.");
+            }
+
+            try
+            {
+                using Stream stream = definition.Assembly.OpenRead();
+                using var peReader = new PEReader(stream);
+                if (!peReader.HasMetadata)
+                    return Decline("External explicit event interface has no metadata.");
+                var externalReader = peReader.GetMetadataReader();
+                if (!definition.Address.TryResolve(
+                        externalReader,
+                        out TypeDefinitionHandle interfaceHandle))
+                {
+                    return Decline("External explicit event interface identity did not resolve.");
+                }
+
+                var interfaceDef = externalReader.GetTypeDefinition(interfaceHandle);
+                if ((interfaceDef.Attributes & TypeAttributes.Interface) == 0
+                    || interfaceDef.GetGenericParameters().Count != 0
+                    || !IsPubliclyAccessible(externalReader, interfaceDef)
+                    || AttributeReader.TryGetObsoleteAttribute(
+                        externalReader,
+                        interfaceDef.GetCustomAttributes(),
+                        out _)
+                    || AttributeReader.HasAttribute(
+                        externalReader,
+                        interfaceDef.GetCustomAttributes(),
+                        KnownAttributeNames.CompilerFeatureRequiredAttribute)
+                    || interfaceDef.GetProperties().Count != 0
+                    || interfaceDef.GetInterfaceImplementations().Count != 0)
+                {
+                    return Decline("External explicit event interface surface is not reconstructable.");
+                }
+
+                var matches = new List<EventDefinitionHandle>();
+                var targetAccessors = targetEvent.GetAccessors();
+                foreach (var eventHandle in interfaceDef.GetEvents())
+                {
+                    var externalEvent = externalReader.GetEventDefinition(eventHandle);
+                    if (externalReader.GetString(externalEvent.Name) != eventName)
+                        continue;
+
+                    var accessors = externalEvent.GetAccessors();
+                    MethodDefinitionHandle externalAccessor =
+                        targetAccessors.Adder == targetAccessor
+                            ? accessors.Adder
+                            : targetAccessors.Remover == targetAccessor
+                                ? accessors.Remover
+                                : default;
+                    if (externalAccessor.IsNil
+                        || externalReader.GetString(
+                            externalReader.GetMethodDefinition(externalAccessor).Name)
+                            != reader.GetString(declaration.Name))
+                    {
+                        continue;
+                    }
+
+                    var externalAccessorDefinition = externalReader.GetMethodDefinition(externalAccessor);
+                    if (externalAccessorDefinition.GetGenericParameters().Count != 0
+                        || SignatureHasUnrepresentableDetail(externalReader, externalAccessorDefinition))
+                    {
+                        return Decline("External explicit event accessor signature is not reconstructable.");
+                    }
+
+                    var externalSignature = GuardedSignatureText.MethodText(
+                        externalReader,
+                        externalAccessorDefinition,
+                        GenericContext.ForMethod(
+                            externalReader,
+                            interfaceDef,
+                            externalAccessorDefinition));
+                    if (!SameExternalEventAccessorSignature(targetSignature, externalSignature)
+                        || !SameExternalEventAccessorSignature(declarationSignature, externalSignature))
+                    {
+                        return Decline("External explicit event accessor signature does not match its declaration.");
+                    }
+                    matches.Add(eventHandle);
+                }
+
+                if (matches.Count != 1)
+                    return Decline("External explicit event declaration is missing or ambiguous.");
+
+                var matchedEvent = externalReader.GetEventDefinition(matches[0]);
+                var matchedAccessors = matchedEvent.GetAccessors();
+                if (matchedAccessors.Adder.IsNil
+                    || matchedAccessors.Remover.IsNil
+                    || interfaceDef.GetEvents().Count != 1
+                    || interfaceDef.GetMethods().Any(methodHandle =>
+                        methodHandle != matchedAccessors.Adder
+                        && methodHandle != matchedAccessors.Remover))
+                {
+                    return Decline("External explicit event interface has unreconstructed required members.");
+                }
+            }
+            catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException or ArgumentException or InvalidOperationException)
+            {
+                return Decline("External explicit event interface could not be inspected.");
+            }
+
+            return (
+                new ExternalExplicitInterfaceEventInfo(
+                    interfaceReference.DisplayFullName,
+                    $"{interfaceReference.DisplayFullName}.{Identifier(eventName)}"),
+                null);
+        }
+
+        return (null, null);
+
+        (ExternalExplicitInterfaceEventInfo? Event, string? DeclineReason) Decline(string reason)
+            => (null, $"{reader.GetFullTypeName(targetType)}::{metadataEventName}: {reason}");
+    }
+
+    static bool SameExternalEventAccessorSignature(
+        MethodSignature<string> left,
+        MethodSignature<string> right)
+        => left.Header.IsInstance == right.Header.IsInstance
+           && left.ReturnType == right.ReturnType
+           && left.ParameterTypes.SequenceEqual(right.ParameterTypes, StringComparer.Ordinal);
+
     static void AddExplicitInterfaceEventDeclaration(
         List<CompileBackTypeRequirement> requirements,
         MetadataReader reader,
@@ -2858,19 +3068,6 @@ public static class CompileBackSourceComposer
         };
         if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
-        if (ImplicitInterfaceTargetIsOmitted(
-                assemblyPath,
-                compilationClosure,
-                reader,
-                targetTypeDef,
-                setter))
-        {
-            diagnostics.Add(new CompileBackPlanningDiagnostic(
-                "type identity",
-                "implicit-interface-not-reconstructed",
-                $"{targetIdentity.MetadataFullName}::{reader.GetString(setter.Name)}"));
-        }
-
         var indexerParameterCount = propertySignature.ParameterTypes.Length;
         var targetMembers = new List<CompileBackMemberRequirement>
         {
@@ -2944,6 +3141,14 @@ public static class CompileBackSourceComposer
             memberSurfaceByDefinitionName,
             diagnostics,
             relationshipResolver);
+        AddImplicitInterfaceTargetDiagnostic(
+            diagnostics,
+            assemblyPath,
+            compilationClosure,
+            reader,
+            targetTypeDef,
+            setter,
+            production.Requirements);
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
             Usings: BuildUsings(function),
@@ -3000,12 +3205,32 @@ public static class CompileBackSourceComposer
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string metadataEventName = reader.GetString(eventDefinition.Name);
         string eventName = Identifier(metadataEventName[(metadataEventName.LastIndexOf('.') + 1)..]);
-        var explicitEvent = ExplicitInterfaceEvent(
+        var sameAssemblyExplicitEvent = ExplicitInterfaceEvent(
             reader,
             targetTypeDef,
             targetAccessor);
+        ExternalExplicitInterfaceEventInfo? externalExplicitEvent = null;
+        string? externalEventDeclineReason = null;
+        if (sameAssemblyExplicitEvent is null)
+        {
+            (externalExplicitEvent, externalEventDeclineReason) = ExternalExplicitInterfaceEvent(
+                reader,
+                assemblyPath,
+                compilationClosure,
+                targetTypeDef,
+                eventDefinition,
+                targetAccessor,
+                closureRoots);
+        }
 
         var diagnostics = new List<CompileBackPlanningDiagnostic>();
+        if (externalEventDeclineReason is not null)
+        {
+            diagnostics.Add(new CompileBackPlanningDiagnostic(
+                "type identity",
+                "external-explicit-interface-event-not-reconstructed",
+                externalEventDeclineReason));
+        }
         var targetRoot = TopLevelRootOf(reader, targetType);
         var targetFacts = new List<CompileBackFact>
         {
@@ -3013,19 +3238,6 @@ public static class CompileBackSourceComposer
         };
         if (closureFacts.TryGetValue(targetType, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
-        if (ImplicitInterfaceTargetIsOmitted(
-                assemblyPath,
-                compilationClosure,
-                reader,
-                targetTypeDef,
-                accessor))
-        {
-            diagnostics.Add(new CompileBackPlanningDiagnostic(
-                "type identity",
-                "implicit-interface-not-reconstructed",
-                $"{targetIdentity.MetadataFullName}::{reader.GetString(accessor.Name)}"));
-        }
-
         var targetMembers = new List<CompileBackMemberRequirement>
         {
             new(
@@ -3048,14 +3260,16 @@ public static class CompileBackSourceComposer
                     && IsOverrideSlotReuse(accessor)
                     && accessor.Attributes.HasFlag(MethodAttributes.Final),
                 RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function),
-                ExplicitInterfaceMemberName: explicitEvent?.QualifiedName,
+                ExplicitInterfaceMemberName: sameAssemblyExplicitEvent?.QualifiedName
+                    ?? externalExplicitEvent?.QualifiedName,
                 SiblingTargetBody: siblingAccessorBody,
                 AdderToken: accessors.Adder.IsNil
                     ? null
                     : MetadataTokens.GetToken(accessors.Adder),
                 RemoverToken: accessors.Remover.IsNil
                     ? null
-                    : MetadataTokens.GetToken(accessors.Remover))
+                    : MetadataTokens.GetToken(accessors.Remover),
+                MetadataName: metadataEventName)
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -3081,16 +3295,12 @@ public static class CompileBackSourceComposer
                 // pass) keeps its pre-existing minimal single-accessor shape for explicit-interface
                 // event targets, leaving the corpus baseline unchanged.
                 //
-                // Explicit-interface event targets are excluded: the surface folds events by the
-                // sanitized full metadata name (`IBaseEvents.Changed`) while this target requirement
-                // carries the stripped identity (`Changed`), so the fold misses and a second
-                // explicit-interface event is appended (CS8646/CS0102). They retain the pre-#3007
-                // single-accessor shape (an honest floor, not a double-declaration false success);
-                // coherent explicit-interface reconstruction is out of #3007's plain-event scope.
                 IncludeMemberSurface = bodyPolicy == RoundTripBodyPolicy.Full
-                    && explicitEvent is null
                     && targetFacts.Any(fact => fact.Id == "closure-member"),
                 IncludeOperatorSurface = targetMembers.Any(member => member.IsOperator),
+                ExternalInterfaces = externalExplicitEvent is null
+                    ? []
+                    : [externalExplicitEvent.InterfaceDisplayName],
             }
         };
         AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
@@ -3099,7 +3309,7 @@ public static class CompileBackSourceComposer
             if (dependency != targetRoot)
                 AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
         }
-        AddExplicitInterfaceEventDeclaration(requirements, reader, explicitEvent);
+        AddExplicitInterfaceEventDeclaration(requirements, reader, sameAssemblyExplicitEvent);
 
         var production = TypeProducer.Produce(
             reader,
@@ -3107,6 +3317,14 @@ public static class CompileBackSourceComposer
             memberSurfaceByDefinitionName,
             diagnostics,
             relationshipResolver);
+        AddImplicitInterfaceTargetDiagnostic(
+            diagnostics,
+            assemblyPath,
+            compilationClosure,
+            reader,
+            targetTypeDef,
+            accessor,
+            production.Requirements);
         var module = new CompileBackModuleRequirement(
             Usings: BuildUsings(function),
             AssemblyAttributes: [],
@@ -3230,18 +3448,6 @@ public static class CompileBackSourceComposer
                 "type identity",
                 "external-interface-base-not-reconstructed",
                 externalInterfaceDeclineReason));
-        }
-        if (ImplicitInterfaceTargetIsOmitted(
-                assemblyPath,
-                compilationClosure,
-                reader,
-                targetTypeDef,
-                method))
-        {
-            diagnostics.Add(new CompileBackPlanningDiagnostic(
-                "type identity",
-                "implicit-interface-not-reconstructed",
-                $"{targetIdentity.MetadataFullName}::{reader.GetString(method.Name)}"));
         }
         string? explicitInterfaceMemberName =
             sameAssemblyExplicitInterfaceMemberName
@@ -3461,6 +3667,14 @@ public static class CompileBackSourceComposer
             memberSurfaceByDefinitionName,
             diagnostics,
             operatorResolver);
+        AddImplicitInterfaceTargetDiagnostic(
+            diagnostics,
+            assemblyPath,
+            compilationClosure,
+            reader,
+            targetTypeDef,
+            method,
+            production.Requirements);
         var declarations = production.Requests;
         var module = new CompileBackModuleRequirement(
             Usings: BuildUsings(function),
@@ -3941,12 +4155,40 @@ public static class CompileBackSourceComposer
         => method.Attributes.HasFlag(MethodAttributes.Virtual)
             && !method.Attributes.HasFlag(MethodAttributes.NewSlot);
 
+    static void AddImplicitInterfaceTargetDiagnostic(
+        List<CompileBackPlanningDiagnostic> diagnostics,
+        string assemblyPath,
+        ReturnToSender.CompilationClosure? compilationClosure,
+        MetadataReader reader,
+        TypeDefinition targetType,
+        MethodDefinition targetMethod,
+        IReadOnlyList<CompileBackTypeRequirement> reconstructedRequirements)
+    {
+        if (!ImplicitInterfaceTargetIsOmitted(
+                assemblyPath,
+                compilationClosure,
+                reader,
+                targetType,
+                targetMethod,
+                reconstructedRequirements))
+        {
+            return;
+        }
+
+        var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetType);
+        diagnostics.Add(new CompileBackPlanningDiagnostic(
+            "type identity",
+            "implicit-interface-not-reconstructed",
+            $"{targetIdentity.MetadataFullName}::{reader.GetString(targetMethod.Name)}"));
+    }
+
     static bool ImplicitInterfaceTargetIsOmitted(
         string assemblyPath,
         ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader reader,
         TypeDefinition typeDef,
-        MethodDefinition method)
+        MethodDefinition method,
+        IReadOnlyList<CompileBackTypeRequirement> reconstructedRequirements)
     {
         if (ShellKind(reader, typeDef) != CompileBackTypeKind.Class)
             return false;
@@ -3977,9 +4219,7 @@ public static class CompileBackSourceComposer
         foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
         {
             var interfaceHandle = reader.GetInterfaceImplementation(implementationHandle).Interface;
-            if (interfaceHandle.Kind == HandleKind.TypeDefinition)
-                continue;
-            if (OmittedInterfaceDeclaresTarget(
+            if (!OmittedInterfaceDeclaresTarget(
                     assemblyPath,
                     compilationClosure,
                     reader,
@@ -3987,11 +4227,311 @@ public static class CompileBackSourceComposer
                     method,
                     targetSignature))
             {
-                return true;
+                continue;
             }
+
+            if (SameAssemblyInterfaceTargetIsReconstructed(
+                    reader,
+                    interfaceHandle,
+                    method,
+                    reconstructedRequirements))
+            {
+                continue;
+            }
+
+            return true;
         }
 
         return false;
+    }
+
+    static bool SameAssemblyInterfaceTargetIsReconstructed(
+        MetadataReader reader,
+        EntityHandle interfaceHandle,
+        MethodDefinition targetMethod,
+        IReadOnlyList<CompileBackTypeRequirement> reconstructedRequirements)
+    {
+        if (!TryDecodeMethodSignature(
+                reader,
+                targetMethod,
+                out MethodSignature<TypeRef> targetSignature)
+            || !TryFindDeclaringInterfaceMethod(
+                reader,
+                interfaceHandle,
+                targetMethod,
+                targetSignature,
+                new HashSet<TypeDefinitionHandle>(),
+                out var declaringType,
+                out var declaringMethod))
+        {
+            return false;
+        }
+
+        var interfaceDef = reader.GetTypeDefinition(declaringType);
+        var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
+        var declaredMember = InterfaceMemberRequirement(
+            reader,
+            interfaceDef,
+            interfaceIdentity,
+            declaringMethod);
+        return declaredMember is not null
+            && reconstructedRequirements.Any(requirement =>
+                requirement.Type == interfaceIdentity
+                && requirement.RequiredMembers.Any(member =>
+                    SameReconstructedInterfaceMember(member, declaredMember)));
+    }
+
+    static bool SameReconstructedInterfaceMember(
+        CompileBackMemberRequirement reconstructed,
+        CompileBackMemberRequirement declared)
+    {
+        if (TypeProducer.SameMemberShape(reconstructed, declared))
+            return true;
+
+        return declared.Kind switch
+        {
+            CompileBackMemberKind.Method or CompileBackMemberKind.Operator =>
+                declared.MetadataToken is int token
+                && reconstructed.MetadataToken == token,
+            CompileBackMemberKind.PropertyGet =>
+                declared.GetterToken is int token
+                && reconstructed.GetterToken == token,
+            CompileBackMemberKind.PropertySet =>
+                declared.SetterToken is int token
+                && reconstructed.SetterToken == token,
+            CompileBackMemberKind.EventAdd =>
+                declared.AdderToken is int token
+                && reconstructed.AdderToken == token,
+            CompileBackMemberKind.EventRemove =>
+                declared.RemoverToken is int token
+                && reconstructed.RemoverToken == token,
+            _ => false,
+        };
+    }
+
+    static bool TryFindDeclaringInterfaceMethod(
+        MetadataReader reader,
+        EntityHandle interfaceHandle,
+        MethodDefinition targetMethod,
+        MethodSignature<TypeRef> targetSignature,
+        HashSet<TypeDefinitionHandle> visited,
+        out TypeDefinitionHandle declaringType,
+        out MethodDefinitionHandle declaringMethod)
+    {
+        declaringType = default;
+        declaringMethod = default;
+        if (!TryResolveSameAssemblyInterface(
+                reader,
+                interfaceHandle,
+                out var interfaceType,
+                out var typeArguments))
+        {
+            return false;
+        }
+
+        return Find(
+            interfaceType,
+            typeArguments,
+            targetMethod,
+            targetSignature,
+            visited,
+            out declaringType,
+            out declaringMethod);
+
+        bool Find(
+            TypeDefinitionHandle interfaceType,
+            ImmutableArray<TypeRef> typeArguments,
+            MethodDefinition targetMethod,
+            MethodSignature<TypeRef> targetSignature,
+            HashSet<TypeDefinitionHandle> visited,
+            out TypeDefinitionHandle declaringType,
+            out MethodDefinitionHandle declaringMethod)
+        {
+            declaringType = default;
+            declaringMethod = default;
+            if (!visited.Add(interfaceType))
+                return false;
+
+            var interfaceDef = reader.GetTypeDefinition(interfaceType);
+            string targetName = reader.GetString(targetMethod.Name);
+            int targetGenericArity = targetMethod.GetGenericParameters().Count;
+            foreach (var methodHandle in interfaceDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != targetName
+                    || method.GetGenericParameters().Count != targetGenericArity
+                    || !TryDecodeMethodSignature(
+                        reader,
+                        method,
+                        out MethodSignature<TypeRef> signature))
+                {
+                    continue;
+                }
+
+                if (!signature.ReturnType
+                        .Instantiate(typeArguments, [])
+                        .Equals(targetSignature.ReturnType)
+                    || !signature.ParameterTypes
+                        .Select(parameter => parameter.Instantiate(typeArguments, []))
+                        .SequenceEqual(targetSignature.ParameterTypes))
+                {
+                    continue;
+                }
+
+                declaringType = interfaceType;
+                declaringMethod = methodHandle;
+                return true;
+            }
+
+            foreach (var implementationHandle in interfaceDef.GetInterfaceImplementations())
+            {
+                var inherited = reader.GetInterfaceImplementation(implementationHandle).Interface;
+                if (!TryDecodeInterfaceType(reader, inherited, out TypeRef inheritedType)
+                    || !TryResolveSameAssemblyInterfaceType(
+                        inheritedType.Instantiate(typeArguments, []),
+                        out var inheritedInterface,
+                        out var inheritedArguments))
+                {
+                    continue;
+                }
+
+                if (Find(
+                        inheritedInterface,
+                        inheritedArguments,
+                        targetMethod,
+                        targetSignature,
+                        visited,
+                        out declaringType,
+                        out declaringMethod))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    static CompileBackMemberRequirement? InterfaceMemberRequirement(
+        MetadataReader reader,
+        TypeDefinition interfaceDef,
+        CompileBackTypeIdentity interfaceIdentity,
+        MethodDefinitionHandle methodHandle)
+    {
+        foreach (var propertyHandle in interfaceDef.GetProperties())
+        {
+            var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+            if (accessors.Getter == methodHandle || accessors.Setter == methodHandle)
+            {
+                return TypeProducer.PropertyRequirement(
+                    reader,
+                    interfaceDef,
+                    interfaceIdentity,
+                    propertyHandle,
+                    reader.GetString(reader.GetMethodDefinition(methodHandle).Name));
+            }
+        }
+
+        foreach (var eventHandle in interfaceDef.GetEvents())
+        {
+            var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
+            if (accessors.Adder == methodHandle || accessors.Remover == methodHandle)
+            {
+                return TypeProducer.EventRequirement(
+                    reader,
+                    interfaceDef,
+                    interfaceIdentity,
+                    eventHandle,
+                    reader.GetString(reader.GetMethodDefinition(methodHandle).Name));
+            }
+        }
+
+        return TypeProducer.MethodRequirement(
+            reader,
+            interfaceDef,
+            interfaceIdentity,
+            methodHandle);
+    }
+
+    static bool TryDecodeMethodSignature(
+        MetadataReader reader,
+        MethodDefinition method,
+        out MethodSignature<TypeRef> signature)
+    {
+        signature = default;
+        try
+        {
+            signature = method.DecodeSignature(
+                TypeRefDecoder.Instance,
+                new GenericScope([], []));
+            return !signature.ReturnType.ContainsUnsupported
+                && signature.ParameterTypes.All(parameter => !parameter.ContainsUnsupported);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    static bool TryResolveSameAssemblyInterface(
+        MetadataReader reader,
+        EntityHandle interfaceHandle,
+        out TypeDefinitionHandle interfaceType,
+        out ImmutableArray<TypeRef> typeArguments)
+    {
+        interfaceType = default;
+        typeArguments = [];
+        return TryDecodeInterfaceType(reader, interfaceHandle, out TypeRef decoded)
+            && TryResolveSameAssemblyInterfaceType(
+                decoded,
+                out interfaceType,
+                out typeArguments);
+    }
+
+    static bool TryDecodeInterfaceType(
+        MetadataReader reader,
+        EntityHandle interfaceHandle,
+        out TypeRef type)
+    {
+        type = TypeRef.Unsupported("not decoded");
+        try
+        {
+            type = interfaceHandle.Kind switch
+            {
+                HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(
+                    reader,
+                    (TypeDefinitionHandle)interfaceHandle,
+                    rawTypeKind: 0),
+                HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(
+                    reader,
+                    GenericScope.Empty,
+                    (TypeSpecificationHandle)interfaceHandle,
+                    rawTypeKind: 0),
+                _ => TypeRef.Unsupported("not a same-assembly interface"),
+            };
+            return !type.ContainsUnsupported;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    static bool TryResolveSameAssemblyInterfaceType(
+        TypeRef type,
+        out TypeDefinitionHandle interfaceType,
+        out ImmutableArray<TypeRef> typeArguments)
+    {
+        typeArguments = type.Kind == TypeRefKind.GenericInstance
+            ? type.TypeArguments
+            : [];
+        TypeRef definition = type.Kind == TypeRefKind.GenericInstance
+            ? type.ElementType!
+            : type;
+        interfaceType = definition.Kind == TypeRefKind.Definition
+            ? definition.DefinitionHandle
+            : default;
+        return !interfaceType.IsNil;
     }
 
     static bool OmittedInterfaceDeclaresTarget(
@@ -5491,7 +6031,8 @@ public static class CompileBackSourceComposer
                     : MetadataTokens.GetToken(accessors.Adder),
                 RemoverToken: accessors.Remover.IsNil
                     ? null
-                    : MetadataTokens.GetToken(accessors.Remover));
+                    : MetadataTokens.GetToken(accessors.Remover),
+                MetadataName: reader.GetString(eventDefinition.Name));
         }
 
         internal static CompileBackMemberRequirement? MethodRequirement(
@@ -6267,9 +6808,6 @@ public static class CompileBackSourceComposer
             CompileBackTypeRequirement baseRequirement,
             CompileBackMemberRequirement member)
         {
-            if (member.TypeParameters.Count != 0)
-                return OverrideSlotState.Missing;
-
             var baseDef = reader.GetTypeDefinition(baseHandle);
             var candidates = new List<CompileBackMemberRequirement>();
             if (member.Kind == CompileBackMemberKind.Method)
@@ -6357,7 +6895,84 @@ public static class CompileBackSourceComposer
                 && !right.IsStatic
                 && left.Identity.Method == right.Identity.Method
                 && left.TypeParameters.Count == right.TypeParameters.Count
-                && SameParameters(left.Parameters, right.Parameters);
+                && SameOverrideSlotParameters(left, right);
+        }
+
+        static bool SameOverrideSlotParameters(
+            CompileBackMemberRequirement left,
+            CompileBackMemberRequirement right)
+        {
+            if (left.Parameters.Count != right.Parameters.Count)
+                return false;
+
+            var leftPositions = GenericParameterPositions(left.TypeParameters);
+            var rightPositions = GenericParameterPositions(right.TypeParameters);
+            if (leftPositions is null || rightPositions is null)
+                return false;
+
+            return left.Parameters.Zip(right.Parameters).All(pair =>
+                string.Equals(pair.First.Modifier, pair.Second.Modifier, StringComparison.Ordinal)
+                && string.Equals(
+                    NormalizeGenericParameterPositions(
+                        pair.First.Type.DisplayName,
+                        leftPositions),
+                    NormalizeGenericParameterPositions(
+                        pair.Second.Type.DisplayName,
+                        rightPositions),
+                    StringComparison.Ordinal));
+        }
+
+        static Dictionary<string, int>? GenericParameterPositions(
+            IReadOnlyList<CompileBackTypeParameter> parameters)
+        {
+            var positions = new Dictionary<string, int>(StringComparer.Ordinal);
+            for (int index = 0; index < parameters.Count; index++)
+            {
+                if (!positions.TryAdd(parameters[index].Name, index))
+                    return null;
+            }
+            return positions;
+        }
+
+        static string NormalizeGenericParameterPositions(
+            string type,
+            IReadOnlyDictionary<string, int> positions)
+        {
+            if (positions.Count == 0)
+                return type;
+
+            var normalized = new StringBuilder(type.Length);
+            for (int index = 0; index < type.Length;)
+            {
+                int start = index;
+                if (type[index] == '@')
+                    index++;
+                if (index < type.Length
+                    && (type[index] == '_' || char.IsLetter(type[index])))
+                {
+                    index++;
+                    while (index < type.Length
+                        && (type[index] == '_' || char.IsLetterOrDigit(type[index])))
+                    {
+                        index++;
+                    }
+
+                    string identifier = type[start..index];
+                    if (positions.TryGetValue(identifier, out int position))
+                    {
+                        normalized.Append('!').Append(position);
+                        continue;
+                    }
+
+                    normalized.Append(identifier);
+                    continue;
+                }
+
+                normalized.Append(type[start]);
+                index = start + 1;
+            }
+
+            return normalized.ToString();
         }
 
         static bool IsSystemObjectOverride(CompileBackMemberRequirement member)
@@ -6777,7 +7392,14 @@ public static class CompileBackSourceComposer
                     continue;
                 int existingEventIndex = members.FindIndex(member =>
                     member.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove
-                    && member.Identity.Method == Identifier(eventName));
+                    && member.MetadataName == eventName);
+                if (existingEventIndex < 0)
+                {
+                    existingEventIndex = members.FindIndex(member =>
+                        member.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove
+                        && member.MetadataName is null
+                        && member.Identity.Method == Identifier(eventName));
+                }
                 int? adderToken = surfaceEvent.AdderToken;
                 int? removerToken = surfaceEvent.RemoverToken;
                 if (existingEventIndex >= 0)
@@ -6812,6 +7434,7 @@ public static class CompileBackSourceComposer
                     AdderToken = adderToken,
                     RemoverToken = removerToken,
                     ExplicitInterfaceMemberName = explicitEvent?.QualifiedName,
+                    MetadataName = eventName,
                 });
             }
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1688,7 +1688,20 @@ public static class CompileBackSourceComposer
             {
                 if (index == matchIndex)
                     continue;
-                if (SynthesizeExternalInterfaceStub(interfaceReference.DisplayFullName, requiredMethods[index]) is not { } stub)
+                var requiredMethod = requiredMethods[index];
+                var implicitImplementation = FindImplicitInterfaceMethod(
+                    reader,
+                    targetMethodDefinition.GetDeclaringType(),
+                    requiredMethod);
+                var stub = implicitImplementation.IsNil
+                    ? SynthesizeExternalInterfaceStub(
+                        interfaceReference.DisplayFullName,
+                        requiredMethod)
+                    : ImplicitInterfaceMethodRequirement(
+                        reader,
+                        targetMethodDefinition.GetDeclaringType(),
+                        implicitImplementation);
+                if (stub is null)
                     return null;
                 additionalInterfaceStubs.Add(stub);
             }
@@ -1702,6 +1715,99 @@ public static class CompileBackSourceComposer
         }
 
         return null;
+    }
+
+    static MethodDefinitionHandle FindImplicitInterfaceMethod(
+        MetadataReader reader,
+        TypeDefinitionHandle targetType,
+        ExternalInterfaceRequiredMethod requiredMethod)
+    {
+        MethodDefinitionHandle match = default;
+        foreach (var methodHandle in reader.GetTypeDefinition(targetType).GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
+                || method.Attributes.HasFlag(MethodAttributes.Static)
+                || reader.GetString(method.Name) != requiredMethod.Name
+                || method.GetGenericParameters().Count != requiredMethod.GenericArity
+                || SignatureHasUnrepresentableDetail(reader, method))
+            {
+                continue;
+            }
+
+            MethodSignature<string> signature;
+            try
+            {
+                signature = method.DecodeSignature(
+                    SignatureDecoder.Instance,
+                    GenericContext.ForMethod(
+                        reader,
+                        reader.GetTypeDefinition(targetType),
+                        method));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                continue;
+            }
+
+            if (signature.ReturnType != requiredMethod.ReturnType
+                || !signature.ParameterTypes.SequenceEqual(
+                    requiredMethod.ParameterTypes,
+                    StringComparer.Ordinal))
+            {
+                continue;
+            }
+            if (!match.IsNil)
+                return default;
+            match = methodHandle;
+        }
+
+        return match;
+    }
+
+    static CompileBackMemberRequirement? ImplicitInterfaceMethodRequirement(
+        MetadataReader reader,
+        TypeDefinitionHandle targetType,
+        MethodDefinitionHandle methodHandle)
+    {
+        var typeDef = reader.GetTypeDefinition(targetType);
+        var method = reader.GetMethodDefinition(methodHandle);
+        try
+        {
+            var signature = GuardedSignatureText.MethodText(
+                reader,
+                method,
+                GenericContext.ForMethod(reader, typeDef, method));
+            var declaration = MetadataDeclarationQuery.GetMethod(
+                reader,
+                typeDef,
+                method,
+                signature);
+            if (declaration.Signature.ReturnType is not { } returnType)
+                return null;
+            string name = reader.GetString(method.Name);
+            return new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(
+                    CompileBackTypeIdentity.FromDefinition(reader, typeDef).FullName,
+                    Identifier(name),
+                    0,
+                    MethodSignatureText(name, signature)),
+                CompileBackMemberKind.Method,
+                IsStatic: false,
+                ToCompileBackParameters(declaration.Signature.Parameters),
+                CompileBackTypeSignature.Display(returnType),
+                ToCompileBackTypeParameters(declaration.Signature.TypeParameters),
+                CompileBackStubBodyKind.Throw,
+                TargetBody: null,
+                [new CompileBackFact("metadata", "external-interface-implicit-method", name)],
+                declaration.Attributes,
+                declaration.Signature.ReturnAttributes,
+                MetadataToken: MetadataTokens.GetToken(methodHandle));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return null;
+        }
     }
 
     // Synthesizes a `throw null` explicit-interface stub for a NON-target member of an external
@@ -4636,6 +4742,7 @@ public static class CompileBackSourceComposer
             var accessorMethod = accessor.IsNil ? default : reader.GetMethodDefinition(accessor);
             bool isStatic = !accessor.IsNil && accessorMethod.Attributes.HasFlag(MethodAttributes.Static);
             var returnType = CompileBackTypeSignature.Display(propertyReturnType);
+            var parameters = ToCompileBackParameters(propertyDeclaration.Signature.Parameters);
             bool isAutoProperty = hasGetter
                 && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
             bool isInitSetter = hasSetter && SetterIsInitOnly(reader, accessors.Setter);
@@ -4648,10 +4755,14 @@ public static class CompileBackSourceComposer
                 isAutoProperty,
                 noBodyProperty);
             return new CompileBackMemberRequirement(
-                new CompileBackMethodIdentity(typeIdentity.FullName, Identifier(propertyName), 0, $"property {propertyReturnType}"),
+                new CompileBackMethodIdentity(
+                    typeIdentity.FullName,
+                    Identifier(propertyName),
+                    0,
+                    PropertySignatureText(propertyName, propertyReturnType, parameters)),
                 hasGetter ? CompileBackMemberKind.PropertyGet : CompileBackMemberKind.PropertySet,
                 isStatic,
-                ToCompileBackParameters(propertyDeclaration.Signature.Parameters),
+                parameters,
                 returnType,
                 [],
                 stubBody,
@@ -5096,9 +5207,23 @@ public static class CompileBackSourceComposer
             TypeDefinition interfaceDef,
             CompileBackMemberRequirement interfaceMember)
         {
+            int? interfaceAccessorToken = interfaceMember.Kind == CompileBackMemberKind.PropertyGet
+                ? interfaceMember.GetterToken
+                : interfaceMember.SetterToken;
             var interfaceProperty = interfaceDef.GetProperties().FirstOrDefault(handle =>
-                Identifier(reader.GetString(reader.GetPropertyDefinition(handle).Name))
-                    == interfaceMember.Identity.Method);
+            {
+                var accessors = reader.GetPropertyDefinition(handle).GetAccessors();
+                var accessor = interfaceMember.Kind == CompileBackMemberKind.PropertyGet
+                    ? accessors.Getter
+                    : accessors.Setter;
+                return interfaceAccessorToken is int token
+                    ? !accessor.IsNil && MetadataTokens.GetToken(accessor) == token
+                    : PropertyMatchesRequirement(
+                        reader,
+                        interfaceDef,
+                        handle,
+                        interfaceMember);
+            });
             if (interfaceProperty.IsNil)
                 return default;
 
@@ -5127,9 +5252,47 @@ public static class CompileBackSourceComposer
             return typeDef.GetProperties().FirstOrDefault(handle =>
             {
                 string candidateName = reader.GetString(reader.GetPropertyDefinition(handle).Name);
-                return candidateName == propertyName
-                    || candidateName == $"{interfaceName}.{propertyName}";
+                return (candidateName == propertyName
+                        || candidateName == $"{interfaceName}.{propertyName}")
+                    && PropertyMatchesRequirement(
+                        reader,
+                        typeDef,
+                        handle,
+                        interfaceMember);
             });
+        }
+
+        static bool PropertyMatchesRequirement(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            PropertyDefinitionHandle propertyHandle,
+            CompileBackMemberRequirement requirement)
+        {
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            var accessors = property.GetAccessors();
+            var accessor = requirement.Kind == CompileBackMemberKind.PropertyGet
+                ? accessors.Getter
+                : accessors.Setter;
+            if (accessor.IsNil
+                || reader.GetMethodDefinition(accessor).Attributes.HasFlag(MethodAttributes.Static)
+                    != requirement.IsStatic)
+            {
+                return false;
+            }
+
+            try
+            {
+                var declaration = MetadataDeclarationQuery.GetProperty(reader, typeDef, property);
+                return declaration.Signature.ReturnType is { } returnType
+                    && CompileBackTypeSignature.Display(returnType) == requirement.ReturnType
+                    && SameParameters(
+                        ToCompileBackParameters(declaration.Signature.Parameters),
+                        requirement.Parameters);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return false;
+            }
         }
 
         static PropertyDefinitionHandle PropertyForAccessor(
@@ -5647,7 +5810,14 @@ public static class CompileBackSourceComposer
                     isAutoProperty,
                     noBodyProperty);
                 members.Add(new CompileBackMemberRequirement(
-                    new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(propertyName), 0, $"property {propertyReturnType}"),
+                    new CompileBackMethodIdentity(
+                        requirement.Type.FullName,
+                        Identifier(propertyName),
+                        0,
+                        PropertySignatureText(
+                            propertyName,
+                            propertyReturnType,
+                            propertyParameters)),
                     hasGetter ? CompileBackMemberKind.PropertyGet : CompileBackMemberKind.PropertySet,
                     IsStatic: isStatic,
                     Parameters: propertyParameters,
@@ -5845,6 +6015,7 @@ public static class CompileBackSourceComposer
                     .Where(candidate =>
                         candidate.member.Kind == memberKind
                         && candidate.member.Identity.Method == identifierName
+                        && candidate.member.ExplicitInterfaceMemberName is null
                         && candidate.member.IsStatic == methodIsStatic
                         && candidate.member.IsOperator == methodIsOperator
                         && candidate.member.TypeParameters.Count == method.GetGenericParameters().Count
@@ -6081,6 +6252,17 @@ public static class CompileBackSourceComposer
 
         static string MethodSignatureText(string name, MethodSignature<string> signature)
             => $"{signature.ReturnType} {name}({string.Join(", ", signature.ParameterTypes)})";
+
+        static string PropertySignatureText(
+            string name,
+            string returnType,
+            IReadOnlyList<CompileBackParameter> parameters)
+            => $"{returnType} {name}[{string.Join(", ", parameters.Select(ParameterSignatureText))}]";
+
+        static string ParameterSignatureText(CompileBackParameter parameter)
+            => parameter.Modifier is { Length: > 0 } modifier
+                ? $"{modifier} {parameter.Type.DisplayName}"
+                : parameter.Type.DisplayName;
 
         internal static TypeDefinitionHandle? FindType(MetadataReader reader, string metadataFullName)
         {

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -2973,7 +2973,7 @@ public static class CompileBackSourceComposer
         var targetParameters = MethodParameters(reader, method, signature);
         var targetTypeParameters = MethodTypeParameters(reader, method);
         bool targetHasOperatorIdentity = !isConstructor
-            && IsMetadataOperator(method, methodName);
+            && IsMetadataOperator(reader, method);
         bool targetOperatorIsRepresentable = targetHasOperatorIdentity
             && IsRepresentableOperator(
                 reader,
@@ -3490,10 +3490,8 @@ public static class CompileBackSourceComposer
                 reader,
                 reader.GetMethodDefinition(right));
 
-    static bool IsMetadataOperator(MethodDefinition method, string name)
-        => method.Attributes.HasFlag(MethodAttributes.SpecialName)
-            && method.GetGenericParameters().Count == 0
-            && OperatorNames.IsOperatorMethodName(name);
+    static bool IsMetadataOperator(MetadataReader reader, MethodDefinition method)
+        => ILInspector.Metadata.OperatorMetadata.IsMetadataOperator(reader, method);
 
     static bool IsRepresentableOperator(
         MetadataReader reader,
@@ -3504,55 +3502,13 @@ public static class CompileBackSourceComposer
         IReadOnlyList<CompileBackParameter> parameters,
         string? returnType)
     {
-        if (!IsMetadataOperator(method, name) || returnType is null)
-            return false;
-
-        bool isStatic = method.Attributes.HasFlag(MethodAttributes.Static);
-        bool isPublic = (method.Attributes & MethodAttributes.MemberAccessMask)
-            == MethodAttributes.Public;
-        if (OperatorNames.IsAssignmentOperatorMethodName(name))
-        {
-            return OperatorNames.IsCSharpInstanceAssignmentOperator(
-                    name,
-                    isStatic,
-                    isPublic,
-                    returnType,
-                    parameters.Count)
-                && parameters.All(parameter => parameter.Modifier is null);
-        }
-
-        int? expectedParameterCount = CSharpOperatorParameterCount(name);
-        if (!isStatic
-            || !isPublic
-            || returnType is "void" or "System.Void"
-            || expectedParameterCount is null
-            || parameters.Count != expectedParameterCount
-            || parameters.Any(parameter => parameter.Modifier is "ref" or "out"))
+        if (returnType is null
+            || !ILInspector.Metadata.OperatorMetadata.IsCSharpOperatorDeclaration(reader, method))
         {
             return false;
         }
 
         var declaringIdentity = CompileBackTypeIdentity.FromDefinition(reader, declaringType);
-        bool hasDeclaringOperand = parameters.Any(parameter =>
-            IsDeclaringTypeSpelling(parameter.Type.DisplayName, declaringIdentity));
-        if (IsConversionOperator(name))
-        {
-            if (!hasDeclaringOperand
-                && !IsDeclaringTypeSpelling(returnType, declaringIdentity))
-            {
-                return false;
-            }
-        }
-        else if (!hasDeclaringOperand)
-        {
-            return false;
-        }
-
-        if (name is "op_True" or "op_False"
-            && returnType is not ("bool" or "System.Boolean"))
-        {
-            return false;
-        }
         if (name is "op_Increment" or "op_Decrement"
             && !IsDeclaringTypeSpelling(returnType, declaringIdentity))
         {
@@ -3561,27 +3517,6 @@ public static class CompileBackSourceComposer
 
         return RequiredOperatorPair(name) is not { } pairName
             || HasOperatorPair(reader, declaringType, pairName, signature);
-    }
-
-    static int? CSharpOperatorParameterCount(string name)
-    {
-        if (IsConversionOperator(name))
-            return 1;
-
-        string uncheckedName = name.StartsWith("op_Checked", StringComparison.Ordinal)
-            ? $"op_{name["op_Checked".Length..]}"
-            : name;
-        return uncheckedName switch
-        {
-            "op_UnaryPlus" or "op_UnaryNegation" or "op_Increment" or "op_Decrement"
-                or "op_OnesComplement" or "op_True" or "op_False" or "op_LogicalNot" => 1,
-            "op_Addition" or "op_Subtraction" or "op_Multiply" or "op_Division"
-                or "op_Modulus" or "op_BitwiseAnd" or "op_BitwiseOr" or "op_ExclusiveOr"
-                or "op_LeftShift" or "op_RightShift" or "op_UnsignedRightShift"
-                or "op_Equality" or "op_Inequality" or "op_LessThan" or "op_GreaterThan"
-                or "op_LessThanOrEqual" or "op_GreaterThanOrEqual" => 2,
-            _ => null,
-        };
     }
 
     static bool IsConversionOperator(string name)
@@ -3625,7 +3560,7 @@ public static class CompileBackSourceComposer
         {
             var method = reader.GetMethodDefinition(methodHandle);
             if (reader.GetString(method.Name) != pairName
-                || !IsMetadataOperator(method, pairName))
+                || !IsMetadataOperator(reader, method))
             {
                 continue;
             }
@@ -5065,7 +5000,7 @@ public static class CompileBackSourceComposer
                 return null;
             }
             bool hasOperatorIdentity = !isConstructor
-                && IsMetadataOperator(method, name);
+                && IsMetadataOperator(reader, method);
             bool operatorIsRepresentable = hasOperatorIdentity
                 && IsRepresentableOperator(
                     reader,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -18,6 +18,38 @@ using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.DecompilerHarness;
 
+internal sealed class CompileBackMemberSurfaceIndex
+{
+    readonly IReadOnlyDictionary<MetadataTypeDefinitionName, ImmutableArray<ApiType>> surfaces;
+
+    internal CompileBackMemberSurfaceIndex(IEnumerable<ApiType> types)
+    {
+        surfaces = types
+            .Where(type => type.DefinitionName is not null)
+            .GroupBy(type => type.DefinitionName!)
+            .ToImmutableDictionary(
+                group => group.Key,
+                group => group.ToImmutableArray());
+    }
+
+    internal bool TryGetValue(MetadataTypeDefinitionName name, out ApiType surface)
+    {
+        if (!surfaces.TryGetValue(name, out var candidates))
+        {
+            surface = null!;
+            return false;
+        }
+        if (candidates.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"Product member surface contains {candidates.Length} definitions named '{name.ToMetadataFullName()}'.");
+        }
+
+        surface = candidates[0];
+        return true;
+    }
+}
+
 internal abstract record ArtifactRequest(
     string AssemblyPath,
     MetadataReader Reader,
@@ -36,6 +68,7 @@ internal abstract record ArtifactRequest(
     internal MetadataSource? BodySource { get; init; }
     internal ReturnToSender.CompilationClosure? CompilationClosure
         { get; set; }
+    internal required CompileBackMemberSurfaceIndex MemberSurfaceByDefinitionName { get; init; }
 }
 
 internal sealed record MethodArtifactRequest(
@@ -390,6 +423,8 @@ public sealed record CompileBackMemberRequirement(
     bool IsSealed = false,
     bool IsAsync = false,
     bool IsExtension = false,
+    bool IsOperator = false,
+    bool IsFinalizer = false,
     CompileBackAccessibility Accessibility = CompileBackAccessibility.Public,
     string? ConstructorInitializer = null,
     string? ExplicitInterfaceMemberName = null,
@@ -400,7 +435,8 @@ public sealed record CompileBackMemberRequirement(
     int? GetterToken = null,
     int? SetterToken = null,
     int? AdderToken = null,
-    int? RemoverToken = null)
+    int? RemoverToken = null,
+    bool SuppressDestructorSyntax = false)
 {
     public string Name => Identity.Method;
     public string Type => ReturnType?.DisplayName ?? "";
@@ -414,7 +450,8 @@ internal sealed record ProductTargetBody(
     IReadOnlyList<DecompilerDecision> Decisions,
     string? ConstructorChain = null,
     bool RequiresAsyncModifier = false,
-    bool RequiresUnsafeModifier = false);
+    bool RequiresUnsafeModifier = false,
+    bool SuppressDestructorSyntax = false);
 
 internal sealed record ExplicitInterfaceEventInfo(
     TypeDefinitionHandle InterfaceType,
@@ -441,6 +478,10 @@ internal sealed record ExternalInterfaceRequiredMethod(
 
 public static class CompileBackSourceComposer
 {
+    internal static CompileBackMemberSurfaceIndex CreateMemberSurfaceIndex(
+        ApiSurface surface)
+        => new(surface.Types);
+
     internal static ProductTargetBody CreateTargetBody(
         MetadataSource source,
         MethodDefinitionHandle methodHandle,
@@ -471,7 +512,8 @@ public static class CompileBackSourceComposer
             produced.Projection.Decisions,
             produced.Projection.ConstructorChain,
             produced.Body.RequiresAsyncModifier,
-            produced.Body.RequiresUnsafeModifier);
+            produced.Body.RequiresUnsafeModifier,
+            produced.Body.SuppressDestructorSyntax);
     }
 
     // ReferencedNamespaces already returns an ordinal-sorted set; route "System"
@@ -524,6 +566,7 @@ public static class CompileBackSourceComposer
                 closure.Roots,
                 closure.Facts,
                 closure.MemberRequirements,
+                request.MemberSurfaceByDefinitionName,
                 request.BodyPolicy,
                 operatorResolver),
             PropertySetterArtifactRequest setter => ComposePropertySetter(
@@ -541,6 +584,7 @@ public static class CompileBackSourceComposer
                 closure.Roots,
                 closure.Facts,
                 closure.MemberRequirements,
+                request.MemberSurfaceByDefinitionName,
                 operatorResolver),
             EventAccessorArtifactRequest eventAccessor => ComposeEventAccessor(
                 request.AssemblyPath,
@@ -557,6 +601,7 @@ public static class CompileBackSourceComposer
                 closure.Roots,
                 closure.Facts,
                 closure.MemberRequirements,
+                request.MemberSurfaceByDefinitionName,
                 eventAccessor.SiblingAccessorBody?.Source,
                 request.BodyPolicy,
                 operatorResolver),
@@ -575,9 +620,11 @@ public static class CompileBackSourceComposer
                 closure.Roots,
                 closure.Facts,
                 closure.MemberRequirements,
+                request.MemberSurfaceByDefinitionName,
                 request.TargetBody.ConstructorChain,
                 operatorResolver,
-                operatorTypeResolver),
+                operatorTypeResolver,
+                request.TargetBody.SuppressDestructorSyntax),
             _ => throw new ArgumentException($"Unknown artifact request type '{request.GetType().FullName}'.", nameof(request)),
         };
 
@@ -1137,7 +1184,7 @@ public static class CompileBackSourceComposer
             facts.Add(fact);
     }
 
-    public static CompileBackSourceResult ComposePropertyGetter(
+    internal static CompileBackSourceResult ComposePropertyGetter(
         string assemblyPath,
         MetadataReader reader,
         IrFunction function,
@@ -1152,6 +1199,7 @@ public static class CompileBackSourceComposer
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
+        CompileBackMemberSurfaceIndex memberSurfaceByDefinitionName,
         RoundTripBodyPolicy bodyPolicy = RoundTripBodyPolicy.Selected,
         IOperatorTypeRelationshipResolver? relationshipResolver = null)
     {
@@ -1247,6 +1295,7 @@ public static class CompileBackSourceComposer
         var production = TypeProducer.Produce(
             reader,
             requirements,
+            memberSurfaceByDefinitionName,
             diagnostics,
             relationshipResolver);
         var declarations = production.Requests;
@@ -1319,7 +1368,7 @@ public static class CompileBackSourceComposer
         {
             var typeDef = reader.GetTypeDefinition(handle);
             var identity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
-            if (requirements.Any(requirement => requirement.Type.MetadataFullName == identity.MetadataFullName))
+            if (requirements.Any(requirement => requirement.Type == identity))
                 return;
             var facts = closureFacts.TryGetValue(handle, out var foundFacts) ? foundFacts : [];
 
@@ -1381,7 +1430,7 @@ public static class CompileBackSourceComposer
                 continue;
 
             int requirementIndex = requirements.FindIndex(
-                requirement => requirement.Type.MetadataFullName == interfaceIdentity.MetadataFullName);
+                requirement => requirement.Type == interfaceIdentity);
             if (requirementIndex < 0)
                 continue;
 
@@ -1477,7 +1526,7 @@ public static class CompileBackSourceComposer
                 return false;
 
             int requirementIndex = requirements.FindIndex(
-                requirement => requirement.Type.MetadataFullName == interfaceIdentity.MetadataFullName);
+                requirement => requirement.Type == interfaceIdentity);
             if (requirementIndex < 0)
                 return false;
 
@@ -2601,7 +2650,7 @@ public static class CompileBackSourceComposer
             return;
 
         int requirementIndex = requirements.FindIndex(
-            requirement => requirement.Type.MetadataFullName == interfaceIdentity.MetadataFullName);
+            requirement => requirement.Type == interfaceIdentity);
         if (requirementIndex < 0)
             return;
 
@@ -2615,7 +2664,7 @@ public static class CompileBackSourceComposer
         };
     }
 
-    public static CompileBackSourceResult ComposePropertySetter(
+    internal static CompileBackSourceResult ComposePropertySetter(
         string assemblyPath,
         MetadataReader reader,
         IrFunction function,
@@ -2630,6 +2679,7 @@ public static class CompileBackSourceComposer
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
+        CompileBackMemberSurfaceIndex memberSurfaceByDefinitionName,
         IOperatorTypeRelationshipResolver? relationshipResolver = null)
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
@@ -2711,6 +2761,7 @@ public static class CompileBackSourceComposer
         var production = TypeProducer.Produce(
             reader,
             requirements,
+            memberSurfaceByDefinitionName,
             diagnostics,
             relationshipResolver);
         var declarations = production.Requests;
@@ -2728,7 +2779,7 @@ public static class CompileBackSourceComposer
         return ComposeCompilationUnit(plan);
     }
 
-    public static CompileBackSourceResult ComposeEventAccessor(
+    internal static CompileBackSourceResult ComposeEventAccessor(
         string assemblyPath,
         MetadataReader reader,
         IrFunction function,
@@ -2743,6 +2794,7 @@ public static class CompileBackSourceComposer
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
+        CompileBackMemberSurfaceIndex memberSurfaceByDefinitionName,
         string? siblingAccessorBody = null,
         RoundTripBodyPolicy bodyPolicy = RoundTripBodyPolicy.Selected,
         IOperatorTypeRelationshipResolver? relationshipResolver = null)
@@ -2846,6 +2898,7 @@ public static class CompileBackSourceComposer
         var production = TypeProducer.Produce(
             reader,
             requirements,
+            memberSurfaceByDefinitionName,
             diagnostics,
             relationshipResolver);
         var module = new CompileBackModuleRequirement(
@@ -2877,9 +2930,11 @@ public static class CompileBackSourceComposer
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
+        CompileBackMemberSurfaceIndex memberSurfaceByDefinitionName,
         string? constructorChain = null,
         IOperatorTypeRelationshipResolver? operatorResolver = null,
-        CrossAssemblyTypeResolver? operatorTypeResolver = null)
+        CrossAssemblyTypeResolver? operatorTypeResolver = null,
+        bool suppressDestructorSyntax = false)
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var method = reader.GetMethodDefinition(targetMethod);
@@ -2917,6 +2972,13 @@ public static class CompileBackSourceComposer
             : CompileBackTypeSignature.Display(MethodReturnType(reader, targetTypeDef, method));
         var targetParameters = MethodParameters(reader, method, signature);
         var targetTypeParameters = MethodTypeParameters(reader, method);
+        bool isFinalizer = !isConstructor
+            && memberSurfaceByDefinitionName.TryGetValue(
+                TypeProducer.DefinitionName(reader, targetType),
+                out var targetSurface)
+            && targetSurface.Members.Any(member =>
+                member.MetadataToken == MetadataTokens.GetToken(targetMethod)
+                && member.IsFinalizer);
         // A class method whose metadata name is an explicit-interface spelling
         // (`IType.Member`) must be reconstructed as an explicit-interface implementation,
         // not a plain method with the dotted name sanitized to `IType_Member`. The latter
@@ -2968,9 +3030,12 @@ public static class CompileBackSourceComposer
                 IsAsync: !isConstructor
                     && (function.RequiresAsyncBodyModifier
                         || function.IsRuntimeAsync == MetadataFactState.Yes),
+                IsOperator: !isConstructor && IsMetadataOperator(method, methodName),
+                IsFinalizer: isFinalizer,
                 ConstructorInitializer: targetConstructorInitializer,
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
-                RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function))
+                RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function),
+                SuppressDestructorSyntax: suppressDestructorSyntax)
         ];
         if (externalExplicitInterfaceMethod is { AdditionalInterfaceStubs.Count: > 0 })
         {
@@ -3138,6 +3203,7 @@ public static class CompileBackSourceComposer
         var production = TypeProducer.Produce(
             reader,
             requirements,
+            memberSurfaceByDefinitionName,
             diagnostics,
             operatorResolver);
         var declarations = production.Requests;
@@ -3195,7 +3261,11 @@ public static class CompileBackSourceComposer
     static CSharpMemberShellSpec ToMemberShellSpec(CompileBackMemberRequirement requirement)
         => new(
             Name: requirement.Identity.Method,
-            Kind: requirement.Kind switch
+            Kind: requirement.IsOperator
+                ? CSharpShellMemberKind.Operator
+                : requirement.IsFinalizer
+                    ? CSharpShellMemberKind.Finalizer
+                : requirement.Kind switch
             {
                 CompileBackMemberKind.PropertyGet => CSharpShellMemberKind.PropertyGet,
                 CompileBackMemberKind.PropertySet => CSharpShellMemberKind.PropertySet,
@@ -3265,7 +3335,8 @@ public static class CompileBackSourceComposer
             GetterToken: requirement.GetterToken,
             SetterToken: requirement.SetterToken,
             AdderToken: requirement.AdderToken,
-            RemoverToken: requirement.RemoverToken);
+            RemoverToken: requirement.RemoverToken,
+            SuppressDestructorSyntax: requirement.SuppressDestructorSyntax);
 
     static CSharpShellParameter ToShellParameter(CompileBackParameter parameter)
         => new(
@@ -3370,7 +3441,8 @@ public static class CompileBackSourceComposer
                 IsAbstract: IsAbstractMethod(method),
                 IsVirtual: IsVirtualMethod(method),
                 IsOverride: false,
-                IsSealed: false);
+                IsSealed: false,
+                IsOperator: true);
         }
 
         return null;
@@ -3386,6 +3458,11 @@ public static class CompileBackSourceComposer
             == MethodStructuralSignature.BuildOperatorPairing(
                 reader,
                 reader.GetMethodDefinition(right));
+
+    static bool IsMetadataOperator(MethodDefinition method, string name)
+        => method.Attributes.HasFlag(MethodAttributes.SpecialName)
+            && method.GetGenericParameters().Count == 0
+            && OperatorNames.IsOperatorMethodName(name);
 
     static bool IsRecordGeneratedFieldReadHelper(
         MetadataReader reader,
@@ -4416,19 +4493,20 @@ public static class CompileBackSourceComposer
         public static TypeProduction Produce(
             MetadataReader reader,
             IReadOnlyList<CompileBackTypeRequirement> requirements,
+            CompileBackMemberSurfaceIndex surfaceByDefinitionName,
             List<CompileBackPlanningDiagnostic> diagnostics,
             IOperatorTypeRelationshipResolver? relationshipResolver = null)
         {
             var requests = new List<CSharpTypePrintRequest>();
             var producedRequirements = new List<CompileBackTypeRequirement>();
-            var requirementsByMetadataName = requirements.ToDictionary(
-                requirement => requirement.Type.MetadataFullName,
+            var requirementsByIdentity = requirements.ToDictionary(
+                requirement => requirement.Type,
                 requirement => requirement,
-                StringComparer.Ordinal);
+                EqualityComparer<CompileBackTypeIdentity>.Default);
             var emittedRoots = new HashSet<TypeDefinitionHandle>();
             foreach (var requirement in requirements)
             {
-                if (FindType(reader, requirement.Type.MetadataFullName) is not { } handle)
+                if (FindType(reader, requirement.Type) is not { } handle)
                 {
                     diagnostics.Add(new CompileBackPlanningDiagnostic("type identity", "type-not-found", requirement.Type.MetadataFullName));
                     continue;
@@ -4440,7 +4518,7 @@ public static class CompileBackSourceComposer
 
                 var rootDef = reader.GetTypeDefinition(rootHandle);
                 var rootIdentity = CompileBackTypeIdentity.FromDefinition(reader, rootDef);
-                if (!requirementsByMetadataName.TryGetValue(rootIdentity.MetadataFullName, out var rootRequirement))
+                if (!requirementsByIdentity.TryGetValue(rootIdentity, out var rootRequirement))
                 {
                     rootRequirement = new CompileBackTypeRequirement(
                         rootIdentity,
@@ -4454,7 +4532,8 @@ public static class CompileBackSourceComposer
                     reader,
                     rootHandle,
                     rootRequirement,
-                    requirementsByMetadataName,
+                    requirementsByIdentity,
+                    surfaceByDefinitionName,
                     producedRequirements,
                     diagnostics,
                     relationshipResolver);
@@ -4467,6 +4546,37 @@ public static class CompileBackSourceComposer
         public sealed record TypeProduction(
             IReadOnlyList<CSharpTypePrintRequest> Requests,
             IReadOnlyList<CompileBackTypeRequirement> Requirements);
+
+        internal static MetadataTypeDefinitionName DefinitionName(
+            MetadataReader reader,
+            TypeDefinitionHandle handle)
+        {
+            var segments = new List<string>();
+            var seen = new HashSet<TypeDefinitionHandle>();
+            string? @namespace = null;
+            for (int guard = 0;
+                !handle.IsNil && guard < MetadataSafetyPolicy.MaxRelationshipNodes;
+                guard++)
+            {
+                if (!seen.Add(handle))
+                    throw new InvalidOperationException("Type declaring chain contains a cycle.");
+
+                var type = reader.GetTypeDefinition(handle);
+                segments.Add(reader.GetString(type.Name));
+                handle = type.GetDeclaringType();
+                if (handle.IsNil)
+                    @namespace = reader.GetString(type.Namespace);
+            }
+
+            if (@namespace is null)
+                throw new InvalidOperationException("Type declaring chain exceeded the metadata safety limit.");
+
+            segments.Reverse();
+            return MetadataTypeDefinitionName.Create(@namespace, segments.ToImmutableArray())
+                is MetadataTypeDefinitionNameResult.Valid valid
+                    ? valid.Name
+                    : throw new InvalidOperationException("Type has an invalid structured metadata name.");
+        }
 
         static PropertyDefinitionHandle? TryFindPropertyForAccessor(
             MetadataReader reader,
@@ -4794,7 +4904,8 @@ public static class CompileBackSourceComposer
                 IsVirtual: !isConstructor && IsVirtualMethod(method),
                 IsOverride: false,
                 IsSealed: false,
-                IsExtension: IsExtensionMethod(reader, typeDef, method));
+                IsExtension: IsExtensionMethod(reader, typeDef, method),
+                IsOperator: !isConstructor && IsMetadataOperator(method, name));
         }
 
         static bool IsExtensionMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
@@ -4823,7 +4934,8 @@ public static class CompileBackSourceComposer
             MetadataReader reader,
             TypeDefinitionHandle handle,
             CompileBackTypeRequirement requirement,
-            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
+            IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity,
+            CompileBackMemberSurfaceIndex surfaceByDefinitionName,
             List<CompileBackTypeRequirement> producedRequirements,
             List<CompileBackPlanningDiagnostic> diagnostics,
             IOperatorTypeRelationshipResolver? relationshipResolver)
@@ -4835,20 +4947,34 @@ public static class CompileBackSourceComposer
                 : RequiredMemberRequirements(requirement);
             bool includeMemberSurface = requirement.IncludeMemberSurface;
             if (includeMemberSurface && kind != CompileBackTypeKind.Delegate)
-                AddClosureMemberSurface(
-                    reader,
-                    typeDef,
-                    requirement,
-                    members,
-                    diagnostics,
-                    relationshipResolver);
+            {
+                if (surfaceByDefinitionName.TryGetValue(
+                        DefinitionName(reader, handle),
+                        out var surface))
+                {
+                    AddClosureMemberSurface(
+                        reader,
+                        typeDef,
+                        requirement,
+                        surface,
+                        members,
+                        diagnostics,
+                        relationshipResolver);
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"Product member surface did not contain required type '{requirement.Type.MetadataFullName}'.");
+                }
+            }
             if (kind is CompileBackTypeKind.Class or CompileBackTypeKind.Record or CompileBackTypeKind.Struct)
             {
                 AddRequiredInterfaceProperties(
                     reader,
                     typeDef,
                     requirement,
-                    requirementsByMetadataName,
+                    requirementsByIdentity,
+                    surfaceByDefinitionName,
                     members,
                     relationshipResolver);
             }
@@ -4861,7 +4987,7 @@ public static class CompileBackSourceComposer
             if (kind == CompileBackTypeKind.Class
                 && members.Any(member => member.Kind == CompileBackMemberKind.Constructor)
                 && !members.Any(member => member.Kind == CompileBackMemberKind.Constructor && member.Parameters.Count == 0)
-                && IsReconstructedBaseOfAnotherType(reader, requirement, requirementsByMetadataName))
+                && IsReconstructedBaseOfAnotherType(reader, requirement, requirementsByIdentity))
             {
                 members.Add(SyntheticParameterlessConstructor(requirement.Type));
             }
@@ -4880,7 +5006,7 @@ public static class CompileBackSourceComposer
                 Namespace: requirement.Type.Namespace,
                 MetadataName: requirement.Type.MetadataName,
                 Kind: ToShellKind(kind),
-                InterfaceDisplayNames: InterfaceSignatures(reader, typeDef, requirementsByMetadataName)
+                InterfaceDisplayNames: InterfaceSignatures(reader, typeDef, requirementsByIdentity)
                     .Select(signature => signature.DisplayName)
                     .Concat(requirement.ExternalInterfaces)
                     .Distinct(StringComparer.Ordinal)
@@ -4890,7 +5016,8 @@ public static class CompileBackSourceComposer
                 NestedTypes: NestedSpecs(
                     reader,
                     typeDef,
-                    requirementsByMetadataName,
+                    requirementsByIdentity,
+                    surfaceByDefinitionName,
                     includeMemberSurface,
                     producedRequirements,
                     diagnostics,
@@ -4901,7 +5028,8 @@ public static class CompileBackSourceComposer
             MetadataReader reader,
             TypeDefinition typeDef,
             CompileBackTypeRequirement requirement,
-            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
+            IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity,
+            CompileBackMemberSurfaceIndex surfaceByDefinitionName,
             List<CompileBackMemberRequirement> members,
             IOperatorTypeRelationshipResolver? relationshipResolver)
         {
@@ -4914,8 +5042,8 @@ public static class CompileBackSourceComposer
                 var interfaceDef = reader.GetTypeDefinition(
                     (TypeDefinitionHandle)implementation.Interface);
                 var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
-                if (!requirementsByMetadataName.TryGetValue(
-                        interfaceIdentity.MetadataFullName,
+                if (!requirementsByIdentity.TryGetValue(
+                        interfaceIdentity,
                         out var interfaceRequirement))
                 {
                     continue;
@@ -4925,10 +5053,20 @@ public static class CompileBackSourceComposer
                 if (interfaceRequirement.IncludeMemberSurface)
                 {
                     // The interface's own BuildSpec call reports surface diagnostics.
+                    if (!surfaceByDefinitionName.TryGetValue(
+                            DefinitionName(
+                                reader,
+                                (TypeDefinitionHandle)implementation.Interface),
+                            out var surface))
+                    {
+                        throw new InvalidOperationException(
+                            $"Product member surface did not contain required interface '{interfaceIdentity.MetadataFullName}'.");
+                    }
                     AddClosureMemberSurface(
                         reader,
                         interfaceDef,
                         interfaceRequirement,
+                        surface,
                         interfaceMembers,
                         diagnostics: [],
                         relationshipResolver);
@@ -5015,6 +5153,8 @@ public static class CompileBackSourceComposer
             TypeDefinition typeDef,
             MethodDefinitionHandle accessor)
         {
+            if (accessor.IsNil)
+                return default;
             foreach (var propertyHandle in typeDef.GetProperties())
             {
                 var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
@@ -5092,7 +5232,8 @@ public static class CompileBackSourceComposer
         static IReadOnlyList<CSharpTypeShellSpec> NestedSpecs(
             MetadataReader reader,
             TypeDefinition typeDef,
-            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
+            IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity,
+            CompileBackMemberSurfaceIndex surfaceByDefinitionName,
             bool includeMemberSurface,
             List<CompileBackTypeRequirement> producedRequirements,
             List<CompileBackPlanningDiagnostic> diagnostics,
@@ -5109,7 +5250,7 @@ public static class CompileBackSourceComposer
                 }
 
                 var identity = CompileBackTypeIdentity.FromDefinition(reader, nestedDef);
-                requirementsByMetadataName.TryGetValue(identity.MetadataFullName, out var requirement);
+                requirementsByIdentity.TryGetValue(identity, out var requirement);
                 var kind = requirement?.RequiredKind ?? ShellKind(reader, nestedDef);
                 requirement ??= new CompileBackTypeRequirement(
                     identity,
@@ -5127,7 +5268,8 @@ public static class CompileBackSourceComposer
                     reader,
                     nestedHandle,
                     nestedRequirement,
-                    requirementsByMetadataName,
+                    requirementsByIdentity,
+                    surfaceByDefinitionName,
                     producedRequirements,
                     diagnostics,
                     relationshipResolver));
@@ -5151,7 +5293,8 @@ public static class CompileBackSourceComposer
                             RequiredMembers: [],
                             PrimaryConstructor: null,
                             SourceFacts: [new CompileBackFact("metadata", "generated-dynamic-delegate", identity.FullName)]),
-                        requirementsByMetadataName,
+                        requirementsByIdentity,
+                        surfaceByDefinitionName,
                         producedRequirements,
                         diagnostics,
                         relationshipResolver));
@@ -5187,36 +5330,38 @@ public static class CompileBackSourceComposer
         // declaration, so its implicit `: base()` depends on this class exposing an
         // accessible parameterless constructor. Nested types are emitted by
         // NestedTypes() from their enclosing requirement and are not present in
-        // requirementsByMetadataName, so each requirement's nested tree is walked.
+        // requirementsByIdentity, so each requirement's nested tree is walked.
         static bool IsReconstructedBaseOfAnotherType(
             MetadataReader reader,
             CompileBackTypeRequirement requirement,
-            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName)
+            IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity)
         {
-            string metadataFullName = requirement.Type.MetadataFullName;
-            foreach (var other in requirementsByMetadataName.Values)
+            foreach (var other in requirementsByIdentity.Values)
             {
-                if (FindType(reader, other.Type.MetadataFullName) is not { } otherHandle)
+                if (FindType(reader, other.Type) is not { } otherHandle)
                     continue;
-                if (TypeOrNestedDerivesFrom(reader, otherHandle, metadataFullName))
+                if (TypeOrNestedDerivesFrom(reader, otherHandle, requirement.Type))
                     return true;
             }
 
             return false;
         }
 
-        static bool TypeOrNestedDerivesFrom(MetadataReader reader, TypeDefinitionHandle handle, string baseMetadataFullName)
+        static bool TypeOrNestedDerivesFrom(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            CompileBackTypeIdentity baseIdentity)
         {
             var typeDef = reader.GetTypeDefinition(handle);
-            if (CompileBackTypeIdentity.FromDefinition(reader, typeDef).MetadataFullName != baseMetadataFullName
-                && ReconstructedSameAssemblyBaseName(reader, handle, ShellKind(reader, typeDef)) == baseMetadataFullName)
+            if (CompileBackTypeIdentity.FromDefinition(reader, typeDef) != baseIdentity
+                && ReconstructedSameAssemblyBaseIdentity(reader, handle, ShellKind(reader, typeDef)) == baseIdentity)
             {
                 return true;
             }
 
             foreach (var nestedHandle in typeDef.GetNestedTypes())
             {
-                if (TypeOrNestedDerivesFrom(reader, nestedHandle, baseMetadataFullName))
+                if (TypeOrNestedDerivesFrom(reader, nestedHandle, baseIdentity))
                     return true;
             }
 
@@ -5226,7 +5371,10 @@ public static class CompileBackSourceComposer
         // The metadata full name of the class's reconstructed same-assembly base, or
         // null when the base is not reconstructed (external base, or a kind that keeps
         // its compiler-implied base).
-        static string? ReconstructedSameAssemblyBaseName(MetadataReader reader, TypeDefinitionHandle handle, CompileBackTypeKind kind)
+        static CompileBackTypeIdentity? ReconstructedSameAssemblyBaseIdentity(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            CompileBackTypeKind kind)
         {
             var typeDef = reader.GetTypeDefinition(handle);
             if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
@@ -5234,7 +5382,7 @@ public static class CompileBackSourceComposer
             if (TypeShellProducer.ReconstructedBaseTypeDisplay(reader, typeDef, kind == CompileBackTypeKind.Class) is null)
                 return null;
             var baseDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType);
-            return CompileBackTypeIdentity.FromDefinition(reader, baseDef).MetadataFullName;
+            return CompileBackTypeIdentity.FromDefinition(reader, baseDef);
         }
 
         static CompileBackMemberRequirement SyntheticParameterlessConstructor(CompileBackTypeIdentity typeIdentity)
@@ -5252,7 +5400,7 @@ public static class CompileBackSourceComposer
         static IReadOnlyList<CompileBackTypeSignature> InterfaceSignatures(
             MetadataReader reader,
             TypeDefinition typeDef,
-            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName)
+            IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity)
         {
             if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
                 return [];
@@ -5280,7 +5428,7 @@ public static class CompileBackSourceComposer
                 // interface here when it is already a known requirement — i.e. it
                 // will actually be declared somewhere in the composed unit — mirroring
                 // the same guard `AddRequiredInterfaceProperties` uses.
-                if (!requirementsByMetadataName.ContainsKey(interfaceIdentity.MetadataFullName))
+                if (!requirementsByIdentity.ContainsKey(interfaceIdentity))
                     continue;
 
                 interfaces.Add(CompileBackTypeSignature.Definition(interfaceIdentity));
@@ -5293,6 +5441,7 @@ public static class CompileBackSourceComposer
             MetadataReader reader,
             TypeDefinition typeDef,
             CompileBackTypeRequirement requirement,
+            ApiType surface,
             List<CompileBackMemberRequirement> members,
             List<CompileBackPlanningDiagnostic> diagnostics,
             IOperatorTypeRelationshipResolver? relationshipResolver,
@@ -5336,18 +5485,25 @@ public static class CompileBackSourceComposer
             allowUnsafeSurface = allowUnsafeSurface
                 || requirement.RequiredMembers.Count != 0
                 || requirement.IncludeMemberSurface;
-            var accessorMethods = new HashSet<MethodDefinitionHandle>();
+            var surfaceAccessorTokens = surface.Members
+                .SelectMany(member => new[]
+                {
+                    member.GetterToken,
+                    member.SetterToken,
+                    member.AdderToken,
+                    member.RemoverToken,
+                })
+                .Where(static token => token.HasValue)
+                .Select(static token => token.GetValueOrDefault())
+                .ToHashSet();
             var typeContext = GenericContext.ForType(reader, typeDef);
-            // The product owns the field-inclusion decision (ApiSurfaceExtractor.SurfaceFieldHandles):
-            // it drops synthesized auto-property backing fields (`<Name>k__BackingField`, which the
-            // compiler re-synthesizes for each reconstructed auto-property, issue #3036), the enum
-            // `value__` slot, and a field-like event's compiler-generated backing field (issue
-            // #3083), while surfacing the closure/state-machine captures reconstruction needs
-            // (includeCompilerGenerated). RTS keeps only the reconstruction-side gates below
-            // (unspeakable names, signature decode, fixed buffers, pointer surface, dedup).
-            foreach (var fieldHandle in ApiSurfaceExtractor.SurfaceFieldHandles(
-                reader, typeDef, includeAll: true, includeCompilerGenerated: true))
+            // Product surface extraction owns member discovery, accessor ownership,
+            // and backing-field exclusion. RTS retains only reconstruction policy:
+            // representability, unsafe gating, deduplication, and stub/full bodies.
+            foreach (var surfaceField in surface.Members.Where(member => member.Kind == "field"))
             {
+                if (FindField(reader, typeDef, surfaceField.Name) is not { } fieldHandle)
+                    continue;
                 var field = reader.GetFieldDefinition(fieldHandle);
                 string fieldName = reader.GetString(field.Name);
                 if (fieldName.Contains('.', StringComparison.Ordinal))
@@ -5387,14 +5543,16 @@ public static class CompileBackSourceComposer
                     DeclarationSignature: fixedBufferSignature));
             }
 
-            foreach (var propertyHandle in typeDef.GetProperties())
+            foreach (var surfaceProperty in surface.Members.Where(member => member.Kind == "property"))
             {
+                var propertyHandle = PropertyForAccessor(
+                    reader,
+                    typeDef,
+                    SurfaceMethodHandle(surfaceProperty.GetterToken ?? surfaceProperty.SetterToken));
+                if (propertyHandle.IsNil)
+                    continue;
                 var property = reader.GetPropertyDefinition(propertyHandle);
                 var accessors = property.GetAccessors();
-                if (!accessors.Getter.IsNil)
-                    accessorMethods.Add(accessors.Getter);
-                if (!accessors.Setter.IsNil)
-                    accessorMethods.Add(accessors.Setter);
 
                 string propertyName = reader.GetString(property.Name);
                 if (propertyName.Contains('<', StringComparison.Ordinal)
@@ -5477,14 +5635,16 @@ public static class CompileBackSourceComposer
                     SetterToken: accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter)));
             }
 
-            foreach (var eventHandle in typeDef.GetEvents())
+            foreach (var surfaceEvent in surface.Members.Where(member => member.Kind == "event"))
             {
+                var eventHandle = EventForAccessor(
+                    reader,
+                    typeDef,
+                    SurfaceMethodHandle(surfaceEvent.AdderToken ?? surfaceEvent.RemoverToken));
+                if (eventHandle.IsNil)
+                    continue;
                 var eventDefinition = reader.GetEventDefinition(eventHandle);
                 var accessors = eventDefinition.GetAccessors();
-                if (!accessors.Adder.IsNil)
-                    accessorMethods.Add(accessors.Adder);
-                if (!accessors.Remover.IsNil)
-                    accessorMethods.Add(accessors.Remover);
 
                 string eventName = reader.GetString(eventDefinition.Name);
                 if (eventName.Contains('<', StringComparison.Ordinal))
@@ -5530,12 +5690,24 @@ public static class CompileBackSourceComposer
             }
 
             int overload = 0;
-            foreach (var methodHandle in typeDef.GetMethods())
+            foreach (var surfaceMethod in surface.Members.Where(member =>
+                member.MetadataToken is not null
+                && !surfaceAccessorTokens.Contains(member.MetadataToken.Value)
+                && member.Kind != "extension-method"))
             {
+                var methodHandle = SurfaceMethodHandle(surfaceMethod.MetadataToken);
+                if (methodHandle.IsNil)
+                    continue;
                 var method = reader.GetMethodDefinition(methodHandle);
+                if (CompileBackTypeIdentity.FromDefinition(
+                        reader,
+                        reader.GetTypeDefinition(method.GetDeclaringType()))
+                    != requirement.Type)
+                {
+                    continue;
+                }
                 string name = reader.GetString(method.Name);
-                if (accessorMethods.Contains(methodHandle)
-                    || name == ".cctor"
+                if (name == ".cctor"
                     || (name.Contains('<', StringComparison.Ordinal)
                         && CSharpNaming.MethodName(name) == name)
                     || (name != ".ctor" && name.Contains('.', StringComparison.Ordinal)))
@@ -5550,66 +5722,9 @@ public static class CompileBackSourceComposer
                     method,
                     isConstructor,
                     relationshipResolver);
-                MethodSignature<string> signature;
-                try
-                {
-                    signature = GuardedSignatureText.MethodText(
-                        reader,
-                        method,
-                        GenericContext.ForMethod(
-                            reader,
-                            typeDef,
-                            method));
-                }
-                catch (Exception ex) when (
-                    ex is BadImageFormatException
-                        or InvalidOperationException
-                        or ArgumentException)
-                {
-                    diagnostics.Add(
-                        new CompileBackPlanningDiagnostic(
-                            "member surface",
-                            "method-signature-decode-failed",
-                            name));
-                    continue;
-                }
-                string signatureIdentity =
-                    MethodSignatureText(identifierName, signature);
-                var generatedLocalFunction =
-                    IsGeneratedLocalFunctionName(name);
-                var methodDeclaration = generatedLocalFunction
-                    ? null
-                    : MetadataDeclarationQuery.GetMethod(
-                        reader,
-                        typeDef,
-                        method,
-                        signature);
-                var parameters = generatedLocalFunction
-                    ? Parameters(reader, method, signature)
-                    : ToCompileBackParameters(
-                        methodDeclaration!.Signature.Parameters);
-                var methodReturnType = generatedLocalFunction
-                    ? signature.ReturnType
-                    : methodDeclaration!.Signature.ReturnType;
-                CompileBackTypeSignature? returnType =
-                    isConstructor || methodReturnType is null
-                    ? null
-                    : CompileBackTypeSignature.Display(
-                        methodReturnType);
-                int typeParameterCount =
-                    method.GetGenericParameters().Count;
                 int existingMethodIndex = members.FindIndex(member =>
                     member.Kind == memberKind
-                    && member.Identity.Method == identifierName
-                    && member.IsStatic
-                        == method.Attributes.HasFlag(
-                            MethodAttributes.Static)
-                    && member.TypeParameters.Count
-                        == typeParameterCount
-                    && (member.Identity.Signature == signatureIdentity
-                        || (member.ReturnType?.DisplayName
-                                == returnType?.DisplayName
-                            && SameParameters(member.Parameters, parameters))));
+                    && member.Identity.Method == identifierName);
                 if (existingMethodIndex >= 0)
                 {
                     var existing = members[existingMethodIndex];
@@ -5621,14 +5736,13 @@ public static class CompileBackSourceComposer
                 }
                 if (!isConstructor
                     && method.Attributes.HasFlag(
-                        MethodAttributes.SpecialName)
-                    && memberKind != CompileBackMemberKind.Operator)
+                        MethodAttributes.SpecialName))
                 {
                     continue;
                 }
                 if (requirement.RequiredKind == CompileBackTypeKind.Interface && method.Attributes.HasFlag(MethodAttributes.Static))
                     continue;
-                if (generatedLocalFunction && typeParameterCount != 0)
+                if (method.GetGenericParameters().Count != 0)
                 {
                     diagnostics.Add(new CompileBackPlanningDiagnostic(
                         "member surface",
@@ -5636,6 +5750,27 @@ public static class CompileBackSourceComposer
                         name));
                     continue;
                 }
+                MethodSignature<string> signature;
+                try
+                {
+                    signature = GuardedSignatureText.MethodText(reader, method, GenericContext.ForMethod(reader, typeDef, method));
+                }
+                catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic("member surface", "method-signature-decode-failed", name));
+                    continue;
+                }
+                string signatureIdentity = MethodSignatureText(identifierName, signature);
+                var generatedLocalFunction = IsGeneratedLocalFunctionName(name);
+                var methodDeclaration = generatedLocalFunction
+                    ? null
+                    : MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
+                var parameters = generatedLocalFunction
+                    ? Parameters(reader, method, signature)
+                    : ToCompileBackParameters(methodDeclaration!.Signature.Parameters);
+                var methodReturnType = generatedLocalFunction
+                    ? signature.ReturnType
+                    : methodDeclaration!.Signature.ReturnType;
                 if (methodReturnType is null
                     || IsUnsupportedSurfaceSignature(methodReturnType)
                     || parameters.Any(parameter => IsUnsupportedSurfaceSignature(parameter.Type.DisplayName))
@@ -5645,10 +5780,55 @@ public static class CompileBackSourceComposer
                 {
                     continue;
                 }
+                bool methodIsStatic = method.Attributes.HasFlag(MethodAttributes.Static);
+                bool methodIsOperator = memberKind == CompileBackMemberKind.Operator;
+                string? returnTypeIdentity = isConstructor
+                    ? null
+                    : CompileBackTypeSignature.Display(methodReturnType).DisplayName;
+                var parameterIdentity = parameters
+                    .Select(parameter => (parameter.Type.DisplayName, parameter.Modifier))
+                    .ToArray();
+                var existingMethodIndexes = members
+                    .Select((member, index) => (member, index))
+                    .Where(candidate =>
+                        candidate.member.Kind == memberKind
+                        && candidate.member.Identity.Method == identifierName
+                        && candidate.member.IsStatic == methodIsStatic
+                        && candidate.member.IsOperator == methodIsOperator
+                        && candidate.member.TypeParameters.Count == method.GetGenericParameters().Count
+                        && candidate.member.ReturnType?.DisplayName == returnTypeIdentity
+                        && candidate.member.Parameters
+                            .Select(parameter => (parameter.Type.DisplayName, parameter.Modifier))
+                            .SequenceEqual(parameterIdentity))
+                    .Select(candidate => candidate.index)
+                    .ToArray();
+                if (existingMethodIndexes.Length == 1)
+                {
+                    int existingMethodIndex = existingMethodIndexes[0];
+                    var existing = members[existingMethodIndex];
+                    members[existingMethodIndex] = existing with
+                    {
+                        MetadataToken = existing.MetadataToken ?? MetadataTokens.GetToken(methodHandle),
+                    };
+                    continue;
+                }
+                if (existingMethodIndexes.Length > 1)
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "method-token-match-ambiguous",
+                        signatureIdentity));
+                    continue;
+                }
+                if (method.GetGenericParameters().Count != 0)
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic("member surface", "generic-method-skipped", name));
+                    continue;
+                }
                 members.Add(new CompileBackMemberRequirement(
-                    new CompileBackMethodIdentity(requirement.Type.FullName, identifierName, overload++, MethodSignatureText(identifierName, signature)),
+                    new CompileBackMethodIdentity(requirement.Type.FullName, identifierName, overload++, signatureIdentity),
                     memberKind,
-                    IsStatic: method.Attributes.HasFlag(MethodAttributes.Static),
+                    IsStatic: methodIsStatic,
                     Parameters: parameters,
                     ReturnType: isConstructor ? null : CompileBackTypeSignature.Display(methodReturnType),
                     TypeParameters: generatedLocalFunction ? [] : ToCompileBackTypeParameters(methodDeclaration!.Signature.TypeParameters),
@@ -5663,6 +5843,8 @@ public static class CompileBackSourceComposer
                     IsVirtual: !isConstructor && IsVirtualMethod(method),
                     IsOverride: false,
                     IsSealed: false,
+                    IsOperator: methodIsOperator,
+                    IsFinalizer: surfaceMethod.IsFinalizer,
                     Accessibility: MethodAccessibility(method),
                     MetadataToken: MetadataTokens.GetToken(methodHandle)));
             }
@@ -5684,6 +5866,39 @@ public static class CompileBackSourceComposer
                     TargetBody: null,
                     SourceFacts: [new CompileBackFact("metadata", "synthetic-parameterless-ctor", "same-assembly closure root")]));
             }
+        }
+
+        static MethodDefinitionHandle SurfaceMethodHandle(int? token)
+        {
+            if (token is null)
+                return default;
+            try
+            {
+                var handle = MetadataTokens.EntityHandle(token.Value);
+                return handle.Kind == HandleKind.MethodDefinition
+                    ? (MethodDefinitionHandle)handle
+                    : default;
+            }
+            catch (ArgumentException)
+            {
+                return default;
+            }
+        }
+
+        static EventDefinitionHandle EventForAccessor(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            MethodDefinitionHandle accessor)
+        {
+            if (accessor.IsNil)
+                return default;
+            foreach (var eventHandle in typeDef.GetEvents())
+            {
+                var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
+                if (accessors.Adder == accessor || accessors.Remover == accessor)
+                    return eventHandle;
+            }
+            return default;
         }
 
         static bool IsUnsupportedSurfaceSignature(string signature)
@@ -5820,6 +6035,20 @@ public static class CompileBackSourceComposer
             {
                 var typeDef = reader.GetTypeDefinition(handle);
                 if (reader.GetFullTypeName(typeDef) == metadataFullName)
+                    return handle;
+            }
+
+            return null;
+        }
+
+        static TypeDefinitionHandle? FindType(
+            MetadataReader reader,
+            CompileBackTypeIdentity identity)
+        {
+            foreach (var handle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(handle);
+                if (CompileBackTypeIdentity.FromDefinition(reader, typeDef) == identity)
                     return handle;
             }
 

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -984,17 +984,25 @@ public static class CompileBackSourceComposer
             // target type's same-assembly interface definitions to typed refs. RTS
             // keeps only closure-root bookkeeping — resolve each interface definition
             // (TryResolveHandle applies the same-assembly + supported-root gates) and
-            // seed it as a root, matching the prior TypeDefinition-only walk.
-            foreach (var interfaceType in IrImporter.ImportImplementedInterfaces(reader, handle))
+            // seed it as a root. ImportImplementedInterfaces deliberately omits
+            // constructed TypeSpec edges, so decode the relationship directly here
+            // to keep those interfaces in the reconstruction closure as well.
+            var targetType = reader.GetTypeDefinition(handle);
+            var genericScope = new GenericScope(
+                [.. GenericContext.ForType(reader, targetType).TypeParameters],
+                []);
+            foreach (var implementationHandle in targetType.GetInterfaceImplementations())
             {
-                if (TryResolveHandle(interfaceType) is not { } interfaceHandle)
+                var interfaceHandle = reader.GetInterfaceImplementation(implementationHandle).Interface;
+                if (!TryDecodeInterfaceType(reader, interfaceHandle, genericScope, out var interfaceType)
+                    || TryResolveHandle(interfaceType) is not { } interfaceDefinition)
                     continue;
 
-                var root = TopLevelRootOf(reader, interfaceHandle);
+                var root = TopLevelRootOf(reader, interfaceDefinition);
                 if (root == targetRoot)
                     continue;
 
-                var interfaceDef = reader.GetTypeDefinition(interfaceHandle);
+                var interfaceDef = reader.GetTypeDefinition(interfaceDefinition);
                 closureRoots.Add(root);
                 AddClosureFact(
                     closureFacts,
@@ -1308,7 +1316,9 @@ public static class CompileBackSourceComposer
             assemblyPath,
             compilationClosure,
             reader,
+            targetType,
             targetTypeDef,
+            targetGetter,
             getter,
             production.Requirements);
         var declarations = production.Requests;
@@ -3185,7 +3195,9 @@ public static class CompileBackSourceComposer
             assemblyPath,
             compilationClosure,
             reader,
+            targetType,
             targetTypeDef,
+            targetSetter,
             setter,
             production.Requirements);
         var declarations = production.Requests;
@@ -3361,7 +3373,9 @@ public static class CompileBackSourceComposer
             assemblyPath,
             compilationClosure,
             reader,
+            targetType,
             targetTypeDef,
+            targetAccessor,
             accessor,
             production.Requirements);
         var module = new CompileBackModuleRequirement(
@@ -3711,7 +3725,9 @@ public static class CompileBackSourceComposer
             assemblyPath,
             compilationClosure,
             reader,
+            targetType,
             targetTypeDef,
+            targetMethod,
             method,
             production.Requirements);
         var declarations = production.Requests;
@@ -4199,7 +4215,9 @@ public static class CompileBackSourceComposer
         string assemblyPath,
         ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader reader,
+        TypeDefinitionHandle targetTypeHandle,
         TypeDefinition targetType,
+        MethodDefinitionHandle targetMethodHandle,
         MethodDefinition targetMethod,
         IReadOnlyList<CompileBackTypeRequirement> reconstructedRequirements)
     {
@@ -4207,7 +4225,9 @@ public static class CompileBackSourceComposer
             assemblyPath,
             compilationClosure,
             reader,
+            targetTypeHandle,
             targetType,
+            targetMethodHandle,
             targetMethod,
             reconstructedRequirements);
         if (omission == MetadataFactState.No)
@@ -4218,6 +4238,163 @@ public static class CompileBackSourceComposer
             diagnostics,
             omission,
             $"{targetIdentity.MetadataFullName}::{reader.GetString(targetMethod.Name)}");
+    }
+
+    static bool SameAssemblyInterfacePathIsReconstructed(
+        MetadataReader reader,
+        TypeDefinitionHandle targetType,
+        EntityHandle interfaceHandle,
+        IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> reconstructedRequirements)
+    {
+        var visited = new HashSet<TypeDefinitionHandle>();
+        return Check(targetType, interfaceHandle);
+
+        bool Check(TypeDefinitionHandle ownerType, EntityHandle edge)
+        {
+            if (TryReconstructedInterfaceSignature(
+                    reader,
+                    ownerType,
+                    edge,
+                    reconstructedRequirements)
+                is null)
+            {
+                return false;
+            }
+
+            if (!TryResolveSameAssemblyInterface(
+                    reader,
+                    edge,
+                    out var interfaceType,
+                    out _)
+                || !visited.Add(interfaceType))
+            {
+                return true;
+            }
+
+            var interfaceDef = reader.GetTypeDefinition(interfaceType);
+            foreach (var inheritedHandle in interfaceDef.GetInterfaceImplementations())
+            {
+                if (!Check(interfaceType, reader.GetInterfaceImplementation(inheritedHandle).Interface))
+                    return false;
+            }
+
+            return true;
+        }
+    }
+
+    static MetadataFactState TargetStaticMethodImplementationEvidence(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinitionHandle targetMethod)
+    {
+        var evidence = MetadataFactState.No;
+        foreach (var implementationHandle in typeDef.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody != targetMethod)
+            {
+                continue;
+            }
+
+            if (implementation.MethodDeclaration.Kind == HandleKind.MethodDefinition)
+            {
+                var declaration = reader.GetMethodDefinition(
+                    (MethodDefinitionHandle)implementation.MethodDeclaration);
+                var declaringType = declaration.GetDeclaringType();
+                if (!declaringType.IsNil
+                    && reader.GetTypeDefinition(declaringType).Attributes
+                        .HasFlag(TypeAttributes.Interface))
+                {
+                    return MetadataFactState.Yes;
+                }
+                continue;
+            }
+
+            if (implementation.MethodDeclaration.Kind == HandleKind.MemberReference)
+            {
+                var declaration = reader.GetMemberReference(
+                    (MemberReferenceHandle)implementation.MethodDeclaration);
+                if (declaration.Parent.Kind is HandleKind.TypeReference
+                    or HandleKind.TypeSpecification)
+                {
+                    // A MemberRef parent can be an external interface. The
+                    // declaration and interface-member checks below decide
+                    // whether the row actually explains this target.
+                    return MetadataFactState.Yes;
+                }
+                evidence = MetadataFactState.Unknown;
+                continue;
+            }
+
+            if (implementation.MethodDeclaration.Kind == HandleKind.TypeSpecification)
+            {
+                if (TryDecodeInterfaceType(
+                        reader,
+                        (TypeSpecificationHandle)implementation.MethodDeclaration,
+                        out var declarationType)
+                    && TryResolveSameAssemblyInterfaceType(
+                        declarationType,
+                        out var declarationInterface,
+                        out _)
+                    && reader.GetTypeDefinition(declarationInterface).Attributes
+                        .HasFlag(TypeAttributes.Interface))
+                {
+                    return MetadataFactState.Yes;
+                }
+
+                evidence = MetadataFactState.Unknown;
+                continue;
+            }
+
+            evidence = MetadataFactState.Unknown;
+        }
+
+        return evidence;
+    }
+
+    static CompileBackTypeSignature? TryReconstructedInterfaceSignature(
+        MetadataReader reader,
+        TypeDefinitionHandle ownerType,
+        EntityHandle interfaceHandle,
+        IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> reconstructedRequirements)
+    {
+        var ownerDef = reader.GetTypeDefinition(ownerType);
+        var genericScope = new GenericScope(
+            [.. GenericContext.ForType(reader, ownerDef).TypeParameters],
+            []);
+        if (!TryDecodeInterfaceType(reader, interfaceHandle, genericScope, out var decoded)
+            || !TryResolveSameAssemblyInterfaceType(
+                decoded,
+                out var interfaceType,
+                out _))
+        {
+            return null;
+        }
+
+        var interfaceDef = reader.GetTypeDefinition(interfaceType);
+        if (!IsSupportedTypedClosureRoot(reader, interfaceDef))
+            return null;
+
+        var identity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
+        if (!reconstructedRequirements.ContainsKey(identity)
+            && !reconstructedRequirements.ContainsKey(
+                CompileBackTypeIdentity.FromDefinition(
+                    reader,
+                    reader.GetTypeDefinition(TopLevelRootOf(reader, interfaceType)))))
+        {
+            return null;
+        }
+
+        if (decoded.Kind != TypeRefKind.GenericInstance)
+            return CompileBackTypeSignature.Definition(identity);
+
+        var ownerRef = TypeRefDecoder.Instance.GetTypeFromDefinition(reader, ownerType, 0);
+        string displayName = decoded.ToDisplayString(ownerRef);
+        string displayNamespace = CSharpFormatter.EscapeNamespace(identity.Namespace);
+        string display = displayNamespace.Length == 0
+            ? displayName
+            : $"{displayNamespace}.{displayName}";
+        return CompileBackTypeSignature.Display(display);
     }
 
     // Whether an interface the reconstruction omits from the target type's base list
@@ -4237,22 +4414,36 @@ public static class CompileBackSourceComposer
         string assemblyPath,
         ReturnToSender.CompilationClosure? compilationClosure,
         MetadataReader reader,
+        TypeDefinitionHandle targetTypeHandle,
         TypeDefinition typeDef,
+        MethodDefinitionHandle targetMethodHandle,
         MethodDefinition method,
         IReadOnlyList<CompileBackTypeRequirement> reconstructedRequirements)
     {
-        if (ShellKind(reader, typeDef) != CompileBackTypeKind.Class)
-            return MetadataFactState.No;
-
         string name = reader.GetString(method.Name);
         if (name.Contains('.', StringComparison.Ordinal)
-            || method.Attributes.HasFlag(MethodAttributes.Static)
-            || (method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
-            || !method.Attributes.HasFlag(MethodAttributes.Virtual)
-            || !method.Attributes.HasFlag(MethodAttributes.Final)
-            || !method.Attributes.HasFlag(MethodAttributes.NewSlot))
+            || (method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
         {
             return MetadataFactState.No;
+        }
+
+        bool isStatic = method.Attributes.HasFlag(MethodAttributes.Static);
+        if (!isStatic
+            && (!method.Attributes.HasFlag(MethodAttributes.Virtual)
+                || !method.Attributes.HasFlag(MethodAttributes.Final)
+                || !method.Attributes.HasFlag(MethodAttributes.NewSlot)))
+        {
+            return MetadataFactState.No;
+        }
+
+        if (isStatic)
+        {
+            var methodImplEvidence = TargetStaticMethodImplementationEvidence(
+                reader,
+                typeDef,
+                targetMethodHandle);
+            if (methodImplEvidence != MetadataFactState.Yes)
+                return methodImplEvidence;
         }
 
         MethodSignature<string> targetSignature;
@@ -4285,6 +4476,7 @@ public static class CompileBackSourceComposer
             // it neither proves an omission nor leaves one unproven.
             if (SameAssemblyInterfaceTargetIsReconstructed(
                     reader,
+                    targetTypeHandle,
                     interfaceHandle,
                     method,
                     reconstructedRequirements))
@@ -4302,6 +4494,7 @@ public static class CompileBackSourceComposer
 
     static bool SameAssemblyInterfaceTargetIsReconstructed(
         MetadataReader reader,
+        TypeDefinitionHandle targetType,
         EntityHandle interfaceHandle,
         MethodDefinition targetMethod,
         IReadOnlyList<CompileBackTypeRequirement> reconstructedRequirements)
@@ -4329,11 +4522,19 @@ public static class CompileBackSourceComposer
             interfaceDef,
             interfaceIdentity,
             declaringMethod);
-        return declaredMember is not null
+        bool memberReconstructed = declaredMember is not null
             && reconstructedRequirements.Any(requirement =>
                 requirement.Type == interfaceIdentity
                 && requirement.RequiredMembers.Any(member =>
                     SameReconstructedInterfaceMember(member, declaredMember)));
+        bool pathReconstructed = memberReconstructed
+            && SameAssemblyInterfacePathIsReconstructed(
+                reader,
+                targetType,
+                interfaceHandle,
+                reconstructedRequirements.ToDictionary(
+                    requirement => requirement.Type));
+        return pathReconstructed;
     }
 
     static bool SameReconstructedInterfaceMember(
@@ -4547,6 +4748,17 @@ public static class CompileBackSourceComposer
         MetadataReader reader,
         EntityHandle interfaceHandle,
         out TypeRef type)
+        => TryDecodeInterfaceType(
+            reader,
+            interfaceHandle,
+            GenericScope.Empty,
+            out type);
+
+    static bool TryDecodeInterfaceType(
+        MetadataReader reader,
+        EntityHandle interfaceHandle,
+        GenericScope genericScope,
+        out TypeRef type)
     {
         type = TypeRef.Unsupported("not decoded");
         try
@@ -4559,7 +4771,7 @@ public static class CompileBackSourceComposer
                     rawTypeKind: 0),
                 HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(
                     reader,
-                    GenericScope.Empty,
+                    genericScope,
                     (TypeSpecificationHandle)interfaceHandle,
                     rawTypeKind: 0),
                 _ => TypeRef.Unsupported("not a same-assembly interface"),
@@ -6415,7 +6627,7 @@ public static class CompileBackSourceComposer
                 Namespace: requirement.Type.Namespace,
                 MetadataName: requirement.Type.MetadataName,
                 Kind: ToShellKind(kind),
-                InterfaceDisplayNames: InterfaceSignatures(reader, typeDef, requirementsByIdentity)
+                InterfaceDisplayNames: InterfaceSignatures(reader, handle, typeDef, requirementsByIdentity)
                     .Select(signature => signature.DisplayName)
                     .Concat(requirement.ExternalInterfaces)
                     .Distinct(StringComparer.Ordinal)
@@ -7221,39 +7433,23 @@ public static class CompileBackSourceComposer
 
         static IReadOnlyList<CompileBackTypeSignature> InterfaceSignatures(
             MetadataReader reader,
+            TypeDefinitionHandle typeHandle,
             TypeDefinition typeDef,
             IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity)
         {
-            if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
-                return [];
-
             var interfaces = new List<CompileBackTypeSignature>();
             foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
             {
                 var implementation = reader.GetInterfaceImplementation(implementationHandle);
-                if (implementation.Interface.Kind != HandleKind.TypeDefinition)
-                    continue;
-
-                var interfaceDef = reader.GetTypeDefinition((TypeDefinitionHandle)implementation.Interface);
-                if (interfaceDef.GetGenericParameters().Count != 0 || !IsSupportedClosureRoot(reader, interfaceDef))
-                    continue;
-
-                var interfaceIdentity = CompileBackTypeIdentity.FromDefinition(reader, interfaceDef);
-                // Naming a base-list interface that this compile-back unit never
-                // declares is worse than omitting it: metadata can carry two
-                // same-named interfaces of different arity in one namespace (a
-                // non-generic `IPropertyValidator` alongside `IPropertyValidator<T,
-                // TProperty>`, as in FluentValidation), and closure discovery may
-                // queue only one of them as an actual requirement. Referencing the
-                // undeclared one by its bare display name lets Roslyn resolve it to
-                // the *other*, wrong-arity type in scope (CS0305). Only name an
-                // interface here when it is already a known requirement — i.e. it
-                // will actually be declared somewhere in the composed unit — mirroring
-                // the same guard `AddRequiredInterfaceProperties` uses.
-                if (!requirementsByIdentity.ContainsKey(interfaceIdentity))
-                    continue;
-
-                interfaces.Add(CompileBackTypeSignature.Definition(interfaceIdentity));
+                if (TryReconstructedInterfaceSignature(
+                        reader,
+                        typeHandle,
+                        implementation.Interface,
+                        requirementsByIdentity)
+                    is { } signature)
+                {
+                    interfaces.Add(signature);
+                }
             }
 
             return interfaces;
@@ -7425,7 +7621,9 @@ public static class CompileBackSourceComposer
 
                 var accessorMethod = accessor.IsNil ? default : reader.GetMethodDefinition(accessor);
                 bool isStatic = !accessor.IsNil && accessorMethod.Attributes.HasFlag(MethodAttributes.Static);
-                if (requirement.RequiredKind == CompileBackTypeKind.Interface && isStatic)
+                if (requirement.RequiredKind == CompileBackTypeKind.Interface
+                    && isStatic
+                    && !propertyDeclaration.IsAbstract)
                     continue;
                 var returnType = CompileBackTypeSignature.Display(propertyReturnType);
                 var propertyParameters = ToCompileBackParameters(
@@ -7642,7 +7840,9 @@ public static class CompileBackSourceComposer
 
                 bool isConstructor = name == ".ctor";
                 string identifierName = MemberIdentifierName(name, isConstructor);
-                if (requirement.RequiredKind == CompileBackTypeKind.Interface && method.Attributes.HasFlag(MethodAttributes.Static))
+                if (requirement.RequiredKind == CompileBackTypeKind.Interface
+                    && method.Attributes.HasFlag(MethodAttributes.Static)
+                    && !IsAbstractMethod(method))
                     continue;
                 var generatedLocalFunction = IsGeneratedLocalFunctionName(name);
                 int typeParameterCount = method.GetGenericParameters().Count;

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -436,7 +436,8 @@ public sealed record CompileBackMemberRequirement(
     int? SetterToken = null,
     int? AdderToken = null,
     int? RemoverToken = null,
-    bool SuppressDestructorSyntax = false)
+    bool SuppressDestructorSyntax = false,
+    string? MetadataName = null)
 {
     public string Name => Identity.Method;
     public string Type => ReturnType?.DisplayName ?? "";
@@ -1241,7 +1242,8 @@ public static class CompileBackSourceComposer
                 GetterToken: MetadataTokens.GetToken(targetGetter),
                 SetterToken: accessors.Setter.IsNil
                     ? null
-                    : MetadataTokens.GetToken(accessors.Setter))
+                    : MetadataTokens.GetToken(accessors.Setter),
+                MetadataName: metadataPropertyName)
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -1689,6 +1691,8 @@ public static class CompileBackSourceComposer
                 if (index == matchIndex)
                     continue;
                 var requiredMethod = requiredMethods[index];
+                if (!MetadataIdentifierRoundTrips(requiredMethod.Name))
+                    return null;
                 var implicitImplementation = FindImplicitInterfaceMethod(
                     reader,
                     targetMethodDefinition.GetDeclaringType(),
@@ -1771,43 +1775,12 @@ public static class CompileBackSourceComposer
         MethodDefinitionHandle methodHandle)
     {
         var typeDef = reader.GetTypeDefinition(targetType);
-        var method = reader.GetMethodDefinition(methodHandle);
-        try
-        {
-            var signature = GuardedSignatureText.MethodText(
-                reader,
-                method,
-                GenericContext.ForMethod(reader, typeDef, method));
-            var declaration = MetadataDeclarationQuery.GetMethod(
-                reader,
-                typeDef,
-                method,
-                signature);
-            if (declaration.Signature.ReturnType is not { } returnType)
-                return null;
-            string name = reader.GetString(method.Name);
-            return new CompileBackMemberRequirement(
-                new CompileBackMethodIdentity(
-                    CompileBackTypeIdentity.FromDefinition(reader, typeDef).FullName,
-                    Identifier(name),
-                    0,
-                    MethodSignatureText(name, signature)),
-                CompileBackMemberKind.Method,
-                IsStatic: false,
-                ToCompileBackParameters(declaration.Signature.Parameters),
-                CompileBackTypeSignature.Display(returnType),
-                ToCompileBackTypeParameters(declaration.Signature.TypeParameters),
-                CompileBackStubBodyKind.Throw,
-                TargetBody: null,
-                [new CompileBackFact("metadata", "external-interface-implicit-method", name)],
-                declaration.Attributes,
-                declaration.Signature.ReturnAttributes,
-                MetadataToken: MetadataTokens.GetToken(methodHandle));
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
-        {
-            return null;
-        }
+        return TypeProducer.MethodRequirement(
+            reader,
+            typeDef,
+            CompileBackTypeIdentity.FromDefinition(reader, typeDef),
+            methodHandle,
+            "external-interface-implicit-method");
     }
 
     // Synthesizes a `throw null` explicit-interface stub for a NON-target member of an external
@@ -2822,7 +2795,8 @@ public static class CompileBackSourceComposer
                 GetterToken: property.GetAccessors().Getter.IsNil
                     ? null
                     : MetadataTokens.GetToken(property.GetAccessors().Getter),
-                SetterToken: MetadataTokens.GetToken(targetSetter))
+                SetterToken: MetadataTokens.GetToken(targetSetter),
+                MetadataName: metadataPropertyName)
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -3436,7 +3410,8 @@ public static class CompileBackSourceComposer
             SuppressDestructorSyntax: requirement.SuppressDestructorSyntax,
             CSharpOperatorDeclaration: requirement.Kind == CompileBackMemberKind.Operator
                 ? requirement.IsOperator
-                : null);
+                : null,
+            MetadataName: requirement.MetadataName);
 
     static CSharpShellParameter ToShellParameter(CompileBackParameter parameter)
         => new(
@@ -4778,7 +4753,8 @@ public static class CompileBackSourceComposer
                     : MetadataTokens.GetToken(accessors.Getter),
                 SetterToken: accessors.Setter.IsNil
                     ? null
-                    : MetadataTokens.GetToken(accessors.Setter));
+                    : MetadataTokens.GetToken(accessors.Setter),
+                MetadataName: propertyName);
         }
 
         static CompileBackStubBodyKind PropertyStubBody(
@@ -5834,7 +5810,8 @@ public static class CompileBackSourceComposer
                         ? CompileBackAccessibility.Public
                         : MethodAccessibility(accessorMethod),
                     GetterToken: surfaceProperty.GetterToken,
-                    SetterToken: surfaceProperty.SetterToken));
+                    SetterToken: surfaceProperty.SetterToken,
+                    MetadataName: propertyName));
             }
 
             foreach (var surfaceEvent in surface.Members.Where(member => member.Kind == "event"))

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -7694,10 +7694,10 @@ public static class CompileBackSourceComposer
                 if (methodHasOperatorIdentity && !methodIsOperator)
                 {
                     // A null classification is unavailable evidence, not a proven negative:
-                    // the surface classifies without a relationship resolver, so an operator
-                    // whose signature names a type outside this assembly is unclassifiable.
-                    // Both cases still emit the raw method, but reporting the unproven one as
-                    // "not representable" claims a fact nothing established.
+                    // the surface classifies through a cross-assembly relationship resolver,
+                    // so an operator whose signature names a type that cannot be resolved is
+                    // unclassifiable. Both cases still emit the raw method, but reporting the
+                    // unproven one as "not representable" claims a fact nothing established.
                     bool classificationUnavailable =
                         surfaceMethod.CSharpOperatorDeclaration is null;
                     diagnostics.Add(new CompileBackPlanningDiagnostic(

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -438,6 +438,8 @@ public sealed record CompileBackMemberRequirement(
     int? AdderToken = null,
     int? RemoverToken = null,
     bool SuppressDestructorSyntax = false,
+    string? OperatorPairingKey = null,
+    bool HasOperatorPairingKey = false,
     string? MetadataName = null)
 {
     public string Name => Identity.Method;
@@ -634,6 +636,7 @@ public static class CompileBackSourceComposer
                 closure.Facts,
                 closure.MemberRequirements,
                 request.MemberSurfaceByDefinitionName,
+                request.BodyPolicy,
                 request.TargetBody.ConstructorChain,
                 operatorResolver,
                 operatorTypeResolver,
@@ -1364,7 +1367,8 @@ public static class CompileBackSourceComposer
         MetadataReader reader,
         TypeDefinitionHandle root,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
-        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
+        bool includeFullMemberSurface = false)
     {
         AddClosureTypeRequirement(root);
         foreach (var handle in closureMemberRequirements.Keys.Concat(closureFacts.Keys)
@@ -1399,9 +1403,10 @@ public static class CompileBackSourceComposer
                         ? [new CompileBackFact("closure", "closure-root", identity.FullName)]
                         : [new CompileBackFact("metadata", "nested-closure-member-owner", identity.FullName)])
             {
-                IncludeMemberSurface = facts.Any(fact => fact.Id == "closure-member")
-                    && (requiredMembers.Length == 0
-                        || requiredMembers.Any(member => !member.IsOperator)),
+                IncludeMemberSurface = includeFullMemberSurface
+                    || (facts.Any(fact => fact.Id == "closure-member")
+                        && (requiredMembers.Length == 0
+                            || requiredMembers.Any(member => !member.IsOperator))),
                 IncludeOperatorSurface = requiredMembers.Any(member => member.IsOperator),
             };
             requirements.Add(requirement);
@@ -3132,6 +3137,7 @@ public static class CompileBackSourceComposer
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements,
         CompileBackMemberSurfaceIndex memberSurfaceByDefinitionName,
+        RoundTripBodyPolicy bodyPolicy = RoundTripBodyPolicy.Selected,
         string? constructorChain = null,
         IOperatorTypeRelationshipResolver? operatorResolver = null,
         CrossAssemblyTypeResolver? operatorTypeResolver = null,
@@ -3375,7 +3381,8 @@ public static class CompileBackSourceComposer
                 primaryConstructor,
                 targetFacts)
             {
-                IncludeMemberSurface = includeRecordSurface
+                IncludeMemberSurface = bodyPolicy == RoundTripBodyPolicy.Full
+                    || includeRecordSurface
                     || targetFacts.Any(fact => fact.Id == "closure-member"),
                 IncludeOperatorSurface = targetOperatorIsRepresentable
                     || targetMembers.Any(member => member.IsOperator),
@@ -3384,14 +3391,28 @@ public static class CompileBackSourceComposer
                     : [externalExplicitInterfaceMethod.InterfaceDisplayName],
             }
         };
-        AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
+        AddClosureTypeRequirements(
+            requirements,
+            reader,
+            targetRoot,
+            closureFacts,
+            closureMemberRequirements,
+            includeFullMemberSurface:
+                bodyPolicy == RoundTripBodyPolicy.Full);
 
         foreach (var dependency in closureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))
         {
             if (dependency == targetRoot)
                 continue;
 
-            AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
+            AddClosureTypeRequirements(
+                requirements,
+                reader,
+                dependency,
+                closureFacts,
+                closureMemberRequirements,
+                includeFullMemberSurface:
+                    bodyPolicy == RoundTripBodyPolicy.Full);
         }
         AddInheritedInterfaceMemberRequirements(
             requirements,
@@ -3623,6 +3644,8 @@ public static class CompileBackSourceComposer
             CSharpOperatorDeclaration: requirement.Kind == CompileBackMemberKind.Operator
                 ? requirement.IsOperator
                 : null,
+            OperatorPairingKey: requirement.OperatorPairingKey,
+            HasOperatorPairingKey: requirement.HasOperatorPairingKey,
             MetadataName: requirement.MetadataName);
 
     static CSharpShellParameter ToShellParameter(CompileBackParameter parameter)
@@ -6833,7 +6856,9 @@ public static class CompileBackSourceComposer
                 string identifierName = MemberIdentifierName(name, isConstructor);
                 if (requirement.RequiredKind == CompileBackTypeKind.Interface && method.Attributes.HasFlag(MethodAttributes.Static))
                     continue;
-                if (method.GetGenericParameters().Count != 0)
+                var generatedLocalFunction = IsGeneratedLocalFunctionName(name);
+                int typeParameterCount = method.GetGenericParameters().Count;
+                if (generatedLocalFunction && typeParameterCount != 0)
                 {
                     diagnostics.Add(new CompileBackPlanningDiagnostic(
                         "member surface",
@@ -6852,7 +6877,6 @@ public static class CompileBackSourceComposer
                     continue;
                 }
                 string signatureIdentity = MethodSignatureText(identifierName, signature);
-                var generatedLocalFunction = IsGeneratedLocalFunctionName(name);
                 var methodDeclaration = generatedLocalFunction
                     ? null
                     : MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
@@ -6914,7 +6938,7 @@ public static class CompileBackSourceComposer
                         && candidate.member.ExplicitInterfaceMemberName is null
                         && candidate.member.IsStatic == methodIsStatic
                         && candidate.member.IsOperator == methodIsOperator
-                        && candidate.member.TypeParameters.Count == method.GetGenericParameters().Count
+                        && candidate.member.TypeParameters.Count == typeParameterCount
                         && candidate.member.ReturnType?.DisplayName == returnTypeIdentity
                         && candidate.member.Parameters
                             .Select(parameter => (parameter.Type.DisplayName, parameter.Modifier))
@@ -6928,6 +6952,8 @@ public static class CompileBackSourceComposer
                     members[existingMethodIndex] = existing with
                     {
                         MetadataToken = existing.MetadataToken ?? surfaceMethod.MetadataToken,
+                        OperatorPairingKey = surfaceMethod.OperatorPairingKey,
+                        HasOperatorPairingKey = surfaceMethod.HasOperatorPairingKey,
                     };
                     continue;
                 }
@@ -6937,11 +6963,6 @@ public static class CompileBackSourceComposer
                         "member surface",
                         "method-token-match-ambiguous",
                         signatureIdentity));
-                    continue;
-                }
-                if (method.GetGenericParameters().Count != 0)
-                {
-                    diagnostics.Add(new CompileBackPlanningDiagnostic("member surface", "generic-method-skipped", name));
                     continue;
                 }
                 members.Add(new CompileBackMemberRequirement(
@@ -6970,7 +6991,9 @@ public static class CompileBackSourceComposer
                     IsOperator: methodIsOperator,
                     IsFinalizer: surfaceMethod.IsFinalizer,
                     Accessibility: MethodAccessibility(method),
-                    MetadataToken: surfaceMethod.MetadataToken));
+                    MetadataToken: surfaceMethod.MetadataToken,
+                    OperatorPairingKey: surfaceMethod.OperatorPairingKey,
+                    HasOperatorPairingKey: surfaceMethod.HasOperatorPairingKey));
             }
 
             if (requirement.RequiredKind == CompileBackTypeKind.Class

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -470,6 +470,10 @@ internal sealed record ExternalInterfaceMemberRequirement(
     TypeDefinitionHandle DeclaringType,
     CompileBackMemberRequirement Member);
 
+internal readonly record struct ImplicitInterfaceMethodLookup(
+    MethodDefinitionHandle Method,
+    bool SearchComplete);
+
 internal sealed record ExternalInterfaceReferenceInfo(
     string MetadataFullName,
     string DisplayFullName,
@@ -1372,8 +1376,10 @@ public static class CompileBackSourceComposer
                         ? [new CompileBackFact("closure", "closure-root", identity.FullName)]
                         : [new CompileBackFact("metadata", "nested-closure-member-owner", identity.FullName)])
             {
-                IncludeMemberSurface = requiredMembers.Any(member => member.IsOperator)
-                    || facts.Any(fact => fact.Id == "closure-member")
+                IncludeMemberSurface = facts.Any(fact => fact.Id == "closure-member")
+                    && (requiredMembers.Length == 0
+                        || requiredMembers.Any(member => !member.IsOperator)),
+                IncludeOperatorSurface = requiredMembers.Any(member => member.IsOperator),
             };
             requirements.Add(requirement);
         }
@@ -1545,8 +1551,10 @@ public static class CompileBackSourceComposer
         string metadataMethodName,
         int targetMethodGenericArity,
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
-        CrossAssemblyTypeResolver? operatorTypeResolver)
+        CrossAssemblyTypeResolver? operatorTypeResolver,
+        out string? declineReason)
     {
+        declineReason = null;
         if (!TrySplitExplicitInterfaceMetadataName(metadataMethodName, out var interfaceMetadataName, out var targetMemberName))
             return null;
 
@@ -1702,20 +1710,28 @@ public static class CompileBackSourceComposer
                     reader,
                     targetTypeHandle,
                     requiredMethod);
-                var member = implicitImplementation.IsNil
+                if (implicitImplementation.Method.IsNil
+                    && !implicitImplementation.SearchComplete)
+                {
+                    declineReason =
+                        $"{reader.GetFullTypeName(targetType)}::{metadataMethodName}: "
+                        + $"required interface member '{requiredMethod.Name}' may be inherited "
+                        + "from a base that the reconstructed shell cannot name";
+                    return null;
+                }
+                var member = implicitImplementation.Method.IsNil
                     ? SynthesizeExternalInterfaceStub(
                         interfaceReference.DisplayFullName,
                         requiredMethod)
                     : ImplicitInterfaceMethodRequirement(
                         reader,
-                        targetMethodDefinition.GetDeclaringType(),
-                        implicitImplementation);
+                        implicitImplementation.Method);
                 if (member is null)
                     return null;
                 additionalInterfaceMembers.Add(new ExternalInterfaceMemberRequirement(
-                    implicitImplementation.IsNil
+                    implicitImplementation.Method.IsNil
                         ? targetTypeHandle
-                        : reader.GetMethodDefinition(implicitImplementation).GetDeclaringType(),
+                        : reader.GetMethodDefinition(implicitImplementation.Method).GetDeclaringType(),
                     member));
             }
 
@@ -1730,7 +1746,7 @@ public static class CompileBackSourceComposer
         return null;
     }
 
-    static MethodDefinitionHandle FindImplicitInterfaceMethod(
+    static ImplicitInterfaceMethodLookup FindImplicitInterfaceMethod(
         MetadataReader reader,
         TypeDefinitionHandle targetType,
         ExternalInterfaceRequiredMethod requiredMethod)
@@ -1774,28 +1790,56 @@ public static class CompileBackSourceComposer
                     continue;
                 }
                 if (!match.IsNil)
-                    return default;
+                    return new(default, SearchComplete: true);
                 match = methodHandle;
             }
 
             if (!match.IsNil)
-                return match;
+                return new(match, SearchComplete: true);
 
-            var baseType = reader.GetTypeDefinition(currentType).BaseType;
-            currentType = baseType.Kind == HandleKind.TypeDefinition
-                ? (TypeDefinitionHandle)baseType
-                : default;
+            var currentDef = reader.GetTypeDefinition(currentType);
+            var baseType = currentDef.BaseType;
+            if (baseType.IsNil || IsCompilerImpliedBase(reader, currentDef))
+                return new(default, SearchComplete: true);
+            if (baseType.Kind != HandleKind.TypeDefinition
+                || TypeShellProducer.ReconstructedBaseTypeDisplay(
+                    reader,
+                    currentDef,
+                    ShellKind(reader, currentDef) == CompileBackTypeKind.Class) is null)
+            {
+                return new(default, SearchComplete: false);
+            }
+            currentType = (TypeDefinitionHandle)baseType;
         }
 
-        return default;
+        return new(default, SearchComplete: true);
+    }
+
+    static bool IsCompilerImpliedBase(MetadataReader reader, TypeDefinition typeDef)
+    {
+        string? baseType;
+        try
+        {
+            baseType = TypeResolver.GetTypeName(
+                reader,
+                typeDef.BaseType,
+                GenericContext.ForType(reader, typeDef));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return false;
+        }
+
+        return baseType is "System.Object" or "System.ValueType" or "System.Enum"
+            or "System.Delegate" or "System.MulticastDelegate";
     }
 
     static CompileBackMemberRequirement? ImplicitInterfaceMethodRequirement(
         MetadataReader reader,
-        TypeDefinitionHandle targetType,
         MethodDefinitionHandle methodHandle)
     {
-        var typeDef = reader.GetTypeDefinition(targetType);
+        var typeDef = reader.GetTypeDefinition(
+            reader.GetMethodDefinition(methodHandle).GetDeclaringType());
         return TypeProducer.MethodRequirement(
             reader,
             typeDef,
@@ -3094,6 +3138,7 @@ public static class CompileBackSourceComposer
         string? sameAssemblyExplicitInterfaceMemberName = isConstructor
             ? null
             : ExplicitInterfaceMemberName(reader, methodName);
+        string? externalInterfaceDeclineReason = null;
         var externalExplicitInterfaceMethod =
             !isConstructor && sameAssemblyExplicitInterfaceMemberName is null
                 ? ExternalExplicitInterfaceMethod(
@@ -3105,8 +3150,16 @@ public static class CompileBackSourceComposer
                     methodName,
                     targetTypeParameters.Count,
                     closureRoots,
-                    operatorTypeResolver)
+                    operatorTypeResolver,
+                    out externalInterfaceDeclineReason)
                 : null;
+        if (externalInterfaceDeclineReason is not null)
+        {
+            diagnostics.Add(new CompileBackPlanningDiagnostic(
+                "type identity",
+                "external-interface-base-not-reconstructed",
+                externalInterfaceDeclineReason));
+        }
         string? explicitInterfaceMemberName =
             sameAssemblyExplicitInterfaceMemberName
             ?? externalExplicitInterfaceMethod?.ExplicitInterfaceMemberName;
@@ -3771,6 +3824,16 @@ public static class CompileBackSourceComposer
 
     static bool IsVirtualMethod(MethodDefinition method)
         => MetadataDeclarationQuery.IsVirtualMethod(method);
+
+    static bool IsVirtualSlotDeclaration(MethodDefinition method)
+        => method.Attributes.HasFlag(MethodAttributes.Virtual)
+            && method.Attributes.HasFlag(MethodAttributes.NewSlot)
+            && !method.Attributes.HasFlag(MethodAttributes.Abstract)
+            && !method.Attributes.HasFlag(MethodAttributes.Final);
+
+    static bool IsOverrideSlotReuse(MethodDefinition method)
+        => method.Attributes.HasFlag(MethodAttributes.Virtual)
+            && !method.Attributes.HasFlag(MethodAttributes.NewSlot);
 
     static bool IsProtectedMethod(MethodDefinition method)
         => MetadataDeclarationQuery.AccessibilityKeyword(method) is "protected" or "protected internal";
@@ -4822,7 +4885,13 @@ public static class CompileBackSourceComposer
                 propertyDeclaration.Attributes,
                 propertyDeclaration.Signature.ReturnAttributes,
                 IsAbstract: isAbstractAccessor,
-                IsVirtual: !accessor.IsNil && propertyDeclaration.IsVirtual,
+                IsVirtual: !accessor.IsNil && IsVirtualSlotDeclaration(accessorMethod),
+                IsOverride: !accessor.IsNil
+                    && !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && propertyDeclaration.IsOverride,
+                IsSealed: !accessor.IsNil
+                    && !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && propertyDeclaration.IsSealed,
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
                 GetterToken: accessors.Getter.IsNil
                     ? null
@@ -4934,7 +5003,12 @@ public static class CompileBackSourceComposer
                 [new CompileBackFact("metadata", factId, accessorName)],
                 MemberAttributes(reader, eventDefinition.GetCustomAttributes()),
                 IsAbstract: isAbstract,
-                IsVirtual: IsVirtualMethod(accessor),
+                IsVirtual: IsVirtualSlotDeclaration(accessor),
+                IsOverride: !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && IsOverrideSlotReuse(accessor),
+                IsSealed: !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && IsOverrideSlotReuse(accessor)
+                    && accessor.Attributes.HasFlag(MethodAttributes.Final),
                 AdderToken: accessors.Adder.IsNil
                     ? null
                     : MetadataTokens.GetToken(accessors.Adder),
@@ -5032,7 +5106,7 @@ public static class CompileBackSourceComposer
                 isConstructor ? null : methodDeclaration?.Attributes,
                 isConstructor ? null : methodDeclaration?.Signature.ReturnAttributes,
                 IsAbstract: !isConstructor && IsAbstractMethod(method),
-                IsVirtual: !isConstructor && IsVirtualMethod(method),
+                IsVirtual: !isConstructor && IsVirtualSlotDeclaration(method),
                 IsOverride: !isConstructor
                     && !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
                     && methodDeclaration?.IsOverride == true,
@@ -5127,6 +5201,12 @@ public static class CompileBackSourceComposer
                     members,
                     relationshipResolver);
             }
+            NormalizeUnavailableOverrides(
+                reader,
+                handle,
+                requirementsByIdentity,
+                members,
+                diagnostics);
             bool isReconstructedBase = kind == CompileBackTypeKind.Class
                 && IsReconstructedBaseOfAnotherType(
                     reader,
@@ -5600,6 +5680,109 @@ public static class CompileBackSourceComposer
             return CompileBackTypeIdentity.FromDefinition(reader, baseDef);
         }
 
+        static void NormalizeUnavailableOverrides(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity,
+            List<CompileBackMemberRequirement> members,
+            List<CompileBackPlanningDiagnostic> diagnostics)
+        {
+            for (int index = 0; index < members.Count; index++)
+            {
+                var member = members[index];
+                if (!member.IsOverride
+                    || OverrideSlotIsAvailable(
+                        reader,
+                        handle,
+                        requirementsByIdentity,
+                        member))
+                {
+                    continue;
+                }
+
+                members[index] = member with
+                {
+                    IsOverride = false,
+                    IsSealed = false,
+                    SourceFacts = member.SourceFacts
+                        .Append(new CompileBackFact(
+                            "synthetic",
+                            "override-slot-unavailable",
+                            member.Identity.Signature))
+                        .ToArray(),
+                };
+                diagnostics.Add(new CompileBackPlanningDiagnostic(
+                    "member surface",
+                    "override-slot-unavailable",
+                    $"{member.Identity.Type}::{member.Identity.Signature}"));
+            }
+        }
+
+        static bool OverrideSlotIsAvailable(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            IReadOnlyDictionary<CompileBackTypeIdentity, CompileBackTypeRequirement> requirementsByIdentity,
+            CompileBackMemberRequirement member)
+        {
+            TypeDefinitionHandle current = handle;
+            while (ReconstructedSameAssemblyBaseIdentity(
+                    reader,
+                    current,
+                    ShellKind(reader, reader.GetTypeDefinition(current))) is { } baseIdentity)
+            {
+                if (!requirementsByIdentity.TryGetValue(baseIdentity, out var baseRequirement))
+                    return false;
+                if ((baseRequirement.IncludeMemberSurface
+                        && member.TypeParameters.Count == 0)
+                    || baseRequirement.RequiredMembers.Any(baseMember =>
+                        (baseMember.IsVirtual || baseMember.IsAbstract || baseMember.IsOverride)
+                        && SameOverrideSlot(baseMember, member)))
+                {
+                    return true;
+                }
+
+                var baseType = reader.GetTypeDefinition(current).BaseType;
+                if (baseType.Kind != HandleKind.TypeDefinition)
+                    return false;
+                current = (TypeDefinitionHandle)baseType;
+            }
+
+            return IsSystemObjectOverride(member);
+        }
+
+        static bool SameOverrideSlot(
+            CompileBackMemberRequirement left,
+            CompileBackMemberRequirement right)
+        {
+            bool sameKind = left.Kind == right.Kind
+                || left.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
+                    && right.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
+                || left.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove
+                    && right.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove;
+            return sameKind
+                && !left.IsStatic
+                && !right.IsStatic
+                && left.Identity.Method == right.Identity.Method
+                && left.TypeParameters.Count == right.TypeParameters.Count
+                && SameParameters(left.Parameters, right.Parameters);
+        }
+
+        static bool IsSystemObjectOverride(CompileBackMemberRequirement member)
+        {
+            if (member.Kind != CompileBackMemberKind.Method
+                || member.IsStatic
+                || member.TypeParameters.Count != 0)
+            {
+                return false;
+            }
+
+            return (member.Identity.Method is "ToString" or "GetHashCode"
+                    && member.Parameters.Count == 0)
+                || (member.Identity.Method == "Equals"
+                    && member.Parameters.Count == 1
+                    && member.Parameters[0].Type.DisplayName is "object" or "System.Object");
+        }
+
         static CompileBackMemberRequirement SyntheticParameterlessConstructor(CompileBackTypeIdentity typeIdentity)
             => new(
                 new CompileBackMethodIdentity(typeIdentity.FullName, ".ctor", 0, "synthetic-base-parameterless-constructor()"),
@@ -5620,18 +5803,24 @@ public static class CompileBackSourceComposer
             for (int index = 0; index < members.Count; index++)
             {
                 var member = members[index];
-                if (member.Kind != CompileBackMemberKind.Method
-                    || !member.IsAbstract
-                    || member.StubBody != CompileBackStubBodyKind.None)
+                if (!member.IsAbstract
+                    || member.IsStatic
+                    || member.Kind is not (
+                        CompileBackMemberKind.Method
+                        or CompileBackMemberKind.PropertyGet
+                        or CompileBackMemberKind.PropertySet
+                        or CompileBackMemberKind.EventAdd
+                        or CompileBackMemberKind.EventRemove))
                 {
                     continue;
                 }
 
                 members[index] = member with
                 {
-                    StubBody = CompileBackStubBodyKind.Throw,
+                    StubBody = ConcreteAbstractMemberBody(member),
                     IsAbstract = false,
                     IsVirtual = !member.IsOverride,
+                    IsSealed = false,
                     SourceFacts = member.SourceFacts
                         .Append(new CompileBackFact(
                             "synthetic",
@@ -5642,8 +5831,32 @@ public static class CompileBackSourceComposer
                 diagnostics.Add(new CompileBackPlanningDiagnostic(
                     "member surface",
                     "abstract-base-member-stubbed",
-                    $"{typeIdentity.MetadataFullName}::{member.Identity.Signature}"));
+                    $"{typeIdentity.MetadataFullName}::{member.Identity.Method} ({member.Identity.Signature})"));
             }
+        }
+
+        static CompileBackStubBodyKind ConcreteAbstractMemberBody(
+            CompileBackMemberRequirement member)
+        {
+            if (member.Kind is CompileBackMemberKind.EventAdd or CompileBackMemberKind.EventRemove)
+                return CompileBackStubBodyKind.Throw;
+            if (member.Kind is not (CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet))
+                return CompileBackStubBodyKind.Throw;
+
+            bool hasGetter = member.GetterToken is not null;
+            bool hasSetter = member.SetterToken is not null;
+            bool isInitSetter = member.StubBody
+                is CompileBackStubBodyKind.AutoPropertyGetInit
+                or CompileBackStubBodyKind.InitOnlyProperty;
+            if (hasGetter && hasSetter)
+            {
+                return isInitSetter
+                    ? CompileBackStubBodyKind.ThrowGetInit
+                    : CompileBackStubBodyKind.ThrowGetSet;
+            }
+            return isInitSetter
+                ? CompileBackStubBodyKind.ThrowInit
+                : CompileBackStubBodyKind.Throw;
         }
 
         static IReadOnlyList<CompileBackTypeSignature> InterfaceSignatures(
@@ -5931,7 +6144,13 @@ public static class CompileBackSourceComposer
                     propertyDeclaration.Attributes,
                     propertyDeclaration.Signature.ReturnAttributes,
                     IsAbstract: isAbstractAccessor,
-                    IsVirtual: !accessor.IsNil && propertyDeclaration.IsVirtual,
+                    IsVirtual: !accessor.IsNil && IsVirtualSlotDeclaration(accessorMethod),
+                    IsOverride: !accessor.IsNil
+                        && !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                        && propertyDeclaration.IsOverride,
+                    IsSealed: !accessor.IsNil
+                        && !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                        && propertyDeclaration.IsSealed,
                     Accessibility: accessor.IsNil
                         ? CompileBackAccessibility.Public
                         : MethodAccessibility(accessorMethod),
@@ -6168,7 +6387,7 @@ public static class CompileBackSourceComposer
                     isConstructor ? null : methodDeclaration?.Attributes,
                     isConstructor ? null : methodDeclaration?.Signature.ReturnAttributes,
                     IsAbstract: !isConstructor && IsAbstractMethod(method),
-                    IsVirtual: !isConstructor && IsVirtualMethod(method),
+                    IsVirtual: !isConstructor && IsVirtualSlotDeclaration(method),
                     IsOverride: !isConstructor
                         && !typeDef.Attributes.HasFlag(TypeAttributes.Interface)
                         && methodDeclaration?.IsOverride == true,

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1237,7 +1237,11 @@ public static class CompileBackSourceComposer
                     : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))],
                 propertyDeclaration.Attributes,
                 MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes,
-                ExplicitInterfaceMemberName: explicitInterfaceMemberName)
+                ExplicitInterfaceMemberName: explicitInterfaceMemberName,
+                GetterToken: MetadataTokens.GetToken(targetGetter),
+                SetterToken: accessors.Setter.IsNil
+                    ? null
+                    : MetadataTokens.GetToken(accessors.Setter))
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -2708,7 +2712,11 @@ public static class CompileBackSourceComposer
                         new CompileBackFact("metadata", "auto-property", propertyName)
                     ]
                     : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))],
-                ExplicitInterfaceMemberName: explicitInterfaceMemberName)
+                ExplicitInterfaceMemberName: explicitInterfaceMemberName,
+                GetterToken: property.GetAccessors().Getter.IsNil
+                    ? null
+                    : MetadataTokens.GetToken(property.GetAccessors().Getter),
+                SetterToken: MetadataTokens.GetToken(targetSetter))
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -2827,7 +2835,13 @@ public static class CompileBackSourceComposer
                 MemberAttributes(reader, eventDefinition.GetCustomAttributes()),
                 RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function),
                 ExplicitInterfaceMemberName: explicitEvent?.QualifiedName,
-                SiblingTargetBody: siblingAccessorBody)
+                SiblingTargetBody: siblingAccessorBody,
+                AdderToken: accessors.Adder.IsNil
+                    ? null
+                    : MetadataTokens.GetToken(accessors.Adder),
+                RemoverToken: accessors.Remover.IsNil
+                    ? null
+                    : MetadataTokens.GetToken(accessors.Remover))
         };
         AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
@@ -3023,6 +3037,7 @@ public static class CompileBackSourceComposer
                 ConstructorInitializer: targetConstructorInitializer,
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
                 RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function),
+                MetadataToken: MetadataTokens.GetToken(targetMethod),
                 SuppressDestructorSyntax: suppressDestructorSyntax)
         ];
         if (externalExplicitInterfaceMethod is { AdditionalInterfaceStubs.Count: > 0 })
@@ -3373,79 +3388,8 @@ public static class CompileBackSourceComposer
     static string MethodReturnType(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
         => MetadataDeclarationQuery.GetMethodReturnType(reader, typeDef, method);
 
-    static bool OperatorSignaturesMatch(MethodSignature<string> left, MethodSignature<string> right)
-        => OperatorNames.OperatorPairingTypesMatch(left.ReturnType, right.ReturnType)
-            && left.ParameterTypes.Length == right.ParameterTypes.Length
-            && left.ParameterTypes.Zip(
-                right.ParameterTypes,
-                OperatorNames.OperatorPairingTypesMatch)
-                .All(static equal => equal);
-
     static bool IsMetadataOperator(MetadataReader reader, MethodDefinition method)
         => ILInspector.Metadata.OperatorMetadata.IsMetadataOperator(reader, method);
-
-    static bool IsRepresentableOperator(
-        MetadataReader reader,
-        TypeDefinition declaringType,
-        MethodDefinition method,
-        string name,
-        MethodSignature<string> signature)
-    {
-        if (!ILInspector.Metadata.OperatorMetadata.IsCSharpOperatorDeclaration(reader, method))
-        {
-            return false;
-        }
-
-        return RequiredOperatorPair(name) is not { } pairName
-            || HasOperatorPair(reader, declaringType, pairName, signature);
-    }
-
-    static string? RequiredOperatorPair(string name)
-        => name switch
-        {
-            "op_Equality" => "op_Inequality",
-            "op_Inequality" => "op_Equality",
-            "op_LessThan" => "op_GreaterThan",
-            "op_GreaterThan" => "op_LessThan",
-            "op_LessThanOrEqual" => "op_GreaterThanOrEqual",
-            "op_GreaterThanOrEqual" => "op_LessThanOrEqual",
-            "op_True" => "op_False",
-            "op_False" => "op_True",
-            _ => OperatorNames.UncheckedOperator(name),
-        };
-
-    static bool HasOperatorPair(
-        MetadataReader reader,
-        TypeDefinition declaringType,
-        string pairName,
-        MethodSignature<string> signature)
-    {
-        foreach (var methodHandle in declaringType.GetMethods())
-        {
-            var method = reader.GetMethodDefinition(methodHandle);
-            if (reader.GetString(method.Name) != pairName
-                || !IsMetadataOperator(reader, method))
-            {
-                continue;
-            }
-
-            try
-            {
-                var pairSignature = GuardedSignatureText.MethodText(
-                    reader,
-                    method,
-                    GenericContext.ForMethod(reader, declaringType, method));
-                if (OperatorSignaturesMatch(signature, pairSignature))
-                    return true;
-            }
-            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
-            {
-                return false;
-            }
-        }
-
-        return false;
-    }
 
     static bool IsRecordGeneratedFieldReadHelper(
         MetadataReader reader,
@@ -4889,12 +4833,7 @@ public static class CompileBackSourceComposer
             bool hasOperatorIdentity = !isConstructor
                 && IsMetadataOperator(reader, method);
             bool operatorIsRepresentable = hasOperatorIdentity
-                && IsRepresentableOperator(
-                    reader,
-                    typeDef,
-                    method,
-                    name,
-                    signature);
+                && IsOperatorMethod(reader, method);
 
             string identifierName = MemberIdentifierName(name, isConstructor);
             IReadOnlyList<CompileBackFact> sourceFacts =
@@ -5621,19 +5560,6 @@ public static class CompileBackSourceComposer
                 {
                     continue;
                 }
-                int existingPropertyIndex = members.FindIndex(member =>
-                    (member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet or CompileBackMemberKind.Field)
-                    && member.Identity.Method == Identifier(propertyName));
-                if (existingPropertyIndex >= 0)
-                {
-                    var existing = members[existingPropertyIndex];
-                    members[existingPropertyIndex] = existing with
-                    {
-                        GetterToken = existing.GetterToken ?? surfaceProperty.GetterToken,
-                        SetterToken = existing.SetterToken ?? surfaceProperty.SetterToken,
-                    };
-                    continue;
-                }
 
                 MetadataPropertyDeclaration propertyDeclaration;
                 try
@@ -5646,10 +5572,10 @@ public static class CompileBackSourceComposer
                     continue;
                 }
 
-                if (propertyDeclaration.Signature.Parameters.Count != 0)
-                    continue;
                 if (propertyDeclaration.Signature.ReturnType is not { } propertyReturnType
                     || IsUnsupportedSurfaceSignature(propertyReturnType)
+                    || propertyDeclaration.Signature.Parameters.Any(parameter =>
+                        IsUnsupportedSurfaceSignature(parameter.Type))
                     || (!allowUnsafeSurface && IsPointerSignature(propertyReturnType)))
                     continue;
 
@@ -5664,6 +5590,51 @@ public static class CompileBackSourceComposer
                 if (requirement.RequiredKind == CompileBackTypeKind.Interface && isStatic)
                     continue;
                 var returnType = CompileBackTypeSignature.Display(propertyReturnType);
+                var propertyParameters = ToCompileBackParameters(
+                    propertyDeclaration.Signature.Parameters);
+                var existingPropertyIndexes = members
+                    .Select((member, index) => (member, index))
+                    .Where(candidate =>
+                        candidate.member.Kind is CompileBackMemberKind.PropertyGet
+                            or CompileBackMemberKind.PropertySet
+                        && candidate.member.Identity.Method == Identifier(propertyName)
+                        && candidate.member.IsStatic == isStatic
+                        && candidate.member.ReturnType?.DisplayName == returnType.DisplayName
+                        && SameParameters(
+                            candidate.member.Parameters,
+                            propertyParameters))
+                    .Select(candidate => candidate.index)
+                    .ToArray();
+                if (existingPropertyIndexes.Length == 1)
+                {
+                    int existingPropertyIndex = existingPropertyIndexes[0];
+                    var existing = members[existingPropertyIndex];
+                    members[existingPropertyIndex] = existing with
+                    {
+                        GetterToken = existing.GetterToken ?? surfaceProperty.GetterToken,
+                        SetterToken = existing.SetterToken ?? surfaceProperty.SetterToken,
+                    };
+                    continue;
+                }
+                if (existingPropertyIndexes.Length > 1)
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "property-token-match-ambiguous",
+                        $"{requirement.Type.MetadataFullName}::{propertyName}"));
+                    continue;
+                }
+                if (members.Any(member =>
+                    member.Kind == CompileBackMemberKind.Field
+                    && member.Identity.Method == Identifier(propertyName)))
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "member surface",
+                        "property-conflicts-with-required-field",
+                        $"{requirement.Type.MetadataFullName}::{propertyName}"));
+                    continue;
+                }
+
                 bool isAutoProperty = hasGetter
                     && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
                 bool isInitSetter = hasSetter && SetterIsInitOnly(reader, accessors.Setter);
@@ -5679,7 +5650,7 @@ public static class CompileBackSourceComposer
                     new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(propertyName), 0, $"property {propertyReturnType}"),
                     hasGetter ? CompileBackMemberKind.PropertyGet : CompileBackMemberKind.PropertySet,
                     IsStatic: isStatic,
-                    Parameters: [],
+                    Parameters: propertyParameters,
                     ReturnType: returnType,
                     TypeParameters: [],
                     StubBody: stubBody,
@@ -5860,7 +5831,16 @@ public static class CompileBackSourceComposer
                 var parameterIdentity = parameters
                     .Select(parameter => (parameter.Type.DisplayName, parameter.Modifier))
                     .ToArray();
-                var existingMethodIndexes = members
+                var tokenMatchedMethodIndexes = members
+                    .Select((member, index) => (member, index))
+                    .Where(candidate =>
+                        surfaceMethod.MetadataToken is int token
+                        && candidate.member.MetadataToken == token)
+                    .Select(candidate => candidate.index)
+                    .ToArray();
+                var existingMethodIndexes = tokenMatchedMethodIndexes.Length != 0
+                    ? tokenMatchedMethodIndexes
+                    : members
                     .Select((member, index) => (member, index))
                     .Where(candidate =>
                         candidate.member.Kind == memberKind

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1247,6 +1247,12 @@ public static class CompileBackSourceComposer
                     : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))],
                 propertyDeclaration.Attributes,
                 MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes,
+                IsVirtual: IsVirtualSlotDeclaration(getter),
+                IsOverride: !targetTypeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && IsOverrideSlotReuse(getter),
+                IsSealed: !targetTypeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && IsOverrideSlotReuse(getter)
+                    && getter.Attributes.HasFlag(MethodAttributes.Final),
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
                 GetterToken: MetadataTokens.GetToken(targetGetter),
                 SetterToken: accessors.Setter.IsNil
@@ -2856,6 +2862,12 @@ public static class CompileBackSourceComposer
                         new CompileBackFact("metadata", "auto-property", propertyName)
                     ]
                     : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))],
+                IsVirtual: IsVirtualSlotDeclaration(setter),
+                IsOverride: !targetTypeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && IsOverrideSlotReuse(setter),
+                IsSealed: !targetTypeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && IsOverrideSlotReuse(setter)
+                    && setter.Attributes.HasFlag(MethodAttributes.Final),
                 ExplicitInterfaceMemberName: explicitInterfaceMemberName,
                 GetterToken: property.GetAccessors().Getter.IsNil
                     ? null
@@ -2978,6 +2990,12 @@ public static class CompileBackSourceComposer
                 targetBody,
                 [new CompileBackFact("metadata", "target-event-accessor", reader.GetString(accessor.Name))],
                 MemberAttributes(reader, eventDefinition.GetCustomAttributes()),
+                IsVirtual: IsVirtualSlotDeclaration(accessor),
+                IsOverride: !targetTypeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && IsOverrideSlotReuse(accessor),
+                IsSealed: !targetTypeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && IsOverrideSlotReuse(accessor)
+                    && accessor.Attributes.HasFlag(MethodAttributes.Final),
                 RequiresUnsafeModifier: ContainsFixedBufferElementAccess(function),
                 ExplicitInterfaceMemberName: explicitEvent?.QualifiedName,
                 SiblingTargetBody: siblingAccessorBody,
@@ -3180,9 +3198,14 @@ public static class CompileBackSourceComposer
                 isConstructor ? null : MemberAttributes(reader, method.GetCustomAttributes()),
                 isConstructor ? null : MethodReturnAttributes(reader, method),
                 IsAbstract: !isConstructor && IsAbstractMethod(method),
-                IsVirtual: !isConstructor && IsVirtualMethod(method),
-                IsOverride: false,
-                IsSealed: false,
+                IsVirtual: !isConstructor && IsVirtualSlotDeclaration(method),
+                IsOverride: !isConstructor
+                    && !targetTypeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && IsOverrideSlotReuse(method),
+                IsSealed: !isConstructor
+                    && !targetTypeDef.Attributes.HasFlag(TypeAttributes.Interface)
+                    && IsOverrideSlotReuse(method)
+                    && method.Attributes.HasFlag(MethodAttributes.Final),
                 IsAsync: !isConstructor
                     && (function.RequiresAsyncBodyModifier
                         || function.IsRuntimeAsync == MetadataFactState.Yes),
@@ -5704,6 +5727,9 @@ public static class CompileBackSourceComposer
                 {
                     IsOverride = false,
                     IsSealed = false,
+                    IsVirtual = !member.IsStatic
+                        && !member.IsAbstract
+                        && !reader.GetTypeDefinition(handle).Attributes.HasFlag(TypeAttributes.Sealed),
                     SourceFacts = member.SourceFacts
                         .Append(new CompileBackFact(
                             "synthetic",
@@ -5715,6 +5741,14 @@ public static class CompileBackSourceComposer
                     "member surface",
                     "override-slot-unavailable",
                     $"{member.Identity.Type}::{member.Identity.Signature}"));
+                if (member.SourceFacts.Any(fact =>
+                        fact.Id.StartsWith("target-", StringComparison.Ordinal)))
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic(
+                        "type identity",
+                        "target-override-slot-unavailable",
+                        $"{member.Identity.Type}::{member.Identity.Signature}"));
+                }
             }
         }
 
@@ -5731,7 +5765,7 @@ public static class CompileBackSourceComposer
                     ShellKind(reader, reader.GetTypeDefinition(current))) is { } baseIdentity)
             {
                 if (!requirementsByIdentity.TryGetValue(baseIdentity, out var baseRequirement))
-                    return false;
+                    return true;
                 if ((baseRequirement.IncludeMemberSurface
                         && member.TypeParameters.Count == 0)
                     || baseRequirement.RequiredMembers.Any(baseMember =>
@@ -5769,6 +5803,8 @@ public static class CompileBackSourceComposer
 
         static bool IsSystemObjectOverride(CompileBackMemberRequirement member)
         {
+            if (member.IsFinalizer)
+                return true;
             if (member.Kind != CompileBackMemberKind.Method
                 || member.IsStatic
                 || member.TypeParameters.Count != 0)

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -1008,6 +1008,17 @@ public static class CompileBackSourceComposer
                     closureFacts,
                     root,
                     new CompileBackFact("metadata", "target-interface", reader.GetFullTypeName(interfaceDef)));
+                if (interfaceDef.GetInterfaceImplementations().Count != 0)
+                {
+                    // An inherited interface edge makes the interface itself the
+                    // receiver type for inherited member references. Preserve its
+                    // direct surface so target-side interface-property projection
+                    // remains available even when the edge now binds directly.
+                    AddClosureFact(
+                        closureFacts,
+                        root,
+                        new CompileBackFact("metadata", "closure-member", "target-interface-inheritance"));
+                }
             }
         }
 


### PR DESCRIPTION
Advances #3091 and #2777

**Conclusion: PASS** — ReturnToSender now consumes product-owned typed member surfaces and shell composition while retaining only closure, selection, body policy, and independent compile-back comparison.

## Stack

- Slice 4 of 4
- Parent: #4146
- Base: `feature/rts-product-member-surface`
- Residual: #2777 retains later type/source-unit and neutral body-fact composition work outside this ownership move.

## Change

- Replaces harness-local member table walks with the product member inventory.
- Resolves type/member targets by structured metadata identity.
- Delegates member shell/accessor/body composition to `ILInspector.CSharp`.
- Preserves RTS-owned closure discovery, representability, unsafe gating, deduplication, and body selection.
- Keeps compile-back unchanged as the independent oracle.

## Evidence

- Release solution build passed at exact head `bbe0d44a`.
- 231 ReturnToSender prototype cases and 13 fault-isolation cases passed with zero failures or skips.
- 455 ILInspector.CSharp tests and the metadata visibility regressions passed.
- The full 5,214-case oracle-backed decompiler suite passed with zero failures or skips.
- The two unrelated CLI subset failures (a load-sensitive timing canary and package-cache cleanup race) both passed immediately in isolation.

Evidence revision: `bbe0d44a`