### PR TITLE
Add typed inspection graph substrate

### DIFF
--- a/docs/design/call-graph-characteristics.md
+++ b/docs/design/call-graph-characteristics.md
@@ -36,6 +36,7 @@ Related:
 | `CallGraphProjection.Nodes` | Member identity, boundary kind, `CallTreePerf`, and graph evidence | Inspection-graph member nodes |
 | `CallGraphProjection.Edges` | One logical caller-to-callee row collapsed by `(From, To)` | Edge with primary `call` relationship |
 | `CallGraphEdge.LoopLabel` | Any collapsed site was in a loop, stored as display text | Legacy source for an aggregated loop descriptor |
+| `CallGraphInspectionGraphAdapter` | `call` edges with typed `call.logical-edge` projection receipts and explicit edge-scoped `call.physical-occurrences-unavailable` limits | Transitional L1 adapter until document-wide physical receipts land |
 | `AnnotatedCallGraphOccurrence` | Retained focus call site joined to an edge row and source fact | Partial occurrence adapter, not document-wide retention |
 | `CallGraphSectionAdapter --fields` | Node signal selection and label projection | L2 bindings over semantic node descriptors |
 | Markout `GraphEdge.Label` | Renderer slot | Projection target, never semantic storage |
@@ -43,8 +44,10 @@ Related:
 `AnnotatedCallGraphOccurrence` currently carries module, caller token, IL
 offset, operand token, `CallKind`, and loop state for focus call sites. It does
 not retain occurrences for every projected edge and does not carry dispatch
-kind. The first implementation slice must fill those gaps rather than describe
-them as current behavior.
+kind. The occurrence delivery slice must fill those gaps rather than describe
+them as current behavior. Until then, the generic adapter preserves each
+logical row as a typed projection receipt and keeps the missing physical detail
+visible as a limit; it does not fabricate call sites from logical rows.
 
 ## Call topology is not a characteristic
 

--- a/docs/design/call-graph-projection.md
+++ b/docs/design/call-graph-projection.md
@@ -86,7 +86,9 @@ The projection owns everything a host must not re-invent in JavaScript:
   correspondence is removed. Detached trees from separate scopes can therefore
   join the same exact physical definition without collapsing different versions
   or artifacts, while repeated unresolved occurrences remain joined within
-  their original scope. These boundaries are gated by
+  their original scope. `CallGraphNode.Identity` exposes the exact identity the
+  projection used; adapters retain that currency rather than reconstructing it
+  from `MemberRef`. These boundaries are gated by
   `DetachedVersionSkewedDefinitionsRemainDistinct`,
   `DetachedRepeatedExternalOccurrencesStayJoined`, and
   `DetachedArtifactIdentityIgnoresAcquisitionRegistration`.

