### PR TITLE
Add browser NuGet mirror fallback

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -56,6 +56,13 @@ Downloaded package bytes are retained in a bounded session cache shared by API,
 documentation, source, call-graph, and Facts queries. The cache holds at most
 four packages or 64 MB and evicts the least recently used entry.
 
+Package acquisition uses nuget.org by default. If the browser cannot reach the
+active source, the app asks for an anonymous, CORS-enabled NuGet v3 mirror
+service-index URL, validates its `PackageBaseAddress`, and retries through the
+mirror. The service-index URL is stored in browser local storage and can be
+replaced or cleared under Settings. Package search uses the mirror's
+`SearchQueryService` when it publishes one.
+
 ## Run the .NET 11 browser-WASM prototype
 
 Install the experimental browser workload selected by the repository SDK:
@@ -71,6 +78,12 @@ Open `http://127.0.0.1:5198`. The browser downloads `System.Text.Json` version
 compile assets, and uses `AssemblyInspectionSession.ApiSurface()` to populate
 the public type workspace. Remote addresses require HTTPS because the .NET
 loader uses secure-context browser APIs.
+
+For a network that blocks nuget.org, open Settings and enter its permitted
+mirror's NuGet v3 service index, for example
+`https://mirror.example/nuget/v3/index.json`. The mirror must allow anonymous
+browser requests and CORS from the site's origin; credential-bearing URLs are
+rejected and are never written to local storage.
 
 Create a deployable static bundle with:
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -61,7 +61,9 @@ active source, the app asks for an anonymous, CORS-enabled NuGet v3 mirror
 service-index URL, validates its `PackageBaseAddress`, and retries through the
 mirror. The service-index URL is stored in browser local storage and can be
 replaced or cleared under Settings. Package search uses the mirror's
-`SearchQueryService` when it publishes one.
+`SearchQueryService` when it publishes one. Symbol packages remain a separate
+NuGet.org capability because `PackageBaseAddress` does not serve `.snupkg`
+payloads; when that endpoint is blocked, Source falls back to decompilation.
 
 ## Run the .NET 11 browser-WASM prototype
 
@@ -83,7 +85,11 @@ For a network that blocks nuget.org, open Settings and enter its permitted
 mirror's NuGet v3 service index, for example
 `https://mirror.example/nuget/v3/index.json`. The mirror must allow anonymous
 browser requests and CORS from the site's origin; credential-bearing URLs are
-rejected and are never written to local storage.
+rejected and are never written to local storage. Some upstream proxies also
+refuse to ingest a cold package from a browser request. Such a mirror must be
+warmed by a non-browser client before the browser can download that package;
+the app reports this as a mirror failure rather than prompting for another
+mirror.
 
 Create a deployable static bundle with:
 

--- a/prototypes/inspect-web/engine/Program.cs
+++ b/prototypes/inspect-web/engine/Program.cs
@@ -508,6 +508,10 @@ public static partial class BrowserInspectionEngine
     static long _packageCacheClock;
     static readonly HashSet<string> DownloadedPackages = new(StringComparer.Ordinal);
     static BrowserPackageSourceConfiguration _packageSource = DefaultPackageSource();
+    // Bumped on every SetPackageSource so in-flight downloads that outlive a
+    // source switch cannot repopulate the cleared caches or return old-source
+    // bytes labeled with the new source.
+    static int _packageSourceGeneration;
 
     sealed record PackageCacheEntry(byte[] Bytes, long LastAccess);
     sealed record SelectedPackageAssembly(
@@ -613,14 +617,16 @@ public static partial class BrowserInspectionEngine
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
 
+        var source = CapturePackageSource();
         var normalizedId = packageId.ToLowerInvariant();
         var resolvedVersion = await ResolvePackageVersionAsync(normalizedId, version);
         var normalizedVersion = resolvedVersion.ToLowerInvariant();
         var packageBytes = await GetPackageBytesAsync(normalizedId, normalizedVersion);
+        EnsurePackageSource(source.Generation);
         var content = new InMemoryPackageContent(
             packageBytes,
-            WasDownloaded(normalizedId, normalizedVersion),
-            _packageSource.ServiceIndexUrl);
+            WasDownloaded(source.Configuration, normalizedId, normalizedVersion),
+            source.Configuration.ServiceIndexUrl);
         PackageCompileAssetSelection selection =
             PackageCompileAssetSelector.Select(content, packageId, targetFramework);
         if (selection.Status == PackageCompileAssetSelectionStatus.NoCompileAssets)
@@ -907,8 +913,10 @@ public static partial class BrowserInspectionEngine
             return requestedVersion;
         }
 
-        var indexUrl = BuildPackageIndexUrl(normalizedId);
+        var source = CapturePackageSource();
+        var indexUrl = BuildPackageIndexUrl(source, normalizedId);
         var indexBytes = await GetPackageSourceBytesAsync(indexUrl);
+        EnsurePackageSource(source.Generation);
         using var document = JsonDocument.Parse(indexBytes);
         var versions = document.RootElement.GetProperty("versions")
             .EnumerateArray()
@@ -1275,13 +1283,15 @@ public static partial class BrowserInspectionEngine
         string targetFramework,
         string assemblyId)
     {
+        var source = CapturePackageSource();
         var normalizedId = packageId.ToLowerInvariant();
         var normalizedVersion = version.ToLowerInvariant();
         var packageBytes = await GetPackageBytesAsync(normalizedId, normalizedVersion);
+        EnsurePackageSource(source.Generation);
         var content = new InMemoryPackageContent(
             packageBytes,
-            WasDownloaded(normalizedId, normalizedVersion),
-            _packageSource.ServiceIndexUrl);
+            WasDownloaded(source.Configuration, normalizedId, normalizedVersion),
+            source.Configuration.ServiceIndexUrl);
         PackageCompileAssetSelection selection =
             PackageCompileAssetSelector.Select(content, packageId, targetFramework);
         PackageCompileAsset? selectedAssembly = selection.Status
@@ -3077,10 +3087,13 @@ public static partial class BrowserInspectionEngine
         string packageId,
         string targetFramework)
     {
+        // Caller already held package bytes for the active source; label with the
+        // current capture so a mid-flight source switch cannot rebrand them.
+        var source = CapturePackageSource();
         var content = new InMemoryPackageContent(
             packageBytes,
             fromCache: false,
-            producerKey: _packageSource.ServiceIndexUrl);
+            producerKey: source.Configuration.ServiceIndexUrl);
         PackageCompileAssetSelection selection =
             PackageCompileAssetSelector.Select(
                 content,
@@ -3142,10 +3155,11 @@ public static partial class BrowserInspectionEngine
         string targetFramework,
         string assemblyName)
     {
+        var source = CapturePackageSource();
         var content = new InMemoryPackageContent(
             packageBytes,
             fromCache: false,
-            producerKey: _packageSource.ServiceIndexUrl);
+            producerKey: source.Configuration.ServiceIndexUrl);
         PackageCompileAssetSelection selection =
             PackageCompileAssetSelector.Select(
                 content,
@@ -3537,11 +3551,12 @@ public static partial class BrowserInspectionEngine
     // the session. packId selects the CoreCLR or ASP.NET Core pack.
     static async Task<byte[]?> AcquireRuntimeFileAsync(string packId, string version, string fileName)
     {
-        var cacheKey = $"{_packageSource.ServiceIndexUrl}\n{packId}/{version}/{fileName}";
+        var source = CapturePackageSource();
+        var cacheKey = $"{source.Configuration.ServiceIndexUrl}\n{packId}/{version}/{fileName}";
         if (RuntimeFileCache.TryGetValue(cacheKey, out var cached))
             return cached;
 
-        var nupkgUrl = BuildPackageContentUrl(packId, version, "nupkg");
+        var nupkgUrl = BuildPackageContentUrl(source.Configuration, packId, version, "nupkg");
         bool IsWanted(string entryName) =>
             entryName.StartsWith("runtimes/", StringComparison.OrdinalIgnoreCase)
             && Path.GetFileName(entryName).Equals(fileName, StringComparison.OrdinalIgnoreCase);
@@ -3555,7 +3570,10 @@ public static partial class BrowserInspectionEngine
             bytes = ExtractEntryFromArchive(fullPack, IsWanted);
         }
         if (bytes is not null)
+        {
+            EnsurePackageSource(source.Generation);
             RuntimeFileCache[cacheKey] = bytes;
+        }
         return bytes;
     }
 
