### PR TITLE
Document full fidelity versus fully raised

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -57,6 +57,30 @@ are not redundant:
 | `--validity-check` | *Does it even compile?* | **Validity**: the rendered C# parses, is statement-legal, and binds | Whether valid C# is *faithful* (fidelity's job) |
 | `--annotation-check` | *Do the IL annotations match the opcodes?* | **Annotation fidelity**: each allocation/unsafety/lifetime annotation agrees with the raw IL opcode at its offset (precision), and every unambiguous opcode produces its annotation (recall) | Whether the C# itself is right — only the annotations |
 
+### Fidelity and raising altitude are independent
+
+`Full` fidelity does not mean fully raised. Fidelity judges whether the emitted
+C# faithfully represents the method body; raising altitude judges whether that
+faithful C# has reached the preferred source idiom. Several C# spellings can
+recompile to the same contract body, so a lower-altitude spelling can be valid,
+correct, and opcode-exact.
+
+Issue #3346 is the concrete example. A disposed-only resource previously
+rendered as `using (IDisposable V_2 = resource)`. That form was already `Full`
+and opcode-faithful, but `using (resource)` is the fully raised endpoint when
+the resource slot has no body reads or positive PDB declaration evidence. The
+`UsingStatementPassTests` pin that discriminator, and
+`CommandExecutionTests.Member_DisposedOnlyUsing_RendersVariableLessInMarkdownAndStructuredDocument`
+pins the Markdown and structured-document surfaces. Meanwhile,
+`FidelityGateTests.PinnedFixesStayExact` independently pins the required
+resource conversion and boxing opcodes. Neither gate substitutes for the
+other.
+
+The corpus completeness floor is intentionally coarser: it detects surviving
+unstructured control flow and unsupported nodes. It does not prove that every
+method has reached every available idiom. Fixture scorecards and pass-specific
+shape tests carry those finer-grained altitude claims.
+
 The deepest is **fidelity**: a body that compiles and reads plausibly but
 recompiles to a different contract body changed the measured program shape —
 the worst failure class, invisible to every check that never runs the output

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -17,6 +17,27 @@ Decompilation is a many-to-one transform twice over: the compiler collapses many
 
 That framing turns style questions into a single question: *which member of the equivalence class do we print?*
 
