### PR TITLE
Bound anchor signature cumulative work during construction

### DIFF
--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -279,10 +279,43 @@ public static class ApiMemberIdentity
         }
     }
 
+    /// <summary>
+    /// Cumulative work budget for one member-anchor signature construction.
+    /// Mirrors <c>StructuralSignatureWorkBudget</c>: charge every materialized
+    /// type-name occurrence so repeated long names cannot amplify past
+    /// <see cref="MetadataSafetyPolicy.MaxAnchorSignatureWorkChars"/> before
+    /// rejection. Gated by
+    /// <c>CreateMethodAnchor_RepeatedTypeNamesFailBeforeLargeAllocation</c>.
+    /// </summary>
+    sealed class AnchorSignatureWorkBudget
+    {
+        int _remaining = MetadataSafetyPolicy.MaxAnchorSignatureWorkChars;
+        bool _exhausted;
+
+        internal void Charge(int characters)
+        {
+            if (_exhausted || characters < 0 || characters > _remaining)
+            {
+                _exhausted = true;
+                throw new BadImageFormatException(
+                    "The member anchor signature exceeds the cumulative work budget.");
+            }
+            _remaining -= characters;
+        }
+    }
+
     sealed class AnchorSignatureTypeProvider
         : ISignatureTypeProvider<AnchorSignatureType, GenericContext?>
     {
-        public static readonly AnchorSignatureTypeProvider Instance = new();
+        readonly AnchorSignatureWorkBudget _workBudget;
+        Dictionary<TypeDefinitionHandle, AnchorSignatureType>? _definitionCache;
+        Dictionary<TypeReferenceHandle, AnchorSignatureType>? _referenceCache;
+
+        internal AnchorSignatureTypeProvider(
+            AnchorSignatureWorkBudget workBudget)
+        {
+            _workBudget = workBudget;
+        }
 
         public AnchorSignatureType GetPrimitiveType(PrimitiveTypeCode typeCode)
             => Encoded(typeCode switch
@@ -312,13 +345,39 @@ public static class ApiMemberIdentity
             MetadataReader reader,
             TypeDefinitionHandle handle,
             byte rawTypeKind)
-            => Encoded(FormatDefinitionTypeName(reader, handle));
+        {
+            _definitionCache ??= [];
+            if (_definitionCache.TryGetValue(handle, out AnchorSignatureType? cached))
+            {
+                // Reuse the composed name, but still charge this occurrence so
+                // repeated references cannot bypass the cumulative work budget.
+                _workBudget.Charge(cached.Length);
+                return cached;
+            }
+
+            AnchorSignatureType encoded =
+                Encoded(FormatDefinitionTypeName(reader, handle));
+            _definitionCache.Add(handle, encoded);
+            return encoded;
+        }
 
         public AnchorSignatureType GetTypeFromReference(
             MetadataReader reader,
             TypeReferenceHandle handle,
             byte rawTypeKind)
-            => Encoded(FormatReferenceTypeName(reader, handle));
+        {
+            _referenceCache ??= [];
+            if (_referenceCache.TryGetValue(handle, out AnchorSignatureType? cached))
+            {
+                _workBudget.Charge(cached.Length);
+                return cached;
+            }
+
+            AnchorSignatureType encoded =
+                Encoded(FormatReferenceTypeName(reader, handle));
+            _referenceCache.Add(handle, encoded);
+            return encoded;
+        }
 
         public AnchorSignatureType GetTypeFromSpecification(
             MetadataReader reader,
@@ -396,7 +455,7 @@ public static class ApiMemberIdentity
             bool isRequired)
             => unmodifiedType;
 
-        static string FormatDefinitionTypeName(
+        string FormatDefinitionTypeName(
             MetadataReader reader,
             TypeDefinitionHandle handle)
         {
@@ -438,7 +497,7 @@ public static class ApiMemberIdentity
             return builder.ToString();
         }
 
-        static string FormatReferenceTypeName(
+        string FormatReferenceTypeName(
             MetadataReader reader,
             TypeReferenceHandle handle)
         {
@@ -493,8 +552,14 @@ public static class ApiMemberIdentity
             builder.Append(value);
         }
 
-        static AnchorSignatureType Encoded(string text)
-            => new EncodedAnchorSignatureType(text);
+        AnchorSignatureType Encoded(string text)
+        {
+            // Charge every occurrence, including repeated references to the same
+            // long name, so the cumulative work budget gates amplification during
+            // tree construction rather than after EnsureAnchorSignatureBudget.
+            _workBudget.Charge(text.Length);
+            return new EncodedAnchorSignatureType(text);
+        }
     }
 
     public static string GetMemberDigest(string canonicalSignature)
@@ -665,10 +730,12 @@ public static class ApiMemberIdentity
         PropertyDefinition property)
     {
         var context = GenericContext.ForType(reader, markerType);
+        var workBudget = new AnchorSignatureWorkBudget();
+        var provider = new AnchorSignatureTypeProvider(workBudget);
         var decodedMarker = GuardedProviderDecode.MethodResult(
             reader,
             markerMethod,
-            AnchorSignatureTypeProvider.Instance,
+            provider,
             context,
             new EncodedAnchorSignatureType("System.Object"));
         if (decodedMarker.IsDegraded)
@@ -684,7 +751,7 @@ public static class ApiMemberIdentity
         var decodedProperty = GuardedProviderDecode.PropertyResult(
             reader,
             property,
-            AnchorSignatureTypeProvider.Instance,
+            provider,
             context,
             new EncodedAnchorSignatureType("System.Object"));
         if (decodedProperty.IsDegraded)
@@ -734,10 +801,12 @@ public static class ApiMemberIdentity
                 method.Name);
         GenericContext context =
             GenericContext.ForMethod(reader, type, method);
+        var workBudget = new AnchorSignatureWorkBudget();
+        var provider = new AnchorSignatureTypeProvider(workBudget);
         var decoded = GuardedProviderDecode.MethodResult(
             reader,
             method,
-            AnchorSignatureTypeProvider.Instance,
+            provider,
             context,
             new EncodedAnchorSignatureType("System.Object"));
         if (decoded.IsDegraded)

--- a/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
@@ -20,6 +20,15 @@ public static class MetadataSafetyPolicy
     public const int MaxStructuralSignatureWorkChars = 4 * 1024 * 1024;
 
     /// <summary>
+    /// Maximum encoded characters charged while constructing one member-anchor
+    /// signature tree. Each occurrence of a type name is charged, so repeated
+    /// references cannot amplify past this ceiling before rejection. Gated by
+    /// <c>CreateMethodAnchor_RepeatedTypeNamesFailBeforeLargeAllocation</c>.
+    /// </summary>
+    public const int MaxAnchorSignatureWorkChars =
+        MaxStructuralSignatureWorkChars;
+
+    /// <summary>
     /// Maximum type nodes examined before decoding one metadata signature.
     /// This bounds the iterative guard stack and SRM's decoded parameter/type
     /// materialization for structurally shallow but hostile signatures. Gated by

--- a/tests/ILInspector.Metadata.Tests/MethodCorrespondenceResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MethodCorrespondenceResolverTests.cs
@@ -301,6 +301,42 @@ public sealed class MethodCorrespondenceResolverTests
     }
 
     [Fact]
