### PR TITLE
Isolate projection capture rendezvous from suite scheduling

### DIFF
--- a/src/dotnet-inspect.Tests/ConsoleCaptureTests.cs
+++ b/src/dotnet-inspect.Tests/ConsoleCaptureTests.cs
@@ -3,6 +3,11 @@ using DotnetInspector.Output;
 
 namespace DotnetInspector.Tests;
 
+// This harness deliberately holds ConsoleCapture across assertions. Isolate it from every
+// external test so acquiring the semaphore tests this class, not suite scheduling (#4141).
+[CollectionDefinition("ConsoleCaptureGuard", DisableParallelization = true)]
+public class ConsoleCaptureGuardCollection;
+
 /// <summary>
 /// Gates for the console-redirection invariant behind #3416. The flake there was not a
 /// wrong assertion in any one test; it was two tests redirecting the process-global
@@ -10,6 +15,7 @@ namespace DotnetInspector.Tests;
 /// excludes concurrent captures, and that no other file in this assembly redirects the
 /// console outside that lock.
 /// </summary>
+[Collection("ConsoleCaptureGuard")]
 public class ConsoleCaptureTests
 {
     /// <summary>
@@ -121,15 +127,11 @@ public class ConsoleCaptureTests
         var capture = ConsoleCapture.RunAsync(async () =>
         {
             captureEntered.SetResult();
-            await releaseCapture.Task.WaitAsync(
-                TimeSpan.FromSeconds(30),
-                TestContext.Current.CancellationToken);
+            await releaseCapture.Task.WaitAsync(TestContext.Current.CancellationToken);
             return 0;
         });
 
-        await captureEntered.Task.WaitAsync(
-            TimeSpan.FromSeconds(30),
-            TestContext.Current.CancellationToken);
+        await captureEntered.Task.WaitAsync(TestContext.Current.CancellationToken);
 
         bool exclusive;
         int exitCode;


### PR DESCRIPTION
Fixes #4141.

`ProjectionAuditDiagnosticsDoNotLeakIntoConcurrentCapture` no longer treats time spent queued behind an unrelated `ConsoleCapture` owner as a failure of projection-audit diagnostic isolation.

`ConsoleCaptureTests` now uses a nonparallel xUnit collection, isolating its deliberate capture ownership from every external test while preserving the eight-worker concurrency exercised inside the class. The projection-audit rendezvous follows the test runner cancellation token instead of imposing a local 30-second scheduling deadline.

This is intentionally limited to the test harness. Product diagnostics and `ConsoleCapture` locking behavior are unchanged.

Validation on `28c6884a29683a8f27f670470923660f4160b51b`:

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build`: 3,653 total, 0 failed, 4 platform skips
- `ConsoleCaptureTests`: 5 passed
- `ConsoleCaptureTests` repeated 10 times: 10/10 runs passed
