### PR TITLE
Extract library body reference metadata resolver

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -732,9 +732,15 @@ Research overlay bridge, and the application layer:
   `IOptimizationOpportunityResolver`; the producer does not own the metadata
   reader, generic scope, or raw IL. The assembly reader retains PE/body
   acquisition, the intentionally throwing decode path, method identity and
-  scope creation, metadata and raw-IL ownership through the shared narrow
-  method-analysis resolver, orchestration and diagnostics, resource/leak
-  analysis, and result aggregation.
+  scope creation, primary-image metadata and raw-IL ownership through the shared
+  narrow method-analysis resolver, orchestration and diagnostics, resource/leak
+  analysis, and result aggregation. Cross-assembly type-definition binding,
+  referenced-image metadata lifetime, and the registration-keyed cache belong
+  to `LibraryBodyReferenceMetadataResolver`, which composes
+  `AssemblyReferenceBindingPolicy` and `TypeResolutionCatalog`.
+  `CrossAssemblyMetadataResolver_FollowsForwardersToDefiningAssembly` and
+  `ForwarderIntoFrameworkSignedAssemblyIsResolvedUnderPlatformScope` gate its
+  forwarder and binding-scope behavior.
   `MethodInstructionFacts` owns the
   metadata-free local/argument-slot, operand, and single-branch-target grammar
   shared by safety and allocation

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -284,12 +284,16 @@ reader, generic scope, or raw IL. Call-site acquisition uses the same
 The assembly reader retains exactly: PE/body
 acquisition, the intentionally throwing `InstructionDecoder.Decode` +
 `BlockGraph.Build` decode, loop-region computation for the context, method
-identity and generic-scope creation, metadata ownership and token resolution,
-raw-IL ownership through the shared narrow method-analysis resolver, per-method
-orchestration and recoverable-failure diagnostics, resource/leak analysis, and
-result aggregation. Topic producers may each traverse the canonical decoded
-instructions for their own policy; this ownership split does not claim one
-instruction traversal overall.
+identity and generic-scope creation, primary-image metadata ownership and token
+resolution, raw-IL ownership through the shared narrow method-analysis resolver,
+per-method orchestration and recoverable-failure diagnostics, resource/leak
+analysis, and result aggregation. `LibraryBodyReferenceMetadataResolver`
+separately owns cross-assembly type-definition binding, referenced-image
+metadata lifetime, and its registration-keyed cache for that acquisition. It
+builds on `AssemblyReferenceBindingPolicy` and `TypeResolutionCatalog` rather
+than adding another binding engine. Topic producers may each traverse the
+canonical decoded instructions for their own policy; this ownership split does
+not claim one instruction traversal overall.
 `MethodInstructionFacts` owns the metadata-free local/argument-slot, operand,
 and single-branch-target grammar shared by safety and allocation interpretation,
 and `CompilerGeneratedNames` owns the unspeakable-name grammar shared by

--- a/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
+++ b/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
@@ -14,21 +14,16 @@ namespace ILInspector.Analysis;
 /// <summary>
 /// Decodes one assembly's IL bodies and metadata into a
 /// <see cref="LibraryBodyAnalysisResult"/> bundle. It consumes one caller-owned
