### PR TITLE
Extract primary-image metadata resolver

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -737,14 +737,23 @@ Research overlay bridge, and the application layer:
   method-local calls and safety evidence. It consumes one
   `ILibraryMethodAnalysisInfrastructure` implemented by the assembly builder;
   that contract supplies the caller-owned primary-image reader/PE pair,
-  method identity and generic scope, and the existing narrow metadata
-  resolvers without exposing them to topic producers.
+  while delegating method identity, generic scope, and the existing narrow
+  metadata resolvers to `LibraryBodyPrimaryMetadataResolver` without exposing
+  them to topic producers.
   `BuildCallTree_PreservesRecoverableBodyAnalysisFailure` gates partial failure
   publication, and
   `LibraryBodyIndex_PrefetchedImageScopeSkipsMalformedUnselectedBody` gates
-  scoped decode through the runner. The assembly builder retains the
-  metadata-ordered work list, parallel scheduling, primary-image metadata
-  judgments, and result aggregation. Cross-assembly type-definition binding,
+  scoped decode through the runner. `LibraryBodyPrimaryMetadataResolver` owns
+  primary-image method identity, unsafe/generated attribute judgments,
+  token/member/type/field/calli/value-type/delegate facts, async-state-machine
+  caching, and the allocation/optimization/call resolver adapters.
+  `CallerUnsafeMode_PointerSignatureIsImplicitWhenModuleNotOptedIn`,
+  `OptimizationOpportunities_AsyncStateMachine_IsAmortized`, and
+  `Allocations_ClassifiesCrossAndInAssemblyValueTypeNewobj_ByShape` gate
+  representative identity, cached classification, and token-shape behavior.
+  The assembly builder retains the metadata-ordered work list, parallel
+  scheduling, assembly-level projections, and result aggregation.
+  Cross-assembly type-definition binding,
   referenced-image metadata lifetime, and the registration-keyed cache belong
   to `LibraryBodyReferenceMetadataResolver`, which composes
   `AssemblyReferenceBindingPolicy` and `TypeResolutionCatalog`.

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -287,16 +287,24 @@ acquisition, the intentionally throwing `InstructionDecoder.Decode` +
 canonical context, topic-producer sequencing, leak-only handling, recoverable
 diagnostics, and method-local result publication. It receives one
 `ILibraryMethodAnalysisInfrastructure` from the assembly builder for the
-caller-owned primary-image reader/PE pair, method identity and generic scope,
-and the existing allocation/optimization/call metadata resolvers. Topic
-producers still receive only their narrow contracts.
+caller-owned primary-image reader/PE pair. The builder delegates method
+identity, generic scope, and the existing allocation/optimization/call
+metadata resolvers to `LibraryBodyPrimaryMetadataResolver`. Topic producers
+still receive only their narrow contracts.
 `BuildCallTree_PreservesRecoverableBodyAnalysisFailure` gates calls, safety
 evidence, and diagnostics surviving a later recoverable failure;
 `LibraryBodyIndex_PrefetchedImageScopeSkipsMalformedUnselectedBody` gates
 scoped decode with an excluded malformed-body close negative. The assembly
 builder retains the metadata-ordered work list, parallel scheduling,
-primary-image metadata judgments, assembly-level projections, and result
-aggregation. `LibraryBodyReferenceMetadataResolver` separately owns
+assembly-level projections, and result aggregation.
+`LibraryBodyPrimaryMetadataResolver` owns primary-image method identity,
+unsafe/generated attribute judgments, token/member/type/field/calli/value-type
+and delegate facts, async-state-machine caching, and the narrow resolver
+adapters. `CallerUnsafeMode_PointerSignatureIsImplicitWhenModuleNotOptedIn`,
+`OptimizationOpportunities_AsyncStateMachine_IsAmortized`, and
+`Allocations_ClassifiesCrossAndInAssemblyValueTypeNewobj_ByShape` gate
+representative identity, cached classification, and token-shape behavior.
+`LibraryBodyReferenceMetadataResolver` separately owns
 cross-assembly type-definition binding, referenced-image metadata lifetime,
 and its registration-keyed cache for that acquisition. It builds on
 `AssemblyReferenceBindingPolicy` and `TypeResolutionCatalog` rather than adding