+Disposed-only `using` resources illustrate the distinction between a faithful
+member of an equivalence class and its canonical endpoint. For synchronous
+compiler lowering whose resource slot is read only by the generated disposal
+machinery, and for which the PDB supplies no source local name, render
+`using (resource)` rather than inventing `using (T V_n = resource)`. Positive
+PDB declaration evidence or a body read retains the declaration. Required
+resource conversions remain explicit, so choosing the higher-altitude spelling
+does not erase boxing or disposal semantics; `UsingStatementPassTests` and
+`FidelityGateTests.PinnedFixesStayExact` enforce those boundaries.
+
+The declared runtime oracle is silent on this choice:
+`csharp_prefer_simple_using_statement = false:none` governs using statements
+versus using declarations, not expression-form resources versus unused named
+resources ([`.editorconfig` lines 86–95](https://github.com/dotnet/runtime/blob/0cfd4076fba54a30ee789fa8d8ad6ed13b9f9f5c/.editorconfig#L86-L95)).
+The revealed oracle uses the expression form in production, including
+[`ComposablePartCatalogCollection`](https://github.com/dotnet/runtime/blob/0cfd4076fba54a30ee789fa8d8ad6ed13b9f9f5c/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ComposablePartCatalogCollection.cs#L56-L75)
+and
+[`ChainPal.OpenSsl`](https://github.com/dotnet/runtime/blob/0cfd4076fba54a30ee789fa8d8ad6ed13b9f9f5c/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.OpenSsl.cs#L105-L108).
+That revealed convention selects the canonical form; it is not an analyzer
+prescription.
+
 ## The style oracle: dotnet/runtime's `.editorconfig`
 
 Where one IL shape admits several C# spellings, render the form that **dotnet/runtime's `.editorconfig` and enabled IDE analyzers (code fixers) encourage**.

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -10,6 +10,11 @@ status, Before, After, and Fully raised. Before and After must each show a
 concrete C# example. After records this PR's output; Fully raised records the
 intended endpoint.
 
+Glossary: **IL fidelity** judges whether the rendered C# recompiles to the
+original contract body; **fully raised** judges whether that faithful rendering
+has reached the preferred source idiom. A `Full`-fidelity render can still be
+short of the fully raised endpoint.
+
 Under Before and After, record independent verdicts on the shown C# so the
 assessment sits next to the code it judges:
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -8612,6 +8612,39 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_DisposedOnlyUsing_RendersVariableLessInMarkdownAndStructuredDocument()
+    {
+        string[] member =
+        [
+            "member",
+            typeof(CommandCaretGestureFixture).FullName!,
+            "--library",
+            TestAssemblyPath,
+            nameof(CommandCaretGestureFixture.DisposedOnlyUsingResource),
+        ];
+        var markdown = await RunAppAsync(
+            [.. member, "-S", "Decompiled Source", "--tips", "q"]);
+        var structured = await RunAppAsync(
+            [.. member, "-S", "Annotated Source Document", "--json", "--tips", "q"]);
+
+        Assert.Equal(0, markdown.Exit);
+        Assert.Empty(markdown.Error);
+        Assert.Contains("using (new MemoryStream())", markdown.Output);
+        Assert.DoesNotContain("using (MemoryStream V_", markdown.Output);
+
+        Assert.Equal(0, structured.Exit);
+        Assert.Empty(structured.Error);
+        using var document = JsonDocument.Parse(structured.Output);
+        string text = document.RootElement.GetProperty("text").GetString()!;
+        Assert.Contains("using (new MemoryStream())", text);
+        Assert.DoesNotContain("using (MemoryStream V_", text);
+        Assert.Contains(
+            document.RootElement.GetProperty("nodes").EnumerateArray(),
+            node => node.GetProperty("medium").GetString() == "CSharp"
+                && node.GetProperty("kind").GetString() == "UsingStatement");
+    }
+
+    [Fact]
     public async Task Member_KeywordParameterNames_EscapesSignatureAndDecompiledSourceHeader()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -20284,6 +20317,16 @@ public sealed class ConstructorSourceCaseFixture
 /// </summary>
 public sealed class CommandCaretGestureFixture
 {
+    public static int DisposedOnlyUsingResource()
+    {
+        int value = 0;
+        using (new MemoryStream())
+        {
+            value = 1;
+        }
+        return value;
+    }
+
     public string Pump(int n)
     {
         var sink = new List<object>();


### PR DESCRIPTION
## Outcome

Closes #3346 by completing the documentation and output-contract evidence paired with #4113. The disposed-only `using (resource)` behavior is unchanged; this PR documents what it proves and pins both user-facing render surfaces.

## Changes

- Distinguishes `Full` fidelity from the fully raised source-idiom endpoint in the quality guide and decompiler PR template.
- Records the canonical disposed-only `using` rule and both dotnet/runtime style-oracle facets with pinned source witnesses.
- Adds a compiler-produced CLI fixture proving the Markdown `Decompiled Source` and structured `Annotated Source Document` JSON both emit `using (new MemoryStream())`, with a typed `UsingStatement` node and no invented resource variable.

**Non-action boundary:** no decompiler, printer, IR, or CLI behavior changes; #4113 contains the product implementation and its fidelity/adversarial evidence.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — passed, 0 errors (3 existing nullable warnings).
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.CommandExecutionTests.Member_DisposedOnlyUsing_RendersVariableLessInMarkdownAndStructuredDocument -noColor` — 1/1 passed.
- `npx markdownlint-cli docs/decompiler-quality.md docs/decompiler-taste.md docs/templates/decompiler-pr.md` — passed.

## Review

Trivial-change exemption: this PR only adds documentation and a focused regression test for already-merged behavior; it changes no production path or contract.
