### PR TITLE
Bind method allocation facts to canonical context

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -715,9 +715,8 @@ Research overlay bridge, and the application layer:
   classification, and the private path-context/confidence/post-dominance indexes
   that produce its multiplicity reading. It receives metadata and raw-IL
   judgments through the narrow `IMethodAllocationResolver` contract the assembly
-  reader implements, and returns one `MethodAllocationFacts` bundle binding the
-  canonical context, discovered and escape-refined occurrences, and Layer-1
-  queries from a single interpretation.
+  reader implements, and binds the canonical context, discovered and
+  escape-refined occurrences, and Layer-1 queries in one object.
   `FactsBundlesBindContextOccurrencesAndQueries` gates that coherence.
   `OptimizationOpportunityAnalysis` owns its per-method instruction walk,
   optimization-shape classification, lazy memoized reaching-definitions use,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -710,17 +710,19 @@ Research overlay bridge, and the application layer:
   member, calli-signature, and definition-token facts through
   `IMethodCallResolver`, appends calls and safety evidence incrementally, and
   delegates unsafe-call/opcode policy back to `MethodSafetyAnalysis`.
-  `MethodAllocationAnalysis` owns allocation interpretation for one decoded
+  `MethodAllocationFacts` owns allocation interpretation for one decoded
   body: occurrence discovery, allocation-shape classification, escape
   classification, and the private path-context/confidence/post-dominance indexes
   that produce its multiplicity reading. It receives metadata and raw-IL
   judgments through the narrow `IMethodAllocationResolver` contract the assembly
-  reader implements, and returns one `MethodAllocationResult` carrying the
-  discovered and escape-refined occurrences from a single scan.
+  reader implements, and returns one `MethodAllocationFacts` bundle binding the
+  canonical context, discovered and escape-refined occurrences, and Layer-1
+  queries from a single interpretation.
+  `FactsBundlesBindContextOccurrencesAndQueries` gates that coherence.
   `OptimizationOpportunityAnalysis` owns its per-method instruction walk,
   optimization-shape classification, lazy memoized reaching-definitions use,
   and allocation metadata projection. It reuses allocation discovery and the
-  allocation analysis's Layer-1 query methods rather than opening another
+  allocation facts' Layer-1 query methods rather than opening another
   allocation or decode path. The collector coordinates the ordered opportunity
   traversal and delegates focused evidence classification to
   `ArrayEscapeAnalysis`, `LoopInvariantMaterializerAnalysis`,

--- a/docs/design/instruction-substrate.md
+++ b/docs/design/instruction-substrate.md
@@ -291,7 +291,7 @@ not attempted in that PR.
   per-method malformed-body diagnostic behavior while giving topic producers
   one shared façade. The allocation-specific path, confidence, and
   post-dominance indexes over those blocks are Analysis-owned Layer 1, private
-  to `MethodAllocationAnalysis`. Remaining: the
+  to `MethodAllocationFacts`. Remaining: the
   decompiler importer (with the minimal-CFG refactor), and consolidating the
   three metadata-token-to-string traversals
   (`ILTokenResolver`/`CanonicalIL`/`IlBodyDiff.MetadataOperandResolver`) if their

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -245,7 +245,7 @@ generic scope. The producer appends to caller-owned call and safety-evidence
 builders so results emitted before a later recoverable metadata failure survive,
 and delegates unsafe-call/opcode classification to `MethodSafetyAnalysis`
 without a second body scan.
-`MethodAllocationAnalysis` owns the allocation topic for one decoded body:
+`MethodAllocationFacts` owns the allocation topic for one decoded body:
 allocation occurrence discovery, allocation-shape classification, escape
 classification, and the private path-context, path-confidence, and
 post-dominance indexes behind its multiplicity reading. It consumes the shared
@@ -255,11 +255,16 @@ delegate-constructor, value-type-box, non-heap-construction, in-assembly
 element, field-owner) and the raw-IL reaching-definitions analysis arrive
 through the narrow `IMethodAllocationResolver` contract implemented by the
 assembly reader, so no metadata reader, `PEReader`, generic scope, IL buffer, or
