### PR TITLE
Specify browser package source architecture

### DIFF
--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -138,12 +138,18 @@ listing status, preserving the listing-aware behavior defined by
 [version resolution](version-resolution.md). Search results are not written
 into the complete version-list cache.
 
-Registration indexes for large packages contain page links whose absolute
-hosts name `api.nuget.org`. The Gallery client never dereferences those hosts.
-It validates that each page link has the expected HTTPS registration-page path
-for the normalized package ID, rejects query, fragment, user information, and
-unexpected path shapes, then resolves that validated path against
-`globalcdn.nuget.org`. This is source-owned path rebasing, not general
+Registration indexes have two page shapes:
+
+- a page with inline `items` is consumed in place; its fragment-bearing `@id`
+  is identity metadata and is never validated or dereferenced as a fetch
+  target; and
+- a page without inline `items` is external. The Gallery client validates that
+  its `@id` has the expected HTTPS registration-page path for the normalized
+  package ID, rejects query, fragment, user information, and unexpected path
+  shapes, then resolves that validated path against `globalcdn.nuget.org`.
+
+The Gallery client never dereferences the absolute `api.nuget.org` host from an
+external page link. This is source-owned path rebasing, not general
 feed-directed navigation.
 
 Its limitations remain visible:
@@ -213,10 +219,11 @@ available transports, not two candidate authorities.
 
 The registry reserves built-in IDs. A bundle may select the canonical Gallery
 descriptor but cannot replace it or register another source under its ID.
-Custom source IDs are unique after import and never overwrite an existing
-descriptor implicitly. Display-name collisions are allowed only when every UI
-and output projection disambiguates custom sources with their redacted endpoint
-host.
+Custom source IDs are regenerated into the receiving registry namespace after
+import and never overwrite an existing descriptor implicitly. Display-name
+collisions are allowed only when every UI and output projection disambiguates
+custom sources with their redacted canonical endpoint, including the path that
+distinguishes feeds on a shared host.
 
 ## Multi-source resolution
 
@@ -253,6 +260,13 @@ while an eligible source timed out or failed authentication. It either fails
 or marks the answer partial. A pinned payload operation may succeed from one
 authorized producer without proving every peer source readable.
 
+Complete listing-aware Gallery enumeration also depends on registration
+metadata. If registration cannot be read, raw enumeration may expose the
+flat-container versions only as a typed partial result with listing status
+`unknown`; it does not report them as listed and does not populate a complete
+candidate cache. Auto-selecting latest, wildcard, or range operations fail
+closed when the missing listing evidence could change the selected coordinate.
+
 ## Cache and provenance
 
 Candidate and payload caches are source-scoped:
@@ -278,23 +292,24 @@ JavaScript cancellation is a host convenience, not the reliability boundary.
 Every network operation in NuGetFetch and the reusable DotnetInspector package
 path has a library-owned finite budget.
 
-The timeout policy distinguishes:
+The library owns two nested bounds:
 
-| Operation | Deadline |
-| --- | ---: |
-| Optional availability probe | The lesser of 2 seconds and the configured network deadline |
-| Search, resolution, metadata, package, or symbol acquisition | The configured network deadline |
+| Bound | Default | Scope |
+| --- | ---: | --- |
+| Request deadline | 30 seconds | One request, including its bounded body read |
+| Operation ceiling | 120 seconds | One public search, resolve, or acquire operation |
 
-The configured network deadline defaults to 30 seconds, preserving the current
-CLI contract. An explicit `--http-timeout` or
-`DOTNET_INSPECT_HTTP_TIMEOUT_IN_SECONDS` value replaces that default for every
-network operation and may shorten or extend it. Reusable library callers
-supply the same validated option directly. Caller cancellation may always
-terminate sooner. Component limits, including metadata body-read timeouts,
-cannot exceed the enclosing operation deadline.
+The request deadline preserves the existing `--http-timeout` contract. An
+explicit `--http-timeout` or
+`DOTNET_INSPECT_HTTP_TIMEOUT_IN_SECONDS` value replaces 30 seconds in either
+direction. The CLI derives an operation ceiling of four request deadlines.
+Reusable library callers may instead supply both validated values explicitly.
+An optional availability probe uses the lesser of 2 seconds and the request
+deadline.
 
-One deadline is created at each public search, resolve, or acquire entry point.
-It covers the complete operation:
+This adds an operation ceiling to the current per-request behavior; it does not
+redefine the existing timeout as one shared 30-second window. The ceiling
+covers:
 
 - connection and response headers;
 - redirects;
@@ -305,14 +320,22 @@ It covers the complete operation:
 - decompression and protocol parsing; and
 - payload streaming into the bounded admission path.
 
-Every source, retry, redirect, and body reader receives the remaining time from
-that deadline; no nested operation resets it. Aggregate source queries run
-concurrently when their contract requires every eligible source. A source
-client links the remaining deadline with caller cancellation. It does not
+Each HTTP request receives the lesser of the request deadline and the remaining
+operation ceiling. No retry, authentication exchange, transport failover,
+redirect, or body reader resets the operation ceiling. Independent source and
+registration-page requests run concurrently when their contract permits it.
+
+A source client links both library bounds with caller cancellation. It does not
 depend solely on `HttpClient.Timeout`, because hosts may supply an infinite or
-unusually large client timeout. The owning host configures `HttpClient.Timeout`
-so it cannot preempt the library deadline; the linked library deadline remains
-the authoritative bound.
+unusually large client timeout. A shorter caller-supplied client timeout is
+treated as caller cancellation and remains a visible failure; it cannot remove
+the library's finite upper bounds.
+
+The existing one-second freshness lookup used when usable local versions exist
+is an explicit library-owned shorter request and operation bound. It remains a
+visible failure with exact-pin guidance and does not reset or escape the
+enclosing resolution policy. Explicit `Name@latest` continues to use the
+configured request deadline and operation ceiling.
 
 Timeouts remain visible source failures. They are not converted into not-found,
 an empty version list, a partial successful search, or an automatic stale-cache
@@ -355,7 +378,8 @@ An illustrative payload is:
 ```
 
 Base64 is an encoding, not a secrecy mechanism. A bundle may contain only
-non-secret HTTPS descriptors and selected source IDs. It must not contain:
+portable HTTPS descriptors and selected source IDs. It has no credential
+fields and must not contain:
 
 - credentials, PATs, API keys, or authorization headers;
 - local paths or `file://` URLs;
@@ -367,6 +391,12 @@ non-secret HTTPS descriptors and selected source IDs. It must not contain:
 Query-bearing source URLs remain valid when supplied through existing desktop
 configuration because signed endpoints are an established feed capability, but
 they are nonportable and cannot enter a browser source bundle.
+
+No schema can prove that an arbitrary display name, ID, or URL path contains no
+secret. Known secret-bearing path shapes are rejected, but remaining descriptor
+text is treated as public: the import preview warns that it will be persisted
+and may be rendered. A user who has placed a secret in an otherwise ordinary
+path or name must not share that bundle.
 
 Feed names and hostnames can still reveal organizational information. The
 fragment keeps them out of the hosting origin's request and access logs. The
@@ -430,22 +460,27 @@ are separate designs.
 
 ## Presentation
 
-`Source: NuGet` is ambiguous and conflicts with source-code terminology.
-Package output names the selected producer as `Package source`.
+The existing `Source` field is the acquisition kind (`NuGet`, `Platform`,
+`File`, `Library`, or `Project`) and remains unchanged. Package-backed output
+adds `Package source` for the selected producer.
 
-The compact package summary includes the producer:
+The compact package summary includes both facts:
 
 ```text
-Version: 0.35.2 | Package source: NuGet Gallery | Type: Library
+Version: 0.35.2 | Source: NuGet | Package source: NuGet Gallery | Type: Library
 ```
 
 Built-in sources use their reserved display name. Custom sources include their
-redacted endpoint host in the compact field so an imported source cannot
-impersonate a built-in or another custom producer:
+redacted canonical endpoint in the compact field so feeds on one shared host
+remain distinct and an imported source cannot impersonate a built-in or another
+custom producer:
 
 ```text
-Package source: Corporate mirror (packagefeedproxy.microsoft.io)
+Package source: Corporate mirror (pkgs.dev.azure.com/org/_packaging/feed/nuget/v3/index.json)
 ```