--- a/docs/design/inspection-graph-document.md
+++ b/docs/design/inspection-graph-document.md
@@ -223,6 +223,8 @@ The following shape is conceptual. Names may change when concrete types land.
 
 ```text
 InspectionGraphDocument
+  Scope
+
   Nodes[]
     Id
     Subject
@@ -284,6 +286,16 @@ relationship whose producer and derivation are part of the edge contract. It
 must not look like observed call or metadata evidence. The first implementation
 should require at least one occurrence for every non-synthetic edge.
 
+The initial call adapter registers the observed `call` relationship with exact
+member-to-member endpoint projection. The current `CallGraphProjection` does
+not retain every physical call site, so each logical row initially contributes
+a typed `call.logical-edge` projection receipt and each edge carries a
+`call.physical-occurrences-unavailable` limit. This preserves positive topology
+without inventing call sites or making occurrence absence look complete. The
+call-occurrence slice replaces those transitional receipts with physical
+receipts. `CallGraphInspectionGraphAdapter` owns this current mapping, gated by
+`CallAdapter_PreservesTypedTopologyAndDisclosesEvidenceGap`.
+
 ## Subject identity
 
 ### Owner-issued currencies
@@ -327,6 +339,14 @@ If a subject kind has no safe portable projection, portability is a typed
 failure or the graph remains session-bound. A display label is never the
 fallback.
 
+`InspectionGraphDocument.Scope` makes that lifetime claim explicit as
+`SessionBound` or `Portable`; consumers do not infer it from subject display or
+from which evidence happens to be present. Each owner-issued subject identity
+declares whether it retains session authority, and portable construction
+rejects any subject that does. The call adapter derives the scope from the
+`GraphNodeIdentity` values the projection actually used rather than accepting a
+caller assertion.
+
 ### Nodes and groups
 
 Package and type are both subject kinds and grouping lenses.
@@ -351,7 +371,8 @@ A relationship descriptor defines:
 
 - a stable id;
 - semantic direction and endpoint roles;
-- admitted source and target subject kinds;
+- admitted edge source and target subject kinds;
+- admitted original-occurrence source and target subject kinds;
 - the producer that owns the relation;
 - whether the relation is observed, derived, or synthetic;
 - the occurrence evidence contract;
@@ -441,6 +462,13 @@ Traversal direction never changes that support relation. A package-inward lens
 may walk an incoming edge, but it cannot bind a source occurrence to the edge's
 target.
 
+Edge and occurrence endpoint domains are distinct descriptor constraints. A
+type-to-package edge can therefore require type and package view endpoints
+while admitting only member-to-member original occurrences. The projection
+rule receives the typed occurrence, including its producer evidence, and the
+semantically directed selected endpoint. It does not recover package ownership
+from labels or capture an unvalidated per-document side map.
+
 Each relationship descriptor owns an occurrence-identity projection within one
 document. Projection deduplicates repeated observations by that key before
 assigning deterministic document-local occurrence ids. For `call`, the key is
@@ -449,6 +477,11 @@ identity as appropriate to the document lifetime, caller token, IL offset, and
 operand token. Observing that call site from caller and callee walks cannot
 create two occurrences. Two distinct IL offsets remain two occurrences even
 when every other field and the logical edge are equal.
+
+Producers perform that projection and deduplication before document
+construction. `InspectionGraphDocument` independently rejects duplicate
+projected identities, so a producer cannot silently publish two receipts for
+one occurrence.
 
 Composition does not weaken the relationship invariant. A composed edge gets a
 derived occurrence of the composed relationship, with its own source and target

--- a/src/DotnetInspector.Queries.Tests/InspectionGraphDocumentTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionGraphDocumentTests.cs
@@ -1,0 +1,962 @@
+using System.Collections.Immutable;
+
+using ILInspector.Analysis;
+using ILInspector.CallGraph;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class InspectionGraphDocumentTests
+{
+    static readonly InspectionGraphEvidenceDescriptor TestEvidence =
+        new("test.evidence", InspectionGraphOwner.Queries);
+
+    static readonly InspectionGraphRelationshipDescriptor TestRelationship =
+        new(
+            "test.relationship",
+            InspectionGraphOwner.Queries,
+            InspectionGraphRelationshipSemantics.Observed,
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            InspectionGraphEndpointProjection.Exact,
+            new TestOccurrenceIdentityProjection(),
+            [TestEvidence]);
+
+    static MemberRef Member(string name) =>
+        new(
+            TypeRef.Definition("Sample", "Sample", "Graph"),
+            name,
+            [],
+            TypeRef.CoreLib("System", "Void"),
+            MemberKind.Method);
+
+    static CallTreeNode Node(
+        MemberRef member,
+        CallTreeStatus status,
+        params CallTreeNode[] children) =>
+        new(member, CallKind.Call, status, [.. children]);
+
+    static InspectionGraphSubject Subject(string name)
+    {
+        MemberRef member = Member(name);
+        return InspectionGraphSubject.ForMember(
+            GraphNodeIdentity.FromMember(member),
+            member);
+    }
+
+    [Fact]
+    public void CallAdapter_PreservesTypedTopologyAndDisclosesEvidenceGap()
+    {
+        MemberRef focus = Member("Focus");
+        MemberRef caller = Member("Caller");
+        MemberRef callee = Member("Callee");
+        var callerRoot = Node(
+            focus,
+            CallTreeStatus.Expanded,
+            Node(caller, CallTreeStatus.Leaf));
+        var calleeRoot = Node(
+            focus,
+            CallTreeStatus.Expanded,
+            Node(callee, CallTreeStatus.External));
+        CallGraphProjection projection =
+            CallGraphProjection.Create(callerRoot, calleeRoot);
+
+        InspectionGraphDocument document =
+            CallGraphInspectionGraphAdapter.Create(projection);
+
+        Assert.Equal([0, 1, 2], document.Nodes.Select(node => node.Id));
+        Assert.Equal(
+            [focus, caller, callee],
+            document.Nodes.Select(node =>
+                Assert.IsType<
+                    InspectionGraphSubject.MemberSubject>(
+                        node.Subject).Member));
+        Assert.Equal(
+            projection.Nodes.Select(node => node.Identity),
+            document.Nodes.Select(node =>
+                Assert.IsType<
+                    InspectionGraphSubject.MemberSubject>(
+                        node.Subject).Identity));
+        Assert.Equal(
+            [
+                InspectionGraphNodeRole.Unclassified,
+                InspectionGraphNodeRole.Ordinary,
+                InspectionGraphNodeRole.External,
+            ],
+            document.Nodes.Select(node => node.Role));
+        Assert.Equal([(1, 0), (0, 2)], document.Edges.Select(
+            edge => (edge.FromNodeId, edge.ToNodeId)));
+        Assert.All(
+            document.Edges,
+            edge => Assert.Same(
+                CallGraphInspectionGraphCatalog.Call,
+                edge.Relationship));
+        Assert.Equal(
+            [0, 1],
+            document.Occurrences.Select(occurrence => occurrence.Id));
+        Assert.All(
+            document.Occurrences,
+            occurrence => Assert.IsType<CallGraphLogicalEdgeEvidence>(
+                occurrence.Evidence));
+        Assert.Equal(
+            document.Edges.Select(edge => edge.Id + 1),
+            document.Occurrences.Select(occurrence =>
+                ((CallGraphLogicalEdgeEvidence)occurrence.Evidence)
+                    .RowNumber));
+        Assert.Equal(
+            document.Edges.Select(edge =>
+                document.Nodes[edge.FromNodeId].Subject),
+            document.Occurrences.Select(
+                occurrence => occurrence.SourceSubject));
+        Assert.Equal(
+            document.Edges.Select(edge =>
+                document.Nodes[edge.ToNodeId].Subject),
+            document.Occurrences.Select(
+                occurrence => occurrence.TargetSubject));
+        InspectionGraphSeed seed = Assert.Single(document.Seeds);
+        Assert.Equal(focus, Assert.IsType<
+            InspectionGraphSubject.MemberSubject>(seed.Subject).Member);
+        Assert.Equal(InspectionGraphTarget.Node(0), seed.Target);
+        Assert.Equal(InspectionGraphSeedRole.Primary, seed.Role);
+        Assert.Contains(
+            document.Limits,
+            limit => ReferenceEquals(
+                limit.Descriptor,
+                CallGraphInspectionGraphCatalog
+                    .TraversalIncomplete));
+        Assert.Contains(
+            document.Limits,
+            limit => ReferenceEquals(
+                limit.Descriptor,
+                CallGraphInspectionGraphCatalog
+                    .PhysicalOccurrencesUnavailable)
+                && limit.Target is { Kind:
+                    InspectionGraphTargetKind.Edge });
+        Assert.Empty(document.Groups);
+        Assert.Empty(document.Characteristics);
+        Assert.Empty(document.Failures);
+        Assert.Equal(
+            InspectionGraphDocumentScope.Portable,
+            document.Scope);
+    }
+
+    [Fact]
+    public void CallAdapter_IsDeterministicAndDoesNotMutateProjection()
+    {
+        MemberRef focus = Member("Focus");
+        MemberRef callee = Member("Callee");
+        CallGraphProjection projection = CallGraphProjection.FromCallees(
+            Node(
+                focus,
+                CallTreeStatus.Expanded,
+                Node(callee, CallTreeStatus.Leaf)));
+
+        InspectionGraphDocument first =
+            CallGraphInspectionGraphAdapter.Create(projection);
+        InspectionGraphDocument second =
+            CallGraphInspectionGraphAdapter.Create(projection);
+
+        Assert.Equal(
+            first.Nodes.Select(node =>
+                (node.Id, node.Subject, node.Role)),
+            second.Nodes.Select(node =>
+                (node.Id, node.Subject, node.Role)));
+        Assert.Equal(
+            first.Edges.Select(edge =>
+                (edge.Id, edge.FromNodeId, edge.ToNodeId)),
+            second.Edges.Select(edge =>
+                (edge.Id, edge.FromNodeId, edge.ToNodeId)));
+        Assert.Equal(
+            first.Occurrences.Select(occurrence =>
+                (occurrence.Id,
+                    occurrence.SourceSubject,
+                    occurrence.TargetSubject)),
+            second.Occurrences.Select(occurrence =>
+                (occurrence.Id,
+                    occurrence.SourceSubject,
+                    occurrence.TargetSubject)));
+        Assert.Single(projection.Rows);
+        Assert.Equal("Callee", projection.Nodes[1].Member.Name);
+    }
+
+    [Fact]
+    public void Document_RejectsDefaultCollectionsAndNonDenseIds()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.SessionBound,
+                default(ImmutableArray<InspectionGraphNode>),
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                []));
+
+        InspectionGraphSubject subject = Subject("Member");
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.SessionBound,
+                [
+                    new InspectionGraphNode(
+                        1,
+                        subject,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                ],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                []));
+    }
+
+    [Fact]
+    public void Document_SnapshotsCollectionsAndRejectsDefaultTarget()
+    {
+        var nodes = new List<InspectionGraphNode>
+        {
+            new(
+                0,
+                Subject("Member"),
+                InspectionGraphNodeRole.Ordinary,
+                []),
+        };
+        var document = new InspectionGraphDocument(
+            InspectionGraphDocumentScope.SessionBound,
+            nodes,
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            []);
+
+        nodes.Clear();
+
+        Assert.Single(document.Nodes);
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.SessionBound,
+                document.Nodes,
+                [],
+                [],
+                [],
+                [],
+                [
+                    new InspectionGraphSeed(
+                        document.Nodes[0].Subject,
+                        default,
+                        InspectionGraphSeedRole.Primary),
+                ],
+                [],
+                []));
+    }
+
+    [Fact]
+    public void SubjectCurrenciesRemainStructuralAndTyped()
+    {
+        var firstPackage = new RealizedMemberCoordinate.Package(
+            "sample.package",
+            "1.0.0",
+            "feed",
+            "net11.0",
+            null);
+        var secondPackage = new RealizedMemberCoordinate.Package(
+            "sample.package",
+            "2.0.0",
+            "feed",
+            "net11.0",
+            null);
+
+        Assert.Equal(
+            Subject("Member"),
+            Subject("Member"));
+        Assert.Equal(
+            InspectionGraphSubject.ForStructuralType(
+                TypeRef.Definition("Sample", "Sample", "Type")),
+            InspectionGraphSubject.ForStructuralType(
+                TypeRef.Definition("Sample", "Sample", "Type")));
+        Assert.NotEqual(
+            InspectionGraphSubject.ForRealizedPackage(firstPackage),
+            InspectionGraphSubject.ForRealizedPackage(secondPackage));
+        Assert.Equal(
+            InspectionGraphSubjectKind.Package,
+            InspectionGraphSubject.ForRealizedPackage(firstPackage).Kind);
+    }
+
+    [Fact]
+    public void Document_RejectsSeedWhoseSubjectDiffersFromTarget()
+    {
+        InspectionGraphSubject first =
+            Subject("First");
+        InspectionGraphSubject second =
+            Subject("Second");
+
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.SessionBound,
+                [
+                    new InspectionGraphNode(
+                        0,
+                        first,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                ],
+                [],
+                [],
+                [],
+                [],
+                [
+                    new InspectionGraphSeed(
+                        second,
+                        InspectionGraphTarget.Node(0),
+                        InspectionGraphSeedRole.Primary),
+                ],
+                [],
+                []));
+    }
+
+    [Fact]
+    public void Document_RejectsDuplicateNodeSubjects()
+    {
+        InspectionGraphSubject subject =
+            Subject("Member");
+
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.SessionBound,
+                [
+                    new InspectionGraphNode(
+                        0,
+                        subject,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                    new InspectionGraphNode(
+                        1,
+                        subject,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                ],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                []));
+    }
+
+    [Fact]
+    public void MemberSubjectsUseProducerIdentityNotStructuralPayload()
+    {
+        MemberRef member = Member("SamePayload");
+        InspectionGraphSubject first =
+            InspectionGraphSubject.ForMember(
+                GraphNodeIdentity.CreateDocumentLocal(),
+                member);
+        InspectionGraphSubject second =
+            InspectionGraphSubject.ForMember(
+                GraphNodeIdentity.CreateDocumentLocal(),
+                member);
+        var synthetic = new InspectionGraphRelationshipDescriptor(
+            "test.identity",
+            InspectionGraphOwner.Queries,
+            InspectionGraphRelationshipSemantics.Synthetic,
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            InspectionGraphEndpointProjection.Exact,
+            InspectionGraphOccurrenceIdentityProjection
+                .SyntheticNoOccurrence,
+            []);
+
+        var document = new InspectionGraphDocument(
+            InspectionGraphDocumentScope.Portable,
+            [
+                new InspectionGraphNode(
+                    0,
+                    first,
+                    InspectionGraphNodeRole.Ordinary,
+                    []),
+                new InspectionGraphNode(
+                    1,
+                    second,
+                    InspectionGraphNodeRole.Ordinary,
+                    []),
+            ],
+            [],
+            [
+                new InspectionGraphEdge(
+                    0,
+                    0,
+                    1,
+                    synthetic,
+                    []),
+            ],
+            [],
+            [],
+            [],
+            [],
+            []);
+
+        Assert.NotEqual(document.Nodes[0].Subject, document.Nodes[1].Subject);
+        Assert.Equal(
+            member,
+            Assert.IsType<InspectionGraphSubject.MemberSubject>(
+                document.Nodes[0].Subject).Member);
+    }
+
+    [Fact]
+    public void PortableDocumentRejectsSessionBoundSubject()
+    {
+        InspectionGraphSubject subject =
+            InspectionGraphSubject.ForType(
+                new TestBoundTypeIdentity());
+
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.Portable,
+                [
+                    new InspectionGraphNode(
+                        0,
+                        subject,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                ],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                []));
+    }
+
+    [Fact]
+    public void EdgeAndOccurrenceEndpointKindsRemainDistinct()
+    {
+        InspectionGraphSubject edgeSource =
+            InspectionGraphSubject.ForStructuralType(
+                TypeRef.Definition("Sample", "Sample", "Type"));
+        InspectionGraphSubject edgeTarget =
+            InspectionGraphSubject.ForRealizedPackage(
+                new RealizedMemberCoordinate.Package(
+                    "sample.package",
+                    "1.0.0",
+                    "feed",
+                    "net11.0",
+                    null));
+        InspectionGraphSubject occurrenceSource = Subject("Source");
+        InspectionGraphSubject occurrenceTarget = Subject("Target");
+        var relationship = new InspectionGraphRelationshipDescriptor(
+            "test.rollup-relationship",
+            InspectionGraphOwner.Queries,
+            InspectionGraphRelationshipSemantics.Observed,
+            [InspectionGraphSubjectKind.Type],
+            [InspectionGraphSubjectKind.Package],
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            new TestRollupEndpointProjection(),
+            new TestOccurrenceIdentityProjection(),
+            [TestEvidence]);
+        var occurrence = new InspectionGraphOccurrence(
+            0,
+            relationship,
+            occurrenceSource,
+            occurrenceTarget,
+            new TestOccurrenceEvidence(0),
+            []);
+
+        var document = new InspectionGraphDocument(
+            InspectionGraphDocumentScope.Portable,
+            [
+                new InspectionGraphNode(
+                    0,
+                    edgeSource,
+                    InspectionGraphNodeRole.Ordinary,
+                    []),
+                new InspectionGraphNode(
+                    1,
+                    edgeTarget,
+                    InspectionGraphNodeRole.Ordinary,
+                    []),
+            ],
+            [],
+            [
+                new InspectionGraphEdge(
+                    0,
+                    0,
+                    1,
+                    relationship,
+                    [0]),
+            ],
+            [occurrence],
+            [],
+            [],
+            [],
+            []);
+
+        Assert.Single(document.Edges);
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.Portable,
+                [
+                    new InspectionGraphNode(
+                        0,
+                        occurrenceSource,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                    new InspectionGraphNode(
+                        1,
+                        edgeTarget,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                ],
+                [],
+                [
+                    new InspectionGraphEdge(
+                        0,
+                        0,
+                        1,
+                        relationship,
+                        [0]),
+                ],
+                [occurrence],
+                [],
+                [],
+                [],
+                []));
+    }
+
+    [Fact]
+    public void Document_RejectsMismatchedAndReversedOccurrenceEndpoints()
+    {
+        InspectionGraphSubject source =
+            Subject("Source");
+        InspectionGraphSubject target =
+            Subject("Target");
+        var nodes = new[]
+        {
+            new InspectionGraphNode(
+                0,
+                source,
+                InspectionGraphNodeRole.Ordinary,
+                []),
+            new InspectionGraphNode(
+                1,
+                target,
+                InspectionGraphNodeRole.Ordinary,
+                []),
+        };
+        var edge = new InspectionGraphEdge(
+            0,
+            0,
+            1,
+            TestRelationship,
+            [0]);
+        var otherRelationship =
+            new InspectionGraphRelationshipDescriptor(
+                "test.other",
+                InspectionGraphOwner.Queries,
+                InspectionGraphRelationshipSemantics.Observed,
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Member],
+                InspectionGraphEndpointProjection.Exact,
+                new TestOccurrenceIdentityProjection(),
+                [TestEvidence]);
+
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                nodes,
+                edge,
+                new InspectionGraphOccurrence(
+                    0,
+                    otherRelationship,
+                    source,
+                    target,
+                    new TestOccurrenceEvidence(0),
+                    [])));
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                nodes,
+                edge,
+                new InspectionGraphOccurrence(
+                    0,
+                    TestRelationship,
+                    target,
+                    source,
+                    new TestOccurrenceEvidence(0),
+                    [])));
+    }
+
+    [Fact]
+    public void Document_RejectsDuplicateDescriptorIdAndOccurrenceIdentity()
+    {
+        InspectionGraphSubject source = Subject("Source");
+        InspectionGraphSubject target = Subject("Target");
+        var duplicateRelationship =
+            new InspectionGraphRelationshipDescriptor(
+                TestRelationship.Id,
+                InspectionGraphOwner.Queries,
+                InspectionGraphRelationshipSemantics.Observed,
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Member],
+                InspectionGraphEndpointProjection.Exact,
+                new TestOccurrenceIdentityProjection(),
+                [TestEvidence]);
+        var evidence = new TestOccurrenceEvidence(0);
+
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.SessionBound,
+                [
+                    new InspectionGraphNode(
+                        0,
+                        source,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                    new InspectionGraphNode(
+                        1,
+                        target,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                ],
+                [],
+                [
+                    new InspectionGraphEdge(
+                        0,
+                        0,
+                        1,
+                        TestRelationship,
+                        [0]),
+                ],
+                [
+                    new InspectionGraphOccurrence(
+                        0,
+                        duplicateRelationship,
+                        source,
+                        target,
+                        evidence,
+                        []),
+                ],
+                [],
+                [],
+                [],
+                []));
+
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.SessionBound,
+                [
+                    new InspectionGraphNode(
+                        0,
+                        source,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                    new InspectionGraphNode(
+                        1,
+                        target,
+                        InspectionGraphNodeRole.Ordinary,
+                        []),
+                ],
+                [],
+                [
+                    new InspectionGraphEdge(
+                        0,
+                        0,
+                        1,
+                        TestRelationship,
+                        [0, 1]),
+                ],
+                [
+                    new InspectionGraphOccurrence(
+                        0,
+                        TestRelationship,
+                        source,
+                        target,
+                        new TestOccurrenceEvidence(0),
+                        []),
+                    new InspectionGraphOccurrence(
+                        1,
+                        TestRelationship,
+                        source,
+                        target,
+                        new TestOccurrenceEvidence(0),
+                        []),
+                ],
+                [],
+                [],
+                [],
+                []));
+    }
+
+    [Fact]
+    public void RolledUpCharacteristicCitesTypedSourceTargets()
+    {
+        InspectionGraphSubject source = Subject("Source");
+        var descriptor = new InspectionGraphCharacteristicDescriptor(
+            "test.rollup",
+            InspectionGraphOwner.Queries,
+            InspectionGraphValueCatalog.Integer,
+            [InspectionGraphTargetKind.Node],
+            [],
+            [InspectionGraphCharacteristicDerivationKind.RolledUp],
+            InspectionGraphAggregationPolicy.Sum);
+        var document = new InspectionGraphDocument(
+            InspectionGraphDocumentScope.SessionBound,
+            [
+                new InspectionGraphNode(
+                    0,
+                    source,
+                    InspectionGraphNodeRole.Ordinary,
+                    []),
+            ],
+            [],
+            [],
+            [],
+            [
+                new InspectionGraphCharacteristic(
+                    descriptor,
+                    InspectionGraphTarget.Node(0),
+                    new InspectionGraphValue.Integer(1),
+                    new InspectionGraphCharacteristicDerivation(
+                        InspectionGraphCharacteristicDerivationKind
+                            .RolledUp,
+                        [InspectionGraphTarget.Node(0)])),
+            ],
+            [],
+            [],
+            []);
+
+        Assert.Equal(
+            InspectionGraphTarget.Node(0),
+            Assert.Single(document.Characteristics)
+                .Derivation.Sources[0]);
+    }
+
+    [Fact]
+    public void DiagnosticDescriptorsRetainTypedProducerEvidence()
+    {
+        var evidenceDescriptor = new InspectionGraphEvidenceDescriptor(
+            "test.limit-detail",
+            InspectionGraphOwner.Queries);
+        var limitDescriptor = new InspectionGraphLimitDescriptor(
+            "test.limit",
+            InspectionGraphOwner.Queries,
+            [evidenceDescriptor]);
+        var evidence = new TestDiagnosticEvidence(evidenceDescriptor);
+        var document = new InspectionGraphDocument(
+            InspectionGraphDocumentScope.SessionBound,
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [new InspectionGraphLimit(limitDescriptor, Evidence: evidence)],
+            []);
+
+        Assert.Same(
+            evidence,
+            Assert.Single(document.Limits).Evidence);
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.SessionBound,
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [
+                    new InspectionGraphLimit(
+                        new InspectionGraphLimitDescriptor(
+                            "test.other-limit",
+                            InspectionGraphOwner.Queries),
+                        Evidence: evidence),
+                ],
+                []));
+    }
+
+    [Fact]
+    public void Document_RejectsConflictingUnusedEvidenceDescriptorIds()
+    {
+        var first = new InspectionGraphEvidenceDescriptor(
+            "test.shared-evidence",
+            InspectionGraphOwner.Queries);
+        var second = new InspectionGraphEvidenceDescriptor(
+            "test.shared-evidence",
+            InspectionGraphOwner.Analysis);
+
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.SessionBound,
+                [],
+                [],
+                [],
+                [],
+                [],
+                [],
+                [
+                    new InspectionGraphLimit(
+                        new InspectionGraphLimitDescriptor(
+                            "test.first-limit",
+                            InspectionGraphOwner.Queries,
+                            [first])),
+                    new InspectionGraphLimit(
+                        new InspectionGraphLimitDescriptor(
+                            "test.second-limit",
+                            InspectionGraphOwner.Analysis,
+                            [second])),
+                ],
+                []));
+    }
+
+    [Fact]
+    public void Document_RequiresOccurrenceUnlessRelationshipIsSynthetic()
+    {
+        InspectionGraphSubject source =
+            Subject("Source");
+        InspectionGraphSubject target =
+            Subject("Target");
+        var nodes = new[]
+        {
+            new InspectionGraphNode(
+                0,
+                source,
+                InspectionGraphNodeRole.Ordinary,
+                []),
+            new InspectionGraphNode(
+                1,
+                target,
+                InspectionGraphNodeRole.Ordinary,
+                []),
+        };
+
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphDocument(
+                InspectionGraphDocumentScope.SessionBound,
+                nodes,
+                [],
+                [
+                    new InspectionGraphEdge(
+                        0,
+                        0,
+                        1,
+                        TestRelationship,
+                        []),
+                ],
+                [],
+                [],
+                [],
+                [],
+                []));
+
+        var synthetic = new InspectionGraphRelationshipDescriptor(
+            "test.synthetic",
+            InspectionGraphOwner.Queries,
+            InspectionGraphRelationshipSemantics.Synthetic,
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            InspectionGraphEndpointProjection.Exact,
+            InspectionGraphOccurrenceIdentityProjection
+                .SyntheticNoOccurrence,
+            []);
+        var document = new InspectionGraphDocument(
+            InspectionGraphDocumentScope.SessionBound,
+            nodes,
+            [],
+            [
+                new InspectionGraphEdge(
+                    0,
+                    0,
+                    1,
+                    synthetic,
+                    []),
+            ],
+            [],
+            [],
+            [],
+            [],
+            []);
+
+        Assert.Single(document.Edges);
+        Assert.Empty(document.Occurrences);
+    }
+
+    static InspectionGraphDocument Document(
+        IEnumerable<InspectionGraphNode> nodes,
+        InspectionGraphEdge edge,
+        InspectionGraphOccurrence occurrence) =>
+        new(
+            InspectionGraphDocumentScope.SessionBound,
+            nodes,
+            [],
+            [edge],
+            [occurrence],
+            [],
+            [],
+            [],
+            []);
+
+    sealed record TestOccurrenceEvidence(int Identity)
+        : IInspectionGraphOccurrenceEvidence
+    {
+        public InspectionGraphEvidenceDescriptor Descriptor =>
+            TestEvidence;
+    }
+
+    sealed class TestOccurrenceIdentityProjection
+        : InspectionGraphOccurrenceIdentityProjection
+    {
+        public override object Project(
+            InspectionGraphOccurrence occurrence) =>
+            ((TestOccurrenceEvidence)occurrence.Evidence).Identity;
+    }
+
+    sealed class TestRollupEndpointProjection
+        : InspectionGraphEndpointProjection
+    {
+        public override bool Supports(
+            InspectionGraphOccurrence occurrence,
+            InspectionGraphEndpointRole role,
+            InspectionGraphSubject endpoint) =>
+            role switch
+            {
+                InspectionGraphEndpointRole.Source =>
+                    occurrence.SourceSubject.Kind
+                        == InspectionGraphSubjectKind.Member
+                    && endpoint.Kind
+                        == InspectionGraphSubjectKind.Type,
+                InspectionGraphEndpointRole.Target =>
+                    occurrence.TargetSubject.Kind
+                        == InspectionGraphSubjectKind.Member
+                    && endpoint.Kind
+                        == InspectionGraphSubjectKind.Package,
+                _ => false,
+            };
+    }
+
+    sealed record TestBoundTypeIdentity
+        : InspectionGraphTypeIdentity
+    {
+        public override bool IsPortable => false;
+    }
+
+    sealed record TestDiagnosticEvidence(
+        InspectionGraphEvidenceDescriptor Descriptor)
+        : IInspectionGraphDiagnosticEvidence;
+}

--- a/src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs
@@ -873,6 +873,9 @@ public sealed class MemberCallGraphSessionTests
             first.Nodes.Select(node => (node.Id, node.Label, node.Kind)),
             second.Nodes.Select(node => (node.Id, node.Label, node.Kind)));
         Assert.Equal(first.Edges.Length, second.Edges.Length);
+        Assert.Equal(
+            InspectionGraphDocumentScope.SessionBound,
+            CallGraphInspectionGraphAdapter.Create(first).Scope);
         Assert.Equal(before, graph.BuildCounts);
         Assert.All(
             context.Sources,

--- a/src/DotnetInspector.Queries/CallGraphInspectionGraphAdapter.cs
+++ b/src/DotnetInspector.Queries/CallGraphInspectionGraphAdapter.cs
@@ -1,0 +1,167 @@
+using ILInspector.CallGraph;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>CallGraph-owned contracts used by the generic L1 envelope.</summary>
+public static class CallGraphInspectionGraphCatalog
+{
+    private static InspectionGraphOccurrenceIdentityProjection
+        LogicalEdgeIdentity { get; } =
+        new LogicalEdgeIdentityProjection();
+
+    public static InspectionGraphEvidenceDescriptor LogicalEdgeEvidence { get; } =
+        new("call.logical-edge", InspectionGraphOwner.CallGraph);
+
+    public static InspectionGraphRelationshipDescriptor Call { get; } =
+        new(
+            "call",
+            InspectionGraphOwner.CallGraph,
+            InspectionGraphRelationshipSemantics.Observed,
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            [InspectionGraphSubjectKind.Member],
+            InspectionGraphEndpointProjection.Exact,
+            LogicalEdgeIdentity,
+            [LogicalEdgeEvidence]);
+
+    public static InspectionGraphLimitDescriptor TraversalIncomplete { get; } =
+        new("call.traversal-incomplete", InspectionGraphOwner.CallGraph);
+
+    public static InspectionGraphLimitDescriptor
+        PhysicalOccurrencesUnavailable { get; } =
+        new(
+            "call.physical-occurrences-unavailable",
+            InspectionGraphOwner.CallGraph);
+
+    public static InspectionGraphFailureDescriptor AnalysisIncomplete { get; } =
+        new("call.analysis-incomplete", InspectionGraphOwner.CallGraph);
+
+    private sealed class LogicalEdgeIdentityProjection
+        : InspectionGraphOccurrenceIdentityProjection
+    {
+        public override object Project(
+            InspectionGraphOccurrence occurrence) =>
+            (occurrence.SourceSubject, occurrence.TargetSubject);
+    }
+}
+
+/// <summary>
+/// Typed receipt for one logical row emitted by the current call projection.
+/// Physical call-site receipts replace this transitional evidence in the next
+/// producer-owned delivery slice.
+/// </summary>
+public sealed record CallGraphLogicalEdgeEvidence(int RowNumber)
+    : IInspectionGraphOccurrenceEvidence
+{
+    public InspectionGraphEvidenceDescriptor Descriptor =>
+        CallGraphInspectionGraphCatalog.LogicalEdgeEvidence;
+}
+
+/// <summary>
+/// Adapts the current member call projection without changing its acquisition
+/// or presentation behavior.
+/// </summary>
+public static class CallGraphInspectionGraphAdapter
+{
+    public static InspectionGraphDocument Create(
+        CallGraphProjection projection)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+
+        InspectionGraphNode[] nodes =
+        [
+            .. projection.Nodes.Select(node =>
+                new InspectionGraphNode(
+                    node.Id,
+                    InspectionGraphSubject.ForMember(
+                        node.Identity,
+                        node.Member),
+                    NodeRole(node.Kind),
+                    [])),
+        ];
+
+        var occurrences =
+            new InspectionGraphOccurrence[projection.Rows.Length];
+        var edges = new InspectionGraphEdge[projection.Rows.Length];
+        for (var index = 0; index < projection.Rows.Length; index++)
+        {
+            CallGraphRow row = projection.Rows[index];
+            InspectionGraphSubject source =
+                nodes[row.Edge.From].Subject;
+            InspectionGraphSubject target =
+                nodes[row.Edge.To].Subject;
+            occurrences[index] = new InspectionGraphOccurrence(
+                index,
+                CallGraphInspectionGraphCatalog.Call,
+                source,
+                target,
+                new CallGraphLogicalEdgeEvidence(row.Number),
+                []);
+            edges[index] = new InspectionGraphEdge(
+                index,
+                row.Edge.From,
+                row.Edge.To,
+                CallGraphInspectionGraphCatalog.Call,
+                [index]);
+        }
+
+        var limits = new List<InspectionGraphLimit>();
+        if (projection.HasUnexploredTraversalBoundary)
+        {
+            limits.Add(
+                new InspectionGraphLimit(
+                    CallGraphInspectionGraphCatalog
+                        .TraversalIncomplete));
+        }
+        foreach (InspectionGraphEdge edge in edges)
+        {
+            limits.Add(
+                new InspectionGraphLimit(
+                    CallGraphInspectionGraphCatalog
+                        .PhysicalOccurrencesUnavailable,
+                    InspectionGraphTarget.Edge(edge.Id)));
+        }
+
+        InspectionGraphFailure[] failures =
+            projection.HasAnalysisFailureBoundary
+                ?
+                [
+                    new InspectionGraphFailure(
+                        CallGraphInspectionGraphCatalog
+                            .AnalysisIncomplete),
+                ]
+                : [];
+
+        return new InspectionGraphDocument(
+            projection.Nodes.All(static node =>
+                node.Identity.IsPortable)
+                ? InspectionGraphDocumentScope.Portable
+                : InspectionGraphDocumentScope.SessionBound,
+            nodes,
+            [],
+            edges,
+            occurrences,
+            [],
+            [
+                new InspectionGraphSeed(
+                    nodes[projection.Focus.Id].Subject,
+                    InspectionGraphTarget.Node(projection.Focus.Id),
+                    InspectionGraphSeedRole.Primary),
+            ],
+            limits,
+            failures);
+    }
+
+    private static InspectionGraphNodeRole NodeRole(
+        CallGraphNodeKind kind) =>
+        kind switch
+        {
+            CallGraphNodeKind.Focus =>
+                InspectionGraphNodeRole.Unclassified,
+            CallGraphNodeKind.Normal => InspectionGraphNodeRole.Ordinary,
+            CallGraphNodeKind.External => InspectionGraphNodeRole.External,
+            CallGraphNodeKind.Truncated => InspectionGraphNodeRole.Truncated,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+}

--- a/src/DotnetInspector.Queries/DotnetInspector.Queries.csproj
+++ b/src/DotnetInspector.Queries/DotnetInspector.Queries.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
+    <ProjectReference Include="..\ILInspector.CallGraph\ILInspector.CallGraph.csproj" />
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
     <ProjectReference Include="..\ILInspector.SourceLink\ILInspector.SourceLink.csproj" />
   </ItemGroup>

--- a/src/DotnetInspector.Queries/InspectionGraphDocument.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphDocument.cs
@@ -1,0 +1,1584 @@
+using System.Collections.Immutable;
+
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>The identity domain carried by one inspection-graph subject.</summary>
+public enum InspectionGraphSubjectKind
+{
+    Member,
+    Type,
+    Assembly,
+    Package,
+}
+
+/// <summary>Owner-issued identity for one type subject.</summary>
+public abstract record InspectionGraphTypeIdentity
+{
+    protected InspectionGraphTypeIdentity()
+    {
+    }
+
+    public abstract bool IsPortable { get; }
+
+    public sealed record Structural : InspectionGraphTypeIdentity
+    {
+        public Structural(TypeRef type)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+            Type = type;
+        }
+
+        public TypeRef Type { get; }
+        public override bool IsPortable => true;
+    }
+}
+
+/// <summary>Owner-issued identity for one assembly subject.</summary>
+public abstract record InspectionGraphAssemblyIdentity
+{
+    protected InspectionGraphAssemblyIdentity()
+    {
+    }
+
+    public abstract bool IsPortable { get; }
+
+    public sealed record Metadata : InspectionGraphAssemblyIdentity
+    {
+        public Metadata(AssemblyReferenceIdentity assembly)
+        {
+            ArgumentNullException.ThrowIfNull(assembly);
+            Assembly = assembly;
+        }
+
+        public AssemblyReferenceIdentity Assembly { get; }
+        public override bool IsPortable => true;
+    }
+}
+
+/// <summary>Owner-issued identity for one package subject.</summary>
+public abstract record InspectionGraphPackageIdentity
+{
+    protected InspectionGraphPackageIdentity()
+    {
+    }
+
+    public abstract bool IsPortable { get; }
+
+    public sealed record Realized : InspectionGraphPackageIdentity
+    {
+        public Realized(RealizedMemberCoordinate.Package package)
+        {
+            ArgumentNullException.ThrowIfNull(package);
+            Package = package;
+        }
+
+        public RealizedMemberCoordinate.Package Package { get; }
+        public override bool IsPortable => true;
+    }
+}
+
+/// <summary>
+/// An owner-issued semantic identity. Display text is never graph identity.
+/// </summary>
+public abstract record InspectionGraphSubject
+{
+    private protected InspectionGraphSubject()
+    {
+    }
+
+    public abstract InspectionGraphSubjectKind Kind { get; }
+    public abstract bool IsPortable { get; }
+
+    public static InspectionGraphSubject ForMember(
+        GraphNodeIdentity identity,
+        MemberRef member) =>
+        new MemberSubject(identity, member);
+
+    public static InspectionGraphSubject ForType(
+        InspectionGraphTypeIdentity identity) =>
+        new TypeSubject(identity);
+
+    public static InspectionGraphSubject ForStructuralType(TypeRef type) =>
+        ForType(new InspectionGraphTypeIdentity.Structural(type));
+
+    public static InspectionGraphSubject ForAssembly(
+        InspectionGraphAssemblyIdentity identity) =>
+        new AssemblySubject(identity);
+
+    public static InspectionGraphSubject ForMetadataAssembly(
+        AssemblyReferenceIdentity assembly) =>
+        ForAssembly(
+            new InspectionGraphAssemblyIdentity.Metadata(assembly));
+
+    public static InspectionGraphSubject ForPackage(
+        InspectionGraphPackageIdentity identity) =>
+        new PackageSubject(identity);
+
+    public static InspectionGraphSubject ForRealizedPackage(
+        RealizedMemberCoordinate.Package package) =>
+        ForPackage(new InspectionGraphPackageIdentity.Realized(package));
+
+    public sealed record MemberSubject : InspectionGraphSubject
+    {
+        internal MemberSubject(
+            GraphNodeIdentity identity,
+            MemberRef member)
+        {
+            ArgumentNullException.ThrowIfNull(identity);
+            ArgumentNullException.ThrowIfNull(member);
+            Identity = identity;
+            Member = member;
+        }
+
+        public override InspectionGraphSubjectKind Kind =>
+            InspectionGraphSubjectKind.Member;
+        public override bool IsPortable => Identity.IsPortable;
+
+        public GraphNodeIdentity Identity { get; }
+        public MemberRef Member { get; }
+
+        public bool Equals(MemberSubject? other) =>
+            other is not null && Identity == other.Identity;
+
+        public override int GetHashCode() => Identity.GetHashCode();
+    }
+
+    public sealed record TypeSubject : InspectionGraphSubject
+    {
+        internal TypeSubject(InspectionGraphTypeIdentity identity)
+        {
+            ArgumentNullException.ThrowIfNull(identity);
+            Identity = identity;
+        }
+
+        public override InspectionGraphSubjectKind Kind =>
+            InspectionGraphSubjectKind.Type;
+        public override bool IsPortable => Identity.IsPortable;
+
+        public InspectionGraphTypeIdentity Identity { get; }
+    }
+
+    public sealed record AssemblySubject : InspectionGraphSubject
+    {
+        internal AssemblySubject(
+            InspectionGraphAssemblyIdentity identity)
+        {
+            ArgumentNullException.ThrowIfNull(identity);
+            Identity = identity;
+        }
+
+        public override InspectionGraphSubjectKind Kind =>
+            InspectionGraphSubjectKind.Assembly;
+        public override bool IsPortable => Identity.IsPortable;
+
+        public InspectionGraphAssemblyIdentity Identity { get; }
+    }
+
+    public sealed record PackageSubject : InspectionGraphSubject
+    {
+        internal PackageSubject(
+            InspectionGraphPackageIdentity identity)
+        {
+            ArgumentNullException.ThrowIfNull(identity);
+            Identity = identity;
+        }
+
+        public override InspectionGraphSubjectKind Kind =>
+            InspectionGraphSubjectKind.Package;
+        public override bool IsPortable => Identity.IsPortable;
+
+        public InspectionGraphPackageIdentity Identity { get; }
+    }
+}
+
+/// <summary>The subsystem that owns one graph contract.</summary>
+public enum InspectionGraphOwner
+{
+    CallGraph,
+    Packages,
+    Metadata,
+    Analysis,
+    Research,
+    Queries,
+}
+
+/// <summary>How a relationship's producer establishes its claim.</summary>
+public enum InspectionGraphRelationshipSemantics
+{
+    Observed,
+    Derived,
+    Synthetic,
+}
+
+/// <summary>The semantically directed endpoint of one occurrence.</summary>
+public enum InspectionGraphEndpointRole
+{
+    Source,
+    Target,
+}
+
+/// <summary>
+/// Defines how an occurrence endpoint supports a selected view endpoint.
+/// </summary>
+public abstract class InspectionGraphEndpointProjection
+{
+    protected InspectionGraphEndpointProjection()
+    {
+    }
+
+    public static InspectionGraphEndpointProjection Exact { get; } =
+        new ExactProjection();
+
+    public abstract bool Supports(
+        InspectionGraphOccurrence occurrence,
+        InspectionGraphEndpointRole role,
+        InspectionGraphSubject endpoint);
+
+    private sealed class ExactProjection : InspectionGraphEndpointProjection
+    {
+        public override bool Supports(
+            InspectionGraphOccurrence occurrence,
+            InspectionGraphEndpointRole role,
+            InspectionGraphSubject endpoint) =>
+            role switch
+            {
+                InspectionGraphEndpointRole.Source =>
+                    occurrence.SourceSubject == endpoint,
+                InspectionGraphEndpointRole.Target =>
+                    occurrence.TargetSubject == endpoint,
+                _ => throw new ArgumentOutOfRangeException(nameof(role)),
+            };
+    }
+}
+
+/// <summary>Identity for one producer-owned occurrence evidence shape.</summary>
+public sealed class InspectionGraphEvidenceDescriptor
+{
+    public InspectionGraphEvidenceDescriptor(
+        string id,
+        InspectionGraphOwner owner)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        InspectionGraphCollections.RequireDefined(owner, nameof(owner));
+        Id = id;
+        Owner = owner;
+    }
+
+    public string Id { get; }
+    public InspectionGraphOwner Owner { get; }
+}
+
+/// <summary>
+/// Typed producer evidence retained by one graph occurrence.
+/// </summary>
+public interface IInspectionGraphEvidence
+{
+    InspectionGraphEvidenceDescriptor Descriptor { get; }
+}
+
+/// <summary>Evidence that contributes one graph occurrence.</summary>
+public interface IInspectionGraphOccurrenceEvidence
+    : IInspectionGraphEvidence
+{
+}
+
+/// <summary>Typed detail retained by one graph limit or failure.</summary>
+public interface IInspectionGraphDiagnosticEvidence
+    : IInspectionGraphEvidence
+{
+}
+
+/// <summary>
+/// Projects producer evidence to its relationship-specific identity within one
+/// document.
+/// </summary>
+public abstract class InspectionGraphOccurrenceIdentityProjection
+{
+    protected InspectionGraphOccurrenceIdentityProjection()
+    {
+    }
+
+    public static InspectionGraphOccurrenceIdentityProjection
+        SyntheticNoOccurrence { get; } =
+        new SyntheticNoOccurrenceProjection();
+
+    public abstract object Project(
+        InspectionGraphOccurrence occurrence);
+
+    private sealed class SyntheticNoOccurrenceProjection
+        : InspectionGraphOccurrenceIdentityProjection
+    {
+        public override object Project(
+            InspectionGraphOccurrence occurrence) =>
+            throw new InvalidOperationException(
+                "A synthetic relationship without occurrences has no occurrence identity.");
+    }
+}
+
+/// <summary>
+/// The L1 semantic contract for one directed relationship family.
+/// </summary>
+public sealed class InspectionGraphRelationshipDescriptor
+{
+    public InspectionGraphRelationshipDescriptor(
+        string id,
+        InspectionGraphOwner owner,
+        InspectionGraphRelationshipSemantics semantics,
+        IEnumerable<InspectionGraphSubjectKind> edgeSourceKinds,
+        IEnumerable<InspectionGraphSubjectKind> edgeTargetKinds,
+        IEnumerable<InspectionGraphSubjectKind> occurrenceSourceKinds,
+        IEnumerable<InspectionGraphSubjectKind> occurrenceTargetKinds,
+        InspectionGraphEndpointProjection endpointProjection,
+        InspectionGraphOccurrenceIdentityProjection occurrenceIdentity,
+        IEnumerable<InspectionGraphEvidenceDescriptor> evidence)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentNullException.ThrowIfNull(endpointProjection);
+        ArgumentNullException.ThrowIfNull(occurrenceIdentity);
+        InspectionGraphCollections.RequireDefined(owner, nameof(owner));
+        InspectionGraphCollections.RequireDefined(
+            semantics,
+            nameof(semantics));
+        Id = id;
+        Owner = owner;
+        Semantics = semantics;
+        EdgeSourceKinds = InspectionGraphCollections.Snapshot(
+            edgeSourceKinds,
+            nameof(edgeSourceKinds));
+        EdgeTargetKinds = InspectionGraphCollections.Snapshot(
+            edgeTargetKinds,
+            nameof(edgeTargetKinds));
+        OccurrenceSourceKinds = InspectionGraphCollections.Snapshot(
+            occurrenceSourceKinds,
+            nameof(occurrenceSourceKinds));
+        OccurrenceTargetKinds = InspectionGraphCollections.Snapshot(
+            occurrenceTargetKinds,
+            nameof(occurrenceTargetKinds));
+        Evidence = InspectionGraphCollections.Snapshot(
+            evidence,
+            nameof(evidence));
+        InspectionGraphCollections.RequireDefined(
+            EdgeSourceKinds,
+            nameof(edgeSourceKinds));
+        InspectionGraphCollections.RequireDefined(
+            EdgeTargetKinds,
+            nameof(edgeTargetKinds));
+        InspectionGraphCollections.RequireDefined(
+            OccurrenceSourceKinds,
+            nameof(occurrenceSourceKinds));
+        InspectionGraphCollections.RequireDefined(
+            OccurrenceTargetKinds,
+            nameof(occurrenceTargetKinds));
+        if (EdgeSourceKinds.IsEmpty)
+            throw new ArgumentException("At least one edge source subject kind is required.", nameof(edgeSourceKinds));
+        if (EdgeTargetKinds.IsEmpty)
+            throw new ArgumentException("At least one edge target subject kind is required.", nameof(edgeTargetKinds));
+        if (OccurrenceSourceKinds.IsEmpty)
+            throw new ArgumentException("At least one occurrence source subject kind is required.", nameof(occurrenceSourceKinds));
+        if (OccurrenceTargetKinds.IsEmpty)
+            throw new ArgumentException("At least one occurrence target subject kind is required.", nameof(occurrenceTargetKinds));
+        if (Evidence.IsEmpty && semantics != InspectionGraphRelationshipSemantics.Synthetic)
+            throw new ArgumentException("A non-synthetic relationship requires an evidence contract.", nameof(evidence));
+        if (EdgeSourceKinds.Distinct().Count() != EdgeSourceKinds.Length)
+            throw new ArgumentException("Edge source subject kinds must be distinct.", nameof(edgeSourceKinds));
+        if (EdgeTargetKinds.Distinct().Count() != EdgeTargetKinds.Length)
+            throw new ArgumentException("Edge target subject kinds must be distinct.", nameof(edgeTargetKinds));
+        if (OccurrenceSourceKinds.Distinct().Count() != OccurrenceSourceKinds.Length)
+            throw new ArgumentException("Occurrence source subject kinds must be distinct.", nameof(occurrenceSourceKinds));
+        if (OccurrenceTargetKinds.Distinct().Count() != OccurrenceTargetKinds.Length)
+            throw new ArgumentException("Occurrence target subject kinds must be distinct.", nameof(occurrenceTargetKinds));
+        if (Evidence.Distinct().Count() != Evidence.Length)
+            throw new ArgumentException("Evidence descriptors must be distinct.", nameof(evidence));
+        if (Evidence.Select(static item => item.Id)
+                .Distinct(StringComparer.Ordinal).Count()
+            != Evidence.Length)
+        {
+            throw new ArgumentException(
+                "Evidence descriptor ids must be distinct.",
+                nameof(evidence));
+        }
+        EndpointProjection = endpointProjection;
+        OccurrenceIdentity = occurrenceIdentity;
+    }
+
+    public string Id { get; }
+    public InspectionGraphOwner Owner { get; }
+    public InspectionGraphRelationshipSemantics Semantics { get; }
+    public ImmutableArray<InspectionGraphSubjectKind> EdgeSourceKinds { get; }
+    public ImmutableArray<InspectionGraphSubjectKind> EdgeTargetKinds { get; }
+    public ImmutableArray<InspectionGraphSubjectKind> OccurrenceSourceKinds
+        { get; }
+    public ImmutableArray<InspectionGraphSubjectKind> OccurrenceTargetKinds
+        { get; }
+    public InspectionGraphEndpointProjection EndpointProjection { get; }
+    public InspectionGraphOccurrenceIdentityProjection OccurrenceIdentity
+        { get; }
+    public ImmutableArray<InspectionGraphEvidenceDescriptor> Evidence { get; }
+
+    internal bool AdmitsEdgeSource(InspectionGraphSubject subject) =>
+        EdgeSourceKinds.Contains(subject.Kind);
+
+    internal bool AdmitsEdgeTarget(InspectionGraphSubject subject) =>
+        EdgeTargetKinds.Contains(subject.Kind);
+
+    internal bool AdmitsOccurrenceSource(
+        InspectionGraphSubject subject) =>
+        OccurrenceSourceKinds.Contains(subject.Kind);
+
+    internal bool AdmitsOccurrenceTarget(
+        InspectionGraphSubject subject) =>
+        OccurrenceTargetKinds.Contains(subject.Kind);
+
+    internal bool AdmitsEvidence(
+        IInspectionGraphOccurrenceEvidence evidence) =>
+        Evidence.Contains(evidence.Descriptor);
+}
+
+/// <summary>Document-local node classification.</summary>
+public enum InspectionGraphNodeRole
+{
+    Unclassified,
+    Ordinary,
+    External,
+    Truncated,
+}
+
+/// <summary>One semantic subject retained as a graph node.</summary>
+public sealed class InspectionGraphNode
+{
+    public InspectionGraphNode(
+        int id,
+        InspectionGraphSubject subject,
+        InspectionGraphNodeRole role,
+        IEnumerable<int> groupIds)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(id);
+        ArgumentNullException.ThrowIfNull(subject);
+        InspectionGraphCollections.RequireDefined(role, nameof(role));
+        Id = id;
+        Subject = subject;
+        Role = role;
+        GroupIds = InspectionGraphCollections.Snapshot(
+            groupIds,
+            nameof(groupIds));
+        if (GroupIds.Distinct().Count() != GroupIds.Length)
+            throw new ArgumentException("Group ids must be distinct.", nameof(groupIds));
+    }
+
+    public int Id { get; }
+    public InspectionGraphSubject Subject { get; }
+    public InspectionGraphNodeRole Role { get; }
+    public ImmutableArray<int> GroupIds { get; }
+}
+
+/// <summary>One typed grouping lens over graph nodes.</summary>
+public sealed class InspectionGraphGroup
+{
+    public InspectionGraphGroup(
+        int id,
+        InspectionGraphSubject subject,
+        int? parentId)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(id);
+        if (parentId is not null)
+            ArgumentOutOfRangeException.ThrowIfNegative(parentId.Value);
+        ArgumentNullException.ThrowIfNull(subject);
+        Id = id;
+        Subject = subject;
+        ParentId = parentId;
+    }
+
+    public int Id { get; }
+    public InspectionGraphSubject Subject { get; }
+    public int? ParentId { get; }
+}
+
+/// <summary>One contribution to a logical graph edge.</summary>
+public sealed class InspectionGraphOccurrence
+{
+    public InspectionGraphOccurrence(
+        int id,
+        InspectionGraphRelationshipDescriptor relationship,
+        InspectionGraphSubject sourceSubject,
+        InspectionGraphSubject targetSubject,
+        IInspectionGraphOccurrenceEvidence evidence,
+        IEnumerable<int> derivedFromOccurrenceIds)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(id);
+        ArgumentNullException.ThrowIfNull(relationship);
+        ArgumentNullException.ThrowIfNull(sourceSubject);
+        ArgumentNullException.ThrowIfNull(targetSubject);
+        ArgumentNullException.ThrowIfNull(evidence);
+        Id = id;
+        Relationship = relationship;
+        SourceSubject = sourceSubject;
+        TargetSubject = targetSubject;
+        Evidence = evidence;
+        DerivedFromOccurrenceIds = InspectionGraphCollections.Snapshot(
+            derivedFromOccurrenceIds,
+            nameof(derivedFromOccurrenceIds));
+        if (DerivedFromOccurrenceIds.Distinct().Count()
+            != DerivedFromOccurrenceIds.Length)
+        {
+            throw new ArgumentException(
+                "Derived occurrence ids must be distinct.",
+                nameof(derivedFromOccurrenceIds));
+        }
+    }
+
+    public int Id { get; }
+    public InspectionGraphRelationshipDescriptor Relationship { get; }
+    public InspectionGraphSubject SourceSubject { get; }
+    public InspectionGraphSubject TargetSubject { get; }
+    public IInspectionGraphOccurrenceEvidence Evidence { get; }
+    public ImmutableArray<int> DerivedFromOccurrenceIds { get; }
+}
+
+/// <summary>One directed logical relationship between two graph nodes.</summary>
+public sealed class InspectionGraphEdge
+{
+    public InspectionGraphEdge(
+        int id,
+        int fromNodeId,
+        int toNodeId,
+        InspectionGraphRelationshipDescriptor relationship,
+        IEnumerable<int> occurrenceIds)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(id);
+        ArgumentOutOfRangeException.ThrowIfNegative(fromNodeId);
+        ArgumentOutOfRangeException.ThrowIfNegative(toNodeId);
+        ArgumentNullException.ThrowIfNull(relationship);
+        Id = id;
+        FromNodeId = fromNodeId;
+        ToNodeId = toNodeId;
+        Relationship = relationship;
+        OccurrenceIds = InspectionGraphCollections.Snapshot(
+            occurrenceIds,
+            nameof(occurrenceIds));
+        if (OccurrenceIds.Distinct().Count() != OccurrenceIds.Length)
+            throw new ArgumentException("Occurrence ids must be distinct.", nameof(occurrenceIds));
+    }
+
+    public int Id { get; }
+    public int FromNodeId { get; }
+    public int ToNodeId { get; }
+    public InspectionGraphRelationshipDescriptor Relationship { get; }
+    public ImmutableArray<int> OccurrenceIds { get; }
+}
+
+/// <summary>The document collection addressed by a graph target.</summary>
+public enum InspectionGraphTargetKind
+{
+    Node,
+    Group,
+    Edge,
+    Occurrence,
+}
+
+/// <summary>A typed document-local characteristic target.</summary>
+public readonly record struct InspectionGraphTarget
+{
+    private readonly bool _initialized;
+
+    private InspectionGraphTarget(InspectionGraphTargetKind kind, int id)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(id);
+        Kind = kind;
+        Id = id;
+        _initialized = true;
+    }
+
+    public InspectionGraphTargetKind Kind { get; }
+    public int Id { get; }
+
+    internal bool IsInitialized => _initialized;
+
+    public static InspectionGraphTarget Node(int id) =>
+        new(InspectionGraphTargetKind.Node, id);
+
+    public static InspectionGraphTarget Group(int id) =>
+        new(InspectionGraphTargetKind.Group, id);
+
+    public static InspectionGraphTarget Edge(int id) =>
+        new(InspectionGraphTargetKind.Edge, id);
+
+    public static InspectionGraphTarget Occurrence(int id) =>
+        new(InspectionGraphTargetKind.Occurrence, id);
+}
+
+/// <summary>The typed storage shape of a characteristic value.</summary>
+public enum InspectionGraphValueShape
+{
+    Boolean,
+    Integer,
+    Token,
+    TokenSet,
+    Structured,
+}
+
+/// <summary>The typed contract for one characteristic value representation.</summary>
+public sealed class InspectionGraphValueDescriptor
+{
+    public InspectionGraphValueDescriptor(
+        string id,
+        InspectionGraphValueShape shape)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        InspectionGraphCollections.RequireDefined(shape, nameof(shape));
+        Id = id;
+        Shape = shape;
+    }
+
+    public string Id { get; }
+    public InspectionGraphValueShape Shape { get; }
+}
+
+/// <summary>Built-in scalar and set value contracts.</summary>
+public static class InspectionGraphValueCatalog
+{
+    public static InspectionGraphValueDescriptor Boolean { get; } =
+        new("boolean", InspectionGraphValueShape.Boolean);
+
+    public static InspectionGraphValueDescriptor Integer { get; } =
+        new("integer", InspectionGraphValueShape.Integer);
+
+    public static InspectionGraphValueDescriptor Token { get; } =
+        new("token", InspectionGraphValueShape.Token);
+
+    public static InspectionGraphValueDescriptor TokenSet { get; } =
+        new("token-set", InspectionGraphValueShape.TokenSet);
+}
+
+/// <summary>One typed L1 characteristic value.</summary>
+public abstract record InspectionGraphValue
+{
+    protected InspectionGraphValue()
+    {
+    }
+
+    public abstract InspectionGraphValueDescriptor Descriptor { get; }
+
+    public InspectionGraphValueShape Shape => Descriptor.Shape;
+
+    public sealed record Boolean(bool Value) : InspectionGraphValue
+    {
+        public override InspectionGraphValueDescriptor Descriptor =>
+            InspectionGraphValueCatalog.Boolean;
+    }
+
+    public sealed record Integer(long Value) : InspectionGraphValue
+    {
+        public override InspectionGraphValueDescriptor Descriptor =>
+            InspectionGraphValueCatalog.Integer;
+    }
+
+    public sealed record Token : InspectionGraphValue
+    {
+        public Token(string value)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(value);
+            Value = value;
+        }
+
+        public string Value { get; }
+
+        public override InspectionGraphValueDescriptor Descriptor =>
+            InspectionGraphValueCatalog.Token;
+    }
+
+    public sealed record TokenSet : InspectionGraphValue
+    {
+        public TokenSet(IEnumerable<string> values)
+        {
+            Values = InspectionGraphCollections.Snapshot(
+                values,
+                nameof(values));
+            if (Values.IsEmpty)
+                throw new ArgumentException("A token set cannot be empty.", nameof(values));
+            if (Values.Any(string.IsNullOrWhiteSpace))
+                throw new ArgumentException("Tokens cannot be empty.", nameof(values));
+            if (Values.Distinct(StringComparer.Ordinal).Count() != Values.Length)
+                throw new ArgumentException("Tokens must be distinct.", nameof(values));
+        }
+
+        public ImmutableArray<string> Values { get; }
+
+        public override InspectionGraphValueDescriptor Descriptor =>
+            InspectionGraphValueCatalog.TokenSet;
+
+        public bool Equals(TokenSet? other) =>
+            other is not null && Values.SequenceEqual(other.Values);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            foreach (string value in Values)
+                hash.Add(value);
+            return hash.ToHashCode();
+        }
+    }
+}
+
+/// <summary>How a characteristic value was established.</summary>
+public enum InspectionGraphCharacteristicDerivationKind
+{
+    Direct,
+    Aggregated,
+    RolledUp,
+    Derived,
+}
+
+/// <summary>A descriptor-owned aggregation rule.</summary>
+public enum InspectionGraphAggregationPolicy
+{
+    None,
+    Any,
+    All,
+    DistinctOccurrenceCount,
+    DistinctSubjectCount,
+    Sum,
+    Maximum,
+    OrderedDistinctSet,
+    StrongestDisposition,
+    ProducerDefined,
+}
+
+/// <summary>The L1 semantic contract for one optional characteristic.</summary>
+public sealed class InspectionGraphCharacteristicDescriptor
+{
+    public InspectionGraphCharacteristicDescriptor(
+        string id,
+        InspectionGraphOwner owner,
+        InspectionGraphValueDescriptor value,
+        IEnumerable<InspectionGraphTargetKind> targets,
+        IEnumerable<InspectionQueryDefinition> prerequisites,
+        IEnumerable<InspectionGraphCharacteristicDerivationKind>
+            admittedDerivations,
+        InspectionGraphAggregationPolicy aggregation)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentNullException.ThrowIfNull(value);
+        InspectionGraphCollections.RequireDefined(owner, nameof(owner));
+        InspectionGraphCollections.RequireDefined(
+            aggregation,
+            nameof(aggregation));
+        Id = id;
+        Owner = owner;
+        Value = value;
+        Targets = InspectionGraphCollections.Snapshot(
+            targets,
+            nameof(targets));
+        Prerequisites = InspectionGraphCollections.Snapshot(
+            prerequisites,
+            nameof(prerequisites));
+        AdmittedDerivations = InspectionGraphCollections.Snapshot(
+            admittedDerivations,
+            nameof(admittedDerivations));
+        InspectionGraphCollections.RequireDefined(
+            Targets,
+            nameof(targets));
+        InspectionGraphCollections.RequireDefined(
+            AdmittedDerivations,
+            nameof(admittedDerivations));
+        if (Targets.IsEmpty)
+            throw new ArgumentException("At least one target kind is required.", nameof(targets));
+        if (AdmittedDerivations.IsEmpty)
+            throw new ArgumentException("At least one derivation kind is required.", nameof(admittedDerivations));
+        if (Targets.Distinct().Count() != Targets.Length)
+            throw new ArgumentException("Target kinds must be distinct.", nameof(targets));
+        if (Prerequisites.Distinct().Count() != Prerequisites.Length)
+            throw new ArgumentException("Prerequisites must be distinct.", nameof(prerequisites));
+        if (AdmittedDerivations.Distinct().Count() != AdmittedDerivations.Length)
+            throw new ArgumentException("Derivation kinds must be distinct.", nameof(admittedDerivations));
+        Aggregation = aggregation;
+    }
+
+    public string Id { get; }
+    public InspectionGraphOwner Owner { get; }
+    public InspectionGraphValueDescriptor Value { get; }
+    public InspectionGraphValueShape ValueShape => Value.Shape;
+    public ImmutableArray<InspectionGraphTargetKind> Targets { get; }
+    public ImmutableArray<InspectionQueryDefinition> Prerequisites { get; }
+    public ImmutableArray<InspectionGraphCharacteristicDerivationKind>
+        AdmittedDerivations { get; }
+    public InspectionGraphAggregationPolicy Aggregation { get; }
+}
+
+/// <summary>Provenance for one characteristic value.</summary>
+public sealed class InspectionGraphCharacteristicDerivation
+{
+    public InspectionGraphCharacteristicDerivation(
+        InspectionGraphCharacteristicDerivationKind kind,
+        IEnumerable<InspectionGraphTarget> sources)
+    {
+        InspectionGraphCollections.RequireDefined(kind, nameof(kind));
+        Kind = kind;
+        Sources = InspectionGraphCollections.Snapshot(
+            sources,
+            nameof(sources));
+        if (Sources.Distinct().Count() != Sources.Length)
+        {
+            throw new ArgumentException(
+                "Derivation sources must be distinct.",
+                nameof(sources));
+        }
+    }
+
+    public InspectionGraphCharacteristicDerivationKind Kind { get; }
+    public ImmutableArray<InspectionGraphTarget> Sources { get; }
+}
+
+/// <summary>One optional typed value attached to a graph target.</summary>
+public sealed record InspectionGraphCharacteristic(
+    InspectionGraphCharacteristicDescriptor Descriptor,
+    InspectionGraphTarget Target,
+    InspectionGraphValue Value,
+    InspectionGraphCharacteristicDerivation Derivation);
+
+/// <summary>The role one requested subject has in the graph.</summary>
+public enum InspectionGraphSeedRole
+{
+    Primary,
+    Peer,
+}
+
+/// <summary>A requested subject bound to its node or group.</summary>
+public sealed record InspectionGraphSeed(
+    InspectionGraphSubject Subject,
+    InspectionGraphTarget Target,
+    InspectionGraphSeedRole Role);
+
+/// <summary>The L1 identity of one completeness limit.</summary>
+public sealed class InspectionGraphLimitDescriptor
+{
+    public InspectionGraphLimitDescriptor(
+        string id,
+        InspectionGraphOwner owner,
+        IEnumerable<InspectionGraphEvidenceDescriptor>? evidence = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        InspectionGraphCollections.RequireDefined(owner, nameof(owner));
+        Id = id;
+        Owner = owner;
+        Evidence = InspectionGraphCollections.Snapshot(
+            evidence ?? [],
+            nameof(evidence));
+        if (Evidence.Select(static item => item.Id)
+                .Distinct(StringComparer.Ordinal).Count()
+            != Evidence.Length)
+        {
+            throw new ArgumentException(
+                "Evidence descriptor ids must be distinct.",
+                nameof(evidence));
+        }
+    }
+
+    public string Id { get; }
+    public InspectionGraphOwner Owner { get; }
+    public ImmutableArray<InspectionGraphEvidenceDescriptor> Evidence { get; }
+
+    internal bool AdmitsEvidence(
+        IInspectionGraphDiagnosticEvidence evidence) =>
+        Evidence.Contains(evidence.Descriptor);
+}
+
+/// <summary>A completeness limit, optionally scoped to one target.</summary>
+public sealed record InspectionGraphLimit(
+    InspectionGraphLimitDescriptor Descriptor,
+    InspectionGraphTarget? Target = null,
+    IInspectionGraphDiagnosticEvidence? Evidence = null);
+
+/// <summary>The L1 identity of one producer failure.</summary>
+public sealed class InspectionGraphFailureDescriptor
+{
+    public InspectionGraphFailureDescriptor(
+        string id,
+        InspectionGraphOwner owner,
+        IEnumerable<InspectionGraphEvidenceDescriptor>? evidence = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        InspectionGraphCollections.RequireDefined(owner, nameof(owner));
+        Id = id;
+        Owner = owner;
+        Evidence = InspectionGraphCollections.Snapshot(
+            evidence ?? [],
+            nameof(evidence));
+        if (Evidence.Select(static item => item.Id)
+                .Distinct(StringComparer.Ordinal).Count()
+            != Evidence.Length)
+        {
+            throw new ArgumentException(
+                "Evidence descriptor ids must be distinct.",
+                nameof(evidence));
+        }
+    }
+
+    public string Id { get; }
+    public InspectionGraphOwner Owner { get; }
+    public ImmutableArray<InspectionGraphEvidenceDescriptor> Evidence { get; }
+
+    internal bool AdmitsEvidence(
+        IInspectionGraphDiagnosticEvidence evidence) =>
+        Evidence.Contains(evidence.Descriptor);
+}
+
+/// <summary>A visible producer failure, optionally scoped to one target.</summary>
+public sealed record InspectionGraphFailure(
+    InspectionGraphFailureDescriptor Descriptor,
+    InspectionGraphTarget? Target = null,
+    IInspectionGraphDiagnosticEvidence? Evidence = null);
+
+/// <summary>
+/// The lifetime authority retained by an inspection graph.
+/// </summary>
+public enum InspectionGraphDocumentScope
+{
+    SessionBound,
+    Portable,
+}
+
+/// <summary>
+/// Immutable, validated L1 graph facts shared by every presentation.
+/// </summary>
+public sealed class InspectionGraphDocument
+{
+    public InspectionGraphDocument(
+        InspectionGraphDocumentScope scope,
+        IEnumerable<InspectionGraphNode> nodes,
+        IEnumerable<InspectionGraphGroup> groups,
+        IEnumerable<InspectionGraphEdge> edges,
+        IEnumerable<InspectionGraphOccurrence> occurrences,
+        IEnumerable<InspectionGraphCharacteristic> characteristics,
+        IEnumerable<InspectionGraphSeed> seeds,
+        IEnumerable<InspectionGraphLimit> limits,
+        IEnumerable<InspectionGraphFailure> failures)
+    {
+        InspectionGraphCollections.RequireDefined(scope, nameof(scope));
+        Scope = scope;
+        Nodes = InspectionGraphCollections.Snapshot(nodes, nameof(nodes));
+        Groups = InspectionGraphCollections.Snapshot(groups, nameof(groups));
+        Edges = InspectionGraphCollections.Snapshot(edges, nameof(edges));
+        Occurrences = InspectionGraphCollections.Snapshot(
+            occurrences,
+            nameof(occurrences));
+        Characteristics = InspectionGraphCollections.Snapshot(
+            characteristics,
+            nameof(characteristics));
+        Seeds = InspectionGraphCollections.Snapshot(seeds, nameof(seeds));
+        Limits = InspectionGraphCollections.Snapshot(limits, nameof(limits));
+        Failures = InspectionGraphCollections.Snapshot(
+            failures,
+            nameof(failures));
+
+        ValidateDenseIds(Nodes, static node => node.Id, nameof(nodes));
+        ValidateDenseIds(Groups, static group => group.Id, nameof(groups));
+        ValidateDenseIds(Edges, static edge => edge.Id, nameof(edges));
+        ValidateDenseIds(
+            Occurrences,
+            static occurrence => occurrence.Id,
+            nameof(occurrences));
+        if (Nodes.Select(static node => node.Subject).Distinct().Count()
+            != Nodes.Length)
+        {
+            throw new ArgumentException(
+                "A semantic subject can appear as at most one node.",
+                nameof(nodes));
+        }
+        if (Scope == InspectionGraphDocumentScope.Portable)
+            ValidatePortableSubjects();
+        foreach (InspectionGraphOccurrence occurrence in Occurrences)
+            ArgumentNullException.ThrowIfNull(occurrence.Evidence.Descriptor);
+        foreach (InspectionGraphCharacteristic characteristic
+            in Characteristics)
+        {
+            ArgumentNullException.ThrowIfNull(characteristic.Descriptor);
+            ArgumentNullException.ThrowIfNull(characteristic.Value);
+            ArgumentNullException.ThrowIfNull(characteristic.Derivation);
+        }
+        foreach (InspectionGraphLimit limit in Limits)
+        {
+            ArgumentNullException.ThrowIfNull(limit.Descriptor);
+            if (limit.Evidence is not null)
+                ArgumentNullException.ThrowIfNull(limit.Evidence.Descriptor);
+        }
+        foreach (InspectionGraphFailure failure in Failures)
+        {
+            ArgumentNullException.ThrowIfNull(failure.Descriptor);
+            if (failure.Evidence is not null)
+                ArgumentNullException.ThrowIfNull(
+                    failure.Evidence.Descriptor);
+        }
+        ValidateDescriptorIds();
+        ValidateGroups();
+        ValidateEdgesAndOccurrences();
+        ValidateCharacteristics();
+        ValidateSeeds();
+        ValidateDiagnostics();
+    }
+
+    public InspectionGraphDocumentScope Scope { get; }
+    public ImmutableArray<InspectionGraphNode> Nodes { get; }
+    public ImmutableArray<InspectionGraphGroup> Groups { get; }
+    public ImmutableArray<InspectionGraphEdge> Edges { get; }
+    public ImmutableArray<InspectionGraphOccurrence> Occurrences { get; }
+    public ImmutableArray<InspectionGraphCharacteristic> Characteristics { get; }
+    public ImmutableArray<InspectionGraphSeed> Seeds { get; }
+    public ImmutableArray<InspectionGraphLimit> Limits { get; }
+    public ImmutableArray<InspectionGraphFailure> Failures { get; }
+
+    private void ValidateGroups()
+    {
+        foreach (InspectionGraphGroup group in Groups)
+        {
+            if (group.ParentId is int parentId)
+            {
+                ValidateId(parentId, Groups.Length, "Group parent");
+                if (parentId == group.Id)
+                    throw new ArgumentException("A group cannot be its own parent.", nameof(Groups));
+            }
+
+        }
+
+        var states = new byte[Groups.Length];
+        for (var id = 0; id < Groups.Length; id++)
+            VisitGroup(id, states);
+
+        foreach (InspectionGraphNode node in Nodes)
+        {
+            foreach (int groupId in node.GroupIds)
+                ValidateId(groupId, Groups.Length, "Node group");
+        }
+    }
+
+    private void ValidatePortableSubjects()
+    {
+        IEnumerable<InspectionGraphSubject> subjects =
+            Nodes.Select(static node => node.Subject)
+                .Concat(Groups.Select(static group => group.Subject))
+                .Concat(Occurrences.SelectMany(static occurrence =>
+                    new[]
+                    {
+                        occurrence.SourceSubject,
+                        occurrence.TargetSubject,
+                    }))
+                .Concat(Seeds.Select(static seed => seed.Subject));
+        if (subjects.Any(static subject => !subject.IsPortable))
+        {
+            throw new ArgumentException(
+                "A portable document cannot retain a session-bound subject identity.",
+                nameof(Scope));
+        }
+    }
+
+    private void VisitGroup(int id, byte[] states)
+    {
+        if (states[id] == 2)
+            return;
+        if (states[id] == 1)
+            throw new ArgumentException("Group parents must not form a cycle.", nameof(Groups));
+
+        states[id] = 1;
+        if (Groups[id].ParentId is int parentId)
+            VisitGroup(parentId, states);
+        states[id] = 2;
+    }
+
+    private void ValidateEdgesAndOccurrences()
+    {
+        var boundOccurrences = new int[Occurrences.Length];
+        var logicalEdges = new HashSet<(
+            int From,
+            int To,
+            InspectionGraphRelationshipDescriptor Relationship)>();
+
+        foreach (InspectionGraphEdge edge in Edges)
+        {
+            ValidateId(edge.FromNodeId, Nodes.Length, "Edge source node");
+            ValidateId(edge.ToNodeId, Nodes.Length, "Edge target node");
+            InspectionGraphSubject source = Nodes[edge.FromNodeId].Subject;
+            InspectionGraphSubject target = Nodes[edge.ToNodeId].Subject;
+            if (!edge.Relationship.AdmitsEdgeSource(source)
+                || !edge.Relationship.AdmitsEdgeTarget(target))
+            {
+                throw new ArgumentException(
+                    "An edge endpoint has a subject kind the relationship does not admit.",
+                    nameof(Edges));
+            }
+            if (!logicalEdges.Add((
+                edge.FromNodeId,
+                edge.ToNodeId,
+                edge.Relationship)))
+            {
+                throw new ArgumentException(
+                    "Logical edges must be unique by source, target, and relationship.",
+                    nameof(Edges));
+            }
+            if (edge.OccurrenceIds.IsEmpty
+                && edge.Relationship.Semantics
+                    != InspectionGraphRelationshipSemantics.Synthetic)
+            {
+                throw new ArgumentException(
+                    "A non-synthetic edge requires at least one occurrence.",
+                    nameof(Edges));
+            }
+
+            foreach (int occurrenceId in edge.OccurrenceIds)
+            {
+                ValidateId(
+                    occurrenceId,
+                    Occurrences.Length,
+                    "Edge occurrence");
+                InspectionGraphOccurrence occurrence =
+                    Occurrences[occurrenceId];
+                if (!ReferenceEquals(
+                    occurrence.Relationship,
+                    edge.Relationship))
+                {
+                    throw new ArgumentException(
+                        "An occurrence relationship must equal its edge relationship.",
+                        nameof(Edges));
+                }
+                if (!edge.Relationship.AdmitsOccurrenceSource(
+                        occurrence.SourceSubject)
+                    || !edge.Relationship.AdmitsOccurrenceTarget(
+                        occurrence.TargetSubject))
+                {
+                    throw new ArgumentException(
+                        "An occurrence endpoint has a subject kind the relationship does not admit.",
+                        nameof(Occurrences));
+                }
+                if (!edge.Relationship.EndpointProjection.Supports(
+                        occurrence,
+                        InspectionGraphEndpointRole.Source,
+                        source)
+                    || !edge.Relationship.EndpointProjection.Supports(
+                        occurrence,
+                        InspectionGraphEndpointRole.Target,
+                        target))
+                {
+                    throw new ArgumentException(
+                        "An occurrence does not project to its edge endpoints in semantic direction.",
+                        nameof(Edges));
+                }
+                if (!edge.Relationship.AdmitsEvidence(
+                    occurrence.Evidence))
+                {
+                    throw new ArgumentException(
+                        "Occurrence evidence is not admitted by its relationship.",
+                        nameof(Occurrences));
+                }
+
+                boundOccurrences[occurrenceId]++;
+            }
+        }
+
+        if (boundOccurrences.Any(static count => count == 0))
+            throw new ArgumentException("Every occurrence must support at least one edge.", nameof(Occurrences));
+
+        var occurrenceIdentities =
+            new Dictionary<
+                InspectionGraphRelationshipDescriptor,
+                HashSet<object>>();
+        foreach (InspectionGraphOccurrence occurrence in Occurrences)
+        {
+            object identity =
+                occurrence.Relationship.OccurrenceIdentity.Project(
+                    occurrence)
+                ?? throw new ArgumentException(
+                    "An occurrence identity cannot be null.",
+                    nameof(Occurrences));
+            if (!occurrenceIdentities.TryGetValue(
+                occurrence.Relationship,
+                out HashSet<object>? identities))
+            {
+                identities = [];
+                occurrenceIdentities.Add(
+                    occurrence.Relationship,
+                    identities);
+            }
+            if (!identities.Add(identity))
+            {
+                throw new ArgumentException(
+                    "Occurrence identities must be unique within a relationship.",
+                    nameof(Occurrences));
+            }
+            if (occurrence.Relationship.Semantics
+                    == InspectionGraphRelationshipSemantics.Derived
+                && occurrence.DerivedFromOccurrenceIds.IsEmpty)
+            {
+                throw new ArgumentException(
+                    "A derived relationship occurrence must cite its source occurrences.",
+                    nameof(Occurrences));
+            }
+            if (occurrence.Relationship.Semantics
+                    != InspectionGraphRelationshipSemantics.Derived
+                && !occurrence.DerivedFromOccurrenceIds.IsEmpty)
+            {
+                throw new ArgumentException(
+                    "Only a derived relationship occurrence can cite source occurrences.",
+                    nameof(Occurrences));
+            }
+            foreach (int sourceId in occurrence.DerivedFromOccurrenceIds)
+            {
+                ValidateId(
+                    sourceId,
+                    Occurrences.Length,
+                    "Derived source occurrence");
+                if (sourceId == occurrence.Id)
+                    throw new ArgumentException("An occurrence cannot derive from itself.", nameof(Occurrences));
+            }
+        }
+
+        var derivationStates = new byte[Occurrences.Length];
+        for (var id = 0; id < Occurrences.Length; id++)
+            VisitOccurrence(id, derivationStates);
+    }
+
+    private void VisitOccurrence(int id, byte[] states)
+    {
+        if (states[id] == 2)
+            return;
+        if (states[id] == 1)
+        {
+            throw new ArgumentException(
+                "Occurrence derivations must not form a cycle.",
+                nameof(Occurrences));
+        }
+
+        states[id] = 1;
+        foreach (int sourceId
+            in Occurrences[id].DerivedFromOccurrenceIds)
+        {
+            VisitOccurrence(sourceId, states);
+        }
+        states[id] = 2;
+    }
+
+    private void ValidateCharacteristics()
+    {
+        var identities = new HashSet<(
+            InspectionGraphCharacteristicDescriptor Descriptor,
+            InspectionGraphTarget Target)>();
+        foreach (InspectionGraphCharacteristic characteristic
+            in Characteristics)
+        {
+            ValidateTarget(characteristic.Target);
+            if (!identities.Add((
+                characteristic.Descriptor,
+                characteristic.Target)))
+            {
+                throw new ArgumentException(
+                    "A descriptor can contribute only one value to a target.",
+                    nameof(Characteristics));
+            }
+            if (!characteristic.Descriptor.Targets.Contains(
+                characteristic.Target.Kind))
+            {
+                throw new ArgumentException(
+                    "A characteristic target kind is not admitted by its descriptor.",
+                    nameof(Characteristics));
+            }
+            if (!ReferenceEquals(
+                characteristic.Value.Descriptor,
+                characteristic.Descriptor.Value))
+            {
+                throw new ArgumentException(
+                    "A characteristic value does not match its descriptor contract.",
+                    nameof(Characteristics));
+            }
+            if (!characteristic.Descriptor.AdmittedDerivations.Contains(
+                characteristic.Derivation.Kind))
+            {
+                throw new ArgumentException(
+                    "A characteristic derivation is not admitted by its descriptor.",
+                    nameof(Characteristics));
+            }
+            if (characteristic.Derivation.Kind
+                    == InspectionGraphCharacteristicDerivationKind.Direct
+                && !characteristic.Derivation.Sources.IsEmpty)
+            {
+                throw new ArgumentException(
+                    "A direct characteristic cannot cite derivation sources.",
+                    nameof(Characteristics));
+            }
+            if (characteristic.Derivation.Kind
+                    != InspectionGraphCharacteristicDerivationKind.Direct
+                && characteristic.Derivation.Sources.IsEmpty)
+            {
+                throw new ArgumentException(
+                    "A non-direct characteristic must cite derivation sources.",
+                    nameof(Characteristics));
+            }
+            if (characteristic.Derivation.Kind
+                    is InspectionGraphCharacteristicDerivationKind.Aggregated
+                        or InspectionGraphCharacteristicDerivationKind.RolledUp
+                && characteristic.Descriptor.Aggregation
+                    == InspectionGraphAggregationPolicy.None)
+            {
+                throw new ArgumentException(
+                    "An aggregate characteristic requires a descriptor-owned aggregation policy.",
+                    nameof(Characteristics));
+            }
+            if (characteristic.Derivation.Kind
+                    == InspectionGraphCharacteristicDerivationKind.Aggregated
+                && characteristic.Derivation.Sources.Any(
+                    static source =>
+                        source.Kind
+                            != InspectionGraphTargetKind.Occurrence))
+            {
+                throw new ArgumentException(
+                    "An aggregated characteristic must cite occurrences.",
+                    nameof(Characteristics));
+            }
+            if (characteristic.Derivation.Kind
+                    == InspectionGraphCharacteristicDerivationKind.RolledUp
+                && characteristic.Derivation.Sources.Any(
+                    static source =>
+                        source.Kind is not (
+                            InspectionGraphTargetKind.Node
+                            or InspectionGraphTargetKind.Group)))
+            {
+                throw new ArgumentException(
+                    "A rolled-up characteristic must cite subject nodes or groups.",
+                    nameof(Characteristics));
+            }
+            foreach (InspectionGraphTarget source
+                in characteristic.Derivation.Sources)
+                ValidateTarget(source);
+        }
+    }
+
+    private void ValidateSeeds()
+    {
+        var targets = new HashSet<InspectionGraphTarget>();
+        var primaryCount = 0;
+        foreach (InspectionGraphSeed seed in Seeds)
+        {
+            ArgumentNullException.ThrowIfNull(seed.Subject);
+            InspectionGraphCollections.RequireDefined(
+                seed.Role,
+                nameof(seed.Role));
+            if (seed.Target.Kind is not (
+                InspectionGraphTargetKind.Node
+                or InspectionGraphTargetKind.Group))
+            {
+                throw new ArgumentException(
+                    "A seed must target a node or group.",
+                    nameof(Seeds));
+            }
+            ValidateTarget(seed.Target);
+            InspectionGraphSubject targetSubject =
+                seed.Target.Kind == InspectionGraphTargetKind.Node
+                    ? Nodes[seed.Target.Id].Subject
+                    : Groups[seed.Target.Id].Subject;
+            if (seed.Subject != targetSubject)
+                throw new ArgumentException("A seed subject must equal its target subject.", nameof(Seeds));
+            if (!targets.Add(seed.Target))
+                throw new ArgumentException("A target can have only one seed role.", nameof(Seeds));
+            if (seed.Role == InspectionGraphSeedRole.Primary)
+                primaryCount++;
+        }
+
+        if (primaryCount > 1)
+            throw new ArgumentException("A graph can have at most one primary seed.", nameof(Seeds));
+    }
+
+    private void ValidateDiagnostics()
+    {
+        var limits = new HashSet<(
+            InspectionGraphLimitDescriptor Descriptor,
+            InspectionGraphTarget? Target)>();
+        foreach (InspectionGraphLimit limit in Limits)
+        {
+            ArgumentNullException.ThrowIfNull(limit.Descriptor);
+            if (limit.Target is InspectionGraphTarget target)
+                ValidateTarget(target);
+            if (limit.Evidence is not null
+                && !limit.Descriptor.AdmitsEvidence(limit.Evidence))
+            {
+                throw new ArgumentException(
+                    "Limit evidence is not admitted by its descriptor.",
+                    nameof(Limits));
+            }
+            if (!limits.Add((limit.Descriptor, limit.Target)))
+                throw new ArgumentException("Limits must be distinct.", nameof(Limits));
+        }
+
+        var failures = new HashSet<(
+            InspectionGraphFailureDescriptor Descriptor,
+            InspectionGraphTarget? Target)>();
+        foreach (InspectionGraphFailure failure in Failures)
+        {
+            ArgumentNullException.ThrowIfNull(failure.Descriptor);
+            if (failure.Target is InspectionGraphTarget target)
+                ValidateTarget(target);
+            if (failure.Evidence is not null
+                && !failure.Descriptor.AdmitsEvidence(failure.Evidence))
+            {
+                throw new ArgumentException(
+                    "Failure evidence is not admitted by its descriptor.",
+                    nameof(Failures));
+            }
+            if (!failures.Add((failure.Descriptor, failure.Target)))
+                throw new ArgumentException("Failures must be distinct.", nameof(Failures));
+        }
+    }
+
+    private void ValidateTarget(InspectionGraphTarget target)
+    {
+        if (!target.IsInitialized)
+            throw new ArgumentException("A graph target must be initialized.", nameof(target));
+
+        int count = target.Kind switch
+        {
+            InspectionGraphTargetKind.Node => Nodes.Length,
+            InspectionGraphTargetKind.Group => Groups.Length,
+            InspectionGraphTargetKind.Edge => Edges.Length,
+            InspectionGraphTargetKind.Occurrence => Occurrences.Length,
+            _ => throw new ArgumentOutOfRangeException(nameof(target)),
+        };
+        ValidateId(target.Id, count, "Graph target");
+    }
+
+    private void ValidateDescriptorIds()
+    {
+        ValidateDescriptorIds(
+            Edges.Select(static edge => (
+                edge.Relationship.Id,
+                (object)edge.Relationship))
+            .Concat(Occurrences.Select(static occurrence => (
+                occurrence.Relationship.Id,
+                (object)occurrence.Relationship))),
+            "relationship");
+        ValidateDescriptorIds(
+            Edges.SelectMany(static edge =>
+                    edge.Relationship.Evidence)
+                .Concat(Occurrences.SelectMany(static occurrence =>
+                    occurrence.Relationship.Evidence))
+                .Concat(Limits.SelectMany(static limit =>
+                    limit.Descriptor.Evidence))
+                .Concat(Failures.SelectMany(static failure =>
+                    failure.Descriptor.Evidence))
+                .Concat(Occurrences.Select(
+                    static occurrence =>
+                        occurrence.Evidence.Descriptor))
+                .Concat(Limits
+                    .Where(static limit => limit.Evidence is not null)
+                    .Select(static limit =>
+                        limit.Evidence!.Descriptor))
+                .Concat(Failures
+                    .Where(static failure => failure.Evidence is not null)
+                    .Select(static failure =>
+                        failure.Evidence!.Descriptor))
+                .Select(static descriptor => (
+                    descriptor.Id,
+                    (object)descriptor)),
+            "evidence");
+        ValidateDescriptorIds(
+            Characteristics.Select(static characteristic => (
+                characteristic.Descriptor.Id,
+                (object)characteristic.Descriptor)),
+            "characteristic");
+        ValidateDescriptorIds(
+            Characteristics.SelectMany(static characteristic =>
+                new[]
+                {
+                    (
+                        characteristic.Descriptor.Value.Id,
+                        (object)characteristic.Descriptor.Value),
+                    (
+                        characteristic.Value.Descriptor.Id,
+                        (object)characteristic.Value.Descriptor),
+                }),
+            "value");
+        ValidateDescriptorIds(
+            Limits.Select(static limit => (
+                limit.Descriptor.Id,
+                (object)limit.Descriptor)),
+            "limit");
+        ValidateDescriptorIds(
+            Failures.Select(static failure => (
+                failure.Descriptor.Id,
+                (object)failure.Descriptor)),
+            "failure");
+    }
+
+    private static void ValidateDescriptorIds(
+        IEnumerable<(string Id, object Descriptor)> descriptors,
+        string family)
+    {
+        var byId = new Dictionary<string, object>(
+            StringComparer.Ordinal);
+        foreach ((string id, object descriptor) in descriptors)
+        {
+            if (byId.TryGetValue(id, out object? existing)
+                && !ReferenceEquals(existing, descriptor))
+            {
+                throw new ArgumentException(
+                    $"Descriptor id '{id}' names more than one {family} contract.");
+            }
+            byId[id] = descriptor;
+        }
+    }
+
+    private static void ValidateDenseIds<T>(
+        ImmutableArray<T> values,
+        Func<T, int> getId,
+        string parameterName)
+    {
+        for (var index = 0; index < values.Length; index++)
+        {
+            if (getId(values[index]) != index)
+            {
+                throw new ArgumentException(
+                    "Document-local ids must be dense, zero-based, and ordered.",
+                    parameterName);
+            }
+        }
+    }
+
+    private static void ValidateId(int id, int count, string name)
+    {
+        if ((uint)id >= (uint)count)
+            throw new ArgumentException($"{name} id {id} is outside the document.");
+    }
+}
+
+static class InspectionGraphCollections
+{
+    public static void RequireDefined<T>(
+        T value,
+        string parameterName)
+        where T : struct, Enum
+    {
+        if (!Enum.IsDefined(value))
+            throw new ArgumentOutOfRangeException(parameterName);
+    }
+
+    public static void RequireDefined<T>(
+        IEnumerable<T> values,
+        string parameterName)
+        where T : struct, Enum
+    {
+        foreach (T value in values)
+            RequireDefined(value, parameterName);
+    }
+
+    public static ImmutableArray<T> Snapshot<T>(
+        IEnumerable<T> values,
+        string parameterName)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(values, parameterName);
+        if (values is ImmutableArray<T> immutable && immutable.IsDefault)
+            throw new ArgumentException("The immutable array must be initialized.", parameterName);
+
+        ImmutableArray<T> snapshot = values.ToImmutableArray();
+        if (snapshot.Any(static value => value is null))
+            throw new ArgumentException("Collection elements cannot be null.", parameterName);
+        return snapshot;
+    }
+}

--- a/src/ILInspector.Analysis.Tests/CatalogCallGraphScopeTests.cs
+++ b/src/ILInspector.Analysis.Tests/CatalogCallGraphScopeTests.cs
@@ -201,6 +201,9 @@ public class CatalogCallGraphScopeTests
             });
 
         Assert.Equal(2, projection.Nodes.Length);
+        Assert.NotEqual(
+            projection.Nodes[0].Identity,
+            projection.Nodes[1].Identity);
         CallGraphEdge edge = Assert.Single(projection.Edges);
         Assert.Equal(0, edge.From);
         Assert.Equal(1, edge.To);

--- a/src/ILInspector.Analysis/CatalogCallGraphScope.cs
+++ b/src/ILInspector.Analysis/CatalogCallGraphScope.cs
@@ -1092,7 +1092,7 @@ public sealed class CatalogCallGraphScope : IDisposable
                 else
                 {
                     identity =
-                        GraphNodeIdentity.CreateDetachedCatalog();
+                        GraphNodeIdentity.CreateDocumentLocal();
                 }
 
                 detached.Add(evidence.Identity, identity);

--- a/src/ILInspector.Analysis/GraphIdentity.cs
+++ b/src/ILInspector.Analysis/GraphIdentity.cs
@@ -119,6 +119,15 @@ public sealed class GraphNodeIdentity : IEquatable<GraphNodeIdentity>
 
     public GraphNodeIdentityKind Kind { get; }
 
+    /// <summary>
+    /// Whether this identity contains no catalog generation or live acquisition
+    /// registration.
+    /// </summary>
+    public bool IsPortable =>
+        Kind is GraphNodeIdentityKind.Structural
+            or GraphNodeIdentityKind.ArtifactMember
+            or GraphNodeIdentityKind.DetachedCatalog;
+
     internal static GraphNodeIdentity FromStorage(
         GraphNodeStorageKey storage) =>
         new(GraphNodeIdentityKind.Storage, storage);
@@ -145,13 +154,21 @@ public sealed class GraphNodeIdentity : IEquatable<GraphNodeIdentity>
                 definition.MethodToken));
     }
 
-    internal static GraphNodeIdentity CreateDetachedCatalog() =>
+    /// <summary>
+    /// Creates a document-local identity for evidence that cannot safely join
+    /// another occurrence.
+    /// </summary>
+    public static GraphNodeIdentity CreateDocumentLocal() =>
         new(GraphNodeIdentityKind.DetachedCatalog, new object());
 
-    internal static GraphNodeIdentity FromMember(MemberRef member) =>
-        new(
+    /// <summary>Creates a structural identity for an unbound member value.</summary>
+    public static GraphNodeIdentity FromMember(MemberRef member)
+    {
+        ArgumentNullException.ThrowIfNull(member);
+        return new(
             GraphNodeIdentityKind.Structural,
             GraphStructuralMemberKey.Create(member));
+    }
 
     public bool Equals(GraphNodeIdentity? other) =>
         other is not null

--- a/src/ILInspector.CallGraph/CallGraphProjection.cs
+++ b/src/ILInspector.CallGraph/CallGraphProjection.cs
@@ -32,8 +32,13 @@ public enum CallGraphNodeKind
 /// always id 0.
 /// </param>
 /// <param name="Member">
-/// The typed member identity. This — not <paramref name="Label"/> — is the node's identity;
-/// hosts must not infer identity from display text.
+/// The typed member payload. Hosts use <paramref name="Identity"/> to join the
+/// node and must not infer identity from this value or from
+/// <paramref name="Label"/>.
+/// </param>
+/// <param name="Identity">
+/// The Analysis-owned identity that the projection used to collapse physical
+/// occurrences onto this logical node.
 /// </param>
 /// <param name="Label">
 /// A host-neutral default spelling of <paramref name="Member"/>, offered as a convenience.
@@ -53,6 +58,7 @@ public enum CallGraphNodeKind
 /// </param>
 public sealed record CallGraphNode(
     int Id,
+    GraphNodeIdentity Identity,
     MemberRef Member,
     string Label,
     CallGraphNodeKind Kind,
@@ -319,12 +325,14 @@ public sealed partial class CallGraphProjection
 
     private sealed class MutableNode(
         int id,
+        GraphNodeIdentity identity,
         MemberRef member,
         string label,
         CallGraphNodeKind kind,
         CallTreePerf? perf)
     {
         public int Id { get; } = id;
+        public GraphNodeIdentity Identity { get; } = identity;
         public MemberRef Member { get; } = member;
         public string Label { get; } = label;
         public CallGraphNodeKind Kind { get; set; } = kind;
@@ -400,6 +408,7 @@ public sealed partial class CallGraphProjection
                 nodes.Add(
                     new CallGraphNode(
                         node.Id,
+                        node.Identity,
                         node.Member,
                         node.Label,
                         node.Kind,
@@ -426,6 +435,7 @@ public sealed partial class CallGraphProjection
                 _ids[identity] = id;
                 var node = new MutableNode(
                     id,
+                    identity,
                     member,
                     Label(member),
                     candidate,


### PR DESCRIPTION
Adds the immutable, validated L1 inspection-graph document and typed descriptor contracts for member, type, assembly, and package subjects. The document keeps relationship topology, original occurrences, characteristics, seeds, limits, failures, producer identity, and portability authority distinct.

Adapts the existing member call projection without changing default output. Each current logical call row becomes an observed `call` edge with a typed transitional receipt and an edge-scoped `call.physical-occurrences-unavailable` limit; physical call-site retention remains the next producer-owned slice rather than being fabricated here. `CallGraphNode` now exposes the exact Analysis-owned identity used for projection so version-skewed or incomplete nodes never rejoin through `MemberRef`.

The contracts remain SRM-only, NativeAOT-friendly, browser/Wasm-compatible, and sequential. No CLI or presentation behavior changes.

Validation:
- `dotnet build dotnet-inspect.slnx -c Release -m:1`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build` (190 passed)
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build` (637 passed)
- `npx markdownlint-cli docs/design/inspection-graph-document.md docs/design/call-graph-characteristics.md docs/design/call-graph-projection.md`

Advances #4139. Physical occurrences and call edge characteristics remain the explicit next slice.