-reader-bound body reaches allocation analysis. One scan produces a
-`MethodAllocationResult` carrying both the discovered occurrences and the
-escape-refined occurrences: the published allocation facts take the latter,
-and `OptimizationOpportunityAnalysis` reuses the former plus the query methods
+reader-bound body reaches allocation analysis. One `MethodAllocationFacts`
+object binds the canonical context and Layer-1 query methods before other topic
+producers run. When allocation collection is selected, one scan populates that
+same object with both the discovered and escape-refined occurrences. The
+published allocation facts take the classified occurrences, and
+`OptimizationOpportunityAnalysis` reuses the discovered occurrences plus the
+query methods
 (`PathContextAt`, `PathConfidenceAt`, `PostDominanceAt`, `MultiplicityAt`).
+`FactsBundlesBindContextOccurrencesAndQueries` gates the bundle's context,
+occurrence, and query coherence.
 That service owns the per-method optimization instruction walk, shape
 classification, lazy memoized reaching-definitions use, and allocation metadata
 projection without opening another allocation or decode path. Its traversal may

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -265,7 +265,8 @@ query methods
 (`PathContextAt`, `PathConfidenceAt`, `PostDominanceAt`, `MultiplicityAt`).
 `FactsBundlesBindContextOccurrencesAndQueries` gates the bundle's context,
 occurrence, and query coherence.
-That service owns the per-method optimization instruction walk, shape
+`OptimizationOpportunityAnalysis` owns the per-method optimization instruction
+walk, shape
 classification, lazy memoized reaching-definitions use, and allocation metadata
 projection without opening another allocation or decode path. Its traversal may
 repeat member and type resolution. It retains opportunity ordering and deferred

--- a/src/ILInspector.Analysis.Tests/MethodAllocationFactsTests.cs
+++ b/src/ILInspector.Analysis.Tests/MethodAllocationFactsTests.cs
@@ -11,7 +11,7 @@ namespace ILInspector.Analysis.Tests;
 /// properties over hand-written IL, so the test says what the analysis claims
 /// rather than how it is wired.
 /// </summary>
-public sealed class MethodAllocationAnalysisTests
+public sealed class MethodAllocationFactsTests
 {
     const int ConstructorToken = 0x06000002;
     const int TypeToken = 0x01000004;
@@ -57,20 +57,40 @@ public sealed class MethodAllocationAnalysisTests
     }
 
     [Fact]
-    public void OneScanFeedsBothDiscoveredAndClassifiedOccurrences()
+    public void FactsBundlesBindContextOccurrencesAndQueries()
     {
-        // newobj Widget::.ctor; ret
-        byte[] il = [0x73, 0x02, 0x00, 0x00, 0x06, 0x2A];
-        var result = Collect(il);
+        // newobj Widget::.ctor; pop; ldarg.0; brtrue.s IL_0000; ret
+        byte[] il =
+        [
+            0x73, 0x02, 0x00, 0x00, 0x06,
+            0x26,
+            0x02,
+            0x2D, 0xF7,
+            0x2A,
+        ];
+        var loopContext = Context(il, [(0, 7)]);
+        var straightContext = Context(il);
+        var loopFacts = MethodAllocationFacts.Create(loopContext);
+        loopFacts.Collect(new Resolver(il));
+        var straightFacts = MethodAllocationFacts.Create(straightContext);
+        straightFacts.Collect(new Resolver(il));
 
-        var discovered = Assert.Single(result.DiscoveredOccurrences);
-        var classified = Assert.Single(result.ClassifiedOccurrences);
-        Assert.Equal(discovered.ILOffset, classified.ILOffset);
-        Assert.Equal(discovered.Kind, classified.Kind);
+        var discovered = Assert.Single(loopFacts.DiscoveredOccurrences);
+        var classified = Assert.Single(loopFacts.ClassifiedOccurrences);
+        Assert.Same(loopContext, loopFacts.Context);
+        Assert.Same(straightContext, straightFacts.Context);
+        Assert.Equal(AllocationKind.Object, discovered.Kind);
+        Assert.Equal(AllocationKind.Object, classified.Kind);
         // The shared scan leaves escape unclassified; only the published
         // occurrences carry the refined verdict.
         Assert.Equal(AllocationEscape.Unknown, discovered.Escape);
-        Assert.Equal(AllocationEscape.Escapes, classified.Escape);
+        Assert.Equal(AllocationEscape.LocalOnly, classified.Escape);
+        Assert.Equal(
+            AllocationMultiplicity.Loop,
+            loopFacts.MultiplicityAt(0));
+        Assert.NotEqual(
+            AllocationMultiplicity.Loop,
+            straightFacts.MultiplicityAt(0));
     }
 
     [Fact]