+
+Non-package `Platform`, `File`, `Library`, and `Project` inspections keep their
+existing `Source` field and omit `Package source`.
 
 Detailed provenance separates:
 
@@ -489,6 +524,9 @@ largely equate a source with a v3 service-index URL. The implementation should:
    changing producer identity above the acquisition layer.
 7. Replace the browser's singleton `default versus mirror` state with a source
    registry and selected source set.
+8. Replace boolean-only NuGet.org listing state with a typed
+   `listed`/`unlisted`/`unknown` result so partial enumeration cannot look
+   authoritative.
 
 The product libraries must own these contracts. A browser harness may present
 configuration and cancellation, but it must not reconstruct package resolution,
@@ -502,6 +540,8 @@ Implementation is not complete until gates prove:
   `api.nuget.org`;
 - complete listing-aware enumeration of a paged package rebases validated page
   paths to the Gallery CDN and makes no `api.nuget.org` request;
+- inline registration pages are consumed without treating their fragment IDs as
+  fetch targets;
 - v3 resource discovery remains source-relative;
 - multi-source latest selection retains every reporting source;
 - selecting Gallery and canonical NuGet.org v3 transports reports one producer,
@@ -509,16 +549,22 @@ Implementation is not complete until gates prove:
   fail;
 - a mirror lag does not redirect a Gallery-only candidate to that mirror;
 - source-scoped candidate and payload caches cannot cross producers;
+- a keyword-search/latest cache entry cannot answer complete listing-aware
+  enumeration, and incomplete listing metadata cannot populate that cache;
 - JavaScript-independent library timeouts cover metadata and payload stalls;
-- bundle imports reject secrets, HTTP URLs, user information, unknown kinds,
-  oversized values, and excessive source counts;
+- request deadlines and the larger operation ceiling cover retries,
+  authentication, transport failover, multi-source work, and paged metadata
+  without resetting;
+- bundle imports reject credential fields, known secret-bearing path forms,
+  HTTP URLs, user information, unknown kinds, oversized values, and excessive
+  source counts;
 - encoded source-bundle values do not enter referrers, telemetry, or source
   requests;
 - source-bundle values do not enter the hosting origin's request or access
   logs;
 - imports require confirmation before persistence;
 - imported descriptors cannot replace reserved IDs, overwrite existing custom
