### PR TITLE
Fix CI change detection compilation

### DIFF
--- a/eng/test-ci-change-detection.cs
+++ b/eng/test-ci-change-detection.cs
@@ -661,7 +661,7 @@ static (
         }
     }
 
-    ValidateDecompilerProjectSkipList(repository);
+    ValidateDecompilerProjectSkipList(Environment.CurrentDirectory);
 
     YamlMappingNode root = RequireMapping(
         yaml.Documents[0].RootNode,


### PR DESCRIPTION
## Summary

Current `main` fails the unconditional change-detection self-test because the newly static
`LoadDetectionBody` local function captures the top-level `repository` variable. Resolve the
repository through `Environment.CurrentDirectory`, matching the file-based app's existing
top-level initialization and allowing every PR lane to run again.

## Validation

- `dotnet run eng/test-ci-change-detection.cs`
- `git diff --check`

This is a trivial one-expression compile fix with no product behavior change, so it does not
require adversarial review.