@@ -101,8 +121,8 @@ public sealed class MethodAllocationAnalysisTests
             0x2A,
         ];
         var context = Context(il);
-        var analysis = new MethodAllocationAnalysis(context);
-        var result = analysis.Collect(new Resolver(il));
+        var result = MethodAllocationFacts.Create(context);
+        result.Collect(new Resolver(il));
 
         var occurrence = Assert.Single(result.ClassifiedOccurrences);
         Assert.Equal(3, occurrence.ILOffset);
@@ -117,7 +137,7 @@ public sealed class MethodAllocationAnalysisTests
         // same interpretation for offsets that are not allocations.
         Assert.Equal(
             AllocationMultiplicity.Conditional,
-            analysis.MultiplicityAt(3));
+            result.MultiplicityAt(3));
     }
 
     [Fact]
@@ -275,7 +295,8 @@ public sealed class MethodAllocationAnalysisTests
             0x2A,
         ];
         var context = Context(il);
-        var result = new MethodAllocationAnalysis(context).Collect(
+        var result = MethodAllocationFacts.Create(context);
+        result.Collect(
             new Resolver(il) { ThrowOnMemberResolution = true });
 
         var raw = Assert.Single(result.DiscoveredOccurrences);
@@ -284,20 +305,20 @@ public sealed class MethodAllocationAnalysisTests
         Assert.Equal(raw.ILOffset, classified.ILOffset);
     }
 