-  entries implicitly, or spoof compact producer display;
+  entries implicitly, or produce a colliding compact producer label;
 - PATs do not enter persisted state, URLs, errors, cross-origin redirect
   targets, or telemetry;
 - Basic PAT credentials include an explicit username and obey same-origin

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -1,0 +1,422 @@
+# Browser package sources
+
+This document defines package-source behavior for browser/Wasm hosts and the
+shared acquisition libraries they consume. It extends the
+[package source model](package-source-model.md) with source implementations,
+browser registration and selection, NuGet Gallery access, portable
+configuration, authentication, timeout ownership, and presentation.
+
+The implementation plan is tracked by
+[#4239](https://github.com/richlander/dotnet-inspect/issues/4239).
+
+## Scope
+
+The browser needs to inspect packages from:
+
+- the NuGet Gallery, including environments that block `api.nuget.org`;
+- one or more standard NuGet v3 feeds;
+- several selected sources at once; and
+- eventually local-folder sources on hosts that can expose them.
+
+This is a package-acquisition concern. ILInspector consumes admitted assembly
+and PDB bytes and has no Gallery or feed personality. DotnetInspector consumes
+typed package coordinates, candidates, payloads, and provenance. NuGetFetch
+owns the protocol-specific clients below that common contract.
+
+Plain HTTP intranet feeds are out of scope. Browser registration accepts HTTPS
+sources only until a concrete HTTP requirement defines its transport,
+mixed-content, and credential rules.
+
+## Validated browser behavior
+
+The motivating corporate-managed browser permits some NuGet.org hosts while
+blocking the v3 entry point:
+
+| Operation | Result |
+| --- | --- |
+| `https://api.nuget.org/v3/index.json` | Blocked |
+| NuGet Gallery search | CORS-readable |
+| NuGet Gallery package CDN | CORS-readable |
+| NuGet Gallery symbol-package CDN | CORS-readable |
+| Corporate Azure proxy | CORS-readable, but delayed |
+
+The `dotnet-inspect` package demonstrated the split: NuGet Gallery search and
+the package CDN supplied `0.18.0` while the corporate proxy's version index
+stopped at `0.16.0`. A source that discovers a coordinate and a source that can
+currently supply its payload therefore cannot be represented by one global
+endpoint or one `default versus mirror` switch.
+
+This evidence establishes compatibility for the observed endpoints and policy;
+it does not make the known NuGet.org CDN routes part of the NuGet v3 protocol.
+
+## One package-source contract
+
+The product presents one package-source model. Protocol specialization remains
+inside NuGetFetch:
+
+```text
+Package resolution and provenance
+    |
+    +-- NuGet v3 source client
+    +-- NuGet Gallery source client
+    +-- Local-folder source client (future)
+```
+
+A source client supplies operations rather than exposing its transport shape:
+
+```csharp
+interface IPackageSourceClient
+{
+    PackageSourceIdentity Identity { get; }
+    PackageSourceCapabilities Capabilities { get; }
+
+    Task<PackageSearchResult> SearchAsync(...);
+    Task<PackageVersionResult> GetVersionsAsync(...);
+    Task<PackagePayloadResult> GetPackageAsync(...);
+    Task<SymbolPayloadResult> TryGetSymbolsAsync(...);
+}
+```
+
+The exact API may differ, but the boundary must preserve these properties:
+
+- source identity is typed and stable;
+- capabilities are explicit rather than inferred from a URL string;
+- every candidate retains the source that reported it;
+- every payload retains its producer and payload location;
+- absence, unsupported capability, timeout, authentication failure, and
+  transport failure are distinct results; and
+- no consumer above NuGetFetch constructs protocol URLs.
+
+`PackageSource` must not mean only "NuGet v3 service-index URL." A registered
+source descriptor identifies the source kind and its non-secret configuration:
+
+```text
+id
+display name
+kind
+endpoint, when the kind requires one
+enabled state
+```
+
+Credentials, resolved resources, response caches, and runtime health are not
+descriptor fields.
+
+## Source implementations
+
+### Standard NuGet v3 source
+
+A v3 source starts from its configured service-index URL and discovers
+resources such as `PackageBaseAddress` and `SearchQueryService`. It may support
+authentication and source-specific resource sets.
+
+The source remains truthful about missing capabilities. A feed without search
+can supply exact packages and versions without pretending to support package
+search. A feed that has no defined symbol-package download resource does not
+construct `.snupkg` URLs under `PackageBaseAddress`.
+
+Resolved resources are runtime state scoped to the canonical source identity.
+They are not persisted into portable source configuration.
+
+### NuGet Gallery source
+
+NuGet Gallery is a first-class built-in source, not a fabricated v3 feed. In a
+browser it can use known web endpoints without requesting
+`api.nuget.org/v3/index.json`:
+
+| Capability | Browser endpoint |
+| --- | --- |
+| Search and listed versions | NuGet Gallery search service |
+| Package payload | `globalcdn.nuget.org/packages/{id}.{version}.nupkg` |
+| Symbol package | `globalcdn.nuget.org/symbol-packages/{id}.{version}.snupkg` |
+
+The Gallery source normalizes package IDs and versions before constructing CDN
+paths. Search requests opt into SemVer 2.0 and carry the caller's prerelease
+policy.
+
+Its limitations remain visible:
+
+- search does not reveal unlisted packages or versions;
+- an exact known unlisted coordinate may be downloadable without being
+  discoverable;
+- the known search and CDN routes are NuGet.org-specific browser behavior, not
+  a general NuGet v3 source contract; and
+- endpoint changes can make the implementation unavailable until the built-in
+  source is updated.
+
+The Gallery source is the browser default. Desktop configuration may continue
+to represent NuGet.org through its canonical v3 service index while sharing the
+same package-source identity and provenance label. Transport strategy is a
+host capability, not a second visible producer.
+
+### Local-folder source
+
+Local-folder support remains a separate implementation because its candidate
+enumeration, payload access, identity, and platform availability differ from
+HTTP sources. It is not required for the initial browser registry.
+
+## Registration, selection, and eligibility
+
+Registration and selection are different:
+
+- a **registered source** is available for use;
+- an **enabled source** may be selected by the host;
+- an **active source** is selected for the current operation; and
+- an **eligible source** is active and authorized for the package ID after
+  package source mapping or an equivalent host policy.
+
+The website provides a Package sources page from the home screen. It supports:
+
+- viewing the built-in NuGet Gallery source;
+- registering, editing, and removing HTTPS NuGet v3 sources;
+- enabling and selecting multiple sources;
+- showing source capability and authentication state; and
+- clearing source-scoped browser caches when requested.
+
+NuGet Gallery is built in and cannot be rewritten into an arbitrary endpoint.
+It may be disabled for a selected operation.
+
+Browser-local registration is persisted in local storage as non-secret source
+descriptors and selected IDs. Runtime credentials are never part of this
+registry.
+
+## Multi-source resolution
+
+Source order is not version precedence. Resolution follows the package source
+model:
+
+1. Determine active and package-ID-eligible sources.
+2. Request candidates from every eligible source capable of discovery.
+3. Retain the reporting source set for every coordinate.
+4. Select the semantic version required by the caller.
+5. Acquire from a source authorized for that coordinate.
+6. Record the producer and payload location independently.
+
+For example, NuGet Gallery may report `0.18.0` while a corporate mirror reports
+only `0.16.0`. Selecting `0.18.0` authorizes its Gallery producer; it does not
+authorize requesting `0.18.0` from the mirror and interpreting a 404 as a
+package-wide absence.
+
+Pinned coordinates are caller-supplied candidates. Any eligible source with
+the required payload may fulfill them, subject to the source-provenance rules
+in the package source model.
+
+An aggregate discovery operation cannot silently report a complete answer
+while an eligible source timed out or failed authentication. It either fails
+or marks the answer partial. A pinned payload operation may succeed from one
+authorized producer without proving every peer source readable.
+
+## Cache and provenance
+
+Candidate and payload caches are source-scoped:
+
+- candidate cache keys include source identity, package ID, and discovery
+  flavor;
+- payload cache keys include source identity and exact coordinate;
+- Gallery and v3 access strategies for the canonical NuGet.org source share
+  producer identity only when the implementation has proved they represent the
+  same producer; and
+- changing the selected source set never reinterprets bytes from an
+  unauthorized producer.
+
+Search metadata does not authorize payload bytes from every active source.
+Candidate provenance determines the producer set for a discovered coordinate.
+
+Symbol packages have independent provenance. NuGet Gallery's known symbol CDN
+is a Gallery capability. A custom v3 feed does not acquire symbols from
+NuGet.org merely because the same package ID exists there.
+
+## Timeout ownership
+
+JavaScript cancellation is a host convenience, not the reliability boundary.
+Every network operation in NuGetFetch and the reusable DotnetInspector package
+path has a library-owned finite budget.
+
+The timeout policy distinguishes:
+
+| Operation class | Examples | Default budget |
+| --- | --- | ---: |
+| Availability probe | Optional source health check | 2 seconds |
+| Metadata | Service index, search, versions | 15 seconds |
+| Payload | Package and symbol-package body | 120 seconds |
+
+These defaults are configurable through validated library options. A caller may
+cancel sooner but cannot extend an operation beyond the library budget without
+explicitly supplying a different validated policy.
+
+Each budget covers the complete operation:
+
+- connection and response headers;
+- redirects;
+- bounded response-body reads;
+- decompression and protocol parsing; and
+- payload streaming into the bounded admission path.
+
+A source client creates a linked cancellation token from caller cancellation
+and its operation budget. It does not depend solely on `HttpClient.Timeout`,
+because hosts may supply an infinite or unusually large client timeout.
+
+Timeouts remain visible source failures. They are not converted into not-found,
+an empty version list, a partial successful search, or an automatic stale-cache
+answer. Cache fallback follows the explicit version-resolution policy and
+retains the timeout diagnostic.
+
+Required gates include stalled-header, stalled-metadata-body, stalled-payload,
+and redirect-chain cases that terminate without JavaScript cooperation.
+
+## Portable source bundles
+
+A shareable website link may carry a versioned source bundle encoded as
+base64url JSON. It does not carry arbitrary `nuget.config` XML.
+
+An illustrative payload is:
+
+```json
+{
+  "v": 1,
+  "sources": [
+    {
+      "id": "gallery",
+      "kind": "nuget-gallery"
+    },
+    {
+      "id": "corp",
+      "kind": "nuget-v3",
+      "name": "Corporate mirror",
+      "url": "https://packagefeedproxy.microsoft.io/nuget/v3/index.json"
+    }
+  ],
+  "selected": [
+    "gallery",
+    "corp"
+  ]
+}
+```
+
+Base64 is an encoding, not a secrecy mechanism. A bundle may contain only
+non-secret HTTPS descriptors and selected source IDs. It must not contain:
+
+- credentials, PATs, API keys, or authorization headers;
+- local paths or `file://` URLs;
+- embedded URL user information;
+- arbitrary NuGet configuration sections; or
+- runtime-discovered resource URLs.
+
+Feed names and hostnames can still reveal organizational information. The
+website uses a `no-referrer` policy, does not emit bundle contents to telemetry,
+and removes the bundle parameter from the address bar with `replaceState`
+before contacting any configured source.
+
+Import is an explicit trust gesture:
+
+1. Decode under a strict encoded and decoded size limit.
+2. Parse a versioned, allow-listed schema with bounded source count and field
+   lengths.
+3. Validate every source descriptor without contacting it.
+4. Show a preview naming additions, replacements, and selected sources.
+5. Require confirmation before writing local storage.
+6. Remove the bundle from the visible URL.
+7. Validate source connectivity separately and report each failure.
+
+Opening a link never silently changes the active package-source set. Declining
+the import leaves existing configuration untouched.
+
+## Browser credentials
+
+The Package sources page may accept a short-lived packaging-read PAT for a
+source that requires authentication.
+
+PAT handling follows these rules:
+
+- the PAT is held only in page-session memory;
+- it is never placed in a URL, source bundle, local storage, IndexedDB, cache,
+  service-worker message, diagnostic, or telemetry event;
+- reload and tab close discard it;
+- the UI identifies the source and requested scope before entry;
+- credentials are attached only to requests authorized for that source;
+- credentials are not forwarded across redirects or to cross-origin resources;
+  and
+- authenticated browser support requires the feed's CORS policy to permit the
+  origin and authorization header.
+
+A shared source bundle can register a private feed, but every recipient supplies
+their own PAT. Registration and authority remain separate.
+
+The initial implementation supports manually entered short-lived PATs. Durable
+credential vaults, refresh tokens, device login, and persisted authentication
+are separate designs.
+
+## Presentation
+
+`Source: NuGet` is ambiguous and conflicts with source-code terminology.
+Package output names the selected producer as `Package source`.
+
+The compact package summary includes the producer:
+
+```text
+Version: 0.35.2 | Package source: NuGet Gallery | Type: Library
+```
+
+Detailed provenance separates:
+
+```text
+Package source: Corporate mirror
+Endpoint: https://packagefeedproxy.microsoft.io/nuget/v3/index.json
+Payload location: dotnet-inspect cache
+Candidate sources: NuGet Gallery, Corporate mirror
+```
+
+The default field is high value because it answers which producer supplied the
+inspected bytes. Endpoint, payload location, and candidate-source expansion are
+normal or detailed evidence. Structured output carries stable source IDs in
+addition to display names.
+
+The website shows source badges in search results, version choices, package
+tabs, and package headings. A version advertised upstream but unavailable from
+a selected mirror is shown as a source-specific availability fact, not as a
+contradictory global package state.
+
+## Implementation direction
+
+The existing NuGetFetch shape is a useful base:
+
+- it resolves multiple configured sources;
+- it implements package source mapping;
+- it source-scopes candidates and payload provenance; and
+- it already special-cases NuGet.org search internally.
+
+The remaining structural problem is that `PackageSource` and `NuGetClient`
+largely equate a source with a v3 service-index URL. The implementation should:
+
+1. Split source descriptors from runtime source clients.
+2. Replace URL-based NuGet.org branching with an explicit Gallery source kind.
+3. Move URL construction into the owning source clients.
+4. Return common candidate, payload, symbol, and failure contracts.
+5. Thread validated timeout policy through every client.
+6. Let desktop and browser hosts choose transport implementations without
+   changing producer identity above the acquisition layer.
+7. Replace the browser's singleton `default versus mirror` state with a source
+   registry and selected source set.
+
+The product libraries must own these contracts. A browser harness may present
+configuration and cancellation, but it must not reconstruct package resolution,
+provenance, URL normalization, timeout, or authentication policy in JavaScript.
+
+## Verification obligations
+
+Implementation is not complete until gates prove:
+
+- Gallery search and package CDN acquisition work without contacting
+  `api.nuget.org`;
+- v3 resource discovery remains source-relative;
+- multi-source latest selection retains every reporting source;
+- a mirror lag does not redirect a Gallery-only candidate to that mirror;
+- source-scoped candidate and payload caches cannot cross producers;
+- JavaScript-independent library timeouts cover metadata and payload stalls;
+- bundle imports reject secrets, HTTP URLs, user information, unknown kinds,
+  oversized values, and excessive source counts;
+- source-bundle values do not enter referrers, telemetry, or source requests;
+- imports require confirmation before persistence;
+- PATs do not enter persisted state, URLs, errors, redirects, or telemetry;
+- authenticated requests obey source-origin boundaries; and
+- Markdown and structured output distinguish package source, payload location,
+  and candidate sources.

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -267,6 +267,26 @@ flat-container versions only as a typed partial result with listing status
 candidate cache. Auto-selecting latest, wildcard, or range operations fail
 closed when the missing listing evidence could change the selected coordinate.
 
+The target listing contract is source-relative:
+
+| Status | Meaning |
+| --- | --- |
+| `listed` | NuGet Gallery registration explicitly reports the version listed |
+| `unlisted` | NuGet Gallery registration explicitly reports the version unlisted |
+| `unknown` | Gallery listing evidence was required but unavailable |
+| `not-applicable` | The reporting source has no NuGet Gallery listing concept |
+
+Candidate results retain this status per reporting source rather than reducing
+it to one package-wide Boolean. An aggregate view can therefore show that a
+coordinate is unlisted on Gallery while available from a private feed.
+
+The current product still uses `PackageVersionInfo.Listed` and reports
+registration-outage enumeration as listed fail-open data. Replacing that
+current behavior and its Markdown/TSV/JSONL projection with the target typed
+status is implementation work for
+[#4239](https://github.com/richlander/dotnet-inspect/issues/4239), not behavior
+claimed by this documentation-only PR.
+
 ## Cache and provenance
 
 Candidate and payload caches are source-scoped:
@@ -419,6 +439,12 @@ Import is an explicit trust gesture:
 Opening a link never silently changes the active package-source set. Declining
 the import leaves existing configuration untouched.
 
+Every imported string is untrusted presentation data. Source IDs use a narrow
+ASCII grammar; display names and endpoints cross into the page through inert
+text or DOM `textContent`, never HTML interpolation. The same rule applies to
+the confirmation preview, settings page, source badges, errors, and provenance
+output.
+
 ## Browser credentials
 
 The Package sources page may accept a short-lived packaging-read PAT for a
@@ -479,6 +505,11 @@ custom producer:
 Package source: Corporate mirror (pkgs.dev.azure.com/org/_packaging/feed/nuget/v3/index.json)
 ```
 
+If redaction makes two distinct producer labels equal, source resolution
+appends a stable, non-secret source-ID discriminator. The discriminator comes
+from the configured source key or browser registry, not from hashing a
+credential-bearing URL. Compact labels must be unique within one result.
+
 Non-package `Platform`, `File`, `Library`, and `Project` inspections keep their
 existing `Source` field and omit `Package source`.
 
@@ -525,8 +556,8 @@ largely equate a source with a v3 service-index URL. The implementation should:
 7. Replace the browser's singleton `default versus mirror` state with a source
    registry and selected source set.
 8. Replace boolean-only NuGet.org listing state with a typed
-   `listed`/`unlisted`/`unknown` result so partial enumeration cannot look
-   authoritative.
+   `listed`/`unlisted`/`unknown`/`not-applicable` result so partial enumeration
+   cannot look authoritative.
 
 The product libraries must own these contracts. A browser harness may present
 configuration and cancellation, but it must not reconstruct package resolution,
@@ -556,13 +587,15 @@ Implementation is not complete until gates prove:
   authentication, transport failover, multi-source work, and paged metadata
   without resetting;
 - bundle imports reject credential fields, known secret-bearing path forms,
-  HTTP URLs, user information, unknown kinds, oversized values, and excessive
-  source counts;
+  HTTP URLs, URL queries and fragments, user information, unknown kinds,
+  oversized values, and excessive source counts;
 - encoded source-bundle values do not enter referrers, telemetry, or source
   requests;
 - source-bundle values do not enter the hosting origin's request or access
   logs;
 - imports require confirmation before persistence;
+- import previews and every later source-label projection render hostile
+  descriptor text inertly rather than as markup;
 - imported descriptors cannot replace reserved IDs, overwrite existing custom
   entries implicitly, or produce a colliding compact producer label;
 - PATs do not enter persisted state, URLs, errors, cross-origin redirect

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -125,19 +125,25 @@ browser it can use known web endpoints without requesting
 
 | Capability | Browser endpoint |
 | --- | --- |
-| Search and listed versions | NuGet Gallery search service |
+| Keyword search and latest listed version | NuGet Gallery search service |
+| Complete version enumeration | `globalcdn.nuget.org/v3-flatcontainer/{id}/index.json` |
+| Per-version listing status | `globalcdn.nuget.org/v3/registration5-gz-semver2/{id}/index.json` |
 | Package payload | `globalcdn.nuget.org/packages/{id}.{version}.nupkg` |
 | Symbol package | `globalcdn.nuget.org/symbol-packages/{id}.{version}.snupkg` |
 
 The Gallery source normalizes package IDs and versions before constructing CDN
 paths. Search requests opt into SemVer 2.0 and carry the caller's prerelease
-policy.
+policy. Version enumeration joins the flat-container list with the registration
+listing status, preserving the listing-aware behavior defined by
+[version resolution](version-resolution.md). Search results are not written
+into the complete version-list cache.
 
 Its limitations remain visible:
 
-- search does not reveal unlisted packages or versions;
-- an exact known unlisted coordinate may be downloadable without being
-  discoverable;
+- keyword search does not reveal unlisted packages or versions;
+- exact known unlisted coordinates remain downloadable without keyword
+  discovery, while complete enumeration uses registration metadata to reveal
+  their listing status;
 - the known search and CDN routes are NuGet.org-specific browser behavior, not
   a general NuGet v3 source contract; and
 - endpoint changes can make the implementation unavailable until the built-in
@@ -147,6 +153,17 @@ The Gallery source is the browser default. Desktop configuration may continue
 to represent NuGet.org through its canonical v3 service index while sharing the
 same package-source identity and provenance label. Transport strategy is a
 host capability, not a second visible producer.
+
+The canonical producer identity for both transports is
+`https://api.nuget.org/v3/index.json`. The Gallery browser client uses that
+identity without requesting the URL. A registry ID is a user-interface handle,
+not a producer identity or cache key.
+
+Candidate caches additionally identify the discovery contract and its version,
+such as complete listing-aware enumeration versus keyword search. A
+search-derived listed-only result cannot answer a complete version-enumeration
+request. Payload caches may be shared across the Gallery browser and v3
+transports because both name the same immutable NuGet.org producer.
 
 ### Local-folder source
 
@@ -179,6 +196,13 @@ Browser-local registration is persisted in local storage as non-secret source
 descriptors and selected IDs. Runtime credentials are never part of this
 registry.
 
+Changing a descriptor's kind or canonical endpoint creates a new source
+identity. The browser invalidates that registry entry's resolved resources,
+candidate state, credentials, and payload-cache eligibility rather than
+rewriting the previous producer. Registering the canonical NuGet.org v3
+endpoint alongside the built-in Gallery source creates one producer with two
+available transports, not two candidate authorities.
+
 ## Multi-source resolution
 
 Source order is not version precedence. Resolution follows the package source
@@ -210,11 +234,10 @@ authorized producer without proving every peer source readable.
 Candidate and payload caches are source-scoped:
 
 - candidate cache keys include source identity, package ID, and discovery
-  flavor;
+  contract/version;
 - payload cache keys include source identity and exact coordinate;
 - Gallery and v3 access strategies for the canonical NuGet.org source share
-  producer identity only when the implementation has proved they represent the
-  same producer; and
+  the producer identity defined above; and
 - changing the selected source set never reinterprets bytes from an
   unauthorized producer.
 
@@ -233,27 +256,36 @@ path has a library-owned finite budget.
 
 The timeout policy distinguishes:
 
-| Operation class | Examples | Default budget |
+| Operation class | Examples | Initial default deadline |
 | --- | --- | ---: |
 | Availability probe | Optional source health check | 2 seconds |
-| Metadata | Service index, search, versions | 15 seconds |
+| Metadata | Service index, search, versions | 30 seconds |
 | Payload | Package and symbol-package body | 120 seconds |
 
-These defaults are configurable through validated library options. A caller may
-cancel sooner but cannot extend an operation beyond the library budget without
-explicitly supplying a different validated policy.
+These defaults are configurable through validated library options. The CLI's
+`--http-timeout` and `DOTNET_INSPECT_HTTP_TIMEOUT_IN_SECONDS` settings supply
+that validated policy and may extend the deadlines for slow feeds. A caller
+may always cancel sooner. Component limits, including metadata body-read
+timeouts, cannot exceed the enclosing operation deadline.
 
-Each budget covers the complete operation:
+One deadline is created at each public search, resolve, or acquire entry point.
+It covers the complete operation:
 
 - connection and response headers;
 - redirects;
+- authentication and retry;
+- all selected sources and producer failover;
+- retry backoff;
 - bounded response-body reads;
 - decompression and protocol parsing; and
 - payload streaming into the bounded admission path.
 
-A source client creates a linked cancellation token from caller cancellation
-and its operation budget. It does not depend solely on `HttpClient.Timeout`,
-because hosts may supply an infinite or unusually large client timeout.
+Every source, retry, redirect, and body reader receives the remaining time from
+that deadline; no nested operation resets it. Aggregate source queries run
+concurrently when their contract requires every eligible source. A source
+client links the remaining deadline with caller cancellation. It does not
+depend solely on `HttpClient.Timeout`, because hosts may supply an infinite or
+unusually large client timeout.
 
 Timeouts remain visible source failures. They are not converted into not-found,
 an empty version list, a partial successful search, or an automatic stale-cache
@@ -261,12 +293,15 @@ answer. Cache fallback follows the explicit version-resolution policy and
 retains the timeout diagnostic.
 
 Required gates include stalled-header, stalled-metadata-body, stalled-payload,
-and redirect-chain cases that terminate without JavaScript cooperation.
+retry, authentication, multi-source, and redirect cases that terminate without
+JavaScript cooperation.
 
 ## Portable source bundles
 
 A shareable website link may carry a versioned source bundle encoded as
-base64url JSON. It does not carry arbitrary `nuget.config` XML.
+base64url JSON in the URL fragment, for example `#sources=...`. Fragments are
+not sent to the hosting server. The link does not carry arbitrary
+`nuget.config` XML.
 
 An illustrative payload is:
 
@@ -298,13 +333,19 @@ non-secret HTTPS descriptors and selected source IDs. It must not contain:
 - credentials, PATs, API keys, or authorization headers;
 - local paths or `file://` URLs;
 - embedded URL user information;
+- URL query strings or fragments;
 - arbitrary NuGet configuration sections; or
 - runtime-discovered resource URLs.
 
+Query-bearing source URLs remain valid when supplied through existing desktop
+configuration because signed endpoints are an established feed capability, but
+they are nonportable and cannot enter a browser source bundle.
+
 Feed names and hostnames can still reveal organizational information. The
-website uses a `no-referrer` policy, does not emit bundle contents to telemetry,
-and removes the bundle parameter from the address bar with `replaceState`
-before contacting any configured source.
+fragment keeps them out of the hosting origin's request and access logs. The
+website also uses a `no-referrer` policy, does not emit bundle contents to
+telemetry, and removes the bundle fragment from the address bar with
+`replaceState` before contacting any configured source.
 
 Import is an explicit trust gesture:
 
@@ -314,7 +355,7 @@ Import is an explicit trust gesture:
 3. Validate every source descriptor without contacting it.
 4. Show a preview naming additions, replacements, and selected sources.
 5. Require confirmation before writing local storage.
-6. Remove the bundle from the visible URL.
+6. Remove the bundle fragment from the visible URL.
 7. Validate source connectivity separately and report each failure.
 
 Opening a link never silently changes the active package-source set. Declining
@@ -323,7 +364,14 @@ the import leaves existing configuration untouched.
 ## Browser credentials
 
 The Package sources page may accept a short-lived packaging-read PAT for a
-source that requires authentication.
+source that declares Basic PAT authentication. The session credential contains
+both the configured username and the secret; the wire form is
+`Authorization: Basic base64(username:PAT)`. A source-specific UI may suggest a
+documented placeholder username, but the common client does not invent one.
+
+OAuth credentials, credential-provider plugins, device login, and feed-specific
+authentication schemes are unsupported in the initial browser implementation
+unless their own explicit credential contract is added.
 
 PAT handling follows these rules:
 
@@ -333,10 +381,17 @@ PAT handling follows these rules:
 - reload and tab close discard it;
 - the UI identifies the source and requested scope before entry;
 - credentials are attached only to requests authorized for that source;
-- credentials are not forwarded across redirects or to cross-origin resources;
+- credentials may remain attached across same-origin redirects;
+- credentials are never attached to a cross-origin redirect target or resource;
   and
 - authenticated browser support requires the feed's CORS policy to permit the
   origin and authorization header.
+
+Desktop transports enforce redirect origin at the HTTP-handler boundary.
+Browser transports rely on Fetch's cross-origin authorization behavior and
+must gate the observed same-origin/cross-origin cases. If a browser cannot
+prove the required origin boundary for an authenticated redirect, it rejects
+that source behavior rather than following it with ambiguous authority.
 
 A shared source bundle can register a private feed, but every recipient supplies
 their own PAT. Registration and authority remain separate.
@@ -368,7 +423,9 @@ Candidate sources: NuGet Gallery, Corporate mirror
 The default field is high value because it answers which producer supplied the
 inspected bytes. Endpoint, payload location, and candidate-source expansion are
 normal or detailed evidence. Structured output carries stable source IDs in
-addition to display names.
+addition to display names. Every human and structured endpoint projection uses
+the shared URL-redaction policy; signed queries and other credential-bearing
+components are never rendered.
 
 The website shows source badges in search results, version choices, package
 tabs, and package headings. A version advertised upstream but unavailable from
@@ -414,9 +471,13 @@ Implementation is not complete until gates prove:
 - JavaScript-independent library timeouts cover metadata and payload stalls;
 - bundle imports reject secrets, HTTP URLs, user information, unknown kinds,
   oversized values, and excessive source counts;
-- source-bundle values do not enter referrers, telemetry, or source requests;
+- encoded source-bundle values do not enter referrers, telemetry, or source
+  requests;
+- source-bundle values do not enter the hosting origin's request or access
+  logs;
 - imports require confirmation before persistence;
 - PATs do not enter persisted state, URLs, errors, redirects, or telemetry;
-- authenticated requests obey source-origin boundaries; and
+- Basic PAT credentials include an explicit username and obey same-origin
+  redirect and resource boundaries; and
 - Markdown and structured output distinguish package source, payload location,
   and candidate sources.

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -267,14 +267,16 @@ Complete listing-aware Gallery enumeration also depends on registration
 metadata. If registration cannot be read, raw enumeration may expose the
 flat-container versions only as a typed partial result with listing status
 `unknown`; it does not report them as listed and does not populate a complete
-candidate cache. Auto-selecting latest, wildcard, or range operations fail
-closed when the missing listing evidence could change the selected coordinate.
+candidate cache. Auto-selecting wildcard or range operations that depend on
+complete enumeration fail closed when the missing listing evidence could change
+the selected coordinate. Search-backed latest selection remains available
+because Gallery search returns listed versions.
 
 The target listing contract is source-relative:
 
 | Status | Meaning |
 | --- | --- |
-| `listed` | NuGet Gallery registration explicitly reports the version listed |
+| `listed` | NuGet Gallery registration reports `listed: true` or omits the optional property |
 | `unlisted` | NuGet Gallery registration explicitly reports the version unlisted |
 | `unknown` | Gallery listing evidence was required but unavailable |
 | `not-applicable` | The reporting source has no NuGet Gallery listing concept |
@@ -601,8 +603,10 @@ Implementation is not complete until gates prove:
   enumeration, and incomplete listing metadata cannot populate that cache;
 - source-relative listing states cover `listed`, `unlisted`, `unknown`, and
   `not-applicable`; registration outages render visibly partial
-  Markdown/TSV/JSONL enumeration and latest, wildcard, and range selection fail
-  closed;
+  Markdown/TSV/JSONL enumeration, registration-dependent wildcard and range
+  selection fail closed, and search-backed latest remains available;
+- a registration entry with no `listed` property is treated as listed, while
+  only explicit `false` is unlisted;
 - a non-Gallery v3 source without a declared symbol resource never constructs
   a `.snupkg` request, and a custom-feed package never probes the NuGet.org
   symbol CDN merely because Gallery carries the same package ID;

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -206,8 +206,11 @@ The website provides a Package sources page from the home screen. It supports:
 NuGet Gallery is built in and cannot be rewritten into an arbitrary endpoint.
 It may be disabled for a selected operation.
 
-Browser-local registration is persisted in local storage as non-secret source
-descriptors and selected IDs. Runtime credentials are never part of this
+Browser-local registration is persisted in local storage as portable source
+descriptors and selected IDs. Every registry write, whether typed manually,
+edited, or imported from a bundle, requires HTTPS and rejects credential
+fields, URL user information, queries, and fragments. Descriptor names, IDs,
+and paths are treated as public. Runtime credentials are never part of this
 registry.
 
 Changing a descriptor's kind or canonical endpoint creates a new source
@@ -357,6 +360,13 @@ visible failure with exact-pin guidance and does not reset or escape the
 enclosing resolution policy. Explicit `Name@latest` continues to use the
 configured request deadline and operation ceiling.
 
+The current implementation separately caps several body reads at
+`min(configured timeout, 30 seconds)`, so increasing `--http-timeout` does not
+extend those reads today. The target request deadline deliberately replaces
+that one-way clamp with the validated configured value in either direction;
+the larger operation ceiling preserves a finite failover bound. Implementation
+must update the private-feed timeout guidance with that behavior change.
+
 Timeouts remain visible source failures. They are not converted into not-found,
 an empty version list, a partial successful search, or an automatic stale-cache
 answer. Cache fallback follows the explicit version-resolution policy and
@@ -444,6 +454,11 @@ ASCII grammar; display names and endpoints cross into the page through inert
 text or DOM `textContent`, never HTML interpolation. The same rule applies to
 the confirmation preview, settings page, source badges, errors, and provenance
 output.
+
+Manual registration and editing use the same admission and inert-rendering
+path. Changing kind or endpoint discards the old session credential, resolved
+resources, candidate state, and payload-cache authority before any request is
+sent to the replacement endpoint.
 
 ## Browser credentials
 
@@ -569,6 +584,8 @@ Implementation is not complete until gates prove:
 
 - Gallery search and package CDN acquisition work without contacting
   `api.nuget.org`;
+- Gallery search requests include `semVerLevel=2.0.0` and preserve stable versus
+  prerelease policy, with a SemVer 2-only package as the non-vacuity case;
 - complete listing-aware enumeration of a paged package rebases validated page
   paths to the Gallery CDN and makes no `api.nuget.org` request;
 - inline registration pages are consumed without treating their fragment IDs as
@@ -582,10 +599,19 @@ Implementation is not complete until gates prove:
 - source-scoped candidate and payload caches cannot cross producers;
 - a keyword-search/latest cache entry cannot answer complete listing-aware
   enumeration, and incomplete listing metadata cannot populate that cache;
+- source-relative listing states cover `listed`, `unlisted`, `unknown`, and
+  `not-applicable`; registration outages render visibly partial
+  Markdown/TSV/JSONL enumeration and latest, wildcard, and range selection fail
+  closed;
+- a non-Gallery v3 source without a declared symbol resource never constructs
+  a `.snupkg` request, and a custom-feed package never probes the NuGet.org
+  symbol CDN merely because Gallery carries the same package ID;
 - JavaScript-independent library timeouts cover metadata and payload stalls;
 - request deadlines and the larger operation ceiling cover retries,
   authentication, transport failover, multi-source work, and paged metadata
   without resetting;
+- an extended configured request deadline reaches bounded body reads rather
+  than being silently clamped to 30 seconds;
 - bundle imports reject credential fields, known secret-bearing path forms,
   HTTP URLs, URL queries and fragments, user information, unknown kinds,
   oversized values, and excessive source counts;
@@ -596,6 +622,9 @@ Implementation is not complete until gates prove:
 - imports require confirmation before persistence;
 - import previews and every later source-label projection render hostile
   descriptor text inertly rather than as markup;
+- manual registration and editing reject the same credential-bearing URL
+  components as bundle import, and endpoint changes discard session
+  credentials, resolved resources, and old cache authority before contact;
 - imported descriptors cannot replace reserved IDs, overwrite existing custom
   entries implicitly, or produce a colliding compact producer label;
 - PATs do not enter persisted state, URLs, errors, cross-origin redirect

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -138,6 +138,14 @@ listing status, preserving the listing-aware behavior defined by
 [version resolution](version-resolution.md). Search results are not written
 into the complete version-list cache.
 
+Registration indexes for large packages contain page links whose absolute
+hosts name `api.nuget.org`. The Gallery client never dereferences those hosts.
+It validates that each page link has the expected HTTPS registration-page path
+for the normalized package ID, rejects query, fragment, user information, and
+unexpected path shapes, then resolves that validated path against
+`globalcdn.nuget.org`. This is source-owned path rebasing, not general
+feed-directed navigation.
+
 Its limitations remain visible:
 
 - keyword search does not reveal unlisted packages or versions;
@@ -203,17 +211,33 @@ rewriting the previous producer. Registering the canonical NuGet.org v3
 endpoint alongside the built-in Gallery source creates one producer with two
 available transports, not two candidate authorities.
 
+The registry reserves built-in IDs. A bundle may select the canonical Gallery
+descriptor but cannot replace it or register another source under its ID.
+Custom source IDs are unique after import and never overwrite an existing
+descriptor implicitly. Display-name collisions are allowed only when every UI
+and output projection disambiguates custom sources with their redacted endpoint
+host.
+
 ## Multi-source resolution
 
 Source order is not version precedence. Resolution follows the package source
 model:
 
-1. Determine active and package-ID-eligible sources.
-2. Request candidates from every eligible source capable of discovery.
-3. Retain the reporting source set for every coordinate.
-4. Select the semantic version required by the caller.
-5. Acquire from a source authorized for that coordinate.
-6. Record the producer and payload location independently.
+1. Determine active and package-ID-eligible source descriptors.
+2. Collapse descriptors and transport profiles by immutable producer identity.
+3. Request candidates from every eligible producer capable of discovery.
+4. Retain the reporting producer set for every coordinate.
+5. Select the semantic version required by the caller.
+6. Acquire from a producer authorized for that coordinate.
+7. Record the producer and payload location independently.
+
+A producer may have more than one transport, such as the Gallery browser
+transport and the canonical NuGet.org v3 transport. The host chooses the
+applicable transport order before a producer query. Failure of one transport
+falls through to the next without creating a partial aggregate or a second
+candidate source. The producer fails only after every applicable transport
+fails. Candidate and provenance output names the producer once, independently
+of which transport succeeded.
 
 For example, NuGet Gallery may report `0.18.0` while a corporate mirror reports
 only `0.16.0`. Selecting `0.18.0` authorizes its Gallery producer; it does not
@@ -256,17 +280,18 @@ path has a library-owned finite budget.
 
 The timeout policy distinguishes:
 
-| Operation class | Examples | Initial default deadline |
-| --- | --- | ---: |
-| Availability probe | Optional source health check | 2 seconds |
-| Metadata | Service index, search, versions | 30 seconds |
-| Payload | Package and symbol-package body | 120 seconds |
+| Operation | Deadline |
+| --- | ---: |
+| Optional availability probe | The lesser of 2 seconds and the configured network deadline |
+| Search, resolution, metadata, package, or symbol acquisition | The configured network deadline |
 
-These defaults are configurable through validated library options. The CLI's
-`--http-timeout` and `DOTNET_INSPECT_HTTP_TIMEOUT_IN_SECONDS` settings supply
-that validated policy and may extend the deadlines for slow feeds. A caller
-may always cancel sooner. Component limits, including metadata body-read
-timeouts, cannot exceed the enclosing operation deadline.
+The configured network deadline defaults to 30 seconds, preserving the current
+CLI contract. An explicit `--http-timeout` or
+`DOTNET_INSPECT_HTTP_TIMEOUT_IN_SECONDS` value replaces that default for every
+network operation and may shorten or extend it. Reusable library callers
+supply the same validated option directly. Caller cancellation may always
+terminate sooner. Component limits, including metadata body-read timeouts,
+cannot exceed the enclosing operation deadline.
 
 One deadline is created at each public search, resolve, or acquire entry point.
 It covers the complete operation:
@@ -285,7 +310,9 @@ that deadline; no nested operation resets it. Aggregate source queries run
 concurrently when their contract requires every eligible source. A source
 client links the remaining deadline with caller cancellation. It does not
 depend solely on `HttpClient.Timeout`, because hosts may supply an infinite or
-unusually large client timeout.
+unusually large client timeout. The owning host configures `HttpClient.Timeout`
+so it cannot preempt the library deadline; the linked library deadline remains
+the authoritative bound.
 
 Timeouts remain visible source failures. They are not converted into not-found,
 an empty version list, a partial successful search, or an automatic stale-cache
@@ -352,7 +379,8 @@ Import is an explicit trust gesture:
 1. Decode under a strict encoded and decoded size limit.
 2. Parse a versioned, allow-listed schema with bounded source count and field
    lengths.
-3. Validate every source descriptor without contacting it.
+3. Validate every source descriptor without contacting it, rejecting reserved
+   ID replacement, duplicate custom IDs, and implicit overwrite.
 4. Show a preview naming additions, replacements, and selected sources.
 5. Require confirmation before writing local storage.
 6. Remove the bundle fragment from the visible URL.
@@ -411,6 +439,14 @@ The compact package summary includes the producer:
 Version: 0.35.2 | Package source: NuGet Gallery | Type: Library
 ```
 
+Built-in sources use their reserved display name. Custom sources include their
+redacted endpoint host in the compact field so an imported source cannot
+impersonate a built-in or another custom producer:
+
+```text
+Package source: Corporate mirror (packagefeedproxy.microsoft.io)
+```
+
 Detailed provenance separates:
 
 ```text
@@ -464,8 +500,13 @@ Implementation is not complete until gates prove:
 
 - Gallery search and package CDN acquisition work without contacting
   `api.nuget.org`;
+- complete listing-aware enumeration of a paged package rebases validated page
+  paths to the Gallery CDN and makes no `api.nuget.org` request;
 - v3 resource discovery remains source-relative;
 - multi-source latest selection retains every reporting source;
+- selecting Gallery and canonical NuGet.org v3 transports reports one producer,
+  succeeds when either applicable transport succeeds, and fails only when both
+  fail;
 - a mirror lag does not redirect a Gallery-only candidate to that mirror;
 - source-scoped candidate and payload caches cannot cross producers;
 - JavaScript-independent library timeouts cover metadata and payload stalls;
@@ -476,7 +517,10 @@ Implementation is not complete until gates prove:
 - source-bundle values do not enter the hosting origin's request or access
   logs;
 - imports require confirmation before persistence;
-- PATs do not enter persisted state, URLs, errors, redirects, or telemetry;
+- imported descriptors cannot replace reserved IDs, overwrite existing custom
+  entries implicitly, or spoof compact producer display;
+- PATs do not enter persisted state, URLs, errors, cross-origin redirect
+  targets, or telemetry;
 - Basic PAT credentials include an explicit username and obey same-origin
   redirect and resource boundaries; and
 - Markdown and structured output distinguish package source, payload location,

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -5,15 +5,20 @@ sources. It covers source configuration, package source mapping, local stores,
 source-bound caches, package discovery, exact payload acquisition, and
 NuGet.org-specific enrichment.
 
+Browser source implementations, NuGet Gallery access without the v3 service
+index, portable source bundles, ephemeral credentials, and library-owned
+timeouts are defined by
+[browser package sources](browser-package-sources.md).
+
 It is the target contract. The
 [implementation boundaries](#implementation-boundaries) section distinguishes
 the behavior already present from the work needed to complete the model.
 
 The central rule is:
 
-> Feeds authorize package candidates. Caches may fulfill an authorized exact
+> Package sources authorize package candidates. Caches may fulfill an authorized exact
 > coordinate, but they do not introduce candidates and their payload must
-> retain the identity of the feed that supplied it.
+> retain the identity of the source that supplied it.
 
 NuGet does not define the declaration order of HTTP sources as precedence. It
 queries applicable sources and may obtain an exact package from any of them.
@@ -36,6 +41,7 @@ package id, and source provenance protects downloaded content after acquisition.
 | Source-bound content | Content dotnet-inspect fetched and recorded against its producer. |
 | Payload location | Where the inspected bytes were opened: an explicit file, global packages, the dotnet-inspect cache, a local feed, or a network response. |
 | Enrichment endpoint | A service such as a symbol server or NuGet.org aggregate metadata API that is not itself a package source. |
+| Source client | A protocol-specific implementation that supplies package-source capabilities behind the common candidate and payload contracts. |
 
 Source identity has two parts with different purposes:
 
@@ -67,6 +73,13 @@ immutable-source assumption; it needs distinct source endpoints to keep those
 content domains separate. Credentials selected for a configured endpoint may
 be sent to package resources discovered on the same origin (scheme, host, and
 port), but never to a cross-origin resource advertised by the feed.
+
+Package-source identity is broader than a NuGet v3 service-index URL. A
+standard v3 feed, the built-in NuGet Gallery browser implementation, and a
+local folder may implement the same candidate and payload contracts through
+different transports. Those implementation differences remain below source
+resolution: consumers receive typed capabilities, candidates, failures, and
+producer provenance rather than protocol URLs.
 
 ## Resolving active and eligible sources
 

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -89,6 +89,12 @@ IDs and transport profiles do not replace producer identity. Candidate cache
 keys also identify the discovery contract and its version so a listed-only
 search result cannot answer a complete listing-aware enumeration.
 
+Several transport profiles may implement one producer. Source resolution
+collapses them by producer identity before candidate queries. A transport
+failure falls through to another applicable profile and does not create a
+second candidate source or a partial aggregate; the producer fails only when
+all of its applicable transports fail.
+
 ## Resolving active and eligible sources
 
 Without source options, dotnet-inspect resolves the same effective

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -81,6 +81,14 @@ different transports. Those implementation differences remain below source
 resolution: consumers receive typed capabilities, candidates, failures, and
 producer provenance rather than protocol URLs.
 
+The NuGet Gallery browser implementation and the canonical NuGet.org v3 source
+share the producer identity
+`https://api.nuget.org/v3/index.json`; the browser implementation may use that
+identity without requesting the blocked service index. User-interface registry
+IDs and transport profiles do not replace producer identity. Candidate cache
+keys also identify the discovery contract and its version so a listed-only
+search result cannot answer a complete listing-aware enumeration.
+
 ## Resolving active and eligible sources
 
 Without source options, dotnet-inspect resolves the same effective

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -217,16 +217,15 @@ the nuget.org gallery:
   NuGet's own behavior of restoring a known unlisted version. `Name@latest`,
   wildcard versions, and addressable-vector endpoints are discovered
   coordinates; they retain the feeds that reported each selected version.
-- **Partial vs. fail-closed on outage.** If the registration index cannot be
+- **Fail-open vs. fail-closed on outage.** If the registration index cannot be
   fetched or parsed (network failure, or a valid-JSON document whose shape
-  defies the expected schema), the condition remains visible and behavior
-  depends on the caller. **Raw enumeration** (`Name --versions`) may return the
-  flat-container list only as a typed partial result whose listing status is
-  `unknown`; it does not label those versions as listed.
+  defies the expected schema), the condition is logged and behavior depends on
+  the caller. **Raw enumeration** (`Name --versions`) fails **open** — the
+  unfiltered list is returned rather than silently dropping real versions.
   **Auto-selecting** callers that pick a single version — nuget.org "latest"
   resolution and wildcard pattern resolution (`Name@3.0.*`) — fail **closed**,
   returning no result rather than risk selecting an unlisted version from an
-  unfiltered snapshot. A partial unfiltered snapshot is **not** cached, so a
+  unfiltered snapshot. A fail-open (unfiltered) snapshot is **not** cached, so a
   transient registration outage cannot re-surface unlisted versions for the
   cache TTL; only an authoritatively filtered list is persisted. The version
   cache category is versioned (`versions-v5`). Every key has unambiguous
@@ -254,10 +253,8 @@ Markdown, `--tsv`, and `--jsonl` shapes. Hiding remains the default, so the bare
 Because a pinned `Name@Version` names an explicit coordinate, the `--versions`
 query that verifies a single pinned version also consults the include-unlisted
 listing, so verifying a known unlisted version reports it rather than
-"not found". When listing status is unknown, NuGet.org enumeration reports
-`unknown` and marks the result partial. A non-nuget.org feed that has no listing
-concept continues to report its discovered versions without inventing
-NuGet.org listing semantics.
+"not found". When listing status is unknown (fail-open, or a non-nuget.org
+feed), versions are reported as listed.
 
 `--include-unlisted` composes with the other `--versions` lenses. With a limit
 (`--versions 1 --include-unlisted`) it takes the listing-aware path. A pinned
@@ -274,12 +271,11 @@ path), so a prerelease-endpoint range resolves without `--preview`. The bare
 range (without the flag) resolves against listed versions only, matching the
 hidden default.
 
-The version-list cache stores authoritative listing state per version. Each
-cache line carries an explicit two-character tab suffix (`\tL` listed,
-`\tU` unlisted). Unknown/partial results are never published. Publication is
-atomic. A malformed or empty latest entry falls through to the listing snapshot
-or feed, while a missing listing suffix, invalid version, or empty snapshot is
-a cache miss rather than authoritative candidate metadata.
+The version-list cache stores the listed bit per version. Each cache line
+carries an explicit two-character tab suffix (`\tL` listed, `\tU` unlisted).
+Publication is atomic. A malformed or empty latest entry falls through to the
+listing snapshot or feed, while a missing listing suffix, invalid version, or
+empty snapshot is a cache miss rather than authoritative candidate metadata.
 
 ## Cache locations
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -217,15 +217,16 @@ the nuget.org gallery:
   NuGet's own behavior of restoring a known unlisted version. `Name@latest`,
   wildcard versions, and addressable-vector endpoints are discovered
   coordinates; they retain the feeds that reported each selected version.
-- **Fail-open vs. fail-closed on outage.** If the registration index cannot be
+- **Partial vs. fail-closed on outage.** If the registration index cannot be
   fetched or parsed (network failure, or a valid-JSON document whose shape
-  defies the expected schema), the condition is logged and behavior depends on
-  the caller. **Raw enumeration** (`Name --versions`) fails **open** — the
-  unfiltered list is returned rather than silently dropping real versions.
+  defies the expected schema), the condition remains visible and behavior
+  depends on the caller. **Raw enumeration** (`Name --versions`) may return the
+  flat-container list only as a typed partial result whose listing status is
+  `unknown`; it does not label those versions as listed.
   **Auto-selecting** callers that pick a single version — nuget.org "latest"
   resolution and wildcard pattern resolution (`Name@3.0.*`) — fail **closed**,
   returning no result rather than risk selecting an unlisted version from an
