### PR TITLE
Resolve authored corpus tokens from copied assemblies

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AuthoredCorpusRatchetTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredCorpusRatchetTests.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using ILInspector.DecompilerHarness;
 
 namespace ILInspector.Decompiler.Tests;
@@ -877,6 +878,27 @@ public class AuthoredCorpusRatchetTests
 
         Assert.Equal(1, shortened.RootElement.GetProperty("malformedRows").GetInt32());
         Assert.False(shortened.RootElement.GetProperty("inputsComplete").GetBoolean());
+    }
+
+    [Fact]
+    public void CorrelatedCorpusRow_RejectsMismatchedMemberIdentity()
+    {
+        string assembly =
+            typeof(ILInspector.CSharp.CSharpFormatter).Assembly.Location;
+        var row = JsonNode.Parse(
+                AuthoredCorpusTestData.CorrelatedRow(assembly))!
+            .AsObject();
+        row["signature"] = "`0(NotTheFixtureSignature)";
+
+        InvalidDataException failure = Assert.Throws<InvalidDataException>(
+            () => AuthoredCorpusTestData.CorrelateRow(
+                row.ToJsonString(),
+                assembly));
+
+        Assert.Contains(
+            "does not match the copied assembly",
+            failure.Message,
+            StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/AuthoredCorpusTestData.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredCorpusTestData.cs
@@ -1,8 +1,10 @@
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text.Json.Nodes;
 
 using ILInspector.DecompilerHarness;
+using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -17,6 +19,9 @@ static class AuthoredCorpusTestData
             File.ReadLines(FixturePath("two-row-authored-corpus.jsonl"))
                 .Select(row => Correlate(row, assemblyPath)))
             + Environment.NewLine;
+
+    public static string CorrelateRow(string rowJson, string assemblyPath)
+        => Correlate(rowJson, assemblyPath);
 
     public static string WriteCorrelatedCorpus(string assemblyPath)
     {
@@ -37,8 +42,84 @@ static class AuthoredCorpusTestData
         row["assembly"] = identity.Name;
         row["assemblyVersion"] = identity.Version;
         row["moduleVersionId"] = reader.GetGuid(reader.GetModuleDefinition().Mvid);
+        row["metadataToken"] = MetadataTokens.GetToken(
+            FindMethodDefinition(reader, row));
         return row.ToJsonString();
     }
+
+    static MethodDefinitionHandle FindMethodDefinition(
+        MetadataReader reader,
+        JsonObject row)
+    {
+        string typeName = RequiredString(row, "type");
+        string methodName = RequiredString(row, "method");
+        int overload = RequiredInt32(row, "overload");
+        string signature = RequiredString(row, "signature");
+        MethodDefinitionHandle? match = null;
+
+        foreach (TypeDefinitionHandle typeHandle in reader.TypeDefinitions)
+        {
+            TypeDefinition type = reader.GetTypeDefinition(typeHandle);
+            if (!string.Equals(
+                    reader.GetFullTypeName(type),
+                    typeName,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (MethodDefinitionHandle methodHandle in type.GetMethods())
+            {
+                MethodDefinition method =
+                    reader.GetMethodDefinition(methodHandle);
+                if (!string.Equals(
+                        reader.GetString(method.Name),
+                        methodName,
+                        StringComparison.Ordinal)
+                    || ReturnToSenderSourceProbe.OverloadIndex(
+                        reader,
+                        type,
+                        methodHandle,
+                        methodName) != overload
+                    || !string.Equals(
+                        ReturnToSenderSourceProbe.UniqueTargetSignature(
+                            reader,
+                            type,
+                            methodName,
+                            methodHandle),
+                        signature,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (match is not null)
+                {
+                    throw new InvalidDataException(
+                        $"The authored-corpus test identity {typeName}::{methodName}#{overload} "
+                            + "matches more than one MethodDef.");
+                }
+
+                match = methodHandle;
+            }
+        }
+
+        return match
+            ?? throw new InvalidDataException(
+                $"The authored-corpus test identity {typeName}::{methodName}#{overload} "
+                    + "does not match the copied assembly.");
+    }
+
+    static string RequiredString(JsonObject row, string propertyName)
+        => row[propertyName]?.GetValue<string>() is { Length: > 0 } value
+            ? value
+            : throw new InvalidDataException(
+                $"The authored-corpus test row requires a non-empty '{propertyName}'.");
+
+    static int RequiredInt32(JsonObject row, string propertyName)
+        => row[propertyName]?.GetValue<int>()
+            ?? throw new InvalidDataException(
+                $"The authored-corpus test row requires an integer '{propertyName}'.");
 
     static string ReadFixture(string fileName)
         => File.ReadAllText(FixturePath(fileName)).TrimEnd();

--- a/src/ILInspector.Decompiler.Tests/IrInvariantsHostContractTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrInvariantsHostContractTests.cs
@@ -297,6 +297,25 @@ public sealed class IrInvariantsHostContractTests
         Assert.Equal(new[] { ShippedToolEntryPoint }, sites);
     }
 
+    [Fact]
+    public void RepositoryLocalWorktreesAreNotCountedAsDuplicateHosts()
+    {
+        string root = Path.Combine(Path.GetTempPath(), "repository");
+        string linkedWorktreeSource = Path.Combine(
+            root,
+            ".worktrees",
+            "review",
+            "src",
+            "Program.cs");
+        string repositorySource = Path.Combine(
+            root,
+            "src",
+            "Program.cs");
+
+        Assert.True(IsExcluded(root, linkedWorktreeSource));
+        Assert.False(IsExcluded(root, repositorySource));
+    }
+
     static List<string> FindOptOutSites()
     {
         string root = FindRepositoryRoot();
@@ -421,8 +440,9 @@ public sealed class IrInvariantsHostContractTests
             .Any(invocation => invocation.Expression is IdentifierNameSyntax { Identifier.ValueText: "nameof" });
 
     /// <summary>
-    /// Build output and version control only. Anything else under the repo root
-    /// is a candidate host, including directories that do not exist yet.
+    /// Build output, version control, and repository-local linked worktrees only.
+    /// Anything else under the repo root is a candidate host, including
+    /// directories that do not exist yet.
     /// </summary>
     static bool IsExcluded(string root, string path)
     {
@@ -430,7 +450,12 @@ public sealed class IrInvariantsHostContractTests
         string[] segments = relative.Split(Path.DirectorySeparatorChar);
 
         return segments.Any(static segment =>
-            segment is "bin" or "obj" or ".git" or "artifacts" or "node_modules");
+            segment is "bin"
+                or "obj"
+                or ".git"
+                or ".worktrees"
+                or "artifacts"
+                or "node_modules");
     }
 
     static bool PathsEqual(string left, string right) =>


### PR DESCRIPTION
Closes #4182.

## Change

- resolves each authored-corpus test row to the exact MethodDef in the copied assembly using type, method, overload, and unique signature instead of retaining the fixture token
- rejects genuinely mismatched member identities rather than repairing or suppressing correlation failures
- excludes repository-local `.worktrees` checkouts from the IR host census, with a direct gate that ordinary source remains included

The change is test-input construction only; production and harness correlation remain strict and unchanged.

## Validation

- Release solution build: pass
- focused erased-row, mismatched-identity, and host-census tests: 4 passed
- fast decompiler suite on macOS: 4,938 passed, 1 skipped, 1 unrelated existing failure in `EvilPoolPinTests.TheSweepReadsAPinFileTheSameWayInBothModes` because macOS reports the same temporary path as `/var/...` and `/private/var/...`
- `ilasm`/`ildasm` activation was unavailable locally because nuget.org returned a socket error; CI remains responsible for Linux/Windows oracle coverage
