### PR TITLE
Own member inventory and MethodImpl identity in metadata

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -627,6 +627,11 @@ public static class ApiSurfaceExtractor
                 }
             }
         }
+        var currentScope = ReadCurrentScope(reader, surface);
+        var localTypes = currentScope is null
+            ? []
+            : LocalTypes(reader, currentScope);
+        var accessorMethods = AccessorMethods(reader, surface);
 
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
@@ -924,8 +929,11 @@ public static class ApiSurfaceExtractor
             {
             apiType.Members = [];
 
-            var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
-
+            var explicitImplementationBodies = GetExplicitImplementationBodies(
+                reader,
+                typeDef,
+                currentScope,
+                localTypes);
             // Methods whose explicit `.override` MethodImpl targets
             // `System.Object::Finalize` — i.e. genuine class finalizers, the
             // slot the C# `~Type()` destructor compiles to.
@@ -937,7 +945,6 @@ public static class ApiSurfaceExtractor
             // Getter/setter and adder/remover bodies are represented by their
             // property or event rows. Raiser and Other semantic methods have no
             // ApiMember token slots, so they stay methods.
-            var accessorMethods = GetSemanticAccessorMethods(reader, typeDef);
             var runtimeJsExportWrapperCandidateMethods =
                 new Dictionary<string, List<int>>(
                     StringComparer.Ordinal);
@@ -948,6 +955,8 @@ public static class ApiSurfaceExtractor
                 var method = reader.GetMethodDefinition(methodHandle);
                 var methodCustomAttributes =
                     method.GetCustomAttributes();
+                var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
+                var isExplicitInterfaceImplementation = explicitImplementationBodies.Contains(methodHandle);
                 string methodName = DecodeString(
                     reader,
                     method.Name,
@@ -973,9 +982,23 @@ public static class ApiSurfaceExtractor
                     }
                     tokens.Add(MetadataTokens.GetToken(methodHandle));
                 }
-                var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
-                var isExplicitInterfaceImplementation = explicitImplementationBodies.Contains(methodHandle);
-                if (methodAccess != MethodAttributes.Public && !includeAll && !isExplicitInterfaceImplementation)
+                var isOwnedAccessor = accessorMethods.Contains(methodHandle);
+                var isRetainedExplicitImplementation = isExplicitInterfaceImplementation
+                    && (!isOwnedAccessor
+                        || methodAccess != MethodAttributes.Public
+                        || methodName.Contains('.', StringComparison.Ordinal));
+                var isFinalizer = apiType.Kind == "class"
+                    && method.GetGenericParameters().Count == 0
+                    && (objectFinalizeOverrides.Contains(methodHandle)
+                        || IsImplicitObjectFinalizeOverride(
+                            reader,
+                            typeDefHandle,
+                            method,
+                            observeDecodeWork));
+                if (methodAccess != MethodAttributes.Public
+                    && !includeAll
+                    && !isRetainedExplicitImplementation
+                    && !isFinalizer)
                 {
                     RetainFilteredRuntimeJsExportFact(
                         apiType,
@@ -985,15 +1008,11 @@ public static class ApiSurfaceExtractor
                     continue;
                 }
 
-                // Ordinary MethodSemantics accessors are omitted from the method
-                // list. A private MethodImpl accessor is the C#/VB explicit-
-                // interface shape: its property or event row is private and would
-                // hide the public contract. Public MethodImpl accessors — static
-                // abstract implementations, covariant overrides, VB Implements —
-                // stay on that public row. ApiSurfaceEmitSetTests is the gate.
-                if (accessorMethods.Contains(methodHandle)
-                    && !(isExplicitInterfaceImplementation
-                        && methodAccess == MethodAttributes.Private))
+                // Ordinary accessors are represented by their owning property/event.
+                // Explicit-interface accessors remain method entries because whole-type
+                // decompilation consumes their bodies. Preserve legal ordinary methods
+                // whose names or flags merely resemble accessors.
+                if (isOwnedAccessor && !isRetainedExplicitImplementation)
                 {
                     RetainFilteredRuntimeJsExportFact(
                         apiType,
@@ -1001,10 +1020,11 @@ public static class ApiSurfaceExtractor
                         methodHandle,
                         jsExportEvidence);
                     continue;
+                }
                 }
 
                 // Skip compiler-generated methods (lambdas, state machines, etc.)
-                if (methodName.StartsWith("<"))
+                if (methodName.StartsWith("<") && !includeCompilerGenerated)
                 {
                     RetainFilteredRuntimeJsExportFact(
                         apiType,
@@ -1016,7 +1036,8 @@ public static class ApiSurfaceExtractor
 
                 // Skip EditorBrowsable(Never) methods unless --all; obsolete are surfaced with marker.
                 if (!includeAll
-                    && !isExplicitInterfaceImplementation
+                    && !isRetainedExplicitImplementation
+                    && !isFinalizer
                     && AttributeReader.HasEditorBrowsableNeverAttribute(
                         reader,
                         methodCustomAttributes,
@@ -1057,7 +1078,7 @@ public static class ApiSurfaceExtractor
                 var isOperator = OperatorMetadata.IsMetadataOperator(reader, method);
                 var isVirtual = (methodAttributes & MethodAttributes.Virtual) != 0;
                 var isNewSlot = (methodAttributes & MethodAttributes.NewSlot) != 0;
-                var isOverride = isVirtual && !isNewSlot && !isExplicitInterfaceImplementation;
+                var isOverride = isVirtual && !isNewSlot && !isRetainedExplicitImplementation && !isFinalizer;
 
                 // A class finalizer is the `object.Finalize` override the C#
                 // `~Type()` destructor compiles to. It is detected by the
@@ -1105,14 +1126,8 @@ public static class ApiSurfaceExtractor
                     {
                         ".ctor" => "constructor",
                         _ when isOperator => "operator",
-                        // A finalizer compiles to a `Finalize` method carrying an
-                        // explicit `.override System.Object::Finalize` MethodImpl,
-                        // so it also lands in `explicitImplementationBodies`. Classify
-                        // it as its own kind before the explicit-interface arm so it
-                        // is not filed under Explicit Interface Implementations; the
-                        // MethodImpl still (correctly) suppresses its accessibility.
                         _ when isFinalizer => "finalizer",
-                        _ when isExplicitInterfaceImplementation => "explicit-interface-implementation",
+                        _ when isRetainedExplicitImplementation => "explicit-interface-implementation",
                         _ => "method"
                     },
                     IsStatic = (methodAttributes & MethodAttributes.Static) != 0,
@@ -1156,7 +1171,9 @@ public static class ApiSurfaceExtractor
                             reader,
                             methodCustomAttributes,
                             observeDecodeWork),
-                    Accessibility = isExplicitInterfaceImplementation && !isOperator ? null : GetAccessibility(methodAccess),
+                    Accessibility = isFinalizer || isRetainedExplicitImplementation && !isOperator
+                        ? null
+                        : GetAccessibility(methodAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
                     HasRuntimeJsExport =
@@ -1675,13 +1692,15 @@ public static class ApiSurfaceExtractor
                 var evt = reader.GetEventDefinition(eventHandle);
                 var accessors = evt.GetAccessors();
 
-                // Check if adder exists
-                if (accessors.Adder.IsNil)
+                var representativeHandle = !accessors.Adder.IsNil
+                    ? accessors.Adder
+                    : accessors.Remover;
+                if (representativeHandle.IsNil)
                     continue;
 
-                var adder = reader.GetMethodDefinition(accessors.Adder);
-                var adderAccess = adder.Attributes & MethodAttributes.MemberAccessMask;
-                if (adderAccess != MethodAttributes.Public && !includeAll)
+                var representative = reader.GetMethodDefinition(representativeHandle);
+                var representativeAccess = representative.Attributes & MethodAttributes.MemberAccessMask;
+                if (representativeAccess != MethodAttributes.Public && !includeAll)
                     continue;
 
                 // Skip EditorBrowsable(Never) events unless --all; obsolete are surfaced with marker.
@@ -1709,7 +1728,7 @@ public static class ApiSurfaceExtractor
                     observeDecodeWork);
                 eventNullableBytes ??= NullabilityReader.GetParameterNullableBytes(
                     reader,
-                    adder.GetParameters(),
+                    representative.GetParameters(),
                     1,
                     observeDecodeWork);
                 if (eventNullableBytes is { Length: > 0 } && eventNullableBytes[0] == 2 && !eventType.EndsWith("?", StringComparison.Ordinal))
@@ -1750,21 +1769,22 @@ public static class ApiSurfaceExtractor
                         eventType = eventNode.Render();
                     }
                 }
-                var adderAttributes = adder.Attributes;
-                var isVirtualEvent = (adderAttributes & MethodAttributes.Virtual) != 0;
-                var isOverrideEvent = isVirtualEvent && (adderAttributes & MethodAttributes.NewSlot) == 0;
-                var accessorModels = new List<ApiAccessor>
+                var representativeAttributes = representative.Attributes;
+                var isVirtualEvent = (representativeAttributes & MethodAttributes.Virtual) != 0;
+                var isOverrideEvent = isVirtualEvent && (representativeAttributes & MethodAttributes.NewSlot) == 0;
+                var accessorModels = new List<ApiAccessor>();
+                if (!accessors.Adder.IsNil)
                 {
-                    new()
+                    accessorModels.Add(new ApiAccessor
                     {
                         Kind = "add",
                         ReturnAttributes = ReturnParameterAttributes(
                             reader,
-                            adder.GetParameters(),
+                            reader.GetMethodDefinition(accessors.Adder).GetParameters(),
                             observeText,
                             observeAttributeMaterialize)
-                    }
-                };
+                    });
+                }
                 if (!accessors.Remover.IsNil)
                 {
                     accessorModels.Add(new ApiAccessor
@@ -1811,12 +1831,12 @@ public static class ApiSurfaceExtractor
                         MemberName = eventName,
                         Accessors = accessorModels
                     },
-                    IsStatic = (adderAttributes & MethodAttributes.Static) != 0,
+                    IsStatic = (representativeAttributes & MethodAttributes.Static) != 0,
                     IsVirtual = isVirtualEvent,
-                    IsAbstract = (adderAttributes & MethodAttributes.Abstract) != 0,
+                    IsAbstract = (representativeAttributes & MethodAttributes.Abstract) != 0,
                     IsOverride = isOverrideEvent,
-                    IsSealed = isOverrideEvent && (adderAttributes & MethodAttributes.Final) != 0,
-                    Accessibility = GetAccessibility(adderAccess),
+                    IsSealed = isOverrideEvent && (representativeAttributes & MethodAttributes.Final) != 0,
+                    Accessibility = GetAccessibility(representativeAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
                     AdderToken = accessors.Adder.IsNil
@@ -2138,6 +2158,203 @@ public static class ApiSurfaceExtractor
         }
     }
 
+    static HashSet<MethodDefinitionHandle> AccessorMethods(
+        MetadataReader reader,
+        ApiSurface surface)
+    {
+        var methods = new HashSet<MethodDefinitionHandle>();
+        foreach (var propertyHandle in reader.PropertyDefinitions)
+        {
+            try
+            {
+                var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+                if (!accessors.Getter.IsNil)
+                    methods.Add(accessors.Getter);
+                if (!accessors.Setter.IsNil)
+                    methods.Add(accessors.Setter);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+            {
+                AddInspectionFailure(
+                    surface,
+                    "property accessors",
+                    propertyHandle,
+                    MetadataTypeNameFailure.Malformed(propertyHandle, ex.Message));
+            }
+        }
+        foreach (var eventHandle in reader.EventDefinitions)
+        {
+            try
+            {
+                var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
+                if (!accessors.Adder.IsNil)
+                    methods.Add(accessors.Adder);
+                if (!accessors.Remover.IsNil)
+                    methods.Add(accessors.Remover);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+            {
+                AddInspectionFailure(
+                    surface,
+                    "event accessors",
+                    eventHandle,
+                    MetadataTypeNameFailure.Malformed(eventHandle, ex.Message));
+            }
+        }
+        methods.UnionWith(ExtensionPropertyImplementationMethods(reader, surface));
+        return methods;
+    }
+
+    static HashSet<MethodDefinitionHandle> ExtensionPropertyImplementationMethods(
+        MetadataReader reader,
+        ApiSurface surface)
+    {
+        HashSet<MethodDefinitionHandle> methods = [];
+        foreach (var extensionClassHandle in reader.TypeDefinitions)
+        {
+            try
+            {
+                var extensionClass = reader.GetTypeDefinition(extensionClassHandle);
+                if (!AttributeReader.HasExtensionAttribute(
+                        reader,
+                        extensionClass.GetCustomAttributes()))
+                {
+                    continue;
+                }
+
+                foreach (var groupingTypeHandle in extensionClass.GetNestedTypes())
+                {
+                    var groupingType = reader.GetTypeDefinition(groupingTypeHandle);
+                    if (!AttributeReader.HasExtensionAttribute(
+                            reader,
+                            groupingType.GetCustomAttributes()))
+                    {
+                        continue;
+                    }
+
+                    foreach (var propertyHandle in groupingType.GetProperties())
+                    {
+                        var property = reader.GetPropertyDefinition(propertyHandle);
+                        var accessors = property.GetAccessors();
+                        if (!TryGetExtensionMarkerName(
+                                reader,
+                                property,
+                                accessors,
+                                out string? markerName))
+                        {
+                            continue;
+                        }
+
+                        var markerTypeHandle = groupingType.GetNestedTypes().FirstOrDefault(handle =>
+                            reader.StringComparer.Equals(
+                                reader.GetTypeDefinition(handle).Name,
+                                markerName!));
+                        if (markerTypeHandle.IsNil)
+                            continue;
+                        var markerType = reader.GetTypeDefinition(markerTypeHandle);
+                        var markerMethodHandle = markerType.GetMethods().FirstOrDefault(handle =>
+                            reader.StringComparer.Equals(
+                                reader.GetMethodDefinition(handle).Name,
+                                "<Extension>$"));
+                        if (markerMethodHandle.IsNil)
+                            continue;
+
+                        var context = GenericContext.ForType(reader, markerType);
+                        if (!GuardedSignatureText.MethodText(
+                                reader,
+                                reader.GetMethodDefinition(markerMethodHandle),
+                                context).TryGetValue(out var markerSignature)
+                            || markerSignature.ParameterTypes.Length != 1
+                            || !GuardedSignatureText.PropertyText(
+                                reader,
+                                property,
+                                context).TryGetValue(out var propertySignature))
+                        {
+                            continue;
+                        }
+
+                        string propertyName = reader.GetString(property.Name);
+                        int implementationGenericArity = groupingType.GetGenericParameters().Count;
+                        foreach (var methodHandle in extensionClass.GetMethods())
+                        {
+                            var method = reader.GetMethodDefinition(methodHandle);
+                            string methodName = reader.GetString(method.Name);
+                            bool getter = !accessors.Getter.IsNil
+                                && methodName == $"get_{propertyName}";
+                            bool setter = !accessors.Setter.IsNil
+                                && methodName == $"set_{propertyName}";
+                            if (!getter && !setter)
+                                continue;
+                            if (!GuardedSignatureText.MethodText(
+                                    reader,
+                                    method,
+                                    GenericContext.ForMethod(reader, extensionClass, method))
+                                .TryGetValue(out var implementationSignature))
+                            {
+                                continue;
+                            }
+
+                            var markerAccessorHandle = getter
+                                ? accessors.Getter
+                                : accessors.Setter;
+                            bool isStaticExtensionMember = reader
+                                .GetMethodDefinition(markerAccessorHandle)
+                                .Attributes.HasFlag(MethodAttributes.Static);
+                            IEnumerable<string> expectedParameters =
+                                isStaticExtensionMember
+                                    ? propertySignature.ParameterTypes
+                                    : new[] { markerSignature.ParameterTypes[0] }
+                                        .Concat(propertySignature.ParameterTypes);
+                            if (setter)
+                                expectedParameters = expectedParameters.Append(
+                                    propertySignature.ReturnType);
+                            if (implementationSignature.ParameterTypes.SequenceEqual(
+                                    expectedParameters,
+                                    StringComparer.Ordinal)
+                                && method.GetGenericParameters().Count == implementationGenericArity
+                                && (getter
+                                    ? implementationSignature.ReturnType
+                                        == propertySignature.ReturnType
+                                    : implementationSignature.ReturnType == "void"))
+                            {
+                                methods.Add(methodHandle);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+            {
+                AddInspectionFailure(
+                    surface,
+                    "extension property accessors",
+                    extensionClassHandle,
+                    MetadataTypeNameFailure.Malformed(extensionClassHandle, ex.Message));
+            }
+        }
+        return methods;
+    }
+
+    static bool TryGetExtensionMarkerName(
+        MetadataReader reader,
+        PropertyDefinition property,
+        PropertyAccessors accessors,
+        out string? markerName)
+        => AttributeReader.TryGetExtensionMarkerName(
+                reader,
+                property.GetCustomAttributes(),
+                out markerName)
+            || !accessors.Getter.IsNil
+            && AttributeReader.TryGetExtensionMarkerName(
+                reader,
+                reader.GetMethodDefinition(accessors.Getter).GetCustomAttributes(),
+                out markerName)
+            || !accessors.Setter.IsNil
+            && AttributeReader.TryGetExtensionMarkerName(
+                reader,
+                reader.GetMethodDefinition(accessors.Setter).GetCustomAttributes(),
+                out markerName);
+
     private static byte? GetEffectiveNullable(
         MetadataReader reader,
         CustomAttributeHandleCollection attributes,
@@ -2441,6 +2658,366 @@ public static class ApiSurfaceExtractor
         }
 
         return handles;
+    }
+
+    private static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> localTypes)
+    {
+        HashSet<MethodDefinitionHandle> handles = [];
+        foreach (var implementationHandle in typeDef.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody.Kind == HandleKind.MethodDefinition
+                && TargetsImplementedInterface(
+                    reader,
+                    typeDef,
+                    implementation.MethodDeclaration,
+                    currentScope,
+                    localTypes) is not InterfaceMethodImplOwnership.ProvenNonInterface)
+            {
+                handles.Add((MethodDefinitionHandle)implementation.MethodBody);
+            }
+        }
+
+        return handles;
+    }
+
+    private enum InterfaceMethodImplOwnership
+    {
+        ProvenNonInterface,
+        ProvenInterface,
+        UnresolvedExternalInheritance,
+    }
+
+    private static InterfaceMethodImplOwnership TargetsImplementedInterface(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        EntityHandle declaration,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> localTypes)
+    {
+        EntityHandle declaringType = declaration.Kind switch
+        {
+            HandleKind.MethodDefinition => reader
+                .GetMethodDefinition((MethodDefinitionHandle)declaration)
+                .GetDeclaringType(),
+            HandleKind.MemberReference => reader
+                .GetMemberReference((MemberReferenceHandle)declaration)
+                .Parent,
+            _ => default,
+        };
+        if (declaringType.Kind is not (
+                HandleKind.TypeDefinition
+                or HandleKind.TypeReference
+                or HandleKind.TypeSpecification))
+        {
+            return InterfaceMethodImplOwnership.ProvenNonInterface;
+        }
+
+        if (declaringType.Kind == HandleKind.TypeDefinition
+            && !reader.GetTypeDefinition((TypeDefinitionHandle)declaringType)
+                .Attributes.HasFlag(TypeAttributes.Interface))
+        {
+            return InterfaceMethodImplOwnership.ProvenNonInterface;
+        }
+
+        foreach (var handle in typeDef.GetInterfaceImplementations())
+        {
+            if (reader.GetInterfaceImplementation(handle).Interface == declaringType)
+                return InterfaceMethodImplOwnership.ProvenInterface;
+        }
+
+        var declarationIdentity = TryGetNamedTypeIdentity(
+            reader,
+            declaringType,
+            currentScope);
+        if (IsSystemObjectType(reader, declaringType)
+            || TargetsClassHierarchy(
+                reader,
+                typeDef,
+                declaringType,
+                declarationIdentity,
+                currentScope,
+                localTypes))
+        {
+            return InterfaceMethodImplOwnership.ProvenNonInterface;
+        }
+
+        var pending = new Queue<EntityHandle>();
+        foreach (var handle in typeDef.GetInterfaceImplementations())
+            pending.Enqueue(reader.GetInterfaceImplementation(handle).Interface);
+
+        HashSet<MetadataNamedTypeIdentity> visited = [];
+        bool hasUnresolvedExternalOwnership = declarationIdentity is null
+            || !localTypes.ContainsKey(declarationIdentity);
+        while (pending.TryDequeue(out var interfaceType))
+        {
+            if (interfaceType == declaringType)
+                return InterfaceMethodImplOwnership.ProvenInterface;
+            if (TryGetNamedTypeIdentity(reader, interfaceType, currentScope) is not { } interfaceIdentity)
+            {
+                hasUnresolvedExternalOwnership = true;
+                continue;
+            }
+            if (!visited.Add(interfaceIdentity))
+            {
+                continue;
+            }
+            if (declarationIdentity is not null
+                && interfaceIdentity == declarationIdentity)
+                return InterfaceMethodImplOwnership.ProvenInterface;
+
+            // Same-module definitions let us close inherited InterfaceImpl edges.
+            // External inheritance cannot be proven from this reader alone. Keep
+            // that uncertainty distinct from a proven class MethodImpl so default
+            // extraction does not silently drop a possible explicit implementation.
+            if (!localTypes.TryGetValue(interfaceIdentity, out var interfaceHandle))
+            {
+                hasUnresolvedExternalOwnership = true;
+                continue;
+            }
+            var interfaceDefinition = reader.GetTypeDefinition(interfaceHandle);
+            foreach (var handle in interfaceDefinition.GetInterfaceImplementations())
+                pending.Enqueue(reader.GetInterfaceImplementation(handle).Interface);
+        }
+
+        return hasUnresolvedExternalOwnership
+            ? InterfaceMethodImplOwnership.UnresolvedExternalInheritance
+            : InterfaceMethodImplOwnership.ProvenNonInterface;
+    }
+
+    private static bool TargetsClassHierarchy(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        EntityHandle declaringType,
+        MetadataNamedTypeIdentity? declarationIdentity,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> localTypes)
+    {
+        EntityHandle baseType = typeDef.BaseType;
+        HashSet<TypeDefinitionHandle> visited = [];
+        while (!baseType.IsNil)
+        {
+            if (baseType == declaringType)
+                return true;
+            if (declarationIdentity is not null
+                && TryGetNamedTypeIdentity(reader, baseType, currentScope) == declarationIdentity)
+            {
+                return true;
+            }
+            if (baseType.Kind == HandleKind.TypeSpecification)
+            {
+                if (TryGetNamedTypeIdentity(reader, baseType, currentScope) is not { } baseIdentity
+                    || !localTypes.TryGetValue(baseIdentity, out var baseDefinition))
+                {
+                    return false;
+                }
+                baseType = baseDefinition;
+            }
+            if (baseType.Kind != HandleKind.TypeDefinition
+                || !visited.Add((TypeDefinitionHandle)baseType))
+            {
+                return false;
+            }
+
+            baseType = reader.GetTypeDefinition((TypeDefinitionHandle)baseType).BaseType;
+        }
+
+        return false;
+    }
+
+    private static Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> LocalTypes(
+        MetadataReader reader,
+        MetadataTypeScope currentScope)
+    {
+        Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> types = [];
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            if (ReadDefinitionIdentity(reader, handle, currentScope) is { } identity)
+                types.TryAdd(identity, handle);
+        }
+
+        return types;
+    }
+
+    private static MetadataNamedTypeIdentity? TryGetNamedTypeIdentity(
+        MetadataReader reader,
+        EntityHandle handle,
+        MetadataTypeScope? currentScope) =>
+        handle.Kind switch
+        {
+            HandleKind.TypeDefinition => currentScope is null
+                ? null
+                : ReadDefinitionIdentity(
+                    reader,
+                    (TypeDefinitionHandle)handle,
+                    currentScope),
+            HandleKind.TypeReference => ReadReferenceIdentity(
+                reader,
+                (TypeReferenceHandle)handle,
+                currentScope),
+            HandleKind.TypeSpecification => GuardedProviderDecode.TypeSpec(
+                reader,
+                (TypeSpecificationHandle)handle,
+                new NamedTypeIdentityProvider(currentScope),
+                context: null,
+                fallback: null),
+            _ => null,
+        };
+
+    private static MetadataNamedTypeIdentity? ReadDefinitionIdentity(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        MetadataTypeScope currentScope) =>
+        MetadataTypeDefinitionNameReader.Read(reader, handle)
+            is MetadataTypeDefinitionNameReadResult.Read read
+                ? new(read.Name, currentScope)
+                : null;
+
+    private static MetadataNamedTypeIdentity? ReadReferenceIdentity(
+        MetadataReader reader,
+        TypeReferenceHandle handle,
+        MetadataTypeScope? currentScope)
+    {
+        if (MetadataTypeDefinitionNameReader.Read(reader, handle)
+                is not MetadataTypeDefinitionNameReadResult.Read read
+            || ReferenceScope(reader, handle, currentScope) is not { } scope)
+        {
+            return null;
+        }
+
+        return new(read.Name, scope);
+    }
+
+    private static MetadataTypeScope CurrentScope(MetadataReader reader) =>
+        reader.IsAssembly
+            ? new(AssemblyReferenceIdentity.FromAssemblyDefinition(reader), null)
+            : new(null, reader.GetString(reader.GetModuleDefinition().Name));
+
+    private static MetadataTypeScope? ReadCurrentScope(
+        MetadataReader reader,
+        ApiSurface surface)
+    {
+        try
+        {
+            return CurrentScope(reader);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            EntityHandle subject = MetadataTokens.EntityHandle(
+                reader.IsAssembly ? 0x20000001 : 0x00000001);
+            AddInspectionFailure(
+                surface,
+                "module identity",
+                subject,
+                MetadataTypeNameFailure.Malformed(subject, ex.Message));
+            return null;
+        }
+    }
+
+    private static MetadataTypeScope? ReferenceScope(
+        MetadataReader reader,
+        TypeReferenceHandle handle,
+        MetadataTypeScope? currentScope)
+    {
+        Span<TypeReferenceHandle> rootToLeaf =
+            stackalloc TypeReferenceHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkTypeReferenceResolutionScope(
+                reader,
+                handle,
+                rootToLeaf,
+                out _,
+                out EntityHandle terminal,
+                out _))
+        {
+            return null;
+        }
+        if (terminal.IsNil)
+            return null;
+
+        return terminal.Kind switch
+        {
+            HandleKind.ModuleDefinition => currentScope,
+            HandleKind.ModuleReference => new(
+                null,
+                reader.GetString(
+                    reader.GetModuleReference((ModuleReferenceHandle)terminal).Name)),
+            HandleKind.AssemblyReference => new(
+                AssemblyReferenceIdentity.From(
+                    reader,
+                    (AssemblyReferenceHandle)terminal),
+                null),
+            _ => null,
+        };
+    }
+
+    private sealed record MetadataTypeScope(
+        AssemblyReferenceIdentity? Assembly,
+        string? Module);
+
+    private sealed record MetadataNamedTypeIdentity(
+        MetadataTypeDefinitionName Name,
+        MetadataTypeScope Scope);
+
+    private sealed class NamedTypeIdentityProvider :
+        ISignatureTypeProvider<MetadataNamedTypeIdentity?, object?>
+    {
+        private readonly MetadataTypeScope? currentScope;
+
+        internal NamedTypeIdentityProvider(MetadataTypeScope? currentScope) =>
+            this.currentScope = currentScope;
+
+        public MetadataNamedTypeIdentity? GetTypeFromDefinition(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            byte rawTypeKind) =>
+            currentScope is null
+                ? null
+                : ReadDefinitionIdentity(reader, handle, currentScope);
+
+        public MetadataNamedTypeIdentity? GetTypeFromReference(
+            MetadataReader reader,
+            TypeReferenceHandle handle,
+            byte rawTypeKind) =>
+            ReadReferenceIdentity(reader, handle, currentScope);
+
+        public MetadataNamedTypeIdentity? GetTypeFromSpecification(
+            MetadataReader reader,
+            object? context,
+            TypeSpecificationHandle handle,
+            byte rawTypeKind) =>
+            GuardedProviderDecode.TypeSpec(
+                reader,
+                handle,
+                this,
+                context,
+                fallback: null);
+
+        public MetadataNamedTypeIdentity? GetGenericInstantiation(
+            MetadataNamedTypeIdentity? genericType,
+            ImmutableArray<MetadataNamedTypeIdentity?> typeArguments) =>
+            // Interface ownership follows the generic type definition while the
+            // MethodImpl signature remains responsible for constructed arguments.
+            genericType;
+
+        public MetadataNamedTypeIdentity? GetModifiedType(
+            MetadataNamedTypeIdentity? modifier,
+            MetadataNamedTypeIdentity? unmodifiedType,
+            bool isRequired) =>
+            unmodifiedType;
+
+        public MetadataNamedTypeIdentity? GetPrimitiveType(PrimitiveTypeCode typeCode) => null;
+        public MetadataNamedTypeIdentity? GetSZArrayType(MetadataNamedTypeIdentity? elementType) => null;
+        public MetadataNamedTypeIdentity? GetArrayType(MetadataNamedTypeIdentity? elementType, ArrayShape shape) => null;
+        public MetadataNamedTypeIdentity? GetByReferenceType(MetadataNamedTypeIdentity? elementType) => null;
+        public MetadataNamedTypeIdentity? GetPointerType(MetadataNamedTypeIdentity? elementType) => null;
+        public MetadataNamedTypeIdentity? GetPinnedType(MetadataNamedTypeIdentity? elementType) => elementType;
+        public MetadataNamedTypeIdentity? GetGenericTypeParameter(object? context, int index) => null;
+        public MetadataNamedTypeIdentity? GetGenericMethodParameter(object? context, int index) => null;
+        public MetadataNamedTypeIdentity? GetFunctionPointerType(MethodSignature<MetadataNamedTypeIdentity?> signature) => null;
     }
 
     /// <summary>

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -703,6 +703,13 @@ public static class ApiSurfaceExtractor
             var typeDef = reader.GetTypeDefinition(typeDefHandle);
             var attributes = typeDef.Attributes;
 
+            if (typesOnly
+                && scope == ApiSurfaceExtractionScope.Public
+                && !typeDef.IsPublic)
+            {
+                continue;
+            }
+
             budget?.BeginTypeCandidate();
             observeDecodeWork?.Invoke(
                 reader.GetBlobReader(typeDef.Name).Length

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -3709,15 +3709,27 @@ public static class ApiSurfaceExtractor
         Action<int>? beforeDecodeWork)
     {
         HashSet<MethodDefinitionHandle> handles = [];
+        Dictionary<EntityHandle, InterfaceMethodImplOwnership> ownershipByDeclaringType = [];
         foreach (var implementation in implementations)
         {
-            if (TargetsImplementedInterface(
+            EntityHandle declaringType = MethodImplementationDeclarationType(
+                reader,
+                implementation.Declaration);
+            if (!ownershipByDeclaringType.TryGetValue(
+                    declaringType,
+                    out InterfaceMethodImplOwnership ownership))
+            {
+                ownership = TargetsImplementedInterface(
                     reader,
                     typeDef,
-                    implementation.Declaration,
+                    declaringType,
                     currentScope,
                     localTypes,
-                    beforeDecodeWork)
+                    beforeDecodeWork);
+                ownershipByDeclaringType.Add(declaringType, ownership);
+            }
+
+            if (ownership
                 is not InterfaceMethodImplOwnership.ProvenNonInterface)
             {
                 handles.Add(implementation.Body);
@@ -3734,15 +3746,10 @@ public static class ApiSurfaceExtractor
         UnresolvedExternalInheritance,
     }
 
-    private static InterfaceMethodImplOwnership TargetsImplementedInterface(
+    private static EntityHandle MethodImplementationDeclarationType(
         MetadataReader reader,
-        TypeDefinition typeDef,
-        EntityHandle declaration,
-        MetadataTypeScope? currentScope,
-        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
-        Action<int>? beforeDecodeWork)
-    {
-        EntityHandle declaringType = declaration.Kind switch
+        EntityHandle declaration)
+        => declaration.Kind switch
         {
             HandleKind.MethodDefinition => reader
                 .GetMethodDefinition((MethodDefinitionHandle)declaration)
@@ -3752,6 +3759,15 @@ public static class ApiSurfaceExtractor
                 .Parent,
             _ => default,
         };
+
+    private static InterfaceMethodImplOwnership TargetsImplementedInterface(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        EntityHandle declaringType,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
+        Action<int>? beforeDecodeWork)
+    {
         if (declaringType.Kind is not (
                 HandleKind.TypeDefinition
                 or HandleKind.TypeReference

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -165,6 +165,10 @@ public static class ApiSurfaceExtractor
         MetadataReader,
         PrimitiveDefinitionClassification>
         PrimitiveDefinitionClassifications = new();
+    private static readonly ConditionalWeakTable<
+        MetadataReader,
+        FinalizerMethodImplementationCache>
+        FinalizerMethodImplementationCaches = new();
 
     /// <summary>
     /// Extracts the public type identities and member-kind counts needed by the compact platform
@@ -2278,6 +2282,7 @@ public static class ApiSurfaceExtractor
         MetadataTypeScope? currentScope)
     {
         var methods = new AccessorMethodOwnership();
+        Dictionary<EntityHandle, TypeDefinitionHandle> associationOwners = [];
         foreach (var typeHandle in reader.TypeDefinitions)
         {
             try
@@ -2285,71 +2290,11 @@ public static class ApiSurfaceExtractor
                 var type = reader.GetTypeDefinition(typeHandle);
                 foreach (var propertyHandle in type.GetProperties())
                 {
-                    try
-                    {
-                        var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
-                        AddOwnedAccessor(
-                            reader,
-                            surface,
-                            budget,
-                            methods,
-                            typeHandle,
-                            propertyHandle,
-                            accessors.Getter,
-                            "property getter");
-                        AddOwnedAccessor(
-                            reader,
-                            surface,
-                            budget,
-                            methods,
-                            typeHandle,
-                            propertyHandle,
-                            accessors.Setter,
-                            "property setter");
-                    }
-                    catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
-                    {
-                        AddInspectionFailure(
-                            surface,
-                            budget,
-                            "property accessors",
-                            propertyHandle,
-                            MetadataTypeNameFailure.Malformed(propertyHandle, ex.Message));
-                    }
+                    associationOwners[(EntityHandle)propertyHandle] = typeHandle;
                 }
                 foreach (var eventHandle in type.GetEvents())
                 {
-                    try
-                    {
-                        var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
-                        AddOwnedAccessor(
-                            reader,
-                            surface,
-                            budget,
-                            methods,
-                            typeHandle,
-                            eventHandle,
-                            accessors.Adder,
-                            "event adder");
-                        AddOwnedAccessor(
-                            reader,
-                            surface,
-                            budget,
-                            methods,
-                            typeHandle,
-                            eventHandle,
-                            accessors.Remover,
-                            "event remover");
-                    }
-                    catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
-                    {
-                        AddInspectionFailure(
-                            surface,
-                            budget,
-                            "event accessors",
-                            eventHandle,
-                            MetadataTypeNameFailure.Malformed(eventHandle, ex.Message));
-                    }
+                    associationOwners[(EntityHandle)eventHandle] = typeHandle;
                 }
             }
             catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -2363,6 +2308,76 @@ public static class ApiSurfaceExtractor
             }
         }
 
+        HashSet<PhysicalAccessorRole> roles = [];
+        int semanticsRows = reader.GetTableRowCount(TableIndex.MethodSemantics);
+        for (int rowId = 1; rowId <= semanticsRows; rowId++)
+        {
+            try
+            {
+                var semantics = ReadMethodSemanticsRow(reader, rowId);
+                if (!TryGetAccessorRole(
+                        semantics.Association,
+                        semantics.Attributes,
+                        out var role,
+                        out string? operation))
+                {
+                    continue;
+                }
+
+                if (!associationOwners.TryGetValue(
+                        semantics.Association,
+                        out TypeDefinitionHandle owningType))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        operation,
+                        semantics.Association,
+                        MetadataTypeNameFailure.Malformed(
+                            semantics.Association,
+                            "The MethodSemantics association has no TypeDef owner."));
+                    continue;
+                }
+
+                if (!roles.Add(new PhysicalAccessorRole(
+                        semantics.Association,
+                        semantics.Attributes)))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        operation,
+                        semantics.Association,
+                        MetadataTypeNameFailure.Malformed(
+                            semantics.Association,
+                            $"The physical MethodSemantics {semantics.Attributes} role "
+                            + "appears more than once for this association."));
+                }
+
+                AddOwnedAccessor(
+                    reader,
+                    surface,
+                    budget,
+                    methods,
+                    owningType,
+                    semantics.Association,
+                    semantics.Method,
+                    operation);
+            }
+            catch (Exception ex) when (
+                ex is BadImageFormatException
+                    or ArgumentOutOfRangeException
+                    or OverflowException)
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget,
+                    "method semantics",
+                    default,
+                    MetadataTypeNameFailure.Malformed(default, ex.Message));
+            }
+        }
+
         methods.AddExtensionImplementations(
             ExtensionPropertyImplementationMethods(
                 reader,
@@ -2371,6 +2386,121 @@ public static class ApiSurfaceExtractor
                 currentScope));
         return methods;
     }
+
+    private readonly record struct PhysicalAccessorRole(
+        EntityHandle Association,
+        MethodSemanticsAttributes Attributes);
+
+    private readonly record struct MethodSemanticsRow(
+        MethodDefinitionHandle Method,
+        EntityHandle Association,
+        MethodSemanticsAttributes Attributes);
+
+    private static bool TryGetAccessorRole(
+        EntityHandle association,
+        MethodSemanticsAttributes attributes,
+        out MethodSemanticsAttributes role,
+        out string operation)
+    {
+        role = attributes;
+        operation = (association.Kind, attributes) switch
+        {
+            (HandleKind.PropertyDefinition, MethodSemanticsAttributes.Getter) =>
+                "property getter",
+            (HandleKind.PropertyDefinition, MethodSemanticsAttributes.Setter) =>
+                "property setter",
+            (HandleKind.EventDefinition, MethodSemanticsAttributes.Adder) =>
+                "event adder",
+            (HandleKind.EventDefinition, MethodSemanticsAttributes.Remover) =>
+                "event remover",
+            _ => "",
+        };
+        return operation.Length != 0;
+    }
+
+    private static unsafe MethodSemanticsRow ReadMethodSemanticsRow(
+        MetadataReader reader,
+        int rowId)
+    {
+        const int SemanticsFlagsSize = sizeof(ushort);
+        int methodIndexSize =
+            reader.GetTableRowCount(TableIndex.MethodDef) <= ushort.MaxValue
+                ? sizeof(ushort)
+                : sizeof(int);
+        int associationIndexSize =
+            Math.Max(
+                reader.GetTableRowCount(TableIndex.Event),
+                reader.GetTableRowCount(TableIndex.Property))
+            <= 0x7fff
+                ? sizeof(ushort)
+                : sizeof(int);
+        int rowSize = reader.GetTableRowSize(TableIndex.MethodSemantics);
+        if (rowSize != SemanticsFlagsSize + methodIndexSize + associationIndexSize)
+        {
+            throw new BadImageFormatException(
+                "The MethodSemantics row size does not match its ECMA-335 schema.");
+        }
+
+        int tableOffset = reader.GetTableMetadataOffset(TableIndex.MethodSemantics);
+        long rowEnd = checked(
+            (long)tableOffset + (long)rowId * rowSize);
+        if (tableOffset < 0
+            || rowId < 1
+            || rowEnd > reader.MetadataLength)
+        {
+            throw new BadImageFormatException(
+                "The MethodSemantics row lies outside the metadata image.");
+        }
+
+        int rowOffset = checked(
+            tableOffset + checked((rowId - 1) * rowSize));
+        byte* metadata = reader.MetadataPointer;
+        var attributes = (MethodSemanticsAttributes)unchecked(
+            (ushort)(metadata[rowOffset] | metadata[rowOffset + 1] << 8));
+        int methodRow = ReadMetadataIndex(
+            metadata,
+            checked(rowOffset + SemanticsFlagsSize),
+            methodIndexSize);
+        int association = ReadMetadataIndex(
+            metadata,
+            checked(rowOffset + SemanticsFlagsSize + methodIndexSize),
+            associationIndexSize);
+        if (methodRow < 1
+            || methodRow > reader.GetTableRowCount(TableIndex.MethodDef))
+        {
+            throw new BadImageFormatException(
+                "The MethodSemantics method index is outside the MethodDef table.");
+        }
+
+        int associationRow = association >> 1;
+        bool isProperty = (association & 1) != 0;
+        int associationLimit = reader.GetTableRowCount(
+            isProperty ? TableIndex.Property : TableIndex.Event);
+        if (associationRow < 1 || associationRow > associationLimit)
+        {
+            throw new BadImageFormatException(
+                "The MethodSemantics association is outside its target table.");
+        }
+
+        EntityHandle associationHandle = isProperty
+            ? (EntityHandle)MetadataTokens.PropertyDefinitionHandle(associationRow)
+            : MetadataTokens.EventDefinitionHandle(associationRow);
+        return new MethodSemanticsRow(
+            MetadataTokens.MethodDefinitionHandle(methodRow),
+            associationHandle,
+            attributes);
+    }
+
+    private static unsafe int ReadMetadataIndex(
+        byte* metadata,
+        int offset,
+        int size)
+        => size == sizeof(ushort)
+            ? metadata[offset] | metadata[offset + 1] << 8
+            : metadata[offset]
+                | metadata[offset + 1] << 8
+                | metadata[offset + 2] << 16
+                | metadata[offset + 3] << 24;
 
     private sealed class AccessorMethodOwnership
     {
@@ -3458,14 +3588,22 @@ public static class ApiSurfaceExtractor
         Action<int>? beforeDecodeWork)
     {
         List<OwnedMethodImplementation> implementations = [];
-        HashSet<EntityHandle> declarations = [];
+        HashSet<MethodImplementationDeclarationKey> declarations =
+            new(MethodImplementationDeclarationKeyComparer.Instance);
         foreach (var implementationHandle in typeDef.GetMethodImplementations())
         {
             try
             {
                 var implementation =
                     reader.GetMethodImplementation(implementationHandle);
-                if (!declarations.Add(implementation.MethodDeclaration))
+                var declaration = new MethodImplementationDeclarationKey(
+                    implementation.MethodDeclaration,
+                    TryGetMethodImplementationDeclarationIdentity(
+                        reader,
+                        implementation.MethodDeclaration,
+                        currentScope,
+                        beforeDecodeWork));
+                if (!declarations.Add(declaration))
                 {
                     AddInspectionFailure(
                         surface,
@@ -3630,10 +3768,10 @@ public static class ApiSurfaceExtractor
         {
             var candidate = reader.GetMethodDefinition(candidateHandle);
             if (!reader.StringComparer.Equals(candidate.Name, memberName)
-                || !SignaturesEqual(
+                || !MethodSignaturesEqual(
                     reader,
-                    candidate.Signature,
-                    memberReference.Signature,
+                    candidate,
+                    memberReference,
                     beforeDecodeWork))
             {
                 continue;
@@ -3647,25 +3785,392 @@ public static class ApiSurfaceExtractor
         return match.IsNil ? null : match;
     }
 
-    private static bool SignaturesEqual(
+    private static bool MethodSignaturesEqual(
         MetadataReader reader,
-        BlobHandle leftHandle,
-        BlobHandle rightHandle,
+        MethodDefinition method,
+        MemberReference memberReference,
         Action<int>? beforeDecodeWork)
     {
-        var left = reader.GetBlobReader(leftHandle);
-        var right = reader.GetBlobReader(rightHandle);
-        beforeDecodeWork?.Invoke(checked(left.Length + right.Length));
-        if (left.Length != right.Length)
-            return false;
+        MethodSignatureIdentity? methodIdentity =
+            TryGetMethodSignatureIdentity(
+                reader,
+                method,
+                beforeDecodeWork);
+        MethodSignatureIdentity? memberReferenceIdentity =
+            TryGetMethodSignatureIdentity(
+                reader,
+                memberReference,
+                beforeDecodeWork);
+        return methodIdentity is not null
+            && methodIdentity.Equals(memberReferenceIdentity);
+    }
 
-        while (left.RemainingBytes > 0)
+    private static MethodImplementationDeclarationIdentity?
+        TryGetMethodImplementationDeclarationIdentity(
+        MetadataReader reader,
+        EntityHandle declaration,
+        MetadataTypeScope? currentScope,
+        Action<int>? beforeDecodeWork)
+    {
+        EntityHandle declaringType;
+        string name;
+        MethodSignatureIdentity? signature;
+        switch (declaration.Kind)
         {
-            if (left.ReadByte() != right.ReadByte())
-                return false;
+            case HandleKind.MethodDefinition:
+                var method = reader.GetMethodDefinition(
+                    (MethodDefinitionHandle)declaration);
+                declaringType = method.GetDeclaringType();
+                name = DecodeString(reader, method.Name, beforeDecodeWork);
+                signature = TryGetMethodSignatureIdentity(
+                    reader,
+                    method,
+                    beforeDecodeWork);
+                break;
+            case HandleKind.MemberReference:
+                var memberReference = reader.GetMemberReference(
+                    (MemberReferenceHandle)declaration);
+                declaringType = memberReference.Parent;
+                name = DecodeString(
+                    reader,
+                    memberReference.Name,
+                    beforeDecodeWork);
+                signature = TryGetMethodSignatureIdentity(
+                    reader,
+                    memberReference,
+                    beforeDecodeWork);
+                break;
+            default:
+                return null;
         }
 
-        return true;
+        MetadataNamedTypeIdentity? typeIdentity = TryGetNamedTypeIdentity(
+            reader,
+            declaringType,
+            currentScope,
+            beforeDecodeWork);
+        if (typeIdentity is null || signature is null)
+            return null;
+
+        string? constructedTypeIdentity = declaringType.Kind
+            == HandleKind.TypeSpecification
+            ? TryGetTypeStructuralIdentity(
+                reader,
+                (TypeSpecificationHandle)declaringType,
+                beforeDecodeWork)
+            : null;
+        if (declaringType.Kind == HandleKind.TypeSpecification
+            && constructedTypeIdentity is null)
+        {
+            return null;
+        }
+
+        return new MethodImplementationDeclarationIdentity(
+            typeIdentity,
+            constructedTypeIdentity,
+            name,
+            signature);
+    }
+
+    private static string? TryGetTypeStructuralIdentity(
+        MetadataReader reader,
+        TypeSpecificationHandle type,
+        Action<int>? beforeDecodeWork)
+    {
+        var node = GuardedProviderDecode.TypeSpec(
+            reader,
+            type,
+            new TypeNodeProvider(beforeMaterialize: beforeDecodeWork),
+            context: null,
+            (TypeNode)new DegradedTypeNode());
+        return node.IsDegraded ? null : node.StructuralIdentity();
+    }
+
+    private static MethodSignatureIdentity? TryGetMethodSignatureIdentity(
+        MetadataReader reader,
+        MethodDefinition method,
+        Action<int>? beforeDecodeWork)
+    {
+        if (!SignatureBlobGuard.IsSafeAndCompleteToDecode(
+                reader,
+                method.Signature,
+                SignatureBlobGuard.Kind.Method))
+        {
+            return null;
+        }
+
+        try
+        {
+            MethodSignature<TypeNode> signature =
+                GuardedProviderDecode.Method(
+                    reader,
+                    method,
+                    new TypeNodeProvider(
+                        beforeMaterialize: beforeDecodeWork),
+                    context: null,
+                    (TypeNode)new DegradedTypeNode());
+            return CreateMethodSignatureIdentity(signature);
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentOutOfRangeException
+                or InvalidOperationException
+                or OverflowException)
+        {
+            return null;
+        }
+    }
+
+    private static MethodSignatureIdentity? TryGetMethodSignatureIdentity(
+        MetadataReader reader,
+        MemberReference memberReference,
+        Action<int>? beforeDecodeWork)
+    {
+        if (!SignatureBlobGuard.IsSafeAndCompleteToDecode(
+                reader,
+                memberReference.Signature,
+                SignatureBlobGuard.Kind.Method))
+        {
+            return null;
+        }
+
+        try
+        {
+            MethodSignature<TypeNode> signature =
+                GuardedProviderDecode.MemberRefMethod(
+                    reader,
+                    memberReference,
+                    new TypeNodeProvider(
+                        beforeMaterialize: beforeDecodeWork),
+                    context: null,
+                    (TypeNode)new DegradedTypeNode());
+            return CreateMethodSignatureIdentity(signature);
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentOutOfRangeException
+                or InvalidOperationException
+                or OverflowException)
+        {
+            return null;
+        }
+    }
+
+    private static MethodSignatureIdentity? CreateMethodSignatureIdentity(
+        MethodSignature<TypeNode> signature)
+    {
+        if (signature.ReturnType.IsDegraded
+            || signature.ParameterTypes.Any(static type => type.IsDegraded))
+        {
+            return null;
+        }
+
+        return new MethodSignatureIdentity(
+            signature.Header.RawValue,
+            signature.GenericParameterCount,
+            signature.RequiredParameterCount,
+            signature.ReturnType.StructuralIdentity(),
+            [.. signature.ParameterTypes.Select(
+                static parameter => parameter.StructuralIdentity())]);
+    }
+
+    private sealed class MethodSignatureIdentity : IEquatable<MethodSignatureIdentity>
+    {
+        private readonly int _hashCode;
+
+        internal MethodSignatureIdentity(
+            byte header,
+            int genericParameterCount,
+            int requiredParameterCount,
+            string returnType,
+            string[] parameterTypes)
+        {
+            Header = header;
+            GenericParameterCount = genericParameterCount;
+            RequiredParameterCount = requiredParameterCount;
+            ReturnType = returnType;
+            ParameterTypes = parameterTypes;
+            var hash = new HashCode();
+            hash.Add(header);
+            hash.Add(genericParameterCount);
+            hash.Add(requiredParameterCount);
+            hash.Add(returnType, StringComparer.Ordinal);
+            foreach (string parameterType in parameterTypes)
+                hash.Add(parameterType, StringComparer.Ordinal);
+            _hashCode = hash.ToHashCode();
+        }
+
+        internal byte Header { get; }
+        internal int GenericParameterCount { get; }
+        internal int RequiredParameterCount { get; }
+        internal string ReturnType { get; }
+        internal string[] ParameterTypes { get; }
+
+        public bool Equals(MethodSignatureIdentity? other)
+            => ReferenceEquals(this, other)
+                || other is not null
+                    && _hashCode == other._hashCode
+                    && Header == other.Header
+                    && GenericParameterCount == other.GenericParameterCount
+                    && RequiredParameterCount == other.RequiredParameterCount
+                    && string.Equals(
+                        ReturnType,
+                        other.ReturnType,
+                        StringComparison.Ordinal)
+                    && ParameterTypes.SequenceEqual(
+                        other.ParameterTypes,
+                        StringComparer.Ordinal);
+
+        public override bool Equals(object? obj)
+            => Equals(obj as MethodSignatureIdentity);
+
+        public override int GetHashCode() => _hashCode;
+    }
+
+    private sealed class MethodImplementationDeclarationIdentity :
+        IEquatable<MethodImplementationDeclarationIdentity>
+    {
+        private readonly int _hashCode;
+
+        internal MethodImplementationDeclarationIdentity(
+            MetadataNamedTypeIdentity declaringType,
+            string? constructedTypeIdentity,
+            string name,
+            MethodSignatureIdentity signature)
+        {
+            DeclaringType = declaringType;
+            ConstructedTypeIdentity = constructedTypeIdentity;
+            Name = name;
+            Signature = signature;
+            var hash = new HashCode();
+            hash.Add(
+                MetadataNamedTypeIdentityComparer.Instance.GetHashCode(
+                    declaringType));
+            hash.Add(constructedTypeIdentity, StringComparer.Ordinal);
+            hash.Add(name, StringComparer.Ordinal);
+            hash.Add(signature);
+            _hashCode = hash.ToHashCode();
+        }
+
+        internal MetadataNamedTypeIdentity DeclaringType { get; }
+        internal string? ConstructedTypeIdentity { get; }
+        internal string Name { get; }
+        internal MethodSignatureIdentity Signature { get; }
+
+        public bool Equals(MethodImplementationDeclarationIdentity? other)
+            => ReferenceEquals(this, other)
+                || other is not null
+                    && _hashCode == other._hashCode
+                    && MetadataNamedTypeIdentityComparer.Instance.Equals(
+                        DeclaringType,
+                        other.DeclaringType)
+                    && string.Equals(
+                        ConstructedTypeIdentity,
+                        other.ConstructedTypeIdentity,
+                        StringComparison.Ordinal)
+                    && string.Equals(Name, other.Name, StringComparison.Ordinal)
+                    && Signature.Equals(other.Signature);
+
+        public override bool Equals(object? obj)
+            => Equals(obj as MethodImplementationDeclarationIdentity);
+
+        public override int GetHashCode() => _hashCode;
+    }
+
+    private readonly record struct MethodImplementationDeclarationKey(
+        EntityHandle Handle,
+        MethodImplementationDeclarationIdentity? CanonicalIdentity);
+
+    private sealed class MethodImplementationDeclarationKeyComparer :
+        IEqualityComparer<MethodImplementationDeclarationKey>
+    {
+        internal static MethodImplementationDeclarationKeyComparer Instance { get; } =
+            new();
+
+        public bool Equals(
+            MethodImplementationDeclarationKey left,
+            MethodImplementationDeclarationKey right)
+            => left.CanonicalIdentity is not null
+                && right.CanonicalIdentity is not null
+                ? left.CanonicalIdentity.Equals(right.CanonicalIdentity)
+                : left.Handle == right.Handle;
+
+        public int GetHashCode(MethodImplementationDeclarationKey value)
+            => value.CanonicalIdentity?.GetHashCode()
+                ?? value.Handle.GetHashCode();
+    }
+
+    private sealed class FinalizerMethodImplementationCache
+    {
+        private readonly object _gate = new();
+        private readonly ApiSurface _failures = new();
+        private Dictionary<
+            MetadataNamedTypeIdentity,
+            TypeDefinitionHandle?> _localTypes = [];
+        private readonly Dictionary<
+            TypeDefinitionHandle,
+            IReadOnlyList<OwnedMethodImplementation>> _implementations = [];
+        private MetadataTypeScope? _currentScope;
+        private bool _initialized;
+
+        internal IReadOnlyList<OwnedMethodImplementation> Get(
+            MetadataReader reader,
+            TypeDefinitionHandle typeHandle,
+            TypeDefinition type)
+        {
+            lock (_gate)
+            {
+                if (_implementations.TryGetValue(
+                        typeHandle,
+                        out IReadOnlyList<OwnedMethodImplementation>? cached))
+                {
+                    return cached;
+                }
+
+                if (!_initialized)
+                {
+                    _initialized = true;
+                    try
+                    {
+                        _currentScope = CurrentScope(
+                            reader,
+                            beforeDecodeWork: null);
+                        if (_currentScope is not null)
+                        {
+                            _localTypes = LocalTypes(
+                                reader,
+                                _currentScope,
+                                _failures,
+                                budget: null);
+                        }
+                    }
+                    catch (Exception ex) when (
+                        ex is BadImageFormatException
+                            or ArgumentOutOfRangeException
+                            or OverflowException)
+                    {
+                        _currentScope = null;
+                        _localTypes = [];
+                    }
+                }
+
+                IReadOnlyList<OwnedMethodImplementation> implementations =
+                    _currentScope is null
+                        ? []
+                        : ReadOwnedMethodImplementations(
+                            reader,
+                            typeHandle,
+                            type,
+                            _failures,
+                            budget: null,
+                            owningTypeDefinition: null,
+                            currentScope: _currentScope,
+                            localTypes: _localTypes,
+                            beforeDecodeWork: null);
+                _implementations.Add(typeHandle, implementations);
+                return implementations;
+            }
+        }
     }
 
     private static bool IsLocalBaseType(
@@ -3834,7 +4339,7 @@ public static class ApiSurfaceExtractor
             || !TryGetUniqueLocalType(localTypes, declarationIdentity, out _);
         var currentType = typeDef;
         HashSet<TypeDefinitionHandle> visitedBaseTypes = [];
-        while (true)
+        for (int depth = 0; depth < MaxBaseChainDepth; depth++)
         {
             foreach (var handle in currentType.GetInterfaceImplementations())
             {
@@ -3880,6 +4385,8 @@ public static class ApiSurfaceExtractor
 
             currentType = reader.GetTypeDefinition(baseDefinition);
         }
+        if (visitedBaseTypes.Count == MaxBaseChainDepth)
+            hasUnresolvedExternalOwnership = true;
 
         while (pending.TryDequeue(out var candidate))
         {
@@ -4345,7 +4852,9 @@ public static class ApiSurfaceExtractor
     {
         EntityHandle baseType = typeDef.BaseType;
         HashSet<TypeDefinitionHandle> visited = [];
-        while (!baseType.IsNil)
+        for (int depth = 0;
+            !baseType.IsNil && depth < MaxBaseChainDepth;
+            depth++)
         {
             if (baseType == declaringType)
                 return true;
@@ -5096,32 +5605,48 @@ public static class ApiSurfaceExtractor
     /// </summary>
     internal static bool IsFinalizerMethod(MetadataReader reader, MethodDefinitionHandle methodHandle)
     {
-        var method = reader.GetMethodDefinition(methodHandle);
-        if (!IsFinalizerBodyShape(reader, method))
-            return false;
-
-        var typeHandle = method.GetDeclaringType();
-        var typeDef = reader.GetTypeDefinition(typeHandle);
-        if (!IsFinalizerOwner(reader, typeDef))
-            return false;
-        foreach (var implementationHandle in typeDef.GetMethodImplementations())
+        try
         {
-            var implementation = reader.GetMethodImplementation(implementationHandle);
-            if (implementation.MethodBody.Kind == HandleKind.MethodDefinition
-                && (MethodDefinitionHandle)implementation.MethodBody == methodHandle
-                && ReferencesObjectFinalize(reader, implementation.MethodDeclaration))
-            {
-                return true;
-            }
-        }
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (!IsFinalizerBodyShape(reader, method))
+                return false;
 
-        // No MethodImpl: fall back to the implicit-slot shape the VB.NET compiler emits.
-        return IsImplicitObjectFinalizeOverride(
-            reader,
-            typeHandle,
-            method,
-            currentScope: null,
-            localTypes: null);
+            var typeHandle = method.GetDeclaringType();
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (!IsFinalizerOwner(reader, typeDef))
+                return false;
+            IReadOnlyList<OwnedMethodImplementation> implementations =
+                FinalizerMethodImplementationCaches
+                    .GetValue(
+                        reader,
+                        static _ => new FinalizerMethodImplementationCache())
+                    .Get(reader, typeHandle, typeDef);
+            foreach (var implementation in implementations)
+            {
+                if (implementation.Body == methodHandle
+                    && ReferencesObjectFinalize(
+                        reader,
+                        implementation.Declaration))
+                {
+                    return true;
+                }
+            }
+
+            // No MethodImpl: fall back to the implicit-slot shape the VB.NET compiler emits.
+            return IsImplicitObjectFinalizeOverride(
+                reader,
+                typeHandle,
+                method,
+                currentScope: null,
+                localTypes: null);
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentOutOfRangeException
+                or OverflowException)
+        {
+            return false;
+        }
     }
 
     private static bool IsFinalizerOwner(
@@ -5152,9 +5677,9 @@ public static class ApiSurfaceExtractor
         }
     }
 
-    // A malformed or adversarial base-type chain can be arbitrarily long or cyclic; the visited-set
-    // below stops in-assembly cycles, and this cap stops an unbounded walk through a long legitimate
-    // (or degenerate) hierarchy. Real finalizer-bearing hierarchies are far shallower than this.
+    // A malformed or adversarial base-type chain can be arbitrarily long or cyclic; visited sets
+    // stop in-assembly cycles, and this cap bounds all hierarchy classifications over a long
+    // legitimate (or degenerate) chain. Real API hierarchies are far shallower than this.
     private const int MaxBaseChainDepth = 256;
 
     /// <summary>
@@ -5343,7 +5868,8 @@ public static class ApiSurfaceExtractor
                 return false;
             // Return type: a plain ELEMENT_TYPE_VOID. Any leading custom modifier or by-ref token is
             // read here instead of Void and correctly rejects.
-            return blob.ReadSignatureTypeCode() == SignatureTypeCode.Void;
+            return blob.ReadSignatureTypeCode() == SignatureTypeCode.Void
+                && blob.RemainingBytes == 0;
         }
         catch (BadImageFormatException)
         {

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -968,17 +968,26 @@ public static class ApiSurfaceExtractor
             {
             apiType.Members = [];
 
+            var methodImplementations = ReadOwnedMethodImplementations(
+                reader,
+                typeDefHandle,
+                typeDef,
+                surface,
+                budget,
+                owningTypeDefinition);
             var explicitImplementationBodies = GetExplicitImplementationBodies(
                 reader,
                 typeDef,
+                methodImplementations,
                 currentScope,
-                localTypes);
+                localTypes,
+                observeDecodeWork);
             // Methods whose explicit `.override` MethodImpl targets
             // `System.Object::Finalize` — i.e. genuine class finalizers, the
             // slot the C# `~Type()` destructor compiles to.
             var objectFinalizeOverrides = GetObjectFinalizeOverrides(
                 reader,
-                typeDef,
+                methodImplementations,
                 observeDecodeWork);
 
             // Getter/setter and adder/remover bodies are represented by their
@@ -1033,6 +1042,8 @@ public static class ApiSurfaceExtractor
                             reader,
                             typeDefHandle,
                             method,
+                            currentScope,
+                            localTypes,
                             observeDecodeWork));
                 if (methodAccess != MethodAttributes.Public
                     && !includeAll
@@ -1731,16 +1742,17 @@ public static class ApiSurfaceExtractor
                 var evt = reader.GetEventDefinition(eventHandle);
                 var accessors = evt.GetAccessors();
 
-                var representativeHandle = !accessors.Adder.IsNil
-                    ? accessors.Adder
-                    : accessors.Remover;
-                if (representativeHandle.IsNil)
+                if (!TrySelectEventAccessors(
+                        reader,
+                        accessors,
+                        accessorMethods,
+                        includeAll,
+                        out var selectedAccessors))
+                {
                     continue;
-
-                var representative = reader.GetMethodDefinition(representativeHandle);
-                var representativeAccess = representative.Attributes & MethodAttributes.MemberAccessMask;
-                if (representativeAccess != MethodAttributes.Public && !includeAll)
-                    continue;
+                }
+                var representative = selectedAccessors.Representative;
+                var representativeAccess = selectedAccessors.Accessibility;
 
                 // Skip EditorBrowsable(Never) events unless --all; obsolete are surfaced with marker.
                 if (!includeAll
@@ -1812,26 +1824,26 @@ public static class ApiSurfaceExtractor
                 var isVirtualEvent = (representativeAttributes & MethodAttributes.Virtual) != 0;
                 var isOverrideEvent = isVirtualEvent && (representativeAttributes & MethodAttributes.NewSlot) == 0;
                 var accessorModels = new List<ApiAccessor>();
-                if (!accessors.Adder.IsNil)
+                if (!selectedAccessors.Adder.IsNil)
                 {
                     accessorModels.Add(new ApiAccessor
                     {
                         Kind = "add",
                         ReturnAttributes = ReturnParameterAttributes(
                             reader,
-                            reader.GetMethodDefinition(accessors.Adder).GetParameters(),
+                            reader.GetMethodDefinition(selectedAccessors.Adder).GetParameters(),
                             observeText,
                             observeAttributeMaterialize)
                     });
                 }
-                if (!accessors.Remover.IsNil)
+                if (!selectedAccessors.Remover.IsNil)
                 {
                     accessorModels.Add(new ApiAccessor
                     {
                         Kind = "remove",
                         ReturnAttributes = ReturnParameterAttributes(
                             reader,
-                            reader.GetMethodDefinition(accessors.Remover).GetParameters(),
+                            reader.GetMethodDefinition(selectedAccessors.Remover).GetParameters(),
                             observeText,
                             observeAttributeMaterialize)
                     });
@@ -1878,12 +1890,12 @@ public static class ApiSurfaceExtractor
                     Accessibility = GetAccessibility(representativeAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
-                    AdderToken = accessors.Adder.IsNil
+                    AdderToken = selectedAccessors.Adder.IsNil
                         ? null
-                        : MetadataTokens.GetToken(accessors.Adder),
-                    RemoverToken = accessors.Remover.IsNil
+                        : MetadataTokens.GetToken(selectedAccessors.Adder),
+                    RemoverToken = selectedAccessors.Remover.IsNil
                         ? null
-                        : MetadataTokens.GetToken(accessors.Remover)
+                        : MetadataTokens.GetToken(selectedAccessors.Remover)
                 };
 
                 budget?.RetainMember(member);
@@ -1970,12 +1982,23 @@ public static class ApiSurfaceExtractor
         MetadataTypeScope? currentScope,
         IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
     {
+        var methodImplementations = ReadOwnedMethodImplementations(
+            reader,
+            typeDefHandle,
+            typeDef,
+            surface,
+            budget: null,
+            apiType.DefinitionName);
         var explicitImplementationBodies = GetExplicitImplementationBodies(
             reader,
             typeDef,
+            methodImplementations,
             currentScope,
-            localTypes);
-        var objectFinalizeOverrides = GetObjectFinalizeOverrides(reader, typeDef);
+            localTypes,
+            beforeDecodeWork: null);
+        var objectFinalizeOverrides = GetObjectFinalizeOverrides(
+            reader,
+            methodImplementations);
 
         foreach (var methodHandle in typeDef.GetMethods())
         {
@@ -1989,7 +2012,12 @@ public static class ApiSurfaceExtractor
                     || methodName.Contains('.', StringComparison.Ordinal));
             bool isFinalizer = method.GetGenericParameters().Count == 0
                 && (objectFinalizeOverrides.Contains(methodHandle)
-                    || IsImplicitObjectFinalizeOverride(reader, typeDefHandle, method));
+                    || IsImplicitObjectFinalizeOverride(
+                        reader,
+                        typeDefHandle,
+                        method,
+                        currentScope,
+                        localTypes));
             if (methodAccess != MethodAttributes.Public
                 && !isRetainedExplicitImplementation
                 && !isFinalizer)
@@ -2091,12 +2119,18 @@ public static class ApiSurfaceExtractor
         {
             var evt = reader.GetEventDefinition(eventHandle);
             var accessors = evt.GetAccessors();
-            if (accessors.Adder.IsNil)
+            if (!TrySelectEventAccessors(
+                    reader,
+                    accessors,
+                    accessorMethods,
+                    includeAll: false,
+                    out _))
+            {
                 continue;
-
-            var adder = reader.GetMethodDefinition(accessors.Adder);
-            if ((adder.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
-                || AttributeReader.HasEditorBrowsableNeverAttribute(reader, evt.GetCustomAttributes()))
+            }
+            if (AttributeReader.HasEditorBrowsableNeverAttribute(
+                    reader,
+                    evt.GetCustomAttributes()))
             {
                 continue;
             }
@@ -2353,11 +2387,69 @@ public static class ApiSurfaceExtractor
         }
     }
 
+    private readonly record struct EventAccessorSelection(
+        MethodDefinitionHandle Adder,
+        MethodDefinitionHandle Remover,
+        MethodDefinition Representative,
+        MethodAttributes Accessibility);
+
+    private static bool TrySelectEventAccessors(
+        MetadataReader reader,
+        EventAccessors accessors,
+        IReadOnlySet<MethodDefinitionHandle> ownedAccessorMethods,
+        bool includeAll,
+        out EventAccessorSelection selection)
+    {
+        MethodDefinitionHandle adder = Owned(accessors.Adder);
+        MethodDefinitionHandle remover = Owned(accessors.Remover);
+        MethodDefinitionHandle representativeHandle = default;
+        MethodDefinition representative = default;
+        MethodAttributes bestAccess = 0;
+
+        Consider(adder);
+        Consider(remover);
+        if (representativeHandle.IsNil
+            || (!includeAll && bestAccess != MethodAttributes.Public))
+        {
+            selection = default;
+            return false;
+        }
+
+        selection = new EventAccessorSelection(
+            adder,
+            remover,
+            representative,
+            bestAccess);
+        return true;
+
+        MethodDefinitionHandle Owned(MethodDefinitionHandle handle) =>
+            !handle.IsNil && ownedAccessorMethods.Contains(handle)
+                ? handle
+                : default;
+
+        void Consider(MethodDefinitionHandle handle)
+        {
+            if (handle.IsNil)
+                return;
+
+            var candidate = reader.GetMethodDefinition(handle);
+            var access = candidate.Attributes & MethodAttributes.MemberAccessMask;
+            if (representativeHandle.IsNil || access > bestAccess)
+            {
+                representativeHandle = handle;
+                representative = candidate;
+                bestAccess = access;
+            }
+        }
+    }
+
     static HashSet<MethodDefinitionHandle> ExtensionPropertyImplementationMethods(
         MetadataReader reader,
         ApiSurface surface,
         ExtractionBudget? budget)
     {
+        Action<int>? beforeDecodeWork =
+            budget is null ? null : budget.ObservePendingDecodeWork;
         HashSet<MethodDefinitionHandle> methods = [];
         foreach (var extensionClassHandle in reader.TypeDefinitions)
         {
@@ -2366,17 +2458,23 @@ public static class ApiSurfaceExtractor
                 var extensionClass = reader.GetTypeDefinition(extensionClassHandle);
                 if (!AttributeReader.HasExtensionAttribute(
                         reader,
-                        extensionClass.GetCustomAttributes()))
+                        extensionClass.GetCustomAttributes(),
+                        beforeDecodeWork))
                 {
                     continue;
                 }
+                var extensionClassContext = GenericContext.ForType(
+                    reader,
+                    extensionClass,
+                    beforeDecodeWork);
 
                 foreach (var groupingTypeHandle in extensionClass.GetNestedTypes())
                 {
                     var groupingType = reader.GetTypeDefinition(groupingTypeHandle);
                     if (!AttributeReader.HasExtensionAttribute(
                             reader,
-                            groupingType.GetCustomAttributes()))
+                            groupingType.GetCustomAttributes(),
+                            beforeDecodeWork))
                     {
                         continue;
                     }
@@ -2389,7 +2487,8 @@ public static class ApiSurfaceExtractor
                                 reader,
                                 property,
                                 accessors,
-                                out string? markerName))
+                                out string? markerName,
+                                beforeDecodeWork))
                         {
                             continue;
                         }
@@ -2408,37 +2507,55 @@ public static class ApiSurfaceExtractor
                         if (markerMethodHandle.IsNil)
                             continue;
 
-                        var context = GenericContext.ForType(reader, markerType);
-                        if (!GuardedSignatureText.MethodText(
+                        var context = GenericContext.ForType(
+                            reader,
+                            markerType,
+                            beforeDecodeWork);
+                        if (!TryDecodeExtensionSignature(
                                 reader,
                                 reader.GetMethodDefinition(markerMethodHandle),
-                                context).TryGetValue(out var markerSignature)
+                                context,
+                                beforeDecodeWork,
+                                out var markerSignature)
                             || markerSignature.ParameterTypes.Length != 1
-                            || !GuardedSignatureText.PropertyText(
+                            || !TryDecodeExtensionSignature(
                                 reader,
                                 property,
-                                context).TryGetValue(out var propertySignature))
+                                context,
+                                beforeDecodeWork,
+                                out var propertySignature))
                         {
                             continue;
                         }
 
-                        string propertyName = reader.GetString(property.Name);
+                        string propertyName = DecodeString(
+                            reader,
+                            property.Name,
+                            beforeDecodeWork);
                         int implementationGenericArity = groupingType.GetGenericParameters().Count;
                         foreach (var methodHandle in extensionClass.GetMethods())
                         {
                             var method = reader.GetMethodDefinition(methodHandle);
-                            string methodName = reader.GetString(method.Name);
+                            string methodName = DecodeString(
+                                reader,
+                                method.Name,
+                                beforeDecodeWork);
                             bool getter = !accessors.Getter.IsNil
-                                && methodName == $"get_{propertyName}";
+                                && HasAccessorName(methodName, "get_", propertyName);
                             bool setter = !accessors.Setter.IsNil
-                                && methodName == $"set_{propertyName}";
+                                && HasAccessorName(methodName, "set_", propertyName);
                             if (!getter && !setter)
                                 continue;
-                            if (!GuardedSignatureText.MethodText(
+                            if (!TryDecodeExtensionSignature(
                                     reader,
                                     method,
-                                    GenericContext.ForMethod(reader, extensionClass, method))
-                                .TryGetValue(out var implementationSignature))
+                                    GenericContext.ForMethod(
+                                        reader,
+                                        extensionClassContext,
+                                        method,
+                                        beforeDecodeWork),
+                                    beforeDecodeWork,
+                                    out var implementationSignature))
                             {
                                 continue;
                             }
@@ -2449,17 +2566,12 @@ public static class ApiSurfaceExtractor
                             bool isStaticExtensionMember = reader
                                 .GetMethodDefinition(markerAccessorHandle)
                                 .Attributes.HasFlag(MethodAttributes.Static);
-                            IEnumerable<string> expectedParameters =
-                                isStaticExtensionMember
-                                    ? propertySignature.ParameterTypes
-                                    : new[] { markerSignature.ParameterTypes[0] }
-                                        .Concat(propertySignature.ParameterTypes);
-                            if (setter)
-                                expectedParameters = expectedParameters.Append(
-                                    propertySignature.ReturnType);
-                            if (implementationSignature.ParameterTypes.SequenceEqual(
-                                    expectedParameters,
-                                    StringComparer.Ordinal)
+                            if (ExtensionParametersMatch(
+                                    implementationSignature.ParameterTypes,
+                                    propertySignature,
+                                    markerSignature.ParameterTypes[0],
+                                    includeReceiver: !isStaticExtensionMember,
+                                    includeValue: setter)
                                 && method.GetGenericParameters().Count == implementationGenericArity
                                 && (getter
                                     ? implementationSignature.ReturnType
@@ -2485,25 +2597,164 @@ public static class ApiSurfaceExtractor
         return methods;
     }
 
+    private readonly record struct ExtensionDecodedSignature(
+        string ReturnType,
+        ImmutableArray<string> ParameterTypes);
+
+    private static bool TryDecodeExtensionSignature(
+        MetadataReader reader,
+        MethodDefinition method,
+        GenericContext context,
+        Action<int>? beforeDecodeWork,
+        out ExtensionDecodedSignature signature)
+    {
+        var decoded = GuardedProviderDecode.MethodResult(
+            reader,
+            method,
+            new TypeNodeProvider(
+                beforeRetain: null,
+                beforeMaterialize: beforeDecodeWork),
+            context,
+            (TypeNode)new DegradedTypeNode());
+        return TryRenderExtensionSignature(decoded, beforeDecodeWork, out signature);
+    }
+
+    private static bool TryDecodeExtensionSignature(
+        MetadataReader reader,
+        PropertyDefinition property,
+        GenericContext context,
+        Action<int>? beforeDecodeWork,
+        out ExtensionDecodedSignature signature)
+    {
+        var decoded = GuardedProviderDecode.PropertyResult(
+            reader,
+            property,
+            new TypeNodeProvider(
+                beforeRetain: null,
+                beforeMaterialize: beforeDecodeWork),
+            context,
+            (TypeNode)new DegradedTypeNode());
+        return TryRenderExtensionSignature(decoded, beforeDecodeWork, out signature);
+    }
+
+    private static bool TryRenderExtensionSignature(
+        GuardedProviderDecode.DecodeResult<MethodSignature<TypeNode>> decoded,
+        Action<int>? beforeDecodeWork,
+        out ExtensionDecodedSignature signature)
+    {
+        if (decoded.IsDegraded
+            || decoded.Value.ReturnType.IsDegraded
+            || decoded.Value.ParameterTypes.Any(static parameter => parameter.IsDegraded))
+        {
+            signature = default;
+            return false;
+        }
+
+        beforeDecodeWork?.Invoke(
+            checked(16 + decoded.Value.ParameterTypes.Length * 8));
+        var parameterTypes = ImmutableArray.CreateBuilder<string>(
+            decoded.Value.ParameterTypes.Length);
+        foreach (var parameter in decoded.Value.ParameterTypes)
+            parameterTypes.Add(parameter.Render());
+        signature = new ExtensionDecodedSignature(
+            decoded.Value.ReturnType.Render(),
+            parameterTypes.MoveToImmutable());
+        return true;
+    }
+
+    private static bool ExtensionParametersMatch(
+        ImmutableArray<string> implementation,
+        ExtensionDecodedSignature property,
+        string receiver,
+        bool includeReceiver,
+        bool includeValue)
+    {
+        int expectedCount =
+            property.ParameterTypes.Length
+            + (includeReceiver ? 1 : 0)
+            + (includeValue ? 1 : 0);
+        if (implementation.Length != expectedCount)
+            return false;
+
+        int index = 0;
+        if (includeReceiver
+            && !string.Equals(
+                implementation[index++],
+                receiver,
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+        foreach (string parameter in property.ParameterTypes)
+        {
+            if (!string.Equals(
+                    implementation[index++],
+                    parameter,
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+        return !includeValue
+            || string.Equals(
+                implementation[index],
+                property.ReturnType,
+                StringComparison.Ordinal);
+    }
+
+    private static bool HasAccessorName(
+        string methodName,
+        string prefix,
+        string propertyName) =>
+        methodName.StartsWith(prefix, StringComparison.Ordinal)
+        && methodName.AsSpan(prefix.Length).SequenceEqual(propertyName);
+
     static bool TryGetExtensionMarkerName(
         MetadataReader reader,
         PropertyDefinition property,
         PropertyAccessors accessors,
-        out string? markerName)
-        => AttributeReader.TryGetExtensionMarkerName(
+        out string? markerName,
+        Action<int>? beforeDecodeWork)
+        => TryGetExtensionMarkerName(
                 reader,
                 property.GetCustomAttributes(),
-                out markerName)
+                out markerName,
+                beforeDecodeWork)
             || !accessors.Getter.IsNil
-            && AttributeReader.TryGetExtensionMarkerName(
+            && TryGetExtensionMarkerName(
                 reader,
                 reader.GetMethodDefinition(accessors.Getter).GetCustomAttributes(),
-                out markerName)
+                out markerName,
+                beforeDecodeWork)
             || !accessors.Setter.IsNil
-            && AttributeReader.TryGetExtensionMarkerName(
+            && TryGetExtensionMarkerName(
                 reader,
                 reader.GetMethodDefinition(accessors.Setter).GetCustomAttributes(),
-                out markerName);
+                out markerName,
+                beforeDecodeWork);
+
+    private static bool TryGetExtensionMarkerName(
+        MetadataReader reader,
+        CustomAttributeHandleCollection attributes,
+        out string? markerName,
+        Action<int>? beforeDecodeWork)
+    {
+        if (beforeDecodeWork is not null)
+        {
+            foreach (var attributeHandle in attributes)
+            {
+                beforeDecodeWork(
+                    reader.GetBlobReader(
+                        reader.GetCustomAttribute(attributeHandle).Value).Length);
+            }
+        }
+
+        return AttributeReader.TryGetExtensionMarkerName(
+            reader,
+            attributes,
+            out markerName,
+            beforeDecodeWork);
+    }
 
     private static byte? GetEffectiveNullable(
         MetadataReader reader,
@@ -2753,68 +3004,93 @@ public static class ApiSurfaceExtractor
             [.. fieldNode.ReferencedTypes().Distinct()]);
     }
 
-    /// <summary>
-    /// Property getter/setter and event adder/remover bodies from
-    /// <c>MethodSemantics</c>. Ordinary accessors are represented by their
-    /// property or event row; raiser and Other semantic methods have no
-    /// <see cref="ApiMember"/> token slots, so they stay methods.
-    /// </summary>
-    /// <remarks>
-    /// <c>ApiSurfaceEmitSetTests</c> is the gate: ordinary <c>get_*</c> methods
-    /// remain methods, ordinary semantic accessors do not, and a private
-    /// MethodImpl accessor remains <c>explicit-interface-implementation</c>
-    /// because its property or event row does not represent the public contract.
-    /// A public MethodImpl accessor is represented by that public row.
-    /// </remarks>
-    private static HashSet<MethodDefinitionHandle> GetSemanticAccessorMethods(
+    private readonly record struct OwnedMethodImplementation(
+        MethodDefinitionHandle Body,
+        EntityHandle Declaration);
+
+    private static List<OwnedMethodImplementation> ReadOwnedMethodImplementations(
         MetadataReader reader,
-        TypeDefinition typeDef)
+        TypeDefinitionHandle owningType,
+        TypeDefinition typeDef,
+        ApiSurface surface,
+        ExtractionBudget? budget,
+        MetadataTypeDefinitionName? owningTypeDefinition)
     {
-        HashSet<MethodDefinitionHandle> accessors = [];
-        foreach (PropertyDefinitionHandle propertyHandle in typeDef.GetProperties())
+        List<OwnedMethodImplementation> implementations = [];
+        foreach (var implementationHandle in typeDef.GetMethodImplementations())
         {
-            PropertyAccessors propertyAccessors =
-                reader.GetPropertyDefinition(propertyHandle).GetAccessors();
-            Add(propertyAccessors.Getter);
-            Add(propertyAccessors.Setter);
-        }
+            try
+            {
+                var implementation =
+                    reader.GetMethodImplementation(implementationHandle);
+                if (implementation.MethodBody.Kind != HandleKind.MethodDefinition)
+                    continue;
 
-        foreach (EventDefinitionHandle eventHandle in typeDef.GetEvents())
-        {
-            EventAccessors eventAccessors =
-                reader.GetEventDefinition(eventHandle).GetAccessors();
-            Add(eventAccessors.Adder);
-            Add(eventAccessors.Remover);
-        }
+                var body = (MethodDefinitionHandle)implementation.MethodBody;
+                var declaringType =
+                    reader.GetMethodDefinition(body).GetDeclaringType();
+                if (declaringType != owningType)
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "method implementation body",
+                        implementationHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            implementationHandle,
+                            $"Method body 0x{MetadataTokens.GetToken(body):x8} belongs to type "
+                            + $"0x{MetadataTokens.GetToken(declaringType):x8}, not MethodImpl owner "
+                            + $"0x{MetadataTokens.GetToken(owningType):x8}."),
+                        owningType: owningType,
+                        owningTypeDefinition: owningTypeDefinition);
+                    continue;
+                }
 
-        return accessors;
-
-        void Add(MethodDefinitionHandle accessor)
-        {
-            if (!accessor.IsNil)
-                accessors.Add(accessor);
+                implementations.Add(
+                    new OwnedMethodImplementation(
+                        body,
+                        implementation.MethodDeclaration));
+            }
+            catch (Exception ex) when (
+                ex is BadImageFormatException or ArgumentOutOfRangeException)
+            {
+                AddInspectionFailure(
+                    surface,
+                    budget,
+                    "method implementation body",
+                    implementationHandle,
+                    MetadataTypeNameFailure.Malformed(
+                        implementationHandle,
+                        ex.Message),
+                    owningType: owningType,
+                    owningTypeDefinition: owningTypeDefinition);
+            }
         }
+        return implementations;
+        return implementations;
     }
 
     private static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(
         MetadataReader reader,
         TypeDefinition typeDef,
+        IReadOnlyList<OwnedMethodImplementation> implementations,
         MetadataTypeScope? currentScope,
-        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
+        Action<int>? beforeDecodeWork)
     {
         HashSet<MethodDefinitionHandle> handles = [];
-        foreach (var implementationHandle in typeDef.GetMethodImplementations())
+        foreach (var implementation in implementations)
         {
-            var implementation = reader.GetMethodImplementation(implementationHandle);
-            if (implementation.MethodBody.Kind == HandleKind.MethodDefinition
-                && TargetsImplementedInterface(
+            if (TargetsImplementedInterface(
                     reader,
                     typeDef,
-                    implementation.MethodDeclaration,
+                    implementation.Declaration,
                     currentScope,
-                    localTypes) is not InterfaceMethodImplOwnership.ProvenNonInterface)
+                    localTypes,
+                    beforeDecodeWork)
+                is not InterfaceMethodImplOwnership.ProvenNonInterface)
             {
-                handles.Add((MethodDefinitionHandle)implementation.MethodBody);
+                handles.Add(implementation.Body);
             }
         }
 
@@ -2833,7 +3109,8 @@ public static class ApiSurfaceExtractor
         TypeDefinition typeDef,
         EntityHandle declaration,
         MetadataTypeScope? currentScope,
-        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
+        Action<int>? beforeDecodeWork)
     {
         EntityHandle declaringType = declaration.Kind switch
         {
@@ -2869,15 +3146,17 @@ public static class ApiSurfaceExtractor
         var declarationIdentity = TryGetNamedTypeIdentity(
             reader,
             declaringType,
-            currentScope);
-        if (IsSystemObjectType(reader, declaringType)
+            currentScope,
+            beforeDecodeWork);
+        if (IsSystemObjectType(reader, declaringType, beforeDecodeWork)
             || TargetsClassHierarchy(
                 reader,
                 typeDef,
                 declaringType,
                 declarationIdentity,
                 currentScope,
-                localTypes))
+                localTypes,
+                beforeDecodeWork))
         {
             return InterfaceMethodImplOwnership.ProvenNonInterface;
         }
@@ -2894,13 +3173,15 @@ public static class ApiSurfaceExtractor
                 pending.Enqueue(reader.GetInterfaceImplementation(handle).Interface);
 
             var baseType = currentType.BaseType;
-            if (baseType.IsNil || IsSystemObjectType(reader, baseType))
+            if (baseType.IsNil
+                || IsSystemObjectType(reader, baseType, beforeDecodeWork))
                 break;
             if (!TryResolveKnownLocalType(
                     reader,
                     baseType,
                     currentScope,
                     localTypes,
+                    beforeDecodeWork,
                     out var baseDefinition)
                 || !visitedBaseTypes.Add(baseDefinition))
             {
@@ -2915,7 +3196,11 @@ public static class ApiSurfaceExtractor
         {
             if (interfaceType == declaringType)
                 return InterfaceMethodImplOwnership.ProvenInterface;
-            if (TryGetNamedTypeIdentity(reader, interfaceType, currentScope) is not { } interfaceIdentity)
+            if (TryGetNamedTypeIdentity(
+                    reader,
+                    interfaceType,
+                    currentScope,
+                    beforeDecodeWork) is not { } interfaceIdentity)
             {
                 hasUnresolvedExternalOwnership = true;
                 continue;
@@ -2928,7 +3213,8 @@ public static class ApiSurfaceExtractor
                     declaringType,
                     declarationIdentity,
                     currentScope,
-                    localTypes))
+                    localTypes,
+                    beforeDecodeWork))
                 return InterfaceMethodImplOwnership.ProvenInterface;
 
             // Same-module definitions let us close inherited InterfaceImpl edges.
@@ -2940,6 +3226,7 @@ public static class ApiSurfaceExtractor
                     interfaceType,
                     currentScope,
                     localTypes,
+                    beforeDecodeWork,
                     out var interfaceHandle))
             {
                 hasUnresolvedExternalOwnership = true;
@@ -2964,7 +3251,8 @@ public static class ApiSurfaceExtractor
         EntityHandle declaringType,
         MetadataNamedTypeIdentity? declarationIdentity,
         MetadataTypeScope? currentScope,
-        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
+        Action<int>? beforeDecodeWork)
     {
         EntityHandle baseType = typeDef.BaseType;
         HashSet<TypeDefinitionHandle> visited = [];
@@ -2972,7 +3260,11 @@ public static class ApiSurfaceExtractor
         {
             if (baseType == declaringType)
                 return true;
-            var baseIdentity = TryGetNamedTypeIdentity(reader, baseType, currentScope);
+            var baseIdentity = TryGetNamedTypeIdentity(
+                reader,
+                baseType,
+                currentScope,
+                beforeDecodeWork);
             if (declarationIdentity is not null
                 && baseIdentity is not null
                 && HaveSameNamedType(
@@ -2982,7 +3274,8 @@ public static class ApiSurfaceExtractor
                     declaringType,
                     declarationIdentity,
                     currentScope,
-                    localTypes))
+                    localTypes,
+                    beforeDecodeWork))
             {
                 return true;
             }
@@ -2991,6 +3284,7 @@ public static class ApiSurfaceExtractor
                     baseType,
                     currentScope,
                     localTypes,
+                    beforeDecodeWork,
                     out var baseDefinition)
                 || !visited.Add(baseDefinition))
             {
@@ -3009,10 +3303,17 @@ public static class ApiSurfaceExtractor
         ApiSurface surface,
         ExtractionBudget? budget)
     {
-        Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> types = [];
+        Action<int>? beforeDecodeWork =
+            budget is null ? null : budget.ObservePendingDecodeWork;
+        Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> types =
+            new(MetadataNamedTypeIdentityComparer.Instance);
         foreach (var handle in reader.TypeDefinitions)
         {
-            if (ReadDefinitionIdentity(reader, handle, currentScope) is { } identity)
+            if (ReadDefinitionIdentity(
+                    reader,
+                    handle,
+                    currentScope,
+                    beforeDecodeWork) is { } identity)
             {
                 if (!types.TryAdd(identity, handle))
                 {
@@ -3053,16 +3354,34 @@ public static class ApiSurfaceExtractor
         EntityHandle type,
         MetadataTypeScope? currentScope,
         IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
+        Action<int>? beforeDecodeWork,
         out TypeDefinitionHandle definition)
     {
-        if (TryResolvePhysicalLocalType(reader, type) is { } physical)
+        if (type.Kind != HandleKind.TypeReference
+            && TryResolvePhysicalLocalType(
+                reader,
+                type,
+                beforeDecodeWork) is { } physical)
         {
             definition = physical;
             return true;
         }
-        if (TryGetNamedTypeIdentity(reader, type, currentScope) is { } identity
+        if (TryGetNamedTypeIdentity(
+                reader,
+                type,
+                currentScope,
+                beforeDecodeWork) is { } identity
             && TryGetUniqueLocalType(localTypes, identity, out definition))
         {
+            return true;
+        }
+        if (type.Kind == HandleKind.TypeReference
+            && TryResolvePhysicalLocalType(
+                reader,
+                type,
+                beforeDecodeWork) is { } fallbackPhysical)
+        {
+            definition = fallbackPhysical;
             return true;
         }
 
@@ -3072,18 +3391,67 @@ public static class ApiSurfaceExtractor
 
     private static TypeDefinitionHandle? TryResolvePhysicalLocalType(
         MetadataReader reader,
-        EntityHandle type) =>
+        EntityHandle type,
+        Action<int>? beforeDecodeWork = null) =>
         type.Kind switch
         {
             HandleKind.TypeDefinition => (TypeDefinitionHandle)type,
+            HandleKind.TypeReference => TryResolveModuleScopedLocalType(
+                reader,
+                (TypeReferenceHandle)type,
+                beforeDecodeWork),
             HandleKind.TypeSpecification => GuardedProviderDecode.TypeSpec(
                 reader,
                 (TypeSpecificationHandle)type,
-                PhysicalLocalTypeProvider.Instance,
+                beforeDecodeWork is null
+                    ? PhysicalLocalTypeProvider.Instance
+                    : new PhysicalLocalTypeProvider(beforeDecodeWork),
                 context: null,
                 fallback: null),
             _ => null,
         };
+
+    private static TypeDefinitionHandle? TryResolveModuleScopedLocalType(
+        MetadataReader reader,
+        TypeReferenceHandle handle,
+        Action<int>? beforeDecodeWork)
+    {
+        Span<TypeReferenceHandle> rootToLeaf =
+            stackalloc TypeReferenceHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
+        if (!MetadataRelationshipTraversal.TryWalkTypeReferenceResolutionScope(
+                reader,
+                handle,
+                rootToLeaf,
+                out _,
+                out EntityHandle terminal,
+                out _)
+            || terminal.Kind != HandleKind.ModuleDefinition
+            || MetadataTypeDefinitionNameReader.Read(
+                reader,
+                handle,
+                beforeDecodeWork)
+                is not MetadataTypeDefinitionNameReadResult.Read read)
+        {
+            return null;
+        }
+
+        TypeDefinitionHandle match = default;
+        foreach (var candidate in reader.TypeDefinitions)
+        {
+            var result = MetadataTypeDefinitionNameReader.Matches(
+                reader,
+                candidate,
+                read.Name,
+                out _);
+            if (result != MetadataTypeDefinitionNameMatch.Match)
+                continue;
+            if (!match.IsNil)
+                return null;
+            match = candidate;
+        }
+
+        return match.IsNil ? null : match;
+    }
 
     private static bool HaveSameNamedType(
         MetadataReader reader,
@@ -3092,11 +3460,14 @@ public static class ApiSurfaceExtractor
         EntityHandle right,
         MetadataNamedTypeIdentity rightIdentity,
         MetadataTypeScope? currentScope,
-        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
+        Action<int>? beforeDecodeWork)
     {
         if (left == right)
             return true;
-        if (leftIdentity != rightIdentity)
+        if (!MetadataNamedTypeIdentityComparer.Instance.Equals(
+                leftIdentity,
+                rightIdentity))
             return false;
         if (!localTypes.ContainsKey(leftIdentity))
             return true;
@@ -3106,12 +3477,14 @@ public static class ApiSurfaceExtractor
                 left,
                 currentScope,
                 localTypes,
+                beforeDecodeWork,
                 out var leftDefinition)
             && TryResolveKnownLocalType(
                 reader,
                 right,
                 currentScope,
                 localTypes,
+                beforeDecodeWork,
                 out var rightDefinition)
             && leftDefinition == rightDefinition;
     }
@@ -3119,7 +3492,8 @@ public static class ApiSurfaceExtractor
     private static MetadataNamedTypeIdentity? TryGetNamedTypeIdentity(
         MetadataReader reader,
         EntityHandle handle,
-        MetadataTypeScope? currentScope) =>
+        MetadataTypeScope? currentScope,
+        Action<int>? beforeDecodeWork) =>
         handle.Kind switch
         {
             HandleKind.TypeDefinition => currentScope is null
@@ -3127,15 +3501,19 @@ public static class ApiSurfaceExtractor
                 : ReadDefinitionIdentity(
                     reader,
                     (TypeDefinitionHandle)handle,
-                    currentScope),
+                    currentScope,
+                    beforeDecodeWork),
             HandleKind.TypeReference => ReadReferenceIdentity(
                 reader,
                 (TypeReferenceHandle)handle,
-                currentScope),
+                currentScope,
+                beforeDecodeWork),
             HandleKind.TypeSpecification => GuardedProviderDecode.TypeSpec(
                 reader,
                 (TypeSpecificationHandle)handle,
-                new NamedTypeIdentityProvider(currentScope),
+                new NamedTypeIdentityProvider(
+                    currentScope,
+                    beforeDecodeWork),
                 context: null,
                 fallback: null),
             _ => null,
@@ -3144,8 +3522,12 @@ public static class ApiSurfaceExtractor
     private static MetadataNamedTypeIdentity? ReadDefinitionIdentity(
         MetadataReader reader,
         TypeDefinitionHandle handle,
-        MetadataTypeScope currentScope) =>
-        MetadataTypeDefinitionNameReader.Read(reader, handle)
+        MetadataTypeScope currentScope,
+        Action<int>? beforeDecodeWork) =>
+        MetadataTypeDefinitionNameReader.Read(
+            reader,
+            handle,
+            beforeDecodeWork)
             is MetadataTypeDefinitionNameReadResult.Read read
                 ? new(read.Name, currentScope)
                 : null;
@@ -3153,11 +3535,19 @@ public static class ApiSurfaceExtractor
     private static MetadataNamedTypeIdentity? ReadReferenceIdentity(
         MetadataReader reader,
         TypeReferenceHandle handle,
-        MetadataTypeScope? currentScope)
+        MetadataTypeScope? currentScope,
+        Action<int>? beforeDecodeWork)
     {
-        if (MetadataTypeDefinitionNameReader.Read(reader, handle)
+        if (MetadataTypeDefinitionNameReader.Read(
+                reader,
+                handle,
+                beforeDecodeWork)
                 is not MetadataTypeDefinitionNameReadResult.Read read
-            || ReferenceScope(reader, handle, currentScope) is not { } scope)
+            || ReferenceScope(
+                reader,
+                handle,
+                currentScope,
+                beforeDecodeWork) is not { } scope)
         {
             return null;
         }
@@ -3165,10 +3555,19 @@ public static class ApiSurfaceExtractor
         return new(read.Name, scope);
     }
 
-    private static MetadataTypeScope CurrentScope(MetadataReader reader) =>
+    private static MetadataTypeScope CurrentScope(
+        MetadataReader reader,
+        Action<int>? beforeDecodeWork) =>
         reader.IsAssembly
-            ? new(AssemblyReferenceIdentity.FromAssemblyDefinition(reader), null)
-            : new(null, reader.GetString(reader.GetModuleDefinition().Name));
+            ? new(
+                ReadAssemblyDefinitionIdentity(reader, beforeDecodeWork),
+                null)
+            : new(
+                null,
+                DecodeString(
+                    reader,
+                    reader.GetModuleDefinition().Name,
+                    beforeDecodeWork));
 
     private static MetadataTypeScope? ReadCurrentScope(
         MetadataReader reader,
@@ -3177,7 +3576,9 @@ public static class ApiSurfaceExtractor
     {
         try
         {
-            return CurrentScope(reader);
+            return CurrentScope(
+                reader,
+                budget is null ? null : budget.ObservePendingDecodeWork);
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
         {
@@ -3196,7 +3597,8 @@ public static class ApiSurfaceExtractor
     private static MetadataTypeScope? ReferenceScope(
         MetadataReader reader,
         TypeReferenceHandle handle,
-        MetadataTypeScope? currentScope)
+        MetadataTypeScope? currentScope,
+        Action<int>? beforeDecodeWork)
     {
         Span<TypeReferenceHandle> rootToLeaf =
             stackalloc TypeReferenceHandle[MetadataSafetyPolicy.MaxRelationshipNodes];
@@ -3218,15 +3620,68 @@ public static class ApiSurfaceExtractor
             HandleKind.ModuleDefinition => currentScope,
             HandleKind.ModuleReference => new(
                 null,
-                reader.GetString(
-                    reader.GetModuleReference((ModuleReferenceHandle)terminal).Name)),
-            HandleKind.AssemblyReference => new(
-                AssemblyReferenceIdentity.From(
+                DecodeString(
                     reader,
-                    (AssemblyReferenceHandle)terminal),
+                    reader.GetModuleReference((ModuleReferenceHandle)terminal).Name,
+                    beforeDecodeWork)),
+            HandleKind.AssemblyReference => new(
+                ReadAssemblyReferenceIdentity(
+                    reader,
+                    (AssemblyReferenceHandle)terminal,
+                    beforeDecodeWork),
                 null),
             _ => null,
         };
+    }
+
+    private static AssemblyReferenceIdentity ReadAssemblyDefinitionIdentity(
+        MetadataReader reader,
+        Action<int>? beforeDecodeWork)
+    {
+        if (!reader.IsAssembly)
+            throw new BadImageFormatException("The metadata image is not an assembly.");
+
+        var definition = reader.GetAssemblyDefinition();
+        if (!definition.PublicKey.IsNil)
+        {
+            beforeDecodeWork?.Invoke(
+                reader.GetBlobReader(definition.PublicKey).Length);
+        }
+        return new AssemblyReferenceIdentity(
+            DecodeString(reader, definition.Name, beforeDecodeWork),
+            definition.Version,
+            definition.Culture.IsNil
+                ? null
+                : DecodeString(
+                    reader,
+                    definition.Culture,
+                    beforeDecodeWork),
+            AssemblyReferenceIdentity.TokenOrNull(
+                reader,
+                definition.PublicKey,
+                isPublicKey: true));
+    }
+
+    private static AssemblyReferenceIdentity ReadAssemblyReferenceIdentity(
+        MetadataReader reader,
+        AssemblyReferenceHandle handle,
+        Action<int>? beforeDecodeWork)
+    {
+        var reference = reader.GetAssemblyReference(handle);
+        beforeDecodeWork?.Invoke(reader.GetBlobReader(reference.Name).Length);
+        if (!reference.Culture.IsNil)
+        {
+            beforeDecodeWork?.Invoke(
+                reader.GetBlobReader(reference.Culture).Length);
+        }
+        if (!reference.PublicKeyOrToken.IsNil)
+        {
+            beforeDecodeWork?.Invoke(
+                reader.GetBlobReader(reference.PublicKeyOrToken).Length);
+        }
+        return AssemblyReferenceIdentity.From(
+            handle,
+            AssemblyReferenceIdentity.RetainedProjection(reader));
     }
 
     private sealed record MetadataTypeScope(
@@ -3237,13 +3692,53 @@ public static class ApiSurfaceExtractor
         MetadataTypeDefinitionName Name,
         MetadataTypeScope Scope);
 
+    private sealed class MetadataNamedTypeIdentityComparer :
+        IEqualityComparer<MetadataNamedTypeIdentity>
+    {
+        internal static MetadataNamedTypeIdentityComparer Instance { get; } =
+            new();
+
+        public bool Equals(
+            MetadataNamedTypeIdentity? left,
+            MetadataNamedTypeIdentity? right) =>
+            ReferenceEquals(left, right)
+            || left is not null
+                && right is not null
+                && left.Name == right.Name
+                && AssemblyReferenceIdentity.EquivalentComparer.Equals(
+                    left.Scope.Assembly,
+                    right.Scope.Assembly)
+                && StringComparer.Ordinal.Equals(
+                    left.Scope.Module,
+                    right.Scope.Module);
+
+        public int GetHashCode(MetadataNamedTypeIdentity identity)
+        {
+            var hash = new HashCode();
+            hash.Add(identity.Name);
+            hash.Add(
+                identity.Scope.Assembly is null
+                    ? 0
+                    : AssemblyReferenceIdentity.EquivalentComparer.GetHashCode(
+                        identity.Scope.Assembly));
+            hash.Add(identity.Scope.Module, StringComparer.Ordinal);
+            return hash.ToHashCode();
+        }
+    }
+
     private sealed class NamedTypeIdentityProvider :
         ISignatureTypeProvider<MetadataNamedTypeIdentity?, object?>
     {
         private readonly MetadataTypeScope? currentScope;
+        private readonly Action<int>? beforeDecodeWork;
 
-        internal NamedTypeIdentityProvider(MetadataTypeScope? currentScope) =>
+        internal NamedTypeIdentityProvider(
+            MetadataTypeScope? currentScope,
+            Action<int>? beforeDecodeWork)
+        {
             this.currentScope = currentScope;
+            this.beforeDecodeWork = beforeDecodeWork;
+        }
 
         public MetadataNamedTypeIdentity? GetTypeFromDefinition(
             MetadataReader reader,
@@ -3251,13 +3746,21 @@ public static class ApiSurfaceExtractor
             byte rawTypeKind) =>
             currentScope is null
                 ? null
-                : ReadDefinitionIdentity(reader, handle, currentScope);
+                : ReadDefinitionIdentity(
+                    reader,
+                    handle,
+                    currentScope,
+                    beforeDecodeWork);
 
         public MetadataNamedTypeIdentity? GetTypeFromReference(
             MetadataReader reader,
             TypeReferenceHandle handle,
             byte rawTypeKind) =>
-            ReadReferenceIdentity(reader, handle, currentScope);
+            ReadReferenceIdentity(
+                reader,
+                handle,
+                currentScope,
+                beforeDecodeWork);
 
         public MetadataNamedTypeIdentity? GetTypeFromSpecification(
             MetadataReader reader,
@@ -3273,44 +3776,111 @@ public static class ApiSurfaceExtractor
 
         public MetadataNamedTypeIdentity? GetGenericInstantiation(
             MetadataNamedTypeIdentity? genericType,
-            ImmutableArray<MetadataNamedTypeIdentity?> typeArguments) =>
+            ImmutableArray<MetadataNamedTypeIdentity?> typeArguments)
+        {
+            Observe(checked(16L + typeArguments.Length * 8L));
             // Interface ownership follows the generic type definition while the
             // MethodImpl signature remains responsible for constructed arguments.
-            genericType;
+            return genericType;
+        }
 
         public MetadataNamedTypeIdentity? GetModifiedType(
             MetadataNamedTypeIdentity? modifier,
             MetadataNamedTypeIdentity? unmodifiedType,
-            bool isRequired) =>
-            unmodifiedType;
+            bool isRequired)
+        {
+            Observe(16);
+            return unmodifiedType;
+        }
 
-        public MetadataNamedTypeIdentity? GetPrimitiveType(PrimitiveTypeCode typeCode) => null;
-        public MetadataNamedTypeIdentity? GetSZArrayType(MetadataNamedTypeIdentity? elementType) => null;
-        public MetadataNamedTypeIdentity? GetArrayType(MetadataNamedTypeIdentity? elementType, ArrayShape shape) => null;
-        public MetadataNamedTypeIdentity? GetByReferenceType(MetadataNamedTypeIdentity? elementType) => null;
-        public MetadataNamedTypeIdentity? GetPointerType(MetadataNamedTypeIdentity? elementType) => null;
-        public MetadataNamedTypeIdentity? GetPinnedType(MetadataNamedTypeIdentity? elementType) => elementType;
-        public MetadataNamedTypeIdentity? GetGenericTypeParameter(object? context, int index) => null;
-        public MetadataNamedTypeIdentity? GetGenericMethodParameter(object? context, int index) => null;
-        public MetadataNamedTypeIdentity? GetFunctionPointerType(MethodSignature<MetadataNamedTypeIdentity?> signature) => null;
+        public MetadataNamedTypeIdentity? GetPrimitiveType(PrimitiveTypeCode typeCode)
+        {
+            Observe(16);
+            return null;
+        }
+        public MetadataNamedTypeIdentity? GetSZArrayType(MetadataNamedTypeIdentity? elementType)
+        {
+            Observe(16);
+            return null;
+        }
+        public MetadataNamedTypeIdentity? GetArrayType(
+            MetadataNamedTypeIdentity? elementType,
+            ArrayShape shape)
+        {
+            Observe(16L + Math.Max(shape.Rank, 0));
+            return null;
+        }
+        public MetadataNamedTypeIdentity? GetByReferenceType(
+            MetadataNamedTypeIdentity? elementType)
+        {
+            Observe(16);
+            return null;
+        }
+        public MetadataNamedTypeIdentity? GetPointerType(
+            MetadataNamedTypeIdentity? elementType)
+        {
+            Observe(16);
+            return null;
+        }
+        public MetadataNamedTypeIdentity? GetPinnedType(
+            MetadataNamedTypeIdentity? elementType)
+        {
+            Observe(16);
+            return elementType;
+        }
+        public MetadataNamedTypeIdentity? GetGenericTypeParameter(
+            object? context,
+            int index)
+        {
+            Observe(16);
+            return null;
+        }
+        public MetadataNamedTypeIdentity? GetGenericMethodParameter(
+            object? context,
+            int index)
+        {
+            Observe(16);
+            return null;
+        }
+        public MetadataNamedTypeIdentity? GetFunctionPointerType(
+            MethodSignature<MetadataNamedTypeIdentity?> signature)
+        {
+            Observe(checked(16L + signature.ParameterTypes.Length * 8L));
+            return null;
+        }
+
+        private void Observe(long units) =>
+            beforeDecodeWork?.Invoke((int)Math.Min(units, int.MaxValue));
     }
 
     private sealed class PhysicalLocalTypeProvider :
         ISignatureTypeProvider<TypeDefinitionHandle?, object?>
     {
-        internal static PhysicalLocalTypeProvider Instance { get; } = new();
+        private readonly Action<int>? beforeDecodeWork;
+
+        internal static PhysicalLocalTypeProvider Instance { get; } =
+            new(beforeDecodeWork: null);
+
+        internal PhysicalLocalTypeProvider(Action<int>? beforeDecodeWork) =>
+            this.beforeDecodeWork = beforeDecodeWork;
 
         public TypeDefinitionHandle? GetTypeFromDefinition(
             MetadataReader reader,
             TypeDefinitionHandle handle,
-            byte rawTypeKind) =>
-            handle;
+            byte rawTypeKind)
+        {
+            Observe(16);
+            return handle;
+        }
 
         public TypeDefinitionHandle? GetTypeFromReference(
             MetadataReader reader,
             TypeReferenceHandle handle,
             byte rawTypeKind) =>
-            null;
+            TryResolveModuleScopedLocalType(
+                reader,
+                handle,
+                beforeDecodeWork);
 
         public TypeDefinitionHandle? GetTypeFromSpecification(
             MetadataReader reader,
@@ -3326,24 +3896,79 @@ public static class ApiSurfaceExtractor
 
         public TypeDefinitionHandle? GetGenericInstantiation(
             TypeDefinitionHandle? genericType,
-            ImmutableArray<TypeDefinitionHandle?> typeArguments) =>
-            genericType;
+            ImmutableArray<TypeDefinitionHandle?> typeArguments)
+        {
+            Observe(checked(16L + typeArguments.Length * 8L));
+            return genericType;
+        }
 
         public TypeDefinitionHandle? GetModifiedType(
             TypeDefinitionHandle? modifier,
             TypeDefinitionHandle? unmodifiedType,
-            bool isRequired) =>
-            unmodifiedType;
+            bool isRequired)
+        {
+            Observe(16);
+            return unmodifiedType;
+        }
 
-        public TypeDefinitionHandle? GetPrimitiveType(PrimitiveTypeCode typeCode) => null;
-        public TypeDefinitionHandle? GetSZArrayType(TypeDefinitionHandle? elementType) => null;
-        public TypeDefinitionHandle? GetArrayType(TypeDefinitionHandle? elementType, ArrayShape shape) => null;
-        public TypeDefinitionHandle? GetByReferenceType(TypeDefinitionHandle? elementType) => null;
-        public TypeDefinitionHandle? GetPointerType(TypeDefinitionHandle? elementType) => null;
-        public TypeDefinitionHandle? GetPinnedType(TypeDefinitionHandle? elementType) => elementType;
-        public TypeDefinitionHandle? GetGenericTypeParameter(object? context, int index) => null;
-        public TypeDefinitionHandle? GetGenericMethodParameter(object? context, int index) => null;
-        public TypeDefinitionHandle? GetFunctionPointerType(MethodSignature<TypeDefinitionHandle?> signature) => null;
+        public TypeDefinitionHandle? GetPrimitiveType(PrimitiveTypeCode typeCode)
+        {
+            Observe(16);
+            return null;
+        }
+        public TypeDefinitionHandle? GetSZArrayType(TypeDefinitionHandle? elementType)
+        {
+            Observe(16);
+            return null;
+        }
+        public TypeDefinitionHandle? GetArrayType(
+            TypeDefinitionHandle? elementType,
+            ArrayShape shape)
+        {
+            Observe(16L + Math.Max(shape.Rank, 0));
+            return null;
+        }
+        public TypeDefinitionHandle? GetByReferenceType(
+            TypeDefinitionHandle? elementType)
+        {
+            Observe(16);
+            return null;
+        }
+        public TypeDefinitionHandle? GetPointerType(
+            TypeDefinitionHandle? elementType)
+        {
+            Observe(16);
+            return null;
+        }
+        public TypeDefinitionHandle? GetPinnedType(
+            TypeDefinitionHandle? elementType)
+        {
+            Observe(16);
+            return elementType;
+        }
+        public TypeDefinitionHandle? GetGenericTypeParameter(
+            object? context,
+            int index)
+        {
+            Observe(16);
+            return null;
+        }
+        public TypeDefinitionHandle? GetGenericMethodParameter(
+            object? context,
+            int index)
+        {
+            Observe(16);
+            return null;
+        }
+        public TypeDefinitionHandle? GetFunctionPointerType(
+            MethodSignature<TypeDefinitionHandle?> signature)
+        {
+            Observe(checked(16L + signature.ParameterTypes.Length * 8L));
+            return null;
+        }
+
+        private void Observe(long units) =>
+            beforeDecodeWork?.Invoke((int)Math.Min(units, int.MaxValue));
     }
 
     /// <summary>
@@ -3357,20 +3982,17 @@ public static class ApiSurfaceExtractor
     /// </summary>
     private static HashSet<MethodDefinitionHandle> GetObjectFinalizeOverrides(
         MetadataReader reader,
-        TypeDefinition typeDef,
+        IReadOnlyList<OwnedMethodImplementation> implementations,
         Action<int>? beforeDecodeWork = null)
     {
         HashSet<MethodDefinitionHandle> handles = [];
-        foreach (var implementationHandle in typeDef.GetMethodImplementations())
+        foreach (var implementation in implementations)
         {
-            var implementation = reader.GetMethodImplementation(implementationHandle);
-            if (implementation.MethodBody.Kind != HandleKind.MethodDefinition)
-                continue;
             if (ReferencesObjectFinalize(
                     reader,
-                    implementation.MethodDeclaration,
+                    implementation.Declaration,
                     beforeDecodeWork))
-                handles.Add((MethodDefinitionHandle)implementation.MethodBody);
+                handles.Add(implementation.Body);
         }
 
         return handles;
@@ -3409,7 +4031,12 @@ public static class ApiSurfaceExtractor
         }
 
         // No MethodImpl: fall back to the implicit-slot shape the VB.NET compiler emits.
-        return IsImplicitObjectFinalizeOverride(reader, typeHandle, method);
+        return IsImplicitObjectFinalizeOverride(
+            reader,
+            typeHandle,
+            method,
+            currentScope: null,
+            localTypes: null);
     }
 
     // A malformed or adversarial base-type chain can be arbitrarily long or cyclic; the visited-set
@@ -3440,6 +4067,8 @@ public static class ApiSurfaceExtractor
         MetadataReader reader,
         TypeDefinitionHandle typeDefHandle,
         MethodDefinition method,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?>? localTypes,
         Action<int>? beforeDecodeWork = null)
     {
         if (!string.Equals(
@@ -3459,7 +4088,10 @@ public static class ApiSurfaceExtractor
             return false;
         if (method.GetGenericParameters().Count != 0)
             return false;
-        if (!HasVoidNullaryInstanceSignature(reader, method))
+        if (!HasVoidNullaryInstanceSignature(
+                reader,
+                method,
+                beforeDecodeWork))
             return false;
 
         // Walk the base-type chain. The slot roots at whichever ancestor first declares a
@@ -3474,15 +4106,29 @@ public static class ApiSurfaceExtractor
             if (baseHandle.IsNil)
                 return false;
 
-            if (baseHandle.Kind == HandleKind.TypeReference)
-            {
-                // Reached a cross-assembly base: only System.Object roots the object.Finalize slot.
-                return IsSystemObjectType(
+            if (IsSystemObjectType(
                     reader,
                     baseHandle,
-                    beforeDecodeWork);
+                    beforeDecodeWork))
+            {
+                return true;
             }
-            if (TryResolvePhysicalLocalType(reader, baseHandle) is not { } baseTypeHandle
+
+            TypeDefinitionHandle? resolvedBase =
+                localTypes is not null
+                    && TryResolveKnownLocalType(
+                        reader,
+                        baseHandle,
+                        currentScope,
+                        localTypes,
+                        beforeDecodeWork,
+                        out var knownLocalBase)
+                        ? knownLocalBase
+                        : TryResolvePhysicalLocalType(
+                            reader,
+                            baseHandle,
+                            beforeDecodeWork);
+            if (resolvedBase is not { } baseTypeHandle
                 || !visited.Add(baseTypeHandle))
             {
                 return false;
@@ -3533,7 +4179,10 @@ public static class ApiSurfaceExtractor
             if ((attributes & MethodAttributes.Virtual) != 0
                 && (attributes & MethodAttributes.NewSlot) != 0
                 && method.GetGenericParameters().Count == 0
-                && HasVoidNullaryInstanceSignature(reader, method))
+                && HasVoidNullaryInstanceSignature(
+                    reader,
+                    method,
+                    beforeDecodeWork))
                 return true;
         }
 
@@ -3549,11 +4198,15 @@ public static class ApiSurfaceExtractor
     /// collision cannot masquerade as a finalizer. A malformed or truncated signature blob is treated
     /// as a non-match (returns false) rather than throwing.
     /// </summary>
-    private static bool HasVoidNullaryInstanceSignature(MetadataReader reader, MethodDefinition method)
+    private static bool HasVoidNullaryInstanceSignature(
+        MetadataReader reader,
+        MethodDefinition method,
+        Action<int>? beforeDecodeWork = null)
     {
         try
         {
             var blob = reader.GetBlobReader(method.Signature);
+            beforeDecodeWork?.Invoke(blob.Length);
             var header = blob.ReadSignatureHeader();
             // object.Finalize is `instance void ()` with the default managed calling convention.
             // Reject anything else: field/property sigs, vararg/unmanaged conventions, generic
@@ -3733,6 +4386,11 @@ public static class ApiSurfaceExtractor
             var assemblyRef = reader.GetAssemblyReference(handle);
             beforeDecodeWork?.Invoke(
                 reader.GetBlobReader(assemblyRef.Name).Length);
+            if (!assemblyRef.Culture.IsNil)
+            {
+                beforeDecodeWork?.Invoke(
+                    reader.GetBlobReader(assemblyRef.Culture).Length);
+            }
             if (!assemblyRef.PublicKeyOrToken.IsNil)
             {
                 beforeDecodeWork?.Invoke(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1137,33 +1137,6 @@ public static class ApiSurfaceExtractor
                 var isNewSlot = (methodAttributes & MethodAttributes.NewSlot) != 0;
                 var isOverride = isVirtual && !isNewSlot && !isRetainedExplicitImplementation && !isFinalizer;
 
-                // A class finalizer is the `object.Finalize` override the C#
-                // `~Type()` destructor compiles to. It is detected by the
-                // overridden slot (not by name/signature shape), which excludes
-                // the false positives a shape heuristic admits: an implicit
-                // generic `Finalize<T>()`, an override of an unrelated
-                // base/interface `Finalize()` slot, and an explicit
-                // `IFoo.Finalize()` implementation. There are two slot-anchored
-                // shapes:
-                //   * Roslyn (C#) emits an explicit `.override` MethodImpl
-                //     targeting `System.Object::Finalize`; `objectFinalizeOverrides`
-                //     carries those.
-                //   * The VB.NET compiler emits `Protected Overrides Sub Finalize()`
-                //     with NO MethodImpl — it reuses the inherited object.Finalize
-                //     slot implicitly; `IsImplicitObjectFinalizeOverride` proves
-                //     that slot roots at `System.Object` over metadata alone.
-                // A finalizer is never generic, so a method that overrides
-                // object.Finalize while declaring its own type parameters is still
-                // rejected — rendering it `~Type()` would erase `<T>`.
-                var isFinalizer = apiType.Kind == "class"
-                    && method.GetGenericParameters().Count == 0
-                    && (objectFinalizeOverrides.Contains(methodHandle)
-                        || IsImplicitObjectFinalizeOverride(
-                            reader,
-                            typeDefHandle,
-                            method,
-                            observeDecodeWork));
-
                 OperatorMetadata.DeclarationClassification?
                     operatorClassification = isOperator
                         ? constraintResolution?.ClassifyOperator(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -185,7 +185,11 @@ public static class ApiSurfaceExtractor
         var localTypes = currentScope is null
             ? []
             : LocalTypes(reader, currentScope, surface, budget: null);
-        var accessorMethods = AccessorMethods(reader, surface, budget: null);
+        var accessorMethods = ReadAccessorMethods(
+            reader,
+            surface,
+            budget: null,
+            currentScope: currentScope);
 
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
@@ -673,8 +677,12 @@ public static class ApiSurfaceExtractor
             ? []
             : LocalTypes(reader, currentScope, surface, budget);
         var accessorMethods = typesOnly
-            ? []
-            : AccessorMethods(reader, surface, budget);
+            ? new AccessorMethodOwnership()
+            : ReadAccessorMethods(
+                reader,
+                surface,
+                budget,
+                currentScope);
 
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
@@ -1043,6 +1051,7 @@ public static class ApiSurfaceExtractor
                         || methodAccess != MethodAttributes.Public
                         || methodName.Contains('.', StringComparison.Ordinal));
                 var isFinalizer = apiType.Kind == "class"
+                    && IsFinalizerOwner(reader, typeDef)
                     && method.GetGenericParameters().Count == 0
                     && (objectFinalizeOverrides.Contains(methodHandle)
                         || IsImplicitObjectFinalizeOverride(
@@ -1318,11 +1327,13 @@ public static class ApiSurfaceExtractor
                 var prop = reader.GetPropertyDefinition(propHandle);
                 var accessors = prop.GetAccessors();
                 MethodDefinitionHandle getterHandle =
-                    !accessors.Getter.IsNil && accessorMethods.Contains(accessors.Getter)
+                    !accessors.Getter.IsNil
+                    && accessorMethods.Contains(propHandle, accessors.Getter)
                         ? accessors.Getter
                         : default;
                 MethodDefinitionHandle setterHandle =
-                    !accessors.Setter.IsNil && accessorMethods.Contains(accessors.Setter)
+                    !accessors.Setter.IsNil
+                    && accessorMethods.Contains(propHandle, accessors.Setter)
                         ? accessors.Setter
                         : default;
                 if (getterHandle.IsNil && setterHandle.IsNil)
@@ -1737,6 +1748,7 @@ public static class ApiSurfaceExtractor
                         reader,
                         accessors,
                         accessorMethods,
+                        eventHandle,
                         includeAll,
                         out var selectedAccessors))
                 {
@@ -1969,7 +1981,7 @@ public static class ApiSurfaceExtractor
         ApiSurface surface,
         bool isExtensionClass,
         Dictionary<ApiMember, MetadataTypeDefinitionName> extensionReceiverDefinitions,
-        IReadOnlySet<MethodDefinitionHandle> accessorMethods,
+        AccessorMethodOwnership accessorMethods,
         MetadataTypeScope? currentScope,
         IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
     {
@@ -2005,6 +2017,7 @@ public static class ApiSurfaceExtractor
                     || methodAccess != MethodAttributes.Public
                     || methodName.Contains('.', StringComparison.Ordinal));
             bool isFinalizer = apiType.Kind == "class"
+                && IsFinalizerOwner(reader, typeDef)
                 && method.GetGenericParameters().Count == 0
                 && (objectFinalizeOverrides.Contains(methodHandle)
                     || IsImplicitObjectFinalizeOverride(
@@ -2067,11 +2080,13 @@ public static class ApiSurfaceExtractor
             var property = reader.GetPropertyDefinition(propertyHandle);
             var accessors = property.GetAccessors();
             MethodDefinitionHandle getterHandle =
-                !accessors.Getter.IsNil && accessorMethods.Contains(accessors.Getter)
+                !accessors.Getter.IsNil
+                && accessorMethods.Contains(propertyHandle, accessors.Getter)
                     ? accessors.Getter
                     : default;
             MethodDefinitionHandle setterHandle =
-                !accessors.Setter.IsNil && accessorMethods.Contains(accessors.Setter)
+                !accessors.Setter.IsNil
+                && accessorMethods.Contains(propertyHandle, accessors.Setter)
                     ? accessors.Setter
                     : default;
             if (getterHandle.IsNil && setterHandle.IsNil)
@@ -2130,6 +2145,7 @@ public static class ApiSurfaceExtractor
                     reader,
                     accessors,
                     accessorMethods,
+                    eventHandle,
                     includeAll: false,
                     out _))
             {
@@ -2255,12 +2271,13 @@ public static class ApiSurfaceExtractor
         }
     }
 
-    static HashSet<MethodDefinitionHandle> AccessorMethods(
+    static AccessorMethodOwnership ReadAccessorMethods(
         MetadataReader reader,
         ApiSurface surface,
-        ExtractionBudget? budget)
+        ExtractionBudget? budget,
+        MetadataTypeScope? currentScope)
     {
-        var methods = new HashSet<MethodDefinitionHandle>();
+        var methods = new AccessorMethodOwnership();
         foreach (var typeHandle in reader.TypeDefinitions)
         {
             try
@@ -2346,15 +2363,43 @@ public static class ApiSurfaceExtractor
             }
         }
 
-        methods.UnionWith(ExtensionPropertyImplementationMethods(reader, surface, budget));
+        methods.AddExtensionImplementations(
+            ExtensionPropertyImplementationMethods(
+                reader,
+                surface,
+                budget,
+                currentScope));
         return methods;
+    }
+
+    private sealed class AccessorMethodOwnership
+    {
+        readonly HashSet<MethodDefinitionHandle> _methods = [];
+        readonly HashSet<(EntityHandle Association, MethodDefinitionHandle Method)> _associations = [];
+
+        internal bool Contains(MethodDefinitionHandle method) => _methods.Contains(method);
+
+        internal bool Contains(EntityHandle association, MethodDefinitionHandle method)
+            => _associations.Contains((association, method));
+
+        internal void Add(EntityHandle association, MethodDefinitionHandle method)
+        {
+            _methods.Add(method);
+            _associations.Add((association, method));
+        }
+
+        internal void AddExtensionImplementations(
+            IEnumerable<MethodDefinitionHandle> methods)
+        {
+            _methods.UnionWith(methods);
+        }
     }
 
     private static void AddOwnedAccessor(
         MetadataReader reader,
         ApiSurface surface,
         ExtractionBudget? budget,
-        HashSet<MethodDefinitionHandle> methods,
+        AccessorMethodOwnership methods,
         TypeDefinitionHandle owningType,
         EntityHandle association,
         MethodDefinitionHandle accessor,
@@ -2368,7 +2413,7 @@ public static class ApiSurfaceExtractor
             var declaringType = reader.GetMethodDefinition(accessor).GetDeclaringType();
             if (declaringType == owningType)
             {
-                methods.Add(accessor);
+                methods.Add(association, accessor);
                 return;
             }
 
@@ -2403,7 +2448,8 @@ public static class ApiSurfaceExtractor
     private static bool TrySelectEventAccessors(
         MetadataReader reader,
         EventAccessors accessors,
-        IReadOnlySet<MethodDefinitionHandle> ownedAccessorMethods,
+        AccessorMethodOwnership ownedAccessorMethods,
+        EventDefinitionHandle association,
         bool includeAll,
         out EventAccessorSelection selection)
     {
@@ -2430,7 +2476,7 @@ public static class ApiSurfaceExtractor
         return true;
 
         MethodDefinitionHandle Owned(MethodDefinitionHandle handle) =>
-            !handle.IsNil && ownedAccessorMethods.Contains(handle)
+            !handle.IsNil && ownedAccessorMethods.Contains(association, handle)
                 ? handle
                 : default;
 
@@ -2453,7 +2499,8 @@ public static class ApiSurfaceExtractor
     static HashSet<MethodDefinitionHandle> ExtensionPropertyImplementationMethods(
         MetadataReader reader,
         ApiSurface surface,
-        ExtractionBudget? budget)
+        ExtractionBudget? budget,
+        MetadataTypeScope? currentScope)
     {
         Action<int>? beforeDecodeWork =
             budget is null ? null : budget.ObservePendingDecodeWork;
@@ -2532,6 +2579,7 @@ public static class ApiSurfaceExtractor
                                 reader,
                                 reader.GetMethodDefinition(markerMethodHandle),
                                 context,
+                                currentScope,
                                 beforeDecodeWork,
                                 out var markerSignature)
                             || markerSignature.ParameterTypes.Length != 1
@@ -2539,6 +2587,7 @@ public static class ApiSurfaceExtractor
                                 reader,
                                 property,
                                 context,
+                                currentScope,
                                 beforeDecodeWork,
                                 out var propertySignature))
                         {
@@ -2571,6 +2620,7 @@ public static class ApiSurfaceExtractor
                                         extensionClassContext,
                                         method,
                                         beforeDecodeWork),
+                                    currentScope,
                                     beforeDecodeWork,
                                     out var implementationSignature))
                             {
@@ -2591,9 +2641,14 @@ public static class ApiSurfaceExtractor
                                     includeValue: setter)
                                 && method.GetGenericParameters().Count == implementationGenericArity
                                 && (getter
-                                    ? implementationSignature.ReturnType
-                                        == propertySignature.ReturnType
-                                    : implementationSignature.ReturnType == "void"))
+                                    ? ExtensionSignatureTypesEqual(
+                                        implementationSignature.ReturnType,
+                                        propertySignature.ReturnType)
+                                    : implementationSignature.ReturnType
+                                        is PrimitiveExtensionSignatureType
+                                        {
+                                            TypeCode: PrimitiveTypeCode.Void
+                                        }))
                             {
                                 methods.Add(methodHandle);
                             }
@@ -2615,74 +2670,424 @@ public static class ApiSurfaceExtractor
     }
 
     private readonly record struct ExtensionDecodedSignature(
-        string ReturnType,
-        ImmutableArray<string> ParameterTypes);
+        ExtensionSignatureType ReturnType,
+        ImmutableArray<ExtensionSignatureType> ParameterTypes);
 
     private static bool TryDecodeExtensionSignature(
         MetadataReader reader,
         MethodDefinition method,
         GenericContext context,
+        MetadataTypeScope? currentScope,
         Action<int>? beforeDecodeWork,
         out ExtensionDecodedSignature signature)
     {
+        var provider = new ExtensionSignatureTypeProvider(
+            currentScope,
+            beforeDecodeWork);
         var decoded = GuardedProviderDecode.MethodResult(
             reader,
             method,
-            new TypeNodeProvider(
-                beforeRetain: null,
-                beforeMaterialize: beforeDecodeWork),
+            provider,
             context,
-            (TypeNode)new DegradedTypeNode());
-        return TryRenderExtensionSignature(decoded, beforeDecodeWork, out signature);
+            fallbackReturn: null);
+        return TryReadExtensionSignature(decoded, out signature);
     }
 
     private static bool TryDecodeExtensionSignature(
         MetadataReader reader,
         PropertyDefinition property,
         GenericContext context,
+        MetadataTypeScope? currentScope,
         Action<int>? beforeDecodeWork,
         out ExtensionDecodedSignature signature)
     {
+        var provider = new ExtensionSignatureTypeProvider(
+            currentScope,
+            beforeDecodeWork);
         var decoded = GuardedProviderDecode.PropertyResult(
             reader,
             property,
-            new TypeNodeProvider(
-                beforeRetain: null,
-                beforeMaterialize: beforeDecodeWork),
+            provider,
             context,
-            (TypeNode)new DegradedTypeNode());
-        return TryRenderExtensionSignature(decoded, beforeDecodeWork, out signature);
+            fallbackReturn: null);
+        return TryReadExtensionSignature(decoded, out signature);
     }
 
-    private static bool TryRenderExtensionSignature(
-        GuardedProviderDecode.DecodeResult<MethodSignature<TypeNode>> decoded,
-        Action<int>? beforeDecodeWork,
+    private static bool TryReadExtensionSignature(
+        GuardedProviderDecode.DecodeResult<
+            MethodSignature<ExtensionSignatureType?>> decoded,
         out ExtensionDecodedSignature signature)
     {
         if (decoded.IsDegraded
-            || decoded.Value.ReturnType.IsDegraded
-            || decoded.Value.ParameterTypes.Any(static parameter => parameter.IsDegraded))
+            || decoded.Value.ReturnType is null
+            || decoded.Value.ParameterTypes.Any(static parameter => parameter is null))
         {
             signature = default;
             return false;
         }
 
-        beforeDecodeWork?.Invoke(
-            checked(16 + decoded.Value.ParameterTypes.Length * 8));
-        var parameterTypes = ImmutableArray.CreateBuilder<string>(
+        var parameterTypes = ImmutableArray.CreateBuilder<ExtensionSignatureType>(
             decoded.Value.ParameterTypes.Length);
-        foreach (var parameter in decoded.Value.ParameterTypes)
-            parameterTypes.Add(parameter.Render());
+        foreach (ExtensionSignatureType? parameter in decoded.Value.ParameterTypes)
+            parameterTypes.Add(parameter!);
         signature = new ExtensionDecodedSignature(
-            decoded.Value.ReturnType.Render(),
+            decoded.Value.ReturnType,
             parameterTypes.MoveToImmutable());
         return true;
     }
 
+    private abstract record ExtensionSignatureType;
+
+    private sealed record PrimitiveExtensionSignatureType(
+        PrimitiveTypeCode TypeCode)
+        : ExtensionSignatureType;
+
+    private sealed record NamedExtensionSignatureType(
+        MetadataNamedTypeIdentity Identity)
+        : ExtensionSignatureType;
+
+    private sealed record ArrayExtensionSignatureType(
+        ExtensionSignatureType ElementType,
+        int Rank,
+        ImmutableArray<int> Sizes,
+        ImmutableArray<int> LowerBounds)
+        : ExtensionSignatureType;
+
+    private sealed record WrappedExtensionSignatureType(
+        ExtensionSignatureType ElementType,
+        ExtensionSignatureTypeKind Kind)
+        : ExtensionSignatureType;
+
+    private sealed record GenericExtensionSignatureType(
+        ExtensionSignatureType GenericType,
+        ImmutableArray<ExtensionSignatureType> TypeArguments)
+        : ExtensionSignatureType;
+
+    private sealed record GenericParameterExtensionSignatureType(
+        string? Name,
+        bool IsMethodParameter,
+        int Index)
+        : ExtensionSignatureType;
+
+    private sealed record FunctionPointerExtensionSignatureType(
+        SignatureCallingConvention CallingConvention,
+        SignatureAttributes Attributes,
+        int GenericParameterCount,
+        int RequiredParameterCount,
+        ImmutableArray<ExtensionSignatureType> ParameterTypes,
+        ExtensionSignatureType ReturnType)
+        : ExtensionSignatureType;
+
+    private sealed record ModifiedExtensionSignatureType(
+        ExtensionSignatureType Modifier,
+        ExtensionSignatureType UnmodifiedType,
+        bool IsRequired)
+        : ExtensionSignatureType;
+
+    private enum ExtensionSignatureTypeKind
+    {
+        SzArray,
+        ByReference,
+        Pointer,
+        Pinned,
+    }
+
+    private sealed class ExtensionSignatureTypeProvider(
+        MetadataTypeScope? currentScope,
+        Action<int>? beforeDecodeWork)
+        : ISignatureTypeProvider<ExtensionSignatureType?, GenericContext?>
+    {
+        public ExtensionSignatureType? GetPrimitiveType(
+            PrimitiveTypeCode typeCode)
+        {
+            Observe(16);
+            return new PrimitiveExtensionSignatureType(typeCode);
+        }
+
+        public ExtensionSignatureType? GetTypeFromDefinition(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            byte rawTypeKind)
+            => currentScope is null
+                ? null
+                : ReadDefinitionIdentity(
+                    reader,
+                    handle,
+                    currentScope,
+                    beforeDecodeWork) is { } identity
+                    ? new NamedExtensionSignatureType(identity)
+                    : null;
+
+        public ExtensionSignatureType? GetTypeFromReference(
+            MetadataReader reader,
+            TypeReferenceHandle handle,
+            byte rawTypeKind)
+            => ReadReferenceIdentity(
+                    reader,
+                    handle,
+                    currentScope,
+                    beforeDecodeWork) is { } identity
+                ? new NamedExtensionSignatureType(identity)
+                : null;
+
+        public ExtensionSignatureType? GetTypeFromSpecification(
+            MetadataReader reader,
+            GenericContext? context,
+            TypeSpecificationHandle handle,
+            byte rawTypeKind)
+            => GuardedProviderDecode.TypeSpec(
+                reader,
+                handle,
+                this,
+                context,
+                fallback: null);
+
+        public ExtensionSignatureType? GetSZArrayType(
+            ExtensionSignatureType? elementType)
+            => Wrap(elementType, ExtensionSignatureTypeKind.SzArray);
+
+        public ExtensionSignatureType? GetArrayType(
+            ExtensionSignatureType? elementType,
+            ArrayShape shape)
+        {
+            Observe(checked(16L + Math.Max(shape.Rank, 0)));
+            return elementType is null
+                ? null
+                : new ArrayExtensionSignatureType(
+                    elementType,
+                    shape.Rank,
+                    shape.Sizes,
+                    shape.LowerBounds);
+        }
+
+        public ExtensionSignatureType? GetByReferenceType(
+            ExtensionSignatureType? elementType)
+            => Wrap(elementType, ExtensionSignatureTypeKind.ByReference);
+
+        public ExtensionSignatureType? GetPointerType(
+            ExtensionSignatureType? elementType)
+            => Wrap(elementType, ExtensionSignatureTypeKind.Pointer);
+
+        public ExtensionSignatureType? GetPinnedType(
+            ExtensionSignatureType? elementType)
+            => Wrap(elementType, ExtensionSignatureTypeKind.Pinned);
+
+        public ExtensionSignatureType? GetGenericInstantiation(
+            ExtensionSignatureType? genericType,
+            ImmutableArray<ExtensionSignatureType?> typeArguments)
+        {
+            Observe(checked(16L + typeArguments.Length * 8L));
+            if (genericType is null
+                || typeArguments.Any(static argument => argument is null))
+            {
+                return null;
+            }
+
+            var arguments = ImmutableArray.CreateBuilder<ExtensionSignatureType>(
+                typeArguments.Length);
+            foreach (ExtensionSignatureType? argument in typeArguments)
+                arguments.Add(argument!);
+            return new GenericExtensionSignatureType(
+                genericType,
+                arguments.MoveToImmutable());
+        }
+
+        public ExtensionSignatureType? GetGenericTypeParameter(
+            GenericContext? context,
+            int index)
+            => GenericParameter(
+                context?.TypeParameters,
+                index,
+                isMethodParameter: false);
+
+        public ExtensionSignatureType? GetGenericMethodParameter(
+            GenericContext? context,
+            int index)
+            => GenericParameter(
+                context?.MethodParameters,
+                index,
+                isMethodParameter: true);
+
+        public ExtensionSignatureType? GetFunctionPointerType(
+            MethodSignature<ExtensionSignatureType?> signature)
+        {
+            Observe(checked(16L + signature.ParameterTypes.Length * 8L));
+            if (signature.ReturnType is null
+                || signature.ParameterTypes.Any(static parameter => parameter is null))
+            {
+                return null;
+            }
+
+            var parameters = ImmutableArray.CreateBuilder<ExtensionSignatureType>(
+                signature.ParameterTypes.Length);
+            foreach (ExtensionSignatureType? parameter in signature.ParameterTypes)
+                parameters.Add(parameter!);
+            return new FunctionPointerExtensionSignatureType(
+                signature.Header.CallingConvention,
+                signature.Header.Attributes,
+                signature.GenericParameterCount,
+                signature.RequiredParameterCount,
+                parameters.MoveToImmutable(),
+                signature.ReturnType);
+        }
+
+        public ExtensionSignatureType? GetModifiedType(
+            ExtensionSignatureType? modifier,
+            ExtensionSignatureType? unmodifiedType,
+            bool isRequired)
+        {
+            Observe(16);
+            return modifier is null || unmodifiedType is null
+                ? null
+                : new ModifiedExtensionSignatureType(
+                    modifier,
+                    unmodifiedType,
+                    isRequired);
+        }
+
+        ExtensionSignatureType? Wrap(
+            ExtensionSignatureType? elementType,
+            ExtensionSignatureTypeKind kind)
+        {
+            Observe(16);
+            return elementType is null
+                ? null
+                : new WrappedExtensionSignatureType(elementType, kind);
+        }
+
+        ExtensionSignatureType? GenericParameter(
+            IReadOnlyList<string>? parameters,
+            int index,
+            bool isMethodParameter)
+        {
+            Observe(16);
+            if (index < 0)
+                return null;
+
+            string? name = parameters is not null && index < parameters.Count
+                ? parameters[index]
+                : null;
+            return new GenericParameterExtensionSignatureType(
+                name,
+                isMethodParameter,
+                index);
+        }
+
+        void Observe(long units) =>
+            beforeDecodeWork?.Invoke((int)Math.Min(units, int.MaxValue));
+    }
+
+    // Extension markers join independently decoded property and implementation
+    // signatures, whose generic contexts may carry equivalent source names.
+    // MethodImpl ownership instead follows metadata identity, where that name
+    // bridge could turn unrelated generic parameters into the same interface.
+    // The structural representation remains shared so the guarded decoder and
+    // safety accounting have one owner; only this extension-specific comparison
+    // permits the source-name bridge.
+    private static bool ExtensionSignatureTypesEqual(
+        ExtensionSignatureType left,
+        ExtensionSignatureType right)
+        => SignatureTypesEqual(left, right, bridgeGenericParameterNames: true);
+
+    private static bool MethodImplSignatureTypesEqual(
+        ExtensionSignatureType left,
+        ExtensionSignatureType right)
+        => SignatureTypesEqual(left, right, bridgeGenericParameterNames: false);
+
+    private static bool SignatureTypesEqual(
+        ExtensionSignatureType left,
+        ExtensionSignatureType right,
+        bool bridgeGenericParameterNames)
+        => (left, right) switch
+        {
+            (PrimitiveExtensionSignatureType l, PrimitiveExtensionSignatureType r) =>
+                l.TypeCode == r.TypeCode,
+            (NamedExtensionSignatureType l, NamedExtensionSignatureType r) =>
+                MetadataNamedTypeIdentityComparer.Instance.Equals(
+                    l.Identity,
+                    r.Identity),
+            (ArrayExtensionSignatureType l, ArrayExtensionSignatureType r) =>
+                l.Rank == r.Rank
+                && l.Sizes.SequenceEqual(r.Sizes)
+                && l.LowerBounds.SequenceEqual(r.LowerBounds)
+                && SignatureTypesEqual(
+                    l.ElementType,
+                    r.ElementType,
+                    bridgeGenericParameterNames),
+            (WrappedExtensionSignatureType l, WrappedExtensionSignatureType r) =>
+                l.Kind == r.Kind
+                && SignatureTypesEqual(
+                    l.ElementType,
+                    r.ElementType,
+                    bridgeGenericParameterNames),
+            (GenericExtensionSignatureType l, GenericExtensionSignatureType r) =>
+                l.TypeArguments.Length == r.TypeArguments.Length
+                && SignatureTypesEqual(
+                    l.GenericType,
+                    r.GenericType,
+                    bridgeGenericParameterNames)
+                && SignatureTypeSequencesEqual(
+                    l.TypeArguments,
+                    r.TypeArguments,
+                    bridgeGenericParameterNames),
+            (GenericParameterExtensionSignatureType l, GenericParameterExtensionSignatureType r) =>
+                bridgeGenericParameterNames
+                && l.Name is not null
+                && r.Name is not null
+                    ? StringComparer.Ordinal.Equals(l.Name, r.Name)
+                    : l.IsMethodParameter == r.IsMethodParameter
+                    && l.Index == r.Index,
+            (FunctionPointerExtensionSignatureType l, FunctionPointerExtensionSignatureType r) =>
+                l.CallingConvention == r.CallingConvention
+                && l.Attributes == r.Attributes
+                && l.GenericParameterCount == r.GenericParameterCount
+                && l.RequiredParameterCount == r.RequiredParameterCount
+                && SignatureTypesEqual(
+                    l.ReturnType,
+                    r.ReturnType,
+                    bridgeGenericParameterNames)
+                && SignatureTypeSequencesEqual(
+                    l.ParameterTypes,
+                    r.ParameterTypes,
+                    bridgeGenericParameterNames),
+            (ModifiedExtensionSignatureType l, ModifiedExtensionSignatureType r) =>
+                l.IsRequired == r.IsRequired
+                && SignatureTypesEqual(
+                    l.Modifier,
+                    r.Modifier,
+                    bridgeGenericParameterNames)
+                && SignatureTypesEqual(
+                    l.UnmodifiedType,
+                    r.UnmodifiedType,
+                    bridgeGenericParameterNames),
+            _ => false,
+        };
+
+    private static bool SignatureTypeSequencesEqual(
+        ImmutableArray<ExtensionSignatureType> left,
+        ImmutableArray<ExtensionSignatureType> right,
+        bool bridgeGenericParameterNames)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        for (int index = 0; index < left.Length; index++)
+        {
+            if (!SignatureTypesEqual(
+                    left[index],
+                    right[index],
+                    bridgeGenericParameterNames))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     private static bool ExtensionParametersMatch(
-        ImmutableArray<string> implementation,
+        ImmutableArray<ExtensionSignatureType> implementation,
         ExtensionDecodedSignature property,
-        string receiver,
+        ExtensionSignatureType receiver,
         bool includeReceiver,
         bool includeValue)
     {
@@ -2695,28 +3100,25 @@ public static class ApiSurfaceExtractor
 
         int index = 0;
         if (includeReceiver
-            && !string.Equals(
+            && !ExtensionSignatureTypesEqual(
                 implementation[index++],
-                receiver,
-                StringComparison.Ordinal))
+                receiver))
         {
             return false;
         }
-        foreach (string parameter in property.ParameterTypes)
+        foreach (ExtensionSignatureType parameter in property.ParameterTypes)
         {
-            if (!string.Equals(
+            if (!ExtensionSignatureTypesEqual(
                     implementation[index++],
-                    parameter,
-                    StringComparison.Ordinal))
+                    parameter))
             {
                 return false;
             }
         }
         return !includeValue
-            || string.Equals(
+            || ExtensionSignatureTypesEqual(
                 implementation[index],
-                property.ReturnType,
-                StringComparison.Ordinal);
+                property.ReturnType);
     }
 
     private static bool HasAccessorName(
@@ -3365,17 +3767,35 @@ public static class ApiSurfaceExtractor
             return InterfaceMethodImplOwnership.ProvenNonInterface;
         }
 
-        foreach (var handle in typeDef.GetInterfaceImplementations())
-        {
-            if (reader.GetInterfaceImplementation(handle).Interface == declaringType)
-                return InterfaceMethodImplOwnership.ProvenInterface;
-        }
-
         var declarationIdentity = TryGetNamedTypeIdentity(
             reader,
             declaringType,
             currentScope,
             beforeDecodeWork);
+        var declarationSignature = TryGetExtensionSignatureType(
+            reader,
+            declaringType,
+            currentScope,
+            beforeDecodeWork);
+        foreach (var handle in typeDef.GetInterfaceImplementations())
+        {
+            EntityHandle interfaceType =
+                reader.GetInterfaceImplementation(handle).Interface;
+            if (interfaceType == declaringType
+                || declarationSignature is not null
+                && TryGetExtensionSignatureType(
+                        reader,
+                        interfaceType,
+                        currentScope,
+                        beforeDecodeWork) is { } interfaceSignature
+                && MethodImplSignatureTypesEqual(
+                    interfaceSignature,
+                    declarationSignature))
+            {
+                return InterfaceMethodImplOwnership.ProvenInterface;
+            }
+        }
+
         if (IsSystemObjectType(reader, declaringType, beforeDecodeWork)
             || TargetsClassHierarchy(
                 reader,
@@ -3389,16 +3809,41 @@ public static class ApiSurfaceExtractor
             return InterfaceMethodImplOwnership.ProvenNonInterface;
         }
 
-        var pending = new Queue<EntityHandle>();
-        HashSet<TypeDefinitionHandle> visitedLocalInterfaces = [];
+        var pending = new Queue<InterfaceImplementationCandidate>();
+        var visitedLocalInterfaces = new List<InterfaceImplementationCandidate>();
+        var traversalBudget = new InterfaceImplementationTraversalBudget(
+            beforeDecodeWork);
         bool hasUnresolvedExternalOwnership = declarationIdentity is null
+            || declarationSignature is null
             || !TryGetUniqueLocalType(localTypes, declarationIdentity, out _);
         var currentType = typeDef;
         HashSet<TypeDefinitionHandle> visitedBaseTypes = [];
         while (true)
         {
             foreach (var handle in currentType.GetInterfaceImplementations())
-                pending.Enqueue(reader.GetInterfaceImplementation(handle).Interface);
+            {
+                EntityHandle interfaceType =
+                    reader.GetInterfaceImplementation(handle).Interface;
+                if (TryGetExtensionSignatureType(
+                        reader,
+                        interfaceType,
+                        currentScope,
+                        beforeDecodeWork) is { } interfaceSignature)
+                {
+                    if (ContainsUnsubstitutedGenericParameter(interfaceSignature)
+                        || !traversalBudget.TryEnqueue(
+                            interfaceType,
+                            interfaceSignature,
+                            pending))
+                    {
+                        hasUnresolvedExternalOwnership = true;
+                    }
+                }
+                else
+                {
+                    hasUnresolvedExternalOwnership = true;
+                }
+            }
 
             var baseType = currentType.BaseType;
             if (baseType.IsNil
@@ -3420,30 +3865,16 @@ public static class ApiSurfaceExtractor
             currentType = reader.GetTypeDefinition(baseDefinition);
         }
 
-        while (pending.TryDequeue(out var interfaceType))
+        while (pending.TryDequeue(out var candidate))
         {
-            if (interfaceType == declaringType)
-                return InterfaceMethodImplOwnership.ProvenInterface;
-            if (TryGetNamedTypeIdentity(
-                    reader,
-                    interfaceType,
-                    currentScope,
-                    beforeDecodeWork) is not { } interfaceIdentity)
+            if (candidate.Handle == declaringType
+                || declarationSignature is not null
+                && MethodImplSignatureTypesEqual(
+                    candidate.Identity,
+                    declarationSignature))
             {
-                hasUnresolvedExternalOwnership = true;
-                continue;
-            }
-            if (declarationIdentity is not null
-                && HaveSameNamedType(
-                    reader,
-                    interfaceType,
-                    interfaceIdentity,
-                    declaringType,
-                    declarationIdentity,
-                    currentScope,
-                    localTypes,
-                    beforeDecodeWork))
                 return InterfaceMethodImplOwnership.ProvenInterface;
+            }
 
             // Same-module definitions let us close inherited InterfaceImpl edges.
             // External inheritance cannot be proven from this reader alone. Keep
@@ -3451,7 +3882,7 @@ public static class ApiSurfaceExtractor
             // extraction does not silently drop a possible explicit implementation.
             if (!TryResolveKnownLocalType(
                     reader,
-                    interfaceType,
+                    candidate.Handle,
                     currentScope,
                     localTypes,
                     beforeDecodeWork,
@@ -3460,18 +3891,432 @@ public static class ApiSurfaceExtractor
                 hasUnresolvedExternalOwnership = true;
                 continue;
             }
-            if (!visitedLocalInterfaces.Add(interfaceHandle))
+            if (visitedLocalInterfaces.Any(
+                    visited => visited.Handle == interfaceHandle
+                        && MethodImplSignatureTypesEqual(
+                            visited.Identity,
+                            candidate.Identity)))
+            {
                 continue;
+            }
+            visitedLocalInterfaces.Add(
+                new InterfaceImplementationCandidate(
+                    interfaceHandle,
+                    candidate.Identity));
 
             var interfaceDefinition = reader.GetTypeDefinition(interfaceHandle);
             foreach (var handle in interfaceDefinition.GetInterfaceImplementations())
-                pending.Enqueue(reader.GetInterfaceImplementation(handle).Interface);
+            {
+                EntityHandle inheritedInterface =
+                    reader.GetInterfaceImplementation(handle).Interface;
+                if (TryGetExtensionSignatureType(
+                        reader,
+                        inheritedInterface,
+                        currentScope,
+                        beforeDecodeWork) is not { } inheritedSignature)
+                {
+                    hasUnresolvedExternalOwnership = true;
+                    continue;
+                }
+
+                if (!traversalBudget.TrySubstitute(
+                        inheritedSignature,
+                        candidate.Identity,
+                        out var substitutedInterface)
+                    || ContainsUnsubstitutedGenericParameter(
+                        substitutedInterface)
+                    || !traversalBudget.TryEnqueue(
+                        inheritedInterface,
+                        substitutedInterface,
+                        pending))
+                {
+                    hasUnresolvedExternalOwnership = true;
+                }
+            }
         }
 
         return hasUnresolvedExternalOwnership
             ? InterfaceMethodImplOwnership.UnresolvedExternalInheritance
             : InterfaceMethodImplOwnership.ProvenNonInterface;
     }
+
+    private readonly record struct InterfaceImplementationCandidate(
+        EntityHandle Handle,
+        ExtensionSignatureType Identity);
+
+    /// <summary>
+    /// Bounds the constructed identities created while following InterfaceImpl
+    /// inheritance. The visited key must include arguments: handle-only keys
+    /// conflate distinct constructed interfaces, while a key containing every
+    /// construction does not terminate for <c>I&lt;T&gt; : I&lt;I&lt;T&gt;&gt;</c>.
+    /// A refused candidate is intentionally reported to the caller as
+    /// unresolved ownership, preserving the MethodImpl body rather than
+    /// confidently suppressing it as an ordinary method.
+    /// </summary>
+    private sealed class InterfaceImplementationTraversalBudget(
+        Action<int>? observeDecodeWork)
+    {
+        int _candidateCount;
+        int _workNodes;
+
+        internal bool TryEnqueue(
+            EntityHandle handle,
+            ExtensionSignatureType identity,
+            Queue<InterfaceImplementationCandidate> pending)
+        {
+            if (_candidateCount >=
+                    MetadataSafetyPolicy.MaxConstructedInterfaceImplementationCandidates
+                || !TryMeasureIdentity(identity, out int nodes)
+                || !TryCharge(nodes))
+            {
+                return false;
+            }
+
+            _candidateCount++;
+            pending.Enqueue(
+                new InterfaceImplementationCandidate(handle, identity));
+            return true;
+        }
+
+        internal bool TrySubstitute(
+            ExtensionSignatureType inheritedInterface,
+            ExtensionSignatureType constructedInterface,
+            out ExtensionSignatureType substitutedInterface)
+        {
+            if (!TryMeasureSubstitution(
+                    inheritedInterface,
+                    constructedInterface,
+                    out int nodes)
+                || !TryCharge(nodes))
+            {
+                substitutedInterface = default!;
+                return false;
+            }
+
+            substitutedInterface = SubstituteInterfaceTypeParameters(
+                inheritedInterface,
+                constructedInterface);
+            return true;
+        }
+
+        bool TryCharge(int nodes)
+        {
+            if (nodes > MetadataSafetyPolicy.MaxConstructedInterfaceImplementationWorkNodes
+                - _workNodes)
+            {
+                return false;
+            }
+
+            // This model is allocated by substitution after SRM decodes the
+            // metadata signature, so charge it through the same extraction-wide
+            // work ledger that pays for all other signature-derived shapes.
+            observeDecodeWork?.Invoke(nodes);
+            _workNodes += nodes;
+            return true;
+        }
+
+        static bool TryMeasureIdentity(
+            ExtensionSignatureType identity,
+            out int nodes)
+        {
+            nodes = 0;
+            return TryMeasureIdentity(identity, depth: 1, ref nodes);
+        }
+
+        static bool TryMeasureIdentity(
+            ExtensionSignatureType type,
+            int depth,
+            ref int nodes)
+        {
+            if (!TryCountNode(depth, ref nodes))
+                return false;
+
+            return type switch
+            {
+                PrimitiveExtensionSignatureType
+                    or NamedExtensionSignatureType
+                    or GenericParameterExtensionSignatureType => true,
+                ArrayExtensionSignatureType array => TryMeasureIdentity(
+                    array.ElementType,
+                    depth + 1,
+                    ref nodes),
+                WrappedExtensionSignatureType wrapped => TryMeasureIdentity(
+                    wrapped.ElementType,
+                    depth + 1,
+                    ref nodes),
+                GenericExtensionSignatureType generic =>
+                    TryMeasureIdentity(generic.GenericType, depth + 1, ref nodes)
+                    && TryMeasureIdentities(
+                        generic.TypeArguments,
+                        depth + 1,
+                        ref nodes),
+                FunctionPointerExtensionSignatureType functionPointer =>
+                    TryMeasureIdentity(
+                        functionPointer.ReturnType,
+                        depth + 1,
+                        ref nodes)
+                    && TryMeasureIdentities(
+                        functionPointer.ParameterTypes,
+                        depth + 1,
+                        ref nodes),
+                ModifiedExtensionSignatureType modified =>
+                    TryMeasureIdentity(modified.Modifier, depth + 1, ref nodes)
+                    && TryMeasureIdentity(
+                        modified.UnmodifiedType,
+                        depth + 1,
+                        ref nodes),
+                _ => false,
+            };
+        }
+
+        static bool TryMeasureIdentities(
+            ImmutableArray<ExtensionSignatureType> types,
+            int depth,
+            ref int nodes)
+        {
+            foreach (ExtensionSignatureType type in types)
+            {
+                if (!TryMeasureIdentity(type, depth, ref nodes))
+                    return false;
+            }
+            return true;
+        }
+
+        static bool TryMeasureSubstitution(
+            ExtensionSignatureType inheritedInterface,
+            ExtensionSignatureType constructedInterface,
+            out int nodes)
+        {
+            ImmutableArray<ExtensionSignatureType> arguments =
+                constructedInterface is GenericExtensionSignatureType generic
+                    ? generic.TypeArguments
+                    : [];
+            nodes = 0;
+            return TryMeasureSubstitution(
+                inheritedInterface,
+                arguments,
+                depth: 1,
+                ref nodes);
+        }
+
+        static bool TryMeasureSubstitution(
+            ExtensionSignatureType type,
+            ImmutableArray<ExtensionSignatureType> arguments,
+            int depth,
+            ref int nodes)
+        {
+            if (type is GenericParameterExtensionSignatureType
+                {
+                    IsMethodParameter: false,
+                    Index: var index
+                }
+                && index < arguments.Length)
+            {
+                return TryMeasureIdentity(arguments[index], depth, ref nodes);
+            }
+
+            if (!TryCountNode(depth, ref nodes))
+                return false;
+
+            return type switch
+            {
+                PrimitiveExtensionSignatureType
+                    or NamedExtensionSignatureType
+                    or GenericParameterExtensionSignatureType => true,
+                ArrayExtensionSignatureType array => TryMeasureSubstitution(
+                    array.ElementType,
+                    arguments,
+                    depth + 1,
+                    ref nodes),
+                WrappedExtensionSignatureType wrapped => TryMeasureSubstitution(
+                    wrapped.ElementType,
+                    arguments,
+                    depth + 1,
+                    ref nodes),
+                GenericExtensionSignatureType generic =>
+                    TryMeasureSubstitution(
+                        generic.GenericType,
+                        arguments,
+                        depth + 1,
+                        ref nodes)
+                    && TryMeasureSubstitutions(
+                        generic.TypeArguments,
+                        arguments,
+                        depth + 1,
+                        ref nodes),
+                FunctionPointerExtensionSignatureType functionPointer =>
+                    TryMeasureSubstitution(
+                        functionPointer.ReturnType,
+                        arguments,
+                        depth + 1,
+                        ref nodes)
+                    && TryMeasureSubstitutions(
+                        functionPointer.ParameterTypes,
+                        arguments,
+                        depth + 1,
+                        ref nodes),
+                ModifiedExtensionSignatureType modified =>
+                    TryMeasureSubstitution(
+                        modified.Modifier,
+                        arguments,
+                        depth + 1,
+                        ref nodes)
+                    && TryMeasureSubstitution(
+                        modified.UnmodifiedType,
+                        arguments,
+                        depth + 1,
+                        ref nodes),
+                _ => false,
+            };
+        }
+
+        static bool TryMeasureSubstitutions(
+            ImmutableArray<ExtensionSignatureType> types,
+            ImmutableArray<ExtensionSignatureType> arguments,
+            int depth,
+            ref int nodes)
+        {
+            foreach (ExtensionSignatureType type in types)
+            {
+                if (!TryMeasureSubstitution(
+                        type,
+                        arguments,
+                        depth,
+                        ref nodes))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        static bool TryCountNode(int depth, ref int nodes)
+        {
+            if (depth >
+                    MetadataSafetyPolicy.MaxConstructedInterfaceImplementationDepth
+                || nodes >=
+                    MetadataSafetyPolicy.MaxConstructedInterfaceImplementationWorkNodes)
+            {
+                return false;
+            }
+
+            nodes++;
+            return true;
+        }
+    }
+
+    private static bool ContainsUnsubstitutedGenericParameter(
+        ExtensionSignatureType type)
+        => type switch
+        {
+            GenericParameterExtensionSignatureType => true,
+            ArrayExtensionSignatureType array =>
+                ContainsUnsubstitutedGenericParameter(array.ElementType),
+            WrappedExtensionSignatureType wrapped =>
+                ContainsUnsubstitutedGenericParameter(wrapped.ElementType),
+            GenericExtensionSignatureType generic =>
+                ContainsUnsubstitutedGenericParameter(generic.GenericType)
+                || generic.TypeArguments.Any(
+                    ContainsUnsubstitutedGenericParameter),
+            FunctionPointerExtensionSignatureType functionPointer =>
+                ContainsUnsubstitutedGenericParameter(functionPointer.ReturnType)
+                || functionPointer.ParameterTypes.Any(
+                    ContainsUnsubstitutedGenericParameter),
+            ModifiedExtensionSignatureType modified =>
+                ContainsUnsubstitutedGenericParameter(modified.Modifier)
+                || ContainsUnsubstitutedGenericParameter(
+                    modified.UnmodifiedType),
+            _ => false,
+        };
+
+    private static ExtensionSignatureType? TryGetExtensionSignatureType(
+        MetadataReader reader,
+        EntityHandle handle,
+        MetadataTypeScope? currentScope,
+        Action<int>? beforeDecodeWork)
+    {
+        var provider = new ExtensionSignatureTypeProvider(
+            currentScope,
+            beforeDecodeWork);
+        return handle.Kind switch
+        {
+            HandleKind.TypeDefinition => provider.GetTypeFromDefinition(
+                reader,
+                (TypeDefinitionHandle)handle,
+                rawTypeKind: 0),
+            HandleKind.TypeReference => provider.GetTypeFromReference(
+                reader,
+                (TypeReferenceHandle)handle,
+                rawTypeKind: 0),
+            HandleKind.TypeSpecification => provider.GetTypeFromSpecification(
+                reader,
+                context: null,
+                handle: (TypeSpecificationHandle)handle,
+                rawTypeKind: 0),
+            _ => null,
+        };
+    }
+
+    private static ExtensionSignatureType SubstituteInterfaceTypeParameters(
+        ExtensionSignatureType type,
+        ExtensionSignatureType constructedInterface)
+    {
+        ImmutableArray<ExtensionSignatureType> arguments =
+            constructedInterface is GenericExtensionSignatureType generic
+                ? generic.TypeArguments
+                : [];
+        return SubstituteInterfaceTypeParameters(type, arguments);
+    }
+
+    private static ExtensionSignatureType SubstituteInterfaceTypeParameters(
+        ExtensionSignatureType type,
+        ImmutableArray<ExtensionSignatureType> arguments)
+        => type switch
+        {
+            GenericParameterExtensionSignatureType
+                {
+                    IsMethodParameter: false,
+                    Index: var index
+                }
+                when index < arguments.Length => arguments[index],
+            ArrayExtensionSignatureType array => new ArrayExtensionSignatureType(
+                SubstituteInterfaceTypeParameters(array.ElementType, arguments),
+                array.Rank,
+                array.Sizes,
+                array.LowerBounds),
+            WrappedExtensionSignatureType wrapped => new WrappedExtensionSignatureType(
+                SubstituteInterfaceTypeParameters(wrapped.ElementType, arguments),
+                wrapped.Kind),
+            GenericExtensionSignatureType generic => new GenericExtensionSignatureType(
+                SubstituteInterfaceTypeParameters(generic.GenericType, arguments),
+                generic.TypeArguments.Select(
+                    argument => SubstituteInterfaceTypeParameters(
+                        argument,
+                        arguments)).ToImmutableArray()),
+            FunctionPointerExtensionSignatureType functionPointer =>
+                new FunctionPointerExtensionSignatureType(
+                    functionPointer.CallingConvention,
+                    functionPointer.Attributes,
+                    functionPointer.GenericParameterCount,
+                    functionPointer.RequiredParameterCount,
+                    functionPointer.ParameterTypes.Select(
+                        parameter => SubstituteInterfaceTypeParameters(
+                            parameter,
+                            arguments)).ToImmutableArray(),
+                    SubstituteInterfaceTypeParameters(
+                        functionPointer.ReturnType,
+                        arguments)),
+            ModifiedExtensionSignatureType modified =>
+                new ModifiedExtensionSignatureType(
+                    SubstituteInterfaceTypeParameters(
+                        modified.Modifier,
+                        arguments),
+                    SubstituteInterfaceTypeParameters(
+                        modified.UnmodifiedType,
+                        arguments),
+                    modified.IsRequired),
+            _ => type,
+        };
 
     private static bool TargetsClassHierarchy(
         MetadataReader reader,
@@ -4241,6 +5086,8 @@ public static class ApiSurfaceExtractor
 
         var typeHandle = method.GetDeclaringType();
         var typeDef = reader.GetTypeDefinition(typeHandle);
+        if (!IsFinalizerOwner(reader, typeDef))
+            return false;
         foreach (var implementationHandle in typeDef.GetMethodImplementations())
         {
             var implementation = reader.GetMethodImplementation(implementationHandle);
@@ -4259,6 +5106,34 @@ public static class ApiSurfaceExtractor
             method,
             currentScope: null,
             localTypes: null);
+    }
+
+    private static bool IsFinalizerOwner(
+        MetadataReader reader,
+        TypeDefinition type)
+    {
+        if ((type.Attributes & TypeAttributes.Interface) != 0)
+            return false;
+
+        // Keep the PDB-only classifier aligned with API extraction's
+        // class-only gate. A malformed value type or delegate can carry a
+        // finalizer-shaped MethodImpl, but it is not a class destructor.
+        try
+        {
+            return TypeResolver.GetTypeName(reader, type.BaseType) is not (
+                "System.Enum"
+                or "System.ValueType"
+                or "System.Delegate"
+                or "System.MulticastDelegate");
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            // PDB projection has no surface failure channel. Treat a malformed
+            // owner as not proven to be a class instead of leaking a reader
+            // exception from a finalizer predicate.
+            return false;
+        }
     }
 
     // A malformed or adversarial base-type chain can be arbitrarily long or cyclic; the visited-set

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -222,7 +222,7 @@ public static class ApiSurfaceExtractor
                         MetadataDeclarationQuery.GetIntroducedTypeParameterCounts(
                             reader,
                             typeDefHandle),
-                    Kind = "class",
+                    Kind = SummaryTypeKind(reader, typeDef),
                     Members = []
                 };
 
@@ -666,11 +666,15 @@ public static class ApiSurfaceExtractor
                 }
             }
         }
-        var currentScope = ReadCurrentScope(reader, surface, budget);
-        var localTypes = currentScope is null
+        var currentScope = typesOnly
+            ? null
+            : ReadCurrentScope(reader, surface, budget);
+        var localTypes = typesOnly || currentScope is null
             ? []
             : LocalTypes(reader, currentScope, surface, budget);
-        var accessorMethods = AccessorMethods(reader, surface, budget);
+        var accessorMethods = typesOnly
+            ? []
+            : AccessorMethods(reader, surface, budget);
 
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
@@ -974,7 +978,10 @@ public static class ApiSurfaceExtractor
                 typeDef,
                 surface,
                 budget,
-                owningTypeDefinition);
+                owningTypeDefinition,
+                currentScope,
+                localTypes,
+                observeDecodeWork);
             var explicitImplementationBodies = GetExplicitImplementationBodies(
                 reader,
                 typeDef,
@@ -1337,6 +1344,16 @@ public static class ApiSurfaceExtractor
             {
                 var prop = reader.GetPropertyDefinition(propHandle);
                 var accessors = prop.GetAccessors();
+                MethodDefinitionHandle getterHandle =
+                    !accessors.Getter.IsNil && accessorMethods.Contains(accessors.Getter)
+                        ? accessors.Getter
+                        : default;
+                MethodDefinitionHandle setterHandle =
+                    !accessors.Setter.IsNil && accessorMethods.Contains(accessors.Setter)
+                        ? accessors.Setter
+                        : default;
+                if (getterHandle.IsNil && setterHandle.IsNil)
+                    continue;
 
                 // Determine best accessor visibility
                 MethodAttributes bestAccess = 0;
@@ -1345,9 +1362,9 @@ public static class ApiSurfaceExtractor
                 bool isAbstractProperty = false;
                 bool isOverrideProperty = false;
                 bool isSealedProperty = false;
-                if (!accessors.Getter.IsNil)
+                if (!getterHandle.IsNil)
                 {
-                    var getter = reader.GetMethodDefinition(accessors.Getter);
+                    var getter = reader.GetMethodDefinition(getterHandle);
                     var getterAttributes = getter.Attributes;
                     bestAccess = getter.Attributes & MethodAttributes.MemberAccessMask;
                     isStaticProperty = (getterAttributes & MethodAttributes.Static) != 0;
@@ -1356,9 +1373,9 @@ public static class ApiSurfaceExtractor
                     isOverrideProperty = isVirtualProperty && (getterAttributes & MethodAttributes.NewSlot) == 0;
                     isSealedProperty = isOverrideProperty && (getterAttributes & MethodAttributes.Final) != 0;
                 }
-                if (!accessors.Setter.IsNil)
+                if (!setterHandle.IsNil)
                 {
-                    var setter = reader.GetMethodDefinition(accessors.Setter);
+                    var setter = reader.GetMethodDefinition(setterHandle);
                     var setterAttributes = setter.Attributes;
                     var setterAccess = setterAttributes & MethodAttributes.MemberAccessMask;
                     if (setterAccess > bestAccess)
@@ -1394,7 +1411,8 @@ public static class ApiSurfaceExtractor
                     reader,
                     typeContext,
                     prop,
-                    accessors,
+                    getterHandle,
+                    setterHandle,
                     typeNullableContext,
                     includeAll,
                     observeText,
@@ -1471,20 +1489,20 @@ public static class ApiSurfaceExtractor
                         prop.GetCustomAttributes(),
                         observeText,
                         observeAttributeMaterialize),
-                    GetterToken = accessors.Getter.IsNil ? null : MetadataTokens.GetToken(accessors.Getter),
-                    SetterToken = accessors.Setter.IsNil ? null : MetadataTokens.GetToken(accessors.Setter),
-                    HasGetter = !accessors.Getter.IsNil,
-                    GetterAccessibility = accessors.Getter.IsNil
+                    GetterToken = getterHandle.IsNil ? null : MetadataTokens.GetToken(getterHandle),
+                    SetterToken = setterHandle.IsNil ? null : MetadataTokens.GetToken(setterHandle),
+                    HasGetter = !getterHandle.IsNil,
+                    GetterAccessibility = getterHandle.IsNil
                         ? null
                         : GetAccessibility(
-                            reader.GetMethodDefinition(accessors.Getter)
+                            reader.GetMethodDefinition(getterHandle)
                                 .Attributes
                                 & MethodAttributes.MemberAccessMask),
-                    HasSetter = !accessors.Setter.IsNil,
-                    SetterAccessibility = accessors.Setter.IsNil
+                    HasSetter = !setterHandle.IsNil,
+                    SetterAccessibility = setterHandle.IsNil
                         ? null
                         : GetAccessibility(
-                            reader.GetMethodDefinition(accessors.Setter)
+                            reader.GetMethodDefinition(setterHandle)
                                 .Attributes
                                 & MethodAttributes.MemberAccessMask),
                 };
@@ -1988,7 +2006,10 @@ public static class ApiSurfaceExtractor
             typeDef,
             surface,
             budget: null,
-            apiType.DefinitionName);
+            apiType.DefinitionName,
+            currentScope,
+            localTypes,
+            beforeDecodeWork: null);
         var explicitImplementationBodies = GetExplicitImplementationBodies(
             reader,
             typeDef,
@@ -2010,7 +2031,8 @@ public static class ApiSurfaceExtractor
                 && (!accessorMethods.Contains(methodHandle)
                     || methodAccess != MethodAttributes.Public
                     || methodName.Contains('.', StringComparison.Ordinal));
-            bool isFinalizer = method.GetGenericParameters().Count == 0
+            bool isFinalizer = apiType.Kind == "class"
+                && method.GetGenericParameters().Count == 0
                 && (objectFinalizeOverrides.Contains(methodHandle)
                     || IsImplicitObjectFinalizeOverride(
                         reader,
@@ -2070,15 +2092,26 @@ public static class ApiSurfaceExtractor
         {
             var property = reader.GetPropertyDefinition(propertyHandle);
             var accessors = property.GetAccessors();
+            MethodDefinitionHandle getterHandle =
+                !accessors.Getter.IsNil && accessorMethods.Contains(accessors.Getter)
+                    ? accessors.Getter
+                    : default;
+            MethodDefinitionHandle setterHandle =
+                !accessors.Setter.IsNil && accessorMethods.Contains(accessors.Setter)
+                    ? accessors.Setter
+                    : default;
+            if (getterHandle.IsNil && setterHandle.IsNil)
+                continue;
+
             MethodAttributes bestAccess = 0;
-            if (!accessors.Getter.IsNil)
+            if (!getterHandle.IsNil)
             {
-                bestAccess = reader.GetMethodDefinition(accessors.Getter).Attributes
+                bestAccess = reader.GetMethodDefinition(getterHandle).Attributes
                     & MethodAttributes.MemberAccessMask;
             }
-            if (!accessors.Setter.IsNil)
+            if (!setterHandle.IsNil)
             {
-                var setterAccess = reader.GetMethodDefinition(accessors.Setter).Attributes
+                var setterAccess = reader.GetMethodDefinition(setterHandle).Attributes
                     & MethodAttributes.MemberAccessMask;
                 if (setterAccess > bestAccess)
                     bestAccess = setterAccess;
@@ -2483,6 +2516,16 @@ public static class ApiSurfaceExtractor
                     {
                         var property = reader.GetPropertyDefinition(propertyHandle);
                         var accessors = property.GetAccessors();
+                        if (!accessors.Getter.IsNil
+                                && reader.GetMethodDefinition(accessors.Getter).GetDeclaringType()
+                                    != groupingTypeHandle
+                            || !accessors.Setter.IsNil
+                                && reader.GetMethodDefinition(accessors.Setter).GetDeclaringType()
+                                    != groupingTypeHandle)
+                        {
+                            continue;
+                        }
+
                         if (!TryGetExtensionMarkerName(
                                 reader,
                                 property,
@@ -2940,6 +2983,25 @@ public static class ApiSurfaceExtractor
             : (rootNamespace, fullName);
     }
 
+    private static string SummaryTypeKind(
+        MetadataReader reader,
+        TypeDefinition typeDef)
+    {
+        if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
+            return "interface";
+
+        if (typeDef.BaseType.IsNil)
+            return "class";
+
+        return TypeResolver.GetTypeName(reader, typeDef.BaseType) switch
+        {
+            "System.Enum" => "enum",
+            "System.ValueType" => "struct",
+            "System.Delegate" or "System.MulticastDelegate" => "delegate",
+            _ => "class"
+        };
+    }
+
     private static string GetMetadataName(
         MetadataReader reader,
         TypeDefinitionHandle handle)
@@ -3014,21 +3076,129 @@ public static class ApiSurfaceExtractor
         TypeDefinition typeDef,
         ApiSurface surface,
         ExtractionBudget? budget,
-        MetadataTypeDefinitionName? owningTypeDefinition)
+        MetadataTypeDefinitionName? owningTypeDefinition,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
+        Action<int>? beforeDecodeWork)
     {
         List<OwnedMethodImplementation> implementations = [];
+        HashSet<EntityHandle> declarations = [];
         foreach (var implementationHandle in typeDef.GetMethodImplementations())
         {
             try
             {
                 var implementation =
                     reader.GetMethodImplementation(implementationHandle);
-                if (implementation.MethodBody.Kind != HandleKind.MethodDefinition)
+                if (!declarations.Add(implementation.MethodDeclaration))
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "method implementation declaration",
+                        implementationHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            implementationHandle,
+                            $"Declaration 0x{MetadataTokens.GetToken(implementation.MethodDeclaration):x8} "
+                            + "appears more than once for the same MethodImpl owner."),
+                        owningType: owningType,
+                        owningTypeDefinition: owningTypeDefinition);
                     continue;
+                }
+
+                if (implementation.MethodBody.Kind == HandleKind.MemberReference)
+                {
+                    var memberReference = reader.GetMemberReference(
+                        (MemberReferenceHandle)implementation.MethodBody);
+                    if (TryResolveKnownLocalType(
+                            reader,
+                            memberReference.Parent,
+                            currentScope,
+                            localTypes,
+                            beforeDecodeWork,
+                            out var referencedType))
+                    {
+                        if (referencedType != owningType
+                            && !IsLocalBaseType(
+                                reader,
+                                owningType,
+                                referencedType,
+                                currentScope,
+                                localTypes,
+                                beforeDecodeWork))
+                        {
+                            AddInspectionFailure(
+                                surface,
+                                budget,
+                                "method implementation body",
+                                implementationHandle,
+                                MetadataTypeNameFailure.Malformed(
+                                    implementationHandle,
+                                    $"MemberRef body 0x{MetadataTokens.GetToken(implementation.MethodBody):x8} "
+                                    + $"belongs to unrelated type 0x{MetadataTokens.GetToken(referencedType):x8}."),
+                                owningType: owningType,
+                                owningTypeDefinition: owningTypeDefinition);
+                        }
+                        else if (referencedType == owningType)
+                        {
+                            var resolvedBody = ResolveLocalMemberReferenceBody(
+                                reader,
+                                referencedType,
+                                memberReference,
+                                beforeDecodeWork);
+                            if (resolvedBody is { } localBody)
+                            {
+                                implementations.Add(
+                                    new OwnedMethodImplementation(
+                                        localBody,
+                                        implementation.MethodDeclaration));
+                            }
+                            else if (memberReference.Parent.Kind
+                                != HandleKind.TypeSpecification)
+                            {
+                                AddInspectionFailure(
+                                    surface,
+                                    budget,
+                                    "method implementation body",
+                                    implementationHandle,
+                                    MetadataTypeNameFailure.Malformed(
+                                        implementationHandle,
+                                        $"MemberRef body 0x{MetadataTokens.GetToken(implementation.MethodBody):x8} "
+                                        + "does not identify one method on the MethodImpl owner."),
+                                    owningType: owningType,
+                                    owningTypeDefinition: owningTypeDefinition);
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                if (implementation.MethodBody.Kind != HandleKind.MethodDefinition)
+                {
+                    AddInspectionFailure(
+                        surface,
+                        budget,
+                        "method implementation body",
+                        implementationHandle,
+                        MetadataTypeNameFailure.Malformed(
+                            implementationHandle,
+                            $"Unsupported MethodImpl body kind {implementation.MethodBody.Kind}."),
+                        owningType: owningType,
+                        owningTypeDefinition: owningTypeDefinition);
+                    continue;
+                }
 
                 var body = (MethodDefinitionHandle)implementation.MethodBody;
                 var declaringType =
                     reader.GetMethodDefinition(body).GetDeclaringType();
+                if (declaringType != owningType
+                    && IsLocalBaseType(
+                        reader,
+                        owningType,
+                        declaringType,
+                        currentScope,
+                        localTypes,
+                        beforeDecodeWork))
+                    continue;
                 if (declaringType != owningType)
                 {
                     AddInspectionFailure(
@@ -3040,7 +3210,7 @@ public static class ApiSurfaceExtractor
                             implementationHandle,
                             $"Method body 0x{MetadataTokens.GetToken(body):x8} belongs to type "
                             + $"0x{MetadataTokens.GetToken(declaringType):x8}, not MethodImpl owner "
-                            + $"0x{MetadataTokens.GetToken(owningType):x8}."),
+                            + $"0x{MetadataTokens.GetToken(owningType):x8} or one of its base types."),
                         owningType: owningType,
                         owningTypeDefinition: owningTypeDefinition);
                     continue;
@@ -3068,6 +3238,91 @@ public static class ApiSurfaceExtractor
         }
         return implementations;
         return implementations;
+    }
+
+    private static MethodDefinitionHandle? ResolveLocalMemberReferenceBody(
+        MetadataReader reader,
+        TypeDefinitionHandle declaringType,
+        MemberReference memberReference,
+        Action<int>? beforeDecodeWork)
+    {
+        MethodDefinitionHandle match = default;
+        string memberName = DecodeString(
+            reader,
+            memberReference.Name,
+            beforeDecodeWork);
+        foreach (var candidateHandle in reader.GetTypeDefinition(declaringType).GetMethods())
+        {
+            var candidate = reader.GetMethodDefinition(candidateHandle);
+            if (!reader.StringComparer.Equals(candidate.Name, memberName)
+                || !SignaturesEqual(
+                    reader,
+                    candidate.Signature,
+                    memberReference.Signature,
+                    beforeDecodeWork))
+            {
+                continue;
+            }
+
+            if (!match.IsNil)
+                return null;
+            match = candidateHandle;
+        }
+
+        return match.IsNil ? null : match;
+    }
+
+    private static bool SignaturesEqual(
+        MetadataReader reader,
+        BlobHandle leftHandle,
+        BlobHandle rightHandle,
+        Action<int>? beforeDecodeWork)
+    {
+        var left = reader.GetBlobReader(leftHandle);
+        var right = reader.GetBlobReader(rightHandle);
+        beforeDecodeWork?.Invoke(checked(left.Length + right.Length));
+        if (left.Length != right.Length)
+            return false;
+
+        while (left.RemainingBytes > 0)
+        {
+            if (left.ReadByte() != right.ReadByte())
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsLocalBaseType(
+        MetadataReader reader,
+        TypeDefinitionHandle derivedType,
+        TypeDefinitionHandle candidateBase,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
+        Action<int>? beforeDecodeWork)
+    {
+        HashSet<TypeDefinitionHandle> visited = [derivedType];
+        var current = reader.GetTypeDefinition(derivedType);
+        for (int depth = 0; depth < MaxBaseChainDepth; depth++)
+        {
+            if (!TryResolveKnownLocalType(
+                    reader,
+                    current.BaseType,
+                    currentScope,
+                    localTypes,
+                    beforeDecodeWork,
+                    out var baseType)
+                || !visited.Add(baseType))
+            {
+                return false;
+            }
+
+            if (baseType == candidateBase)
+                return true;
+            current = reader.GetTypeDefinition(baseType);
+        }
+
+        return false;
     }
 
     private static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(
@@ -3325,7 +3580,8 @@ public static class ApiSurfaceExtractor
                         handle,
                         MetadataTypeNameFailure.Malformed(
                             handle,
-                            $"Duplicate type definition identity '{identity.Name}'."));
+                            "Duplicate type definition identity "
+                            + $"'{identity.Name.ToMetadataFullName()}'."));
                 }
             }
         }
@@ -3375,16 +3631,6 @@ public static class ApiSurfaceExtractor
         {
             return true;
         }
-        if (type.Kind == HandleKind.TypeReference
-            && TryResolvePhysicalLocalType(
-                reader,
-                type,
-                beforeDecodeWork) is { } fallbackPhysical)
-        {
-            definition = fallbackPhysical;
-            return true;
-        }
-
         definition = default;
         return false;
     }
@@ -3438,6 +3684,7 @@ public static class ApiSurfaceExtractor
         TypeDefinitionHandle match = default;
         foreach (var candidate in reader.TypeDefinitions)
         {
+            beforeDecodeWork?.Invoke(1);
             var result = MetadataTypeDefinitionNameReader.Matches(
                 reader,
                 candidate,
@@ -3974,11 +4221,10 @@ public static class ApiSurfaceExtractor
     /// <summary>
     /// The set of methods on <paramref name="typeDef"/> whose explicit
     /// <c>.override</c> MethodImpl targets <c>System.Object::Finalize</c> — the
-    /// slot a C# <c>~Type()</c> destructor compiles to. Keying on the overridden
-    /// declaration (not the method's own name/slot/signature) is what lets the
-    /// C# writer spell <c>~Type()</c> for real finalizers while excluding a
-    /// same-named override of an unrelated <c>Finalize</c> slot or an explicit
-    /// interface implementation.
+    /// slot a C# <c>~Type()</c> destructor compiles to. Requiring exact body and
+    /// declaration signatures lets the C# writer spell <c>~Type()</c> for real
+    /// finalizers while excluding malformed MethodImpl rows, an unrelated
+    /// <c>Finalize</c> slot, or an explicit interface implementation.
     /// </summary>
     private static HashSet<MethodDefinitionHandle> GetObjectFinalizeOverrides(
         MetadataReader reader,
@@ -3988,7 +4234,12 @@ public static class ApiSurfaceExtractor
         HashSet<MethodDefinitionHandle> handles = [];
         foreach (var implementation in implementations)
         {
-            if (ReferencesObjectFinalize(
+            var body = reader.GetMethodDefinition(implementation.Body);
+            if (IsFinalizerBodyShape(
+                    reader,
+                    body,
+                    beforeDecodeWork)
+                && ReferencesObjectFinalize(
                     reader,
                     implementation.Declaration,
                     beforeDecodeWork))
@@ -4012,9 +4263,7 @@ public static class ApiSurfaceExtractor
     internal static bool IsFinalizerMethod(MetadataReader reader, MethodDefinitionHandle methodHandle)
     {
         var method = reader.GetMethodDefinition(methodHandle);
-        if (!string.Equals(reader.GetString(method.Name), "Finalize", StringComparison.Ordinal))
-            return false;
-        if (method.GetGenericParameters().Count != 0)
+        if (!IsFinalizerBodyShape(reader, method))
             return false;
 
         var typeHandle = method.GetDeclaringType();
@@ -4201,11 +4450,20 @@ public static class ApiSurfaceExtractor
     private static bool HasVoidNullaryInstanceSignature(
         MetadataReader reader,
         MethodDefinition method,
+        Action<int>? beforeDecodeWork = null) =>
+        HasVoidNullaryInstanceSignature(
+            reader,
+            method.Signature,
+            beforeDecodeWork);
+
+    private static bool HasVoidNullaryInstanceSignature(
+        MetadataReader reader,
+        BlobHandle signature,
         Action<int>? beforeDecodeWork = null)
     {
         try
         {
-            var blob = reader.GetBlobReader(method.Signature);
+            var blob = reader.GetBlobReader(signature);
             beforeDecodeWork?.Invoke(blob.Length);
             var header = blob.ReadSignatureHeader();
             // object.Finalize is `instance void ()` with the default managed calling convention.
@@ -4254,8 +4512,32 @@ public static class ApiSurfaceExtractor
         }
     }
 
+    private static bool IsFinalizerBodyShape(
+        MetadataReader reader,
+        MethodDefinition method,
+        Action<int>? beforeDecodeWork = null)
+    {
+        if (!string.Equals(
+                DecodeString(reader, method.Name, beforeDecodeWork),
+                "Finalize",
+                StringComparison.Ordinal)
+            || method.GetGenericParameters().Count != 0)
+        {
+            return false;
+        }
+
+        var attributes = method.Attributes;
+        return (attributes & MethodAttributes.Static) == 0
+            && (attributes & MethodAttributes.Abstract) == 0
+            && HasVoidNullaryInstanceSignature(
+                reader,
+                method,
+                beforeDecodeWork);
+    }
+
     /// <summary>
-    /// <c>.override</c> MethodImpl) names <c>Finalize</c> on <c>System.Object</c>.
+    /// True when a <c>.override</c> MethodImpl declaration names the exact
+    /// <c>void System.Object::Finalize()</c> slot.
     /// The target is a <see cref="MemberReferenceHandle"/> in the common case
     /// (object lives in another assembly) and a <see cref="MethodDefinitionHandle"/>
     /// only when inspecting the assembly that defines <c>System.Object</c>.
@@ -4276,6 +4558,10 @@ public static class ApiSurfaceExtractor
                     && IsSystemObjectType(
                         reader,
                         memberRef.Parent,
+                        beforeDecodeWork)
+                    && HasVoidNullaryInstanceSignature(
+                        reader,
+                        memberRef.Signature,
                         beforeDecodeWork);
             case HandleKind.MethodDefinition:
                 var methodDef = reader.GetMethodDefinition((MethodDefinitionHandle)methodDeclaration);
@@ -4286,6 +4572,10 @@ public static class ApiSurfaceExtractor
                     && IsSystemObjectType(
                         reader,
                         methodDef.GetDeclaringType(),
+                        beforeDecodeWork)
+                    && HasVoidNullaryInstanceSignature(
+                        reader,
+                        methodDef,
                         beforeDecodeWork);
             default:
                 return false;
@@ -5913,7 +6203,8 @@ public static class ApiSurfaceExtractor
         MetadataReader reader,
         GenericContext context,
         PropertyDefinition prop,
-        PropertyAccessors accessors,
+        MethodDefinitionHandle getterHandle,
+        MethodDefinitionHandle setterHandle,
         byte typeNullableContext,
         bool includeAll = false,
         Action<string>? beforeRetainText = null,
@@ -5958,18 +6249,18 @@ public static class ApiSurfaceExtractor
         // Determine accessor visibility
         MethodAttributes getterAccess = 0;
         MethodAttributes setterAccess = 0;
-        bool hasGetter = !accessors.Getter.IsNil;
-        bool hasSetter = !accessors.Setter.IsNil;
+        bool hasGetter = !getterHandle.IsNil;
+        bool hasSetter = !setterHandle.IsNil;
 
         if (hasGetter)
         {
-            var getter = reader.GetMethodDefinition(accessors.Getter);
+            var getter = reader.GetMethodDefinition(getterHandle);
             getterAccess = getter.Attributes & MethodAttributes.MemberAccessMask;
         }
 
         if (hasSetter)
         {
-            var setter = reader.GetMethodDefinition(accessors.Setter);
+            var setter = reader.GetMethodDefinition(setterHandle);
             setterAccess = setter.Attributes & MethodAttributes.MemberAccessMask;
         }
 
@@ -5991,7 +6282,7 @@ public static class ApiSurfaceExtractor
                     Accessibility = AccessorAccessibility(getterAccess, Math.Max((int)getterAccess, (int)setterAccess)),
                     ReturnAttributes = ReturnParameterAttributes(
                         reader,
-                        reader.GetMethodDefinition(accessors.Getter).GetParameters(),
+                        reader.GetMethodDefinition(getterHandle).GetParameters(),
                         beforeRetainText,
                         attributeMaterialize)
                 });
@@ -6002,7 +6293,7 @@ public static class ApiSurfaceExtractor
                     Accessibility = AccessorAccessibility(setterAccess, Math.Max((int)getterAccess, (int)setterAccess)),
                     ReturnAttributes = ReturnParameterAttributes(
                         reader,
-                        reader.GetMethodDefinition(accessors.Setter).GetParameters(),
+                        reader.GetMethodDefinition(setterHandle).GetParameters(),
                         beforeRetainText,
                         attributeMaterialize)
                 });
@@ -6024,7 +6315,7 @@ public static class ApiSurfaceExtractor
                     Kind = "get",
                     ReturnAttributes = ReturnParameterAttributes(
                         reader,
-                        reader.GetMethodDefinition(accessors.Getter).GetParameters(),
+                        reader.GetMethodDefinition(getterHandle).GetParameters(),
                         beforeRetainText,
                         attributeMaterialize)
                 });
@@ -6033,7 +6324,7 @@ public static class ApiSurfaceExtractor
                     Kind = "set",
                     ReturnAttributes = ReturnParameterAttributes(
                         reader,
-                        reader.GetMethodDefinition(accessors.Setter).GetParameters(),
+                        reader.GetMethodDefinition(setterHandle).GetParameters(),
                         beforeRetainText,
                         attributeMaterialize)
                 });
@@ -6046,7 +6337,7 @@ public static class ApiSurfaceExtractor
                     Kind = "get",
                     ReturnAttributes = ReturnParameterAttributes(
                         reader,
-                        reader.GetMethodDefinition(accessors.Getter).GetParameters(),
+                        reader.GetMethodDefinition(getterHandle).GetParameters(),
                         beforeRetainText,
                         attributeMaterialize)
                 });
@@ -6056,7 +6347,7 @@ public static class ApiSurfaceExtractor
                     Accessibility = "private",
                     ReturnAttributes = ReturnParameterAttributes(
                         reader,
-                        reader.GetMethodDefinition(accessors.Setter).GetParameters(),
+                        reader.GetMethodDefinition(setterHandle).GetParameters(),
                         beforeRetainText,
                         attributeMaterialize)
                 });
@@ -6069,7 +6360,7 @@ public static class ApiSurfaceExtractor
                     Kind = "get",
                     ReturnAttributes = ReturnParameterAttributes(
                         reader,
-                        reader.GetMethodDefinition(accessors.Getter).GetParameters(),
+                        reader.GetMethodDefinition(getterHandle).GetParameters(),
                         beforeRetainText,
                         attributeMaterialize)
                 });
@@ -6082,7 +6373,7 @@ public static class ApiSurfaceExtractor
                     Kind = "set",
                     ReturnAttributes = ReturnParameterAttributes(
                         reader,
-                        reader.GetMethodDefinition(accessors.Setter).GetParameters(),
+                        reader.GetMethodDefinition(setterHandle).GetParameters(),
                         beforeRetainText,
                         attributeMaterialize)
                 });
@@ -6117,8 +6408,8 @@ public static class ApiSurfaceExtractor
         var isRequired = requiredPrefix.Length > 0;
 
         MethodDefinitionHandle parameterAccessor = hasGetter
-            ? accessors.Getter
-            : accessors.Setter;
+            ? getterHandle
+            : setterHandle;
         var parameterAccessorMethod = parameterAccessor.IsNil
             ? default
             : reader.GetMethodDefinition(parameterAccessor);

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1008,6 +1008,7 @@ public static class ApiSurfaceExtractor
                 reader,
                 methodImplementations,
                 observeDecodeWork);
+            bool isFinalizerOwner = IsFinalizerOwner(typeDef, apiType.Kind);
 
             // Getter/setter and adder/remover bodies are represented by their
             // property or event rows. Raiser and Other semantic methods have no
@@ -1054,8 +1055,7 @@ public static class ApiSurfaceExtractor
                     && (!isOwnedAccessor
                         || methodAccess != MethodAttributes.Public
                         || methodName.Contains('.', StringComparison.Ordinal));
-                var isFinalizer = apiType.Kind == "class"
-                    && IsFinalizerOwner(reader, typeDef)
+                var isFinalizer = isFinalizerOwner
                     && method.GetGenericParameters().Count == 0
                     && (objectFinalizeOverrides.Contains(methodHandle)
                         || IsImplicitObjectFinalizeOverride(
@@ -2009,6 +2009,7 @@ public static class ApiSurfaceExtractor
         var objectFinalizeOverrides = GetObjectFinalizeOverrides(
             reader,
             methodImplementations);
+        bool isFinalizerOwner = IsFinalizerOwner(typeDef, apiType.Kind);
 
         foreach (var methodHandle in typeDef.GetMethods())
         {
@@ -2020,8 +2021,7 @@ public static class ApiSurfaceExtractor
                 && (!accessorMethods.Contains(methodHandle)
                     || methodAccess != MethodAttributes.Public
                     || methodName.Contains('.', StringComparison.Ordinal));
-            bool isFinalizer = apiType.Kind == "class"
-                && IsFinalizerOwner(reader, typeDef)
+            bool isFinalizer = isFinalizerOwner
                 && method.GetGenericParameters().Count == 0
                 && (objectFinalizeOverrides.Contains(methodHandle)
                     || IsImplicitObjectFinalizeOverride(
@@ -3214,6 +3214,85 @@ public static class ApiSurfaceExtractor
         return true;
     }
 
+    private static int GetMethodImplSignatureTypeHashCode(
+        ExtensionSignatureType type)
+    {
+        var hash = new HashCode();
+        AddMethodImplSignatureTypeHashCode(ref hash, type);
+        return hash.ToHashCode();
+    }
+
+    private static void AddMethodImplSignatureTypeHashCode(
+        ref HashCode hash,
+        ExtensionSignatureType type)
+    {
+        switch (type)
+        {
+            case PrimitiveExtensionSignatureType primitive:
+                hash.Add(0);
+                hash.Add(primitive.TypeCode);
+                return;
+            case NamedExtensionSignatureType named:
+                hash.Add(1);
+                hash.Add(
+                    MetadataNamedTypeIdentityComparer.Instance.GetHashCode(
+                        named.Identity));
+                return;
+            case ArrayExtensionSignatureType array:
+                hash.Add(2);
+                hash.Add(array.Rank);
+                foreach (int size in array.Sizes)
+                    hash.Add(size);
+                foreach (int lowerBound in array.LowerBounds)
+                    hash.Add(lowerBound);
+                AddMethodImplSignatureTypeHashCode(ref hash, array.ElementType);
+                return;
+            case WrappedExtensionSignatureType wrapped:
+                hash.Add(3);
+                hash.Add(wrapped.Kind);
+                AddMethodImplSignatureTypeHashCode(ref hash, wrapped.ElementType);
+                return;
+            case GenericExtensionSignatureType generic:
+                hash.Add(4);
+                AddMethodImplSignatureTypeHashCode(ref hash, generic.GenericType);
+                hash.Add(generic.TypeArguments.Length);
+                foreach (ExtensionSignatureType argument in generic.TypeArguments)
+                    AddMethodImplSignatureTypeHashCode(ref hash, argument);
+                return;
+            case GenericParameterExtensionSignatureType parameter:
+                hash.Add(5);
+                hash.Add(parameter.IsMethodParameter);
+                hash.Add(parameter.Index);
+                return;
+            case FunctionPointerExtensionSignatureType functionPointer:
+                hash.Add(6);
+                hash.Add(functionPointer.CallingConvention);
+                hash.Add(functionPointer.Attributes);
+                hash.Add(functionPointer.GenericParameterCount);
+                hash.Add(functionPointer.RequiredParameterCount);
+                AddMethodImplSignatureTypeHashCode(
+                    ref hash,
+                    functionPointer.ReturnType);
+                foreach (ExtensionSignatureType parameterType
+                    in functionPointer.ParameterTypes)
+                {
+                    AddMethodImplSignatureTypeHashCode(ref hash, parameterType);
+                }
+                return;
+            case ModifiedExtensionSignatureType modified:
+                hash.Add(7);
+                hash.Add(modified.IsRequired);
+                AddMethodImplSignatureTypeHashCode(ref hash, modified.Modifier);
+                AddMethodImplSignatureTypeHashCode(
+                    ref hash,
+                    modified.UnmodifiedType);
+                return;
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported MethodImpl signature type {type.GetType().Name}.");
+        }
+    }
+
     private static bool ExtensionParametersMatch(
         ImmutableArray<ExtensionSignatureType> implementation,
         ExtensionDecodedSignature property,
@@ -3658,6 +3737,7 @@ public static class ApiSurfaceExtractor
                                 reader,
                                 referencedType,
                                 memberReference,
+                                currentScope,
                                 beforeDecodeWork);
                             if (resolvedBody is { } localBody)
                             {
@@ -3757,6 +3837,7 @@ public static class ApiSurfaceExtractor
         MetadataReader reader,
         TypeDefinitionHandle declaringType,
         MemberReference memberReference,
+        MetadataTypeScope? currentScope,
         Action<int>? beforeDecodeWork)
     {
         MethodDefinitionHandle match = default;
@@ -3772,6 +3853,7 @@ public static class ApiSurfaceExtractor
                     reader,
                     candidate,
                     memberReference,
+                    currentScope,
                     beforeDecodeWork))
             {
                 continue;
@@ -3789,17 +3871,20 @@ public static class ApiSurfaceExtractor
         MetadataReader reader,
         MethodDefinition method,
         MemberReference memberReference,
+        MetadataTypeScope? currentScope,
         Action<int>? beforeDecodeWork)
     {
         MethodSignatureIdentity? methodIdentity =
             TryGetMethodSignatureIdentity(
                 reader,
                 method,
+                currentScope,
                 beforeDecodeWork);
         MethodSignatureIdentity? memberReferenceIdentity =
             TryGetMethodSignatureIdentity(
                 reader,
                 memberReference,
+                currentScope,
                 beforeDecodeWork);
         return methodIdentity is not null
             && methodIdentity.Equals(memberReferenceIdentity);
@@ -3825,6 +3910,7 @@ public static class ApiSurfaceExtractor
                 signature = TryGetMethodSignatureIdentity(
                     reader,
                     method,
+                    currentScope,
                     beforeDecodeWork);
                 break;
             case HandleKind.MemberReference:
@@ -3838,6 +3924,7 @@ public static class ApiSurfaceExtractor
                 signature = TryGetMethodSignatureIdentity(
                     reader,
                     memberReference,
+                    currentScope,
                     beforeDecodeWork);
                 break;
             default:
@@ -3852,11 +3939,12 @@ public static class ApiSurfaceExtractor
         if (typeIdentity is null || signature is null)
             return null;
 
-        string? constructedTypeIdentity = declaringType.Kind
+        ExtensionSignatureType? constructedTypeIdentity = declaringType.Kind
             == HandleKind.TypeSpecification
             ? TryGetTypeStructuralIdentity(
                 reader,
                 (TypeSpecificationHandle)declaringType,
+                currentScope,
                 beforeDecodeWork)
             : null;
         if (declaringType.Kind == HandleKind.TypeSpecification
@@ -3872,23 +3960,26 @@ public static class ApiSurfaceExtractor
             signature);
     }
 
-    private static string? TryGetTypeStructuralIdentity(
+    private static ExtensionSignatureType? TryGetTypeStructuralIdentity(
         MetadataReader reader,
         TypeSpecificationHandle type,
+        MetadataTypeScope? currentScope,
         Action<int>? beforeDecodeWork)
     {
-        var node = GuardedProviderDecode.TypeSpec(
+        return GuardedProviderDecode.TypeSpec(
             reader,
             type,
-            new TypeNodeProvider(beforeMaterialize: beforeDecodeWork),
+            new ExtensionSignatureTypeProvider(
+                currentScope,
+                beforeDecodeWork),
             context: null,
-            (TypeNode)new DegradedTypeNode());
-        return node.IsDegraded ? null : node.StructuralIdentity();
+            fallback: null);
     }
 
     private static MethodSignatureIdentity? TryGetMethodSignatureIdentity(
         MetadataReader reader,
         MethodDefinition method,
+        MetadataTypeScope? currentScope,
         Action<int>? beforeDecodeWork)
     {
         if (!SignatureBlobGuard.IsSafeAndCompleteToDecode(
@@ -3901,14 +3992,15 @@ public static class ApiSurfaceExtractor
 
         try
         {
-            MethodSignature<TypeNode> signature =
+            MethodSignature<ExtensionSignatureType?> signature =
                 GuardedProviderDecode.Method(
                     reader,
                     method,
-                    new TypeNodeProvider(
-                        beforeMaterialize: beforeDecodeWork),
+                    new ExtensionSignatureTypeProvider(
+                        currentScope,
+                        beforeDecodeWork),
                     context: null,
-                    (TypeNode)new DegradedTypeNode());
+                    fallbackReturn: null);
             return CreateMethodSignatureIdentity(signature);
         }
         catch (Exception ex) when (
@@ -3924,6 +4016,7 @@ public static class ApiSurfaceExtractor
     private static MethodSignatureIdentity? TryGetMethodSignatureIdentity(
         MetadataReader reader,
         MemberReference memberReference,
+        MetadataTypeScope? currentScope,
         Action<int>? beforeDecodeWork)
     {
         if (!SignatureBlobGuard.IsSafeAndCompleteToDecode(
@@ -3936,14 +4029,15 @@ public static class ApiSurfaceExtractor
 
         try
         {
-            MethodSignature<TypeNode> signature =
+            MethodSignature<ExtensionSignatureType?> signature =
                 GuardedProviderDecode.MemberRefMethod(
                     reader,
                     memberReference,
-                    new TypeNodeProvider(
-                        beforeMaterialize: beforeDecodeWork),
+                    new ExtensionSignatureTypeProvider(
+                        currentScope,
+                        beforeDecodeWork),
                     context: null,
-                    (TypeNode)new DegradedTypeNode());
+                    fallbackReturn: null);
             return CreateMethodSignatureIdentity(signature);
         }
         catch (Exception ex) when (
@@ -3957,10 +4051,10 @@ public static class ApiSurfaceExtractor
     }
 
     private static MethodSignatureIdentity? CreateMethodSignatureIdentity(
-        MethodSignature<TypeNode> signature)
+        MethodSignature<ExtensionSignatureType?> signature)
     {
-        if (signature.ReturnType.IsDegraded
-            || signature.ParameterTypes.Any(static type => type.IsDegraded))
+        if (signature.ReturnType is null
+            || signature.ParameterTypes.Any(static type => type is null))
         {
             return null;
         }
@@ -3969,9 +4063,9 @@ public static class ApiSurfaceExtractor
             signature.Header.RawValue,
             signature.GenericParameterCount,
             signature.RequiredParameterCount,
-            signature.ReturnType.StructuralIdentity(),
+            signature.ReturnType,
             [.. signature.ParameterTypes.Select(
-                static parameter => parameter.StructuralIdentity())]);
+                static parameter => parameter!)]);
     }
 
     private sealed class MethodSignatureIdentity : IEquatable<MethodSignatureIdentity>
@@ -3982,8 +4076,8 @@ public static class ApiSurfaceExtractor
             byte header,
             int genericParameterCount,
             int requiredParameterCount,
-            string returnType,
-            string[] parameterTypes)
+            ExtensionSignatureType returnType,
+            ExtensionSignatureType[] parameterTypes)
         {
             Header = header;
             GenericParameterCount = genericParameterCount;
@@ -3994,17 +4088,17 @@ public static class ApiSurfaceExtractor
             hash.Add(header);
             hash.Add(genericParameterCount);
             hash.Add(requiredParameterCount);
-            hash.Add(returnType, StringComparer.Ordinal);
-            foreach (string parameterType in parameterTypes)
-                hash.Add(parameterType, StringComparer.Ordinal);
+            hash.Add(GetMethodImplSignatureTypeHashCode(returnType));
+            foreach (ExtensionSignatureType parameterType in parameterTypes)
+                hash.Add(GetMethodImplSignatureTypeHashCode(parameterType));
             _hashCode = hash.ToHashCode();
         }
 
         internal byte Header { get; }
         internal int GenericParameterCount { get; }
         internal int RequiredParameterCount { get; }
-        internal string ReturnType { get; }
-        internal string[] ParameterTypes { get; }
+        internal ExtensionSignatureType ReturnType { get; }
+        internal ExtensionSignatureType[] ParameterTypes { get; }
 
         public bool Equals(MethodSignatureIdentity? other)
             => ReferenceEquals(this, other)
@@ -4013,13 +4107,13 @@ public static class ApiSurfaceExtractor
                     && Header == other.Header
                     && GenericParameterCount == other.GenericParameterCount
                     && RequiredParameterCount == other.RequiredParameterCount
-                    && string.Equals(
-                        ReturnType,
-                        other.ReturnType,
-                        StringComparison.Ordinal)
-                    && ParameterTypes.SequenceEqual(
+                    && MethodImplSignatureTypesEqual(ReturnType, other.ReturnType)
+                    && ParameterTypes.Length == other.ParameterTypes.Length
+                    && ParameterTypes.Zip(
                         other.ParameterTypes,
-                        StringComparer.Ordinal);
+                        static (left, right) =>
+                            MethodImplSignatureTypesEqual(left, right))
+                        .All(static equal => equal);
 
         public override bool Equals(object? obj)
             => Equals(obj as MethodSignatureIdentity);
@@ -4034,7 +4128,7 @@ public static class ApiSurfaceExtractor
 
         internal MethodImplementationDeclarationIdentity(
             MetadataNamedTypeIdentity declaringType,
-            string? constructedTypeIdentity,
+            ExtensionSignatureType? constructedTypeIdentity,
             string name,
             MethodSignatureIdentity signature)
         {
@@ -4046,14 +4140,18 @@ public static class ApiSurfaceExtractor
             hash.Add(
                 MetadataNamedTypeIdentityComparer.Instance.GetHashCode(
                     declaringType));
-            hash.Add(constructedTypeIdentity, StringComparer.Ordinal);
+            hash.Add(
+                constructedTypeIdentity is null
+                    ? 0
+                    : GetMethodImplSignatureTypeHashCode(
+                        constructedTypeIdentity));
             hash.Add(name, StringComparer.Ordinal);
             hash.Add(signature);
             _hashCode = hash.ToHashCode();
         }
 
         internal MetadataNamedTypeIdentity DeclaringType { get; }
-        internal string? ConstructedTypeIdentity { get; }
+        internal ExtensionSignatureType? ConstructedTypeIdentity { get; }
         internal string Name { get; }
         internal MethodSignatureIdentity Signature { get; }
 
@@ -4064,10 +4162,12 @@ public static class ApiSurfaceExtractor
                     && MetadataNamedTypeIdentityComparer.Instance.Equals(
                         DeclaringType,
                         other.DeclaringType)
-                    && string.Equals(
-                        ConstructedTypeIdentity,
-                        other.ConstructedTypeIdentity,
-                        StringComparison.Ordinal)
+                    && (ConstructedTypeIdentity is null
+                        ? other.ConstructedTypeIdentity is null
+                        : other.ConstructedTypeIdentity is not null
+                        && MethodImplSignatureTypesEqual(
+                            ConstructedTypeIdentity,
+                            other.ConstructedTypeIdentity))
                     && string.Equals(Name, other.Name, StringComparison.Ordinal)
                     && Signature.Equals(other.Signature);
 
@@ -4104,6 +4204,8 @@ public static class ApiSurfaceExtractor
     {
         private readonly object _gate = new();
         private readonly ApiSurface _failures = new();
+        private readonly Dictionary<TypeDefinitionHandle, bool>
+            _finalizerOwners = [];
         private Dictionary<
             MetadataNamedTypeIdentity,
             TypeDefinitionHandle?> _localTypes = [];
@@ -4113,62 +4215,112 @@ public static class ApiSurfaceExtractor
         private MetadataTypeScope? _currentScope;
         private bool _initialized;
 
-        internal IReadOnlyList<OwnedMethodImplementation> Get(
+        internal bool IsFinalizerMethod(
+            MetadataReader reader,
+            MethodDefinitionHandle methodHandle)
+        {
+            lock (_gate)
+            {
+                MethodDefinition method =
+                    reader.GetMethodDefinition(methodHandle);
+                if (!IsFinalizerBodyShape(reader, method))
+                {
+                    return false;
+                }
+
+                TypeDefinitionHandle typeHandle = method.GetDeclaringType();
+                TypeDefinition type = reader.GetTypeDefinition(typeHandle);
+                EnsureInitialized(reader);
+                if (!_finalizerOwners.TryGetValue(
+                        typeHandle,
+                        out bool isFinalizerOwner))
+                {
+                    isFinalizerOwner = IsFinalizerOwner(reader, type);
+                    _finalizerOwners.Add(typeHandle, isFinalizerOwner);
+                }
+                if (!isFinalizerOwner)
+                {
+                    return false;
+                }
+
+                foreach (OwnedMethodImplementation implementation
+                    in GetImplementations(reader, typeHandle, type))
+                {
+                    if (implementation.Body == methodHandle
+                        && ReferencesObjectFinalize(
+                            reader,
+                            implementation.Declaration))
+                    {
+                        return true;
+                    }
+                }
+
+                // No MethodImpl: fall back to the implicit-slot shape the VB.NET compiler emits.
+                return IsImplicitObjectFinalizeOverride(
+                    reader,
+                    typeHandle,
+                    method,
+                    _currentScope,
+                    _localTypes);
+            }
+        }
+
+        IReadOnlyList<OwnedMethodImplementation> GetImplementations(
             MetadataReader reader,
             TypeDefinitionHandle typeHandle,
             TypeDefinition type)
         {
-            lock (_gate)
+            if (_implementations.TryGetValue(
+                    typeHandle,
+                    out IReadOnlyList<OwnedMethodImplementation>? cached))
             {
-                if (_implementations.TryGetValue(
+                return cached;
+            }
+
+            IReadOnlyList<OwnedMethodImplementation> implementations =
+                _currentScope is null
+                    ? []
+                    : ReadOwnedMethodImplementations(
+                        reader,
                         typeHandle,
-                        out IReadOnlyList<OwnedMethodImplementation>? cached))
-                {
-                    return cached;
-                }
+                        type,
+                        _failures,
+                        budget: null,
+                        owningTypeDefinition: null,
+                        currentScope: _currentScope,
+                        localTypes: _localTypes,
+                        beforeDecodeWork: null);
+            _implementations.Add(typeHandle, implementations);
+            return implementations;
+        }
 
-                if (!_initialized)
-                {
-                    _initialized = true;
-                    try
-                    {
-                        _currentScope = CurrentScope(
-                            reader,
-                            beforeDecodeWork: null);
-                        if (_currentScope is not null)
-                        {
-                            _localTypes = LocalTypes(
-                                reader,
-                                _currentScope,
-                                _failures,
-                                budget: null);
-                        }
-                    }
-                    catch (Exception ex) when (
-                        ex is BadImageFormatException
-                            or ArgumentOutOfRangeException
-                            or OverflowException)
-                    {
-                        _currentScope = null;
-                        _localTypes = [];
-                    }
-                }
+        void EnsureInitialized(MetadataReader reader)
+        {
+            if (_initialized)
+                return;
 
-                IReadOnlyList<OwnedMethodImplementation> implementations =
-                    _currentScope is null
-                        ? []
-                        : ReadOwnedMethodImplementations(
-                            reader,
-                            typeHandle,
-                            type,
-                            _failures,
-                            budget: null,
-                            owningTypeDefinition: null,
-                            currentScope: _currentScope,
-                            localTypes: _localTypes,
-                            beforeDecodeWork: null);
-                _implementations.Add(typeHandle, implementations);
-                return implementations;
+            _initialized = true;
+            try
+            {
+                _currentScope = CurrentScope(
+                    reader,
+                    beforeDecodeWork: null);
+                if (_currentScope is not null)
+                {
+                    _localTypes = LocalTypes(
+                        reader,
+                        _currentScope,
+                        _failures,
+                        budget: null);
+                }
+            }
+            catch (Exception ex) when (
+                ex is BadImageFormatException
+                    or ArgumentOutOfRangeException
+                    or OverflowException)
+            {
+                _currentScope = null;
+                _localTypes = [];
             }
         }
     }
@@ -5607,38 +5759,11 @@ public static class ApiSurfaceExtractor
     {
         try
         {
-            var method = reader.GetMethodDefinition(methodHandle);
-            if (!IsFinalizerBodyShape(reader, method))
-                return false;
-
-            var typeHandle = method.GetDeclaringType();
-            var typeDef = reader.GetTypeDefinition(typeHandle);
-            if (!IsFinalizerOwner(reader, typeDef))
-                return false;
-            IReadOnlyList<OwnedMethodImplementation> implementations =
-                FinalizerMethodImplementationCaches
-                    .GetValue(
-                        reader,
-                        static _ => new FinalizerMethodImplementationCache())
-                    .Get(reader, typeHandle, typeDef);
-            foreach (var implementation in implementations)
-            {
-                if (implementation.Body == methodHandle
-                    && ReferencesObjectFinalize(
-                        reader,
-                        implementation.Declaration))
-                {
-                    return true;
-                }
-            }
-
-            // No MethodImpl: fall back to the implicit-slot shape the VB.NET compiler emits.
-            return IsImplicitObjectFinalizeOverride(
-                reader,
-                typeHandle,
-                method,
-                currentScope: null,
-                localTypes: null);
+            return FinalizerMethodImplementationCaches
+                .GetValue(
+                    reader,
+                    static _ => new FinalizerMethodImplementationCache())
+                .IsFinalizerMethod(reader, methodHandle);
         }
         catch (Exception ex) when (
             ex is BadImageFormatException
@@ -5648,6 +5773,12 @@ public static class ApiSurfaceExtractor
             return false;
         }
     }
+
+    private static bool IsFinalizerOwner(
+        TypeDefinition type,
+        string typeKind)
+        => (type.Attributes & TypeAttributes.Interface) == 0
+            && string.Equals(typeKind, "class", StringComparison.Ordinal);
 
     private static bool IsFinalizerOwner(
         MetadataReader reader,

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -630,7 +630,7 @@ public static class ApiSurfaceExtractor
         var currentScope = ReadCurrentScope(reader, surface);
         var localTypes = currentScope is null
             ? []
-            : LocalTypes(reader, currentScope);
+            : LocalTypes(reader, currentScope, surface);
         var accessorMethods = AccessorMethods(reader, surface);
 
         foreach (var typeDefHandle in reader.TypeDefinitions)
@@ -2163,46 +2163,127 @@ public static class ApiSurfaceExtractor
         ApiSurface surface)
     {
         var methods = new HashSet<MethodDefinitionHandle>();
-        foreach (var propertyHandle in reader.PropertyDefinitions)
+        foreach (var typeHandle in reader.TypeDefinitions)
         {
             try
             {
-                var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
-                if (!accessors.Getter.IsNil)
-                    methods.Add(accessors.Getter);
-                if (!accessors.Setter.IsNil)
-                    methods.Add(accessors.Setter);
+                var type = reader.GetTypeDefinition(typeHandle);
+                foreach (var propertyHandle in type.GetProperties())
+                {
+                    try
+                    {
+                        var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+                        AddOwnedAccessor(
+                            reader,
+                            surface,
+                            methods,
+                            typeHandle,
+                            propertyHandle,
+                            accessors.Getter,
+                            "property getter");
+                        AddOwnedAccessor(
+                            reader,
+                            surface,
+                            methods,
+                            typeHandle,
+                            propertyHandle,
+                            accessors.Setter,
+                            "property setter");
+                    }
+                    catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+                    {
+                        AddInspectionFailure(
+                            surface,
+                            "property accessors",
+                            propertyHandle,
+                            MetadataTypeNameFailure.Malformed(propertyHandle, ex.Message));
+                    }
+                }
+                foreach (var eventHandle in type.GetEvents())
+                {
+                    try
+                    {
+                        var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
+                        AddOwnedAccessor(
+                            reader,
+                            surface,
+                            methods,
+                            typeHandle,
+                            eventHandle,
+                            accessors.Adder,
+                            "event adder");
+                        AddOwnedAccessor(
+                            reader,
+                            surface,
+                            methods,
+                            typeHandle,
+                            eventHandle,
+                            accessors.Remover,
+                            "event remover");
+                    }
+                    catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+                    {
+                        AddInspectionFailure(
+                            surface,
+                            "event accessors",
+                            eventHandle,
+                            MetadataTypeNameFailure.Malformed(eventHandle, ex.Message));
+                    }
+                }
             }
             catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
             {
                 AddInspectionFailure(
                     surface,
-                    "property accessors",
-                    propertyHandle,
-                    MetadataTypeNameFailure.Malformed(propertyHandle, ex.Message));
+                    "accessor owner",
+                    typeHandle,
+                    MetadataTypeNameFailure.Malformed(typeHandle, ex.Message));
             }
         }
-        foreach (var eventHandle in reader.EventDefinitions)
-        {
-            try
-            {
-                var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
-                if (!accessors.Adder.IsNil)
-                    methods.Add(accessors.Adder);
-                if (!accessors.Remover.IsNil)
-                    methods.Add(accessors.Remover);
-            }
-            catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
-            {
-                AddInspectionFailure(
-                    surface,
-                    "event accessors",
-                    eventHandle,
-                    MetadataTypeNameFailure.Malformed(eventHandle, ex.Message));
-            }
-        }
+
         methods.UnionWith(ExtensionPropertyImplementationMethods(reader, surface));
         return methods;
+    }
+
+    private static void AddOwnedAccessor(
+        MetadataReader reader,
+        ApiSurface surface,
+        HashSet<MethodDefinitionHandle> methods,
+        TypeDefinitionHandle owningType,
+        EntityHandle association,
+        MethodDefinitionHandle accessor,
+        string operation)
+    {
+        if (accessor.IsNil)
+            return;
+
+        try
+        {
+            var declaringType = reader.GetMethodDefinition(accessor).GetDeclaringType();
+            if (declaringType == owningType)
+            {
+                methods.Add(accessor);
+                return;
+            }
+
+            AddInspectionFailure(
+                surface,
+                operation,
+                association,
+                MetadataTypeNameFailure.Malformed(
+                    association,
+                    $"Accessor 0x{MetadataTokens.GetToken(accessor):x8} belongs to type "
+                    + $"0x{MetadataTokens.GetToken(declaringType):x8}, not association owner "
+                    + $"0x{MetadataTokens.GetToken(owningType):x8}."));
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
+        {
+            AddInspectionFailure(
+                surface,
+                operation,
+                association,
+                MetadataTypeNameFailure.Malformed(association, ex.Message));
+        }
     }
 
     static HashSet<MethodDefinitionHandle> ExtensionPropertyImplementationMethods(
@@ -2664,7 +2745,7 @@ public static class ApiSurfaceExtractor
         MetadataReader reader,
         TypeDefinition typeDef,
         MetadataTypeScope? currentScope,
-        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> localTypes)
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
     {
         HashSet<MethodDefinitionHandle> handles = [];
         foreach (var implementationHandle in typeDef.GetMethodImplementations())
@@ -2697,7 +2778,7 @@ public static class ApiSurfaceExtractor
         TypeDefinition typeDef,
         EntityHandle declaration,
         MetadataTypeScope? currentScope,
-        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> localTypes)
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
     {
         EntityHandle declaringType = declaration.Kind switch
         {
@@ -2747,12 +2828,34 @@ public static class ApiSurfaceExtractor
         }
 
         var pending = new Queue<EntityHandle>();
-        foreach (var handle in typeDef.GetInterfaceImplementations())
-            pending.Enqueue(reader.GetInterfaceImplementation(handle).Interface);
-
-        HashSet<MetadataNamedTypeIdentity> visited = [];
+        HashSet<TypeDefinitionHandle> visitedLocalInterfaces = [];
         bool hasUnresolvedExternalOwnership = declarationIdentity is null
-            || !localTypes.ContainsKey(declarationIdentity);
+            || !TryGetUniqueLocalType(localTypes, declarationIdentity, out _);
+        var currentType = typeDef;
+        HashSet<TypeDefinitionHandle> visitedBaseTypes = [];
+        while (true)
+        {
+            foreach (var handle in currentType.GetInterfaceImplementations())
+                pending.Enqueue(reader.GetInterfaceImplementation(handle).Interface);
+
+            var baseType = currentType.BaseType;
+            if (baseType.IsNil || IsSystemObjectType(reader, baseType))
+                break;
+            if (!TryResolveKnownLocalType(
+                    reader,
+                    baseType,
+                    currentScope,
+                    localTypes,
+                    out var baseDefinition)
+                || !visitedBaseTypes.Add(baseDefinition))
+            {
+                hasUnresolvedExternalOwnership = true;
+                break;
+            }
+
+            currentType = reader.GetTypeDefinition(baseDefinition);
+        }
+
         while (pending.TryDequeue(out var interfaceType))
         {
             if (interfaceType == declaringType)
@@ -2762,23 +2865,34 @@ public static class ApiSurfaceExtractor
                 hasUnresolvedExternalOwnership = true;
                 continue;
             }
-            if (!visited.Add(interfaceIdentity))
-            {
-                continue;
-            }
             if (declarationIdentity is not null
-                && interfaceIdentity == declarationIdentity)
+                && HaveSameNamedType(
+                    reader,
+                    interfaceType,
+                    interfaceIdentity,
+                    declaringType,
+                    declarationIdentity,
+                    currentScope,
+                    localTypes))
                 return InterfaceMethodImplOwnership.ProvenInterface;
 
             // Same-module definitions let us close inherited InterfaceImpl edges.
             // External inheritance cannot be proven from this reader alone. Keep
             // that uncertainty distinct from a proven class MethodImpl so default
             // extraction does not silently drop a possible explicit implementation.
-            if (!localTypes.TryGetValue(interfaceIdentity, out var interfaceHandle))
+            if (!TryResolveKnownLocalType(
+                    reader,
+                    interfaceType,
+                    currentScope,
+                    localTypes,
+                    out var interfaceHandle))
             {
                 hasUnresolvedExternalOwnership = true;
                 continue;
             }
+            if (!visitedLocalInterfaces.Add(interfaceHandle))
+                continue;
+
             var interfaceDefinition = reader.GetTypeDefinition(interfaceHandle);
             foreach (var handle in interfaceDefinition.GetInterfaceImplementations())
                 pending.Enqueue(reader.GetInterfaceImplementation(handle).Interface);
@@ -2795,7 +2909,7 @@ public static class ApiSurfaceExtractor
         EntityHandle declaringType,
         MetadataNamedTypeIdentity? declarationIdentity,
         MetadataTypeScope? currentScope,
-        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> localTypes)
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
     {
         EntityHandle baseType = typeDef.BaseType;
         HashSet<TypeDefinitionHandle> visited = [];
@@ -2803,44 +2917,146 @@ public static class ApiSurfaceExtractor
         {
             if (baseType == declaringType)
                 return true;
+            var baseIdentity = TryGetNamedTypeIdentity(reader, baseType, currentScope);
             if (declarationIdentity is not null
-                && TryGetNamedTypeIdentity(reader, baseType, currentScope) == declarationIdentity)
+                && baseIdentity is not null
+                && HaveSameNamedType(
+                    reader,
+                    baseType,
+                    baseIdentity,
+                    declaringType,
+                    declarationIdentity,
+                    currentScope,
+                    localTypes))
             {
                 return true;
             }
-            if (baseType.Kind == HandleKind.TypeSpecification)
-            {
-                if (TryGetNamedTypeIdentity(reader, baseType, currentScope) is not { } baseIdentity
-                    || !localTypes.TryGetValue(baseIdentity, out var baseDefinition))
-                {
-                    return false;
-                }
-                baseType = baseDefinition;
-            }
-            if (baseType.Kind != HandleKind.TypeDefinition
-                || !visited.Add((TypeDefinitionHandle)baseType))
+            if (!TryResolveKnownLocalType(
+                    reader,
+                    baseType,
+                    currentScope,
+                    localTypes,
+                    out var baseDefinition)
+                || !visited.Add(baseDefinition))
             {
                 return false;
             }
 
-            baseType = reader.GetTypeDefinition((TypeDefinitionHandle)baseType).BaseType;
+            baseType = reader.GetTypeDefinition(baseDefinition).BaseType;
         }
 
         return false;
     }
 
-    private static Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> LocalTypes(
+    private static Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> LocalTypes(
         MetadataReader reader,
-        MetadataTypeScope currentScope)
+        MetadataTypeScope currentScope,
+        ApiSurface surface)
     {
-        Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle> types = [];
+        Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> types = [];
         foreach (var handle in reader.TypeDefinitions)
         {
             if (ReadDefinitionIdentity(reader, handle, currentScope) is { } identity)
-                types.TryAdd(identity, handle);
+            {
+                if (!types.TryAdd(identity, handle))
+                {
+                    types[identity] = null;
+                    AddInspectionFailure(
+                        surface,
+                        "type identity",
+                        handle,
+                        MetadataTypeNameFailure.Malformed(
+                            handle,
+                            $"Duplicate type definition identity '{identity.Name}'."));
+                }
+            }
         }
 
         return types;
+    }
+
+    private static bool TryGetUniqueLocalType(
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
+        MetadataNamedTypeIdentity identity,
+        out TypeDefinitionHandle handle)
+    {
+        if (localTypes.TryGetValue(identity, out var candidate)
+            && candidate is { } unique)
+        {
+            handle = unique;
+            return true;
+        }
+
+        handle = default;
+        return false;
+    }
+
+    private static bool TryResolveKnownLocalType(
+        MetadataReader reader,
+        EntityHandle type,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes,
+        out TypeDefinitionHandle definition)
+    {
+        if (TryResolvePhysicalLocalType(reader, type) is { } physical)
+        {
+            definition = physical;
+            return true;
+        }
+        if (TryGetNamedTypeIdentity(reader, type, currentScope) is { } identity
+            && TryGetUniqueLocalType(localTypes, identity, out definition))
+        {
+            return true;
+        }
+
+        definition = default;
+        return false;
+    }
+
+    private static TypeDefinitionHandle? TryResolvePhysicalLocalType(
+        MetadataReader reader,
+        EntityHandle type) =>
+        type.Kind switch
+        {
+            HandleKind.TypeDefinition => (TypeDefinitionHandle)type,
+            HandleKind.TypeSpecification => GuardedProviderDecode.TypeSpec(
+                reader,
+                (TypeSpecificationHandle)type,
+                PhysicalLocalTypeProvider.Instance,
+                context: null,
+                fallback: null),
+            _ => null,
+        };
+
+    private static bool HaveSameNamedType(
+        MetadataReader reader,
+        EntityHandle left,
+        MetadataNamedTypeIdentity leftIdentity,
+        EntityHandle right,
+        MetadataNamedTypeIdentity rightIdentity,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
+    {
+        if (left == right)
+            return true;
+        if (leftIdentity != rightIdentity)
+            return false;
+        if (!localTypes.ContainsKey(leftIdentity))
+            return true;
+
+        return TryResolveKnownLocalType(
+                reader,
+                left,
+                currentScope,
+                localTypes,
+                out var leftDefinition)
+            && TryResolveKnownLocalType(
+                reader,
+                right,
+                currentScope,
+                localTypes,
+                out var rightDefinition)
+            && leftDefinition == rightDefinition;
     }
 
     private static MetadataNamedTypeIdentity? TryGetNamedTypeIdentity(
@@ -3020,6 +3236,57 @@ public static class ApiSurfaceExtractor
         public MetadataNamedTypeIdentity? GetFunctionPointerType(MethodSignature<MetadataNamedTypeIdentity?> signature) => null;
     }
 
+    private sealed class PhysicalLocalTypeProvider :
+        ISignatureTypeProvider<TypeDefinitionHandle?, object?>
+    {
+        internal static PhysicalLocalTypeProvider Instance { get; } = new();
+
+        public TypeDefinitionHandle? GetTypeFromDefinition(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            byte rawTypeKind) =>
+            handle;
+
+        public TypeDefinitionHandle? GetTypeFromReference(
+            MetadataReader reader,
+            TypeReferenceHandle handle,
+            byte rawTypeKind) =>
+            null;
+
+        public TypeDefinitionHandle? GetTypeFromSpecification(
+            MetadataReader reader,
+            object? context,
+            TypeSpecificationHandle handle,
+            byte rawTypeKind) =>
+            GuardedProviderDecode.TypeSpec(
+                reader,
+                handle,
+                this,
+                context,
+                fallback: null);
+
+        public TypeDefinitionHandle? GetGenericInstantiation(
+            TypeDefinitionHandle? genericType,
+            ImmutableArray<TypeDefinitionHandle?> typeArguments) =>
+            genericType;
+
+        public TypeDefinitionHandle? GetModifiedType(
+            TypeDefinitionHandle? modifier,
+            TypeDefinitionHandle? unmodifiedType,
+            bool isRequired) =>
+            unmodifiedType;
+
+        public TypeDefinitionHandle? GetPrimitiveType(PrimitiveTypeCode typeCode) => null;
+        public TypeDefinitionHandle? GetSZArrayType(TypeDefinitionHandle? elementType) => null;
+        public TypeDefinitionHandle? GetArrayType(TypeDefinitionHandle? elementType, ArrayShape shape) => null;
+        public TypeDefinitionHandle? GetByReferenceType(TypeDefinitionHandle? elementType) => null;
+        public TypeDefinitionHandle? GetPointerType(TypeDefinitionHandle? elementType) => null;
+        public TypeDefinitionHandle? GetPinnedType(TypeDefinitionHandle? elementType) => elementType;
+        public TypeDefinitionHandle? GetGenericTypeParameter(object? context, int index) => null;
+        public TypeDefinitionHandle? GetGenericMethodParameter(object? context, int index) => null;
+        public TypeDefinitionHandle? GetFunctionPointerType(MethodSignature<TypeDefinitionHandle?> signature) => null;
+    }
+
     /// <summary>
     /// The set of methods on <paramref name="typeDef"/> whose explicit
     /// <c>.override</c> MethodImpl targets <c>System.Object::Finalize</c> — the
@@ -3103,9 +3370,11 @@ public static class ApiSurfaceExtractor
     /// <item>a base reference resolving to the strong-name-anchored <c>System.Object</c> confirms;</item>
     /// <item>an in-assembly base that introduces its own <c>new virtual void Finalize()</c> slot is a
     /// custom slot (the round-1 false-positive shape) and rejects;</item>
-    /// <item>a base that leaves the assembly without resolving to <c>System.Object</c> — including a
-    /// generic (<see cref="TypeSpecification"/>) base — cannot be proven and rejects conservatively,
-    /// so no guessed <c>~Type()</c> is spelled for an unresolvable chain.</item>
+    /// <item>a local generic base is followed through its
+    /// <see cref="TypeSpecification"/> to its physical type definition;</item>
+    /// <item>a base that leaves the assembly without resolving to <c>System.Object</c> cannot be
+    /// proven and rejects conservatively, so no guessed <c>~Type()</c> is spelled for an
+    /// unresolvable chain.</item>
     /// </list>
     /// </summary>
     private static bool IsImplicitObjectFinalizeOverride(
@@ -3146,40 +3415,36 @@ public static class ApiSurfaceExtractor
             if (baseHandle.IsNil)
                 return false;
 
-            switch (baseHandle.Kind)
+            if (baseHandle.Kind == HandleKind.TypeReference)
             {
-                case HandleKind.TypeReference:
-                    // Reached a cross-assembly base: only System.Object roots the object.Finalize slot.
-                    return IsSystemObjectType(
-                        reader,
-                        baseHandle,
-                        beforeDecodeWork);
-                case HandleKind.TypeDefinition:
-                    var baseTypeHandle = (TypeDefinitionHandle)baseHandle;
-                    if (!visited.Add(baseTypeHandle))
-                        return false; // cyclic base chain in malformed metadata
-                    // Recognize the in-assembly System.Object root before the custom-slot rejection:
-                    // the genuine object.Finalize is itself a NewSlot virtual, so testing
-                    // DeclaresNewVirtualFinalize first would wrongly reject the real root when
-                    // inspecting the core library that defines System.Object.
-                    if (IsSystemObjectType(
-                            reader,
-                            baseTypeHandle,
-                            beforeDecodeWork))
-                        return true; // in-assembly System.Object (inspecting the core library itself)
-                    var baseType = reader.GetTypeDefinition(baseTypeHandle);
-                    if (DeclaresNewVirtualFinalize(
-                            reader,
-                            baseType,
-                            beforeDecodeWork))
-                        return false; // custom Finalize slot introduced below object — not a destructor
-                    currentType = baseType;
-                    continue;
-                default:
-                    // TypeSpecification (generic base) or any other shape: the slot root cannot be
-                    // proven from the handle alone, so reject rather than guess.
-                    return false;
+                // Reached a cross-assembly base: only System.Object roots the object.Finalize slot.
+                return IsSystemObjectType(
+                    reader,
+                    baseHandle,
+                    beforeDecodeWork);
             }
+            if (TryResolvePhysicalLocalType(reader, baseHandle) is not { } baseTypeHandle
+                || !visited.Add(baseTypeHandle))
+            {
+                return false;
+            }
+
+            // Recognize the in-assembly System.Object root before the custom-slot rejection:
+            // the genuine object.Finalize is itself a NewSlot virtual, so testing
+            // DeclaresNewVirtualFinalize first would wrongly reject the real root when
+            // inspecting the core library that defines System.Object.
+            if (IsSystemObjectType(
+                    reader,
+                    baseTypeHandle,
+                    beforeDecodeWork))
+                return true; // in-assembly System.Object (inspecting the core library itself)
+            var baseType = reader.GetTypeDefinition(baseTypeHandle);
+            if (DeclaresNewVirtualFinalize(
+                    reader,
+                    baseType,
+                    beforeDecodeWork))
+                return false; // custom Finalize slot introduced below object — not a destructor
+            currentType = baseType;
         }
 
         return false;

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1091,7 +1091,6 @@ public static class ApiSurfaceExtractor
                         jsExportEvidence);
                     continue;
                 }
-                }
 
                 // Skip compiler-generated methods (lambdas, state machines, etc.)
                 if (methodName.StartsWith("<") && !includeCompilerGenerated)

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2046,6 +2046,7 @@ public static class ApiSurfaceExtractor
             {
                 continue;
             }
+
             if ((accessorMethods.Contains(methodHandle) && !isRetainedExplicitImplementation)
                 || methodName.StartsWith('<'))
             {
@@ -3236,7 +3237,6 @@ public static class ApiSurfaceExtractor
                     owningTypeDefinition: owningTypeDefinition);
             }
         }
-        return implementations;
         return implementations;
     }
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -6390,8 +6390,8 @@ public static class ApiSurfaceExtractor
             reader,
             kind => kind switch
             {
-                "get" => accessors.Getter,
-                "set" => accessors.Setter,
+                "get" => getterHandle,
+                "set" => setterHandle,
                 _ => default,
             },
             typeNodeProvider,

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1983,22 +1983,26 @@ public static class ApiSurfaceExtractor
             var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
             bool isExplicitImplementation = explicitImplementationBodies.Contains(methodHandle);
             string methodName = reader.GetString(method.Name);
+            bool isRetainedExplicitImplementation = isExplicitImplementation
+                && (!accessorMethods.Contains(methodHandle)
+                    || methodAccess != MethodAttributes.Public
+                    || methodName.Contains('.', StringComparison.Ordinal));
             bool isFinalizer = method.GetGenericParameters().Count == 0
                 && (objectFinalizeOverrides.Contains(methodHandle)
                     || IsImplicitObjectFinalizeOverride(reader, typeDefHandle, method));
             if (methodAccess != MethodAttributes.Public
-                && !isExplicitImplementation
+                && !isRetainedExplicitImplementation
                 && !isFinalizer)
             {
                 continue;
             }
-            if ((accessorMethods.Contains(methodHandle) && !isExplicitImplementation)
+            if ((accessorMethods.Contains(methodHandle) && !isRetainedExplicitImplementation)
                 || methodName.StartsWith('<'))
             {
                 continue;
             }
 
-            if (!isExplicitImplementation
+            if (!isRetainedExplicitImplementation
                 && !isFinalizer
                 && AttributeReader.HasEditorBrowsableNeverAttribute(reader, method.GetCustomAttributes()))
             {

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -168,7 +168,8 @@ public static class ApiSurfaceExtractor
 
     /// <summary>
     /// Extracts the public type identities and member-kind counts needed by the compact platform
-    /// API view without decoding signatures or materializing rich member models.
+    /// API view without decoding ordinary member signatures or materializing rich member models.
+    /// Extension-property association signatures are decoded only to keep method counts exact.
     /// </summary>
     public static ApiSurface ExtractSummary(PEReader peReader)
     {
@@ -180,6 +181,11 @@ public static class ApiSurfaceExtractor
         surface.AssemblyIdentity = currentAssemblyIdentity;
         var extensionReceiverDefinitions =
             new Dictionary<ApiMember, MetadataTypeDefinitionName>();
+        var currentScope = ReadCurrentScope(reader, surface, budget: null);
+        var localTypes = currentScope is null
+            ? []
+            : LocalTypes(reader, currentScope, surface, budget: null);
+        var accessorMethods = AccessorMethods(reader, surface, budget: null);
 
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
@@ -228,11 +234,15 @@ public static class ApiSurfaceExtractor
                         typeDef.GetCustomAttributes());
                 CountSummaryMembers(
                     reader,
+                    typeDefHandle,
                     typeDef,
                     apiType,
                     surface,
                     isExtensionClass,
-                    extensionReceiverDefinitions);
+                    extensionReceiverDefinitions,
+                    accessorMethods,
+                    currentScope,
+                    localTypes);
                 surface.Types.Add(apiType);
                 surface.PublicTypeCount++;
             }
@@ -277,6 +287,21 @@ public static class ApiSurfaceExtractor
                 : ApiSurfaceExtractionScope.Public,
             typesOnly,
             includeCompilerGenerated);
+
+    public static ApiSurface Extract(
+        MetadataReader reader,
+        bool includeAll = false,
+        bool typesOnly = false,
+        bool includeCompilerGenerated = false)
+        => Extract(
+            reader,
+            includeAll
+                ? ApiSurfaceExtractionScope.IncludeAll
+                : ApiSurfaceExtractionScope.Public,
+            typesOnly,
+            includeCompilerGenerated,
+            budget: null,
+            constraintResolution: null);
 
     /// <summary>
     /// Extracts one API surface at an explicit scope.
@@ -468,12 +493,26 @@ public static class ApiSurfaceExtractor
         bool includeCompilerGenerated,
         ExtractionBudget? budget,
         TypeParameterConstraintResolution? constraintResolution)
+        => Extract(
+            peReader.GetMetadataReader(),
+            scope,
+            typesOnly,
+            includeCompilerGenerated,
+            budget,
+            constraintResolution);
+
+    static ApiSurface Extract(
+        MetadataReader reader,
+        ApiSurfaceExtractionScope scope,
+        bool typesOnly,
+        bool includeCompilerGenerated,
+        ExtractionBudget? budget,
+        TypeParameterConstraintResolution? constraintResolution)
     {
         if (!Enum.IsDefined(scope))
             throw new ArgumentOutOfRangeException(nameof(scope));
 
         var surface = new ApiSurface();
-        var reader = peReader.GetMetadataReader();
         Guid moduleVersionId = reader.GetGuid(
             reader.GetModuleDefinition().Mvid);
         var extensionReceiverDefinitions =
@@ -627,11 +666,11 @@ public static class ApiSurfaceExtractor
                 }
             }
         }
-        var currentScope = ReadCurrentScope(reader, surface);
+        var currentScope = ReadCurrentScope(reader, surface, budget);
         var localTypes = currentScope is null
             ? []
-            : LocalTypes(reader, currentScope, surface);
-        var accessorMethods = AccessorMethods(reader, surface);
+            : LocalTypes(reader, currentScope, surface, budget);
+        var accessorMethods = AccessorMethods(reader, surface, budget);
 
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
@@ -1921,33 +1960,46 @@ public static class ApiSurfaceExtractor
 
     private static void CountSummaryMembers(
         MetadataReader reader,
+        TypeDefinitionHandle typeDefHandle,
         TypeDefinition typeDef,
         ApiType apiType,
         ApiSurface surface,
         bool isExtensionClass,
-        Dictionary<ApiMember, MetadataTypeDefinitionName> extensionReceiverDefinitions)
+        Dictionary<ApiMember, MetadataTypeDefinitionName> extensionReceiverDefinitions,
+        IReadOnlySet<MethodDefinitionHandle> accessorMethods,
+        MetadataTypeScope? currentScope,
+        IReadOnlyDictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> localTypes)
     {
-        var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
-        var accessorMethods = GetSemanticAccessorMethods(reader, typeDef);
+        var explicitImplementationBodies = GetExplicitImplementationBodies(
+            reader,
+            typeDef,
+            currentScope,
+            localTypes);
+        var objectFinalizeOverrides = GetObjectFinalizeOverrides(reader, typeDef);
 
         foreach (var methodHandle in typeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
             var methodAccess = method.Attributes & MethodAttributes.MemberAccessMask;
             bool isExplicitImplementation = explicitImplementationBodies.Contains(methodHandle);
-            if (methodAccess != MethodAttributes.Public && !isExplicitImplementation)
-                continue;
-
             string methodName = reader.GetString(method.Name);
-            if ((accessorMethods.Contains(methodHandle)
-                    && !(isExplicitImplementation
-                        && methodAccess == MethodAttributes.Private))
+            bool isFinalizer = method.GetGenericParameters().Count == 0
+                && (objectFinalizeOverrides.Contains(methodHandle)
+                    || IsImplicitObjectFinalizeOverride(reader, typeDefHandle, method));
+            if (methodAccess != MethodAttributes.Public
+                && !isExplicitImplementation
+                && !isFinalizer)
+            {
+                continue;
+            }
+            if ((accessorMethods.Contains(methodHandle) && !isExplicitImplementation)
                 || methodName.StartsWith('<'))
             {
                 continue;
             }
 
             if (!isExplicitImplementation
+                && !isFinalizer
                 && AttributeReader.HasEditorBrowsableNeverAttribute(reader, method.GetCustomAttributes()))
             {
                 continue;
@@ -2160,7 +2212,8 @@ public static class ApiSurfaceExtractor
 
     static HashSet<MethodDefinitionHandle> AccessorMethods(
         MetadataReader reader,
-        ApiSurface surface)
+        ApiSurface surface,
+        ExtractionBudget? budget)
     {
         var methods = new HashSet<MethodDefinitionHandle>();
         foreach (var typeHandle in reader.TypeDefinitions)
@@ -2176,6 +2229,7 @@ public static class ApiSurfaceExtractor
                         AddOwnedAccessor(
                             reader,
                             surface,
+                            budget,
                             methods,
                             typeHandle,
                             propertyHandle,
@@ -2184,6 +2238,7 @@ public static class ApiSurfaceExtractor
                         AddOwnedAccessor(
                             reader,
                             surface,
+                            budget,
                             methods,
                             typeHandle,
                             propertyHandle,
@@ -2194,6 +2249,7 @@ public static class ApiSurfaceExtractor
                     {
                         AddInspectionFailure(
                             surface,
+                            budget,
                             "property accessors",
                             propertyHandle,
                             MetadataTypeNameFailure.Malformed(propertyHandle, ex.Message));
@@ -2207,6 +2263,7 @@ public static class ApiSurfaceExtractor
                         AddOwnedAccessor(
                             reader,
                             surface,
+                            budget,
                             methods,
                             typeHandle,
                             eventHandle,
@@ -2215,6 +2272,7 @@ public static class ApiSurfaceExtractor
                         AddOwnedAccessor(
                             reader,
                             surface,
+                            budget,
                             methods,
                             typeHandle,
                             eventHandle,
@@ -2225,6 +2283,7 @@ public static class ApiSurfaceExtractor
                     {
                         AddInspectionFailure(
                             surface,
+                            budget,
                             "event accessors",
                             eventHandle,
                             MetadataTypeNameFailure.Malformed(eventHandle, ex.Message));
@@ -2235,19 +2294,21 @@ public static class ApiSurfaceExtractor
             {
                 AddInspectionFailure(
                     surface,
+                    budget,
                     "accessor owner",
                     typeHandle,
                     MetadataTypeNameFailure.Malformed(typeHandle, ex.Message));
             }
         }
 
-        methods.UnionWith(ExtensionPropertyImplementationMethods(reader, surface));
+        methods.UnionWith(ExtensionPropertyImplementationMethods(reader, surface, budget));
         return methods;
     }
 
     private static void AddOwnedAccessor(
         MetadataReader reader,
         ApiSurface surface,
+        ExtractionBudget? budget,
         HashSet<MethodDefinitionHandle> methods,
         TypeDefinitionHandle owningType,
         EntityHandle association,
@@ -2268,6 +2329,7 @@ public static class ApiSurfaceExtractor
 
             AddInspectionFailure(
                 surface,
+                budget,
                 operation,
                 association,
                 MetadataTypeNameFailure.Malformed(
@@ -2280,6 +2342,7 @@ public static class ApiSurfaceExtractor
         {
             AddInspectionFailure(
                 surface,
+                budget,
                 operation,
                 association,
                 MetadataTypeNameFailure.Malformed(association, ex.Message));
@@ -2288,7 +2351,8 @@ public static class ApiSurfaceExtractor
 
     static HashSet<MethodDefinitionHandle> ExtensionPropertyImplementationMethods(
         MetadataReader reader,
-        ApiSurface surface)
+        ApiSurface surface,
+        ExtractionBudget? budget)
     {
         HashSet<MethodDefinitionHandle> methods = [];
         foreach (var extensionClassHandle in reader.TypeDefinitions)
@@ -2408,6 +2472,7 @@ public static class ApiSurfaceExtractor
             {
                 AddInspectionFailure(
                     surface,
+                    budget,
                     "extension property accessors",
                     extensionClassHandle,
                     MetadataTypeNameFailure.Malformed(extensionClassHandle, ex.Message));
@@ -2728,20 +2793,6 @@ public static class ApiSurfaceExtractor
     }
 
     private static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(
-        MetadataReader reader, TypeDefinition typeDef)
-    {
-        HashSet<MethodDefinitionHandle> handles = [];
-        foreach (var implementationHandle in typeDef.GetMethodImplementations())
-        {
-            var implementation = reader.GetMethodImplementation(implementationHandle);
-            if (implementation.MethodBody.Kind == HandleKind.MethodDefinition)
-                handles.Add((MethodDefinitionHandle)implementation.MethodBody);
-        }
-
-        return handles;
-    }
-
-    private static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(
         MetadataReader reader,
         TypeDefinition typeDef,
         MetadataTypeScope? currentScope,
@@ -2951,7 +3002,8 @@ public static class ApiSurfaceExtractor
     private static Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> LocalTypes(
         MetadataReader reader,
         MetadataTypeScope currentScope,
-        ApiSurface surface)
+        ApiSurface surface,
+        ExtractionBudget? budget)
     {
         Dictionary<MetadataNamedTypeIdentity, TypeDefinitionHandle?> types = [];
         foreach (var handle in reader.TypeDefinitions)
@@ -2963,6 +3015,7 @@ public static class ApiSurfaceExtractor
                     types[identity] = null;
                     AddInspectionFailure(
                         surface,
+                        budget,
                         "type identity",
                         handle,
                         MetadataTypeNameFailure.Malformed(
@@ -3115,7 +3168,8 @@ public static class ApiSurfaceExtractor
 
     private static MetadataTypeScope? ReadCurrentScope(
         MetadataReader reader,
-        ApiSurface surface)
+        ApiSurface surface,
+        ExtractionBudget? budget)
     {
         try
         {
@@ -3127,6 +3181,7 @@ public static class ApiSurfaceExtractor
                 reader.IsAssembly ? 0x20000001 : 0x00000001);
             AddInspectionFailure(
                 surface,
+                budget,
                 "module identity",
                 subject,
                 MetadataTypeNameFailure.Malformed(subject, ex.Message));

--- a/src/ILInspector.Metadata/ILInspector.Metadata.csproj
+++ b/src/ILInspector.Metadata/ILInspector.Metadata.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
@@ -98,6 +98,36 @@ public static class MetadataSafetyPolicy
     public const int MaxRelationshipNodes = 256;
 
     /// <summary>
+    /// Maximum constructed interface candidates followed while determining
+    /// whether a MethodImpl declaration is an implemented interface. A visited
+    /// key includes constructed arguments, so a self-referential interface such
+    /// as <c>I&lt;T&gt; : I&lt;I&lt;T&gt;&gt;</c> cannot rely on handle identity to
+    /// terminate. Gated by
+    /// <c>Extract_MalformedRecursiveConstructedInterfaceInheritanceIsBoundedAndVisible</c>.
+    /// </summary>
+    public const int MaxConstructedInterfaceImplementationCandidates =
+        MaxRelationshipNodes;
+
+    /// <summary>
+    /// Maximum nesting depth of one constructed interface identity produced
+    /// while following InterfaceImpl substitutions. This is below the
+    /// signature-decoder ceiling because substitution creates a new in-memory
+    /// shape for every relationship edge. Gated by
+    /// <c>Extract_MalformedRecursiveConstructedInterfaceInheritanceIsBoundedAndVisible</c>.
+    /// </summary>
+    public const int MaxConstructedInterfaceImplementationDepth =
+        MaxRelationshipNodes;
+
+    /// <summary>
+    /// Maximum aggregate structural nodes charged by one MethodImpl
+    /// constructed-interface traversal. The limit shares the signature-node
+    /// policy because both bound artifact-derived tree work. Gated by
+    /// <c>Extract_MalformedRecursiveConstructedInterfaceInheritanceIsBoundedAndVisible</c>.
+    /// </summary>
+    public const int MaxConstructedInterfaceImplementationWorkNodes =
+        MaxSignatureTypeNodes;
+
+    /// <summary>
     /// Maximum characters in one structured type name: its namespace plus every root-to-leaf
     /// segment, plus one delimiter per segment boundary.
     /// </summary>

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1,8 +1,11 @@
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using ILInspector.CSharp;
 using ILInspector.Metadata;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace DotnetInspector.Tests;
 
@@ -1751,6 +1754,25 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_RejectsOwnedMemberReferenceMethodImplBodyWithUnauthenticatedSignatureScope()
+    {
+        using var stream = new MemoryStream(
+            EmitOwnedMemberReferenceMethodImplBody(
+                structuralSignature: true,
+                unauthenticatedStructuralSignatureScope: true));
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+
+        Assert.Contains(
+            surface.InspectionFailures,
+            failure => failure.Operation == "method implementation body"
+                && failure.Detail.Contains(
+                    "does not identify one method",
+                    StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_ReportsDuplicateMethodImplDeclaration()
     {
         using var stream = new MemoryStream(
@@ -1782,6 +1804,34 @@ public class ApiSurfaceExtractorTests
                 && failure.Detail.Contains(
                     "appears more than once",
                     StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_PreservesExternAliasMethodImplDeclarationsWithDistinctScopes()
+    {
+        byte[] firstContract = CompileAliasContract("ContractsOne");
+        byte[] secondContract = CompileAliasContract("ContractsTwo");
+        byte[] implementation = CompileExternAliasImplementation(
+            firstContract,
+            secondContract);
+        using var stream = new MemoryStream(implementation, writable: false);
+        using var peReader = new PEReader(stream);
+
+        ApiSurface surface = ApiSurfaceExtractor.Extract(
+            peReader,
+            includeAll: true);
+        ApiType type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "Implementation");
+
+        Assert.Equal(
+            2,
+            type.Members.Count(
+                member => member.Kind == "explicit-interface-implementation"
+                    && member.Name.EndsWith(".Map", StringComparison.Ordinal)));
+        Assert.DoesNotContain(
+            surface.InspectionFailures,
+            failure => failure.Operation == "method implementation declaration");
     }
 
     [Fact]
@@ -2514,7 +2564,8 @@ public class ApiSurfaceExtractorTests
 
     static byte[] EmitOwnedMemberReferenceMethodImplBody(
         bool structuralSignature = false,
-        bool mismatchedStructuralSignature = false)
+        bool mismatchedStructuralSignature = false,
+        bool unauthenticatedStructuralSignatureScope = false)
     {
         var metadata = CreateAdversarialMetadata("OwnedMemberRefMethodImpl");
         var objectRef = AddCoreLibraryReferences(metadata);
@@ -2554,11 +2605,13 @@ public class ApiSurfaceExtractorTests
             MetadataTokens.FieldDefinitionHandle(1),
             MetadataTokens.MethodDefinitionHandle(3));
         var other = metadata.AddTypeReference(
-            default,
+            MetadataTokens.EntityHandle(0x00000001),
             default,
             metadata.GetOrAddString("Other"));
         var valueReference = metadata.AddTypeReference(
-            default,
+            unauthenticatedStructuralSignatureScope
+                ? default
+                : MetadataTokens.EntityHandle(0x00000001),
             default,
             metadata.GetOrAddString("Value"));
         var signature = metadata.GetOrAddBlob(
@@ -3418,6 +3471,89 @@ public class ApiSurfaceExtractorTests
         pe.Serialize(image);
         return image.ToArray();
     }
+
+    static byte[] CompileAliasContract(string assemblyName)
+        => CompileRoslynFixture(
+            assemblyName,
+            """
+            namespace Contracts;
+
+            public sealed class Marker;
+
+            public interface IContract<T>
+            {
+                void Map(T value);
+            }
+            """,
+            TrustedPlatformReferences());
+
+    static byte[] CompileExternAliasImplementation(
+        byte[] firstContract,
+        byte[] secondContract)
+    {
+        ImmutableArray<MetadataReference> references =
+        [
+            .. TrustedPlatformReferences(),
+            MetadataReference.CreateFromImage(
+                ImmutableArray.Create(firstContract),
+                MetadataReferenceProperties.Assembly.WithAliases(
+                    ImmutableArray.Create("First"))),
+            MetadataReference.CreateFromImage(
+                ImmutableArray.Create(secondContract),
+                MetadataReferenceProperties.Assembly.WithAliases(
+                    ImmutableArray.Create("Second"))),
+        ];
+        return CompileRoslynFixture(
+            "ExternAliasImplementation",
+            """
+            extern alias First;
+            extern alias Second;
+
+            public sealed class Implementation :
+                First::Contracts.IContract<First::Contracts.Marker>,
+                Second::Contracts.IContract<Second::Contracts.Marker>
+            {
+                void First::Contracts.IContract<First::Contracts.Marker>.Map(
+                    First::Contracts.Marker value)
+                {
+                }
+
+                void Second::Contracts.IContract<Second::Contracts.Marker>.Map(
+                    Second::Contracts.Marker value)
+                {
+                }
+            }
+            """,
+            references);
+    }
+
+    static byte[] CompileRoslynFixture(
+        string assemblyName,
+        string source,
+        IEnumerable<MetadataReference> references)
+    {
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName,
+            [CSharpSyntaxTree.ParseText(source)],
+            references,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                optimizationLevel: OptimizationLevel.Release,
+                deterministic: true));
+        using var stream = new MemoryStream();
+        var result = compilation.Emit(stream);
+        Assert.True(
+            result.Success,
+            string.Join(
+                Environment.NewLine,
+                result.Diagnostics.Select(static diagnostic => diagnostic.ToString())));
+        return stream.ToArray();
+    }
+
+    static IEnumerable<MetadataReference> TrustedPlatformReferences()
+        => ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(static path => MetadataReference.CreateFromFile(path));
 
     static byte[] VoidNullaryInstanceSignature() => [0x20, 0x00, 0x01];
     static byte[] Int32NullaryInstanceSignature() => [0x20, 0x00, 0x08];

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -124,6 +124,25 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_PreservesExtensionPropertyLookalikeWithOptionalModifier()
+    {
+        using var stream = new MemoryStream(
+            EmitExtensionPropertyImplementationLookalike());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var host = Assert.Single(surface.Types, type => type.Name == "Host");
+        var lookalike = Assert.Single(
+            host.Members,
+            member => member.Kind == "method" && member.Name == "get_Value");
+
+        Assert.Equal("bool get_Value(int arg0)", lookalike.Signature);
+        Assert.NotNull(
+            Assert.Single(lookalike.SignatureModel!.Parameters).StructuralType);
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
     public void Extract_PreservesRefReadonlyReturnInMethodSignatures()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
@@ -1541,6 +1560,78 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_RecognizesExactConstructedInterfaceMethodImpl()
+    {
+        using var stream = new MemoryStream(
+            EmitConstructedInterfaceMethodImpl(matchesImplementedInterface: true));
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var member = Assert.Single(
+            Assert.Single(surface.Types, type => type.Name == "Implementation").Members,
+            candidate => candidate.Name == "Mapped");
+
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void Extract_RejectsMismatchedConstructedInterfaceMethodImpl()
+    {
+        using var stream = new MemoryStream(
+            EmitConstructedInterfaceMethodImpl(matchesImplementedInterface: false));
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var member = Assert.Single(
+            Assert.Single(surface.Types, type => type.Name == "Implementation").Members,
+            candidate => candidate.Name == "Mapped");
+
+        Assert.Equal("method", member.Kind);
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void Extract_PreservesMethodImplThroughUnsubstitutedGenericBaseInterface()
+    {
+        using var stream = new MemoryStream(
+            EmitInterfaceInheritedThroughConstructedGenericBase());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var member = Assert.Single(
+            Assert.Single(surface.Types, type => type.Name == "Derived").Members,
+            candidate => candidate.Name == "Mapped");
+
+        // Base<int>'s InterfaceImpl is encoded as I<!0>. Until the base
+        // construction is carried through this walk, treating it as a proven
+        // non-match would hide a possible explicit implementation.
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Null(member.Accessibility);
+    }
+
+    [Fact]
+    public void Extract_MalformedRecursiveConstructedInterfaceInheritanceIsBoundedAndVisible()
+    {
+        using var stream = new MemoryStream(
+            EmitRecursiveConstructedInterfaceMethodImpl());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var member = Assert.Single(
+            Assert.Single(
+                surface.Types,
+                type => type.Name == "Implementation").Members,
+            candidate => candidate.Name == "Mapped");
+
+        // IRecursive<T> : IRecursive<IRecursive<T>> grows its constructed
+        // identity at every breadth-first edge. Hitting the safety bound is
+        // unresolved ownership, not proof that this named method is ordinary.
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Null(member.Accessibility);
+    }
+
+    [Fact]
     public void Extract_TreatsAssemblySimpleNamesCaseInsensitivelyForClassOverrides()
     {
         using var stream = new MemoryStream(EmitCaseVariantClassOverride());
@@ -1778,7 +1869,7 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
-    public void Extract_ReportsCrossTypeAccessorWithoutSuppressingUnrelatedMethod()
+    public void Extract_DoesNotReuseAccessorOwnershipAcrossAssociations()
     {
         byte[] image = EmitCrossTypeMethodSemantics();
         ApiSurface surface;
@@ -1790,20 +1881,49 @@ public class ApiSurfaceExtractorTests
         var victim = Assert.Single(surface.Types, candidate => candidate.Name == "Victim");
 
         Assert.DoesNotContain(holder.Members, member => member.Kind == "property");
-        Assert.Contains(victim.Members, member => member.Kind == "method" && member.Name == "UnrelatedMethod");
+        Assert.DoesNotContain(holder.Members, member => member.Kind == "event");
+        Assert.Contains(victim.Members, member => member.Kind == "property" && member.Name == "Owned");
+        Assert.Contains(victim.Members, member => member.Kind == "event" && member.Name == "OwnedEvent");
+        Assert.DoesNotContain(
+            victim.Members,
+            member => member.Kind == "method"
+                && member.Name is "get_Owned" or "add_OwnedEvent" or "remove_OwnedEvent");
         Assert.Contains(
             surface.InspectionFailures,
             failure => failure.Operation == "property getter"
+                && failure.Detail.Contains("not association owner", StringComparison.Ordinal));
+        Assert.Contains(
+            surface.InspectionFailures,
+            failure => failure.Operation == "event adder"
                 && failure.Detail.Contains("not association owner", StringComparison.Ordinal));
 
         using var summaryStream = new MemoryStream(image);
         using var summaryReader = new PEReader(summaryStream);
         var summary = ApiSurfaceExtractor.ExtractSummary(summaryReader);
-        Assert.Equal(0, summary.PublicPropertyCount);
+        Assert.Equal(1, summary.PublicPropertyCount);
+        Assert.Equal(1, summary.PublicEventCount);
         Assert.Contains(
             summary.InspectionFailures,
             failure => failure.Operation == "property getter"
                 && failure.Detail.Contains("not association owner", StringComparison.Ordinal));
+        Assert.Contains(
+            summary.InspectionFailures,
+            failure => failure.Operation == "event adder"
+                && failure.Detail.Contains("not association owner", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_ForeignAssociationDoesNotSuppressNamedMethodOnOwningType()
+    {
+        using var stream = new MemoryStream(EmitCrossTypeMethodSemantics());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var victim = Assert.Single(surface.Types, candidate => candidate.Name == "Victim");
+
+        Assert.Contains(
+            victim.Members,
+            member => member.Kind == "method" && member.Name == "get_Foreign");
     }
 
     [Fact]
@@ -2435,7 +2555,7 @@ public class ApiSurfaceExtractorTests
             objectRef,
             MetadataTokens.FieldDefinitionHandle(1),
             MetadataTokens.MethodDefinitionHandle(1));
-        metadata.AddTypeDefinition(
+        var victim = metadata.AddTypeDefinition(
             System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
             default,
             metadata.GetOrAddString("Victim"),
@@ -2443,23 +2563,530 @@ public class ApiSurfaceExtractorTests
             MetadataTokens.FieldDefinitionHandle(1),
             MetadataTokens.MethodDefinitionHandle(1));
 
-        var unrelatedMethod = metadata.AddMethodDefinition(
+        var ownedGetter = metadata.AddMethodDefinition(
             System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.HideBySig,
             System.Reflection.MethodImplAttributes.IL,
-            metadata.GetOrAddString("UnrelatedMethod"),
+            metadata.GetOrAddString("get_Owned"),
             metadata.GetOrAddBlob(Int32NullaryInstanceSignature()),
             bodyOffset,
             parameterList: MetadataTokens.ParameterHandle(1));
-        var property = metadata.AddProperty(
+        var foreignGetter = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("get_Foreign"),
+            metadata.GetOrAddBlob(Int32NullaryInstanceSignature()),
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var ownedAdder = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("add_OwnedEvent"),
+            metadata.GetOrAddBlob(VoidNullaryInstanceSignature()),
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var ownedRemover = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("remove_OwnedEvent"),
+            metadata.GetOrAddBlob(VoidNullaryInstanceSignature()),
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var stolenProperty = metadata.AddProperty(
             System.Reflection.PropertyAttributes.None,
             metadata.GetOrAddString("Value"),
             metadata.GetOrAddBlob(Int32PropertySignature()));
-        metadata.AddPropertyMap(holder, property);
+        var ownedProperty = metadata.AddProperty(
+            System.Reflection.PropertyAttributes.None,
+            metadata.GetOrAddString("Owned"),
+            metadata.GetOrAddBlob(Int32PropertySignature()));
+        metadata.AddPropertyMap(holder, stolenProperty);
+        metadata.AddPropertyMap(victim, ownedProperty);
+        metadata.AddMethodSemantics(
+            stolenProperty,
+            System.Reflection.MethodSemanticsAttributes.Getter,
+            foreignGetter);
+        metadata.AddMethodSemantics(
+            ownedProperty,
+            System.Reflection.MethodSemanticsAttributes.Getter,
+            ownedGetter);
+
+        var stolenEvent = metadata.AddEvent(
+            System.Reflection.EventAttributes.None,
+            metadata.GetOrAddString("Changed"),
+            objectRef);
+        var ownedEvent = metadata.AddEvent(
+            System.Reflection.EventAttributes.None,
+            metadata.GetOrAddString("OwnedEvent"),
+            objectRef);
+        metadata.AddEventMap(holder, stolenEvent);
+        metadata.AddEventMap(victim, ownedEvent);
+        foreach (var @event in new[] { stolenEvent, ownedEvent })
+        {
+            metadata.AddMethodSemantics(
+                @event,
+                System.Reflection.MethodSemanticsAttributes.Adder,
+                ownedAdder);
+            metadata.AddMethodSemantics(
+                @event,
+                System.Reflection.MethodSemanticsAttributes.Remover,
+                ownedRemover);
+        }
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitExtensionPropertyImplementationLookalike()
+    {
+        var metadata = CreateAdversarialMetadata(
+            "ExtensionPropertyImplementationLookalike");
+        var runtime = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Runtime"),
+            new Version(11, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        var extensionAttribute = metadata.AddTypeReference(
+            runtime,
+            metadata.GetOrAddString("System.Runtime.CompilerServices"),
+            metadata.GetOrAddString("ExtensionAttribute"));
+        var markerAttribute = metadata.AddTypeReference(
+            runtime,
+            metadata.GetOrAddString("System.Runtime.CompilerServices"),
+            metadata.GetOrAddString("ExtensionMarkerAttribute"));
+        var modifier = metadata.AddTypeReference(
+            runtime,
+            metadata.GetOrAddString("System.Runtime.CompilerServices"),
+            metadata.GetOrAddString("IsConst"));
+        BlobHandle attributeConstructorSignature =
+            metadata.GetOrAddBlob(VoidNullaryInstanceSignature());
+        var extensionConstructor = metadata.AddMemberReference(
+            extensionAttribute,
+            metadata.GetOrAddString(".ctor"),
+            attributeConstructorSignature);
+        var markerConstructor = metadata.AddMemberReference(
+            markerAttribute,
+            metadata.GetOrAddString(".ctor"),
+            attributeConstructorSignature);
+        BlobHandle emptyAttribute = metadata.GetOrAddBlob(
+            new byte[] { 0x01, 0x00 });
+        var markerValue = new BlobBuilder();
+        markerValue.WriteUInt16(1);
+        markerValue.WriteSerializedString("Marker");
+
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var host = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Abstract
+                | System.Reflection.TypeAttributes.Sealed,
+            default,
+            metadata.GetOrAddString("Host"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var group = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.NestedPublic
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Group"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(3));
+        var marker = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.NestedPublic
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Marker"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(4));
+        metadata.AddNestedType(group, host);
+        metadata.AddNestedType(marker, group);
+
+        BlobHandle implementationSignature = metadata.GetOrAddBlob(
+            new byte[] { 0x00, 0x01, 0x02, 0x08 }); // static bool (int)
+        metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Static
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("get_Value"),
+            implementationSignature,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+
+        var modifiedSignature = new BlobBuilder();
+        modifiedSignature.WriteByte(0x00); // static default
+        modifiedSignature.WriteByte(0x01); // one parameter
+        modifiedSignature.WriteByte(0x02); // bool return
+        modifiedSignature.WriteByte(0x20); // modopt
+        modifiedSignature.WriteCompressedInteger(
+            MetadataTokens.GetRowNumber(modifier) << 2 | 1);
+        modifiedSignature.WriteByte(0x08); // int32
+        metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Static
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("get_Value"),
+            metadata.GetOrAddBlob(modifiedSignature),
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+
+        var getter = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.SpecialName
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("get_Value"),
+            metadata.GetOrAddBlob(
+                new byte[] { 0x20, 0x00, 0x02 }), // instance bool ()
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Static
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("<Extension>$"),
+            metadata.GetOrAddBlob(
+                new byte[] { 0x00, 0x01, 0x01, 0x08 }), // static void (int)
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+
+        var property = metadata.AddProperty(
+            System.Reflection.PropertyAttributes.None,
+            metadata.GetOrAddString("Value"),
+            metadata.GetOrAddBlob(
+                new byte[] { 0x08, 0x00, 0x02 })); // bool Value
+        metadata.AddPropertyMap(group, property);
         metadata.AddMethodSemantics(
             property,
             System.Reflection.MethodSemanticsAttributes.Getter,
-            unrelatedMethod);
+            getter);
+        metadata.AddCustomAttribute(host, extensionConstructor, emptyAttribute);
+        metadata.AddCustomAttribute(group, extensionConstructor, emptyAttribute);
+        metadata.AddCustomAttribute(
+            property,
+            markerConstructor,
+            metadata.GetOrAddBlob(markerValue));
         return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitConstructedInterfaceMethodImpl(
+        bool matchesImplementedInterface)
+    {
+        var metadata = CreateAdversarialMetadata("ConstructedInterfaceMethodImpl");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var contract = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IContract`1"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var implementation = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Implementation"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        metadata.AddGenericParameter(
+            contract,
+            System.Reflection.GenericParameterAttributes.None,
+            metadata.GetOrAddString("T"),
+            index: 0);
+
+        BlobHandle signature = metadata.GetOrAddBlob(
+            VoidNullaryInstanceSignature());
+        metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var body = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        TypeSpecificationHandle implemented =
+            AddConstructedInterface(metadata, contract, SignatureTypeCode.String);
+        TypeSpecificationHandle declaration =
+            AddConstructedInterface(
+                metadata,
+                contract,
+                matchesImplementedInterface
+                    ? SignatureTypeCode.String
+                    : SignatureTypeCode.Int32);
+        metadata.AddInterfaceImplementation(implementation, implemented);
+        metadata.AddMethodImplementation(
+            implementation,
+            body,
+            metadata.AddMemberReference(
+                declaration,
+                metadata.GetOrAddString("Mapped"),
+                signature));
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitInterfaceInheritedThroughConstructedGenericBase()
+    {
+        var metadata = CreateAdversarialMetadata("ConstructedGenericBaseInterface");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var contract = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IContract`1"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var genericBase = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Base`1"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        TypeSpecificationHandle baseOfInt = AddConstructedInterface(
+            metadata,
+            genericBase,
+            SignatureTypeCode.Int32);
+        var derived = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Derived"),
+            baseOfInt,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        metadata.AddGenericParameter(
+            contract,
+            System.Reflection.GenericParameterAttributes.None,
+            metadata.GetOrAddString("T"),
+            index: 0);
+        metadata.AddGenericParameter(
+            genericBase,
+            System.Reflection.GenericParameterAttributes.None,
+            metadata.GetOrAddString("T"),
+            index: 0);
+
+        BlobHandle signature = metadata.GetOrAddBlob(
+            VoidNullaryInstanceSignature());
+        metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var body = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        metadata.AddInterfaceImplementation(
+            genericBase,
+            AddConstructedInterfaceWithTypeParameter(
+                metadata,
+                contract,
+                parameterIndex: 0));
+        metadata.AddMethodImplementation(
+            derived,
+            body,
+            metadata.AddMemberReference(
+                AddConstructedInterface(
+                    metadata,
+                    contract,
+                    SignatureTypeCode.Int32),
+                metadata.GetOrAddString("Mapped"),
+                signature));
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitRecursiveConstructedInterfaceMethodImpl()
+    {
+        var metadata = CreateAdversarialMetadata("RecursiveConstructedInterface");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var target = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("ITarget"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var recursive = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IRecursive`1"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var implementation = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Implementation"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddGenericParameter(
+            recursive,
+            System.Reflection.GenericParameterAttributes.None,
+            metadata.GetOrAddString("T"),
+            index: 0);
+
+        BlobHandle signature = metadata.GetOrAddBlob(
+            VoidNullaryInstanceSignature());
+        var body = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        metadata.AddInterfaceImplementation(
+            recursive,
+            AddRecursiveInterface(metadata, recursive));
+        metadata.AddInterfaceImplementation(
+            implementation,
+            AddConstructedInterface(
+                metadata,
+                recursive,
+                SignatureTypeCode.Int32));
+        metadata.AddMethodImplementation(
+            implementation,
+            body,
+            metadata.AddMemberReference(
+                target,
+                metadata.GetOrAddString("Mapped"),
+                signature));
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static TypeSpecificationHandle AddConstructedInterface(
+        MetadataBuilder metadata,
+        TypeDefinitionHandle contract,
+        SignatureTypeCode argument)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x15); // generic instantiation
+        signature.WriteByte(0x12); // class
+        signature.WriteCompressedInteger(
+            MetadataTokens.GetRowNumber(contract) << 2);
+        signature.WriteByte(0x01); // one type argument
+        signature.WriteByte((byte)argument);
+        return metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature));
+    }
+
+    static TypeSpecificationHandle AddConstructedInterfaceWithTypeParameter(
+        MetadataBuilder metadata,
+        TypeDefinitionHandle contract,
+        int parameterIndex)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x15); // generic instantiation
+        signature.WriteByte(0x12); // class
+        signature.WriteCompressedInteger(
+            MetadataTokens.GetRowNumber(contract) << 2);
+        signature.WriteByte(0x01); // one type argument
+        signature.WriteByte(0x13); // VAR
+        signature.WriteCompressedInteger(parameterIndex);
+        return metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature));
+    }
+
+    static TypeSpecificationHandle AddRecursiveInterface(
+        MetadataBuilder metadata,
+        TypeDefinitionHandle recursive)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x15); // generic instantiation
+        signature.WriteByte(0x12); // class
+        signature.WriteCompressedInteger(
+            MetadataTokens.GetRowNumber(recursive) << 2);
+        signature.WriteByte(0x01); // one type argument
+        signature.WriteByte(0x15); // generic instantiation
+        signature.WriteByte(0x12); // class
+        signature.WriteCompressedInteger(
+            MetadataTokens.GetRowNumber(recursive) << 2);
+        signature.WriteByte(0x01); // one type argument
+        signature.WriteByte(0x13); // VAR
+        signature.WriteByte(0x00); // !0
+        return metadata.AddTypeSpecification(metadata.GetOrAddBlob(signature));
     }
 
     static MetadataBuilder CreateAdversarialMetadata(string assemblyName)

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1538,6 +1538,87 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_PreservesImplementationOfInterfaceInheritedThroughBaseClass()
+    {
+        using var stream = new MemoryStream(EmitInterfaceInheritedThroughBaseClass());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == "Derived");
+        var member = Assert.Single(type.Members, candidate => candidate.Name == "Mapped");
+
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Null(member.Accessibility);
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void Extract_ReportsDuplicateTypeIdentityWithoutSelectingArbitraryDefinition()
+    {
+        using var stream = new MemoryStream(EmitDuplicateTypeDefinitionIdentity());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+        var member = Assert.Single(type.Members, candidate => candidate.Name == "Mapped");
+
+        Assert.Equal(2, surface.Types.Count(candidate => candidate.Name == "IDerived"));
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Contains(
+            surface.InspectionFailures,
+            failure => failure.Operation == "type identity"
+                && failure.Detail.Contains("Duplicate type definition identity", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_FollowsLocalGenericBaseWhenClassifyingImplicitFinalizer()
+    {
+        using var stream = new MemoryStream(EmitGenericBaseFinalizer());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == "Derived");
+        var finalizer = Assert.Single(type.Members, candidate => candidate.Name == "Finalize");
+
+        Assert.Equal("finalizer", finalizer.Kind);
+        Assert.True(finalizer.IsFinalizer);
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void Extract_DoesNotTreatOverrideOfGenericBaseCustomFinalizeSlotAsFinalizer()
+    {
+        using var stream = new MemoryStream(EmitGenericBaseFinalizer(baseIntroducesFinalizeSlot: true));
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == "Derived");
+        var method = Assert.Single(type.Members, candidate => candidate.Name == "Finalize");
+
+        Assert.Equal("method", method.Kind);
+        Assert.False(method.IsFinalizer);
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void Extract_ReportsCrossTypeAccessorWithoutSuppressingUnrelatedMethod()
+    {
+        using var stream = new MemoryStream(EmitCrossTypeMethodSemantics());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var holder = Assert.Single(surface.Types, candidate => candidate.Name == "Holder");
+        var victim = Assert.Single(surface.Types, candidate => candidate.Name == "Victim");
+
+        Assert.Contains(holder.Members, member => member.Kind == "property" && member.Name == "Value");
+        Assert.Contains(victim.Members, member => member.Kind == "method" && member.Name == "UnrelatedMethod");
+        Assert.Contains(
+            surface.InspectionFailures,
+            failure => failure.Operation == "property getter"
+                && failure.Detail.Contains("not association owner", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_MetadataReaderOverloadMatchesPeReaderSurface()
     {
         using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
@@ -1646,6 +1727,330 @@ public class ApiSurfaceExtractorTests
             .SurfaceFieldHandles(reader, typeDef, includeAll: true, includeCompilerGenerated)
             .Select(h => reader.GetString(reader.GetFieldDefinition(h).Name))
             .ToHashSet(StringComparer.Ordinal);
+
+    static byte[] EmitInterfaceInheritedThroughBaseClass()
+    {
+        var metadata = CreateAdversarialMetadata("BaseClassInheritedInterface");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var contract = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IContract"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var baseType = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Base"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        var derived = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Derived"),
+            baseType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+
+        var declaration = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            metadata.GetOrAddBlob(VoidNullaryInstanceSignature()),
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var implementation = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            metadata.GetOrAddBlob(VoidNullaryInstanceSignature()),
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        metadata.AddInterfaceImplementation(baseType, contract);
+        metadata.AddMethodImplementation(derived, implementation, declaration);
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitDuplicateTypeDefinitionIdentity()
+    {
+        var metadata = CreateAdversarialMetadata("DuplicateTypeDefIdentity");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var contract = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IBase"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var shadow = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IDerived"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        var duplicate = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IDerived"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        var implementationType = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Implementation"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+
+        var declaration = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            metadata.GetOrAddBlob(VoidNullaryInstanceSignature()),
+            bodyOffset: 0,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var implementation = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            metadata.GetOrAddBlob(VoidNullaryInstanceSignature()),
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        metadata.AddInterfaceImplementation(duplicate, contract);
+        metadata.AddInterfaceImplementation(implementationType, shadow);
+        metadata.AddInterfaceImplementation(implementationType, duplicate);
+        metadata.AddMethodImplementation(implementationType, implementation, declaration);
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitGenericBaseFinalizer(bool baseIntroducesFinalizeSlot = false)
+    {
+        var metadata = CreateAdversarialMetadata("GenericBaseFinalizer");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var genericBase = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("GenericBase`1"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddGenericParameter(
+            genericBase,
+            System.Reflection.GenericParameterAttributes.None,
+            metadata.GetOrAddString("T"),
+            index: 0);
+
+        var genericBaseOfIntSignature = new BlobBuilder();
+        genericBaseOfIntSignature.WriteByte(0x15);
+        genericBaseOfIntSignature.WriteByte(0x12);
+        genericBaseOfIntSignature.WriteCompressedInteger(
+            MetadataTokens.GetRowNumber(genericBase) << 2);
+        genericBaseOfIntSignature.WriteCompressedInteger(1);
+        genericBaseOfIntSignature.WriteByte(0x08);
+        var genericBaseOfInt = metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(genericBaseOfIntSignature));
+        var derived = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Derived"),
+            genericBaseOfInt,
+            MetadataTokens.FieldDefinitionHandle(1),
+            baseIntroducesFinalizeSlot
+                ? MetadataTokens.MethodDefinitionHandle(2)
+                : MetadataTokens.MethodDefinitionHandle(1));
+
+        if (baseIntroducesFinalizeSlot)
+        {
+            metadata.AddMethodDefinition(
+                System.Reflection.MethodAttributes.Family
+                    | System.Reflection.MethodAttributes.Virtual
+                    | System.Reflection.MethodAttributes.NewSlot
+                    | System.Reflection.MethodAttributes.HideBySig,
+                System.Reflection.MethodImplAttributes.IL,
+                metadata.GetOrAddString("Finalize"),
+                metadata.GetOrAddBlob(VoidNullaryInstanceSignature()),
+                bodyOffset,
+                parameterList: MetadataTokens.ParameterHandle(1));
+        }
+
+        metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Family
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Finalize"),
+            metadata.GetOrAddBlob(VoidNullaryInstanceSignature()),
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitCrossTypeMethodSemantics()
+    {
+        var metadata = CreateAdversarialMetadata("CrossTypeMethodSemantics");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var holder = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Holder"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Victim"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var unrelatedMethod = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("UnrelatedMethod"),
+            metadata.GetOrAddBlob(Int32NullaryInstanceSignature()),
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var property = metadata.AddProperty(
+            System.Reflection.PropertyAttributes.None,
+            metadata.GetOrAddString("Value"),
+            metadata.GetOrAddBlob(Int32PropertySignature()));
+        metadata.AddPropertyMap(holder, property);
+        metadata.AddMethodSemantics(
+            property,
+            System.Reflection.MethodSemanticsAttributes.Getter,
+            unrelatedMethod);
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static MetadataBuilder CreateAdversarialMetadata(string assemblyName)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString($"{assemblyName}.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString(assemblyName),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        return metadata;
+    }
+
+    static TypeReferenceHandle AddCoreLibraryReferences(MetadataBuilder metadata)
+    {
+        var coreLib = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Private.CoreLib"),
+            new Version(11, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: metadata.GetOrAddBlob(
+                new byte[] { 0x7c, 0xec, 0x85, 0xd7, 0xbe, 0xa7, 0x79, 0x8e }),
+            flags: default,
+            hashValue: default);
+        return metadata.AddTypeReference(
+            coreLib,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+    }
+
+    static int AddRetBody(BlobBuilder methodBodies)
+    {
+        var instructions = new BlobBuilder();
+        var encoder = new InstructionEncoder(instructions, new ControlFlowBuilder());
+        encoder.OpCode(ILOpCode.Ret);
+        return new MethodBodyStreamEncoder(methodBodies).AddMethodBody(encoder, maxStack: 0);
+    }
+
+    static byte[] SerializeAdversarialMetadata(
+        MetadataBuilder metadata,
+        BlobBuilder methodBodies)
+    {
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static byte[] VoidNullaryInstanceSignature() => [0x20, 0x00, 0x01];
+    static byte[] Int32NullaryInstanceSignature() => [0x20, 0x00, 0x08];
+    static byte[] Int32PropertySignature() => [0x08, 0x00, 0x08];
 
     static string EmitUnownedSpecialNameAccessorMethod()
     {

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using ILInspector.CSharp;
 using ILInspector.Metadata;
@@ -45,7 +46,7 @@ public class ApiSurfaceExtractorTests
         using var stream = File.OpenRead(assemblyPath);
         using var peReader = new PEReader(stream);
 
-        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var surface = ApiSurfaceExtractor.Extract(peReader);
 
         // Find a method with known parameters
         var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
@@ -78,6 +79,48 @@ public class ApiSurfaceExtractorTests
         var staticMethod = testType.Members.FirstOrDefault(m => m.Name == nameof(SampleKeywordParameterHost.Static));
         Assert.NotNull(staticMethod);
         Assert.Equal("int Static(int @params, int @void)", staticMethod.Signature);
+    }
+
+    [Fact]
+    public void Extract_FinalizerHasNoSourceModifiers()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == nameof(SampleFinalizerHost));
+        var finalizer = Assert.Single(type.Members, member => member.Kind == "finalizer");
+        Assert.True(finalizer.IsFinalizer);
+        Assert.Null(finalizer.Accessibility);
+        Assert.False(finalizer.IsOverride);
+        Assert.False(finalizer.IsSealed);
+    }
+
+    [Fact]
+    public void Extract_DoesNotLeakExtensionPropertyImplementationAccessor()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(SampleExtensionPropertyHost));
+        var ordinaryInstanceOverload = Assert.Single(
+            type.Members,
+            member => member.Name == "get_IsEven");
+        Assert.Equal(1, ordinaryInstanceOverload.SignatureModel?.TypeParameters.Count);
+        Assert.DoesNotContain(type.Members, member => member.Name == "get_Echo");
+        Assert.DoesNotContain(type.Members, member => member.Name == "set_Echo");
+        Assert.DoesNotContain(type.Members, member => member.Name == "get_Zero");
+        var ordinaryGenericOverload = Assert.Single(
+            type.Members,
+            member => member.Name == "get_GenericValue");
+        Assert.Equal(2, ordinaryGenericOverload.SignatureModel?.TypeParameters.Count);
     }
 
     [Fact]
@@ -1233,13 +1276,288 @@ public class ApiSurfaceExtractorTests
         Assert.Contains(
             surface.Types,
             t => (t.MetadataName ?? "").Contains("DisplayClass")
-                 && t.Members.Any(m => m.Kind == "field"));
+                 && t.Members.Any(m => m.Kind == "field")
+                 && t.Members.Any(m => m.Name.StartsWith("<", StringComparison.Ordinal)));
 
         // Auto-property backing fields (<Prop>k__BackingField) are never surfaced as fields, even
         // once compiler-generated members are opted in.
         Assert.DoesNotContain(
             surface.Types.SelectMany(t => t.Members),
             m => m.Kind == "field" && m.Name.EndsWith("k__BackingField", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_LinksExplicitInterfaceAccessorsToOwningMembers()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(ExplicitSurfaceFixture));
+
+        var property = Assert.Single(
+            type.Members,
+            member => member.Kind == "property"
+                && member.Name.EndsWith(".Value", StringComparison.Ordinal));
+        var @event = Assert.Single(
+            type.Members,
+            member => member.Kind == "event"
+                && member.Name.EndsWith(".Changed", StringComparison.Ordinal));
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(".Run", StringComparison.Ordinal));
+        Assert.Contains(type.Members, member =>
+            member.MetadataToken == property.GetterToken
+            && member.Name.Contains(".get_", StringComparison.Ordinal));
+        Assert.Contains(type.Members, member =>
+            member.MetadataToken == @event.AdderToken
+            && member.Name.Contains(".add_", StringComparison.Ordinal));
+        Assert.Contains(type.Members, member =>
+            member.MetadataToken == @event.RemoverToken
+            && member.Name.Contains(".remove_", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_PreservesStandaloneAccessorPrefixedMethods()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(AccessorPrefixMethodFixture));
+
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "get_Unused");
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "set_Unused");
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "add_Unused");
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "remove_Unused");
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "op_Custom");
+        Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "op_AdditionAssignment");
+    }
+
+    [Fact]
+    public void Extract_PreservesUnownedSpecialNameAccessorMethod()
+    {
+        var path = EmitUnownedSpecialNameAccessorMethod();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "SpecialNameFixture");
+
+            Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "get_Value");
+            Assert.Contains(
+                type.Members,
+                member => member.Kind == "operator" && member.Name == "op_AdditionAssignment");
+            Assert.Contains(
+                type.Members,
+                member => member.Kind == "method" && member.Name == "op_IncrementAssignment");
+            Assert.DoesNotContain(type.Members, member => member.Kind == "property");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Extract_DoesNotDuplicateMethodImplBackedOrdinaryAccessor()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(CovariantSurfaceDerived));
+        var property = Assert.Single(
+            type.Members,
+            member => member.Kind == "property" && member.Name == "Value");
+
+        Assert.DoesNotContain(type.Members, member => member.MetadataToken == property.GetterToken);
+        Assert.DoesNotContain(type.Members, member => member.Name == "get_Value");
+    }
+
+    [Fact]
+    public void Extract_PreservesOtherAndRaiserMethodSemantics()
+    {
+        var path = EmitUnownedSpecialNameAccessorMethod();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "SemanticsFixture");
+
+            Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "OtherProperty");
+            Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "RaiseChanged");
+            Assert.Contains(type.Members, member => member.Kind == "method" && member.Name == "OtherEvent");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Extract_ClassifiesInterfaceMethodImplRowsByAccessorOwnership()
+    {
+        var path = EmitPrivateUnqualifiedInterfaceAccessor();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+            var method = Assert.Single(
+                type.Members,
+                member => member.Name == "get_Value");
+            var ordinaryMethod = Assert.Single(
+                type.Members,
+                member => member.Name == "MappedMethod");
+
+            Assert.Equal("explicit-interface-implementation", method.Kind);
+            Assert.Equal("explicit-interface-implementation", ordinaryMethod.Kind);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Extract_PreservesAccessorsImplementingInheritedInterfaces()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(InheritedInterfaceSurfaceFixture));
+
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.Contains("get_Value", StringComparison.Ordinal));
+
+        var genericType = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(GenericInheritedInterfaceSurfaceFixture));
+        Assert.Contains(
+            genericType.Members,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.Contains("get_Value", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_PreservesAccessorWhenOnlyDerivedInterfaceIsListed()
+    {
+        var path = EmitInheritedInterfaceAccessor();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+
+            Assert.Contains(
+                type.Members,
+                member => member.Kind == "explicit-interface-implementation"
+                    && member.Name == "get_Value");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Extract_PreservesImplementationInheritedThroughExternalInterface()
+    {
+        var path = EmitExternalInheritedInterfaceImplementation();
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader);
+            var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+            var member = Assert.Single(
+                type.Members,
+                candidate => candidate.Name == "ICollectionGetEnumerator");
+
+            Assert.Equal("explicit-interface-implementation", member.Kind);
+            Assert.Null(member.Accessibility);
+
+            Assert.DoesNotContain(
+                type.Members,
+                candidate => candidate.Name == "MappedToExternalBase");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Extract_PreservesMethodImplWhenInterfaceScopeIsUnresolved()
+    {
+        using var stream = new MemoryStream(EmitUnresolvedInterfaceIdentityImplementation());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+        var member = Assert.Single(type.Members, candidate => candidate.Name == "Mapped");
+
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Null(member.Accessibility);
+    }
+
+    [Fact]
+    public void Extract_PreservesMethodImplWhenDeclarationIdentityIsUnresolved()
+    {
+        using var stream = new MemoryStream(EmitUnresolvedMethodImplDeclarationIdentity());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == "Implementation");
+        var member = Assert.Single(type.Members, candidate => candidate.Name == "Mapped");
+
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Null(member.Accessibility);
+    }
+
+    [Fact]
+    public void Extract_MetadataReaderOverloadMatchesPeReaderSurface()
+    {
+        using var stream = File.OpenRead(typeof(ApiSurfaceExtractorTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var fromPe = ApiSurfaceExtractor.Extract(
+            peReader,
+            includeAll: true,
+            includeCompilerGenerated: true);
+        var fromMetadata = ApiSurfaceExtractor.Extract(
+            peReader.GetMetadataReader(),
+            includeAll: true,
+            includeCompilerGenerated: true);
+
+        Assert.Equal(
+            fromPe.Types.Select(type => type.DefinitionName).ToArray(),
+            fromMetadata.Types.Select(type => type.DefinitionName).ToArray());
+        Assert.Equal(
+            fromPe.Types.SelectMany(type => type.Members).Select(member => member.Name).ToArray(),
+            fromMetadata.Types.SelectMany(type => type.Members).Select(member => member.Name).ToArray());
     }
 
     [Fact]
@@ -1328,6 +1646,484 @@ public class ApiSurfaceExtractorTests
             .SurfaceFieldHandles(reader, typeDef, includeAll: true, includeCompilerGenerated)
             .Select(h => reader.GetString(reader.GetFieldDefinition(h).Name))
             .ToHashSet(StringComparer.Ordinal);
+
+    static string EmitUnownedSpecialNameAccessorMethod()
+    {
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("UnownedSpecialNameAccessor"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("UnownedSpecialNameAccessor");
+        var type = module.DefineType(
+            "SpecialNameFixture",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        var method = type.DefineMethod(
+            "get_Value",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Static
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var compoundAssignment = type.DefineMethod(
+            "op_AdditionAssignment",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(void),
+            [type]);
+        compoundAssignment.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+        var genericAssignment = type.DefineMethod(
+            "op_IncrementAssignment",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(void),
+            Type.EmptyTypes);
+        genericAssignment.DefineGenericParameters("T");
+        genericAssignment.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+        type.CreateType();
+
+        var semanticsType = module.DefineType(
+            "SemanticsFixture",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        var otherProperty = DefineVoidMethod(semanticsType, "OtherProperty");
+        var property = semanticsType.DefineProperty(
+            "Value",
+            System.Reflection.PropertyAttributes.None,
+            typeof(int),
+            null);
+        property.AddOtherMethod(otherProperty);
+        var raiser = DefineVoidMethod(semanticsType, "RaiseChanged");
+        var otherEvent = DefineVoidMethod(semanticsType, "OtherEvent");
+        var @event = semanticsType.DefineEvent(
+            "Changed",
+            System.Reflection.EventAttributes.None,
+            typeof(Action));
+        @event.SetRaiseMethod(raiser);
+        @event.AddOtherMethod(otherEvent);
+        semanticsType.CreateType();
+
+        var path = Path.Combine(Path.GetTempPath(), $"unowned-special-name-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+
+        static System.Reflection.Emit.MethodBuilder DefineVoidMethod(
+            System.Reflection.Emit.TypeBuilder type,
+            string name)
+        {
+            var method = type.DefineMethod(
+                name,
+                System.Reflection.MethodAttributes.Public | System.Reflection.MethodAttributes.Static,
+                typeof(void),
+                Type.EmptyTypes);
+            method.GetILGenerator().Emit(System.Reflection.Emit.OpCodes.Ret);
+            return method;
+        }
+    }
+
+    static string EmitPrivateUnqualifiedInterfaceAccessor()
+    {
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("PrivateUnqualifiedInterfaceAccessor"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("PrivateUnqualifiedInterfaceAccessor");
+        var contract = module.DefineType(
+            "IContract",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract);
+        var contractGetter = contract.DefineMethod(
+            "get_Value",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var contractProperty = contract.DefineProperty(
+            "Value",
+            System.Reflection.PropertyAttributes.None,
+            typeof(int),
+            null);
+        contractProperty.SetGetMethod(contractGetter);
+        var contractMethod = contract.DefineMethod(
+            "ContractMethod",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual,
+            typeof(int),
+            Type.EmptyTypes);
+
+        var implementation = module.DefineType(
+            "Implementation",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        implementation.AddInterfaceImplementation(contract);
+        var implementationGetter = implementation.DefineMethod(
+            "get_Value",
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var il = implementationGetter.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var implementationProperty = implementation.DefineProperty(
+            "Value",
+            System.Reflection.PropertyAttributes.None,
+            typeof(int),
+            null);
+        implementationProperty.SetGetMethod(implementationGetter);
+        implementation.DefineMethodOverride(implementationGetter, contractGetter);
+        var implementationMethod = implementation.DefineMethod(
+            "MappedMethod",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            typeof(int),
+            Type.EmptyTypes);
+        var methodIl = implementationMethod.GetILGenerator();
+        methodIl.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_2);
+        methodIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        implementation.DefineMethodOverride(implementationMethod, contractMethod);
+
+        contract.CreateType();
+        implementation.CreateType();
+
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"private-unqualified-interface-accessor-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitInheritedInterfaceAccessor()
+    {
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("InheritedInterfaceAccessor"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("InheritedInterfaceAccessor");
+        var baseInterface = module.DefineType(
+            "IBase",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract);
+        var baseGetter = baseInterface.DefineMethod(
+            "get_Value",
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var baseProperty = baseInterface.DefineProperty(
+            "Value",
+            System.Reflection.PropertyAttributes.None,
+            typeof(int),
+            null);
+        baseProperty.SetGetMethod(baseGetter);
+
+        var derivedInterface = module.DefineType(
+            "IDerived",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract);
+        derivedInterface.AddInterfaceImplementation(baseInterface);
+
+        var implementation = module.DefineType(
+            "Implementation",
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class);
+        implementation.AddInterfaceImplementation(derivedInterface);
+        var implementationGetter = implementation.DefineMethod(
+            "get_Value",
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.SpecialName,
+            typeof(int),
+            Type.EmptyTypes);
+        var il = implementationGetter.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4_1);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        var implementationProperty = implementation.DefineProperty(
+            "Value",
+            System.Reflection.PropertyAttributes.None,
+            typeof(int),
+            null);
+        implementationProperty.SetGetMethod(implementationGetter);
+        implementation.DefineMethodOverride(implementationGetter, baseGetter);
+
+        baseInterface.CreateType();
+        derivedInterface.CreateType();
+        implementation.CreateType();
+
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"inherited-interface-accessor-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static string EmitExternalInheritedInterfaceImplementation()
+    {
+        var assembly = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new System.Reflection.AssemblyName("ExternalInheritedInterfaceImplementation"),
+            typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("ExternalInheritedInterfaceImplementation");
+        var intermediateBase = module.DefineType(
+            "IntermediateBase",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Abstract
+                | System.Reflection.TypeAttributes.Class,
+            typeof(System.IO.Stream));
+        intermediateBase.DefineGenericParameters("T");
+        var implementation = module.DefineType(
+            "Implementation",
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Abstract
+                | System.Reflection.TypeAttributes.Class,
+            intermediateBase.MakeGenericType(typeof(int)));
+        implementation.AddInterfaceImplementation(typeof(System.Collections.ICollection));
+        var body = implementation.DefineMethod(
+            "ICollectionGetEnumerator",
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            typeof(System.Collections.IEnumerator),
+            Type.EmptyTypes);
+        var il = body.GetILGenerator();
+        il.Emit(System.Reflection.Emit.OpCodes.Ldnull);
+        il.Emit(System.Reflection.Emit.OpCodes.Ret);
+        implementation.DefineMethodOverride(
+            body,
+            typeof(System.Collections.IEnumerable).GetMethod("GetEnumerator")!);
+        var classOverride = implementation.DefineMethod(
+            "MappedToExternalBase",
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            typeof(void),
+            Type.EmptyTypes);
+        var classOverrideIl = classOverride.GetILGenerator();
+        classOverrideIl.Emit(System.Reflection.Emit.OpCodes.Ret);
+        implementation.DefineMethodOverride(
+            classOverride,
+            typeof(System.IO.Stream).GetMethod(nameof(System.IO.Stream.Flush), Type.EmptyTypes)!);
+        intermediateBase.CreateType();
+        implementation.CreateType();
+
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"external-inherited-interface-{Guid.NewGuid():N}.dll");
+        assembly.Save(path);
+        return path;
+    }
+
+    static byte[] EmitUnresolvedInterfaceIdentityImplementation()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("UnresolvedInterface.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("UnresolvedInterface"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        var coreLib = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Private.CoreLib"),
+            new Version(11, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        var objectRef = metadata.AddTypeReference(
+            coreLib,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+        var targetInterface = metadata.AddTypeReference(
+            coreLib,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("IDisposable"));
+        var unresolvedInterfaceSignature = new BlobBuilder();
+        unresolvedInterfaceSignature.WriteByte(0x1d);
+        unresolvedInterfaceSignature.WriteByte(0x12);
+        unresolvedInterfaceSignature.WriteCompressedInteger(
+            (MetadataTokens.GetRowNumber(targetInterface) << 2) | 1);
+        var unresolvedInterface = metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(unresolvedInterfaceSignature));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var derivedInterface = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IDerived"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var implementation = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Implementation"),
+            objectRef,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var instructions = new BlobBuilder();
+        var encoder = new InstructionEncoder(instructions, new ControlFlowBuilder());
+        encoder.OpCode(ILOpCode.Ret);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = new MethodBodyStreamEncoder(methodBodies)
+            .AddMethodBody(encoder, maxStack: 0);
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x01);
+        var signatureHandle = metadata.GetOrAddBlob(signature);
+        var body = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signatureHandle,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        var declaration = metadata.AddMemberReference(
+            targetInterface,
+            metadata.GetOrAddString("Dispose"),
+            signatureHandle);
+        metadata.AddInterfaceImplementation(derivedInterface, unresolvedInterface);
+        metadata.AddInterfaceImplementation(implementation, derivedInterface);
+        metadata.AddMethodImplementation(implementation, body, declaration);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static byte[] EmitUnresolvedMethodImplDeclarationIdentity()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("UnresolvedDeclaration.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("UnresolvedDeclaration"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        var coreLib = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Private.CoreLib"),
+            new Version(11, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        var objectRef = metadata.AddTypeReference(
+            coreLib,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var targetInterface = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("ITarget"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var implementation = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Implementation"),
+            objectRef,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var malformedParentSignature = new BlobBuilder();
+        malformedParentSignature.WriteByte(0x1d);
+        malformedParentSignature.WriteByte(0x12);
+        malformedParentSignature.WriteCompressedInteger(
+            MetadataTokens.GetRowNumber(targetInterface) << 2);
+        var malformedDeclarationParent = metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(malformedParentSignature));
+
+        var instructions = new BlobBuilder();
+        var encoder = new InstructionEncoder(instructions, new ControlFlowBuilder());
+        encoder.OpCode(ILOpCode.Ret);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = new MethodBodyStreamEncoder(methodBodies)
+            .AddMethodBody(encoder, maxStack: 0);
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x01);
+        var signatureHandle = metadata.GetOrAddBlob(signature);
+        var body = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signatureHandle,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        var declaration = metadata.AddMemberReference(
+            malformedDeclarationParent,
+            metadata.GetOrAddString("Mapped"),
+            signatureHandle);
+        metadata.AddInterfaceImplementation(implementation, targetInterface);
+        metadata.AddMethodImplementation(implementation, body, declaration);
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
 
     // Emits (via Reflection.Emit) types that exercise every branch of the field-inclusion
     // primitive: an ordinary field, a user field that merely contains "__BackingField", a genuine
@@ -1555,6 +2351,77 @@ public class SampleCustomEventHost
     }
 }
 
+public interface IExplicitSurfaceFixture
+{
+    int Value { get; }
+    event Action Changed;
+    void Run();
+}
+
+public sealed class ExplicitSurfaceFixture : IExplicitSurfaceFixture
+{
+    int IExplicitSurfaceFixture.Value => 42;
+
+    event Action IExplicitSurfaceFixture.Changed
+    {
+        add { }
+        remove { }
+    }
+
+    void IExplicitSurfaceFixture.Run()
+    {
+    }
+}
+
+public sealed class AccessorPrefixMethodFixture
+{
+    public int get_Unused() => 1;
+    public void set_Unused(int value) { }
+    public void add_Unused(int value) { }
+    public void remove_Unused(int value) { }
+    public int op_Custom() => 2;
+    public void op_AdditionAssignment(int value) { }
+}
+
+public class CovariantSurfaceBase
+{
+    public virtual object Value => "base";
+}
+
+public sealed class CovariantSurfaceDerived : CovariantSurfaceBase
+{
+    public override string Value => "derived";
+}
+
+public interface IInheritedSurfaceBase
+{
+    int Value { get; }
+}
+
+public interface IInheritedSurfaceDerived : IInheritedSurfaceBase
+{
+}
+
+public sealed class InheritedInterfaceSurfaceFixture : IInheritedSurfaceDerived
+{
+    int IInheritedSurfaceBase.Value => 1;
+}
+
+public interface IGenericInheritedSurfaceBase<T>
+{
+    T Value { get; }
+}
+
+public interface IGenericInheritedSurfaceDerived<T> : IGenericInheritedSurfaceBase<T>
+{
+}
+
+public sealed class GenericInheritedInterfaceSurfaceFixture :
+    IGenericInheritedSurfaceDerived<int>
+{
+    int IGenericInheritedSurfaceBase<int>.Value => 1;
+}
+
 /// <summary>
 /// Sample class used for testing signature extraction.
 /// </summary>
@@ -1626,6 +2493,36 @@ public class SampleKeywordParameterHost
 
     public static int Static(int @params, int @void) => @params + @void;
 }
+
+public sealed class SampleFinalizerHost
+{
+    ~SampleFinalizerHost() { }
+}
+
+public static class SampleExtensionPropertyHost
+{
+    extension(int number)
+    {
+        public bool IsEven => number % 2 == 0;
+        public int Echo
+        {
+            get => number;
+            set { }
+        }
+        public static int Zero => 0;
+    }
+
+    public static bool get_IsEven<T>(int number) => true;
+
+    extension<T>(SampleExtensionBox<T> value)
+    {
+        public T GenericValue => default!;
+    }
+
+    public static T get_GenericValue<T, TOther>(SampleExtensionBox<T> value) => default!;
+}
+
+public sealed class SampleExtensionBox<T> { }
 
 [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 public class SampleTypeAttributeHost

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1277,6 +1277,9 @@ public class ApiSurfaceExtractorTests
             surface.Types,
             t => (t.MetadataName ?? "").Contains("DisplayClass")
                  && t.Members.Any(m => m.Kind == "field")
+                 && t.Members.Any(
+                     m => m.Kind == "method"
+                         && m.Name.StartsWith("<", StringComparison.Ordinal))
                  && t.Members.Any(m => m.Name.StartsWith("<", StringComparison.Ordinal)));
 
         // Auto-property backing fields (<Prop>k__BackingField) are never surfaced as fields, even
@@ -1581,6 +1584,60 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_AcceptsInheritedAndMemberReferenceMethodImplBodies()
+    {
+        foreach (byte[] image in new[]
+        {
+            EmitCrossOwnerMethodImplBody(inheritedBody: true),
+            EmitCrossOwnerMethodImplBody(memberReferenceBody: true)
+        })
+        {
+            using var stream = new MemoryStream(image);
+            using var peReader = new PEReader(stream);
+
+            var surface = ApiSurfaceExtractor.Extract(peReader);
+
+            Assert.Empty(surface.InspectionFailures);
+        }
+    }
+
+    [Fact]
+    public void Extract_ResolvesOwnedMemberReferenceMethodImplBody()
+    {
+        using var stream = new MemoryStream(
+            EmitOwnedMemberReferenceMethodImplBody());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "Implementation");
+        var member = Assert.Single(
+            type.Members,
+            candidate => candidate.Name == "Mapped");
+
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void Extract_ReportsDuplicateMethodImplDeclaration()
+    {
+        using var stream = new MemoryStream(
+            EmitCrossOwnerMethodImplBody(duplicateDeclaration: true));
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+
+        Assert.Contains(
+            surface.InspectionFailures,
+            failure => failure.Operation == "method implementation declaration"
+                && failure.Detail.Contains(
+                    "appears more than once",
+                    StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_PreservesImplementationOfInterfaceInheritedThroughBaseClass()
     {
         using var stream = new MemoryStream(EmitInterfaceInheritedThroughBaseClass());
@@ -1610,7 +1667,8 @@ public class ApiSurfaceExtractorTests
         Assert.Contains(
             surface.InspectionFailures,
             failure => failure.Operation == "type identity"
-                && failure.Detail.Contains("Duplicate type definition identity", StringComparison.Ordinal));
+                && failure.Detail.Contains("Duplicate type definition identity", StringComparison.Ordinal)
+                && failure.Detail.Contains("IDerived", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -1722,17 +1780,28 @@ public class ApiSurfaceExtractorTests
     [Fact]
     public void Extract_ReportsCrossTypeAccessorWithoutSuppressingUnrelatedMethod()
     {
-        using var stream = new MemoryStream(EmitCrossTypeMethodSemantics());
-        using var peReader = new PEReader(stream);
+        byte[] image = EmitCrossTypeMethodSemantics();
+        ApiSurface surface;
+        using (var stream = new MemoryStream(image))
+        using (var peReader = new PEReader(stream))
+            surface = ApiSurfaceExtractor.Extract(peReader);
 
-        var surface = ApiSurfaceExtractor.Extract(peReader);
         var holder = Assert.Single(surface.Types, candidate => candidate.Name == "Holder");
         var victim = Assert.Single(surface.Types, candidate => candidate.Name == "Victim");
 
-        Assert.Contains(holder.Members, member => member.Kind == "property" && member.Name == "Value");
+        Assert.DoesNotContain(holder.Members, member => member.Kind == "property");
         Assert.Contains(victim.Members, member => member.Kind == "method" && member.Name == "UnrelatedMethod");
         Assert.Contains(
             surface.InspectionFailures,
+            failure => failure.Operation == "property getter"
+                && failure.Detail.Contains("not association owner", StringComparison.Ordinal));
+
+        using var summaryStream = new MemoryStream(image);
+        using var summaryReader = new PEReader(summaryStream);
+        var summary = ApiSurfaceExtractor.ExtractSummary(summaryReader);
+        Assert.Equal(0, summary.PublicPropertyCount);
+        Assert.Contains(
+            summary.InspectionFailures,
             failure => failure.Operation == "property getter"
                 && failure.Detail.Contains("not association owner", StringComparison.Ordinal));
     }
@@ -2127,7 +2196,10 @@ public class ApiSurfaceExtractorTests
         return SerializeAdversarialMetadata(metadata, methodBodies);
     }
 
-    static byte[] EmitCrossOwnerMethodImplBody()
+    static byte[] EmitCrossOwnerMethodImplBody(
+        bool inheritedBody = false,
+        bool memberReferenceBody = false,
+        bool duplicateDeclaration = false)
     {
         var metadata = CreateAdversarialMetadata("CrossOwnerMethodImpl");
         var objectRef = AddCoreLibraryReferences(metadata);
@@ -2155,7 +2227,9 @@ public class ApiSurfaceExtractorTests
                 | System.Reflection.TypeAttributes.Class,
             default,
             metadata.GetOrAddString("Holder"),
-            objectRef,
+            inheritedBody || memberReferenceBody
+                ? MetadataTokens.TypeDefinitionHandle(4)
+                : objectRef,
             MetadataTokens.FieldDefinitionHandle(1),
             MetadataTokens.MethodDefinitionHandle(2));
         metadata.AddTypeDefinition(
@@ -2189,9 +2263,82 @@ public class ApiSurfaceExtractorTests
             MetadataTokens.ParameterHandle(1));
 
         metadata.AddInterfaceImplementation(holder, contract);
+        EntityHandle methodBody = memberReferenceBody
+            ? metadata.AddMemberReference(
+                MetadataTokens.TypeDefinitionHandle(4),
+                metadata.GetOrAddString("Mapped"),
+                signature)
+            : victimBody;
         metadata.AddMethodImplementation(
             holder,
-            victimBody,
+            methodBody,
+            declaration);
+        if (duplicateDeclaration)
+            metadata.AddMethodImplementation(holder, methodBody, declaration);
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitOwnedMemberReferenceMethodImplBody()
+    {
+        var metadata = CreateAdversarialMetadata("OwnedMemberRefMethodImpl");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var contract = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IContract"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var implementation = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Implementation"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        var signature = metadata.GetOrAddBlob(VoidNullaryInstanceSignature());
+        var declaration = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset: 0,
+            MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        var bodyReference = metadata.AddMemberReference(
+            implementation,
+            metadata.GetOrAddString("Mapped"),
+            signature);
+
+        metadata.AddInterfaceImplementation(implementation, contract);
+        metadata.AddMethodImplementation(
+            implementation,
+            bodyReference,
             declaration);
         return SerializeAdversarialMetadata(metadata, methodBodies);
     }

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1538,6 +1538,49 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_TreatsAssemblySimpleNamesCaseInsensitivelyForClassOverrides()
+    {
+        using var stream = new MemoryStream(EmitCaseVariantClassOverride());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "Implementation");
+
+        Assert.DoesNotContain(
+            type.Members,
+            candidate => candidate.Name == "Mapped");
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void Extract_ReportsMethodImplBodyOwnedByAnotherType()
+    {
+        using var stream = new MemoryStream(EmitCrossOwnerMethodImplBody());
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var holder = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "Holder");
+        var victim = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "Victim");
+
+        Assert.Empty(holder.Members);
+        Assert.DoesNotContain(
+            victim.Members,
+            candidate => candidate.Name == "Mapped");
+        Assert.Contains(
+            surface.InspectionFailures,
+            failure => failure.Operation == "method implementation body"
+                && failure.Detail.Contains(
+                    "not MethodImpl owner",
+                    StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_PreservesImplementationOfInterfaceInheritedThroughBaseClass()
     {
         using var stream = new MemoryStream(EmitInterfaceInheritedThroughBaseClass());
@@ -1598,6 +1641,82 @@ public class ApiSurfaceExtractorTests
         Assert.Equal("method", method.Kind);
         Assert.False(method.IsFinalizer);
         Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void ExtractAndSummary_IncludePublicRemoverOnlyEvent()
+    {
+        var (full, summary) = ExtractAsymmetricEventSurfaces();
+        var fullType = Assert.Single(
+            full.Types,
+            candidate => candidate.Name == "EventHost");
+        var summaryType = Assert.Single(
+            summary.Types,
+            candidate => candidate.Name == "EventHost");
+
+        var removerOnly = Assert.Single(
+            fullType.Members,
+            member => member.Kind == "event"
+                && member.Name == "RemoverOnly");
+        Assert.Null(removerOnly.Accessibility);
+        Assert.Null(removerOnly.AdderToken);
+        Assert.NotNull(removerOnly.RemoverToken);
+        var removerAccessor = Assert.Single(
+            Assert.IsType<ApiSignature>(removerOnly.SignatureModel).Accessors);
+        Assert.Equal("remove", removerAccessor.Kind);
+        Assert.Contains(
+            summaryType.Members,
+            member => member.Kind == "event"
+                && member.Name == "RemoverOnly");
+        Assert.Empty(full.InspectionFailures);
+        Assert.Empty(summary.InspectionFailures);
+    }
+
+    [Fact]
+    public void ExtractAndSummary_UsePublicRemoverForMixedAccessibilityEvent()
+    {
+        var (full, summary) = ExtractAsymmetricEventSurfaces();
+        var fullType = Assert.Single(
+            full.Types,
+            candidate => candidate.Name == "EventHost");
+        var summaryType = Assert.Single(
+            summary.Types,
+            candidate => candidate.Name == "EventHost");
+        var mixed = Assert.Single(
+            fullType.Members,
+            member => member.Kind == "event"
+                && member.Name == "Mixed");
+        Assert.Null(mixed.Accessibility);
+        Assert.NotNull(mixed.AdderToken);
+        Assert.NotNull(mixed.RemoverToken);
+        Assert.Equal(
+            new[] { "add", "remove" },
+            Assert.IsType<ApiSignature>(mixed.SignatureModel)
+                .Accessors
+                .Select(accessor => accessor.Kind)
+                .ToArray());
+        Assert.Contains(
+            summaryType.Members,
+            member => member.Kind == "event"
+                && member.Name == "Mixed");
+        Assert.Empty(full.InspectionFailures);
+        Assert.Empty(summary.InspectionFailures);
+    }
+
+    static (ApiSurface Full, ApiSurface Summary) ExtractAsymmetricEventSurfaces()
+    {
+        byte[] image = EmitAsymmetricEvents();
+        ApiSurface full;
+        using (var stream = new MemoryStream(image))
+        using (var peReader = new PEReader(stream))
+            full = ApiSurfaceExtractor.Extract(peReader);
+
+        ApiSurface summary;
+        using (var stream = new MemoryStream(image))
+        using (var peReader = new PEReader(stream))
+            summary = ApiSurfaceExtractor.ExtractSummary(peReader);
+        Assert.Equal(full.PublicEventCount, summary.PublicEventCount);
+        return (full, summary);
     }
 
     [Fact]
@@ -1940,6 +2059,211 @@ public class ApiSurfaceExtractorTests
             metadata.GetOrAddBlob(VoidNullaryInstanceSignature()),
             bodyOffset,
             parameterList: MetadataTokens.ParameterHandle(1));
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitCaseVariantClassOverride()
+    {
+        var metadata = CreateAdversarialMetadata("CaseVariantClassOverride");
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+        var upperScope = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("BaseLib"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        var lowerScope = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("baselib"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        var baseType = metadata.AddTypeReference(
+            upperScope,
+            metadata.GetOrAddString("Samples"),
+            metadata.GetOrAddString("Base"));
+        var declarationType = metadata.AddTypeReference(
+            lowerScope,
+            metadata.GetOrAddString("Samples"),
+            metadata.GetOrAddString("Base"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var implementation = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Implementation"),
+            baseType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var signature = metadata.GetOrAddBlob(VoidNullaryInstanceSignature());
+        var body = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        var declaration = metadata.AddMemberReference(
+            declarationType,
+            metadata.GetOrAddString("Mapped"),
+            signature);
+        metadata.AddMethodImplementation(
+            implementation,
+            body,
+            declaration);
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitCrossOwnerMethodImplBody()
+    {
+        var metadata = CreateAdversarialMetadata("CrossOwnerMethodImpl");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var contract = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IContract"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var holder = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Holder"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Victim"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        var signature = metadata.GetOrAddBlob(VoidNullaryInstanceSignature());
+        var declaration = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset: 0,
+            MetadataTokens.ParameterHandle(1));
+        var victimBody = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+
+        metadata.AddInterfaceImplementation(holder, contract);
+        metadata.AddMethodImplementation(
+            holder,
+            victimBody,
+            declaration);
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitAsymmetricEvents()
+    {
+        var metadata = CreateAdversarialMetadata("AsymmetricEvents");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var host = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("EventHost"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var signature = metadata.GetOrAddBlob(VoidNullaryInstanceSignature());
+        var removerOnly = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.SpecialName,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("remove_RemoverOnly"),
+            signature,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        var privateAdder = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.SpecialName,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("add_Mixed"),
+            signature,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        var publicRemover = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.SpecialName,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("remove_Mixed"),
+            signature,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        var firstEvent = metadata.AddEvent(
+            System.Reflection.EventAttributes.None,
+            metadata.GetOrAddString("RemoverOnly"),
+            objectRef);
+        var mixedEvent = metadata.AddEvent(
+            System.Reflection.EventAttributes.None,
+            metadata.GetOrAddString("Mixed"),
+            objectRef);
+        metadata.AddEventMap(host, firstEvent);
+        metadata.AddMethodSemantics(
+            firstEvent,
+            System.Reflection.MethodSemanticsAttributes.Remover,
+            removerOnly);
+        metadata.AddMethodSemantics(
+            mixedEvent,
+            System.Reflection.MethodSemanticsAttributes.Adder,
+            privateAdder);
+        metadata.AddMethodSemantics(
+            mixedEvent,
+            System.Reflection.MethodSemanticsAttributes.Remover,
+            publicRemover);
         return SerializeAdversarialMetadata(metadata, methodBodies);
     }
 

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -1712,10 +1712,66 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_ResolvesOwnedMemberReferenceMethodImplBodyByStructuralSignature()
+    {
+        using var stream = new MemoryStream(
+            EmitOwnedMemberReferenceMethodImplBody(
+                structuralSignature: true));
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+        var type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == "Implementation");
+        var member = Assert.Single(
+            type.Members,
+            candidate => candidate.Name == "Mapped");
+
+        Assert.Equal("explicit-interface-implementation", member.Kind);
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void Extract_RejectsOwnedMemberReferenceMethodImplBodyWithDifferentStructuralSignature()
+    {
+        using var stream = new MemoryStream(
+            EmitOwnedMemberReferenceMethodImplBody(
+                structuralSignature: true,
+                mismatchedStructuralSignature: true));
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+
+        Assert.Contains(
+            surface.InspectionFailures,
+            failure => failure.Operation == "method implementation body"
+                && failure.Detail.Contains(
+                    "does not identify one method",
+                    StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Extract_ReportsDuplicateMethodImplDeclaration()
     {
         using var stream = new MemoryStream(
             EmitCrossOwnerMethodImplBody(duplicateDeclaration: true));
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+
+        Assert.Contains(
+            surface.InspectionFailures,
+            failure => failure.Operation == "method implementation declaration"
+                && failure.Detail.Contains(
+                    "appears more than once",
+                    StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Extract_ReportsDuplicateCanonicalMethodImplDeclaration()
+    {
+        using var stream = new MemoryStream(
+            EmitDuplicateCanonicalMethodImplDeclarations());
         using var peReader = new PEReader(stream);
 
         var surface = ApiSurfaceExtractor.Extract(peReader);
@@ -1790,6 +1846,42 @@ public class ApiSurfaceExtractorTests
         Assert.Equal("method", method.Kind);
         Assert.False(method.IsFinalizer);
         Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void Extract_DoesNotTreatFinalizerSignatureWithTrailingBytesAsFinalizer()
+    {
+        using var stream = new MemoryStream(
+            EmitGenericBaseFinalizer(
+                malformedTrailingFinalizerSignature: true));
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        var type = Assert.Single(surface.Types, candidate => candidate.Name == "Derived");
+        var method = Assert.Single(type.Members, candidate => candidate.Name == "Finalize");
+
+        Assert.Equal("method", method.Kind);
+        Assert.False(method.IsFinalizer);
+    }
+
+    [Fact]
+    public void PdbFinalizerClassification_NormalizesMemberReferenceMethodImplBodies()
+    {
+        using var stream = new MemoryStream(EmitOwnedMemberReferenceFinalizer());
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var finalizer = reader.TypeDefinitions
+            .SelectMany(handle => reader.GetTypeDefinition(handle).GetMethods())
+            .Single(handle =>
+            {
+                var method = reader.GetMethodDefinition(handle);
+                return reader.StringComparer.Equals(method.Name, "Finalize")
+                    && reader.StringComparer.Equals(
+                        reader.GetTypeDefinition(method.GetDeclaringType()).Name,
+                        "Derived");
+            });
+
+        Assert.True(ApiSurfaceExtractor.IsFinalizerMethod(reader, finalizer));
     }
 
     [Fact]
@@ -1924,6 +2016,23 @@ public class ApiSurfaceExtractorTests
         Assert.Contains(
             victim.Members,
             member => member.Kind == "method" && member.Name == "get_Foreign");
+    }
+
+    [Fact]
+    public void Extract_ReportsDuplicatePhysicalMethodSemanticsRoles()
+    {
+        byte[] image = EmitCrossTypeMethodSemantics(duplicateGetter: true);
+        using var stream = new MemoryStream(image);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader);
+
+        Assert.Contains(
+            surface.InspectionFailures,
+            failure => failure.Operation == "property getter"
+                && failure.Detail.Contains(
+                    "physical MethodSemantics Getter role appears more than once",
+                    StringComparison.Ordinal));
     }
 
     [Fact]
@@ -2179,7 +2288,9 @@ public class ApiSurfaceExtractorTests
         return SerializeAdversarialMetadata(metadata, methodBodies);
     }
 
-    static byte[] EmitGenericBaseFinalizer(bool baseIntroducesFinalizeSlot = false)
+    static byte[] EmitGenericBaseFinalizer(
+        bool baseIntroducesFinalizeSlot = false,
+        bool malformedTrailingFinalizerSignature = false)
     {
         var metadata = CreateAdversarialMetadata("GenericBaseFinalizer");
         var objectRef = AddCoreLibraryReferences(metadata);
@@ -2245,7 +2356,10 @@ public class ApiSurfaceExtractorTests
                 | System.Reflection.MethodAttributes.HideBySig,
             System.Reflection.MethodImplAttributes.IL,
             metadata.GetOrAddString("Finalize"),
-            metadata.GetOrAddBlob(VoidNullaryInstanceSignature()),
+            metadata.GetOrAddBlob(
+                malformedTrailingFinalizerSignature
+                    ? [0x20, 0x00, 0x01, 0xff]
+                    : VoidNullaryInstanceSignature()),
             bodyOffset,
             parameterList: MetadataTokens.ParameterHandle(1));
         return SerializeAdversarialMetadata(metadata, methodBodies);
@@ -2398,9 +2512,100 @@ public class ApiSurfaceExtractorTests
         return SerializeAdversarialMetadata(metadata, methodBodies);
     }
 
-    static byte[] EmitOwnedMemberReferenceMethodImplBody()
+    static byte[] EmitOwnedMemberReferenceMethodImplBody(
+        bool structuralSignature = false,
+        bool mismatchedStructuralSignature = false)
     {
         var metadata = CreateAdversarialMetadata("OwnedMemberRefMethodImpl");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var contract = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Interface
+                | System.Reflection.TypeAttributes.Abstract,
+            default,
+            metadata.GetOrAddString("IContract"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var implementation = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Implementation"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        var value = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Value"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(3));
+        var other = metadata.AddTypeReference(
+            default,
+            default,
+            metadata.GetOrAddString("Other"));
+        var valueReference = metadata.AddTypeReference(
+            default,
+            default,
+            metadata.GetOrAddString("Value"));
+        var signature = metadata.GetOrAddBlob(
+            structuralSignature
+                ? ClassReturnSignature(value)
+                : VoidNullaryInstanceSignature());
+        var memberReferenceSignature = metadata.GetOrAddBlob(
+            structuralSignature
+                ? ClassReturnSignature(
+                    mismatchedStructuralSignature ? other : valueReference)
+                : VoidNullaryInstanceSignature());
+        var declaration = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.Abstract
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset: 0,
+            MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Private
+                | System.Reflection.MethodAttributes.Final
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signature,
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+        var bodyReference = metadata.AddMemberReference(
+            implementation,
+            metadata.GetOrAddString("Mapped"),
+            memberReferenceSignature);
+
+        metadata.AddInterfaceImplementation(implementation, contract);
+        metadata.AddMethodImplementation(
+            implementation,
+            bodyReference,
+            declaration);
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitDuplicateCanonicalMethodImplDeclarations()
+    {
+        var metadata = CreateAdversarialMetadata("DuplicateCanonicalMethodImpl");
         var objectRef = AddCoreLibraryReferences(metadata);
         var methodBodies = new BlobBuilder();
         int bodyOffset = AddRetBody(methodBodies);
@@ -2439,27 +2644,88 @@ public class ApiSurfaceExtractorTests
             metadata.GetOrAddString("Mapped"),
             signature,
             bodyOffset: 0,
-            MetadataTokens.ParameterHandle(1));
-        metadata.AddMethodDefinition(
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var body = metadata.AddMethodDefinition(
             System.Reflection.MethodAttributes.Private
                 | System.Reflection.MethodAttributes.Final
                 | System.Reflection.MethodAttributes.Virtual
-                | System.Reflection.MethodAttributes.NewSlot,
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.HideBySig,
             System.Reflection.MethodImplAttributes.IL,
             metadata.GetOrAddString("Mapped"),
             signature,
             bodyOffset,
-            MetadataTokens.ParameterHandle(1));
-        var bodyReference = metadata.AddMemberReference(
-            implementation,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var duplicateDeclaration = metadata.AddMemberReference(
+            contract,
             metadata.GetOrAddString("Mapped"),
             signature);
 
         metadata.AddInterfaceImplementation(implementation, contract);
-        metadata.AddMethodImplementation(
-            implementation,
-            bodyReference,
-            declaration);
+        metadata.AddMethodImplementation(implementation, body, declaration);
+        metadata.AddMethodImplementation(implementation, body, duplicateDeclaration);
+        return SerializeAdversarialMetadata(metadata, methodBodies);
+    }
+
+    static byte[] EmitOwnedMemberReferenceFinalizer()
+    {
+        var metadata = CreateAdversarialMetadata("OwnedMemberRefFinalizer");
+        var objectRef = AddCoreLibraryReferences(metadata);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = AddRetBody(methodBodies);
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var baseType = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Base"),
+            objectRef,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        var derived = metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.Public
+                | System.Reflection.TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Derived"),
+            baseType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2));
+        var signature = metadata.GetOrAddBlob(VoidNullaryInstanceSignature());
+        metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Family
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.NewSlot
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Finalize"),
+            signature,
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Family
+                | System.Reflection.MethodAttributes.Virtual
+                | System.Reflection.MethodAttributes.HideBySig,
+            System.Reflection.MethodImplAttributes.IL,
+            metadata.GetOrAddString("Finalize"),
+            signature,
+            bodyOffset,
+            parameterList: MetadataTokens.ParameterHandle(1));
+        var body = metadata.AddMemberReference(
+            derived,
+            metadata.GetOrAddString("Finalize"),
+            signature);
+        var declaration = metadata.AddMemberReference(
+            objectRef,
+            metadata.GetOrAddString("Finalize"),
+            signature);
+        metadata.AddMethodImplementation(derived, body, declaration);
         return SerializeAdversarialMetadata(metadata, methodBodies);
     }
 
@@ -2534,7 +2800,7 @@ public class ApiSurfaceExtractorTests
         return SerializeAdversarialMetadata(metadata, methodBodies);
     }
 
-    static byte[] EmitCrossTypeMethodSemantics()
+    static byte[] EmitCrossTypeMethodSemantics(bool duplicateGetter = false)
     {
         var metadata = CreateAdversarialMetadata("CrossTypeMethodSemantics");
         var objectRef = AddCoreLibraryReferences(metadata);
@@ -2609,6 +2875,13 @@ public class ApiSurfaceExtractorTests
             ownedProperty,
             System.Reflection.MethodSemanticsAttributes.Getter,
             ownedGetter);
+        if (duplicateGetter)
+        {
+            metadata.AddMethodSemantics(
+                ownedProperty,
+                System.Reflection.MethodSemanticsAttributes.Getter,
+                ownedGetter);
+        }
 
         var stolenEvent = metadata.AddEvent(
             System.Reflection.EventAttributes.None,
@@ -3149,6 +3422,24 @@ public class ApiSurfaceExtractorTests
     static byte[] VoidNullaryInstanceSignature() => [0x20, 0x00, 0x01];
     static byte[] Int32NullaryInstanceSignature() => [0x20, 0x00, 0x08];
     static byte[] Int32PropertySignature() => [0x08, 0x00, 0x08];
+
+    static byte[] ClassReturnSignature(EntityHandle type)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x20);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x12);
+        signature.WriteCompressedInteger(
+            type.Kind switch
+            {
+                HandleKind.TypeDefinition => MetadataTokens.GetRowNumber(
+                    (TypeDefinitionHandle)type) << 2,
+                HandleKind.TypeReference => (MetadataTokens.GetRowNumber(
+                    (TypeReferenceHandle)type) << 2) | 1,
+                _ => throw new ArgumentOutOfRangeException(nameof(type))
+            });
+        return signature.ToArray();
+    }
 
     static string EmitUnownedSpecialNameAccessorMethod()
     {

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -542,6 +542,15 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
+    public void LocalTypes_ChargesSharedLongTypeDefinitionNamesBeforeIndexing()
+    {
+        AssertTextAmplificationIsBounded(
+            BuildSharedLongTypeDefinitionNameImage(
+                typeCount: 12_000,
+                nameLength: 4_000));
+    }
+
+    [Fact]
     public void RepeatedLongSkippedFieldName_StopsBeforeLargeAllocationAmplification()
     {
         AssertTextAmplificationIsBounded(
@@ -1438,6 +1447,34 @@ public sealed class ApiSurfaceExtractorBoundsTests
         Assert.True(
             allocated < 64L * 1024 * 1024,
             $"bounded extraction allocated {allocated:N0} bytes");
+    }
+
+    static byte[] BuildSharedLongTypeDefinitionNameImage(
+        int typeCount,
+        int nameLength)
+    {
+        var metadata = Metadata("LocalTypesAmplification");
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        StringHandle sharedName = metadata.GetOrAddString(
+            new string('T', nameLength));
+        for (int index = 0; index < typeCount; index++)
+        {
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public | TypeAttributes.Abstract,
+                metadata.GetOrAddString($"N{index:D5}"),
+                sharedName,
+                default,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        }
+
+        return Serialize(metadata);
     }
 
     static byte[] BuildRepeatedLongMethodNameImage(

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -152,6 +152,54 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
+    public void TypesOnlyExtraction_DoesNotBuildMemberOrLocalTypeIndexes()
+    {
+        byte[] image = BuildSharedLongTypeDefinitionNameImage(
+            typeCount: 5_000,
+            nameLength: 4_000,
+            publicTypes: false);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+
+        ApiSurfaceExtractionResult result = ApiSurfaceExtractor.ExtractBounded(
+            peReader,
+            ApiSurfaceExtractionScope.Public,
+            new ApiSurfaceExtractionBounds(
+                maxTypes: 1,
+                maxMembers: 0,
+                maxInspectionFailures: 0,
+                maxTypeForwarders: 0,
+                maxMetadataRows: 10_000,
+                maxRetainedTextCharacters: 32_000_000),
+            typesOnly: true);
+
+        var extracted = Assert.IsType<ApiSurfaceExtractionResult.Extracted>(result);
+        Assert.Empty(extracted.Surface.Types);
+    }
+
+    [Fact]
+    public void ModuleScopedFinalizerLookup_DoesNotRescanAllTypeDefinitions()
+    {
+        byte[] image = BuildModuleScopedFinalizerImage(typePairCount: 3_000);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+
+        ApiSurfaceExtractionResult result = ApiSurfaceExtractor.ExtractBounded(
+            peReader,
+            ApiSurfaceExtractionScope.Public,
+            new ApiSurfaceExtractionBounds(
+                maxTypes: 6_000,
+                maxMembers: 3_000,
+                maxInspectionFailures: 0,
+                maxTypeForwarders: 0,
+                maxMetadataRows: 20_000,
+                maxRetainedTextCharacters: 8_000_000));
+
+        var extracted = Assert.IsType<ApiSurfaceExtractionResult.Extracted>(result);
+        Assert.Equal(3_000, extracted.Surface.PublicMethodCount);
+    }
+
+    [Fact]
     public void OneTypeForwarderShortOfTheSurfaceSize_IsAbandoned()
     {
         ApiSurface unbounded = Unbounded();
@@ -1451,7 +1499,8 @@ public sealed class ApiSurfaceExtractorBoundsTests
 
     static byte[] BuildSharedLongTypeDefinitionNameImage(
         int typeCount,
-        int nameLength)
+        int nameLength,
+        bool publicTypes = true)
     {
         var metadata = Metadata("LocalTypesAmplification");
         metadata.AddTypeDefinition(
@@ -1466,12 +1515,80 @@ public sealed class ApiSurfaceExtractorBoundsTests
         for (int index = 0; index < typeCount; index++)
         {
             metadata.AddTypeDefinition(
-                TypeAttributes.Public | TypeAttributes.Abstract,
+                (publicTypes ? TypeAttributes.Public : TypeAttributes.NotPublic)
+                    | TypeAttributes.Abstract,
                 metadata.GetOrAddString($"N{index:D5}"),
                 sharedName,
                 default,
                 MetadataTokens.FieldDefinitionHandle(1),
                 MetadataTokens.MethodDefinitionHandle(1));
+        }
+
+        return Serialize(metadata);
+    }
+
+    static byte[] BuildModuleScopedFinalizerImage(int typePairCount)
+    {
+        var metadata = Metadata("ModuleScopedFinalizers");
+        AssemblyReferenceHandle coreLibrary = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Private.CoreLib"),
+            new Version(11, 0, 0, 0),
+            default,
+            metadata.GetOrAddBlob(
+                new byte[] { 0x7c, 0xec, 0x85, 0xd7, 0xbe, 0xa7, 0x79, 0x8e }),
+            default,
+            default);
+        TypeReferenceHandle objectType = metadata.AddTypeReference(
+            coreLibrary,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+
+        for (int index = 0; index < typePairCount; index++)
+        {
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("Samples"),
+                metadata.GetOrAddString($"Base{index}"),
+                objectType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        }
+
+        for (int index = 0; index < typePairCount; index++)
+        {
+            TypeReferenceHandle baseType = metadata.AddTypeReference(
+                MetadataTokens.EntityHandle(0x00000001),
+                metadata.GetOrAddString("Samples"),
+                metadata.GetOrAddString($"Base{index}"));
+            metadata.AddTypeDefinition(
+                TypeAttributes.Public,
+                metadata.GetOrAddString("Samples"),
+                metadata.GetOrAddString($"Derived{index}"),
+                baseType,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(index + 1));
+        }
+
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(
+            SignatureCallingConvention.Default,
+            genericParameterCount: 0,
+            isInstanceMethod: true).Parameters(
+                0,
+                returnType => returnType.Void(),
+                _ => { });
+        BlobHandle signatureHandle = metadata.GetOrAddBlob(signature);
+        for (int index = 0; index < typePairCount; index++)
+        {
+            metadata.AddMethodDefinition(
+                MethodAttributes.Public
+                    | MethodAttributes.Virtual
+                    | MethodAttributes.HideBySig,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Finalize"),
+                signatureHandle,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
         }
 
         return Serialize(metadata);

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -200,6 +200,69 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
+    public void FinalizerOwnerClassification_DoesNotRematerializeBaseNamesPerMethod()
+    {
+        byte[] attack = BuildFinalizerOwnerMaterializationImage(
+            methodCount: 512,
+            baseTypeNameLength: 4_000);
+        byte[] control = BuildFinalizerOwnerMaterializationImage(
+            methodCount: 512,
+            baseTypeNameLength: 8);
+
+        AssertFinalizerOwnerAllocationScaling(
+            "Extract",
+            attack,
+            control,
+            static image => MeasureFinalizerOwnerExtraction(
+                image,
+                FinalizerOwnerExtractionEntryPoint.Extract));
+        AssertFinalizerOwnerAllocationScaling(
+            "ExtractSummary",
+            attack,
+            control,
+            static image => MeasureFinalizerOwnerExtraction(
+                image,
+                FinalizerOwnerExtractionEntryPoint.ExtractSummary));
+        AssertFinalizerOwnerAllocationScaling(
+            "ExtractBounded",
+            attack,
+            control,
+            static image => MeasureFinalizerOwnerExtraction(
+                image,
+                FinalizerOwnerExtractionEntryPoint.ExtractBounded));
+    }
+
+    [Fact]
+    public void PdbFinalizerClassifier_UsesIndexedModuleScopedLookup()
+    {
+        byte[] moduleScoped = BuildModuleScopedFinalizerImage(
+            typePairCount: 3_000);
+        byte[] assemblyReference = BuildModuleScopedFinalizerImage(
+            typePairCount: 3_000,
+            useModuleScopedBase: false);
+
+        // Warm both classifier paths before measuring the independent readers.
+        _ = MeasurePdbFinalizerClassification(moduleScoped);
+        _ = MeasurePdbFinalizerClassification(assemblyReference);
+
+        long moduleScopedAllocated =
+            MeasurePdbFinalizerClassification(moduleScoped);
+        long assemblyReferenceAllocated =
+            MeasurePdbFinalizerClassification(assemblyReference);
+
+        Assert.True(
+            moduleScopedAllocated < 32L * 1024 * 1024,
+            $"PDB module-scoped finalizer classification allocated "
+            + $"{moduleScopedAllocated:N0} bytes");
+        Assert.True(
+            moduleScopedAllocated < assemblyReferenceAllocated
+                + 12L * 1024 * 1024,
+            $"PDB module-scoped finalizer classification allocated "
+            + $"{moduleScopedAllocated:N0} bytes; the AssemblyRef control allocated "
+            + $"{assemblyReferenceAllocated:N0} bytes");
+    }
+
+    [Fact]
     public void MethodImplementationBaseChainClassification_IsBounded()
     {
         byte[] image = BuildMethodImplementationBaseChainImage(
@@ -1517,6 +1580,119 @@ public sealed class ApiSurfaceExtractorBoundsTests
             $"bounded extraction allocated {allocated:N0} bytes");
     }
 
+    static void AssertFinalizerOwnerAllocationScaling(
+        string entryPoint,
+        byte[] attack,
+        byte[] control,
+        Func<byte[], long> measure)
+    {
+        _ = measure(control);
+        long controlAllocated = measure(control);
+        long attackAllocated = measure(attack);
+
+        Assert.True(
+            attackAllocated < 8L * 1024 * 1024,
+            $"{entryPoint} finalizer-owner attack allocated "
+            + $"{attackAllocated:N0} bytes");
+        Assert.True(
+            attackAllocated < controlAllocated + 1L * 1024 * 1024,
+            $"{entryPoint} finalizer-owner attack allocated "
+            + $"{attackAllocated:N0} bytes; the close control allocated "
+            + $"{controlAllocated:N0} bytes");
+    }
+
+    static long MeasureFinalizerOwnerExtraction(
+        byte[] image,
+        FinalizerOwnerExtractionEntryPoint entryPoint)
+    {
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        switch (entryPoint)
+        {
+            case FinalizerOwnerExtractionEntryPoint.Extract:
+                Assert.True(
+                    ApiSurfaceExtractor.Extract(peReader).PublicMethodCount == 512,
+                    $"{entryPoint} did not retain the test methods.");
+                break;
+            case FinalizerOwnerExtractionEntryPoint.ExtractSummary:
+                Assert.True(
+                    ApiSurfaceExtractor.ExtractSummary(peReader).PublicMethodCount == 512,
+                    $"{entryPoint} did not retain the test methods.");
+                break;
+            case FinalizerOwnerExtractionEntryPoint.ExtractBounded:
+                ApiSurfaceExtractionResult result =
+                    ApiSurfaceExtractor.ExtractBounded(
+                        peReader,
+                        ApiSurfaceExtractionScope.Public,
+                        new ApiSurfaceExtractionBounds(
+                            maxTypes: 8,
+                            maxMembers: 1_024,
+                            maxInspectionFailures: 8,
+                            maxTypeForwarders: 8,
+                            maxMetadataRows: 2_000,
+                            maxRetainedTextCharacters: 2 * 1024 * 1024));
+                switch (result)
+                {
+                    case ApiSurfaceExtractionResult.Extracted extracted:
+                        Assert.True(
+                            extracted.Surface.PublicMethodCount == 512,
+                            $"{entryPoint} did not retain the test methods.");
+                        break;
+                    case ApiSurfaceExtractionResult.Exceeded exceeded:
+                        Assert.Equal(
+                            ApiSurfaceExtractionBound.RetainedTextCharacters,
+                            exceeded.Bound);
+                        break;
+                    default:
+                        throw new Xunit.Sdk.XunitException(
+                            "Unknown bounded extraction result.");
+                }
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(entryPoint));
+        }
+
+        return GC.GetAllocatedBytesForCurrentThread() - before;
+    }
+
+    static long MeasurePdbFinalizerClassification(byte[] image)
+    {
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        MetadataReader reader = peReader.GetMetadataReader();
+        MethodDefinitionHandle[] finalizers =
+        [
+            .. reader.TypeDefinitions
+                .SelectMany(
+                    type => reader.GetTypeDefinition(type).GetMethods())
+                .Where(
+                    handle => reader.StringComparer.Equals(
+                        reader.GetMethodDefinition(handle).Name,
+                        "Finalize")),
+        ];
+        Assert.Equal(3_000, finalizers.Length);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        int classified = 0;
+        foreach (MethodDefinitionHandle finalizer in finalizers)
+        {
+            if (ApiSurfaceExtractor.IsFinalizerMethod(reader, finalizer))
+                classified++;
+        }
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Equal(finalizers.Length, classified);
+        return allocated;
+    }
+
+    enum FinalizerOwnerExtractionEntryPoint
+    {
+        Extract,
+        ExtractSummary,
+        ExtractBounded,
+    }
+
     static byte[] BuildSharedLongTypeDefinitionNameImage(
         int typeCount,
         int nameLength,
@@ -1547,7 +1723,63 @@ public sealed class ApiSurfaceExtractorBoundsTests
         return Serialize(metadata);
     }
 
-    static byte[] BuildModuleScopedFinalizerImage(int typePairCount)
+    static byte[] BuildFinalizerOwnerMaterializationImage(
+        int methodCount,
+        int baseTypeNameLength)
+    {
+        var metadata = Metadata("FinalizerOwnerMaterialization");
+        AssemblyReferenceHandle contracts = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Contracts"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        TypeReferenceHandle longBaseType = metadata.AddTypeReference(
+            contracts,
+            metadata.GetOrAddString("Contracts"),
+            metadata.GetOrAddString(new string('B', baseTypeNameLength)));
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            metadata.GetOrAddString("Samples"),
+            metadata.GetOrAddString("Host"),
+            longBaseType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(
+            SignatureCallingConvention.Default,
+            genericParameterCount: 0,
+            isInstanceMethod: false).Parameters(
+                0,
+                returnType => returnType.Void(),
+                _ => { });
+        BlobHandle signatureHandle = metadata.GetOrAddBlob(signature);
+        for (int index = 0; index < methodCount; index++)
+        {
+            metadata.AddMethodDefinition(
+                MethodAttributes.Public | MethodAttributes.Static,
+                MethodImplAttributes.IL,
+                metadata.GetOrAddString("Finalize"),
+                signatureHandle,
+                bodyOffset: -1,
+                MetadataTokens.ParameterHandle(1));
+        }
+
+        return Serialize(metadata);
+    }
+
+    static byte[] BuildModuleScopedFinalizerImage(
+        int typePairCount,
+        bool useModuleScopedBase = true)
     {
         var metadata = Metadata("ModuleScopedFinalizers");
         AssemblyReferenceHandle coreLibrary = metadata.AddAssemblyReference(
@@ -1576,10 +1808,12 @@ public sealed class ApiSurfaceExtractorBoundsTests
 
         for (int index = 0; index < typePairCount; index++)
         {
-            TypeReferenceHandle baseType = metadata.AddTypeReference(
-                MetadataTokens.EntityHandle(0x00000001),
-                metadata.GetOrAddString("Samples"),
-                metadata.GetOrAddString($"Base{index}"));
+            EntityHandle baseType = useModuleScopedBase
+                ? metadata.AddTypeReference(
+                    MetadataTokens.EntityHandle(0x00000001),
+                    metadata.GetOrAddString("Samples"),
+                    metadata.GetOrAddString($"Base{index}"))
+                : objectType;
             metadata.AddTypeDefinition(
                 TypeAttributes.Public,
                 metadata.GetOrAddString("Samples"),

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -200,6 +200,26 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
+    public void MethodImplementationBaseChainClassification_IsBounded()
+    {
+        byte[] image = BuildMethodImplementationBaseChainImage(
+            typeCount: 4_096,
+            methodImplementationCount: 256);
+        using var stream = new MemoryStream(image, writable: false);
+        using var peReader = new PEReader(stream);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader);
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Equal(1, surface.PublicMethodCount);
+        Assert.Empty(surface.InspectionFailures);
+        Assert.True(
+            allocated < 96L * 1024 * 1024,
+            $"MethodImpl base-chain classification allocated {allocated:N0} bytes");
+    }
+
+    [Fact]
     public void OneTypeForwarderShortOfTheSurfaceSize_IsAbandoned()
     {
         ApiSurface unbounded = Unbounded();
@@ -1589,6 +1609,89 @@ public sealed class ApiSurfaceExtractorBoundsTests
                 signatureHandle,
                 bodyOffset: -1,
                 MetadataTokens.ParameterHandle(1));
+        }
+
+        return Serialize(metadata);
+    }
+
+    static byte[] BuildMethodImplementationBaseChainImage(
+        int typeCount,
+        int methodImplementationCount)
+    {
+        var metadata = Metadata("MethodImplementationBaseChain");
+        AssemblyReferenceHandle coreLibrary = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("System.Private.CoreLib"),
+            new Version(11, 0, 0, 0),
+            default,
+            metadata.GetOrAddBlob(
+                new byte[] { 0x7c, 0xec, 0x85, 0xd7, 0xbe, 0xa7, 0x79, 0x8e }),
+            default,
+            default);
+        TypeReferenceHandle objectType = metadata.AddTypeReference(
+            coreLibrary,
+            metadata.GetOrAddString("System"),
+            metadata.GetOrAddString("Object"));
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        TypeDefinitionHandle root = metadata.AddTypeDefinition(
+            TypeAttributes.NotPublic,
+            metadata.GetOrAddString("Samples"),
+            metadata.GetOrAddString("Root"),
+            objectType,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature).MethodSignature(
+            SignatureCallingConvention.Default,
+            genericParameterCount: 0,
+            isInstanceMethod: true).Parameters(
+                0,
+                returnType => returnType.Void(),
+                _ => { });
+        BlobHandle signatureHandle = metadata.GetOrAddBlob(signature);
+        var rootTypeSpecSignature = new BlobBuilder();
+        rootTypeSpecSignature.WriteByte(0x12);
+        rootTypeSpecSignature.WriteCompressedInteger(
+            MetadataTokens.GetRowNumber(root) << 2);
+        TypeSpecificationHandle rootTypeSpec = metadata.AddTypeSpecification(
+            metadata.GetOrAddBlob(rootTypeSpecSignature));
+
+        TypeDefinitionHandle current = root;
+        for (int index = 1; index < typeCount; index++)
+        {
+            current = metadata.AddTypeDefinition(
+                index == typeCount - 1
+                    ? TypeAttributes.Public
+                    : TypeAttributes.NotPublic,
+                metadata.GetOrAddString("Samples"),
+                metadata.GetOrAddString($"Derived{index}"),
+                current,
+                MetadataTokens.FieldDefinitionHandle(1),
+                MetadataTokens.MethodDefinitionHandle(1));
+        }
+        MethodDefinitionHandle body = metadata.AddMethodDefinition(
+            MethodAttributes.Public
+                | MethodAttributes.Virtual
+                | MethodAttributes.NewSlot
+                | MethodAttributes.HideBySig,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("Mapped"),
+            signatureHandle,
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+        for (int index = 0; index < methodImplementationCount; index++)
+        {
+            MemberReferenceHandle distinctDeclaration = metadata.AddMemberReference(
+                rootTypeSpec,
+                metadata.GetOrAddString($"Mapped{index}"),
+                signatureHandle);
+            metadata.AddMethodImplementation(current, body, distinctDeclaration);
         }
 
         return Serialize(metadata);

--- a/tests/ILInspector.Metadata.Tests/ImplicitFinalizerDetectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ImplicitFinalizerDetectionTests.cs
@@ -186,6 +186,41 @@ public class ImplicitFinalizerDetectionTests
     }
 
     [Fact]
+    public void MalformedValueTypeAndDelegateOwnersAreNotFinalizers()
+    {
+        foreach (var (name, baseKind) in new[]
+                 {
+                     ("ValueLike", BaseKind.ValueType),
+                     ("DelegateLike", BaseKind.MulticastDelegate),
+                 })
+        {
+            byte[] image = BuildImage(
+                new TypeSpec(
+                    name,
+                    baseKind,
+                    new MethodSpec("Finalize", ReuseSlot, VoidNullary),
+                    OverrideDeclarationSignature: VoidNullary));
+            using var stream = new MemoryStream(image);
+            using var reader = new PEReader(stream);
+            var metadata = reader.GetMetadataReader();
+            MethodDefinitionHandle finalizer = metadata
+                .GetTypeDefinition(
+                    metadata.TypeDefinitions.Single(
+                        handle => metadata.StringComparer.Equals(
+                            metadata.GetTypeDefinition(handle).Name,
+                            name)))
+                .GetMethods()
+                .Single();
+
+            // PDB projection calls IsFinalizerMethod directly, while API
+            // extraction already has a class-kind gate. Both must reject the
+            // malformed finalizer-shaped MethodImpl owner.
+            Assert.False(ApiSurfaceExtractor.IsFinalizerMethod(metadata, finalizer));
+            Assert.False(ExtractMember(image, name, "Finalize").IsFinalizer);
+        }
+    }
+
+    [Fact]
     public void InAssemblyObjectRoot_DerivedFinalize_IsClassifiedAsFinalizer()
     {
         // Inspecting the core library that defines System.Object itself: the genuine
@@ -278,6 +313,8 @@ public class ImplicitFinalizerDetectionTests
     {
         Object,
         Exception,
+        ValueType,
+        MulticastDelegate,
         Def,
         ModuleRef,
         MalformedModuleRef,
@@ -288,6 +325,9 @@ public class ImplicitFinalizerDetectionTests
     {
         public static readonly BaseKind Object = new(BaseTag.Object, null);
         public static readonly BaseKind Exception = new(BaseTag.Exception, null);
+        public static readonly BaseKind ValueType = new(BaseTag.ValueType, null);
+        public static readonly BaseKind MulticastDelegate =
+            new(BaseTag.MulticastDelegate, null);
         public static readonly BaseKind Nil = new(BaseTag.Nil, null);
         public static BaseKind Def(string name) => new(BaseTag.Def, name);
         public static BaseKind ModuleRef(string name) =>
@@ -325,9 +365,15 @@ public class ImplicitFinalizerDetectionTests
 
         EntityHandle objectRef = default;
         EntityHandle exceptionRef = default;
+        EntityHandle valueTypeRef = default;
+        EntityHandle multicastDelegateRef = default;
         if (Array.Exists(
                 types,
-                static type => type.Base.Tag is BaseTag.Object or BaseTag.Exception
+                static type => type.Base.Tag is
+                    BaseTag.Object
+                    or BaseTag.Exception
+                    or BaseTag.ValueType
+                    or BaseTag.MulticastDelegate
                     || type.OverrideDeclarationSignature is not null))
         {
             // Cross-assembly fixtures use the real core-library identity. The
@@ -348,6 +394,14 @@ public class ImplicitFinalizerDetectionTests
                 coreLib,
                 metadata.GetOrAddString("System"),
                 metadata.GetOrAddString("Exception"));
+            valueTypeRef = metadata.AddTypeReference(
+                coreLib,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("ValueType"));
+            multicastDelegateRef = metadata.AddTypeReference(
+                coreLib,
+                metadata.GetOrAddString("System"),
+                metadata.GetOrAddString("MulticastDelegate"));
         }
 
         // Shared trivial `ret` body; the extractor never reads method bodies.
@@ -373,6 +427,8 @@ public class ImplicitFinalizerDetectionTests
             {
                 BaseTag.Object => objectRef,
                 BaseTag.Exception => exceptionRef,
+                BaseTag.ValueType => valueTypeRef,
+                BaseTag.MulticastDelegate => multicastDelegateRef,
                 BaseTag.Def => defHandles[types[i].Base.DefName!],
                 BaseTag.ModuleRef => metadata.AddTypeReference(
                     module,

--- a/tests/ILInspector.Metadata.Tests/ImplicitFinalizerDetectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ImplicitFinalizerDetectionTests.cs
@@ -127,6 +127,64 @@ public class ImplicitFinalizerDetectionTests
         Assert.False(member.IsFinalizer);
     }
 
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void ExplicitObjectFinalizeOverride_RequiresExactBodyAndDeclarationSignatures(
+        bool malformedBody,
+        bool malformedDeclaration)
+    {
+        byte[] image = BuildImage(
+            new TypeSpec(
+                "Handle",
+                BaseKind.Object,
+                new MethodSpec(
+                    "Finalize",
+                    malformedDeclaration ? NewSlot : ReuseSlot,
+                    malformedBody ? VoidOneParam : VoidNullary),
+                OverrideDeclarationSignature:
+                    malformedDeclaration ? VoidOneParam : VoidNullary));
+
+        Assert.False(ExtractMember(image, "Handle", "Finalize").IsFinalizer);
+    }
+
+    [Fact]
+    public void ExplicitObjectFinalizeOverride_WithExactSignatures_IsClassifiedAsFinalizer()
+    {
+        byte[] image = BuildImage(
+            new TypeSpec(
+                "Handle",
+                BaseKind.Object,
+                new MethodSpec("Finalize", ReuseSlot, VoidNullary),
+                OverrideDeclarationSignature: VoidNullary));
+
+        Assert.True(ExtractMember(image, "Handle", "Finalize").IsFinalizer);
+    }
+
+    [Fact]
+    public void InterfaceMethodImplTargetingObjectFinalize_IsNotRetainedAsFinalizer()
+    {
+        byte[] image = BuildImage(
+            new TypeSpec(
+                "IHandle",
+                BaseKind.Nil,
+                new MethodSpec("Finalize", ReuseSlot, VoidNullary),
+                Attributes: TypeAttributes.Public
+                    | TypeAttributes.Interface
+                    | TypeAttributes.Abstract,
+                OverrideDeclarationSignature: VoidNullary));
+
+        using var fullStream = new MemoryStream(image);
+        using var fullReader = new PEReader(fullStream);
+        var full = ApiSurfaceExtractor.Extract(fullReader);
+        Assert.Empty(Assert.Single(full.Types, type => type.Name == "IHandle").Members);
+
+        using var summaryStream = new MemoryStream(image);
+        using var summaryReader = new PEReader(summaryStream);
+        var summary = ApiSurfaceExtractor.ExtractSummary(summaryReader);
+        Assert.Equal(0, summary.PublicMethodCount);
+    }
+
     [Fact]
     public void InAssemblyObjectRoot_DerivedFinalize_IsClassifiedAsFinalizer()
     {
@@ -240,7 +298,13 @@ public class ImplicitFinalizerDetectionTests
 
     sealed record MethodSpec(string Name, MethodAttributes Attributes, byte[] Signature);
 
-    sealed record TypeSpec(string Name, BaseKind Base, MethodSpec Method, string? Namespace = null);
+    sealed record TypeSpec(
+        string Name,
+        BaseKind Base,
+        MethodSpec Method,
+        string? Namespace = null,
+        TypeAttributes Attributes = TypeAttributes.Public | TypeAttributes.Class,
+        byte[]? OverrideDeclarationSignature = null);
 
     static byte[] BuildImage(params TypeSpec[] types)
     {
@@ -263,7 +327,8 @@ public class ImplicitFinalizerDetectionTests
         EntityHandle exceptionRef = default;
         if (Array.Exists(
                 types,
-                static type => type.Base.Tag is BaseTag.Object or BaseTag.Exception))
+                static type => type.Base.Tag is BaseTag.Object or BaseTag.Exception
+                    || type.OverrideDeclarationSignature is not null))
         {
             // Cross-assembly fixtures use the real core-library identity. The
             // in-assembly System.Object fixture stays reference-free like a corelib.
@@ -320,7 +385,7 @@ public class ImplicitFinalizerDetectionTests
                 _ => default,
             };
             var handle = metadata.AddTypeDefinition(
-                TypeAttributes.Public | TypeAttributes.Class,
+                types[i].Attributes,
                 types[i].Namespace is { } ns ? metadata.GetOrAddString(ns) : default,
                 metadata.GetOrAddString(types[i].Name),
                 baseHandle,
@@ -330,16 +395,32 @@ public class ImplicitFinalizerDetectionTests
             methodRow++;
         }
 
+        var methodHandles = new List<MethodDefinitionHandle>(types.Length);
         foreach (var type in types)
         {
             var spec = type.Method;
-            metadata.AddMethodDefinition(
+            methodHandles.Add(metadata.AddMethodDefinition(
                 spec.Attributes,
                 MethodImplAttributes.IL,
                 metadata.GetOrAddString(spec.Name),
                 metadata.GetOrAddBlob(spec.Signature),
                 bodyOffset,
-                parameterList: MetadataTokens.ParameterHandle(1));
+                parameterList: MetadataTokens.ParameterHandle(1)));
+        }
+
+        for (int i = 0; i < types.Length; i++)
+        {
+            if (types[i].OverrideDeclarationSignature is not { } declarationSignature)
+                continue;
+
+            var declaration = metadata.AddMemberReference(
+                objectRef,
+                metadata.GetOrAddString("Finalize"),
+                metadata.GetOrAddBlob(declarationSignature));
+            metadata.AddMethodImplementation(
+                defHandles[types[i].Name],
+                methodHandles[i],
+                declaration);
         }
 
         var pe = new ManagedPEBuilder(

--- a/tests/ILInspector.Metadata.Tests/ImplicitFinalizerDetectionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ImplicitFinalizerDetectionTests.cs
@@ -142,6 +142,71 @@ public class ImplicitFinalizerDetectionTests
         Assert.True(ExtractMember(image, "Derived", "Finalize").IsFinalizer);
     }
 
+    [Fact]
+    public void ModuleScopedLocalBase_IsFollowedToObjectFinalizeSlot()
+    {
+        byte[] image = BuildImage(
+            new TypeSpec(
+                "VbBase",
+                BaseKind.Object,
+                new MethodSpec("Finalize", ReuseSlot, VoidNullary)),
+            new TypeSpec(
+                "Derived",
+                BaseKind.ModuleRef("VbBase"),
+                new MethodSpec("Finalize", ReuseSlot, VoidNullary)));
+
+        using (var stream = new MemoryStream(image))
+        using (var pe = new PEReader(stream))
+        {
+            var reader = pe.GetMetadataReader();
+            TypeDefinitionHandle derived = reader.TypeDefinitions.Single(
+                handle => reader.StringComparer.Equals(
+                    reader.GetTypeDefinition(handle).Name,
+                    "Derived"));
+            MethodDefinitionHandle finalizer = reader
+                .GetTypeDefinition(derived)
+                .GetMethods()
+                .Single(handle => reader.StringComparer.Equals(
+                    reader.GetMethodDefinition(handle).Name,
+                    "Finalize"));
+            Assert.True(
+                ApiSurfaceExtractor.IsFinalizerMethod(reader, finalizer));
+        }
+        Assert.True(ExtractMember(image, "Derived", "Finalize").IsFinalizer);
+    }
+
+    [Fact]
+    public void CyclicModuleScopedBaseReference_IsRejectedVisibly()
+    {
+        byte[] image = BuildImage(
+            new TypeSpec(
+                "Derived",
+                BaseKind.MalformedModuleRef("Cycle"),
+                new MethodSpec("Finalize", ReuseSlot, VoidNullary)));
+        using var stream = new MemoryStream(image);
+        using var pe = new PEReader(stream);
+
+        var reader = pe.GetMetadataReader();
+        TypeDefinitionHandle derived = reader.TypeDefinitions.Single(
+            handle => reader.StringComparer.Equals(
+                reader.GetTypeDefinition(handle).Name,
+                "Derived"));
+        MethodDefinitionHandle finalizer = reader
+            .GetTypeDefinition(derived)
+            .GetMethods()
+            .Single();
+        Assert.False(
+            ApiSurfaceExtractor.IsFinalizerMethod(reader, finalizer));
+        var surface = ApiSurfaceExtractor.Extract(pe, includeAll: true);
+
+        Assert.DoesNotContain(
+            surface.Types,
+            type => type.Name == "Derived");
+        Assert.Contains(
+            surface.InspectionFailures,
+            failure => failure.Operation == "type name");
+    }
+
     static ApiMember ExtractMember(byte[] image, string typeName, string memberName)
     {
         using var stream = new MemoryStream(image);
@@ -151,7 +216,15 @@ public class ImplicitFinalizerDetectionTests
         return Assert.Single(type.Members, m => m.Name == memberName);
     }
 
-    enum BaseTag { Object, Exception, Def, Nil }
+    enum BaseTag
+    {
+        Object,
+        Exception,
+        Def,
+        ModuleRef,
+        MalformedModuleRef,
+        Nil
+    }
 
     readonly record struct BaseKind(BaseTag Tag, string? DefName)
     {
@@ -159,6 +232,10 @@ public class ImplicitFinalizerDetectionTests
         public static readonly BaseKind Exception = new(BaseTag.Exception, null);
         public static readonly BaseKind Nil = new(BaseTag.Nil, null);
         public static BaseKind Def(string name) => new(BaseTag.Def, name);
+        public static BaseKind ModuleRef(string name) =>
+            new(BaseTag.ModuleRef, name);
+        public static BaseKind MalformedModuleRef(string name) =>
+            new(BaseTag.MalformedModuleRef, name);
     }
 
     sealed record MethodSpec(string Name, MethodAttributes Attributes, byte[] Signature);
@@ -168,7 +245,7 @@ public class ImplicitFinalizerDetectionTests
     static byte[] BuildImage(params TypeSpec[] types)
     {
         var metadata = new MetadataBuilder();
-        metadata.AddModule(
+        ModuleDefinitionHandle module = metadata.AddModule(
             generation: 0,
             moduleName: metadata.GetOrAddString("Synthetic.dll"),
             mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
@@ -232,6 +309,14 @@ public class ImplicitFinalizerDetectionTests
                 BaseTag.Object => objectRef,
                 BaseTag.Exception => exceptionRef,
                 BaseTag.Def => defHandles[types[i].Base.DefName!],
+                BaseTag.ModuleRef => metadata.AddTypeReference(
+                    module,
+                    default,
+                    metadata.GetOrAddString(types[i].Base.DefName!)),
+                BaseTag.MalformedModuleRef => metadata.AddTypeReference(
+                    MetadataTokens.TypeReferenceHandle(1),
+                    default,
+                    metadata.GetOrAddString(types[i].Base.DefName!)),
                 _ => default,
             };
             var handle = metadata.AddTypeDefinition(

--- a/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
+++ b/tests/ILInspector.Metadata.Tests/PdbContextDescriptorTests.cs
@@ -528,6 +528,45 @@ public class PdbContextDescriptorTests
                     .InspectAssemblySurface(rejected, subject).Value);
     }
 
+    [Fact]
+    public void EnumerateMemberDocuments_DoesNotClassifyInterfaceMethodImplAsFinalizer()
+    {
+        string path = typeof(PdbContextDescriptorTests).Assembly.Location;
+        byte[] original = File.ReadAllBytes(path);
+        TypeDefinitionHandle typeHandle;
+        MethodDefinitionHandle finalizerHandle;
+        using (var stream = new MemoryStream(original, writable: false))
+        using (var reader = new PEReader(stream))
+        {
+            var metadata = reader.GetMetadataReader();
+            typeHandle = metadata.TypeDefinitions.Single(
+                handle => metadata.StringComparer.Equals(
+                    metadata.GetTypeDefinition(handle).Name,
+                    nameof(PdbFinalizerFixture)));
+            finalizerHandle = metadata.GetTypeDefinition(typeHandle)
+                .GetMethods()
+                .Single(
+                    handle => metadata.StringComparer.Equals(
+                        metadata.GetMethodDefinition(handle).Name,
+                        "Finalize"));
+        }
+
+        byte[] image = ReclassifyTypeAsInterface(original, typeHandle);
+        var descriptor = ResolvedAssemblyReference.Create(
+            ReadIdentity(original),
+            path,
+            () => new MemoryStream(image, writable: false),
+            AssemblyResolutionProvenance.Local("PDB finalizer interface fixture"));
+
+        using var context = PdbContext.Open(descriptor);
+        Assert.True(context.HasPdb);
+        var documents = context.EnumerateMemberDocuments(
+            new HashSet<int> { MetadataTokens.GetToken(finalizerHandle) }).ToArray();
+
+        Assert.NotEmpty(documents);
+        Assert.All(documents, document => Assert.False(document.IsFinalizer));
+    }
+
     static AssemblyReferenceIdentity ReadIdentity(byte[] image)
     {
         using var stream = new MemoryStream(image, writable: false);
@@ -651,6 +690,135 @@ public class PdbContextDescriptorTests
         throw new InvalidOperationException(
             "Expected a CodeView debug-directory entry.");
     }
+
+    static byte[] ReclassifyTypeAsInterface(
+        byte[] image,
+        TypeDefinitionHandle typeHandle)
+    {
+        byte[] patched = (byte[])image.Clone();
+        using var stream = new MemoryStream(image, writable: false);
+        using var reader = new PEReader(stream);
+        int metadataOffset = RvaToFileOffset(
+            reader.PEHeaders,
+            Assert.IsType<CorHeader>(reader.PEHeaders.CorHeader)
+                .MetadataDirectory.RelativeVirtualAddress);
+        int tableStreamOffset = FindTableStreamOffset(
+            patched,
+            metadataOffset);
+        int typeDefinitionOffset = TypeDefinitionRowOffset(
+            patched,
+            tableStreamOffset,
+            MetadataTokens.GetRowNumber(typeHandle));
+        var attributes = (TypeAttributes)BinaryPrimitives.ReadUInt32LittleEndian(
+            patched.AsSpan(typeDefinitionOffset, sizeof(uint)));
+        attributes &= ~TypeAttributes.ClassSemanticsMask;
+        attributes |= TypeAttributes.Interface | TypeAttributes.Abstract;
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            patched.AsSpan(typeDefinitionOffset, sizeof(uint)),
+            (uint)attributes);
+        return patched;
+    }
+
+    static int FindTableStreamOffset(byte[] image, int metadataOffset)
+    {
+        int versionLength = BinaryPrimitives.ReadInt32LittleEndian(
+            image.AsSpan(metadataOffset + 12, sizeof(int)));
+        int streamHeaders = metadataOffset + 16 + Align4(versionLength);
+        ushort streamCount = BinaryPrimitives.ReadUInt16LittleEndian(
+            image.AsSpan(streamHeaders + 2, sizeof(ushort)));
+        int offset = streamHeaders + 4;
+        for (int index = 0; index < streamCount; index++)
+        {
+            int relativeOffset = BinaryPrimitives.ReadInt32LittleEndian(
+                image.AsSpan(offset, sizeof(int)));
+            int nameOffset = offset + 8;
+            int nameLength = 0;
+            while (image[nameOffset + nameLength] != 0)
+                nameLength++;
+            if (nameLength == 2
+                && image[nameOffset] == (byte)'#'
+                && image[nameOffset + 1] == (byte)'~')
+            {
+                return metadataOffset + relativeOffset;
+            }
+
+            offset = nameOffset + Align4(nameLength + 1);
+        }
+
+        throw new InvalidOperationException(
+            "Expected a compressed metadata table stream.");
+    }
+
+    static int TypeDefinitionRowOffset(
+        byte[] image,
+        int tableStreamOffset,
+        int rowNumber)
+    {
+        const int TypeDefinitionTable = 2;
+        byte heapSizes = image[tableStreamOffset + 6];
+        ulong validTables = BinaryPrimitives.ReadUInt64LittleEndian(
+            image.AsSpan(tableStreamOffset + 8, sizeof(ulong)));
+        int rowCountOffset = tableStreamOffset + 24;
+        Span<int> rowCounts = stackalloc int[64];
+        for (int table = 0; table < rowCounts.Length; table++)
+        {
+            if ((validTables & (1UL << table)) == 0)
+                continue;
+
+            rowCounts[table] = BinaryPrimitives.ReadInt32LittleEndian(
+                image.AsSpan(rowCountOffset, sizeof(int)));
+            rowCountOffset += sizeof(int);
+        }
+
+        if (rowNumber <= 0 || rowNumber > rowCounts[TypeDefinitionTable])
+        {
+            throw new ArgumentOutOfRangeException(nameof(rowNumber));
+        }
+
+        int stringIndexSize = (heapSizes & 0x01) != 0 ? 4 : 2;
+        int guidIndexSize = (heapSizes & 0x02) != 0 ? 4 : 2;
+        int tableDataOffset = rowCountOffset;
+        int moduleRowSize = 2 + stringIndexSize + 3 * guidIndexSize;
+        int resolutionScopeSize = CodedIndexSize(
+            rowCounts,
+            tagBits: 2,
+            0,
+            1,
+            26,
+            35);
+        int typeReferenceRowSize = resolutionScopeSize + 2 * stringIndexSize;
+        int typeDefinitionOrReferenceSize = CodedIndexSize(
+            rowCounts,
+            tagBits: 2,
+            1,
+            2,
+            27);
+        int typeDefinitionRowSize =
+            4
+            + 2 * stringIndexSize
+            + typeDefinitionOrReferenceSize
+            + TableIndexSize(rowCounts[4])
+            + TableIndexSize(rowCounts[6]);
+        return tableDataOffset
+            + rowCounts[0] * moduleRowSize
+            + rowCounts[1] * typeReferenceRowSize
+            + (rowNumber - 1) * typeDefinitionRowSize;
+    }
+
+    static int CodedIndexSize(
+        ReadOnlySpan<int> rowCounts,
+        int tagBits,
+        params int[] tables)
+    {
+        int maximumRows = 0;
+        foreach (int table in tables)
+            maximumRows = Math.Max(maximumRows, rowCounts[table]);
+        return maximumRows < 1 << (16 - tagBits) ? 2 : 4;
+    }
+
+    static int TableIndexSize(int rows) => rows < 1 << 16 ? 2 : 4;
+
+    static int Align4(int value) => (value + 3) & ~3;
 
     static (byte[] Image, int ImageStart)
         PrefixWithDecoyEmbeddedPdbHeader(byte[] image)
@@ -807,6 +975,16 @@ public class PdbContextDescriptorTests
                 throw cleanupFailure;
             }
             base.Dispose(disposing);
+        }
+    }
+
+    sealed class PdbFinalizerFixture
+    {
+        static int s_touch;
+
+        ~PdbFinalizerFixture()
+        {
+            s_touch++;
         }
     }
 }


### PR DESCRIPTION
Advances #3091 and #2777

**Conclusion: PASS** — product metadata now owns accessor membership, finalizer disclosure, extension-property implementation methods, and proven MethodImpl ownership without silently dropping unresolved external declarations.

## Stack

- Slice 3 of 4
- Parent: #4142
- Child: #4143
- Base: `feature/rts-operator-identity`
- Supersedes the non-clean monolith #3810
- Residual: #4143 moves RTS reconstruction onto this product-owned inventory.

## Change

- Adds the `MetadataReader` extraction entry point and complete typed member inventory.
- Tracks accessor ownership by metadata handle rather than name prefixes.
- Distinguishes interface MethodImpl ownership from class overrides, including generic bases and finalizers.
- Preserves unresolved external MethodImpl declarations as visible inspection evidence.
- Handles extension-property implementation accessors with generic-arity identity.
- Reuses one immutable assembly surface index across consumers.

## Scope and safety

This slice changes only `ApiSurfaceExtractor` and its direct product tests. RTS orchestration is intentionally deferred to #4143.

## Evidence

- Product test project builds independently at `2fe5a768c`.
- All 63 `ApiSurfaceExtractorTests` pass.
- The cross-platform `BodyShapeSearchMetadataTests.Search_DefaultIncludesNestedExternalExplicitInterface` regression now passes.
- The complete reconstructed stack builds and passes the full 5,214-case oracle-backed decompiler suite with zero failures or skips.

Evidence revision: `2fe5a768c`