-  unfiltered snapshot. A fail-open (unfiltered) snapshot is **not** cached, so a
+  unfiltered snapshot. A partial unfiltered snapshot is **not** cached, so a
   transient registration outage cannot re-surface unlisted versions for the
   cache TTL; only an authoritatively filtered list is persisted. The version
   cache category is versioned (`versions-v5`). Every key has unambiguous
@@ -253,8 +254,10 @@ Markdown, `--tsv`, and `--jsonl` shapes. Hiding remains the default, so the bare
 Because a pinned `Name@Version` names an explicit coordinate, the `--versions`
 query that verifies a single pinned version also consults the include-unlisted
 listing, so verifying a known unlisted version reports it rather than
-"not found". When listing status is unknown (fail-open, or a non-nuget.org
-feed), versions are reported as listed.
+"not found". When listing status is unknown, NuGet.org enumeration reports
+`unknown` and marks the result partial. A non-nuget.org feed that has no listing
+concept continues to report its discovered versions without inventing
+NuGet.org listing semantics.
 
 `--include-unlisted` composes with the other `--versions` lenses. With a limit
 (`--versions 1 --include-unlisted`) it takes the listing-aware path. A pinned
@@ -271,11 +274,12 @@ path), so a prerelease-endpoint range resolves without `--preview`. The bare
 range (without the flag) resolves against listed versions only, matching the
 hidden default.
 
