### PR TITLE
Add explicit object creation style option (#3169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,9 @@ for compatibility. The same config file
 spellings using `.editorconfig` key names. Named enum labels that share one
 switch body are alphabetical by default; set
 `dotnet_inspect_style_enum_case_label_order = value` to retain recovered numeric
-order. `--taste` requests the whole
+order. Object creation uses target-typed `new(...)` by default; set
+`csharp_style_implicit_object_creation_when_type_is_apparent = false` to keep
+the explicit constructed type in `new T(...)`. `--taste` requests the whole
 oracle-endorsed set for one invocation without a config file. `Annotated Source`
 names the applied spellings in a trailing comment on the member signature, and
 drops its interleaved IL for any member a byte-divergent lens actually rewrote.

--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -144,8 +144,8 @@ syntax, while `p[i]` is pointer arithmetic, not an indexer call on the pointee.
 
 `T x = new T(args)` and `T x = new(args)` compile to the identical
 `newobj T::.ctor(args)` — the constructed type is fixed by the IL token, so the
-spelling has no IL consequence. This is a class-3 no-anchor choice, and the
-oracle decides it: `dotnet/runtime`'s `.editorconfig` sets
+spelling has no IL consequence. This is a class-3 no-anchor choice, and the declared oracle decides the shipped
+default: `dotnet/runtime`'s `.editorconfig` sets
 `csharp_style_implicit_object_creation_when_type_is_apparent = true`, so when the
 type is apparent from the left-hand side we drop the redundant type name.
 
@@ -155,6 +155,26 @@ type is apparent from the left-hand side we drop the redundant type name.
 StringBuilder sb = new StringBuilder(n);   // type named twice
 StringBuilder sb = new(n);                 // target-typed: type apparent on the left
 ```
+
+The `object-creation-style` catalog axis exposes the other faithful spelling as
+the `explicit-object-creation` opt-out. Its default `target-typed` value keeps
+the shipped rendering; selecting `explicit` or copying
+`csharp_style_implicit_object_creation_when_type_is_apparent = false` into
+`.dotnet-inspectconfig` retains `new T(...)` at every site where the shortener
+would otherwise fire. The option does not broaden the firing set or alter any
+decline boundary below.
+
+Together with the independent apparent-`var` category, that makes exactly three
+reachable declaration spellings:
+
+| Local type | Object creation | Selection |
+| --- | --- | --- |
+| `List<int>` | `new()` | shipped `target-typed` default |
+| `List<int>` | `new List<int>()` | `explicit` object creation |
+| `var` | `new List<int>()` | apparent `var` |
+
+`var x = new()` remains unreachable and invalid (CS8754). If both apparent
+`var` and explicit object creation are selected, the third row still wins.
 
 Unlike `var` or brace style, this spelling carries a **binding hazard**, so it is
 adopted as a sound conservative over-approximation rather than everywhere the
@@ -180,6 +200,23 @@ adopting it could change binding, and each decline is proven by recompile/corpus
 fidelity. Optional-argument elision (below) is the other spelling that ships
 under this binding-hazard discipline; any future one that shares the hazard —
 apparent-type or argument-omission — is scoped the same way.
+
+At dotnet/runtime commit `c2de915bb1560b5008499d61b1d1afaa2acc659b`, the
+revealed facet is mixed: target-typed forms appear in
+`src/mono/wasm/host/Program.cs:22,32` and
+`src/mono/wasi/testassets/Http.cs:35,52`, while same-type explicit construction
+remains in `src/coreclr/tools/dotnet-pgo/MethodMemoryMap.cs:58,195,258` and
+`src/libraries/System.Memory/src/System/Text/EncodingExtensions.cs:166,353`.
+The explicit opt-out is therefore not corpus-endorsed and does not join a taste
+aggregate. The declared facet, rather than a corpus claim, is what selects the
+target-typed shipped default.
+
+`ByteNeutralityGateTests.CompileBackValue_On_RecompilesToTheSameIlAsOff`
+enforces compile-back identity for the emitting `explicit` value, and
+`ValueTokenState_MatchesEmits` prevents it from becoming an inert catalog row.
+`TargetTypedNewPassTests` pins default/explicit behavior at declaration and
+assignment sites, while `VarWhenApparentTests` pins the three reachable
+declaration spellings.
 
 ### `var` spelling
 
@@ -866,9 +903,9 @@ The recognized knobs are described once, in the library, by
 `StyleOptionDescriptor` carries a knob's stable id, human-facing title and
 summary, its tier (`Formatting`, `Spelling`, `Lens`, or `Synthesis`), whether it
 is `ByteDivergent`, and the **value domain** it ranges over — its ordered list of
-`StyleOptionValue`s. Most knobs are two-state (a `false`/`true` domain); the
-guarded-boolean-return knob is a single multi-value axis
-(`flat` / `conditional-expression` / `branchless`). Each `StyleOptionValue`
+`StyleOptionValue`s. Plain booleans use a `false`/`true` domain; semantic axes
+use named tokens such as `explicit` / `target-typed` or the guarded-return
+`flat` / `conditional-expression` / `branchless` family. Each `StyleOptionValue`
 carries its stable token, optional title, whether that value is `OracleEndorsed`
 (declared) and `CorpusEndorsed` (revealed),
 its `.dotnet-inspectconfig` key (`null` for values without a persistent CLI
@@ -949,12 +986,12 @@ single-select by construction — `GetValue` reports the first selected value in
 `branchless` when both are set, exactly as the printer resolves it — the aggregate
 selects the ternary and the axis never resolves ambiguously.
 
-Every opt-in knob's value domain is carried by the descriptor directly: the
-two-state knobs (including the expression-body arrow wrap, `WrapExpressionBodyArrow`)
-have a `false`/`true` domain, and the guarded-boolean-return family is one
-three-token axis rather than two coupled booleans. The catalog is exhaustive: a
-test-only drift guard asserts every backing `PrinterOptions` property is reachable
-through some descriptor value, so a new knob cannot land without a catalog entry.
+Every opt-in knob's value domain is carried by the descriptor directly: plain
+two-state toggles (including the expression-body arrow wrap,
+`WrapExpressionBodyArrow`) have a `false`/`true` domain, while semantic axes use
+named tokens. The catalog is exhaustive: a test-only drift guard asserts every
+backing `PrinterOptions` property is reachable through some descriptor value, so
+a new knob cannot land without a catalog entry.
 
 The enum-label ordering family is a two-token `Spelling` axis:
 `alphabetical` (the tool-owned default) and `value`. It is endorsed by neither
@@ -979,6 +1016,14 @@ declared type spelling but never changes the IL — so the family sits in the
 category endorsement. The family is therefore **opt-in only** and never part of
 the "full taste" aggregate — the shipped default spells explicit types
 everywhere, matching the declared runtime policy.
+
+The object-creation family is a third value-domain axis:
+`object-creation-style` has `target-typed` as its shipped default and `explicit`
+as its sole selectable opt-out (`explicit-object-creation`). The default value's
+`csharp_style_implicit_object_creation_when_type_is_apparent` config key
+preserves editorconfig polarity directly: `true` selects `target-typed`, while
+`false` selects `explicit`. The axis is byte-neutral `Spelling`; neither the
+explicit choice nor the mixed revealed corpus joins an endorsement aggregate.
 
 ## Verification and soundness
 

--- a/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ByteNeutralityGateTests.cs
@@ -128,6 +128,9 @@ public sealed class ByteNeutralityGateTests
         new("var-spelling-style", "var-elsewhere",
             typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.NotApparent),
             "() -> corelib:System.Int32"),
+        new("object-creation-style", "explicit",
+            typeof(VarWhenApparentSpecimen), nameof(VarWhenApparentSpecimen.NestedObjectCreation),
+            "() -> corelib:System.Int32"),
         // Synthesis: suppress symbols so the product default invents `num`, while
         // slot-local-names restores V_0. Both forms must compile back identically.
         new("slot-local-names", "true",

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -333,8 +333,8 @@ public class StyleOptionCatalogTests
     {
         // A two-state knob's key = false is the keyed value's
         // SetSelected(false) path: it deselects that value and selects its sibling.
-        // This covers ordinary default-off booleans and the target-typed-new
-        // editorconfig preference, whose keyed value is the default-on value.
+        // Descriptor-level ConfigKey exposes only default-off knobs, so Get and
+        // ConfigKey retain the same polarity for generic hosts.
         foreach (var o in Options.Where(o => o.Values.Count == 2 && o.ConfigKey is not null))
         {
             var keyedValue = o.Values.Single(v => v.ConfigKey is not null);
@@ -668,6 +668,10 @@ public class StyleOptionCatalogTests
         Assert.Equal(
             "csharp_style_implicit_object_creation_when_type_is_apparent",
             targetTyped.ConfigKey);
+        // The key controls the default-on value, so the descriptor-level
+        // ConfigKey/Get convenience pair deliberately does not expose it with
+        // inverted polarity. Config resolution still consumes the value key.
+        Assert.Null(style.ConfigKey);
         Assert.False(style.OracleEndorsed);
         Assert.False(style.CorpusEndorsed);
         Assert.DoesNotContain(StyleOptionCatalog.OracleEndorsedOptions, o => o.Id == style.Id);

--- a/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StyleOptionCatalogTests.cs
@@ -14,8 +14,7 @@ namespace ILInspector.Decompiler.Tests;
 /// NativeAOT-safe accessors. These tests pin that contract so a host (the CLI
 /// resolver, a Wasm UI, the "full taste" aggregate) can rely on it, and so the
 /// catalog cannot silently drift from the <see cref="PrinterOptions"/> surface.
-/// Most knobs are two-state (boolean) toggles; the guarded-boolean-return knob is
-/// a single multi-value axis whose value domain the descriptor carries directly.
+/// Each knob carries its complete boolean or semantic value domain directly.
 /// </summary>
 public class StyleOptionCatalogTests
 {
@@ -146,6 +145,7 @@ public class StyleOptionCatalogTests
                 "var-spelling-style:var-for-built-in-types",
                 "var-spelling-style:var-when-type-apparent",
                 "var-spelling-style:var-elsewhere",
+                "explicit-object-creation",
                 "enum-case-label-order",
                 "prefer-long-literal-suffix",
             },
@@ -331,17 +331,20 @@ public class StyleOptionCatalogTests
     [Fact]
     public void ConfigKeyFalse_TogglesAnAxisOffWithoutTouchingSiblings()
     {
-        // A boolean knob's key = false is the per-value SetSelected(false) path: it
-        // clears its own backing state and nothing else. Proven on the four
-        // qualification knobs (each is a two-state axis with a config key).
+        // A two-state knob's key = false is the keyed value's
+        // SetSelected(false) path: it deselects that value and selects its sibling.
+        // This covers ordinary default-off booleans and the target-typed-new
+        // editorconfig preference, whose keyed value is the default-on value.
         foreach (var o in Options.Where(o => o.Values.Count == 2 && o.ConfigKey is not null))
         {
-            var onValue = o.Values.Single(v => v.ConfigKey is not null);
-            var enabled = onValue.SetSelected(PrinterOptions.Default, true);
-            Assert.Equal(onValue.Token, o.GetValue(enabled));
+            var keyedValue = o.Values.Single(v => v.ConfigKey is not null);
+            var sibling = o.Values.Single(v => v.ConfigKey is null);
+            var enabled = keyedValue.SetSelected(PrinterOptions.Default, true);
+            Assert.True(keyedValue.IsSelected(enabled));
 
-            var disabled = onValue.SetSelected(enabled, false);
-            Assert.Equal("false", o.GetValue(disabled));
+            var disabled = keyedValue.SetSelected(enabled, false);
+            Assert.False(keyedValue.IsSelected(disabled));
+            Assert.True(sibling.IsSelected(disabled));
         }
     }
 
@@ -636,6 +639,41 @@ public class StyleOptionCatalogTests
         // Full taste leaves the axis on its explicit default.
         var full = StyleOptionCatalog.ApplyFullTaste(PrinterOptions.Default);
         Assert.Equal("explicit", varStyle.GetValue(full));
+    }
+
+    [Fact]
+    public void ObjectCreationStyle_IsAByteNeutralExplicitOptOut()
+    {
+        var style = Options.Single(o => o.Id == "object-creation-style");
+
+        Assert.Equal(StyleOptionTier.Spelling, style.Tier);
+        Assert.False(style.ByteDivergent);
+        Assert.Equal(
+            new[] { "explicit", "target-typed" },
+            style.Values.Select(v => v.Token).ToArray());
+        Assert.Equal("target-typed", style.DefaultValue);
+        Assert.Equal("target-typed", style.GetValue(PrinterOptions.Default));
+
+        var explicitOptions = style.WithValue(PrinterOptions.Default, "explicit");
+        Assert.False(explicitOptions.PreferImplicitObjectCreation);
+        Assert.Equal("explicit", style.GetValue(explicitOptions));
+    }
+
+    [Fact]
+    public void ObjectCreationStyle_MirrorsEditorconfigPolarity_WithoutJoiningFullTaste()
+    {
+        var style = Options.Single(o => o.Id == "object-creation-style");
+        var targetTyped = style.Values.Single(v => v.Token == "target-typed");
+
+        Assert.Equal(
+            "csharp_style_implicit_object_creation_when_type_is_apparent",
+            targetTyped.ConfigKey);
+        Assert.False(style.OracleEndorsed);
+        Assert.False(style.CorpusEndorsed);
+        Assert.DoesNotContain(StyleOptionCatalog.OracleEndorsedOptions, o => o.Id == style.Id);
+
+        Assert.True(targetTyped.SetSelected(PrinterOptions.Default, true).PreferImplicitObjectCreation);
+        Assert.False(targetTyped.SetSelected(PrinterOptions.Default, false).PreferImplicitObjectCreation);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TargetTypedNewPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TargetTypedNewPassTests.cs
@@ -7,14 +7,14 @@ public class TargetTypedNewPassTests
     static readonly ILInspector.Metadata.IAssemblyReferenceResolver RuntimeResolver =
         TestAssemblyReferenceResolvers.RuntimeAssemblies();
 
-    static string PrintRaised(string methodName)
+    static string PrintRaised(string methodName, PrinterOptions? options = null)
     {
         using var context = new MetadataContext(RuntimeResolver);
         using var source = MetadataSource.Open(typeof(TargetTypedNewFixtures).Assembly.Location, null, RuntimeResolver, context);
         var function = IrImporter.Import(source, typeof(TargetTypedNewFixtures).FullName!, methodName);
         Assert.NotNull(function);
 
-        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method), options);
         Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
         Assert.NotNull(result.Output);
         return result.Output!.ReplaceLineEndings("\n").Trim();
@@ -27,6 +27,28 @@ public class TargetTypedNewPassTests
 
         Assert.Contains("= new(", output);
         Assert.DoesNotContain("new StringBuilder(", output);
+    }
+
+    [Fact]
+    public void LocalDeclaration_ExplicitOption_KeepsConstructedType()
+    {
+        string output = PrintRaised(
+            nameof(TargetTypedNewFixtures.LocalDeclaration),
+            new PrinterOptions { PreferImplicitObjectCreation = false });
+
+        Assert.Contains("= new StringBuilder(", output);
+        Assert.DoesNotContain("= new(", output);
+    }
+
+    [Fact]
+    public void FieldStore_ExplicitOption_KeepsConstructedType()
+    {
+        string output = PrintRaised(
+            nameof(TargetTypedNewFixtures.FieldStore),
+            new PrinterOptions { PreferImplicitObjectCreation = false });
+
+        Assert.Contains("= new StringBuilder(", output);
+        Assert.DoesNotContain("= new(", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/VarWhenApparentTests.cs
+++ b/src/ILInspector.Decompiler.Tests/VarWhenApparentTests.cs
@@ -26,6 +26,7 @@ public sealed class VarWhenApparentTests
     static readonly PrinterOptions VarForBuiltInTypes = new() { PreferVarForBuiltInTypes = true };
     static readonly PrinterOptions VarWhenApparent = new() { PreferVarWhenTypeApparent = true };
     static readonly PrinterOptions VarElsewhere = new() { PreferVarElsewhere = true };
+    static readonly PrinterOptions ExplicitObjectCreation = new() { PreferImplicitObjectCreation = false };
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef String = TypeRef.CoreLib("System", "String");
 
@@ -96,6 +97,33 @@ public sealed class VarWhenApparentTests
         Assert.Contains("var ", text);
         // Either/or: spelling `var` suppresses the shortener, so the RHS keeps its
         // explicit `new List<int>()`. A bare `var x = new()` would be CS8754.
+        Assert.Contains("= new List<int>();", text);
+        Assert.DoesNotContain("new();", text);
+    }
+
+    [Fact]
+    public void ObjectCreation_ExplicitOption_KeepsExplicitTypeOnBothSides()
+    {
+        var text = Render(nameof(VarWhenApparentSpecimen.ObjectCreation), ExplicitObjectCreation);
+
+        Assert.Contains("List<int>", text);
+        Assert.Contains("= new List<int>();", text);
+        Assert.DoesNotContain("var ", text);
+        Assert.DoesNotContain("= new();", text);
+    }
+
+    [Fact]
+    public void ObjectCreation_VarAndExplicitOptions_StillUseVarWithExplicitNew()
+    {
+        var text = Render(
+            nameof(VarWhenApparentSpecimen.ObjectCreation),
+            new PrinterOptions
+            {
+                PreferVarWhenTypeApparent = true,
+                PreferImplicitObjectCreation = false,
+            });
+
+        Assert.Contains("var ", text);
         Assert.Contains("= new List<int>();", text);
         Assert.DoesNotContain("new();", text);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -5069,7 +5069,8 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string? TargetTypedNewText(IrExpression value, TypeRef? target)
     {
-        if (target is null
+        if (!_options.PreferImplicitObjectCreation
+            || target is null
             || value is not NewObject creation
             || MultiDimArrayCreationText(creation) is not null
             || IsSystemObjectType(creation.Constructor.DeclaringType)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/PrinterOptions.cs
@@ -152,6 +152,18 @@ public sealed record PrinterOptions
     public bool PreferVarElsewhere { get; init; }
 
     /// <summary>
+    /// When set, an eligible object creation whose constructed type is already
+    /// apparent from its assignment/declaration target renders as target-typed
+    /// <c>new(args)</c> instead of repeating the type in <c>new T(args)</c>.
+    /// On by default, preserving the shipped output and matching dotnet/runtime's
+    /// <c>csharp_style_implicit_object_creation_when_type_is_apparent = true</c>.
+    /// Setting it to <see langword="false"/> is a byte-neutral explicit-spelling
+    /// opt-out; compile-back identity is enforced by
+    /// <c>ByteNeutralityGateTests.CompileBackValue_On_RecompilesToTheSameIlAsOff</c>.
+    /// </summary>
+    public bool PreferImplicitObjectCreation { get; init; } = true;
+
+    /// <summary>
     /// When set, a guarded boolean return the default view must render as a flat
     /// <c>if (c) return A; return B;</c> — because no short-circuit fold is
     /// opcode-faithful for that shape (see <c>ShortCircuitFidelity</c> / #3114) —

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -152,8 +152,9 @@ public sealed record StyleOptionValue
     /// <summary>
     /// The <c>.dotnet-inspectconfig</c> key whose <c>= true</c> selects this value
     /// (and whose <c>= false</c> deselects it), or <see langword="null"/> when the
-    /// value is not directly config-selectable — the default/off value of a knob,
-    /// or an API-only knob with no config vocabulary. Oracle-endorsed keys use the
+    /// value is not directly config-selectable. A key normally lives on a
+    /// non-default value, but may live on the default value when the mirrored
+    /// editorconfig preference defaults on. Oracle-endorsed keys use the
     /// editorconfig <c>dotnet_style_*</c> vocabulary; tool-owned values (e.g. the
     /// branchless "bool hack") use a <c>dotnet_inspect_style_*</c> key.
     /// </summary>
@@ -310,7 +311,7 @@ public sealed record StyleOptionDescriptor
     public bool CorpusEndorsed => CorpusEndorsedValue is not null;
 
     /// <summary>
-    /// The config key that turns a two-state (boolean) knob on, or
+    /// The config key that controls the second value of a two-state knob, or
     /// <see langword="null"/> for an API-only or multi-value knob. Multi-value
     /// axes may use either per-value keys or <see cref="ValueConfigKey"/>.
     /// Convenience for the common boolean case
@@ -364,14 +365,15 @@ public sealed record StyleOptionDescriptor
 /// The catalog of every configurable <see cref="PrinterOptions"/> knob, exposed as the
 /// shared source of truth for hosts (CLI config resolution, a Wasm UI, the "full
 /// taste" aggregate) so option metadata lives in exactly one place and cannot
-/// drift between the library and its consumers. Most knobs are two-state
-/// (boolean) toggles; the guarded-boolean-return family is a single multi-value
-/// axis whose value domain the descriptor carries directly.
+/// drift between the library and its consumers. Each knob carries its complete
+/// value domain, whether that is a plain boolean or semantic tokens such as
+/// object-creation and guarded-return styles.
 /// </summary>
 public static class StyleOptionCatalog
 {
     private const string GuardedReturnId = "guarded-boolean-return-style";
     private const string VarStyleId = "var-spelling-style";
+    private const string ObjectCreationStyleId = "object-creation-style";
     private const string EnumLabelOrderId = "enum-case-label-order";
 
     // Value tokens for the guarded-boolean-return family axis.
@@ -384,6 +386,10 @@ public static class StyleOptionCatalog
     private const string VarStyleBuiltInTypes = "var-for-built-in-types";
     private const string VarStyleWhenApparent = "var-when-type-apparent";
     private const string VarStyleElsewhere = "var-elsewhere";
+
+    // Value tokens for the object-creation-spelling axis.
+    private const string ObjectCreationExplicit = "explicit";
+    private const string ObjectCreationTargetTyped = "target-typed";
 
     // Value tokens for shared-body enum case-label ordering.
     private const string EnumLabelAlphabetical = "alphabetical";
@@ -451,12 +457,11 @@ public static class StyleOptionCatalog
 
     /// <summary>
     /// Every configurable knob, in a stable presentation order (formatting and
-    /// spelling first, then the byte-divergent lens). Two-state knobs carry a
-    /// <c>false</c>/<c>true</c> value domain; the guarded-boolean-return knob is a
-    /// single multi-value axis (<c>flat</c> / <c>conditional-expression</c> /
-    /// <c>branchless</c>). The catalog is exhaustive: the drift-guard test asserts
-    /// every backing <see cref="PrinterOptions"/> property is reachable through
-    /// some descriptor value.
+    /// spelling first, then the byte-divergent lens). Plain booleans carry a
+    /// <c>false</c>/<c>true</c> domain; semantic axes carry stable named tokens.
+    /// The catalog is exhaustive: the drift-guard test asserts every backing
+    /// <see cref="PrinterOptions"/> property is reachable through some descriptor
+    /// value.
     /// </summary>
     public static IReadOnlyList<StyleOptionDescriptor> Options { get; } =
     [
@@ -543,6 +548,7 @@ public static class StyleOptionCatalog
             with: static (o, v) => o with { QualifyEventAccess = v }),
         GuardedBooleanReturnStyle(),
         VarSpellingStyle(),
+        ObjectCreationStyle(),
         EnumCaseLabelOrderStyle(),
         Boolean(
             id: "prefer-long-literal-suffix",
@@ -920,6 +926,36 @@ public static class StyleOptionCatalog
                     ConfigKey = "csharp_style_var_elsewhere",
                     IsSelected = static o => o.PreferVarElsewhere,
                     SetSelected = static (o, on) => o with { PreferVarElsewhere = on },
+                },
+            ],
+        };
+
+    private static StyleOptionDescriptor ObjectCreationStyle()
+        => new()
+        {
+            Id = ObjectCreationStyleId,
+            Title = "Use explicit object creation",
+            Summary = "Keep the constructed type in new T(...) instead of shortening to target-typed new(...) where the assignment target already supplies it.",
+            Tier = StyleOptionTier.Spelling,
+            ByteDivergent = false,
+            DefaultValue = ObjectCreationTargetTyped,
+            Values =
+            [
+                new StyleOptionValue
+                {
+                    Token = ObjectCreationExplicit,
+                    ChoiceId = "explicit-object-creation",
+                    Title = "Explicit new T(...)",
+                    IsSelected = static o => !o.PreferImplicitObjectCreation,
+                    SetSelected = static (o, on) => o with { PreferImplicitObjectCreation = !on },
+                },
+                new StyleOptionValue
+                {
+                    Token = ObjectCreationTargetTyped,
+                    Title = "Target-typed new(...) (default)",
+                    ConfigKey = "csharp_style_implicit_object_creation_when_type_is_apparent",
+                    IsSelected = static o => o.PreferImplicitObjectCreation,
+                    SetSelected = static (o, on) => o with { PreferImplicitObjectCreation = on },
                 },
             ],
         };

--- a/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/StyleOptionCatalog.cs
@@ -311,15 +311,18 @@ public sealed record StyleOptionDescriptor
     public bool CorpusEndorsed => CorpusEndorsedValue is not null;
 
     /// <summary>
-    /// The config key that controls the second value of a two-state knob, or
-    /// <see langword="null"/> for an API-only or multi-value knob. Multi-value
+    /// The config key that selects the sole non-default value of a two-state
+    /// knob, or <see langword="null"/> when the key belongs to the default value,
+    /// the knob is API-only, or the axis has more than two values. Multi-value
     /// axes may use either per-value keys or <see cref="ValueConfigKey"/>.
-    /// Convenience for the common boolean case
-    /// so a host recording a two-state taste choice can name the key without
-    /// walking <see cref="Values"/>.
+    /// Keeping this convenience aligned with <see cref="Get"/> lets a host persist
+    /// <c>ConfigKey = Get(options)</c> without inverting a default-on preference.
     /// </summary>
     public string? ConfigKey =>
-        Values.Count == 2 ? Values[1].ConfigKey : null;
+        Values.Count == 2
+            && !string.Equals(Values[1].Token, DefaultValue, StringComparison.Ordinal)
+                ? Values[1].ConfigKey
+                : null;
 
     /// <summary>
     /// The token of the value currently selected on <paramref name="options"/> —

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -151,6 +151,22 @@ public class RenderStyleConfigTests
     }
 
     [Fact]
+    public void Parse_ImplicitObjectCreationKey_UsesEditorconfigPolarity()
+    {
+        var targetTyped = RenderStyleConfig.Parse(
+            "csharp_style_implicit_object_creation_when_type_is_apparent = true",
+            origin: null);
+        Assert.True(targetTyped.Options.PreferImplicitObjectCreation);
+        Assert.Empty(targetTyped.Warnings);
+
+        var explicitCreation = RenderStyleConfig.Parse(
+            "csharp_style_implicit_object_creation_when_type_is_apparent = false:suggestion",
+            origin: null);
+        Assert.False(explicitCreation.Options.PreferImplicitObjectCreation);
+        Assert.Empty(explicitCreation.Warnings);
+    }
+
+    [Fact]
     public void Parse_EnumCaseLabelOrder_SelectsAValueToken()
     {
         var value = RenderStyleConfig.Parse(
@@ -989,9 +1005,12 @@ public class RenderStyleConfigTests
         foreach (var knob in StyleOptionCatalog.Options.Where(o => o.ConfigKey is not null))
         {
             var result = RenderStyleConfig.Parse($"{knob.ConfigKey} = true", origin: "cfg");
+            var keyedValue = knob.Values.Single(value => value.ConfigKey == knob.ConfigKey);
 
             Assert.Empty(result.Warnings);
-            Assert.True(knob.Get(result.Options), $"'{knob.ConfigKey}' should set {knob.Id}");
+            Assert.True(
+                keyedValue.IsSelected(result.Options),
+                $"'{knob.ConfigKey}' should select {knob.Id}:{keyedValue.Token}");
         }
     }
 

--- a/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
+++ b/src/dotnet-inspect.Tests/RenderStyleConfigTests.cs
@@ -1021,7 +1021,9 @@ public class RenderStyleConfigTests
         // reachable through the file vocabulary; a made-up key still warns. The
         // whitespace-only wrappers are the standing API-only examples (the
         // synthesis tier's slot-local-names is file-reachable under a tool-owned key).
-        var apiOnly = StyleOptionCatalog.Options.Where(o => o.ConfigKey is null).ToArray();
+        var apiOnly = StyleOptionCatalog.Options
+            .Where(o => o.ValueConfigKey is null && o.Values.All(v => v.ConfigKey is null))
+            .ToArray();
         Assert.Contains(apiOnly, o => o.Id == "wrap-splittable-expressions");
         Assert.Contains(apiOnly, o => o.Id == "disable-one-liner-wrapping");
 

--- a/src/dotnet-inspect/Services/RenderStyleConfig.cs
+++ b/src/dotnet-inspect/Services/RenderStyleConfig.cs
@@ -48,11 +48,8 @@ internal static class RenderStyleConfig
     // The recognized style keys and how they set PrinterOptions come from the
     // library-owned StyleOptionCatalog — the single source of truth — so this
     // resolver never drifts from the option surface. Every catalog VALUE with a
-    // config key is honored here (the four byte-preserving this.-qualification
-    // spellings, the oracle-endorsed conditional-expression lens value, and the
-    // tool-owned branchless "bool hack" value); values with no config key — the
-    // off/default value of a knob and any API-only knob — simply do not appear in
-    // the file vocabulary. A key = true selects its value; key = false deselects
+    // config key is honored here; values with no config key simply do not appear
+    // in the file vocabulary. A key = true selects its value; key = false deselects
     // it (setting only that value's own backing state, so, exactly as before, two
     // members of a multi-value axis set independently and the printer resolves any
     // overlap deterministically).


### PR DESCRIPTION
Closes #3169

## Change

**Conclusion: PASS** — adds the missing explicit-object-creation opt-out without changing shipped rendering.

- Adds one product-owned `object-creation-style` axis with:
  - default `target-typed`
  - selectable `explicit` value, persisted as `explicit-object-creation`
- Mirrors `csharp_style_implicit_object_creation_when_type_is_apparent` directly:
  - `true` keeps target-typed `new(...)`
  - `false` keeps explicit `new T(...)`
- Projects automatically through CLI config and the Browser/Wasm style picker.
- Gates only the existing `TargetTypedNewText` shortener, so all current safety declines and firing boundaries remain unchanged.

## Demo

Default output remains unchanged:

```csharp
List<int> items = new();
```

With this config:

```ini
csharp_style_implicit_object_creation_when_type_is_apparent = false
```

the same declaration renders:

```csharp
List<int> items = new List<int>();
```

The independent apparent-`var` choice remains:

```csharp
var items = new List<int>();
```

Those are the three reachable spellings. `var items = new()` remains impossible.

## Contract

- **Default compatibility:** `PreferImplicitObjectCreation` defaults to `true`; the exact-base render A/B reports no shipped-output movement.
- **Fidelity:** both spellings compile to the same `newobj`; the catalog classifies the opt-out as byte-neutral `Spelling`.
- **Non-vacuity:** the catalog-derived byte-neutrality gate requires the `explicit` value to change a compiler-produced render and compile back identically.
- **Oracle:** dotnet/runtime declares target-typed creation preferred. Its source corpus contains both forms, so the explicit opt-out is not included in a taste aggregate.
- **Platform:** no new dependencies, reflection, assembly loading, or host-specific path; Browser/Wasm consumes the existing catalog projection.

## Validation

Candidate: `d1940d8bcfea4aa263dffd75d95a79793191cdcb`  
Integrated base: `5c8da8a2c3d88646dd9b2c58ba28508efb0fec55`

- Release solution build: pass
- Focused decompiler/catalog/byte-neutrality tests: 88/88
- Render-style config tests: 62/62
- Browser style projection tests: 2/2
- Full Release decompiler suite with restored IL tools: 5,305/5,305
- Markdown lint: pass
- Official render A/B over 3,000 `System.Private.CoreLib` methods: 0 changed, 0 added, 0 removed

