### PR TITLE
Isolate HttpClientFactory shared-state tests

### DIFF
--- a/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
+++ b/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
@@ -6,10 +6,15 @@ using DotnetInspector.Packages;
 
 namespace DotnetInspector.Tests;
 
+// HttpClientFactory configuration and shared clients are process-wide. Isolate these
+// invariants from every external test that can initialize or reset that state (#4246).
+[CollectionDefinition("HttpClientFactoryGuard", DisableParallelization = true)]
+public sealed class HttpClientFactoryGuardCollection;
+
 /// <summary>
 /// Tests for HttpClientFactory shared instance behavior.
 /// </summary>
-[Collection("Console")]
+[Collection("HttpClientFactoryGuard")]
 public class HttpClientFactoryTests : IDisposable
 {
     private readonly string _cacheDir = Path.Combine(Path.GetTempPath(), $"dotnet-inspect-http-client-tests-{Guid.NewGuid():N}");


### PR DESCRIPTION
`HttpClientFactoryTests` now runs in a non-parallel guard collection,
preventing unrelated test collections from changing process-wide factory
options or shared clients while its invariants are executing.

| | Before | After |
| --- | --- | --- |
| Scheduling | The class shared the `Console` collection, which serialized it only with other `Console` tests; other collections could still run concurrently and reset `HttpClientFactory`. | `HttpClientFactoryGuard` has `DisableParallelization = true`, so the factory invariant tests run outside the suite's parallel phase. |
| Result | `Initialize_OnceSharedExists_GovernsOnlyLaterClients` could observe the baseline 30-second timeout after configuring 45 seconds. | The configured timeout and shared-client snapshot cannot be overwritten by another test during the assertion. |

This is better because the test now matches the process-wide ownership of the
state it verifies. Production behavior and factory semantics are unchanged.

Validation: 149 relevant tests passed under unlimited collection threads with
the aggressive scheduler, including every CLI test class that directly
initializes or resets `HttpClientFactory`.

Closes #4246