-The version-list cache stores the listed bit per version. Each cache line
-carries an explicit two-character tab suffix (`\tL` listed, `\tU` unlisted).
-Publication is atomic. A malformed or empty latest entry falls through to the
-listing snapshot or feed, while a missing listing suffix, invalid version, or
-empty snapshot is a cache miss rather than authoritative candidate metadata.
+The version-list cache stores authoritative listing state per version. Each
+cache line carries an explicit two-character tab suffix (`\tL` listed,
+`\tU` unlisted). Unknown/partial results are never published. Publication is
+atomic. A malformed or empty latest entry falls through to the listing snapshot
+or feed, while a missing listing suffix, invalid version, or empty snapshot is
+a cache miss rather than authoritative candidate metadata.
 
 ## Cache locations
 


### PR DESCRIPTION
## Summary

- define one package-source contract with separate NuGet v3 and NuGet Gallery source clients
- specify multi-source registration, selection, candidate provenance, payload producer identity, and cache isolation
- require library-owned operation deadlines independent of JavaScript cancellation and composed across retries and sources
- define fragment-carried source bundles, confirmation-based import, and in-memory short-lived Basic PAT handling
- make package source provenance visible in compact and detailed output

Implements the specification portion of #4239. Product implementation remains tracked by that issue.

## Evidence

The design records browser validation where `api.nuget.org` is blocked while NuGet Gallery search, flat-container/registration metadata, and package/symbol CDN endpoints remain CORS-readable. It also records the observed `dotnet-inspect` skew: Gallery `0.18.0` versus corporate mirror `0.16.0`.

## Validation

- `npx markdownlint-cli docs/design/browser-package-sources.md docs/design/package-source-model.md`
- `git diff --check origin/main...HEAD`

## Adversarial review

Round 1 at `b37aac6b3` found blocking ambiguity in Gallery metadata completeness and producer identity, source-bundle URL leakage, PAT wire semantics, authenticated redirects, and timeout composition. Follow-up `d5839cbf2` addresses those findings; a clean fixed-head confirmation is required.