@@ -3648,8 +3666,10 @@ public static partial class BrowserInspectionEngine
 
     static async Task<string> ResolveRuntimePackVersionAsync(string packId, int major)
     {
-        var indexUrl = BuildPackageIndexUrl(packId);
+        var source = CapturePackageSource();
+        var indexUrl = BuildPackageIndexUrl(source, packId);
         var indexBytes = await GetPackageSourceBytesAsync(indexUrl);
+        EnsurePackageSource(source.Generation);
         using var document = JsonDocument.Parse(indexBytes);
         var versions = document.RootElement.GetProperty("versions")
             .EnumerateArray()
@@ -3881,7 +3901,8 @@ public static partial class BrowserInspectionEngine
 
     static async Task<byte[]> GetPackageBytesAsync(string normalizedId, string normalizedVersion)
     {
-        var key = PackageCacheKey(normalizedId, normalizedVersion);
+        var source = CapturePackageSource();
+        var key = PackageCacheKey(source.Configuration, normalizedId, normalizedVersion);
         lock (PackageCacheLock)
         {
             if (PackageCache.TryGetValue(key, out var cached))
@@ -3892,19 +3913,25 @@ public static partial class BrowserInspectionEngine
         }
 
         var packageUrl = BuildPackageContentUrl(
+            source.Configuration,
             normalizedId,
             normalizedVersion,
             "nupkg");
         var bytes = await GetPackageSourceBytesAsync(packageUrl);
+        EnsurePackageSource(source.Generation);
         lock (PackageCacheLock)
         {
+            // Re-check generation under the lock so a switch that lands between
+            // EnsurePackageSource and the cache write cannot repopulate a cleared cache.
+            if (source.Generation != _packageSourceGeneration)
+            {
+                throw new InvalidOperationException(
+                    $"{PackageSourceUnavailableMarker} The NuGet source changed during the request.");
+            }
             DownloadedPackages.Add(key);
-        }
-        if (bytes.LongLength > MaxCachedPackageBytes)
-            return bytes;
+            if (bytes.LongLength > MaxCachedPackageBytes)
+                return bytes;
 
-        lock (PackageCacheLock)
-        {
             while (PackageCache.Count >= MaxCachedPackages
                 || PackageCache.Values.Sum(entry => entry.Bytes.LongLength) + bytes.LongLength
                     > MaxCachedPackageBytes)
@@ -3929,9 +3956,26 @@ public static partial class BrowserInspectionEngine
             DefaultSearchQueryService,
             IsDefault: true);
 
+    sealed record CapturedPackageSource(
+        BrowserPackageSourceConfiguration Configuration,
+        int Generation);
+
+    static CapturedPackageSource CapturePackageSource() =>
+        new(_packageSource, _packageSourceGeneration);
+
+    static void EnsurePackageSource(int generation)
+    {
+        if (generation != _packageSourceGeneration)
+        {
+            throw new InvalidOperationException(
+                $"{PackageSourceUnavailableMarker} The NuGet source changed during the request.");
+        }
+    }
+
     static void SetPackageSource(BrowserPackageSourceConfiguration configuration)
     {
         _packageSource = configuration;
+        _packageSourceGeneration++;
         lock (PackageCacheLock)
         {
             PackageCache.Clear();
@@ -4005,9 +4049,13 @@ public static partial class BrowserInspectionEngine
         string resourceId,
         string resourceKind)
     {
+        // Match ValidateServiceIndexUrl: no credentials, query, or fragment.
+        // A query on PackageBaseAddress is dropped or mangled by EnsureTrailingSlash
+        // + relative Uri resolution, so reject it at validation time.
         if (!Uri.TryCreate(serviceIndex, resourceId, out Uri? resource)
             || resource.Scheme != Uri.UriSchemeHttps
             || !string.IsNullOrEmpty(resource.UserInfo)
+            || !string.IsNullOrEmpty(resource.Query)
             || !string.IsNullOrEmpty(resource.Fragment))
         {
             throw new InvalidDataException(
@@ -4019,30 +4067,44 @@ public static partial class BrowserInspectionEngine
     static string EnsureTrailingSlash(string value) =>
         value.EndsWith("/", StringComparison.Ordinal) ? value : value + "/";
 
-    static string PackageCacheKey(string normalizedId, string normalizedVersion) =>
-        $"{_packageSource.ServiceIndexUrl}\n{normalizedId}@{normalizedVersion}";
+    static string PackageCacheKey(
+        BrowserPackageSourceConfiguration source,
+        string normalizedId,
+        string normalizedVersion) =>
+        $"{source.ServiceIndexUrl}\n{normalizedId}@{normalizedVersion}";
 
-    static bool WasDownloaded(string normalizedId, string normalizedVersion)
+    static bool WasDownloaded(
+        BrowserPackageSourceConfiguration source,
+        string normalizedId,
+        string normalizedVersion)
     {
         lock (PackageCacheLock)
         {
             return DownloadedPackages.Contains(
-                PackageCacheKey(normalizedId, normalizedVersion));
+                PackageCacheKey(source, normalizedId, normalizedVersion));
         }
     }
 
-    static string BuildPackageIndexUrl(string normalizedId) =>
+    static string BuildPackageIndexUrl(
+        CapturedPackageSource source,
+        string normalizedId) =>
+        BuildPackageIndexUrl(source.Configuration, normalizedId);
+
+    static string BuildPackageIndexUrl(
+        BrowserPackageSourceConfiguration source,
+        string normalizedId) =>
         new Uri(
-            new Uri(_packageSource.PackageBaseAddress),
+            new Uri(source.PackageBaseAddress),
             $"{Uri.EscapeDataString(normalizedId)}/index.json")
         .AbsoluteUri;
 
     static string BuildPackageContentUrl(
+        BrowserPackageSourceConfiguration source,
         string normalizedId,
         string normalizedVersion,
         string extension) =>
         new Uri(
-            new Uri(_packageSource.PackageBaseAddress),
+            new Uri(source.PackageBaseAddress),
             $"{Uri.EscapeDataString(normalizedId)}/"
             + $"{Uri.EscapeDataString(normalizedVersion)}/"
             + $"{Uri.EscapeDataString(normalizedId)}."

--- a/prototypes/inspect-web/engine/Program.cs
+++ b/prototypes/inspect-web/engine/Program.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Collections.Immutable;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -458,8 +459,15 @@ public sealed record BrowserMetadataHeaders(
     int? MinorRuntimeVersion,
     int? EntryPointToken);
 
+public sealed record BrowserPackageSourceConfiguration(
+    string ServiceIndexUrl,
+    string PackageBaseAddress,
+    string? SearchQueryService,
+    bool IsDefault);
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(BrowserPackageSurface))]
+[JsonSerializable(typeof(BrowserPackageSourceConfiguration))]
 [JsonSerializable(typeof(BrowserPackageDocumentContent))]
 [JsonSerializable(typeof(BrowserMemberSource))]
 [JsonSerializable(typeof(BrowserCallGraph))]
@@ -484,6 +492,11 @@ internal sealed partial class BrowserJsonContext : JsonSerializerContext;
 [SupportedOSPlatform("browser")]
 public static partial class BrowserInspectionEngine
 {
+    const string DefaultServiceIndexUrl = "https://api.nuget.org/v3/index.json";
+    const string DefaultPackageBaseAddress = "https://api.nuget.org/v3-flatcontainer/";
+    const string DefaultSearchQueryService = "https://azuresearch-usnc.nuget.org/query";
+    const string PackageSourceUnavailableMarker = "[package-source-unreachable]";
+    const int MaxServiceIndexBytes = 1024 * 1024;
     static readonly HttpClient Http = new();
     static readonly InspectionQueryRegistry<AssemblyInspectionSession> AssemblyQueries =
         new InspectionQueryRegistry<AssemblyInspectionSession>()
@@ -494,11 +507,106 @@ public static partial class BrowserInspectionEngine
     const long MaxCachedPackageBytes = 128L * 1024 * 1024;
     static long _packageCacheClock;
     static readonly HashSet<string> DownloadedPackages = new(StringComparer.Ordinal);
+    static BrowserPackageSourceConfiguration _packageSource = DefaultPackageSource();
 
     sealed record PackageCacheEntry(byte[] Bytes, long LastAccess);
     sealed record SelectedPackageAssembly(
         PackageCompileAsset Asset,
         byte[] Image);
+
+    [JSExport]
+    public static async Task<string> ConfigurePackageSource(string serviceIndexUrl)
+    {
+        Uri serviceIndex = ValidateServiceIndexUrl(serviceIndexUrl);
+        byte[] indexBytes;
+        try
+        {
+            indexBytes = await ReadBoundedServiceIndexAsync(serviceIndex);
+        }
+        catch (Exception exception) when (
+            exception is HttpRequestException
+            or TaskCanceledException)
+        {
+            throw new InvalidOperationException(
+                "The NuGet mirror service index could not be reached from this browser. "
+                + "Use an anonymous, CORS-enabled mirror.",
+                exception);
+        }
+
+        BrowserPackageSourceConfiguration configuration;
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(indexBytes);
+            if (!document.RootElement.TryGetProperty("resources", out JsonElement resources)
+                || resources.ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidDataException(
+                    "The NuGet mirror service index has no resources array.");
+            }
+
+            string? packageBaseAddress = null;
+            string? searchQueryService = null;
+            foreach (JsonElement resource in resources.EnumerateArray())
+            {
+                if (!resource.TryGetProperty("@id", out JsonElement idElement)
+                    || idElement.ValueKind != JsonValueKind.String
+                    || idElement.GetString() is not { Length: > 0 } resourceId)
+                {
+                    continue;
+                }
+
+                if (packageBaseAddress is null
+                    && ResourceHasType(resource, "PackageBaseAddress/"))
+                {
+                    packageBaseAddress = ValidateResourceUrl(
+                        serviceIndex,
+                        resourceId,
+                        "PackageBaseAddress");
+                }
+                else if (searchQueryService is null
+                    && ResourceHasType(resource, "SearchQueryService/"))
+                {
+                    searchQueryService = ValidateResourceUrl(
+                        serviceIndex,
+                        resourceId,
+                        "SearchQueryService");
+                }
+            }
+
+            if (packageBaseAddress is null)
+            {
+                throw new InvalidDataException(
+                    "The NuGet mirror does not publish a PackageBaseAddress resource.");
+            }
+
+            configuration = new BrowserPackageSourceConfiguration(
+                serviceIndex.AbsoluteUri,
+                EnsureTrailingSlash(packageBaseAddress),
+                searchQueryService,
+                IsDefault: false);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidDataException(
+                "The NuGet mirror service index is not valid JSON.",
+                exception);
+        }
+
+        SetPackageSource(configuration);
+        return JsonSerializer.Serialize(
+            configuration,
+            BrowserJsonContext.Default.BrowserPackageSourceConfiguration);
+    }
+
+    [JSExport]
+    public static string UseDefaultPackageSource()
+    {
+        BrowserPackageSourceConfiguration configuration = DefaultPackageSource();
+        SetPackageSource(configuration);
+        return JsonSerializer.Serialize(
+            configuration,
+            BrowserJsonContext.Default.BrowserPackageSourceConfiguration);
+    }
 
     [JSExport]
     public static async Task<string> QueryPackage(string packageId, string version, string targetFramework)
@@ -511,8 +619,8 @@ public static partial class BrowserInspectionEngine
         var packageBytes = await GetPackageBytesAsync(normalizedId, normalizedVersion);
         var content = new InMemoryPackageContent(
             packageBytes,
-            DownloadedPackages.Contains($"{normalizedId}@{normalizedVersion}"),
-            "nuget.org");
+            WasDownloaded(normalizedId, normalizedVersion),
+            _packageSource.ServiceIndexUrl);
         PackageCompileAssetSelection selection =
             PackageCompileAssetSelector.Select(content, packageId, targetFramework);
         if (selection.Status == PackageCompileAssetSelectionStatus.NoCompileAssets)
@@ -799,9 +907,8 @@ public static partial class BrowserInspectionEngine
             return requestedVersion;
         }
 
-        var indexUrl =
-            $"https://api.nuget.org/v3-flatcontainer/{Uri.EscapeDataString(normalizedId)}/index.json";
-        var indexBytes = await Http.GetByteArrayAsync(indexUrl);
+        var indexUrl = BuildPackageIndexUrl(normalizedId);
+        var indexBytes = await GetPackageSourceBytesAsync(indexUrl);
         using var document = JsonDocument.Parse(indexBytes);
         var versions = document.RootElement.GetProperty("versions")
             .EnumerateArray()
@@ -931,9 +1038,10 @@ public static partial class BrowserInspectionEngine
                 normalizedId, normalizedVersion, targetFramework, assemblyName, tempRoot, allowRefFallback: true);
 
             var pdbPath = Path.ChangeExtension(implementationPath, ".pdb");
-            var symbolPackageUrl =
-                $"https://globalcdn.nuget.org/symbol-packages/" +
-                $"{Uri.EscapeDataString(normalizedId)}.{Uri.EscapeDataString(normalizedVersion)}.snupkg";
+            var symbolPackageUrl = BuildPackageContentUrl(
+                normalizedId,
+                normalizedVersion,
+                "snupkg");
             await TryAcquirePackagePdbAsync(symbolPackageUrl, targetFramework, assemblyName, pdbPath);
 
             using var inspection = AssemblyInspectionSession.Open(ResolvedAssemblyReference.Create(
@@ -1006,9 +1114,10 @@ public static partial class BrowserInspectionEngine
                 normalizedId, normalizedVersion, targetFramework, assemblyName, tempRoot, allowRefFallback: false);
 
             var pdbPath = Path.ChangeExtension(implementationPath, ".pdb");
-            var symbolPackageUrl =
-                $"https://globalcdn.nuget.org/symbol-packages/" +
-                $"{Uri.EscapeDataString(normalizedId)}.{Uri.EscapeDataString(normalizedVersion)}.snupkg";
+            var symbolPackageUrl = BuildPackageContentUrl(
+                normalizedId,
+                normalizedVersion,
+                "snupkg");
             await TryAcquirePackagePdbAsync(symbolPackageUrl, targetFramework, assemblyName, pdbPath);
 
             using var inspection = AssemblyInspectionSession.Open(ResolvedAssemblyReference.Create(
@@ -1173,8 +1282,8 @@ public static partial class BrowserInspectionEngine
         var packageBytes = await GetPackageBytesAsync(normalizedId, normalizedVersion);
         var content = new InMemoryPackageContent(
             packageBytes,
-            DownloadedPackages.Contains($"{normalizedId}@{normalizedVersion}"),
-            "nuget.org");
+            WasDownloaded(normalizedId, normalizedVersion),
+            _packageSource.ServiceIndexUrl);
         PackageCompileAssetSelection selection =
             PackageCompileAssetSelector.Select(content, packageId, targetFramework);
         PackageCompileAsset? selectedAssembly = selection.Status
@@ -2354,9 +2463,10 @@ public static partial class BrowserInspectionEngine
                 normalizedId, normalizedVersion, targetFramework, assemblyName, tempRoot, allowRefFallback: true);
 
             var pdbPath = Path.ChangeExtension(implementationPath, ".pdb");
-            var symbolPackageUrl =
-                $"https://globalcdn.nuget.org/symbol-packages/" +
-                $"{Uri.EscapeDataString(normalizedId)}.{Uri.EscapeDataString(normalizedVersion)}.snupkg";
+            var symbolPackageUrl = BuildPackageContentUrl(
+                normalizedId,
+                normalizedVersion,
+                "snupkg");
             await TryAcquirePackagePdbAsync(symbolPackageUrl, targetFramework, assemblyName, pdbPath);
 
             using var inspection = AssemblyInspectionSession.Open(ResolvedAssemblyReference.Create(
@@ -2431,9 +2541,10 @@ public static partial class BrowserInspectionEngine
                 normalizedId, normalizedVersion, targetFramework, assemblyName, tempRoot, allowRefFallback: true);
 
             var pdbPath = Path.ChangeExtension(implementationPath, ".pdb");
-            var symbolPackageUrl =
-                $"https://globalcdn.nuget.org/symbol-packages/" +
-                $"{Uri.EscapeDataString(normalizedId)}.{Uri.EscapeDataString(normalizedVersion)}.snupkg";
+            var symbolPackageUrl = BuildPackageContentUrl(
+                normalizedId,
+                normalizedVersion,
+                "snupkg");
             await TryAcquirePackagePdbAsync(symbolPackageUrl, targetFramework, assemblyName, pdbPath);
 
             using var inspection = AssemblyInspectionSession.Open(ResolvedAssemblyReference.Create(
@@ -2919,13 +3030,11 @@ public static partial class BrowserInspectionEngine
         return actual.Length > 0 && CryptographicOperations.FixedTimeEquals(actual, expected);
     }
 
-    // WASM PDB-acquisition policy: NuGet .snupkg only.
+    // WASM PDB-acquisition policy: the active NuGet source's .snupkg only.
     //
-    // This runs inside the browser, so every fetch is subject to CORS. NuGet's
-    // symbol-package endpoint (globalcdn.nuget.org/symbol-packages) is CORS-open
-    // and works for packages that publish symbols. Packages that ship no snupkg
-    // (e.g. Microsoft runtime libraries like System.Text.Json) simply 404 here and
-    // we fall back to decompiling with pdb=null — that is expected, not an error.
+    // This runs inside the browser, so every fetch is subject to CORS. PackageBaseAddress
+    // serves both .nupkg and .snupkg payloads. Packages that publish no symbols simply 404
+    // here and we fall back to decompiling with pdb=null — that is expected, not an error.
     //
     // Do NOT add the Microsoft symbol server (MSDL) as a fallback in this engine.
     // MSDL answers with a cross-origin 302 to an Azure blob (SAS-signed, expiring,
@@ -2975,7 +3084,7 @@ public static partial class BrowserInspectionEngine
         var content = new InMemoryPackageContent(
             packageBytes,
             fromCache: false,
-            producerKey: "nuget.org");
+            producerKey: _packageSource.ServiceIndexUrl);
         PackageCompileAssetSelection selection =
             PackageCompileAssetSelector.Select(
                 content,
@@ -3040,7 +3149,7 @@ public static partial class BrowserInspectionEngine
         var content = new InMemoryPackageContent(
             packageBytes,
             fromCache: false,
-            producerKey: "nuget.org");
+            producerKey: _packageSource.ServiceIndexUrl);
         PackageCompileAssetSelection selection =
             PackageCompileAssetSelector.Select(
                 content,
@@ -3432,14 +3541,11 @@ public static partial class BrowserInspectionEngine
     // the session. packId selects the CoreCLR or ASP.NET Core pack.
     static async Task<byte[]?> AcquireRuntimeFileAsync(string packId, string version, string fileName)
     {
-        var cacheKey = $"{packId}/{version}/{fileName}";
+        var cacheKey = $"{_packageSource.ServiceIndexUrl}\n{packId}/{version}/{fileName}";
         if (RuntimeFileCache.TryGetValue(cacheKey, out var cached))
             return cached;
 
-        var nupkgUrl =
-            $"https://api.nuget.org/v3-flatcontainer/{Uri.EscapeDataString(packId)}/" +
-            $"{Uri.EscapeDataString(version)}/" +
-            $"{Uri.EscapeDataString(packId)}.{Uri.EscapeDataString(version)}.nupkg";
+        var nupkgUrl = BuildPackageContentUrl(packId, version, "nupkg");
         bool IsWanted(string entryName) =>
             entryName.StartsWith("runtimes/", StringComparison.OrdinalIgnoreCase)
             && Path.GetFileName(entryName).Equals(fileName, StringComparison.OrdinalIgnoreCase);
@@ -3546,8 +3652,8 @@ public static partial class BrowserInspectionEngine
 
     static async Task<string> ResolveRuntimePackVersionAsync(string packId, int major)
     {
-        var indexUrl = $"https://api.nuget.org/v3-flatcontainer/{Uri.EscapeDataString(packId)}/index.json";
-        var indexBytes = await Http.GetByteArrayAsync(indexUrl);
+        var indexUrl = BuildPackageIndexUrl(packId);
+        var indexBytes = await GetPackageSourceBytesAsync(indexUrl);
         using var document = JsonDocument.Parse(indexBytes);
         var versions = document.RootElement.GetProperty("versions")
             .EnumerateArray()
@@ -3779,7 +3885,7 @@ public static partial class BrowserInspectionEngine
 
     static async Task<byte[]> GetPackageBytesAsync(string normalizedId, string normalizedVersion)
     {
-        var key = $"{normalizedId}@{normalizedVersion}";
+        var key = PackageCacheKey(normalizedId, normalizedVersion);
         lock (PackageCacheLock)
         {
             if (PackageCache.TryGetValue(key, out var cached))
@@ -3789,11 +3895,11 @@ public static partial class BrowserInspectionEngine
             }
         }
 
-        var packageUrl =
-            $"https://api.nuget.org/v3-flatcontainer/{Uri.EscapeDataString(normalizedId)}/" +
-            $"{Uri.EscapeDataString(normalizedVersion)}/" +
-            $"{Uri.EscapeDataString(normalizedId)}.{Uri.EscapeDataString(normalizedVersion)}.nupkg";
-        var bytes = await Http.GetByteArrayAsync(packageUrl);
+        var packageUrl = BuildPackageContentUrl(
+            normalizedId,
+            normalizedVersion,
+            "nupkg");
+        var bytes = await GetPackageSourceBytesAsync(packageUrl);
         lock (PackageCacheLock)
         {
             DownloadedPackages.Add(key);
@@ -3818,6 +3924,154 @@ public static partial class BrowserInspectionEngine
             PackageCache[key] = new PackageCacheEntry(bytes, ++_packageCacheClock);
         }
         return bytes;
+    }
+
+    static BrowserPackageSourceConfiguration DefaultPackageSource() =>
+        new(
+            DefaultServiceIndexUrl,
+            DefaultPackageBaseAddress,
+            DefaultSearchQueryService,
+            IsDefault: true);
+
+    static void SetPackageSource(BrowserPackageSourceConfiguration configuration)
+    {
+        _packageSource = configuration;
+        lock (PackageCacheLock)
+        {
+            PackageCache.Clear();
+            DownloadedPackages.Clear();
+            _packageCacheClock = 0;
+        }
+        RuntimeFileCache.Clear();
+    }
+
+    static Uri ValidateServiceIndexUrl(string value)
+    {
+        if (!Uri.TryCreate(value?.Trim(), UriKind.Absolute, out Uri? uri)
+            || uri.Scheme != Uri.UriSchemeHttps
+            || !string.IsNullOrEmpty(uri.UserInfo)
+            || !string.IsNullOrEmpty(uri.Query)
+            || !string.IsNullOrEmpty(uri.Fragment))
+        {
+            throw new ArgumentException(
+                "Enter an HTTPS NuGet v3 service-index URL without credentials, query parameters, or a fragment.",
+                nameof(value));
+        }
+
+        return uri;
+    }
+
+    static async Task<byte[]> ReadBoundedServiceIndexAsync(Uri serviceIndex)
+    {
+        using HttpResponseMessage response = await Http.GetAsync(
+            serviceIndex,
+            HttpCompletionOption.ResponseHeadersRead);
+        response.EnsureSuccessStatusCode();
+        if (response.Content.Headers.ContentLength is > MaxServiceIndexBytes)
+        {
+            throw new InvalidDataException(
+                "The NuGet mirror service index exceeds the 1 MB limit.");
+        }
+
+        await using Stream input = await response.Content.ReadAsStreamAsync();
+        using var output = new MemoryStream();
+        var buffer = new byte[8192];
+        while (true)
+        {
+            int read = await input.ReadAsync(buffer);
+            if (read == 0)
+                break;
+            if (output.Length + read > MaxServiceIndexBytes)
+            {
+                throw new InvalidDataException(
+                    "The NuGet mirror service index exceeds the 1 MB limit.");
+            }
+            output.Write(buffer, 0, read);
+        }
+        return output.ToArray();
+    }
+
+    static bool ResourceHasType(JsonElement resource, string prefix)
+    {
+        if (!resource.TryGetProperty("@type", out JsonElement type))
+            return false;
+        if (type.ValueKind == JsonValueKind.String)
+            return type.GetString()?.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) == true;
+        if (type.ValueKind != JsonValueKind.Array)
+            return false;
+        return type.EnumerateArray().Any(candidate =>
+            candidate.ValueKind == JsonValueKind.String
+            && candidate.GetString()?.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) == true);
+    }
+
+    static string ValidateResourceUrl(
+        Uri serviceIndex,
+        string resourceId,
+        string resourceKind)
+    {
+        if (!Uri.TryCreate(serviceIndex, resourceId, out Uri? resource)
+            || resource.Scheme != Uri.UriSchemeHttps
+            || !string.IsNullOrEmpty(resource.UserInfo)
+            || !string.IsNullOrEmpty(resource.Fragment))
+        {
+            throw new InvalidDataException(
+                $"The NuGet mirror publishes an invalid {resourceKind} resource.");
+        }
+        return resource.AbsoluteUri;
+    }
+
+    static string EnsureTrailingSlash(string value) =>
+        value.EndsWith("/", StringComparison.Ordinal) ? value : value + "/";
+
+    static string PackageCacheKey(string normalizedId, string normalizedVersion) =>
+        $"{_packageSource.ServiceIndexUrl}\n{normalizedId}@{normalizedVersion}";
+
+    static bool WasDownloaded(string normalizedId, string normalizedVersion)
+    {
+        lock (PackageCacheLock)
+        {
+            return DownloadedPackages.Contains(
+                PackageCacheKey(normalizedId, normalizedVersion));
+        }
+    }
+
+    static string BuildPackageIndexUrl(string normalizedId) =>
+        new Uri(
+            new Uri(_packageSource.PackageBaseAddress),
+            $"{Uri.EscapeDataString(normalizedId)}/index.json")
+        .AbsoluteUri;
+
+    static string BuildPackageContentUrl(
+        string normalizedId,
+        string normalizedVersion,
+        string extension) =>
+        new Uri(
+            new Uri(_packageSource.PackageBaseAddress),
+            $"{Uri.EscapeDataString(normalizedId)}/"
+            + $"{Uri.EscapeDataString(normalizedVersion)}/"
+            + $"{Uri.EscapeDataString(normalizedId)}."
+            + $"{Uri.EscapeDataString(normalizedVersion)}.{extension}")
+        .AbsoluteUri;
+
+    static async Task<byte[]> GetPackageSourceBytesAsync(string url)
+    {
+        try
+        {
+            return await Http.GetByteArrayAsync(url);
+        }
+        catch (HttpRequestException exception)
+            when (exception.StatusCode != HttpStatusCode.NotFound)
+        {
+            throw new InvalidOperationException(
+                $"{PackageSourceUnavailableMarker} The active NuGet source could not be reached.",
+                exception);
+        }
+        catch (TaskCanceledException exception)
+        {
+            throw new InvalidOperationException(
+                $"{PackageSourceUnavailableMarker} The active NuGet source timed out.",
+                exception);
+        }
     }
 
     static BrowserTypeSurface ToBrowserType(ApiType type, string assembly)

--- a/prototypes/inspect-web/engine/Program.cs
+++ b/prototypes/inspect-web/engine/Program.cs
@@ -1038,10 +1038,9 @@ public static partial class BrowserInspectionEngine
                 normalizedId, normalizedVersion, targetFramework, assemblyName, tempRoot, allowRefFallback: true);
 
             var pdbPath = Path.ChangeExtension(implementationPath, ".pdb");
-            var symbolPackageUrl = BuildPackageContentUrl(
+            var symbolPackageUrl = BuildNuGetOrgSymbolPackageUrl(
                 normalizedId,
-                normalizedVersion,
-                "snupkg");
+                normalizedVersion);
             await TryAcquirePackagePdbAsync(symbolPackageUrl, targetFramework, assemblyName, pdbPath);
 
             using var inspection = AssemblyInspectionSession.Open(ResolvedAssemblyReference.Create(
@@ -1114,10 +1113,9 @@ public static partial class BrowserInspectionEngine
                 normalizedId, normalizedVersion, targetFramework, assemblyName, tempRoot, allowRefFallback: false);
 
             var pdbPath = Path.ChangeExtension(implementationPath, ".pdb");
-            var symbolPackageUrl = BuildPackageContentUrl(
+            var symbolPackageUrl = BuildNuGetOrgSymbolPackageUrl(
                 normalizedId,
-                normalizedVersion,
-                "snupkg");
+                normalizedVersion);
             await TryAcquirePackagePdbAsync(symbolPackageUrl, targetFramework, assemblyName, pdbPath);
 
             using var inspection = AssemblyInspectionSession.Open(ResolvedAssemblyReference.Create(
@@ -2463,10 +2461,9 @@ public static partial class BrowserInspectionEngine
                 normalizedId, normalizedVersion, targetFramework, assemblyName, tempRoot, allowRefFallback: true);
 
             var pdbPath = Path.ChangeExtension(implementationPath, ".pdb");
-            var symbolPackageUrl = BuildPackageContentUrl(
+            var symbolPackageUrl = BuildNuGetOrgSymbolPackageUrl(
                 normalizedId,
-                normalizedVersion,
-                "snupkg");
+                normalizedVersion);
             await TryAcquirePackagePdbAsync(symbolPackageUrl, targetFramework, assemblyName, pdbPath);
 
             using var inspection = AssemblyInspectionSession.Open(ResolvedAssemblyReference.Create(
@@ -2541,10 +2538,9 @@ public static partial class BrowserInspectionEngine
                 normalizedId, normalizedVersion, targetFramework, assemblyName, tempRoot, allowRefFallback: true);
 
             var pdbPath = Path.ChangeExtension(implementationPath, ".pdb");
-            var symbolPackageUrl = BuildPackageContentUrl(
+            var symbolPackageUrl = BuildNuGetOrgSymbolPackageUrl(
                 normalizedId,
-                normalizedVersion,
-                "snupkg");
+                normalizedVersion);
             await TryAcquirePackagePdbAsync(symbolPackageUrl, targetFramework, assemblyName, pdbPath);
 
             using var inspection = AssemblyInspectionSession.Open(ResolvedAssemblyReference.Create(
@@ -3030,11 +3026,11 @@ public static partial class BrowserInspectionEngine
         return actual.Length > 0 && CryptographicOperations.FixedTimeEquals(actual, expected);
     }
 
-    // WASM PDB-acquisition policy: the active NuGet source's .snupkg only.
+    // WASM PDB-acquisition policy: NuGet.org's dedicated .snupkg endpoint only.
     //
-    // This runs inside the browser, so every fetch is subject to CORS. PackageBaseAddress
-    // serves both .nupkg and .snupkg payloads. Packages that publish no symbols simply 404
-    // here and we fall back to decompiling with pdb=null — that is expected, not an error.
+    // PackageBaseAddress is a package-content resource and does not serve symbol packages.
+    // NuGet.org's CORS-open symbol endpoint works for packages that publish symbols. If it is
+    // blocked, or a package publishes no snupkg, we fall back to decompiling with pdb=null.
     //
     // Do NOT add the Microsoft symbol server (MSDL) as a fallback in this engine.
     // MSDL answers with a cross-origin 302 to an Azure blob (SAS-signed, expiring,
@@ -4052,6 +4048,13 @@ public static partial class BrowserInspectionEngine
             + $"{Uri.EscapeDataString(normalizedId)}."
             + $"{Uri.EscapeDataString(normalizedVersion)}.{extension}")
         .AbsoluteUri;
+
+    static string BuildNuGetOrgSymbolPackageUrl(
+        string normalizedId,
+        string normalizedVersion) =>
+        "https://globalcdn.nuget.org/symbol-packages/"
+        + $"{Uri.EscapeDataString(normalizedId)}."
+        + $"{Uri.EscapeDataString(normalizedVersion)}.snupkg";
 
     static async Task<byte[]> GetPackageSourceBytesAsync(string url)
     {

--- a/prototypes/inspect-web/engine/wwwroot/engine.js
+++ b/prototypes/inspect-web/engine/wwwroot/engine.js
@@ -30,6 +30,8 @@ let searchTypes;
 let listStyleTiers;
 let listStyleOptions;
 let packageCacheStats;
+let configurePackageSource;
+let useDefaultPackageSource;
 
 export async function initializeEngine(onStatus = () => {}) {
   onStatus("Loading .NET 11 WebAssembly…");
@@ -66,6 +68,8 @@ export async function initializeEngine(onStatus = () => {}) {
   listStyleTiers = exports.BrowserInspectionEngine.ListStyleTiers;
   listStyleOptions = exports.BrowserInspectionEngine.ListStyleOptions;
   packageCacheStats = exports.BrowserInspectionEngine.PackageCacheStats;
+  configurePackageSource = exports.BrowserInspectionEngine.ConfigurePackageSource;
+  useDefaultPackageSource = exports.BrowserInspectionEngine.UseDefaultPackageSource;
   await runtime.runMain();
   onStatus("Reading package assemblies…");
 }
@@ -74,6 +78,16 @@ export async function inspectPackage(packageId, version, framework) {
   if (!queryPackage) throw new Error("The browser inspection engine is not initialized.");
   const json = await queryPackage(packageId, version, framework);
   return JSON.parse(json);
+}
+
+export async function inspectConfigurePackageSource(serviceIndexUrl) {
+  if (!configurePackageSource) throw new Error("The browser inspection engine is not initialized.");
+  return JSON.parse(await configurePackageSource(serviceIndexUrl));
+}
+
+export function inspectUseDefaultPackageSource() {
+  if (!useDefaultPackageSource) throw new Error("The browser inspection engine is not initialized.");
+  return JSON.parse(useDefaultPackageSource());
 }
 
 export async function inspectPackageDocument(request) {

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -1,6 +1,6 @@
 import { lenses, packageLenses, rootCommands } from "./data.js";
 import { loadPlatformIndex } from "/src/platform-index.js";
-import { initializeEngine, inspectExpandPlatformCallGraph, inspectListStyleOptions, inspectListStyleTiers, inspectLoadRuntimePack, inspectLoadRuntimePackAssembly, inspectMemberAnnotatedSource, inspectMemberCallGraph, inspectMemberDocumentation, inspectMemberFacts, inspectMemberSource, inspectPackage, inspectPackageCacheStats, inspectPackageDependencies, inspectPackageDocument, inspectPackageHeapEntries, inspectPackageIntegrations, inspectPackageMetadata, inspectPackageMetadataTable, inspectPackageOpportunities, inspectPackagePerformance, inspectPlatformHeapEntries, inspectPlatformIntegrations, inspectPlatformMetadata, inspectPlatformMetadataTable, inspectPlatformOpportunities, inspectPlatformPerformance, inspectSearchTypes, inspectTypeMemberSource, inspectTypeProjection, inspectTypeSource } from "/engine.js";
+import { initializeEngine, inspectConfigurePackageSource, inspectExpandPlatformCallGraph, inspectListStyleOptions, inspectListStyleTiers, inspectLoadRuntimePack, inspectLoadRuntimePackAssembly, inspectMemberAnnotatedSource, inspectMemberCallGraph, inspectMemberDocumentation, inspectMemberFacts, inspectMemberSource, inspectPackage, inspectPackageCacheStats, inspectPackageDependencies, inspectPackageDocument, inspectPackageHeapEntries, inspectPackageIntegrations, inspectPackageMetadata, inspectPackageMetadataTable, inspectPackageOpportunities, inspectPackagePerformance, inspectPlatformHeapEntries, inspectPlatformIntegrations, inspectPlatformMetadata, inspectPlatformMetadataTable, inspectPlatformOpportunities, inspectPlatformPerformance, inspectSearchTypes, inspectTypeMemberSource, inspectTypeProjection, inspectTypeSource, inspectUseDefaultPackageSource } from "/engine.js";
 
 function loadStoredTaste() {
   try {
@@ -13,6 +13,21 @@ function loadStoredTaste() {
 
 const PLATFORM_RECENT_MAX = 8;
 const RECENT_PACKAGES_MAX = 12;
+const NUGET_MIRROR_STORAGE_KEY = "inspect-nuget-mirror";
+const DEFAULT_PACKAGE_SOURCE = Object.freeze({
+  serviceIndexUrl: "https://api.nuget.org/v3/index.json",
+  packageBaseAddress: "https://api.nuget.org/v3-flatcontainer/",
+  searchQueryService: "https://azuresearch-usnc.nuget.org/query",
+  isDefault: true,
+});
+
+function loadStoredNuGetMirror() {
+  try {
+    return localStorage.getItem(NUGET_MIRROR_STORAGE_KEY)?.trim() || "";
+  } catch {
+    return "";
+  }
+}
 
 // Recently-opened NuGet packages, most-recent first, persisted across sessions so the
 // Home listing survives a refresh (the in-memory workspace does not). Written only from
@@ -149,6 +164,7 @@ const state = {
   spotlightPkgQuery: "",
   packageVersions: {},
   packageVersionsLoading: {},
+  packageSource: DEFAULT_PACKAGE_SOURCE,
   runtimePackLoading: false,
   runtimePackError: "",
   graphSourceOpen: false,
@@ -4449,7 +4465,18 @@ function scheduleSpotlightPackageFetch() {
 }
 
 async function fetchSpotlightPackages(query) {
-  const url = `https://azuresearch-usnc.nuget.org/query?q=${encodeURIComponent(query)}&take=8&prerelease=true&semVerLevel=2.0.0`;
+  if (!state.packageSource.searchQueryService) {
+    state.spotlightPkgHits = [];
+    state.spotlightPkgQuery = query;
+    state.spotlightPkgLoading = false;
+    updateSpotlightResults();
+    return;
+  }
+  const url = new URL(state.packageSource.searchQueryService);
+  url.searchParams.set("q", query);
+  url.searchParams.set("take", "8");
+  url.searchParams.set("prerelease", "true");
+  url.searchParams.set("semVerLevel", "2.0.0");
   try {
     const response = await fetch(url);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -4603,7 +4630,9 @@ async function ensurePackageVersions(pkg) {
   if (state.packageVersions[idLower] || state.packageVersionsLoading[idLower]) return;
   state.packageVersionsLoading[idLower] = true;
   try {
-    const url = `https://api.nuget.org/v3-flatcontainer/${encodeURIComponent(idLower)}/index.json`;
+    const url = new URL(
+      `${encodeURIComponent(idLower)}/index.json`,
+      state.packageSource.packageBaseAddress);
     const response = await fetch(url);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const payload = await response.json();
@@ -5157,6 +5186,13 @@ function showToast(message, duration = 2200) {
 // name surfaces as a NuGet 404; call that out plainly instead of showing a stack trace.
 function friendlyLoadError(error, packageId, version) {
   const raw = String(error?.message || error || "");
+  if (raw.includes("[package-source-unreachable]")) {
+    return {
+      notFound: false,
+      title: "NuGet source unavailable",
+      message: "The browser could not reach the active NuGet source. Configure an anonymous, CORS-enabled mirror in Settings and try again."
+    };
+  }
   if (/\b404\b|not\s*found/i.test(raw)) {
     const suffix = version && version !== "latest" ? `@${version}` : "";
     return {
@@ -5170,6 +5206,47 @@ function friendlyLoadError(error, packageId, version) {
     title: "Inspection query failed",
     message: `Couldn’t load “${packageId}”: ${raw || "unknown error"}`
   };
+}
+
+function isPackageSourceUnavailable(error) {
+  return String(error?.message || error || "").includes("[package-source-unreachable]");
+}
+
+function resetSourceScopedWorkspace() {
+  state.packages = [];
+  state.package = null;
+  state.packageVersions = {};
+  state.packageVersionsLoading = {};
+  state.workspaceDependencies = {};
+  state.spotlightPkgHits = [];
+  state.spotlightPkgQuery = "";
+  state.spotlightPkgLoading = false;
+}
+
+async function configureNuGetMirror(serviceIndexUrl) {
+  const configuration = await inspectConfigurePackageSource(serviceIndexUrl);
+  localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, configuration.serviceIndexUrl);
+  state.packageSource = configuration;
+  resetSourceScopedWorkspace();
+  return configuration;
+}
+
+async function promptForNuGetMirror() {
+  const current = loadStoredNuGetMirror();
+  const entered = window.prompt(
+    "The browser could not reach the active NuGet source. Your network may block nuget.org.\n\n"
+      + "Enter an anonymous, CORS-enabled NuGet v3 mirror service-index URL. "
+      + "The validated URL will be stored only in this browser.",
+    current);
+  if (entered === null || !entered.trim()) return false;
+
+  try {
+    await configureNuGetMirror(entered);
+    return true;
+  } catch (error) {
+    window.alert(`That NuGet mirror could not be used: ${String(error?.message || error)}`);
+    return false;
+  }
 }
 
 async function copyText(value, confirmation) {
@@ -6876,6 +6953,8 @@ function renderSettingsView() {
   const styleBody = catalog
     || '<div class="taste-empty">Style catalog is still loading — reopen Settings in a moment.</div>';
   const activeCount = state.taste.length;
+  const storedMirror = loadStoredNuGetMirror();
+  const sourceBadge = state.packageSource.isDefault ? "nuget.org" : "mirror";
   app.innerHTML = `
     <div class="settings-page">
       <header class="settings-bar">
@@ -6903,6 +6982,22 @@ function renderSettingsView() {
 
         <section class="settings-section">
           <div class="settings-section-head">
+            <h2>NuGet source <span class="settings-badge">${sourceBadge}</span></h2>
+            <p>Package downloads use nuget.org by default. If your network blocks it, enter an anonymous, CORS-enabled NuGet v3 mirror service-index URL. The URL is validated before it is stored locally.</p>
+          </div>
+          <form id="settings-nuget-source" class="settings-source">
+            <label for="settings-nuget-source-url">Mirror service index</label>
+            <input id="settings-nuget-source-url" type="url" inputmode="url" autocomplete="off" spellcheck="false" placeholder="https://mirror.example/nuget/v3/index.json" value="${escapeHtml(storedMirror)}" />
+            <div class="settings-source-actions">
+              <button type="submit" class="settings-reset">Validate and use mirror</button>
+              ${storedMirror ? '<button id="settings-nuget-source-reset" type="button" class="settings-reset">Use nuget.org</button>' : ""}
+            </div>
+            <small>Current source: ${escapeHtml(state.packageSource.serviceIndexUrl)}</small>
+          </form>
+        </section>
+
+        <section class="settings-section">
+          <div class="settings-section-head">
             <h2>Decompiler style <span class="settings-badge">${activeCount ? `${activeCount} on` : "default"}</span></h2>
             <p>Tune how decompiled C# is spelled and synthesized — including <strong>readable local names</strong>. These apply to every source and call-graph view. The default is opcode-faithful.</p>
           </div>
@@ -6925,6 +7020,27 @@ function bindSettingsEvents() {
   document.querySelectorAll(".settings-taste [data-taste]").forEach(checkbox =>
     checkbox.addEventListener("change", () => toggleTaste(checkbox.dataset.taste)));
   document.querySelector("#settings-taste-clear")?.addEventListener("click", clearTaste);
+  document.querySelector("#settings-nuget-source")?.addEventListener("submit", async event => {
+    event.preventDefault();
+    const input = document.querySelector("#settings-nuget-source-url");
+    const submit = event.currentTarget.querySelector('button[type="submit"]');
+    const value = input?.value.trim() || "";
+    if (!value) return;
+    submit.disabled = true;
+    try {
+      const configuration = await inspectConfigurePackageSource(value);
+      localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, configuration.serviceIndexUrl);
+      location.reload();
+    } catch (error) {
+      submit.disabled = false;
+      showToast(`Mirror not saved: ${String(error?.message || error)}`, 6000);
+    }
+  });
+  document.querySelector("#settings-nuget-source-reset")?.addEventListener("click", () => {
+    inspectUseDefaultPackageSource();
+    localStorage.removeItem(NUGET_MIRROR_STORAGE_KEY);
+    location.reload();
+  });
 }
 
 function renderGraphSource() {
@@ -7084,6 +7200,14 @@ async function loadPackage(packageId, version, framework, options = {}) {
     // A failed background restore of a non-target tab must not disrupt the workbench or the
     // real target; drop it silently (the tab simply won't appear).
     if (background) return null;
+    if (!options.sourceFallbackAttempted
+        && isPackageSourceUnavailable(error)
+        && await promptForNuGetMirror()) {
+      return loadPackage(packageId, version, framework, {
+        ...options,
+        sourceFallbackAttempted: true,
+      });
+    }
     state.loading = false;
     const friendly = friendlyLoadError(error, packageId, version);
     if (prevPackage) {
@@ -7204,7 +7328,7 @@ function isRuntimePackId(id) {
 // a resident pseudo-package flagged isRuntimePack, so its BCL types become searchable in
 // Spotlight and browsable/navigable like any package. SPC is fetched eagerly; sibling pack
 // assemblies load lazily as navigation reaches them. Does not switch the active package.
-async function loadRuntimePack(framework) {
+async function loadRuntimePack(framework, sourceFallbackAttempted = false) {
   if (state.runtimePackLoading) return runtimePackPackage();
   const existing = runtimePackPackage();
   if (existing) return existing;
@@ -7243,6 +7367,11 @@ async function loadRuntimePack(framework) {
     return packageModel;
   } catch (error) {
     state.runtimePackLoading = false;
+    if (!sourceFallbackAttempted
+        && isPackageSourceUnavailable(error)
+        && await promptForNuGetMirror()) {
+      return loadRuntimePack(framework, true);
+    }
     state.runtimePackError = String(error?.message || error);
     return null;
   }
@@ -7256,7 +7385,11 @@ async function loadRuntimePack(framework) {
 // Platform drill-in: the Platform scope roster comes from the static index with no download,
 // and picking a library fetches just that assembly here. Types/assemblies are merged (deduped
 // by id/name) so the runtime pack accumulates the libraries the user visits.
-async function loadRuntimePackAssembly(framework, assemblyFileName, pack) {
+async function loadRuntimePackAssembly(
+  framework,
+  assemblyFileName,
+  pack,
+  sourceFallbackAttempted = false) {
   if (state.runtimePackLoading) return runtimePackPackage();
   state.runtimePackLoading = true;
   state.runtimePackError = "";
@@ -7295,6 +7428,11 @@ async function loadRuntimePackAssembly(framework, assemblyFileName, pack) {
     return packageModel;
   } catch (error) {
     state.runtimePackLoading = false;
+    if (!sourceFallbackAttempted
+        && isPackageSourceUnavailable(error)
+        && await promptForNuGetMirror()) {
+      return loadRuntimePackAssembly(framework, assemblyFileName, pack, true);
+    }
     state.runtimePackError = String(error?.message || error);
     return null;
   }
@@ -7421,6 +7559,16 @@ async function bootstrap() {
       render();
     });
     const tEngine = performance.now();
+    const storedMirror = loadStoredNuGetMirror();
+    if (storedMirror) {
+      state.loadingMessage = "Connecting to your NuGet mirror…";
+      render();
+      try {
+        state.packageSource = await inspectConfigurePackageSource(storedMirror);
+      } catch {
+        state.packageSource = inspectUseDefaultPackageSource();
+      }
+    }
     try {
       [state.styleTiers, state.styleOptions] = await Promise.all([
         inspectListStyleTiers(),

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -20,6 +20,9 @@ const DEFAULT_PACKAGE_SOURCE = Object.freeze({
   searchQueryService: "https://azuresearch-usnc.nuget.org/query",
   isDefault: true,
 });
+// Bumped whenever the active package source changes so late package/search
+// completions from a previous source cannot repopulate a cleared workspace.
+let packageSourceGeneration = 0;
 
 function loadStoredNuGetMirror() {
   try {
@@ -27,6 +30,11 @@ function loadStoredNuGetMirror() {
   } catch {
     return "";
   }
+}
+
+function bumpPackageSourceGeneration() {
+  packageSourceGeneration += 1;
+  return packageSourceGeneration;
 }
 
 // Recently-opened NuGet packages, most-recent first, persisted across sessions so the
@@ -4477,11 +4485,13 @@ async function fetchSpotlightPackages(query) {
   url.searchParams.set("take", "8");
   url.searchParams.set("prerelease", "true");
   url.searchParams.set("semVerLevel", "2.0.0");
+  const sourceGeneration = packageSourceGeneration;
   try {
     const response = await fetch(url);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const payload = await response.json();
-    if (state.spotlightQuery.trim() !== query) return; // stale
+    if (state.spotlightQuery.trim() !== query
+        || sourceGeneration !== packageSourceGeneration) return; // stale
     state.spotlightPkgHits = (payload.data || []).map(item => ({
       id: item.id,
       version: item.version,
@@ -4489,11 +4499,13 @@ async function fetchSpotlightPackages(query) {
     }));
     state.spotlightPkgQuery = query;
   } catch (error) {
-    if (state.spotlightQuery.trim() !== query) return;
+    if (state.spotlightQuery.trim() !== query
+        || sourceGeneration !== packageSourceGeneration) return;
     state.spotlightPkgHits = [];
     state.spotlightPkgQuery = query;
   } finally {
-    if (state.spotlightQuery.trim() === query) {
+    if (state.spotlightQuery.trim() === query
+        && sourceGeneration === packageSourceGeneration) {
       state.spotlightPkgLoading = false;
       updateSpotlightResults();
     }
@@ -4629,6 +4641,7 @@ async function ensurePackageVersions(pkg) {
   const idLower = pkg.id.toLowerCase();
   if (state.packageVersions[idLower] || state.packageVersionsLoading[idLower]) return;
   state.packageVersionsLoading[idLower] = true;
+  const sourceGeneration = packageSourceGeneration;
   try {
     const url = new URL(
       `${encodeURIComponent(idLower)}/index.json`,
@@ -4636,6 +4649,7 @@ async function ensurePackageVersions(pkg) {
     const response = await fetch(url);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const payload = await response.json();
+    if (sourceGeneration !== packageSourceGeneration) return;
     const versions = (payload.versions || []).slice().sort(compareVersionsDesc);
     state.packageVersions[idLower] = versions;
     updateVersionSelect(idLower);
@@ -4643,7 +4657,9 @@ async function ensurePackageVersions(pkg) {
     // Leave the selector on the single current-version option; a transient index failure
     // must not break the workbench.
   } finally {
-    state.packageVersionsLoading[idLower] = false;
+    if (sourceGeneration === packageSourceGeneration) {
+      state.packageVersionsLoading[idLower] = false;
+    }
   }
 }
 
@@ -5226,10 +5242,47 @@ function resetSourceScopedWorkspace() {
   state.spotlightPkgLoading = false;
 }
 
+function persistNuGetMirror(serviceIndexUrl) {
+  try {
+    localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, serviceIndexUrl);
+  } catch (error) {
+    // Roll the engine back so JS and C# cannot disagree about the active source
+    // when storage is disabled or full.
+    inspectUseDefaultPackageSource();
+    state.packageSource = DEFAULT_PACKAGE_SOURCE;
+    bumpPackageSourceGeneration();
+    resetSourceScopedWorkspace();
+    throw error;
+  }
+}
+
+function clearPersistedNuGetMirror() {
+  try {
+    localStorage.removeItem(NUGET_MIRROR_STORAGE_KEY);
+  } catch {
+    // Best-effort: engine is already on the default source.
+  }
+}
+
 async function configureNuGetMirror(serviceIndexUrl) {
   const configuration = await inspectConfigurePackageSource(serviceIndexUrl);
-  localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, configuration.serviceIndexUrl);
+  try {
+    persistNuGetMirror(configuration.serviceIndexUrl);
+  } catch (error) {
+    throw new Error(
+      `Mirror validated but could not be stored in this browser: ${String(error?.message || error)}`);
+  }
   state.packageSource = configuration;
+  bumpPackageSourceGeneration();
+  resetSourceScopedWorkspace();
+  return configuration;
+}
+
+function useDefaultNuGetSource() {
+  const configuration = inspectUseDefaultPackageSource();
+  clearPersistedNuGetMirror();
+  state.packageSource = configuration;
+  bumpPackageSourceGeneration();
   resetSourceScopedWorkspace();
   return configuration;
 }
@@ -7031,8 +7084,7 @@ function bindSettingsEvents() {
     if (!value) return;
     submit.disabled = true;
     try {
-      const configuration = await inspectConfigurePackageSource(value);
-      localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, configuration.serviceIndexUrl);
+      await configureNuGetMirror(value);
       location.reload();
     } catch (error) {
       submit.disabled = false;
@@ -7040,8 +7092,7 @@ function bindSettingsEvents() {
     }
   });
   document.querySelector("#settings-nuget-source-reset")?.addEventListener("click", () => {
-    inspectUseDefaultPackageSource();
-    localStorage.removeItem(NUGET_MIRROR_STORAGE_KEY);
+    useDefaultNuGetSource();
     location.reload();
   });
 }
@@ -7126,6 +7177,7 @@ async function loadPackage(packageId, version, framework, options = {}) {
   // reset, no loading toggle, no render. The caller (workspace restore) keeps the loading
   // overlay up and focuses the real target once, so non-target tabs never flash into view.
   const background = options.background === true;
+  const sourceGeneration = packageSourceGeneration;
   const prevPackage = state.package;
   const prevRequested = {
     package: state.requestedPackage,
@@ -7147,6 +7199,10 @@ async function loadPackage(packageId, version, framework, options = {}) {
 
   try {
     const result = await inspectPackage(packageId, version, framework);
+    if (sourceGeneration !== packageSourceGeneration) {
+      // Source switched while this request was in flight; drop the stale result.
+      return null;
+    }
     refreshPackageStats();
     const types = (result.types ?? []).map(type => ({
       ...type,
@@ -7203,6 +7259,7 @@ async function loadPackage(packageId, version, framework, options = {}) {
     // A failed background restore of a non-target tab must not disrupt the workbench or the
     // real target; drop it silently (the tab simply won't appear).
     if (background) return null;
+    if (sourceGeneration !== packageSourceGeneration) return null;
     if (!options.sourceFallbackAttempted
         && state.packageSource.isDefault
         && isPackageSourceUnavailable(error)
@@ -7338,8 +7395,13 @@ async function loadRuntimePack(framework, sourceFallbackAttempted = false) {
   if (existing) return existing;
   state.runtimePackLoading = true;
   state.runtimePackError = "";
+  const sourceGeneration = packageSourceGeneration;
   try {
     const result = await inspectLoadRuntimePack(framework || "");
+    if (sourceGeneration !== packageSourceGeneration) {
+      state.runtimePackLoading = false;
+      return null;
+    }
     refreshPackageStats();
     const types = (result.types ?? []).map(type => ({ ...type, api: type.api ?? [] }));
     const defaultAssembly = (result.assemblies ?? [])
@@ -7371,6 +7433,7 @@ async function loadRuntimePack(framework, sourceFallbackAttempted = false) {
     return packageModel;
   } catch (error) {
     state.runtimePackLoading = false;
+    if (sourceGeneration !== packageSourceGeneration) return null;
     if (!sourceFallbackAttempted
         && state.packageSource.isDefault
         && isPackageSourceUnavailable(error)
@@ -7398,8 +7461,13 @@ async function loadRuntimePackAssembly(
   if (state.runtimePackLoading) return runtimePackPackage();
   state.runtimePackLoading = true;
   state.runtimePackError = "";
+  const sourceGeneration = packageSourceGeneration;
   try {
     const result = await inspectLoadRuntimePackAssembly(framework || "", assemblyFileName, pack || "");
+    if (sourceGeneration !== packageSourceGeneration) {
+      state.runtimePackLoading = false;
+      return null;
+    }
     refreshPackageStats();
     const newTypes = (result.types ?? []).map(type => ({ ...type, api: type.api ?? [] }));
     const existing = runtimePackPackage();
@@ -7433,6 +7501,7 @@ async function loadRuntimePackAssembly(
     return packageModel;
   } catch (error) {
     state.runtimePackLoading = false;
+    if (sourceGeneration !== packageSourceGeneration) return null;
     if (!sourceFallbackAttempted
         && state.packageSource.isDefault
         && isPackageSourceUnavailable(error)
@@ -7571,8 +7640,12 @@ async function bootstrap() {
       render();
       try {
         state.packageSource = await inspectConfigurePackageSource(storedMirror);
+        bumpPackageSourceGeneration();
       } catch {
+        // Leave the stored URL so a transient failure can recover on reload;
+        // the engine is on the default source for this session.
         state.packageSource = inspectUseDefaultPackageSource();
+        bumpPackageSourceGeneration();
       }
     }
     try {

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -1406,7 +1406,9 @@ function renderPackageView() {
 
 function packageDependenciesSignature() {
   const pkg = state.package;
-  return `${pkg.id}@${pkg.version}/${pkg.activeFramework}#${pkg.assemblyId}`;
+  // Include packageSourceGeneration so a late completion from a previous NuGet
+  // source cannot satisfy the cache after a mirror switch.
+  return `g${packageSourceGeneration}|${pkg.id}@${pkg.version}/${pkg.activeFramework}#${pkg.assemblyId}`;
 }
 
 function renderPackageDependencies() {
@@ -1578,17 +1580,21 @@ async function loadPackageDependencies() {
       framework: state.package.activeFramework,
       assemblyId: state.package.assemblyId
     });
-    if (state.packageDependenciesKey === signature) state.packageDependencies = result;
-    if (result?.dependencyGroups) {
-      state.workspaceDependencies[`${state.package.id.toLowerCase()}@${state.package.version.toLowerCase()}`] = result.dependencyGroups;
+    if (state.packageDependenciesKey === signature) {
+      state.packageDependencies = result;
+      if (result?.dependencyGroups) {
+        state.workspaceDependencies[`${state.package.id.toLowerCase()}@${state.package.version.toLowerCase()}`] = result.dependencyGroups;
+      }
     }
   } catch (error) {
     if (state.packageDependenciesKey === signature) state.packageDependenciesError = String(error?.message || error);
   } finally {
-    if (state.packageDependenciesKey === signature) state.packageDependenciesLoading = false;
-    refreshPackageStats();
-    render();
-    ensureWorkspaceDependencies();
+    if (state.packageDependenciesKey === signature) {
+      state.packageDependenciesLoading = false;
+      refreshPackageStats();
+      render();
+      ensureWorkspaceDependencies();
+    }
   }
 }
 
@@ -1607,6 +1613,7 @@ function maybeAutoLoadPackageDependencies() {
 // Fetches dependency manifests for every other open package so the dependency graph can
 // draw incoming "caller" edges (open packages that declare a dependency on the current one).
 async function ensureWorkspaceDependencies() {
+  const sourceGeneration = packageSourceGeneration;
   const missing = state.packages.filter(item =>
     !state.workspaceDependencies[`${item.id.toLowerCase()}@${item.version.toLowerCase()}`]);
   if (!missing.length) {
@@ -1614,6 +1621,7 @@ async function ensureWorkspaceDependencies() {
     return;
   }
   for (const item of missing) {
+    if (sourceGeneration !== packageSourceGeneration) return;
     const key = `${item.id.toLowerCase()}@${item.version.toLowerCase()}`;
     try {
       const result = await inspectPackageDependencies({
@@ -1622,11 +1630,14 @@ async function ensureWorkspaceDependencies() {
         framework: item.activeFramework,
         assemblyId: item.assemblyId
       });
+      if (sourceGeneration !== packageSourceGeneration) return;
       state.workspaceDependencies[key] = result?.dependencyGroups || [];
     } catch {
+      if (sourceGeneration !== packageSourceGeneration) return;
       state.workspaceDependencies[key] = [];
     }
   }
+  if (sourceGeneration !== packageSourceGeneration) return;
   if (state.atPackageRoot && state.packageLens === "dependencies") renderDependencyGraph();
   refreshPackageStats();
 }
@@ -1634,7 +1645,7 @@ async function ensureWorkspaceDependencies() {
 function packageIntegrationsSignature() {
   const pkg = state.package;
   const lib = scopedPlatformLibrary();
-  return `${pkg.id}@${pkg.version}/${pkg.activeFramework}${lib ? `#${lib}` : ""}`;
+  return `g${packageSourceGeneration}|${pkg.id}@${pkg.version}/${pkg.activeFramework}${lib ? `#${lib}` : ""}`;
 }
 
 function renderPackageIntegrations() {
@@ -1749,7 +1760,7 @@ function maybeAutoLoadPackageIntegrations() {
 function packageScopeSignature() {
   const pkg = state.package;
   const lib = scopedPlatformLibrary();
-  return `${pkg.id}@${pkg.version}/${pkg.activeFramework}${lib ? `#${lib}` : ""}`;
+  return `g${packageSourceGeneration}|${pkg.id}@${pkg.version}/${pkg.activeFramework}${lib ? `#${lib}` : ""}`;
 }
 
 // The Opportunities and Analysis lenses run over one platform library at a time, so on the
@@ -5231,29 +5242,39 @@ function isPackageSourceUnavailable(error) {
   return String(error?.message || error || "").includes("[package-source-unreachable]");
 }
 
+function resetPackageLensCaches() {
+  state.packageDependencies = null;
+  state.packageDependenciesLoading = false;
+  state.packageDependenciesError = "";
+  state.packageDependenciesKey = "";
+  state.workspaceDependencies = {};
+  state.packageIntegrations = null;
+  state.packageIntegrationsLoading = false;
+  state.packageIntegrationsError = "";
+  state.packageIntegrationsKey = "";
+  state.packageOpportunities = null;
+  state.packageOpportunitiesLoading = false;
+  state.packageOpportunitiesError = "";
+  state.packageOpportunitiesKey = "";
+  state.packagePerformance = null;
+  state.packagePerformanceLoading = false;
+  state.packagePerformanceError = "";
+  state.packagePerformanceKey = "";
+  state.packageMetadata = null;
+  state.packageMetadataLoading = false;
+  state.packageMetadataError = "";
+  state.packageMetadataKey = "";
+}
+
 function resetSourceScopedWorkspace() {
   state.packages = [];
   state.package = null;
   state.packageVersions = {};
   state.packageVersionsLoading = {};
-  state.workspaceDependencies = {};
   state.spotlightPkgHits = [];
   state.spotlightPkgQuery = "";
   state.spotlightPkgLoading = false;
-}
-
-function persistNuGetMirror(serviceIndexUrl) {
-  try {
-    localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, serviceIndexUrl);
-  } catch (error) {
-    // Roll the engine back so JS and C# cannot disagree about the active source
-    // when storage is disabled or full.
-    inspectUseDefaultPackageSource();
-    state.packageSource = DEFAULT_PACKAGE_SOURCE;
-    bumpPackageSourceGeneration();
-    resetSourceScopedWorkspace();
-    throw error;
-  }
+  resetPackageLensCaches();
 }
 
 function clearPersistedNuGetMirror() {
@@ -5264,11 +5285,35 @@ function clearPersistedNuGetMirror() {
   }
 }
 
+async function restorePackageSource(previousSource) {
+  if (!previousSource || previousSource.isDefault) {
+    const configuration = inspectUseDefaultPackageSource();
+    state.packageSource = configuration;
+    bumpPackageSourceGeneration();
+    return configuration;
+  }
+  try {
+    const configuration = await inspectConfigurePackageSource(previousSource.serviceIndexUrl);
+    state.packageSource = configuration;
+    bumpPackageSourceGeneration();
+    return configuration;
+  } catch {
+    const configuration = inspectUseDefaultPackageSource();
+    state.packageSource = configuration;
+    bumpPackageSourceGeneration();
+    return configuration;
+  }
+}
+
 async function configureNuGetMirror(serviceIndexUrl) {
+  const previousSource = state.packageSource;
   const configuration = await inspectConfigurePackageSource(serviceIndexUrl);
   try {
-    persistNuGetMirror(configuration.serviceIndexUrl);
+    localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, configuration.serviceIndexUrl);
   } catch (error) {
+    // Engine already switched; restore the prior source and keep the workbench.
+    // Do not clear packages — that strands the UI on a permanent loading screen.
+    await restorePackageSource(previousSource);
     throw new Error(
       `Mirror validated but could not be stored in this browser: ${String(error?.message || error)}`);
   }

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -5187,10 +5187,13 @@ function showToast(message, duration = 2200) {
 function friendlyLoadError(error, packageId, version) {
   const raw = String(error?.message || error || "");
   if (raw.includes("[package-source-unreachable]")) {
+    const message = state.packageSource.isDefault
+      ? "The browser could not reach nuget.org. Configure an anonymous, CORS-enabled mirror in Settings and try again."
+      : "The configured mirror rejected or could not complete the package request. Some upstream proxies require the package to be warmed by a non-browser client before a browser can download it.";
     return {
       notFound: false,
       title: "NuGet source unavailable",
-      message: "The browser could not reach the active NuGet source. Configure an anonymous, CORS-enabled mirror in Settings and try again."
+      message
     };
   }
   if (/\b404\b|not\s*found/i.test(raw)) {
@@ -7201,6 +7204,7 @@ async function loadPackage(packageId, version, framework, options = {}) {
     // real target; drop it silently (the tab simply won't appear).
     if (background) return null;
     if (!options.sourceFallbackAttempted
+        && state.packageSource.isDefault
         && isPackageSourceUnavailable(error)
         && await promptForNuGetMirror()) {
       return loadPackage(packageId, version, framework, {
@@ -7368,6 +7372,7 @@ async function loadRuntimePack(framework, sourceFallbackAttempted = false) {
   } catch (error) {
     state.runtimePackLoading = false;
     if (!sourceFallbackAttempted
+        && state.packageSource.isDefault
         && isPackageSourceUnavailable(error)
         && await promptForNuGetMirror()) {
       return loadRuntimePack(framework, true);
@@ -7429,6 +7434,7 @@ async function loadRuntimePackAssembly(
   } catch (error) {
     state.runtimePackLoading = false;
     if (!sourceFallbackAttempted
+        && state.packageSource.isDefault
         && isPackageSourceUnavailable(error)
         && await promptForNuGetMirror()) {
       return loadRuntimePackAssembly(framework, assemblyFileName, pack, true);

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1596,6 +1596,38 @@ kbd {
 .settings-seg + .settings-seg { border-left: 1px solid var(--line-strong); }
 .settings-seg:hover { color: var(--text); }
 .settings-seg.active { background: var(--accent); color: #fff; }
+.settings-source {
+  display: grid;
+  gap: 9px;
+}
+.settings-source label, .settings-source small {
+  color: var(--muted);
+  font: 10px/1.5 var(--mono);
+}
+.settings-source input {
+  width: 100%;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font: 11px var(--mono);
+}
+.settings-source input:focus {
+  border-color: var(--accent);
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+.settings-source-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.settings-source button:disabled {
+  cursor: wait;
+  opacity: .6;
+}
 .settings-taste {
   border: 1px solid var(--line);
   border-radius: 8px;


### PR DESCRIPTION
## Summary

Make the browser prototype usable when corporate policy blocks nuget.org:

- detect package-source connectivity failures and prompt for a NuGet v3 mirror
- validate the mirror service index and require an HTTPS, credential-free URL
- persist the validated service-index URL in browser local storage
- route package versions, nupkg/snupkg payloads, runtime packs, and package search through the mirror's advertised resources
- expose mirror replacement/reset under Settings
- source-qualify and clear in-memory caches when the source changes

The default remains nuget.org. This slice targets the deployed `prototype/wasm-command-ui` branch.

## Local evidence

- JavaScript syntax checks pass for `app.js` and `engine.js`
- Markdown lint passes
- The mandated `https://packagefeedproxy.microsoft.io/nuget/v3/index.json` proxy was verified from the deployed site's origin: its service index, package index, package payload redirect, and search endpoint all return CORS access

## Required browser-machine validation

Local Wasm publish is blocked because the centrally installed SDK cannot install the browser workload under this machine's policy. On a machine with `wasm-experimental` available, run:

```bash
dotnet publish prototypes/inspect-web/engine/InspectWeb.Engine.csproj \
  -c Release --output artifacts/inspect-web-publish
```

Then smoke-test with direct nuget.org requests blocked:

1. Open `System.Text.Json@10.0.0` and confirm the mirror prompt appears.
2. Enter `https://packagefeedproxy.microsoft.io/nuget/v3/index.json`.
3. Confirm the package retries successfully and `inspect-nuget-mirror` is stored in local storage.
4. Confirm package search, version selection, and a Platform runtime-pack load use the mirror.
5. Reload and confirm the stored mirror is restored without another prompt.
6. Clear the mirror in Settings and confirm the source returns to nuget.org.