-    static MethodAllocationResult Collect(
+    static MethodAllocationFacts Collect(
         byte[] il,
         IReadOnlyList<(int Start, int End)>? loopRegions = null,
         (TypeRef? DeclaringType, string? Name) fieldOwner = default,
         bool nonHeapConstruction = false)
     {
         var context = Context(il, loopRegions);
-        var analysis = new MethodAllocationAnalysis(context);
-        return analysis.Collect(
-            new Resolver(il)
+        var result = MethodAllocationFacts.Create(context);
+        result.Collect(new Resolver(il)
             {
                 FieldOwner = fieldOwner,
                 NonHeapConstruction = nonHeapConstruction,
             });
+        return result;
     }
 
     static MethodBodyAnalysisContext Context(

--- a/src/ILInspector.Analysis.Tests/OptimizationOpportunityAnalysisTests.cs
+++ b/src/ILInspector.Analysis.Tests/OptimizationOpportunityAnalysisTests.cs
@@ -31,9 +31,7 @@ public sealed class OptimizationOpportunityAnalysisTests
         var resolver = new Resolver(il);
 
         var opportunities = OptimizationOpportunityAnalysis.Collect(
-            context,
-            [],
-            new MethodAllocationAnalysis(context),
+            MethodAllocationFacts.Create(context),
             resolver);
 
         Assert.Equal(
@@ -74,9 +72,7 @@ public sealed class OptimizationOpportunityAnalysisTests
         var unrelatedResolver = new Resolver(unrelatedIl);
 
         var unrelated = OptimizationOpportunityAnalysis.Collect(
-            unrelatedContext,
-            [],
-            new MethodAllocationAnalysis(unrelatedContext),
+            MethodAllocationFacts.Create(unrelatedContext),
             unrelatedResolver);
 
         Assert.Single(unrelated);
@@ -95,9 +91,7 @@ public sealed class OptimizationOpportunityAnalysisTests
 
         var outsideLoopMaterializer =
             OptimizationOpportunityAnalysis.Collect(
-                outsideLoopMaterializerContext,
-                [],
-                new MethodAllocationAnalysis(
+                MethodAllocationFacts.Create(
                     outsideLoopMaterializerContext),
                 outsideLoopMaterializerResolver);
 
@@ -118,9 +112,7 @@ public sealed class OptimizationOpportunityAnalysisTests
         var spanResolver = new Resolver(spanCopiesIl);
 
         var spanCopies = OptimizationOpportunityAnalysis.Collect(
-            spanContext,
-            [],
-            new MethodAllocationAnalysis(spanContext),
+            MethodAllocationFacts.Create(spanContext),
             spanResolver);
 
         Assert.Empty(spanCopies);
@@ -145,9 +137,7 @@ public sealed class OptimizationOpportunityAnalysisTests
 
         var exception = Assert.Throws<BadImageFormatException>(
             () => OptimizationOpportunityAnalysis.Collect(
-                context,
-                [],
-                new MethodAllocationAnalysis(context),
+                MethodAllocationFacts.Create(context),
                 resolver));
 
         Assert.Equal(

--- a/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
+++ b/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
@@ -576,11 +576,9 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
                 body.ExceptionRegions,
                 loopRegions,
                 localTypes);
-            // One allocation interpretation per decoded body. It owns the path,
-            // confidence, post-dominance, and multiplicity reading of the shared
-            // control flow, which call-site acquisition and optimization-opportunity
-            // collection query rather than rebuild.
-            var allocationAnalysis = new MethodAllocationAnalysis(context);
+            // Build allocation's Layer-1 indexes before other topic producers,
+            // then keep every result and query bound to this exact context.
+            var allocationFacts = MethodAllocationFacts.Create(context);
             var methodAnalysisResolver = new MethodAnalysisResolver(
                 this,
                 scope,
@@ -596,11 +594,12 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
             // reuses the same discovered occurrences (it keys them by IL offset and does not read escape
             // state). Refining once and sharing the discovery scan avoids a second full instruction/
             // token scan per method whenever opportunities are computed.
-            var allocations = includeAllocations
-                ? allocationAnalysis.Collect(
-                    methodAnalysisResolver)
-                : MethodAllocationResult.Empty;
-            result.Allocations = allocations.ClassifiedOccurrences;
+            if (includeAllocations)
+            {
+                allocationFacts.Collect(methodAnalysisResolver);
+            }
+            result.Allocations =
+                allocationFacts.ClassifiedOccurrences;
             result.Unsafety = MethodSafetyAnalysis.CollectOccurrences(
                 context,
                 token => CalliReturnDetail(token, scope));
@@ -613,9 +612,7 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
                     && !IsBlazorRenderMethod(caller))
                     result.Opportunities =
                         OptimizationOpportunityAnalysis.Collect(
-                            context,
-                            allocations.DiscoveredOccurrences,
-                            allocationAnalysis,
+                            allocationFacts,
                             methodAnalysisResolver);
                 else
                     result.Suppressed = true;
@@ -633,7 +630,7 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
             MethodCallAnalysis.Collect(
                 context,
                 new CallResolver(this, scope),
-                offset => allocationAnalysis.MultiplicityAt(offset),
+                offset => allocationFacts.MultiplicityAt(offset),
                 calls,
                 evidence,
                 includeIndirectOpcodes: hasUnsafeApiMember || hasUnsafeSignature || hasUnsafeLocals);

--- a/src/ILInspector.Analysis/MethodAllocationFacts.cs
+++ b/src/ILInspector.Analysis/MethodAllocationFacts.cs
@@ -14,7 +14,7 @@ internal enum NewObjectConstructionKind
 }
 
 /// <summary>
-/// The metadata- and IL-dependent judgments <see cref="MethodAllocationAnalysis"/>
+/// The metadata- and IL-dependent judgments <see cref="MethodAllocationFacts"/>
 /// cannot make from the shared Layer-0 context. The assembly reader that owns the
 /// metadata reader, the caller's generic scope, and the raw IL bytes implements
 /// this, so none of them reach allocation analysis and no second decode or
@@ -76,22 +76,9 @@ internal interface IMethodAllocationResolver
 }
 
 /// <summary>
-/// One method's allocation occurrences from a single scan: the discovered
-/// occurrences that optimization-opportunity collection reuses, and the
-/// escape-refined occurrences the allocation output publishes. Discovery may
-/// already identify an allocation on a throw path.
-/// </summary>
-internal sealed record MethodAllocationResult(
-    ImmutableArray<AllocationOccurrence> DiscoveredOccurrences,
-    ImmutableArray<AllocationOccurrence> ClassifiedOccurrences)
-{
-    internal static readonly MethodAllocationResult Empty = new([], []);
-}
-
-/// <summary>
-/// Owns allocation interpretation for one decoded method body: where allocations
-/// occur, what shape they are, how often a call executes them, and whether the
-/// produced value escapes.
+/// One method's allocation facts from a single interpretation: the canonical
+/// body context, discovered and escape-refined occurrences, and the allocation
+/// Layer-1 queries consumed by call and optimization analysis.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -107,15 +94,19 @@ internal sealed record MethodAllocationResult(
 /// collection and call-site acquisition consume them through the query methods
 /// rather than rebuilding them.
 /// </para>
+/// <para>
+/// <c>MethodAllocationFactsTests.FactsBundlesBindContextOccurrencesAndQueries</c>
+/// gates the context, occurrence, and query coherence.
+/// </para>
 /// </remarks>
-internal sealed class MethodAllocationAnalysis
+internal sealed class MethodAllocationFacts
 {
     readonly MethodBodyAnalysisContext _context;
     readonly AllocationPathContextIndex _pathContexts;
     readonly AllocationPathConfidenceIndex _pathConfidences;
     readonly AllocationPostDominanceIndex _postDominances;
 
-    internal MethodAllocationAnalysis(MethodBodyAnalysisContext context)
+    MethodAllocationFacts(MethodBodyAnalysisContext context)
     {
         _context = context;
         _pathContexts = AllocationPathContextIndex.Create(context);
@@ -125,17 +116,37 @@ internal sealed class MethodAllocationAnalysis
             AllocationPostDominanceIndex.Create(context, _pathContexts);
     }
 
+    internal MethodBodyAnalysisContext Context => _context;
+
+    internal ImmutableArray<AllocationOccurrence> DiscoveredOccurrences
+    {
+        get;
+        private set;
+    } = [];
+
+    internal ImmutableArray<AllocationOccurrence> ClassifiedOccurrences
+    {
+        get;
+        private set;
+    } = [];
+
+    internal static MethodAllocationFacts Create(
+        MethodBodyAnalysisContext context)
+        => new(context);
+
     /// <summary>
     /// Scans the body once for allocation occurrences and returns both the raw
     /// occurrences and their escape-refined form. One scan feeds both the
     /// published allocation facts and optimization-opportunity collection.
     /// </summary>
-    internal MethodAllocationResult Collect(IMethodAllocationResolver resolver)
+    internal void Collect(
+        IMethodAllocationResolver resolver)
     {
         var raw = CollectOccurrences(resolver);
-        return new MethodAllocationResult(
-            raw,
-            raw.IsDefaultOrEmpty ? raw : ClassifyEscapes(raw, resolver));
+        var classified =
+            raw.IsDefaultOrEmpty ? raw : ClassifyEscapes(raw, resolver);
+        DiscoveredOccurrences = raw;
+        ClassifiedOccurrences = classified;
     }
 
     internal AllocationPathContext PathContextAt(

--- a/src/ILInspector.Analysis/OptimizationOpportunityAnalysis.Collect.cs
+++ b/src/ILInspector.Analysis/OptimizationOpportunityAnalysis.Collect.cs
@@ -30,16 +30,16 @@ internal interface IOptimizationOpportunityResolver
 internal static partial class OptimizationOpportunityAnalysis
 {
     internal static ImmutableArray<OptimizationOpportunity> Collect(
-        MethodBodyAnalysisContext context,
-        ImmutableArray<AllocationOccurrence> discoveredAllocations,
-        MethodAllocationAnalysis allocationAnalysis,
+        MethodAllocationFacts allocationFacts,
         IOptimizationOpportunityResolver resolver)
     {
+        var context = allocationFacts.Context;
         var caller = context.Method;
         var opportunities = ImmutableArray.CreateBuilder<OptimizationOpportunity>();
         // Discovered allocation occurrences for this method, scanned once by the caller
         // and shared here to avoid a redundant second allocation scan. Escape state is not read.
-        var allocationByOffset = discoveredAllocations.ToDictionary(occurrence => occurrence.ILOffset);
+        var allocationByOffset = allocationFacts.DiscoveredOccurrences
+            .ToDictionary(occurrence => occurrence.ILOffset);
         ReachingDefinitionsResult? reachingDefinitions = null;
         ReachingDefinitionsResult GetReachingDefinitions()
             => reachingDefinitions ??= resolver.AnalyzeReachingDefinitions();
@@ -169,7 +169,7 @@ internal static partial class OptimizationOpportunityAnalysis
                             // including a loop early-exit that runs once — is low, especially
                             // since .NET 10+ partially stack-allocates non-escaping ones.
                             var inLoop = context.IsInLoopRegion(offset);
-                            bool iteratesInLoop = allocationAnalysis.MultiplicityAt(offset) == AllocationMultiplicity.Loop;
+                            bool iteratesInLoop = allocationFacts.MultiplicityAt(offset) == AllocationMultiplicity.Loop;
                             pendingDelegateOpportunityIndex = opportunities.Count;
                             opportunities.Add(new OptimizationOpportunity(
                                 caller,
@@ -184,7 +184,7 @@ internal static partial class OptimizationOpportunityAnalysis
                         else if (!cachedOnce && pendingDelegateInstanceGroup)
                         {
                             var inLoop = context.IsInLoopRegion(offset);
-                            bool iteratesInLoop = allocationAnalysis.MultiplicityAt(offset) == AllocationMultiplicity.Loop;
+                            bool iteratesInLoop = allocationFacts.MultiplicityAt(offset) == AllocationMultiplicity.Loop;
                             bool stackGuardFallback = StackGuardFallbackAnalysis.IsFallbackAllocation(
                                 context,
                                 offset,
@@ -520,14 +520,14 @@ internal static partial class OptimizationOpportunityAnalysis
                 annotated = annotated with
                 {
                     RuntimeAllocationType = runtimeAllocation,
-                    PathContext = opportunity.PathContext ?? OptimizationOpportunityAnalysis.FormatPathContext(allocationAnalysis.PathContextAt(opportunityOffset)),
-                    PathConfidence = opportunity.PathConfidence ?? OptimizationOpportunityAnalysis.FormatPathConfidence(allocationAnalysis.PathConfidenceAt(opportunityOffset)),
-                    PostDominance = opportunity.PostDominance ?? OptimizationOpportunityAnalysis.FormatPostDominance(allocationAnalysis.PostDominanceAt(opportunityOffset)),
+                    PathContext = opportunity.PathContext ?? OptimizationOpportunityAnalysis.FormatPathContext(allocationFacts.PathContextAt(opportunityOffset)),
+                    PathConfidence = opportunity.PathConfidence ?? OptimizationOpportunityAnalysis.FormatPathConfidence(allocationFacts.PathConfidenceAt(opportunityOffset)),
+                    PostDominance = opportunity.PostDominance ?? OptimizationOpportunityAnalysis.FormatPostDominance(allocationFacts.PostDominanceAt(opportunityOffset)),
                     Multiplicity = opportunity.Multiplicity ?? OptimizationOpportunityAnalysis.FormatMultiplicity(
                         allocation?.Multiplicity is { } allocationMultiplicity
                             && allocationMultiplicity != AllocationMultiplicity.Unknown
                                 ? allocationMultiplicity
-                                : allocationAnalysis.MultiplicityAt(opportunityOffset)),
+                                : allocationFacts.MultiplicityAt(opportunityOffset)),
                     EstimatedSizeBytes = opportunity.EstimatedSizeBytes ?? allocation?.EstimatedSizeBytes,
                 };
             }


### PR DESCRIPTION
## Summary

- replace the separate method allocation analysis/result pairing with one `MethodAllocationFacts` owner
- bind each method's canonical context, allocation indexes, discovered/classified occurrences, and Layer-1 queries so consumers cannot combine mismatched inputs
- preserve acquisition, failure, partial-result, and disabled-collection ordering while keeping call analysis on its narrow multiplicity callback

## Evidence

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`: 627 passed
- `npx markdownlint-cli docs/architecture.md docs/design/method-body-inspection.md`: passed
- `FactsBundlesBindContextOccurrencesAndQueries` pins context/query coherence across loop and non-loop contexts

## Compatibility boundary

This is an internal ownership consolidation. It does not change public output, command behavior, acquisition count, or analysis enablement. It introduces no additional per-method allocation object: the facts object replaces the former analysis object and removes the separate result object.

## Review sequencing

The user explicitly approved running fixed-head adversarial review in parallel with CI. Review and CI are both pinned to head `2b75fe40a7863d524293c912efb99e47b1fdf567`; CI must still pass before readiness.