+    public void CreateMethodAnchor_RepeatedTypeNamesFailBeforeLargeAllocation()
+    {
+        // Many parameters each naming the same long TypeRef: per-name caps alone
+        // still allow O(params × name) amplification because EnsureAnchorSignatureBudget
+        // runs only after the full type tree is built. The cumulative work budget must
+        // reject during construction. Gated by MaxAnchorSignatureWorkChars.
+        const int parameterCount = 1_000;
+        const int typeNameLength = 20_000;
+        byte[] image = BuildRepeatedTypeReferenceNameImage(
+            parameterCount,
+            typeNameLength);
+        using var pe = new PEReader(new MemoryStream(image));
+        MetadataReader reader = pe.GetMetadataReader();
+        MethodDefinitionHandle methodHandle =
+            reader.MethodDefinitions.Single();
+        MethodDefinition method =
+            reader.GetMethodDefinition(methodHandle);
+
+        long allocatedBefore =
+            GC.GetAllocatedBytesForCurrentThread();
+        BadImageFormatException ex =
+            Assert.Throws<BadImageFormatException>(
+                () => ApiMemberIdentity.CreateMethodAnchorInfo(
+                    reader,
+                    method.GetDeclaringType(),
+                    method));
+        long allocated =
+            GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.Contains("cumulative work budget", ex.Message);
+        Assert.True(
+            allocated < 16 * 1024 * 1024,
+            $"Repeated type-name anchor rejection allocated {allocated:N0} bytes.");
+    }
+
+    [Fact]
     public void Resolve_TrailingConstraintTypeSpecBytesFailClosed()
     {
         byte[] sourceImage =
@@ -835,6 +871,44 @@ public sealed class MethodCorrespondenceResolverTests
         signature.WriteByte(0x01);
         signature.WriteByte(0x12);
         signature.WriteCompressedInteger((1 << 2) | 1);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("M"),
+            metadata.GetOrAddBlob(signature),
+            bodyOffset: 0,
+            MetadataTokens.ParameterHandle(1));
+        return Serialize(metadata);
+    }
+
+    static byte[] BuildRepeatedTypeReferenceNameImage(
+        int parameterCount,
+        int typeNameLength)
+    {
+        var metadata = CreateSingleTypeMetadata(
+            "RepeatedTypeReferenceName");
+        AssemblyReferenceHandle assembly =
+            metadata.AddAssemblyReference(
+                metadata.GetOrAddString("Dependency"),
+                new Version(1, 0, 0, 0),
+                default,
+                default,
+                default,
+                default);
+        metadata.AddTypeReference(
+            assembly,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString(
+                new string('T', typeNameLength)));
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00);
+        signature.WriteCompressedInteger(parameterCount);
+        signature.WriteByte(0x01);
+        for (int i = 0; i < parameterCount; i++)
+        {
+            signature.WriteByte(0x12);
+            signature.WriteCompressedInteger((1 << 2) | 1);
+        }
         metadata.AddMethodDefinition(
             MethodAttributes.Public | MethodAttributes.Static,
             MethodImplAttributes.IL,


### PR DESCRIPTION
## Summary

Closes #4152. Member-anchor signature construction now has a cumulative work budget during type-tree building, not only a post-hoc encoded-length check.

`EnsureAnchorSignatureBudget` previously ran only after the full signature tree was built. A signature with many parameters referencing the same long type name could therefore allocate O(params × name) before anything rejected it (measured at ~120 MB for a 22 KB image after #3857, and ~354 MB on the pre-#3857 base).

## Changes

- Add `MetadataSafetyPolicy.MaxAnchorSignatureWorkChars` (4 MiB, same ceiling as structural work).
- Replace the singleton `AnchorSignatureTypeProvider` with a per-construction instance that owns an `AnchorSignatureWorkBudget`.
- Charge every materialized type-name occurrence (including cache hits) so repeated references cannot bypass the budget.
- Memoize `TypeDef` / `TypeRef` compositions within one construction so repeated long names reuse one string instead of re-decoding and re-allocating.
- Keep `EnsureAnchorSignatureBudget` as the final encoded-length gate.

## Evidence

New gate: `CreateMethodAnchor_RepeatedTypeNamesFailBeforeLargeAllocation`
- 1,000 `CLASS <TypeRef>` parameters
- 20,000-character type name
- Asserts `BadImageFormatException` containing `cumulative work budget`
- Asserts allocation &lt; 16 MiB

## Validation

```text
dotnet build tests/ILInspector.Metadata.Tests -c Release
dotnet run --project tests/ILInspector.Metadata.Tests -c Release
# 1397/1397 passed

Focused:
CreateMethodAnchor_RepeatedTypeNamesFailBeforeLargeAllocation
Resolve_OversizedAnchorTypeNameRejectsBeforeLargeAllocation
Resolve_WideGenericParameterAnchorFailsWithinBudget
Resolve_OversizedMethodNameRejectsBeforeLargeAllocation
Resolve_MethodGenericNamesRespectAnchorBudget
Resolve_ReturnsExactAddressAcrossReadersOfSameArtifact
```

Frozen-candidate base tip: `0d11af30b7361a84d334bd5410a7031d3153e715`
Head: `7010b19abe96f3bb8264214392cf2f9f4a5db717`

## Compatibility

- No public API change.
- Well-formed assemblies are unchanged; only hostile multi-occurrence amplification fails earlier and cheaper.