### PR TITLE
Pin release tag to resolved commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,5 +313,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
+          target_commitish: ${{ needs.resolve.outputs.sha }}
           files: packages/*.nupkg
           generate_release_notes: true

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -121,7 +121,8 @@ The workflow then:
 4. Validates that the managed fallback retains its supported runtime reach and
    that the pointer remains TFM-agnostic.
 5. Publishes Native AOT packages, then the managed fallback, then the pointer.
-6. Creates a GitHub release from the package version and attaches all packages.
+6. Creates a GitHub release from the package version at the resolved CI commit
+   and attaches all packages.
 
 The pointer is deliberately published last because it references the
 runtime-specific packages.
@@ -138,6 +139,9 @@ runtime-specific packages.
   package job. Restore the pinned tools successfully before retrying.
 - **Reach validation fails:** fix the package shape rather than bypassing the
   guard.
+- **The release tag targets another commit:** move it to the resolved CI commit
+  and fix the workflow before the next release. The
+  `ReleaseWorkflow_TagsResolvedCiCommit` test gates this wiring.
 - **A package version already exists:** advance `VersionPrefix`; published
   package versions are immutable.
 - **A partially published release is retried:** the workflow uses

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -706,6 +706,21 @@ public class IlToolsActivationTests
     }
 
     [Fact]
+    public void ReleaseWorkflow_TagsResolvedCiCommit()
+    {
+        string workflow = File.ReadAllText(
+            Path.Combine(RepoRoot, ".github", "workflows", "release.yml"));
+        int releaseStep = workflow.IndexOf(
+            "- name: Create GitHub Release",
+            StringComparison.Ordinal);
+
+        Assert.True(releaseStep >= 0);
+        Assert.Contains(
+            "target_commitish: ${{ needs.resolve.outputs.sha }}",
+            workflow[releaseStep..]);
+    }
+
+    [Fact]
     public void ReleaseWorkflow_OracleTestLaneBlocksAllPackageJobs()
     {
         string workflow = File.ReadAllText(


### PR DESCRIPTION
## Summary

Ensure the GitHub release tag targets the exact CI commit resolved by the Publish workflow, rather than the workflow-dispatch branch tip. Add a focused wiring gate and document tag-target recovery.

This was exposed by v0.18.0: packages were correctly built from `45538e23147e2ec6be0867fd5bace60ec19c6abb`, but the release action initially created `v0.18.0` at unrelated `main` tip `22912c3c78918d42b09ba2adac322cabae1f08e3`. The public tag has been corrected to the package source commit.

**Validation:** `dotnet run --project src/dotnet-inspect.Tests -c Release -- -class "*IlToolsActivationTests"` (34 passed); `npx markdownlint-cli docs/release-workflow.md`.