-/// <see cref="MetadataReader"/>/<see cref="PEReader"/> pair and owns the
-/// cross-assembly reference-resolution state created for that acquisition.
+/// <see cref="MetadataReader"/>/<see cref="PEReader"/> pair and owns the lifetime
+/// of the cross-assembly reference-resolution service created for that
+/// acquisition.
 /// </summary>
 internal sealed class LibraryBodyAnalysisBuilder : IDisposable
 {
     readonly string _path;
     readonly MetadataReader _reader;
     readonly PEReader _peReader;
-    readonly TypeResolutionCatalog? _resolutionCatalog;
-    readonly AssemblyReferenceBindingPolicy? _bindingPolicy;
-    readonly ResolvedAssemblyReference? _rootAssembly;
-    readonly Dictionary<
-        AssemblyAcquisitionRegistration,
-        ReferencedAssemblyMetadata?> _referencedAssemblyCache =
-            new(ReferenceEqualityComparer.Instance);
+    readonly LibraryBodyReferenceMetadataResolver? _referenceMetadataResolver;
     readonly string _assemblyName;
     readonly Guid _mvid;
     readonly bool _memorySafetyRulesEnabled;
@@ -42,194 +37,25 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
         _mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
         _memorySafetyRulesEnabled = DetectMemorySafetyRules();
         if (resolver is not null && reader.IsAssembly)
-        {
-            string fullPath = System.IO.Path.GetFullPath(path);
-            _rootAssembly = ResolvedAssemblyReference.Create(
-                AssemblyReferenceIdentity.FromAssemblyDefinition(reader),
-                fullPath,
-                () => File.OpenRead(fullPath),
-                AssemblyResolutionProvenance.Local(
-                    "LibraryBodyIndex"));
-            _bindingPolicy =
-                new AssemblyReferenceBindingPolicy(resolver);
-            _resolutionCatalog = new TypeResolutionCatalog();
-        }
+            _referenceMetadataResolver =
+                new LibraryBodyReferenceMetadataResolver(
+                    path,
+                    reader,
+                    resolver);
     }
 
-    public void Dispose()
-    {
-        foreach (var assembly in _referencedAssemblyCache.Values)
-            assembly?.Dispose();
-        _referencedAssemblyCache.Clear();
-        _resolutionCatalog?.Dispose();
-    }
+    public void Dispose() =>
+        _referenceMetadataResolver?.Dispose();
+
+    internal (MetadataReader DefiningReader, TypeDefinitionHandle Definition)?
+        TryResolveExternalTypeDefinition(TypeReferenceHandle handle) =>
+        _referenceMetadataResolver?.TryResolveExternalTypeDefinition(
+            handle);
 
     // Roslyn's ModuleSymbol.UseUpdatedMemorySafetyRules: the module opted in
     // when MemorySafetyRulesAttribute is applied (emitted [module:], like
     // RefSafetyRulesAttribute). Check the module and assembly scopes.
     public bool MemorySafetyRulesEnabled => _memorySafetyRulesEnabled;