--- a/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
+++ b/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
@@ -20,22 +20,25 @@ internal sealed class LibraryBodyAnalysisBuilder :
     IDisposable,
     ILibraryMethodAnalysisInfrastructure
 {
-    readonly string _path;
     readonly MetadataReader _reader;
     readonly PEReader _peReader;
+    readonly LibraryBodyPrimaryMetadataResolver _primaryMetadataResolver;
     readonly LibraryBodyReferenceMetadataResolver? _referenceMetadataResolver;
-    readonly string _assemblyName;
-    readonly Guid _mvid;
-    readonly bool _memorySafetyRulesEnabled;
 
     internal LibraryBodyAnalysisBuilder(string path, MetadataReader reader, PEReader peReader, IAssemblyReferenceResolver? resolver = null)
     {
-        _path = path;
         _reader = reader;
         _peReader = peReader;
-        _assemblyName = reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : System.IO.Path.GetFileNameWithoutExtension(path);
-        _mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
-        _memorySafetyRulesEnabled = DetectMemorySafetyRules();
+        string assemblyName = reader.IsAssembly
+            ? reader.GetString(reader.GetAssemblyDefinition().Name)
+            : System.IO.Path.GetFileNameWithoutExtension(path);
+        Guid mvid =
+            reader.GetGuid(reader.GetModuleDefinition().Mvid);
+        _primaryMetadataResolver =
+            new LibraryBodyPrimaryMetadataResolver(
+                reader,
+                assemblyName,
+                mvid);
         if (resolver is not null && reader.IsAssembly)
             _referenceMetadataResolver =
                 new LibraryBodyReferenceMetadataResolver(
@@ -54,15 +57,15 @@ internal sealed class LibraryBodyAnalysisBuilder :
         _peReader;
 
     string ILibraryMethodAnalysisInfrastructure.AssemblyName =>
-        _assemblyName;
+        _primaryMetadataResolver.AssemblyName;
 
     Guid ILibraryMethodAnalysisInfrastructure.Mvid =>
-        _mvid;
+        _primaryMetadataResolver.Mvid;
 
     GenericScope ILibraryMethodAnalysisInfrastructure.CreateScope(
         TypeDefinition typeDefinition,
         MethodDefinition methodDefinition) =>
-        CreateScope(
+        _primaryMetadataResolver.CreateScope(
             typeDefinition,
             methodDefinition);
 
@@ -72,7 +75,7 @@ internal sealed class LibraryBodyAnalysisBuilder :
             MethodDefinitionHandle methodHandle,
             MethodDefinition methodDefinition,
             GenericScope scope) =>
-        CreateMethodIdentity(
+        _primaryMetadataResolver.CreateMethodIdentity(
             typeHandle,
             methodHandle,
             methodDefinition,
@@ -84,8 +87,7 @@ internal sealed class LibraryBodyAnalysisBuilder :
             MethodIdentity caller,
             byte[] il,
             IReadOnlyCollection<ExceptionRegion> exceptionRegions) =>
-        new MethodAnalysisResolver(
-            this,
+        _primaryMetadataResolver.CreateMethodAnalysisResolver(
             scope,
             caller,
             il,
@@ -94,38 +96,37 @@ internal sealed class LibraryBodyAnalysisBuilder :
     IMethodCallResolver
         ILibraryMethodAnalysisInfrastructure.CreateCallResolver(
             GenericScope scope) =>
-        new CallResolver(
-            this,
-            scope);
+        _primaryMetadataResolver.CreateCallResolver(scope);
 
     string? ILibraryMethodAnalysisInfrastructure.CalliReturnDetail(
         int token,
         GenericScope scope) =>
-        CalliReturnDetail(
+        _primaryMetadataResolver.CalliReturnDetail(
             token,
             scope);
 
     bool ILibraryMethodAnalysisInfrastructure.IsAllocatingValueTypeBox(
         int token,
         GenericScope scope) =>
-        IsAllocatingValueTypeBox(
+        _primaryMetadataResolver.IsAllocatingValueTypeBox(
             token,
-            ResolveTypeToken(
-                token,
-                scope));
+            scope);
 
     bool ILibraryMethodAnalysisInfrastructure.HasGeneratedCodeAttribute(
         CustomAttributeHandleCollection attributes) =>
-        HasGeneratedCodeAttribute(attributes);
+        _primaryMetadataResolver.HasGeneratedCodeAttribute(
+            attributes);
 
     bool ILibraryMethodAnalysisInfrastructure.HasCompilerGeneratedAttribute(
         CustomAttributeHandleCollection attributes) =>
-        HasCompilerGeneratedAttribute(attributes);
+        _primaryMetadataResolver.HasCompilerGeneratedAttribute(
+            attributes);
 
     bool ILibraryMethodAnalysisInfrastructure.DispatchCanTargetOverride(
         TypeDefinition declaringType,
         MethodDefinition method) =>
-        DispatchCanTargetOverride(
+        LibraryBodyPrimaryMetadataResolver
+            .DispatchCanTargetOverride(
             declaringType,
             method);
 
@@ -134,19 +135,8 @@ internal sealed class LibraryBodyAnalysisBuilder :
         _referenceMetadataResolver?.TryResolveExternalTypeDefinition(
             handle);
 
-    // Roslyn's ModuleSymbol.UseUpdatedMemorySafetyRules: the module opted in
-    // when MemorySafetyRulesAttribute is applied (emitted [module:], like
-    // RefSafetyRulesAttribute). Check the module and assembly scopes.
-    public bool MemorySafetyRulesEnabled => _memorySafetyRulesEnabled;
-
-    bool DetectMemorySafetyRules()
-    {
-        const string ns = "System.Runtime.CompilerServices";
-        if (HasAttributeNamed(_reader.GetModuleDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns))
-            return true;
-        return _reader.IsAssembly
-            && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
-    }
+    public bool MemorySafetyRulesEnabled =>
+        _primaryMetadataResolver.MemorySafetyRulesEnabled;
 
     public LibraryBodyAnalysisResult Build(
         LibraryBodyAnalysisPlan plan)
@@ -201,7 +191,9 @@ internal sealed class LibraryBodyAnalysisBuilder :
             // actionable source-shape opportunities, so skip optimization-opportunity
             // collection for them (they are still indexed for calls/leverage/signals).
             bool typeSourceGenerated = includeOpportunities
-                && HasGeneratedCodeAttribute(typeDef.GetCustomAttributes());
+                && _primaryMetadataResolver
+                    .HasGeneratedCodeAttribute(
+                        typeDef.GetCustomAttributes());
             foreach (var methodHandle in typeDef.GetMethods())
                 workItems.Add((typeHandle, typeDef, typeSourceGenerated, methodHandle));
         }
@@ -217,7 +209,8 @@ internal sealed class LibraryBodyAnalysisBuilder :
             // Prewarm the async-state-machine set so it is fully computed before the parallel
             // pass reads it read-only.
             if (includeMethodEvidence)
-                _ = AsyncStateMachineTypes();
+                _ = _primaryMetadataResolver
+                    .AsyncStateMachineTypes();
             Parallel.For(0, workItems.Count, i =>
             {
                 var w = workItems[i];
@@ -361,61 +354,12 @@ internal sealed class LibraryBodyAnalysisBuilder :
         {
             if (call.Kind != CallKind.NewObject || set.Contains(call.OperandToken))
                 continue;
-            if (IsNonHeapNewObj(call.OperandToken, call.Callee.DeclaringType))
+            if (_primaryMetadataResolver.IsNonHeapNewObj(
+                    call.OperandToken,
+                    call.Callee.DeclaringType))
                 set.Add(call.OperandToken);
         }
         return set;
-    }
-
-    // True when a `newobj` of this operand constructs a value type. Combines a name-based
-    // FRAMEWORK fast path with an authoritative metadata resolution of the constructor's
-    // declaring type (TypeDef base chain, or TypeSpec signature blob for constructed
-    // generics) — the latter is what classifies in-assembly and cross-assembly structs.
-    bool IsNonHeapNewObj(int operandToken, TypeRef declaringType)
-    {
-        if (IsNonHeapConstructionByName(declaringType))
-            return true;
-        try
-        {
-            var handle = MetadataTokens.EntityHandle(operandToken);
-            EntityHandle typeHandle = handle.Kind switch
-            {
-                HandleKind.MethodDefinition => _reader.GetMethodDefinition((MethodDefinitionHandle)handle).GetDeclaringType(),
-                HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).Parent,
-                _ => default,
-            };
-            if (typeHandle.Kind == HandleKind.TypeDefinition)
-                return IsValueTypeDefinition((TypeDefinitionHandle)typeHandle);
-            if (typeHandle.Kind == HandleKind.TypeSpecification)
-                return IsValueTypeSpec((TypeSpecificationHandle)typeHandle);
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
-        {
-            return false;
-        }
-        return false;
-    }
-
-    // Name-based recognition of FRAMEWORK value types whose `newobj` resolves to a bare
-    // TypeRef the token dispatch cannot follow (a non-generic framework struct like DateTime
-    // or Guid lives in an assembly this one does not load). The common generic framework
-    // value types (Span/ReadOnlySpan/Memory/Nullable/ValueTuple`n) are constructed through a
-    // TypeSpec and are resolved authoritatively by the signature blob, so they are listed
-    // here only as a fast path. In-assembly and cross-assembly value types are NOT matched by
-    // name — that is the operand-token metadata path's job — because a display name omits
-    // assembly identity and would misclassify an external reference type that shares a
-    // namespace+name with an in-assembly struct (#1804 review).
-    static bool IsNonHeapConstructionByName(TypeRef type)
-    {
-        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
-        if (definition.Kind != TypeRefKind.Definition || !definition.TrustedFrameworkAssembly)
-            return false;
-        if (definition.Namespace == "System" && definition.Name is
-                "Span`1" or "ReadOnlySpan`1" or "Memory`1" or "ReadOnlyMemory`1" or "Nullable`1"
-                or "ValueTuple" or "ValueTuple`1" or "ValueTuple`2" or "ValueTuple`3" or "ValueTuple`4"
-                or "ValueTuple`5" or "ValueTuple`6" or "ValueTuple`7" or "ValueTuple`8")
-            return true;
-        return IsWellKnownValueType(definition.Namespace, definition.Name);
     }
 
     // Classifies in-assembly types by whether they derive from System.Exception,
@@ -518,626 +462,6 @@ internal sealed class LibraryBodyAnalysisBuilder :
     {
         var type = TypeRefDecoder.Instance.GetTypeFromReference(_reader, handle, 0);
         return type.Name.EndsWith("Exception", StringComparison.Ordinal);
-    }
-
-    MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, MethodDefinition methodDef, GenericScope scope)
-    {
-        var declaringType = TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0);
-        ImmutableArray<TypeRef> parameterTypes;
-        TypeRef returnType;
-        byte signatureHeader;
-        int requiredParameterCount;
-        if (SignatureBlobGuard.IsSafeToDecode(_reader, methodDef.Signature, SignatureBlobGuard.Kind.Method))
-        {
-            var signature = methodDef.DecodeSignature(TypeRefDecoder.Instance, scope);
-            parameterTypes = signature.ParameterTypes;
-            returnType = signature.ReturnType;
-            signatureHeader = signature.Header.RawValue;
-            requiredParameterCount = signature.RequiredParameterCount;
-        }
-        else
-        {
-            parameterTypes = [];
-            returnType = TypeRef.Unsupported("method signature nesting depth exceeded");
-            signatureHeader = 0;
-            requiredParameterCount = -1;
-        }
-        return new MethodIdentity(
-            _assemblyName,
-            _mvid,
-            declaringType,
-            _reader.GetString(methodDef.Name),
-            parameterTypes,
-            returnType,
-            MetadataTokens.GetToken(methodHandle),
-            (methodDef.Attributes & MethodAttributes.Static) != 0,
-            IsExtensionMethod(typeHandle, methodDef),
-            ComputeCallerUnsafeMode(typeHandle, methodDef, parameterTypes, returnType),
-            methodDef.GetGenericParameters().Count,
-            GenericParameterNames(methodDef))
-        {
-            SignatureHeader = signatureHeader,
-            RequiredParameterCount = requiredParameterCount,
-            IsVirtualDispatchOpen =
-                DispatchCanTargetOverride(
-                    _reader.GetTypeDefinition(typeHandle),
-                    methodDef),
-        };
-    }
-
-    static bool DispatchCanTargetOverride(
-        TypeDefinition declaringType,
-        MethodDefinition method) =>
-        (method.Attributes & MethodAttributes.Virtual) != 0
-        && (method.Attributes & MethodAttributes.Final) == 0
-        && (declaringType.Attributes & TypeAttributes.Sealed) == 0;
-
-    ImmutableArray<string> GenericParameterNames(MethodDefinition methodDef)
-    {
-        var handles = methodDef.GetGenericParameters();
-        if (handles.Count == 0)
-            return [];
-        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
-        foreach (var handle in handles)
-            names.Add(_reader.GetString(_reader.GetGenericParameter(handle).Name));
-        return names.MoveToImmutable();
-    }
-
-    bool IsExtensionMethod(TypeDefinitionHandle typeHandle, MethodDefinition methodDef)
-    {
-        var type = _reader.GetTypeDefinition(typeHandle);
-        return (type.Attributes & TypeAttributes.Abstract) != 0
-            && (type.Attributes & TypeAttributes.Sealed) != 0
-            && (methodDef.Attributes & MethodAttributes.Static) != 0
-            && AttributeReader.HasExtensionAttribute(_reader, type.GetCustomAttributes())
-            && AttributeReader.HasExtensionAttribute(_reader, methodDef.GetCustomAttributes());
-    }
-
-    // Mirrors Roslyn's PEMethodSymbol.CallerUnsafeMode: a member "requires
-    // unsafe" when it carries RequiresUnsafeAttribute (the metadata form of
-    // the `unsafe` modifier) or has a pointer/function pointer in its
-    // signature; the mode is then gated on the module opting into the rules.
-    CallerUnsafeMode ComputeCallerUnsafeMode(
-        TypeDefinitionHandle typeHandle, MethodDefinition methodDef,
-        ImmutableArray<TypeRef> parameterTypes, TypeRef returnType)
-    {
-        bool requiresUnsafe =
-            HasRequiresUnsafe(methodDef.GetCustomAttributes())
-            || HasRequiresUnsafe(_reader.GetTypeDefinition(typeHandle).GetCustomAttributes())
-            || parameterTypes.Any(type => type.ContainsPointer())
-            || returnType.ContainsPointer();
-
-        if (!requiresUnsafe)
-            return CallerUnsafeMode.None;
-        return _memorySafetyRulesEnabled ? CallerUnsafeMode.Explicit : CallerUnsafeMode.Implicit;
-    }
-
-    // Read attributes straight from SRM — a simple has-attribute check needs
-    // no shared decode/render machinery, so Analysis stays independent.
-    bool HasRequiresUnsafe(CustomAttributeHandleCollection attributes)
-        // Match the distinctive simple name: the implemented attribute is in
-        // System.Diagnostics.CodeAnalysis, while the design doc says
-        // System.Runtime.CompilerServices — tolerate the namespace churn.
-        => HasAttributeNamed(attributes, "RequiresUnsafeAttribute",
-            "System.Diagnostics.CodeAnalysis", "System.Runtime.CompilerServices");
-
-    bool HasAttributeNamed(CustomAttributeHandleCollection attributes, string simpleName, params string[] namespaces)
-    {
-        foreach (var handle in attributes)
-        {
-            var (ns, name) = AttributeTypeName(_reader.GetCustomAttribute(handle).Constructor);
-            if (name == simpleName && (namespaces.Length == 0 || Array.IndexOf(namespaces, ns) >= 0))
-                return true;
-        }
-        return false;
-    }
-
-    // True when the member/type is marked [System.CodeDom.Compiler.GeneratedCode] —
-    // the universal source-generator signal (System.Text.Json, regex, etc.). Such code
-    // has ordinary names (so the compiler-generated name heuristics miss it) but is not
-    // an actionable source-shape optimization target.
-    bool HasGeneratedCodeAttribute(CustomAttributeHandleCollection attributes)
-        => HasAttributeNamed(attributes, "GeneratedCodeAttribute", "System.CodeDom.Compiler");
-
-    // True when the method is marked [System.Runtime.CompilerServices.CompilerGenerated]
-    // — record synthesized members (EqualityContract/PrintMembers/Equals/GetHashCode/
-    // ToString), lambdas, iterators, and async state machines. These have ordinary names
-    // (e.g. get_EqualityContract) that the angle-bracket name heuristics miss, yet none
-    // are user-actionable source-shape rewrite targets, so exclude them from collection.
-    bool HasCompilerGeneratedAttribute(CustomAttributeHandleCollection attributes)
-        => HasAttributeNamed(attributes, "CompilerGeneratedAttribute", "System.Runtime.CompilerServices");
-
-    (string Namespace, string Name) AttributeTypeName(EntityHandle constructor)
-    {
-        if (constructor.Kind == HandleKind.MemberReference
-            && _reader.GetMemberReference((MemberReferenceHandle)constructor).Parent is { Kind: HandleKind.TypeReference } parent)
-        {
-            var typeRef = _reader.GetTypeReference((TypeReferenceHandle)parent);
-            return (_reader.GetString(typeRef.Namespace), _reader.GetString(typeRef.Name));
-        }
-        if (constructor.Kind == HandleKind.MethodDefinition)
-        {
-            var declType = _reader.GetTypeDefinition(_reader.GetMethodDefinition((MethodDefinitionHandle)constructor).GetDeclaringType());
-            return (_reader.GetString(declType.Namespace), _reader.GetString(declType.Name));
-        }
-        return ("", "");
-    }
-
-    // Metadata- and IL-dependent judgments for one method's body analyses.
-    // The builder owns the metadata reader, the caller's generic scope, and the raw
-    // IL bytes; topic producers see only these narrow answers, so they cannot open a
-    // second decode or metadata traversal path.
-    sealed class MethodAnalysisResolver(
-        LibraryBodyAnalysisBuilder owner,
-        GenericScope scope,
-        MethodIdentity caller,
-        byte[] il,
-        IReadOnlyCollection<ExceptionRegion> exceptionRegions)
-        : ILibraryMethodAnalysisResolver
-    {
-        public TypeRef ResolveType(int token)
-            => owner.ResolveTypeToken(token, scope);
-
-        public MemberRef ResolveMember(int token)
-            => MemberResolver.ResolveMethod(
-                owner._reader,
-                MetadataTokens.EntityHandle(token),
-                scope);
-
-        public NewObjectConstructionKind ClassifyConstruction(
-            int operandToken,
-            TypeRef declaringType)
-        {
-            if (!owner.IsNonHeapNewObj(operandToken, declaringType))
-                return NewObjectConstructionKind.Heap;
-            return owner.IsUnresolvedExternalValueTypeConstruction(
-                operandToken,
-                declaringType)
-                    ? NewObjectConstructionKind.UnresolvedExternalValueType
-                    : NewObjectConstructionKind.NonHeap;
-        }
-
-        public bool IsDelegateConstructor(int operandToken, MemberRef constructor)
-            => owner.IsDelegateConstructorToken(operandToken, constructor);
-
-        public bool IsAllocatingValueTypeBox(int operandToken, TypeRef boxed)
-            => owner.IsAllocatingValueTypeBox(operandToken, boxed);
-
-        public bool IsAsyncStateMachineType(TypeRef? type)
-            => owner.IsAsyncStateMachineType(type);
-
-        public bool IsInAssemblyReferenceType(int typeToken)
-            => owner.IsInAssemblyReferenceTypeElement(typeToken);
-
-        public (TypeRef? DeclaringType, string? Name) ResolveFieldOwner(int fieldToken)
-            => owner.ResolveFieldOwner(fieldToken, scope);
-
-        public ReachingDefinitionsResult AnalyzeReachingDefinitions()
-            => ReachingDefinitions.Analyze(
-                il,
-                ArgumentSlotCount(caller),
-                exceptionRegions);
-    }
-
-    // Metadata-dependent call-site facts for one method. MethodCallAnalysis owns
-    // the body traversal and projection while this resolver retains reader/scope
-    // ownership and the established malformed-metadata behavior.
-    sealed class CallResolver(
-        LibraryBodyAnalysisBuilder owner,
-        GenericScope scope)
-        : IMethodCallResolver
-    {
-        public MemberRef ResolveMember(int token)
-            => MemberResolver.ResolveMethod(
-                owner._reader,
-                MetadataTokens.EntityHandle(token),
-                scope);
-
-        public MemberRef ResolveIndirectCall(int signatureToken)
-            => owner.ResolveCalliMember(signatureToken, scope);
-
-        public int DefinitionToken(int operandToken)
-            => owner.PeelToDefinitionToken(operandToken);
-    }
-
-    // A value-type `newobj` whose operand is an unresolvable external TypeRef is still
-    // recorded (as a non-heap annotation) when the type is a recognized framework value
-    // type by name, so the row is not silently dropped.
-    bool IsUnresolvedExternalValueTypeConstruction(
-        int operandToken,
-        TypeRef type)
-    {
-        try
-        {
-            var handle = MetadataTokens.EntityHandle(operandToken);
-            var parent = handle.Kind switch
-            {
-                HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).Parent,
-                _ => default,
-            };
-            return parent.Kind == HandleKind.TypeReference
-                && IsNonHeapConstructionByName(type);
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
-        {
-            return false;
-        }
-    }
-
-    // The declaring type and name behind a field-store operand. Returns (null, null)
-    // when the operand is not a resolvable field, leaving the escape-kind judgment to
-    // the allocation analysis that asked.
-    (TypeRef? DeclaringType, string? Name) ResolveFieldOwner(int fieldToken, GenericScope callerScope)
-    {
-        try
-        {
-            var handle = MetadataTokens.EntityHandle(fieldToken);
-            switch (handle.Kind)
-            {
-                case HandleKind.FieldDefinition:
-                    var field = _reader.GetFieldDefinition((FieldDefinitionHandle)handle);
-                    return (
-                        TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, field.GetDeclaringType(), 0),
-                        _reader.GetString(field.Name));
-                case HandleKind.MemberReference:
-                    return (
-                        ResolveMemberReferenceParentType(handle, callerScope),
-                        _reader.GetString(_reader.GetMemberReference((MemberReferenceHandle)handle).Name));
-                default:
-                    return (null, null);
-            }
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException)
-        {
-            return (null, null);
-        }
-    }
-
-    bool IsDelegateConstructorToken(int operandToken, MemberRef constructor)
-    {
-        if (constructor.Kind != MemberKind.Constructor
-            || constructor.ParameterTypes.Length != 2
-            || !constructor.ParameterTypes[0].Equals(TypeRef.CoreLib("System", "Object"))
-            || !constructor.ParameterTypes[1].Equals(TypeRef.CoreLib("System", "IntPtr")))
-        {
-            return false;
-        }
-
-        var definition = constructor.DeclaringType.Kind == TypeRefKind.GenericInstance
-            ? constructor.DeclaringType.ElementType ?? constructor.DeclaringType
-            : constructor.DeclaringType;
-        if (definition.TrustedFrameworkAssembly
-            && definition.Assembly == TypeRef.CoreLibrary
-            && definition.Namespace == "System"
-            && (definition.Name.StartsWith("Func`", StringComparison.Ordinal)
-                || definition.Name.StartsWith("Action`", StringComparison.Ordinal)
-                || definition.Name == "Action"))
-        {
-            return true;
-        }
-
-        try
-        {
-            var handle = MetadataTokens.EntityHandle(operandToken);
-            EntityHandle parent = handle.Kind switch
-            {
-                HandleKind.MethodDefinition => _reader.GetMethodDefinition((MethodDefinitionHandle)handle).GetDeclaringType(),
-                HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).Parent,
-                _ => default,
-            };
-            return parent.Kind == HandleKind.TypeDefinition
-                && TypeDerivesFromMulticastDelegate((TypeDefinitionHandle)parent);
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
-        {
-            return false;
-        }
-    }
-
-    bool TypeDerivesFromMulticastDelegate(TypeDefinitionHandle handle)
-    {
-        var visited = new HashSet<TypeDefinitionHandle>();
-        var current = handle;
-        while (visited.Add(current))
-        {
-            var baseHandle = _reader.GetTypeDefinition(current).BaseType;
-            switch (baseHandle.Kind)
-            {
-                case HandleKind.TypeReference:
-                    var baseRef = _reader.GetTypeReference((TypeReferenceHandle)baseHandle);
-                    return _reader.GetString(baseRef.Namespace) == "System"
-                        && _reader.GetString(baseRef.Name) == "MulticastDelegate";
-                case HandleKind.TypeDefinition:
-                    current = (TypeDefinitionHandle)baseHandle;
-                    continue;
-                default:
-                    return false;
-            }
-        }
-        return false;
-    }
-
-    string? CalliReturnDetail(int token, GenericScope scope)
-    {
-        try
-        {
-            var handle = MetadataTokens.EntityHandle(token);
-            if (handle.Kind != HandleKind.StandaloneSignature)
-                return null;
-            var standalone = _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle);
-            if (!SignatureBlobGuard.IsSafeToDecode(
-                    _reader,
-                    standalone.Signature,
-                    SignatureBlobGuard.Kind.StandaloneMethod))
-                return null;
-            var signature = standalone.DecodeMethodSignature(TypeRefDecoder.Instance, scope);
-            return signature.ReturnType.ToDisplayString();
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
-        {
-            return null;
-        }
-    }
-
-    IReadOnlySet<string>? _asyncStateMachineTypes;
-
-    bool IsAsyncStateMachineType(TypeRef? type)
-    {
-        if (type is null)
-            return false;
-        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
-        return AsyncStateMachineTypes().Contains(definition.ToQualifiedDisplayString());
-    }
-
-    IReadOnlySet<string> AsyncStateMachineTypes()
-    {
-        if (_asyncStateMachineTypes is not null)
-            return _asyncStateMachineTypes;
-
-        var set = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var typeHandle in _reader.TypeDefinitions)
-        {
-            var typeDef = _reader.GetTypeDefinition(typeHandle);
-            var type = TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0);
-            if (!type.Name.Contains(">d__", StringComparison.Ordinal))
-                continue;
-            foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
-            {
-                var implementation = _reader.GetInterfaceImplementation(implementationHandle);
-                var interfaceType = TypeFromEntity(implementation.Interface);
-                var definition = interfaceType.Kind == TypeRefKind.GenericInstance
-                    ? interfaceType.ElementType ?? interfaceType
-                    : interfaceType;
-                if (FrameworkIdentity.IsCoreLibraryType(definition, "System.Runtime.CompilerServices", "IAsyncStateMachine"))
-                {
-                    set.Add(type.ToQualifiedDisplayString());
-                    break;
-                }
-            }
-        }
-        _asyncStateMachineTypes = set;
-        return set;
-    }
-
-    TypeRef TypeFromEntity(EntityHandle handle)
-    {
-        try
-        {
-            return handle.Kind switch
-            {
-                HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, (TypeDefinitionHandle)handle, 0),
-                HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(_reader, (TypeReferenceHandle)handle, 0),
-                HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(_reader, new GenericScope([], []), (TypeSpecificationHandle)handle, 0),
-                _ => TypeRef.Unsupported("interface implementation"),
-            };
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
-        {
-            return TypeRef.Unsupported("interface implementation");
-        }
-    }
-
-    // True only when a `box` operand is positively identified as a value type that
-    // unconditionally allocates. ECMA-335 allows `box` on reference types (no allocation),
-    // generic parameters (compiler-mandated / JIT-specialized), and `Nullable<T>` (no
-    // allocation when null) — all excluded to avoid false positives. In-assembly types are
-    // resolved authoritatively via their base type; external types are accepted only from a
-    // curated set of well-known framework value types.
-    bool IsAllocatingValueTypeBox(int token, TypeRef boxed)
-    {
-        // Nullable<T> boxing allocates only when HasValue; conservatively exclude.
-        var leaf = boxed.Kind == TypeRefKind.GenericInstance ? boxed.ElementType ?? boxed : boxed;
-        if (leaf.Kind == TypeRefKind.Definition && leaf.Namespace == "System" && leaf.Name == "Nullable`1")
-            return false;
-
-        try
-        {
-            var handle = MetadataTokens.EntityHandle(token);
-            if (handle.Kind == HandleKind.TypeDefinition)
-                return IsValueTypeDefinition((TypeDefinitionHandle)handle);
-            // A constructed generic type (e.g. Box<int>) is a TypeSpec whose signature blob
-            // directly encodes value-type-ness (ELEMENT_TYPE_VALUETYPE vs ELEMENT_TYPE_CLASS),
-            // so we don't need to resolve the definition. Covers in-assembly and external
-            // generic structs alike; Nullable<T> is already excluded above.
-            if (handle.Kind == HandleKind.TypeSpecification)
-                return IsValueTypeSpec((TypeSpecificationHandle)handle);
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
-        {
-            return false;
-        }
-
-        return leaf.Kind == TypeRefKind.Definition
-            && leaf.TrustedFrameworkAssembly
-            && IsWellKnownValueType(leaf.Namespace, leaf.Name);
-    }
-
-    // Reads a TypeSpec signature blob to decide value-type-ness directly from metadata. The
-    // signature is an ELEMENT_TYPE_* stream; a generic instance is GENERICINST followed by
-    // VALUETYPE (0x11) or CLASS (0x12), and a bare value/class spec starts with that byte.
-    bool IsValueTypeSpec(TypeSpecificationHandle handle)
-    {
-        const byte ElementTypeValueType = 0x11;
-        const byte ElementTypeGenericInst = 0x15;
-        var blob = _reader.GetBlobReader(_reader.GetTypeSpecification(handle).Signature);
-        if (blob.RemainingBytes == 0)
-            return false;
-        byte code = blob.ReadByte();
-        if (code == ElementTypeGenericInst)
-        {
-            if (blob.RemainingBytes == 0)
-                return false;
-            code = blob.ReadByte();
-        }
-        // VALUETYPE (0x11) is a value type; CLASS (0x12) and everything else is not.
-        return code == ElementTypeValueType;
-    }
-
-    // Authoritative in-assembly check: a value type extends System.ValueType or System.Enum.
-    bool IsValueTypeDefinition(TypeDefinitionHandle handle)
-    {
-        var baseHandle = _reader.GetTypeDefinition(handle).BaseType;
-        if (baseHandle.IsNil)
-            return false;
-        var (ns, name) = baseHandle.Kind switch
-        {
-            HandleKind.TypeReference => (_reader.GetString(_reader.GetTypeReference((TypeReferenceHandle)baseHandle).Namespace),
-                _reader.GetString(_reader.GetTypeReference((TypeReferenceHandle)baseHandle).Name)),
-            HandleKind.TypeDefinition => (_reader.GetString(_reader.GetTypeDefinition((TypeDefinitionHandle)baseHandle).Namespace),
-                _reader.GetString(_reader.GetTypeDefinition((TypeDefinitionHandle)baseHandle).Name)),
-            _ => ("", ""),
-        };
-        return ns == "System" && name is "ValueType" or "Enum";
-    }
-
-    static bool IsWellKnownValueType(string ns, string name)
-        => (ns == "System" && name is "Boolean" or "Byte" or "SByte" or "Char"
-                or "Int16" or "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64"
-                or "Single" or "Double" or "IntPtr" or "UIntPtr" or "Decimal"
-                or "Half" or "Int128" or "UInt128"
-                or "DateTime" or "DateTimeOffset" or "TimeSpan" or "Guid")
-           || (ns == "System.Numerics" && name is "BigInteger" or "Complex")
-           || (ns == "System" && name.StartsWith("ValueTuple", StringComparison.Ordinal))
-           || (ns == "System.Collections.Generic" && name == "KeyValuePair`2");
-
-    // Resolves a metadata type token (TypeDef/TypeRef/TypeSpec) to a TypeRef, used to
-    // inspect a newarr element type. Returns Unsupported on any malformed/unknown token.
-    TypeRef ResolveTypeToken(int token, GenericScope scope)
-    {
-        try
-        {
-            var handle = MetadataTokens.EntityHandle(token);
-            return handle.Kind switch
-            {
-                HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, (TypeDefinitionHandle)handle, 0),
-                HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(_reader, (TypeReferenceHandle)handle, 0),
-                HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(_reader, scope, (TypeSpecificationHandle)handle, 0),
-                _ => TypeRef.Unsupported("newarr element"),
-            };
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
-        {
-            return TypeRef.Unsupported("newarr element");
-        }
-    }
-
-    bool IsInAssemblyReferenceTypeElement(int elementToken)
-    {
-        try
-        {
-            var handle = MetadataTokens.EntityHandle(elementToken);
-            return handle.Kind == HandleKind.TypeDefinition
-                && !IsValueTypeDefinition((TypeDefinitionHandle)handle);
-        }
-        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
-        {
-            return false;
-        }
-    }
-
-    TypeRef? ResolveMemberReferenceParentType(EntityHandle handle, GenericScope callerScope)
-    {
-        var parent = _reader.GetMemberReference((MemberReferenceHandle)handle).Parent;
-        return parent.Kind switch
-        {
-            HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, (TypeDefinitionHandle)parent, 0),
-            HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(_reader, (TypeReferenceHandle)parent, 0),
-            HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(_reader, callerScope, (TypeSpecificationHandle)parent, 0),
-            _ => null,
-        };
-    }
-
-    static int ArgumentSlotCount(MethodIdentity method)
-        => method.ParameterTypes.Length + (method.IsStatic ? 0 : 1);
-
-    MemberRef ResolveCalliMember(int token, GenericScope scope)
-    {
-        try
-        {
-            var handle = MetadataTokens.EntityHandle(token);
-            if (handle.Kind != HandleKind.StandaloneSignature)
-                return MemberRef.Unsupported("calli signature unavailable");
-            var standalone = _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle);
-            if (!SignatureBlobGuard.IsSafeToDecode(
-                    _reader,
-                    standalone.Signature,
-                    SignatureBlobGuard.Kind.StandaloneMethod))
-            {
-                return MemberRef.Unsupported("calli signature unavailable");
-            }
-
-            var signature = standalone.DecodeMethodSignature(TypeRefDecoder.Instance, scope);
-            return new MemberRef(
-                TypeRef.Unsupported("function pointer"),
-                "calli",
-                signature.ParameterTypes,
-                signature.ReturnType,
-                MemberKind.FunctionPointer)
-            {
-                HasThis = signature.Header.IsInstance,
-                SignatureHeader = signature.Header.RawValue,
-                RequiredParameterCount =
-                    signature.RequiredParameterCount,
-                GenericArity = signature.GenericParameterCount,
-                OpenParameterTypes = signature.ParameterTypes,
-                OpenReturnType = signature.ReturnType,
-            };
-        }
-        catch (Exception ex) when (ex is BadImageFormatException
-            or InvalidOperationException
-            or ArgumentException
-            or OverflowException)
-        {
-            return MemberRef.Unsupported("calli signature unavailable");
-        }
-    }
-
-    // Peel a generic-method call operand (MethodSpec) to the underlying MethodDef
-    // token in this assembly, so a call to G<int> is attributed to G's definition.
-    // Returns the token unchanged when it is not a same-assembly MethodSpec instantiation.
-    int PeelToDefinitionToken(int token)
-    {
-        var handle = MetadataTokens.EntityHandle(token);
-        if (handle.Kind == HandleKind.MethodSpecification)
-        {
-            var spec = _reader.GetMethodSpecification((MethodSpecificationHandle)handle);
-            if (spec.Method.Kind == HandleKind.MethodDefinition)
-                return MetadataTokens.GetToken(spec.Method);
-        }
-        return token;
-    }
-
-    GenericScope CreateScope(TypeDefinition typeDef, MethodDefinition methodDef)
-        => new(GenericParameterNames(typeDef.GetGenericParameters()), GenericParameterNames(methodDef.GetGenericParameters()));
-
-    ImmutableArray<string> GenericParameterNames(GenericParameterHandleCollection handles)
-    {
-        if (handles.Count == 0)
-            return [];
-        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
-        foreach (var handle in handles)
-            names.Add(_reader.GetString(_reader.GetGenericParameter(handle).Name));
-        return names.MoveToImmutable();
     }
 
 }

--- a/src/ILInspector.Analysis/LibraryBodyPrimaryMetadataResolver.cs
+++ b/src/ILInspector.Analysis/LibraryBodyPrimaryMetadataResolver.cs
@@ -1,0 +1,741 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Metadata;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Owns primary-image metadata judgments and the narrow per-method resolver
+/// adapters consumed by body-analysis producers.
+/// </summary>
+internal sealed class LibraryBodyPrimaryMetadataResolver
+{
+    readonly MetadataReader _reader;
+    readonly string _assemblyName;
+    readonly Guid _mvid;
+    readonly bool _memorySafetyRulesEnabled;
+
+    internal LibraryBodyPrimaryMetadataResolver(
+        MetadataReader reader,
+        string assemblyName,
+        Guid mvid)
+    {
+        _reader = reader;
+        _assemblyName = assemblyName;
+        _mvid = mvid;
+        _memorySafetyRulesEnabled = DetectMemorySafetyRules();
+    }
+
+    internal bool MemorySafetyRulesEnabled =>
+        _memorySafetyRulesEnabled;
+
+    internal string AssemblyName => _assemblyName;
+
+    internal Guid Mvid => _mvid;
+
+    internal ILibraryMethodAnalysisResolver CreateMethodAnalysisResolver(
+        GenericScope scope,
+        MethodIdentity caller,
+        byte[] il,
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions) =>
+        new MethodAnalysisResolver(
+            this,
+            scope,
+            caller,
+            il,
+            exceptionRegions);
+
+    internal IMethodCallResolver CreateCallResolver(GenericScope scope) =>
+        new CallResolver(this, scope);
+
+    internal bool IsAllocatingValueTypeBox(int token, GenericScope scope) =>
+        IsAllocatingValueTypeBox(token, ResolveTypeToken(token, scope));
+
+    // Roslyn's ModuleSymbol.UseUpdatedMemorySafetyRules: the module opted in
+    // when MemorySafetyRulesAttribute is applied (emitted [module:], like
+    // RefSafetyRulesAttribute). Check the module and assembly scopes.
+    bool DetectMemorySafetyRules()
+    {
+        const string ns = "System.Runtime.CompilerServices";
+        if (HasAttributeNamed(_reader.GetModuleDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns))
+            return true;
+        return _reader.IsAssembly
+            && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
+    }
+
+    // True when a `newobj` of this operand constructs a value type. Combines a name-based
+    // FRAMEWORK fast path with an authoritative metadata resolution of the constructor's
+    // declaring type (TypeDef base chain, or TypeSpec signature blob for constructed
+    // generics) — the latter is what classifies in-assembly and cross-assembly structs.
+    internal bool IsNonHeapNewObj(int operandToken, TypeRef declaringType)
+    {
+        if (IsNonHeapConstructionByName(declaringType))
+            return true;
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(operandToken);
+            EntityHandle typeHandle = handle.Kind switch
+            {
+                HandleKind.MethodDefinition => _reader.GetMethodDefinition((MethodDefinitionHandle)handle).GetDeclaringType(),
+                HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).Parent,
+                _ => default,
+            };
+            if (typeHandle.Kind == HandleKind.TypeDefinition)
+                return IsValueTypeDefinition((TypeDefinitionHandle)typeHandle);
+            if (typeHandle.Kind == HandleKind.TypeSpecification)
+                return IsValueTypeSpec((TypeSpecificationHandle)typeHandle);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+        {
+            return false;
+        }
+        return false;
+    }
+
+    // Name-based recognition of FRAMEWORK value types whose `newobj` resolves to a bare
+    // TypeRef the token dispatch cannot follow (a non-generic framework struct like DateTime
+    // or Guid lives in an assembly this one does not load). The common generic framework
+    // value types (Span/ReadOnlySpan/Memory/Nullable/ValueTuple`n) are constructed through a
+    // TypeSpec and are resolved authoritatively by the signature blob, so they are listed
+    // here only as a fast path. In-assembly and cross-assembly value types are NOT matched by
+    // name — that is the operand-token metadata path's job — because a display name omits
+    // assembly identity and would misclassify an external reference type that shares a
+    // namespace+name with an in-assembly struct (#1804 review).
+    static bool IsNonHeapConstructionByName(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+        if (definition.Kind != TypeRefKind.Definition || !definition.TrustedFrameworkAssembly)
+            return false;
+        if (definition.Namespace == "System" && definition.Name is
+                "Span`1" or "ReadOnlySpan`1" or "Memory`1" or "ReadOnlyMemory`1" or "Nullable`1"
+                or "ValueTuple" or "ValueTuple`1" or "ValueTuple`2" or "ValueTuple`3" or "ValueTuple`4"
+                or "ValueTuple`5" or "ValueTuple`6" or "ValueTuple`7" or "ValueTuple`8")
+            return true;
+        return IsWellKnownValueType(definition.Namespace, definition.Name);
+    }
+
+    internal MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, MethodDefinition methodDef, GenericScope scope)
+    {
+        var declaringType = TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0);
+        ImmutableArray<TypeRef> parameterTypes;
+        TypeRef returnType;
+        byte signatureHeader;
+        int requiredParameterCount;
+        if (SignatureBlobGuard.IsSafeToDecode(_reader, methodDef.Signature, SignatureBlobGuard.Kind.Method))
+        {
+            var signature = methodDef.DecodeSignature(TypeRefDecoder.Instance, scope);
+            parameterTypes = signature.ParameterTypes;
+            returnType = signature.ReturnType;
+            signatureHeader = signature.Header.RawValue;
+            requiredParameterCount = signature.RequiredParameterCount;
+        }
+        else
+        {
+            parameterTypes = [];
+            returnType = TypeRef.Unsupported("method signature nesting depth exceeded");
+            signatureHeader = 0;
+            requiredParameterCount = -1;
+        }
+        return new MethodIdentity(
+            _assemblyName,
+            _mvid,
+            declaringType,
+            _reader.GetString(methodDef.Name),
+            parameterTypes,
+            returnType,
+            MetadataTokens.GetToken(methodHandle),
+            (methodDef.Attributes & MethodAttributes.Static) != 0,
+            IsExtensionMethod(typeHandle, methodDef),
+            ComputeCallerUnsafeMode(typeHandle, methodDef, parameterTypes, returnType),
+            methodDef.GetGenericParameters().Count,
+            GenericParameterNames(methodDef))
+        {
+            SignatureHeader = signatureHeader,
+            RequiredParameterCount = requiredParameterCount,
+            IsVirtualDispatchOpen =
+                DispatchCanTargetOverride(
+                    _reader.GetTypeDefinition(typeHandle),
+                    methodDef),
+        };
+    }
+
+    internal static bool DispatchCanTargetOverride(
+        TypeDefinition declaringType,
+        MethodDefinition method) =>
+        (method.Attributes & MethodAttributes.Virtual) != 0
+        && (method.Attributes & MethodAttributes.Final) == 0
+        && (declaringType.Attributes & TypeAttributes.Sealed) == 0;
+
+    ImmutableArray<string> GenericParameterNames(MethodDefinition methodDef)
+    {
+        var handles = methodDef.GetGenericParameters();
+        if (handles.Count == 0)
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+        foreach (var handle in handles)
+            names.Add(_reader.GetString(_reader.GetGenericParameter(handle).Name));
+        return names.MoveToImmutable();
+    }
+
+    bool IsExtensionMethod(TypeDefinitionHandle typeHandle, MethodDefinition methodDef)
+    {
+        var type = _reader.GetTypeDefinition(typeHandle);
+        return (type.Attributes & TypeAttributes.Abstract) != 0
+            && (type.Attributes & TypeAttributes.Sealed) != 0
+            && (methodDef.Attributes & MethodAttributes.Static) != 0
+            && AttributeReader.HasExtensionAttribute(_reader, type.GetCustomAttributes())
+            && AttributeReader.HasExtensionAttribute(_reader, methodDef.GetCustomAttributes());
+    }
+
+    // Mirrors Roslyn's PEMethodSymbol.CallerUnsafeMode: a member "requires
+    // unsafe" when it carries RequiresUnsafeAttribute (the metadata form of
+    // the `unsafe` modifier) or has a pointer/function pointer in its
+    // signature; the mode is then gated on the module opting into the rules.
+    CallerUnsafeMode ComputeCallerUnsafeMode(
+        TypeDefinitionHandle typeHandle, MethodDefinition methodDef,
+        ImmutableArray<TypeRef> parameterTypes, TypeRef returnType)
+    {
+        bool requiresUnsafe =
+            HasRequiresUnsafe(methodDef.GetCustomAttributes())
+            || HasRequiresUnsafe(_reader.GetTypeDefinition(typeHandle).GetCustomAttributes())
+            || parameterTypes.Any(type => type.ContainsPointer())
+            || returnType.ContainsPointer();
+
+        if (!requiresUnsafe)
+            return CallerUnsafeMode.None;
+        return _memorySafetyRulesEnabled ? CallerUnsafeMode.Explicit : CallerUnsafeMode.Implicit;
+    }
+
+    // Read attributes straight from SRM — a simple has-attribute check needs
+    // no shared decode/render machinery, so Analysis stays independent.
+    bool HasRequiresUnsafe(CustomAttributeHandleCollection attributes)
+        // Match the distinctive simple name: the implemented attribute is in
+        // System.Diagnostics.CodeAnalysis, while the design doc says
+        // System.Runtime.CompilerServices — tolerate the namespace churn.
+        => HasAttributeNamed(attributes, "RequiresUnsafeAttribute",
+            "System.Diagnostics.CodeAnalysis", "System.Runtime.CompilerServices");
+
+    bool HasAttributeNamed(CustomAttributeHandleCollection attributes, string simpleName, params string[] namespaces)
+    {
+        foreach (var handle in attributes)
+        {
+            var (ns, name) = AttributeTypeName(_reader.GetCustomAttribute(handle).Constructor);
+            if (name == simpleName && (namespaces.Length == 0 || Array.IndexOf(namespaces, ns) >= 0))
+                return true;
+        }
+        return false;
+    }
+
+    // True when the member/type is marked [System.CodeDom.Compiler.GeneratedCode] —
+    // the universal source-generator signal (System.Text.Json, regex, etc.). Such code
+    // has ordinary names (so the compiler-generated name heuristics miss it) but is not
+    // an actionable source-shape optimization target.
+    internal bool HasGeneratedCodeAttribute(CustomAttributeHandleCollection attributes)
+        => HasAttributeNamed(attributes, "GeneratedCodeAttribute", "System.CodeDom.Compiler");
+
+    // True when the method is marked [System.Runtime.CompilerServices.CompilerGenerated]
+    // — record synthesized members (EqualityContract/PrintMembers/Equals/GetHashCode/
+    // ToString), lambdas, iterators, and async state machines. These have ordinary names
+    // (e.g. get_EqualityContract) that the angle-bracket name heuristics miss, yet none
+    // are user-actionable source-shape rewrite targets, so exclude them from collection.
+    internal bool HasCompilerGeneratedAttribute(CustomAttributeHandleCollection attributes)
+        => HasAttributeNamed(attributes, "CompilerGeneratedAttribute", "System.Runtime.CompilerServices");
+
+    (string Namespace, string Name) AttributeTypeName(EntityHandle constructor)
+    {
+        if (constructor.Kind == HandleKind.MemberReference
+            && _reader.GetMemberReference((MemberReferenceHandle)constructor).Parent is { Kind: HandleKind.TypeReference } parent)
+        {
+            var typeRef = _reader.GetTypeReference((TypeReferenceHandle)parent);
+            return (_reader.GetString(typeRef.Namespace), _reader.GetString(typeRef.Name));
+        }
+        if (constructor.Kind == HandleKind.MethodDefinition)
+        {
+            var declType = _reader.GetTypeDefinition(_reader.GetMethodDefinition((MethodDefinitionHandle)constructor).GetDeclaringType());
+            return (_reader.GetString(declType.Namespace), _reader.GetString(declType.Name));
+        }
+        return ("", "");
+    }
+
+    // Metadata- and IL-dependent judgments for one method's body analyses.
+    // The builder owns the metadata reader, the caller's generic scope, and the raw
+    // IL bytes; topic producers see only these narrow answers, so they cannot open a
+    // second decode or metadata traversal path.
+    sealed class MethodAnalysisResolver(
+        LibraryBodyPrimaryMetadataResolver owner,
+        GenericScope scope,
+        MethodIdentity caller,
+        byte[] il,
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions)
+        : ILibraryMethodAnalysisResolver
+    {
+        public TypeRef ResolveType(int token)
+            => owner.ResolveTypeToken(token, scope);
+
+        public MemberRef ResolveMember(int token)
+            => MemberResolver.ResolveMethod(
+                owner._reader,
+                MetadataTokens.EntityHandle(token),
+                scope);
+
+        public NewObjectConstructionKind ClassifyConstruction(
+            int operandToken,
+            TypeRef declaringType)
+        {
+            if (!owner.IsNonHeapNewObj(operandToken, declaringType))
+                return NewObjectConstructionKind.Heap;
+            return owner.IsUnresolvedExternalValueTypeConstruction(
+                operandToken,
+                declaringType)
+                    ? NewObjectConstructionKind.UnresolvedExternalValueType
+                    : NewObjectConstructionKind.NonHeap;
+        }
+
+        public bool IsDelegateConstructor(int operandToken, MemberRef constructor)
+            => owner.IsDelegateConstructorToken(operandToken, constructor);
+
+        public bool IsAllocatingValueTypeBox(int operandToken, TypeRef boxed)
+            => owner.IsAllocatingValueTypeBox(operandToken, boxed);
+
+        public bool IsAsyncStateMachineType(TypeRef? type)
+            => owner.IsAsyncStateMachineType(type);
+
+        public bool IsInAssemblyReferenceType(int typeToken)
+            => owner.IsInAssemblyReferenceTypeElement(typeToken);
+
+        public (TypeRef? DeclaringType, string? Name) ResolveFieldOwner(int fieldToken)
+            => owner.ResolveFieldOwner(fieldToken, scope);
+
+        public ReachingDefinitionsResult AnalyzeReachingDefinitions()
+            => ReachingDefinitions.Analyze(
+                il,
+                ArgumentSlotCount(caller),
+                exceptionRegions);
+    }
+
+    // Metadata-dependent call-site facts for one method. MethodCallAnalysis owns
+    // the body traversal and projection while this resolver retains reader/scope
+    // ownership and the established malformed-metadata behavior.
+    sealed class CallResolver(
+        LibraryBodyPrimaryMetadataResolver owner,
+        GenericScope scope)
+        : IMethodCallResolver
+    {
+        public MemberRef ResolveMember(int token)
+            => MemberResolver.ResolveMethod(
+                owner._reader,
+                MetadataTokens.EntityHandle(token),
+                scope);
+
+        public MemberRef ResolveIndirectCall(int signatureToken)
+            => owner.ResolveCalliMember(signatureToken, scope);
+
+        public int DefinitionToken(int operandToken)
+            => owner.PeelToDefinitionToken(operandToken);
+    }
+
+    // A value-type `newobj` whose operand is an unresolvable external TypeRef is still
+    // recorded (as a non-heap annotation) when the type is a recognized framework value
+    // type by name, so the row is not silently dropped.
+    bool IsUnresolvedExternalValueTypeConstruction(
+        int operandToken,
+        TypeRef type)
+    {
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(operandToken);
+            var parent = handle.Kind switch
+            {
+                HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).Parent,
+                _ => default,
+            };
+            return parent.Kind == HandleKind.TypeReference
+                && IsNonHeapConstructionByName(type);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+        {
+            return false;
+        }
+    }
+
+    // The declaring type and name behind a field-store operand. Returns (null, null)
+    // when the operand is not a resolvable field, leaving the escape-kind judgment to
+    // the allocation analysis that asked.
+    (TypeRef? DeclaringType, string? Name) ResolveFieldOwner(int fieldToken, GenericScope callerScope)
+    {
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(fieldToken);
+            switch (handle.Kind)
+            {
+                case HandleKind.FieldDefinition:
+                    var field = _reader.GetFieldDefinition((FieldDefinitionHandle)handle);
+                    return (
+                        TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, field.GetDeclaringType(), 0),
+                        _reader.GetString(field.Name));
+                case HandleKind.MemberReference:
+                    return (
+                        ResolveMemberReferenceParentType(handle, callerScope),
+                        _reader.GetString(_reader.GetMemberReference((MemberReferenceHandle)handle).Name));
+                default:
+                    return (null, null);
+            }
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException)
+        {
+            return (null, null);
+        }
+    }
+
+    bool IsDelegateConstructorToken(int operandToken, MemberRef constructor)
+    {
+        if (constructor.Kind != MemberKind.Constructor
+            || constructor.ParameterTypes.Length != 2
+            || !constructor.ParameterTypes[0].Equals(TypeRef.CoreLib("System", "Object"))
+            || !constructor.ParameterTypes[1].Equals(TypeRef.CoreLib("System", "IntPtr")))
+        {
+            return false;
+        }
+
+        var definition = constructor.DeclaringType.Kind == TypeRefKind.GenericInstance
+            ? constructor.DeclaringType.ElementType ?? constructor.DeclaringType
+            : constructor.DeclaringType;
+        if (definition.TrustedFrameworkAssembly
+            && definition.Assembly == TypeRef.CoreLibrary
+            && definition.Namespace == "System"
+            && (definition.Name.StartsWith("Func`", StringComparison.Ordinal)
+                || definition.Name.StartsWith("Action`", StringComparison.Ordinal)
+                || definition.Name == "Action"))
+        {
+            return true;
+        }
+
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(operandToken);
+            EntityHandle parent = handle.Kind switch
+            {
+                HandleKind.MethodDefinition => _reader.GetMethodDefinition((MethodDefinitionHandle)handle).GetDeclaringType(),
+                HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).Parent,
+                _ => default,
+            };
+            return parent.Kind == HandleKind.TypeDefinition
+                && TypeDerivesFromMulticastDelegate((TypeDefinitionHandle)parent);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+        {
+            return false;
+        }
+    }
+
+    bool TypeDerivesFromMulticastDelegate(TypeDefinitionHandle handle)
+    {
+        var visited = new HashSet<TypeDefinitionHandle>();
+        var current = handle;
+        while (visited.Add(current))
+        {
+            var baseHandle = _reader.GetTypeDefinition(current).BaseType;
+            switch (baseHandle.Kind)
+            {
+                case HandleKind.TypeReference:
+                    var baseRef = _reader.GetTypeReference((TypeReferenceHandle)baseHandle);
+                    return _reader.GetString(baseRef.Namespace) == "System"
+                        && _reader.GetString(baseRef.Name) == "MulticastDelegate";
+                case HandleKind.TypeDefinition:
+                    current = (TypeDefinitionHandle)baseHandle;
+                    continue;
+                default:
+                    return false;
+            }
+        }
+        return false;
+    }
+
+    internal string? CalliReturnDetail(int token, GenericScope scope)
+    {
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            if (handle.Kind != HandleKind.StandaloneSignature)
+                return null;
+            var standalone = _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle);
+            if (!SignatureBlobGuard.IsSafeToDecode(
+                    _reader,
+                    standalone.Signature,
+                    SignatureBlobGuard.Kind.StandaloneMethod))
+                return null;
+            var signature = standalone.DecodeMethodSignature(TypeRefDecoder.Instance, scope);
+            return signature.ReturnType.ToDisplayString();
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+        {
+            return null;
+        }
+    }
+
+    IReadOnlySet<string>? _asyncStateMachineTypes;
+
+    bool IsAsyncStateMachineType(TypeRef? type)
+    {
+        if (type is null)
+            return false;
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+        return AsyncStateMachineTypes().Contains(definition.ToQualifiedDisplayString());
+    }
+
+    internal IReadOnlySet<string> AsyncStateMachineTypes()
+    {
+        if (_asyncStateMachineTypes is not null)
+            return _asyncStateMachineTypes;
+
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var typeHandle in _reader.TypeDefinitions)
+        {
+            var typeDef = _reader.GetTypeDefinition(typeHandle);
+            var type = TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0);
+            if (!type.Name.Contains(">d__", StringComparison.Ordinal))
+                continue;
+            foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
+            {
+                var implementation = _reader.GetInterfaceImplementation(implementationHandle);
+                var interfaceType = TypeFromEntity(implementation.Interface);
+                var definition = interfaceType.Kind == TypeRefKind.GenericInstance
+                    ? interfaceType.ElementType ?? interfaceType
+                    : interfaceType;
+                if (FrameworkIdentity.IsCoreLibraryType(definition, "System.Runtime.CompilerServices", "IAsyncStateMachine"))
+                {
+                    set.Add(type.ToQualifiedDisplayString());
+                    break;
+                }
+            }
+        }
+        _asyncStateMachineTypes = set;
+        return set;
+    }
+
+    TypeRef TypeFromEntity(EntityHandle handle)
+    {
+        try
+        {
+            return handle.Kind switch
+            {
+                HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, (TypeDefinitionHandle)handle, 0),
+                HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(_reader, (TypeReferenceHandle)handle, 0),
+                HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(_reader, new GenericScope([], []), (TypeSpecificationHandle)handle, 0),
+                _ => TypeRef.Unsupported("interface implementation"),
+            };
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+        {
+            return TypeRef.Unsupported("interface implementation");
+        }
+    }
+
+    // True only when a `box` operand is positively identified as a value type that
+    // unconditionally allocates. ECMA-335 allows `box` on reference types (no allocation),
+    // generic parameters (compiler-mandated / JIT-specialized), and `Nullable<T>` (no
+    // allocation when null) — all excluded to avoid false positives. In-assembly types are
+    // resolved authoritatively via their base type; external types are accepted only from a
+    // curated set of well-known framework value types.
+    bool IsAllocatingValueTypeBox(int token, TypeRef boxed)
+    {
+        // Nullable<T> boxing allocates only when HasValue; conservatively exclude.
+        var leaf = boxed.Kind == TypeRefKind.GenericInstance ? boxed.ElementType ?? boxed : boxed;
+        if (leaf.Kind == TypeRefKind.Definition && leaf.Namespace == "System" && leaf.Name == "Nullable`1")
+            return false;
+
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            if (handle.Kind == HandleKind.TypeDefinition)
+                return IsValueTypeDefinition((TypeDefinitionHandle)handle);
+            // A constructed generic type (e.g. Box<int>) is a TypeSpec whose signature blob
+            // directly encodes value-type-ness (ELEMENT_TYPE_VALUETYPE vs ELEMENT_TYPE_CLASS),
+            // so we don't need to resolve the definition. Covers in-assembly and external
+            // generic structs alike; Nullable<T> is already excluded above.
+            if (handle.Kind == HandleKind.TypeSpecification)
+                return IsValueTypeSpec((TypeSpecificationHandle)handle);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+        {
+            return false;
+        }
+
+        return leaf.Kind == TypeRefKind.Definition
+            && leaf.TrustedFrameworkAssembly
+            && IsWellKnownValueType(leaf.Namespace, leaf.Name);
+    }
+
+    // Reads a TypeSpec signature blob to decide value-type-ness directly from metadata. The
+    // signature is an ELEMENT_TYPE_* stream; a generic instance is GENERICINST followed by
+    // VALUETYPE (0x11) or CLASS (0x12), and a bare value/class spec starts with that byte.
+    bool IsValueTypeSpec(TypeSpecificationHandle handle)
+    {
+        const byte ElementTypeValueType = 0x11;
+        const byte ElementTypeGenericInst = 0x15;
+        var blob = _reader.GetBlobReader(_reader.GetTypeSpecification(handle).Signature);
+        if (blob.RemainingBytes == 0)
+            return false;
+        byte code = blob.ReadByte();
+        if (code == ElementTypeGenericInst)
+        {
+            if (blob.RemainingBytes == 0)
+                return false;
+            code = blob.ReadByte();
+        }
+        // VALUETYPE (0x11) is a value type; CLASS (0x12) and everything else is not.
+        return code == ElementTypeValueType;
+    }
+
+    // Authoritative in-assembly check: a value type extends System.ValueType or System.Enum.
+    bool IsValueTypeDefinition(TypeDefinitionHandle handle)
+    {
+        var baseHandle = _reader.GetTypeDefinition(handle).BaseType;
+        if (baseHandle.IsNil)
+            return false;
+        var (ns, name) = baseHandle.Kind switch
+        {
+            HandleKind.TypeReference => (_reader.GetString(_reader.GetTypeReference((TypeReferenceHandle)baseHandle).Namespace),
+                _reader.GetString(_reader.GetTypeReference((TypeReferenceHandle)baseHandle).Name)),
+            HandleKind.TypeDefinition => (_reader.GetString(_reader.GetTypeDefinition((TypeDefinitionHandle)baseHandle).Namespace),
+                _reader.GetString(_reader.GetTypeDefinition((TypeDefinitionHandle)baseHandle).Name)),
+            _ => ("", ""),
+        };
+        return ns == "System" && name is "ValueType" or "Enum";
+    }
+
+    static bool IsWellKnownValueType(string ns, string name)
+        => (ns == "System" && name is "Boolean" or "Byte" or "SByte" or "Char"
+                or "Int16" or "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64"
+                or "Single" or "Double" or "IntPtr" or "UIntPtr" or "Decimal"
+                or "Half" or "Int128" or "UInt128"
+                or "DateTime" or "DateTimeOffset" or "TimeSpan" or "Guid")
+           || (ns == "System.Numerics" && name is "BigInteger" or "Complex")
+           || (ns == "System" && name.StartsWith("ValueTuple", StringComparison.Ordinal))
+           || (ns == "System.Collections.Generic" && name == "KeyValuePair`2");
+
+    // Resolves a metadata type token (TypeDef/TypeRef/TypeSpec) to a TypeRef, used to
+    // inspect a newarr element type. Returns Unsupported on any malformed/unknown token.
+    TypeRef ResolveTypeToken(int token, GenericScope scope)
+    {
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            return handle.Kind switch
+            {
+                HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, (TypeDefinitionHandle)handle, 0),
+                HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(_reader, (TypeReferenceHandle)handle, 0),
+                HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(_reader, scope, (TypeSpecificationHandle)handle, 0),
+                _ => TypeRef.Unsupported("newarr element"),
+            };
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+        {
+            return TypeRef.Unsupported("newarr element");
+        }
+    }
+
+    bool IsInAssemblyReferenceTypeElement(int elementToken)
+    {
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(elementToken);
+            return handle.Kind == HandleKind.TypeDefinition
+                && !IsValueTypeDefinition((TypeDefinitionHandle)handle);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+        {
+            return false;
+        }
+    }
+
+    TypeRef? ResolveMemberReferenceParentType(EntityHandle handle, GenericScope callerScope)
+    {
+        var parent = _reader.GetMemberReference((MemberReferenceHandle)handle).Parent;
+        return parent.Kind switch
+        {
+            HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, (TypeDefinitionHandle)parent, 0),
+            HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(_reader, (TypeReferenceHandle)parent, 0),
+            HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(_reader, callerScope, (TypeSpecificationHandle)parent, 0),
+            _ => null,
+        };
+    }
+
+    static int ArgumentSlotCount(MethodIdentity method)
+        => method.ParameterTypes.Length + (method.IsStatic ? 0 : 1);
+
+    MemberRef ResolveCalliMember(int token, GenericScope scope)
+    {
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            if (handle.Kind != HandleKind.StandaloneSignature)
+                return MemberRef.Unsupported("calli signature unavailable");
+            var standalone = _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle);
+            if (!SignatureBlobGuard.IsSafeToDecode(
+                    _reader,
+                    standalone.Signature,
+                    SignatureBlobGuard.Kind.StandaloneMethod))
+            {
+                return MemberRef.Unsupported("calli signature unavailable");
+            }
+
+            var signature = standalone.DecodeMethodSignature(TypeRefDecoder.Instance, scope);
+            return new MemberRef(
+                TypeRef.Unsupported("function pointer"),
+                "calli",
+                signature.ParameterTypes,
+                signature.ReturnType,
+                MemberKind.FunctionPointer)
+            {
+                HasThis = signature.Header.IsInstance,
+                SignatureHeader = signature.Header.RawValue,
+                RequiredParameterCount =
+                    signature.RequiredParameterCount,
+                GenericArity = signature.GenericParameterCount,
+                OpenParameterTypes = signature.ParameterTypes,
+                OpenReturnType = signature.ReturnType,
+            };
+        }
+        catch (Exception ex) when (ex is BadImageFormatException
+            or InvalidOperationException
+            or ArgumentException
+            or OverflowException)
+        {
+            return MemberRef.Unsupported("calli signature unavailable");
+        }
+    }
+
+    // Peel a generic-method call operand (MethodSpec) to the underlying MethodDef
+    // token in this assembly, so a call to G<int> is attributed to G's definition.
+    // Returns the token unchanged when it is not a same-assembly MethodSpec instantiation.
+    int PeelToDefinitionToken(int token)
+    {
+        var handle = MetadataTokens.EntityHandle(token);
+        if (handle.Kind == HandleKind.MethodSpecification)
+        {
+            var spec = _reader.GetMethodSpecification((MethodSpecificationHandle)handle);
+            if (spec.Method.Kind == HandleKind.MethodDefinition)
+                return MetadataTokens.GetToken(spec.Method);
+        }
+        return token;
+    }
+
+    internal GenericScope CreateScope(TypeDefinition typeDef, MethodDefinition methodDef)
+        => new(GenericParameterNames(typeDef.GetGenericParameters()), GenericParameterNames(methodDef.GetGenericParameters()));
+
+    ImmutableArray<string> GenericParameterNames(GenericParameterHandleCollection handles)
+    {
+        if (handles.Count == 0)
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+        foreach (var handle in handles)
+            names.Add(_reader.GetString(_reader.GetGenericParameter(handle).Name));
+        return names.MoveToImmutable();
+    }
+
+}

