### PR TITLE
docs: call graph characteristics and modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,8 @@ change ready to merge.
 | Security and untrusted input | `docs/design/untrusted-data-threat-model.md` |
 | Analysis, Findings, and Research | `docs/design/finding-adoption.md` |
 | Call-graph projection | `docs/design/call-graph-projection.md` |
+| Call-graph characteristics (node/edge description) | `docs/design/call-graph-characteristics.md` |
+| Call-graph modes (seed-centric vs ad hoc) | `docs/design/call-graph-modes.md` |
 | Shared IL/control-flow substrate | `docs/design/instruction-substrate.md`, plus the consuming subsystem's docs |
 | IL round-trip tests | `tests/DotnetInspector.ILRoundtrip.Tests/README.md` |
 | Decompiler raising, structuring, typing, or printer behavior | `docs/decompiler-correctness-pipeline.md`, then `docs/decompiler-raise-discipline.md` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,9 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | -------- | ----------- |
 | [Style Guide](design/style-guide.md) | Output formatting conventions. |
 | [Output Shapes](design/output-shapes.md) | The Document → Table → Vector → Scalar shape ladder, how Markout produces it, and how the output flags select a shape. |
-| [Graph Signal Annotations](design/graph-signal-annotations.md) | Projecting analysis signals (alloc/copy/unsafe, and exception-risk follow-ups) onto call-graph nodes via `--fields`. |
+| [Graph Signal Annotations](design/graph-signal-annotations.md) | Projecting analysis signals (alloc/copy/unsafe, and exception-risk follow-ups) onto call-graph nodes via `--fields` (node slice of characteristics). |
+| [Call Graph Characteristics](design/call-graph-characteristics.md) | Descriptive layers on a member-centric graph: node/edge characteristics, viewer selection, dual type↔package lens (#4139). |
+| [Call Graph Modes](design/call-graph-modes.md) | Seed-centric vs ad hoc multi-input graph build (#4133). |
 | [Allocation Triage Pre-Filters](design/allocation-triage-prefilters.md) | Which allocation candidates Performance Triage surfaces, why the pre-filters prune cold-by-construction shapes, and what realized cost the static side cannot predict. |
 | [Finding Nomenclature](design/finding-nomenclature.md) | Canonical observation/change vocabulary, arity ladder, operation outcomes, and Research composition boundary. |
 | [Finding Producer Design](design/finding-producers.md) | Choosing producer ownership, payloads, identities, result shapes, matching modes, and higher-rung boundaries. |

--- a/docs/design/call-graph-characteristics.md
+++ b/docs/design/call-graph-characteristics.md
@@ -1,0 +1,233 @@
+# Call graph characteristics
+
+Descriptive layers on a **member-centric** call graph: topology keeps identity;
+characteristics carry optional richness. Same separation AnnotatedSource uses
+for text vs facts/carets — here the carrier is the graph and the carets are
+**arcs** (and node annotations).
+
+| Owns | Does not own |
+| ---- | ------------ |
+| Characteristic model, catalogs, subject binding, viewer selection, sink projection | How the graph is **built** ([modes](call-graph-modes.md), #4133) |
+| Folding today’s node `--fields` into one catalog | Cross-library body resolution (#3632) |
+| Edge description beyond loop labels | Integrations census sections ([integrations.md](integrations.md)) as tables |
+
+Tracking: [#4139](https://github.com/richlander/dotnet-inspect/issues/4139).  
+Consumer north star: [IChatClient dual-lens demo](../workflows/discovery/aspire-ai-package-graph.md).
+
+Related:
+
+- [Call-graph projection](call-graph-projection.md) — topology, identity, edges
+- [Graph signal annotations](graph-signal-annotations.md) — current node signals via `--fields` (fold in; do not fork)
+- [Call graph modes](call-graph-modes.md) — seed-centric vs ad hoc
+- [Hidden-fact annotations](hidden-fact-annotations.md) / [caret stacking](caret-stacking.md) — AnnotatedSource fact/display split
+- [Integrations](integrations.md) — section currency that arcs may **cite**, not replace
+
+## Problem
+
+Member identity and call evidence are right for “what calls what.” Demos and
+triage still need description that is **not** identity:
+
+- package / library / type **context** without making those the node id
+- **arc** meaning (call kind, loop, package boundary, integration relationship)
+- body **signals** (alloc, throw, …) already partially on nodes
+- optional Findings overlays
+- lean defaults; density only when selected
+
+Today most description is formatted into node label strings. Edges expose almost
+only `LoopLabel` (`CallGraphEdge` → Markout `GraphEdge.Label`). Package webs and
+integration stories live in **other** sections (`extensions` tables, `Integration:*`),
+so dual-lens demos are presenter-stitched.
+
+AnnotatedSource lesson: **carrier + facts + targets + viewer filter**, not a
+fatter string. Call graph analogue: **topology + characteristics + subject
+binding + viewer filter**.
+
+## Envelope
+
+```text
+CallGraphDocument (conceptual)
+  nodes[]              // member identity + optional groups
+  edges[]              // call evidence identity (caller → callee)
+  focus?               // seed-centric mode; absent or multi in ad hoc
+  characteristics[]    // first-class descriptors
+```
+
+Each characteristic:
+
+| Field | Role |
+| ----- | ---- |
+| `id` | Stable within the document |
+| `layer` | Catalog layer (scale, body-cost, relationship, …) |
+| `subject` | `node` \| `edge` \| (later) `path` / `group` |
+| `subjectRef` | Node id or edge/row id |
+| `key` | Field name within the layer (`alloc`, `integration`, …) |
+| `value` | Typed payload (count, enum, string token, finding id) |
+| `provenance` | Optional: which analysis/index produced it |
+
+**Identity never moves into characteristics.** Changing selected layers must not
+change which member an edge connects.
+
+Groups (package, library, type) are **aggregation / presentation lenses** over
+the same nodes. A package label may appear as a group header, a node
+characteristic, and/or an edge boundary characteristic — still not a second IR.
+
+## Layers (v1 catalog)
+
+Illustrative and open to growth. Implementation maps existing surface first.
+
+### Node layers
+
+| Layer | Keys (examples) | Today |
+| ----- | --------------- | ----- |
+| **Identity display** | spelling, truncated name | Always in node text (not a selectable characteristic) |
+| **Scale** | `fanin`, `fanout`, `depth` | `--fields` defaults / scale cues |
+| **Body cost / risk** | `alloc`, `copy`, `unsafe`, `reflection`, `throw`, `catch`, `finally`, `exceptions`, `evidenceIL` | [graph-signal-annotations.md](graph-signal-annotations.md) |
+| **Boundary** | `package`, `library`, `source` (`from <assembly>`) | Partial: `Source` / cross-assembly |
+| **Type context** | declaring type, API surface role | Missing as structured field |
+| **Findings** | finding id, kind | Opt-in later |
+
+### Edge layers
+
+| Layer | Keys (examples) | Today |
+| ----- | --------------- | ----- |
+| **Call facts** | `loop` / loop hint | `LoopLabel` only |
+| **Relationship kind** | `call`, `callvirt`, `newobj`, … | In analysis; not projected as selectable edge fields |
+| **Boundary** | `cross-package`, `cross-library`, from/to package ids | Missing |
+| **Integration** | `Integration: AI`, category token | Missing on graph (lives in library sections) |
+| **API spelling on relationship graphs** | adapter/method name on package-web style edges (`AsIChatClient`, `AddOpenAI`) | Missing as graph producer |
+| **Resolution** | `external`, `external→resolved` | Incomplete node spelling; richer with #3632 |
+| **Findings** | cycle witness row, finding id | Cycles exist separately; not edge characteristics yet |
+
+**Integration on arcs** is the dual-lens demo’s pay dirt: the same currency
+[integrations.md](integrations.md) lists becomes an edge (or edge+node) payload
+when the graph is about wiring, not when every call edge is flooded with
+section text.
+
+## Viewer selection
+
+Progressive disclosure matches the rest of the tool:
+
+- **Default graph:** identity + minimal scale (current lean defaults). No body
+  signals, no integration labels, no finding noise.
+- **Node fields:** today’s `--fields` remains the user-facing selector for node
+  layers; implementation should read a characteristic catalog rather than a
+  one-off formatter forever.
+- **Edge fields:** new selector (name TBD: `--edge-fields`, or a unified
+  `node.alloc` / `edge.loop` syntax). Default empty or loop-only if loop is
+  already shown.
+- **Sinks project; they do not store.** Mermaid edge labels
+  (`A -->|label| B`), tree suffixes, table columns, and JSON properties are
+  **projections** of the selected characteristic set. Hosts must not each invent
+  a second label grammar.
+
+GitHub and Markout can render Mermaid edge labels when `GraphEdge.Label` is set;
+the contract is still structured characteristics first.
+
+## Relationship to modes and other maps
+
+| Concern | Owner |
+| ------- | ----- |
+| Seed-centric vs ad hoc build | [call-graph-modes.md](call-graph-modes.md) / #4133 |
+| Resolve external callees into bodies | #3632 |
+| Depth / multi-lib UX surface | #3292 |
+| Integrations as **sections** | [integrations.md](integrations.md) / #3629 roll-up |
+| Reference touchpoints | #3630 (sibling map; may share presentation machinery) |
+| Package `depends` | Dependency graph — not call graph |
+
+Same **envelope** (nodes, edges, groups, focus, characteristics) can host:
+
+1. **Call graph** — member nodes, call edges (this doc’s home).
+2. **Package web** — hub type or builder → packages; arcs carry extends /
+   method / integration (sibling **producer**; member- or type-keyed evidence
+   underneath where real).
+3. **Type rollup** — aggregation lens over member edges, not replacement
+   identity.
+
+Do not force `depends` or touchpoints to become call graphs.
+
+## Dual lens (type ↔ package)
+
+Characteristics are what make dual lens honest:
+
+- **Type outward** — nodes stay members of/around a hub type; edge/node
+  characteristics surface provider **packages** and integration kind.
+- **Package inward** — scope or groups are packages; characteristics surface the
+  **type** and adapter members that unify them.
+
+Without a characteristic plane, “package call graph” collapses to either
+relabeling nodes as packages (wrong identity) or leaving richness in side
+tables (current state).
+
+Locked demo arcs to enable when product catches up:
+
+- `AsIChatClient` · `Integration: AI` on adapter edges  
+- package group labels on OpenAI / Bedrock / Azure nodes  
+- optional reference edge Azure.AI.OpenAI → OpenAI SDK  
+
+## Mapping current code
+
+| Piece | Role under this model |
+| ----- | --------------------- |
+| `CallGraphProjection` nodes/edges/focus/rows | Topology + identity (unchanged duty) |
+| `CallGraphEdge.LoopLabel` | First edge characteristic projection (legacy field) |
+| `CallTreePerf` / `MethodSignals` | Node body-cost / scale characteristic sources |
+| `CallGraphSectionAdapter` `--fields` | Viewer selection + sink projection for **nodes** |
+| `GraphEdge.Label` in Markout | Sink slot for **selected** edge characteristics |
+| Library `Integration:*` sections | Authoritative integration **discovery**; graph cites tokens |
+
+Slice order (from #4139):
+
+1. **This doc + catalog** — done here; keep catalog in sync as keys land.
+2. **Store off the label string** — projection/adapter builds labels from
+   selected characteristics for nodes and edges.
+3. **Edge field selection** — at least one edge characteristic beyond loop
+   (e.g. cross-library boundary or call kind) in Mermaid + table/JSON.
+4. **Package-web producer** (optional follow-up issue once envelope exists).
+5. **Findings overlay** — opt-in characteristic kind.
+
+## Non-goals
+
+- Replacing member identity with package- or type-only nodes as the sole model.
+- Putting every body Finding on every node by default.
+- Faking multi-provider edges from seeds that do not reference those assemblies
+  (e.g. `Aspire.Hosting.OpenAI.AddOpenAI` → MEAI/Bedrock).
+- Blocking seed-centric demos until the full catalog lands.
+- One mega-enum frozen forever — catalog grows like `MethodSignals` does today.
+
+## Acceptance (design + later implementation)
+
+Design (this document):
+
+- [x] Member-centric substrate + characteristic plane named.
+- [x] Current node signals mapped into the catalog.
+- [x] Edge layers beyond loop described; dual-lens consumer cited.
+- [x] Modes, integrations tables, and depends/touchpoints de-scoped.
+
+Implementation (follow-up PRs citing #4139):
+
+- [ ] Existing node signals remain; defaults stay lean.
+- [ ] ≥1 edge characteristic beyond loop selectable in Mermaid and table/JSON.
+- [ ] Package or library boundary expressible without node id = package.
+- [ ] No second ad hoc label formatter per sink — one projection path.
+
+## Worked projection sketch
+
+Selected: node `alloc`, edge `loop`, edge `boundary=cross-package`.
+
+```text
+characteristics:
+  { layer: body-cost, subject: node, ref: 2, key: alloc, value: 13 }
+  { layer: call-facts, subject: edge, ref: row:4, key: loop, value: "loop" }
+  { layer: boundary, subject: edge, ref: row:4, key: cross-package, value: true }
+```
+
+Mermaid projection (illustrative):
+
+```mermaid
+flowchart LR
+  A["BuildCallTree (alloc 13)"]
+  B["MethodKey"]
+  A -->|"loop · cross-pkg"| B
+```
+
+JSON/table sinks expose the same rows without parsing label strings.

--- a/docs/design/call-graph-modes.md
+++ b/docs/design/call-graph-modes.md
@@ -1,0 +1,116 @@
+# Call graph modes
+
+Two ways to **build** a call graph from the same member-centric evidence. Modes
+choose the subgraph; [characteristics](call-graph-characteristics.md) describe
+what is already in it.
+
+Tracking: [#4133](https://github.com/richlander/dotnet-inspect/issues/4133).
+
+| Mode | Center | Input | Primary question |
+| ---- | ------ | ----- | ---------------- |
+| **Seed-centric** | One focus member (sometimes one type entry rule) | Member + optional scope wideners | “What surrounds *this* API?” |
+| **Ad hoc** | No single privileged node (or several equal seeds) | A **set** of packages / libraries / types / members | “What graph do *these* inputs induce?” |
+
+Related:
+
+- [Call-graph projection](call-graph-projection.md) — shared topology IR
+- [Call graph characteristics](call-graph-characteristics.md) — description layers
+- [IChatClient dual-lens demo](../workflows/discovery/aspire-ai-package-graph.md) — needs ad hoc + characteristics for one diagram
+- #3632 external body resolution — evidence quality for both modes
+- #3292 depth / multi-lib UX — flag and command surface
+
+## Why split
+
+Today’s product path (`member -S "Call Graph"`) is **seed-centric**. Scope
+flags (`--caller-package`, `--bin`, `--project`) widen **coverage of that seed**;
+they do not redefine the question as “graph among these packages.”
+
+Multi-package and multi-provider demos expose the gap:
+
+- Picking a clever seed (`AddAzureOpenAI`) that fans across hubs is demo craft,
+  not a mode.
+- Multi-package `extensions` / integrations / `depends` are **sibling maps**,
+  not call graphs.
+- Repeating seed queries and mentally unioning results is not a product graph.
+
+Both modes share identity rules, failure visibility, bounds, and (eventually)
+the characteristic envelope. They must not silently become each other via flags
+that only make sense for one question.
+
+## Seed-centric
+
+**Required:** one focus identity (member; later stable type-scoped entry rules).
+
+**Optional:** scope set that participates in caller/callee resolution.
+
+**Output:** one focus node; inbound/outbound neighborhoods; focus styling in
+Mermaid/tree; progressive tiers and wasm focus navigation stay here.
+
+**Non-goal:** equal treatment of every package in the scope set.
+
+This remains the **default** for `member -S "Call Graph"`.
+
+## Ad hoc
+
+**Required:** an input set (packages and/or libraries; optionally explicit seed
+members or types).
+
+**Center:** none, or N declared seeds with equal status.
+
+**Output (v1 target):** graph induced by the set — at minimum boundary-crossing
+call edges and/or union of neighborhoods around declared seeds; package/library
+as group labels (and boundary characteristics once #4139 lands).
+
+**Non-goals for v1:** whole-program unbounded closure; replacing `depends`,
+touchpoints (#3630), or integrations roll-up (#3629).
+
+Ad hoc may be a **different command or explicit lens** if packing it into
+`member -S "Call Graph"` harms seed-centric UX (#3292). Implementation PRs
+should label `mode: seed`, `mode: adhoc`, or both with separate evidence.
+
+## Shared contract
+
+- Same underlying call evidence and member identity (no second IR).
+- Incomplete nodes/edges stay typed and visible — never success-shaped empty.
+- Expensive wideners and network stay explicit / capability-gated.
+- Workspace or multi-assembly ownership of snapshots stays with existing
+  session/scope direction (`MemberCallGraphSession` and catalog scopes).
+- Characteristics (#4139) apply to whichever subgraph the mode produced.
+
+## Sibling maps (not modes of call graph)
+
+| Map | Question |
+| --- | -------- |
+| `depends` | Package/assembly dependency edges |
+| Integrations sections | Ecosystem currency census |
+| `extensions` | Extension methods on a hub type (table today) |
+| Touchpoints (#3630) | Reference edges worth surfacing |
+| Characteristics on a call graph | Description of call topology — still call graph |
+
+An ad hoc **call** graph may *cite* integration or package tokens on arcs; it
+does not absorb those features’ full product surfaces.
+
+## Slice order
+
+1. **Vocabulary + docs** — this file; demos point at the right mode.
+2. **#3632** — resolve externals (shared substrate).
+3. **Ad hoc v1** — input set → cross-participant edges and/or multi-seed union;
+   strict bounds; named entry surface.
+4. **Seed-centric polish** — depth flags, type-scoped seeds, stable share anchors.
+
+## Acceptance
+
+- [x] Two-mode split and non-overlap with depends / integrations / touchpoints
+      documented here.
+- [ ] Seed-centric remains default for `member -S "Call Graph"`.
+- [ ] Ad hoc has a named entry surface that accepts a **set** without one hero
+      member.
+- [ ] At least one demo/workflow cites ad hoc instead of “pick a lucky seed”
+      (IChatClient dual-lens is the locked candidate once product exists).
+- [ ] Implementation PRs declare mode.
+
+## Non-goals
+
+- Replacing extension package webs or dependency graphs with call graphs.
+- Requiring ad hoc before shipping further seed-centric demos.
+- Multi-root unbounded whole-program analysis without bounds.

--- a/docs/design/call-graph-projection.md
+++ b/docs/design/call-graph-projection.md
@@ -8,6 +8,10 @@ Related docs:
 
 - [Graph signal annotations](graph-signal-annotations.md) — the per-node
   perf/kind-of-work cues the CLI projects onto the same call trees
+- [Call graph characteristics](call-graph-characteristics.md) — descriptive
+  layers on nodes and edges (topology stays here; description generalizes
+  signals and edge labels)
+- [Call graph modes](call-graph-modes.md) — seed-centric vs ad hoc graph build
 - [Output shapes](output-shapes.md) — the projection/shape model the CLI uses
 
 ## Layering

--- a/docs/design/graph-signal-annotations.md
+++ b/docs/design/graph-signal-annotations.md
@@ -3,8 +3,18 @@
 How analysis **signals** are projected onto call-graph nodes, and how the same
 mechanism extends to exception-risk triage.
 
+This document is the **node body-cost / scale** slice of the broader
+[call graph characteristics](call-graph-characteristics.md) model (#4139). New
+descriptive work — especially **edge** fields, package boundary, and integration
+on arcs — extends that catalog rather than adding a second `--fields` grammar
+here. Identity and topology remain in
+[call-graph projection](call-graph-projection.md).
+
 Related docs:
 
+- [Call graph characteristics](call-graph-characteristics.md) — full node/edge
+  characteristic plane; fold signals into that catalog
+- [Call-graph projection](call-graph-projection.md) — topology and identity
 - [Output shapes](output-shapes.md) — the projection/shape model these fields plug into
 - [Hidden-fact annotations](hidden-fact-annotations.md) — the per-method evidence model
 

--- a/docs/workflows/discovery/aspire-ai-package-graph.md
+++ b/docs/workflows/discovery/aspire-ai-package-graph.md
@@ -13,7 +13,9 @@ status: locked-demo
 > integration richness the way AnnotatedSource carets carry facts.
 >
 > Status: **locked narrative + pins + works-now path.** Full single-diagram
-> product experience is target (characteristics #4139, ad hoc mode #4133).
+> product experience is target
+> ([characteristics](../../design/call-graph-characteristics.md) #4139,
+> [ad hoc mode](../../design/call-graph-modes.md) #4133).
 
 ## Why this demo
 
@@ -210,10 +212,10 @@ Call Graph
 
 ## Product gaps (this demo only)
 
-| Gap | Issue |
-| --- | ----- |
-| One multi-input / multi-seed graph | #4133 |
-| Arc + node characteristics (integration, package on edges) | #4139 |
+| Gap | Design / issue |
+| --- | -------------- |
+| One multi-input / multi-seed graph | [call-graph-modes.md](../../design/call-graph-modes.md) · #4133 |
+| Arc + node characteristics (integration, package on edges) | [call-graph-characteristics.md](../../design/call-graph-characteristics.md) · #4139 |
 | Deeper external body resolution | #3632 |
 | Workspace integrations roll-up across the pin set | #3629 |
 | Reference edge Azure→OpenAI as first-class arc | #3630 |


### PR DESCRIPTION
## Summary

Design docs for the two call-graph product tracks unlocked by the locked
IChatClient demo:

| Doc | Issue | Owns |
| --- | ----- | ---- |
| `docs/design/call-graph-characteristics.md` | #4139 | Node/edge characteristic plane; catalog; dual type↔package lens; fold `--fields` signals |
| `docs/design/call-graph-modes.md` | #4133 | Seed-centric vs ad hoc multi-input build |

Also cross-links from projection, graph-signal-annotations, locked demo workflow,
`docs/README.md`, and `AGENTS.md`.

## Claim

Docs only. Settles vocabulary so implementation PRs can cite layers/modes without
re-litigating identity vs description.

## Non-action

No product code. No ad hoc command. No edge-field CLI yet.

## Validation

`markdownlint` clean on touched Markdown.

## Ready when

Docs review is enough for this tier; no product CI claim.