### PR TITLE
Isolate the repository line-ending Git probe

### DIFF
--- a/src/dotnet-inspect.Tests/RepositoryLineEndingTests.cs
+++ b/src/dotnet-inspect.Tests/RepositoryLineEndingTests.cs
@@ -3,6 +3,12 @@ using System.Text;
 
 namespace DotnetInspector.Tests;
 
+// Git inventories the entire working tree for this gate. Keep that external process out of
+// the suite's parallel phase so its timeout detects a stuck Git process, not CPU contention.
+[CollectionDefinition("RepositoryWorkingTreeGuard", DisableParallelization = true)]
+public sealed class RepositoryWorkingTreeGuardCollection;
+
+[Collection("RepositoryWorkingTreeGuard")]
 public sealed class RepositoryLineEndingTests
 {
     /// <summary>


### PR DESCRIPTION
Fixes #4197.

`RepositoryLineEndingTests` now runs in a nonparallel xUnit collection, keeping its repository-wide `git ls-files --eol -z` inventory out of the suite's parallel phase.

The Git process retains its 30-second bound, complete stdout/stderr draining, process-tree cleanup, and nonzero-exit diagnostics. The bound now detects a stuck Git process instead of CPU contention from unrelated tests.

Evidence:

- Idle Git EOL inventory: approximately 2 seconds.
- Parallel inventory load raised the same probe to 14 seconds.
- A deterministic PATH-local Git shim delayed 31 seconds reproduced the pre-fix `TaskCanceledException`.
- `RepositoryLineEndingTests`: 2 passed.
- The class repeated 10 times: 10/10 runs passed.
- Release solution build succeeded.
- Full CLI suite on `4a5efbba88d9e052c18d6f992390221fe2d17b05`: 3,764 total, 0 failed, 4 platform skips.
- TRX timing for the full suite: the Git inventory completed in 1.176 seconds with zero external test overlaps; its companion parser test also had zero overlaps.

No product behavior changes.