-
-    sealed class ReferencedAssemblyMetadata(Stream stream, PEReader peReader) : IDisposable
-    {
-        public MetadataReader Reader { get; } = peReader.GetMetadataReader();
-
-        internal static ReferencedAssemblyMetadata? TryOpen(
-            ResolvedAssemblyReference assembly)
-        {
-            Stream? stream = null;
-            PEReader? peReader = null;
-            try
-            {
-                stream = assembly.OpenRead();
-                peReader = new PEReader(stream);
-                if (!peReader.HasMetadata)
-                    return null;
-                var metadata =
-                    new ReferencedAssemblyMetadata(stream, peReader);
-                stream = null;
-                peReader = null;
-                return metadata;
-            }
-            catch (Exception ex) when (
-                ex is IOException
-                    or UnauthorizedAccessException
-                    or BadImageFormatException
-                    or InvalidOperationException
-                    or NotSupportedException
-                    or ArgumentException)
-            {
-                return null;
-            }
-            finally
-            {
-                peReader?.Dispose();
-                stream?.Dispose();
-            }
-        }
-
-        public void Dispose()
-        {
-            peReader.Dispose();
-            stream.Dispose();
-        }
-    }
-
-    internal (MetadataReader DefiningReader, TypeDefinitionHandle Definition)? TryResolveExternalTypeDefinition(TypeReferenceHandle handle)
-        => TryResolveExternalTypeDefinition(handle, new HashSet<TypeReferenceHandle>());
-
-    (MetadataReader DefiningReader, TypeDefinitionHandle Definition)? TryResolveExternalTypeDefinition(
-        TypeReferenceHandle handle,
-        HashSet<TypeReferenceHandle> visited)
-    {
-        if (handle.IsNil || !visited.Add(handle))
-            return null;
-
-        var typeRef = _reader.GetTypeReference(handle);
-        string name = _reader.GetString(typeRef.Name);
-        string ns = _reader.GetString(typeRef.Namespace);
-        return typeRef.ResolutionScope.Kind switch
-        {
-            HandleKind.AssemblyReference => TryResolveTopLevelExternalType(
-                (AssemblyReferenceHandle)typeRef.ResolutionScope,
-                ns,
-                name),
-            HandleKind.TypeReference => TryResolveNestedExternalType(
-                (TypeReferenceHandle)typeRef.ResolutionScope,
-                ns,
-                name,
-                visited),
-            _ => null,
-        };
-    }
-
-    (MetadataReader DefiningReader, TypeDefinitionHandle Definition)? TryResolveTopLevelExternalType(
-        AssemblyReferenceHandle assemblyReference,
-        string ns,
-        string name)
-    {
-        if (_resolutionCatalog is null
-            || _bindingPolicy is null
-            || _rootAssembly is null
-            || MetadataTypeDefinitionName.Create(ns, [name])
-                is not MetadataTypeDefinitionNameResult.Valid valid)
-        {
-            return null;
-        }
-
-        var identity = AssemblyReferenceIdentity.From(_reader, assemblyReference);
-        var scope = ScopeForReference(assemblyReference);
-        var request = TypeResolutionRequest.FromReference(
-            identity,
-            AssemblyBindingOrigin.FromAssembly(_rootAssembly),
-            scope,
-            valid.Name);
-        using TypeResolutionContext context =
-            _resolutionCatalog.CreateContext(
-                _bindingPolicy,
-                [_rootAssembly],
-                [request]);
-        if (context.Resolve(request)
-            is not TypeResolutionOutcome.Resolved resolved)
-        {
-            return null;
-        }
-
-        ReferencedAssemblyMetadata? metadata =
-            OpenReferencedAssembly(
-                resolved.Definition.Assembly.Assembly);
-        return metadata is not null
-            && resolved.Definition.Address.TryResolve(
-                metadata.Reader,
-                out TypeDefinitionHandle definition)
-                ? (metadata.Reader, definition)
-                : null;
-    }
-
-    (MetadataReader DefiningReader, TypeDefinitionHandle Definition)? TryResolveNestedExternalType(
-        TypeReferenceHandle declaringReference,
-        string ns,
-        string name,
-        HashSet<TypeReferenceHandle> visited)
-    {
-        var declaring = TryResolveExternalTypeDefinition(declaringReference, visited);
-        if (declaring is not { } resolvedDeclaring)
-            return null;
-
-        var declaringDefinition = resolvedDeclaring.DefiningReader.GetTypeDefinition(resolvedDeclaring.Definition);
-        foreach (var nestedHandle in declaringDefinition.GetNestedTypes())
-        {
-            var nested = resolvedDeclaring.DefiningReader.GetTypeDefinition(nestedHandle);
-            if ((ns.Length == 0 || resolvedDeclaring.DefiningReader.StringComparer.Equals(nested.Namespace, ns))
-                && resolvedDeclaring.DefiningReader.StringComparer.Equals(nested.Name, name))
-                return (resolvedDeclaring.DefiningReader, nestedHandle);
-        }
-
-        return null;
-    }
-
-    ReferencedAssemblyMetadata? OpenReferencedAssembly(
-        ResolvedAssemblyReference assembly)
-    {
-        lock (_referencedAssemblyCache)
-        {
-            if (_referencedAssemblyCache.TryGetValue(
-                    assembly.Registration,
-                    out ReferencedAssemblyMetadata? cached))
-            {
-                return cached;
-            }
-
-            ReferencedAssemblyMetadata? opened =
-                ReferencedAssemblyMetadata.TryOpen(assembly);
-            _referencedAssemblyCache[assembly.Registration] = opened;
-            return opened;
-        }
-    }
-
-    AssemblyResolutionScope ScopeForReference(AssemblyReferenceHandle handle)
-        => FrameworkAssemblyKeys.IsFrameworkReference(_reader, handle)
-            ? AssemblyResolutionScope.Platform
-            : AssemblyResolutionScope.Any;
 
     static MethodInstructions DecodeBody(byte[] il, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
     {
@@ -325,9 +151,8 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
         // method body. For a full (unscoped) build the analysis runs in parallel across cores;
         // each method writes only to method-local builders, and results are merged back in
         // metadata order below, so output is byte-identical to a sequential build. Metadata/PE
-        // reads are thread-safe on the immutable prefetched image (see Open); the two lazily
-        // populated caches touched during analysis are made concurrency-safe (AsyncStateMachineTypes
-        // is prewarmed here, _referencedAssemblyCache is lock-guarded).
+        // reads are thread-safe on the immutable prefetched image (see Open); the lazily
+        // populated AsyncStateMachineTypes cache is prewarmed here.
         var workItems = new List<(TypeDefinitionHandle TypeHandle, TypeDefinition TypeDef, bool TypeSourceGenerated, MethodDefinitionHandle MethodHandle)>();
         foreach (var typeHandle in _reader.TypeDefinitions)
         {
@@ -505,8 +330,7 @@ internal sealed class LibraryBodyAnalysisBuilder : IDisposable
     // Analyze a single method into a MethodBuildResult. Mirrors the original per-method loop body
     // statement-for-statement, writing to method-local builders instead of the shared Build()
     // builders. Safe to run concurrently: metadata/PE reads are thread-safe on the prefetched
-    // image, and the only lazily-populated shared caches it can touch are AsyncStateMachineTypes
-    // (prewarmed) and _referencedAssemblyCache (lock-guarded).
+    // image, and its lazily-populated AsyncStateMachineTypes cache is prewarmed.
     MethodBuildResult ProcessMethod(TypeDefinitionHandle typeHandle, TypeDefinition typeDef, bool typeSourceGenerated,
         MethodDefinitionHandle methodHandle, bool includeMethodEvidence,
         bool includeAllocations, bool includeOpportunities, bool includeLeakTriage,

--- a/src/ILInspector.Analysis/LibraryBodyReferenceMetadataResolver.cs
+++ b/src/ILInspector.Analysis/LibraryBodyReferenceMetadataResolver.cs
@@ -1,0 +1,245 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Metadata;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Owns cross-assembly type-definition resolution and acquired metadata for one
+/// library-body analysis.
+/// </summary>
+internal sealed class LibraryBodyReferenceMetadataResolver : IDisposable
+{
+    readonly MetadataReader _reader;
+    readonly TypeResolutionCatalog? _resolutionCatalog;
+    readonly AssemblyReferenceBindingPolicy? _bindingPolicy;
+    readonly ResolvedAssemblyReference? _rootAssembly;
+    readonly Dictionary<
+        AssemblyAcquisitionRegistration,
+        ReferencedAssemblyMetadata?> _referencedAssemblyCache =
+            new(ReferenceEqualityComparer.Instance);
+
+    internal LibraryBodyReferenceMetadataResolver(
+        string path,
+        MetadataReader reader,
+        IAssemblyReferenceResolver? resolver)
+    {
+        _reader = reader;
+        if (resolver is not null && reader.IsAssembly)
+        {
+            string fullPath = Path.GetFullPath(path);
+            _rootAssembly = ResolvedAssemblyReference.Create(
+                AssemblyReferenceIdentity.FromAssemblyDefinition(reader),
+                fullPath,
+                () => File.OpenRead(fullPath),
+                AssemblyResolutionProvenance.Local(
+                    "LibraryBodyIndex"));
+            _bindingPolicy =
+                new AssemblyReferenceBindingPolicy(resolver);
+            _resolutionCatalog = new TypeResolutionCatalog();
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var assembly in _referencedAssemblyCache.Values)
+            assembly?.Dispose();
+        _referencedAssemblyCache.Clear();
+        _resolutionCatalog?.Dispose();
+    }
+
+    internal (MetadataReader DefiningReader, TypeDefinitionHandle Definition)?
+        TryResolveExternalTypeDefinition(TypeReferenceHandle handle) =>
+        TryResolveExternalTypeDefinition(
+            handle,
+            new HashSet<TypeReferenceHandle>());
+
+    (MetadataReader DefiningReader, TypeDefinitionHandle Definition)?
+        TryResolveExternalTypeDefinition(
+            TypeReferenceHandle handle,
+            HashSet<TypeReferenceHandle> visited)
+    {
+        if (handle.IsNil || !visited.Add(handle))
+            return null;
+
+        var typeRef = _reader.GetTypeReference(handle);
+        string name = _reader.GetString(typeRef.Name);
+        string ns = _reader.GetString(typeRef.Namespace);
+        return typeRef.ResolutionScope.Kind switch
+        {
+            HandleKind.AssemblyReference => TryResolveTopLevelExternalType(
+                (AssemblyReferenceHandle)typeRef.ResolutionScope,
+                ns,
+                name),
+            HandleKind.TypeReference => TryResolveNestedExternalType(
+                (TypeReferenceHandle)typeRef.ResolutionScope,
+                ns,
+                name,
+                visited),
+            _ => null,
+        };
+    }
+
+    (MetadataReader DefiningReader, TypeDefinitionHandle Definition)?
+        TryResolveTopLevelExternalType(
+            AssemblyReferenceHandle assemblyReference,
+            string ns,
+            string name)
+    {
+        if (_resolutionCatalog is null
+            || _bindingPolicy is null
+            || _rootAssembly is null
+            || MetadataTypeDefinitionName.Create(ns, [name])
+                is not MetadataTypeDefinitionNameResult.Valid valid)
+        {
+            return null;
+        }
+
+        var identity =
+            AssemblyReferenceIdentity.From(
+                _reader,
+                assemblyReference);
+        var scope = ScopeForReference(assemblyReference);
+        var request = TypeResolutionRequest.FromReference(
+            identity,
+            AssemblyBindingOrigin.FromAssembly(_rootAssembly),
+            scope,
+            valid.Name);
+        using TypeResolutionContext context =
+            _resolutionCatalog.CreateContext(
+                _bindingPolicy,
+                [_rootAssembly],
+                [request]);
+        if (context.Resolve(request)
+            is not TypeResolutionOutcome.Resolved resolved)
+        {
+            return null;
+        }
+
+        ReferencedAssemblyMetadata? metadata =
+            OpenReferencedAssembly(
+                resolved.Definition.Assembly.Assembly);
+        return metadata is not null
+            && resolved.Definition.Address.TryResolve(
+                metadata.Reader,
+                out TypeDefinitionHandle definition)
+                ? (metadata.Reader, definition)
+                : null;
+    }
+
+    (MetadataReader DefiningReader, TypeDefinitionHandle Definition)?
+        TryResolveNestedExternalType(
+            TypeReferenceHandle declaringReference,
+            string ns,
+            string name,
+            HashSet<TypeReferenceHandle> visited)
+    {
+        var declaring =
+            TryResolveExternalTypeDefinition(
+                declaringReference,
+                visited);
+        if (declaring is not { } resolvedDeclaring)
+            return null;
+
+        var declaringDefinition =
+            resolvedDeclaring.DefiningReader.GetTypeDefinition(
+                resolvedDeclaring.Definition);
+        foreach (var nestedHandle
+            in declaringDefinition.GetNestedTypes())
+        {
+            var nested =
+                resolvedDeclaring.DefiningReader.GetTypeDefinition(
+                    nestedHandle);
+            if ((ns.Length == 0
+                    || resolvedDeclaring.DefiningReader.StringComparer.Equals(
+                        nested.Namespace,
+                        ns))
+                && resolvedDeclaring.DefiningReader.StringComparer.Equals(
+                    nested.Name,
+                    name))
+            {
+                return (
+                    resolvedDeclaring.DefiningReader,
+                    nestedHandle);
+            }
+        }
+
+        return null;
+    }
+
+    ReferencedAssemblyMetadata? OpenReferencedAssembly(
+        ResolvedAssemblyReference assembly)
+    {
+        lock (_referencedAssemblyCache)
+        {
+            if (_referencedAssemblyCache.TryGetValue(
+                    assembly.Registration,
+                    out ReferencedAssemblyMetadata? cached))
+            {
+                return cached;
+            }
+
+            ReferencedAssemblyMetadata? opened =
+                ReferencedAssemblyMetadata.TryOpen(assembly);
+            _referencedAssemblyCache[assembly.Registration] = opened;
+            return opened;
+        }
+    }
+
+    AssemblyResolutionScope ScopeForReference(
+        AssemblyReferenceHandle handle) =>
+        FrameworkAssemblyKeys.IsFrameworkReference(_reader, handle)
+            ? AssemblyResolutionScope.Platform
+            : AssemblyResolutionScope.Any;
+
+    sealed class ReferencedAssemblyMetadata(
+        Stream stream,
+        PEReader peReader) : IDisposable
+    {
+        public MetadataReader Reader { get; } =
+            peReader.GetMetadataReader();
+
+        internal static ReferencedAssemblyMetadata? TryOpen(
+            ResolvedAssemblyReference assembly)
+        {
+            Stream? stream = null;
+            PEReader? peReader = null;
+            try
+            {
+                stream = assembly.OpenRead();
+                peReader = new PEReader(stream);
+                if (!peReader.HasMetadata)
+                    return null;
+                var metadata =
+                    new ReferencedAssemblyMetadata(
+                        stream,
+                        peReader);
+                stream = null;
+                peReader = null;
+                return metadata;
+            }
+            catch (Exception ex) when (
+                ex is IOException
+                    or UnauthorizedAccessException
+                    or BadImageFormatException
+                    or InvalidOperationException
+                    or NotSupportedException
+                    or ArgumentException)
+            {
+                return null;
+            }
+            finally
+            {
+                peReader?.Dispose();
+                stream?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            peReader.Dispose();
+            stream.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- move cross-assembly type-definition binding, referenced-image metadata lifetime, and the registration-keyed cache from `LibraryBodyAnalysisBuilder` into `LibraryBodyReferenceMetadataResolver`
- compose the existing `AssemblyReferenceBindingPolicy` and `TypeResolutionCatalog` rather than introducing another binding engine
- retain the builder internal resolution entry point as a one-line compatibility façade while preserving constructor and disposal ordering

## Behavioral claim

Reference resolution, forwarder traversal, scope tightening, recoverable acquisition failures, cache identity, and disposal behavior are unchanged. The default no-resolver path allocates no resolver service; resolver-enabled acquisitions add one assembly-scoped owner and no per-method objects. Body acquisition, decode, orchestration, failure ordering, output, and command behavior are untouched.

## Evidence

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore`: 637 passed on head `148ad36b848ab1a6bf5a3e1406b51127a19a3f99`
- `npx markdownlint-cli docs/architecture.md docs/design/method-body-inspection.md`: passed
- existing forwarder, cycle, null-resolver, readable-metadata, non-downgrade, scope-tightening, and unchanged-index-shape gates continue through the builder façade

## Compatibility boundary

This is an internal ownership extraction. It does not change public APIs or make cross-assembly resolution eager. `LibraryBodyAnalysisBuilder` remains the assembly scheduler/orchestrator and owns the focused service lifetime.

## Review sequencing

The user explicitly requested that adversarial review start with the PR rather than waiting for CI completion. Review and CI are pinned to base `9a38cb892a7dad0bff02a22964dd9099acbe388d` and head `148ad36b848ab1a6bf5a3e1406b51127a19a3f99`; CI must still pass before readiness.