### PR TITLE
Distinguish static call graph member selectors

### DIFF
--- a/src/ILInspector.Analysis.Tests/CallGraphMemberResolverTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphMemberResolverTests.cs
@@ -42,6 +42,65 @@ public sealed class CallGraphMemberResolverTests
     }
 
     [Fact]
+    public void Resolve_DistinguishesInstanceAndStaticMethodsWithTheSameSignature()
+    {
+        var instanceMember = Method("int");
+        instanceMember.MetadataToken = 0x06000001;
+        var staticMember = Method("int");
+        staticMember.MetadataToken = 0x06000002;
+        staticMember.IsStatic = true;
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Owner",
+            Members = [instanceMember, staticMember],
+        };
+        var declaringType = TypeRef.Definition("Samples", "Samples", "Owner");
+        var instanceReference = new MemberRef(
+            declaringType,
+            "M",
+            [TypeRef.CoreLib("System", "Int32")],
+            TypeRef.CoreLib("System", "Void"),
+            MemberKind.Method)
+        {
+            HasThis = true,
+        };
+        var staticReference = new MemberRef(
+            declaringType,
+            "M",
+            [TypeRef.CoreLib("System", "Int32")],
+            TypeRef.CoreLib("System", "Void"),
+            MemberKind.Method);
+
+        CallGraphMemberSelector instanceSelector =
+            CallGraphMemberResolver.CreateSelector(instanceReference);
+        CallGraphMemberSelector staticSelector =
+            CallGraphMemberResolver.CreateSelector(staticReference);
+
+        Assert.NotEqual(instanceSelector.Key, staticSelector.Key);
+        Assert.Equal(
+            CallGraphMemberResolver.CreateSelector(type, instanceMember).Key,
+            instanceSelector.Key);
+        Assert.Equal(
+            CallGraphMemberResolver.CreateSelector(type, staticMember).Key,
+            staticSelector.Key);
+        Assert.Same(
+            instanceMember,
+            CallGraphMemberResolver.Resolve(
+                type,
+                instanceSelector.Name,
+                instanceSelector.Key)!
+                .Member);
+        Assert.Same(
+            staticMember,
+            CallGraphMemberResolver.Resolve(
+                type,
+                staticSelector.Name,
+                staticSelector.Key)!
+                .Member);
+    }
+
+    [Fact]
     public void Resolve_UsesStructuredIndexerAccessorIdentity()
     {
         var type = new ApiType
@@ -59,7 +118,10 @@ public sealed class CallGraphMemberResolverTests
             "get_Item",
             [TypeRef.CoreLib("System", "String")],
             TypeRef.CoreLib("System", "Int32"),
-            MemberKind.Method));
+            MemberKind.Method)
+        {
+            HasThis = true,
+        });
 
         var resolved = CallGraphMemberResolver.Resolve(
             type,
@@ -87,7 +149,10 @@ public sealed class CallGraphMemberResolverTests
             "get_Item",
             [TypeRef.CoreLib("System", "Int32")],
             TypeRef.CoreLib("System", "Int32"),
-            MemberKind.Method));
+            MemberKind.Method)
+        {
+            HasThis = true,
+        });
 
         var resolved = CallGraphMemberResolver.Resolve(
             type,
@@ -204,7 +269,10 @@ public sealed class CallGraphMemberResolverTests
             "M",
             [modified],
             TypeRef.CoreLib("System", "Void"),
-            MemberKind.Method));
+            MemberKind.Method)
+        {
+            HasThis = true,
+        });
         var type = new ApiType { Namespace = "Samples", Name = "Owner" };
         var member = Method("int");
 
@@ -230,7 +298,10 @@ public sealed class CallGraphMemberResolverTests
             "M",
             [TypeRef.UnsupportedFunctionPointer(signature)],
             TypeRef.CoreLib("System", "Void"),
-            MemberKind.Method));
+            MemberKind.Method)
+        {
+            HasThis = true,
+        });
         var type = new ApiType { Namespace = "Samples", Name = "Owner" };
         var member = Method("delegate* unmanaged[Cdecl]<int, void>");
 
@@ -258,7 +329,10 @@ public sealed class CallGraphMemberResolverTests
                     ]),
             ],
             TypeRef.CoreLib("System", "Void"),
