### PR TITLE
Prepare dotnet-inspect 0.18.0 release

### DIFF
--- a/skills/decompiler/SKILL.md
+++ b/skills/decompiler/SKILL.md
@@ -33,7 +33,8 @@ full zero-network evidence set:
 Use `Annotated Source` or `IL` when exact opcodes, offsets, branches, tokens, or
 calls matter. Use `--bare` for a whole-type listing.
 `-S @Source` is broader and may fetch network `Original Source` content when
-SourceLink is available; that network body is not checksum-verified by default.
+SourceLink is available; the fetch verifies the final redirect origin and PDB
+checksum before returning the body.
 `--project` reads existing restored assets; restore/build first if dependencies
 changed.
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.17.0
+version: 0.18.0
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and version-to-version API changes.
 ---
 

--- a/skills/sourcelink/SKILL.md
+++ b/skills/sourcelink/SKILL.md
@@ -8,10 +8,10 @@ description: Find SourceLink-mapped original source through PDB data — map fil
 
 Use this skill to get the original source mapped by the PDB. dotnet-inspect
 verifies local files and GitHub committed blobs read through `--repo` against
-the PDB checksum. A network `Original Source` fetch follows the SourceLink URL
-without performing that checksum check; use
-`library -S "SourceLink: Integrity"` for opt-in content verification of
-fetchable, non-embedded compiler-source documents. Without a usable PDB,
+the PDB checksum. A network `Original Source` fetch also verifies the checksum
+and requires the final redirect origin to match before returning the body. Use
+`library -S "SourceLink: Integrity"` for opt-in verification of every
+fetchable, non-embedded compiler-source document. Without a usable PDB,
 SourceLink map, or matching source, use the always-local `decompiler` skill.
 
 ```bash

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3527,6 +3527,21 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task BareQualifiedAspNetCoreType_RoutesPastNonOwningAssemblyPrefix()
+    {
+        SkipUnlessAspNetCoreAvailable();
+
+        var (exit, output, error) = await RunAppAsync(
+            "Microsoft.AspNetCore.Http.HttpContext", "--markdown", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("best-effort prefix", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("# Microsoft.AspNetCore.Http.HttpContext", output);
+        Assert.Contains("Library: Microsoft.AspNetCore.Http.Abstractions", output);
+        Assert.Contains("Source: Platform", output);
+    }
+
+    [Fact]
     public async Task BareQualifiedAspNetCoreMember_RoutesAcrossPlatformFrameworks()
     {
         SkipUnlessAspNetCoreAvailable();

--- a/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
+++ b/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
@@ -127,6 +127,27 @@ public sealed class SourceScopedRoutingTests : IDisposable
     }
 
     [Fact]
+    public async Task Router_PlatformPrefixBrowse_IgnoresCachedPackageCandidate()
+    {
+        const string Target = "System.Text.Json.Serialization";
+        SeedLatestCandidate(
+            Target,
+            ExcludedSource,
+            "1.0.0");
+
+        var observations = await RunAppAsync(
+            [Target, "--source", ExcludedSource]);
+
+        var rewrite = Assert.Single(
+            observations,
+            observation => observation.Stage == "router-rewrite");
+        Assert.Contains(
+            $" -> type {Target}",
+            rewrite.Detail,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task Router_InvalidNuGetConfig_ReportsCleanParseError()
     {
         string missingConfig = Path.Combine(_testRoot, "missing.nuget.config");

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -290,11 +290,6 @@ public static class RouterCommandDefinition
                 bool isNonExactPlatformProbe =
                     typeProbe.Kind == SourceResolver.LocalSourceKind.Platform
                     && !await IsExactPlatformTypeAsync(typeProbe, context);
-                if (isNonExactPlatformProbe && platformLookupFailure is null)
-                {
-                    return ["type", target, .. tail];
-                }
-
                 if (!isNonExactPlatformProbe)
                 {
                     RequestTelemetry.Breadcrumb(

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -285,12 +285,13 @@ public static class RouterCommandDefinition
                 sourceOptions,
                 allowPlatformPrefixFallback,
                 message => platformLookupFailure ??= message);
+            bool hasNonExactPlatformProbe = false;
             if (typeProbe != null)
             {
-                bool isNonExactPlatformProbe =
+                hasNonExactPlatformProbe =
                     typeProbe.Kind == SourceResolver.LocalSourceKind.Platform
                     && !await IsExactPlatformTypeAsync(typeProbe, context);
-                if (!isNonExactPlatformProbe)
+                if (!hasNonExactPlatformProbe)
                 {
                     RequestTelemetry.Breadcrumb(
                         "qualified-type",
@@ -320,6 +321,9 @@ public static class RouterCommandDefinition
                 CommandError.Write(platformLookupFailure);
                 return tokens;
             }
+
+            if (hasNonExactPlatformProbe)
+                return ["type", target, .. tail];
 
             if (PlatformResolver.IsPlatformCandidate(target))
             {

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -19,7 +19,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.17.0</VersionPrefix>
+    <VersionPrefix>0.18.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -6,7 +6,7 @@
 
 - Fixes fully qualified ASP.NET Core type and member routing when runtime
   catalogs span multiple shared frameworks or a namespace prefix names a
-  non-owning facade assembly, while retaining real ambiguity errors (#4135).
+  non-owning assembly, while retaining real ambiguity errors (#4135).
 - Uses a bounded declaration index for authored `Original Source` and `Source
   Diff` slicing. Accessors now select their enclosing property or event,
   constructors retain their exact identity, and ambiguous or overly complex
@@ -37,6 +37,9 @@
 - Separates package-source policy by acquisition owner so package, symbol,
   platform-pack, and related fetches retain their intended source boundaries
   (#4136).
+- Contains restored dependency-manifest paths beneath their target,
+  global-packages, and owning-package roots, rejecting hostile entries without
+  echoing them (#4132).
 
 ### Experimental analysis and decompilation fixes
 
@@ -49,6 +52,9 @@
 - Improves generated-member and authored-source correspondence, body-inspection
   session reuse, and full-body structural diagnostics used to find
   decompilation fidelity regressions (#3857, #3927, #4037, #4092).
+- Raises local functions inside generic types through their generic type
+  definitions while continuing to decline unsupported generic iterator imports
+  visibly (#4116).
 
 ## v0.17.0
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,55 @@
 # Release Notes
 
+## v0.18.0
+
+### Inspection correctness
+
+- Fixes fully qualified ASP.NET Core type and member routing when runtime
+  catalogs span multiple shared frameworks or a namespace prefix names a
+  non-owning facade assembly, while retaining real ambiguity errors (#4135).
+- Uses a bounded declaration index for authored `Original Source` and `Source
+  Diff` slicing. Accessors now select their enclosing property or event,
+  constructors retain their exact identity, and ambiguous or overly complex
+  source boundaries fail visibly instead of returning fragments or empty
+  output (#3927).
+- Uses document-scoped PDB sequence points to select live conditional branches
+  in authored source, and refuses invalid coordinates or unsafe declaration
+  boundaries instead of leaking inactive sibling declarations (#4158).
+- Resolves assembly references by metadata identity rather than derived paths,
+  preserving sibling/platform precedence, culture and token constraints, and
+  visible failure state for unreadable or mismatched candidates (#3928).
+- Uses structural keys for generated-member correspondence and exact IL
+  coordinate evidence for allocation, safety, and callsite rows (#3857,
+  #4107).
+- Bounds cumulative API member-anchor signature construction work and memoizes
+  repeated metadata type names, preventing long repeated names from amplifying
+  allocations before the safety budget rejects them (#4162).
+
+### Source and network safety
+
+- Verifies fetched SourceLink content against its portable-PDB checksum and
+  validates the final redirect origin before buffering the response. Source
+  reads are bounded, retry-aware, and fail closed when final-origin evidence is
+  unavailable (#4041).
+- Recognizes commit-pinned Azure SourceLink URLs as immutable and bounds NuGet
+  advisory JSON responses while retaining redacted diagnostics (#4104,
+  #4117).
+- Separates package-source policy by acquisition owner so package, symbol,
+  platform-pack, and related fetches retain their intended source boundaries
+  (#4136).
+
+### Experimental analysis and decompilation fixes
+
+- Extends `ArrayPool<T>` ownership analysis across progressively acquired call
+  graphs while retaining bounded, exact path evidence and treating indirect
+  calls as incomplete rather than safe (#4081).
+- Orders named enum labels that share a switch body alphabetically by default;
+  `dotnet_inspect_style_enum_case_label_order = value` retains recovered
+  numeric order (#4072).
+- Improves generated-member and authored-source correspondence, body-inspection
+  session reuse, and full-body structural diagnostics used to find
+  decompilation fidelity regressions (#3857, #3927, #4037, #4092).
+
 ## v0.17.0
 
 ### Curated inspection and query model


### PR DESCRIPTION
## Summary

- bump `dotnet-inspect` and its base embedded skill to 0.18.0
- add release notes focused on inspection correctness, SourceLink/network safety, and experimental analysis/decompiler fixes
- correct shipped SourceLink/decompiler guidance for checksum and final-origin verification; README already reflects current behavior and needs no release-only change
- fix fully qualified ASP.NET type routing when the namespace prefix names a non-owning facade assembly, found during installed-package usability testing

## Validation

- `npx markdownlint-cli` on all changed Markdown
- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build` (3,645 tests; 4 platform skips)
- release-style Linux Native AOT, pointer, and managed-fallback packages built and installed from an isolated local feed
- packaged-tool usability: version and embedded skills, ASP.NET type/member routing, NuGet package inspection, JSON projection, and checksum-verified `Original Source`

## Compatibility

This is primarily a bug-fix and hardening release. The documented experimental enum-label ordering and ArrayPool ownership improvements are the intentional behavior additions.
