### PR TITLE
Extract field deconstruction compiler fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5532,20 +5532,3 @@ public static class ExtensionMethodSamples
 
     public static int Combine(int left, int right) => left + right;
 }
-
-// Issue #1142: deconstruction into field targets. Top-level (the test importer
-// helper resolves by simple FullName, not nested `+` names).
-public sealed class FieldDeconstructionTargets
-{
-    public int InstanceX;
-    public int InstanceY;
-    public static int StaticX;
-    public static int StaticY;
-
-    // Two instance fields. An instance-field receiver keeps the importer from
-    // promoting the tuple temp to a stack slot, so the seed is a StoreLocal.
-    public void IntoTwoInstanceFields((int, int) pair) => (InstanceX, InstanceY) = pair;
-
-    // Two static fields — no receiver, so the temp promotes to a stack slot.
-    public static void IntoTwoStaticFields((int, int) pair) => (StaticX, StaticY) = pair;
-}

--- a/src/ILInspector.Decompiler.Tests/FieldDeconstructionSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/FieldDeconstructionSamples.cs
@@ -1,0 +1,18 @@
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #1142: deconstruction into field targets. Top-level (the test importer
+// helper resolves by simple FullName, not nested `+` names).
+public sealed class FieldDeconstructionTargets
+{
+    public int InstanceX;
+    public int InstanceY;
+    public static int StaticX;
+    public static int StaticY;
+
+    // Two instance fields. An instance-field receiver keeps the importer from
+    // promoting the tuple temp to a stack slot, so the seed is a StoreLocal.
+    public void IntoTwoInstanceFields((int, int) pair) => (InstanceX, InstanceY) = pair;
+
+    // Two static fields — no receiver, so the temp promotes to a stack slot.
+    public static void IntoTwoStaticFields((int, int) pair) => (StaticX, StaticY) = pair;
+}


### PR DESCRIPTION
## Summary

Moves the compiler-produced `FieldDeconstructionTargets` fixture unchanged from the tail of `CfgSampleClass.cs` into feature-focused `FieldDeconstructionSamples.cs`.

This keeps the field-target deconstruction fixture with its sole owner, `DeconstructionAssignmentPassTests`. The source move intentionally changes PDB document provenance and may relocate metadata rows; rendered method inventory and bodies remain identical.

## Evidence

- Release solution build succeeded.
- `DeconstructionAssignmentPassTests`: 32 total, 0 failed.
- Decompiler fast gate rerun: 5,015 total, 0 failed, 8 expected privilege-dependent skips.
- Exact-base stable-path render A/B at `d1bf2872749788b6924cf771ae3203925987ce65`: 20,338 methods evaluated; 0 changed, 0 added, 0 removed.
- The first fast-gate run had one unrelated three-minute subprocess timeout in `EvilPoolPinTests.TheSweepReadsAPinFileTheSameWayInBothModes`; that test passed alone in 38 seconds, and the complete fast-gate rerun passed.

Related to #3913. Leaves #3913 open for the remaining fixture groups.