-            MemberKind.Method));
+            MemberKind.Method)
+        {
+            HasThis = true,
+        });
         var type = new ApiType { Namespace = "Samples", Name = "Owner" };
         var member = Method("Samples.Outer<int>.Inner<string>");
 

--- a/src/ILInspector.Analysis/CallGraphMemberResolver.cs
+++ b/src/ILInspector.Analysis/CallGraphMemberResolver.cs
@@ -11,6 +11,10 @@ namespace ILInspector.Analysis;
 /// Hosts transport and compare <see cref="CallGraphMemberSelector.Key"/> as opaque identity;
 /// they do not parse display signatures or recreate metadata matching rules.
 /// </summary>
+/// <remarks>
+/// <c>CallGraphMemberResolverTests.Resolve_DistinguishesInstanceAndStaticMethodsWithTheSameSignature</c>
+/// gates the instance/static identity discriminator across both producers and structural remapping.
+/// </remarks>
 public static class CallGraphMemberResolver
 {
     /// <summary>
@@ -106,6 +110,7 @@ public static class CallGraphMemberResolver
         return CreateSelector(
             member.Name,
             member.GenericArity,
+            member.HasThis,
             member.OpenSignatureParameters.Select(TypeIdentity),
             TypeIdentity(member.OpenSignatureReturn));
     }
@@ -129,6 +134,7 @@ public static class CallGraphMemberResolver
         return CreateSelector(
             member.Name,
             member.SignatureModel?.TypeParameters.Count ?? 0,
+            !member.IsStatic,
             (member.SignatureModel?.Parameters ?? [])
                 .Select(parameter => Normalize(parameter.CanonicalTypeWithModifier)),
             Normalize(
@@ -200,6 +206,7 @@ public static class CallGraphMemberResolver
             var selector = CreateSelector(
                 $"get_{member.Name}",
                 0,
+                !member.IsStatic,
                 owner.ParameterTypes,
                 owner.ReturnType);
             yield return new(selector.Name, selector.Key, new(member, getter));
@@ -210,6 +217,7 @@ public static class CallGraphMemberResolver
             var selector = CreateSelector(
                 $"set_{member.Name}",
                 0,
+                !member.IsStatic,
                 owner.ParameterTypes.Append(owner.ReturnType),
                 "System.Void");
             yield return new(selector.Name, selector.Key, new(member, setter));
@@ -220,6 +228,7 @@ public static class CallGraphMemberResolver
             var selector = CreateSelector(
                 $"add_{member.Name}",
                 0,
+                !member.IsStatic,
                 [owner.ReturnType],
                 "System.Void");
             yield return new(selector.Name, selector.Key, new(member, adder));
@@ -230,6 +239,7 @@ public static class CallGraphMemberResolver
             var selector = CreateSelector(
                 $"remove_{member.Name}",
                 0,
+                !member.IsStatic,
                 [owner.ReturnType],
                 "System.Void");
             yield return new(selector.Name, selector.Key, new(member, remover));
@@ -239,12 +249,14 @@ public static class CallGraphMemberResolver
     static CallGraphMemberSelector CreateSelector(
         string name,
         int genericArity,
+        bool hasThis,
         IEnumerable<string> parameterTypes,
         string returnType)
     {
         var parameters = parameterTypes.ToImmutableArray();
         var key = new StringBuilder();
         Append(key, name);
+        key.Append(hasThis ? 'I' : 'S').Append(';');
         key.Append(genericArity).Append(';');
         key.Append(parameters.Length).Append(';');
         foreach (string parameter in parameters)


### PR DESCRIPTION
## Outcome

Call-graph-to-API correspondence now distinguishes static and instance members even when their name, generic arity, parameter types, and return type are identical. Both selector producers include the same instance/static discriminator, and property/event accessor selectors preserve their owner shape.

The opaque selector wire format changes intentionally; hosts only transport and compare this result-scoped value and do not parse or persist it. Existing synthetic resolver fixtures now state their intended instance shape explicitly.

Fixes #4053.

## Evidence

- `CallGraphMemberResolverTests.Resolve_DistinguishesInstanceAndStaticMethodsWithTheSameSignature` constructs the close pair, proves distinct selectors, and remaps each API surface member to its corresponding MethodDef token.
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — 654 passed
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release` — 32 passed
- `npm --prefix prototypes/inspect-web test` — 48 passed