--- a/src/ILInspector.Analysis/LibraryMethodAnalysisRunner.cs
+++ b/src/ILInspector.Analysis/LibraryMethodAnalysisRunner.cs
@@ -91,8 +91,8 @@ internal sealed class LibraryMethodAnalysisResult
 
 /// <summary>
 /// Runs the ordered topic producers for one method while the assembly builder
-/// retains scheduling, primary-image ownership and metadata-dependent resolver
-/// implementations, and result aggregation.
+/// retains scheduling, primary-image lifetime, and result aggregation. The
+/// primary metadata resolver owns metadata-dependent judgments and adapters.
 /// </summary>
 internal sealed class LibraryMethodAnalysisRunner(
     ILibraryMethodAnalysisInfrastructure infrastructure)


### PR DESCRIPTION
## Summary

Extract primary-image metadata judgments and narrow per-method resolver adapters from `LibraryBodyAnalysisBuilder` into `LibraryBodyPrimaryMetadataResolver`.

The assembly builder is reduced from 1,144 to 467 lines and now retains its intended assembly-level role: metadata-ordered scheduling, parallel coordination, assembly projections, result aggregation, and service lifetime composition. The new resolver owns method identity and generic scope, unsafe/generated attribute judgments, token/member/type/field/calli/value-type/delegate facts, async-state-machine caching, and the allocation/optimization/call adapters.

## Behavioral claim

This is an ownership move with no output or analysis-policy change. The existing method lifecycle still has one primary body acquisition and canonical throwing decode; producer ordering, recoverable partial-result publication, malformed-metadata behavior, and metadata-order aggregation are unchanged. One resolver service is added per builder; the existing two narrow adapter objects per analyzed method are moved, not multiplied.

## Evidence

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` with `source eng/activate-iltools.sh --mdv`: **653/653 passed**
- Focused identity, unsafe-mode, generated-code, async-state-machine, value-type construction, and recoverable-publication gates passed
- `npx markdownlint-cli docs/architecture.md docs/design/method-body-inspection.md`
- `git diff --check origin/main..HEAD`
- Git recognizes the extraction as a 61% code copy/move from the builder

## Compatibility and non-action boundary

No public API, output shape, feature default, dependency, platform requirement, cross-assembly resolution behavior, or decode path changes. Assembly projections and result accumulation intentionally remain in the builder for a later slice.
