### PR TITLE
Fix decompiler control-flow ownership regressions

### DIFF
--- a/docs/decompiler-raise-discipline.md
+++ b/docs/decompiler-raise-discipline.md
@@ -162,6 +162,12 @@ required review shape.
   outside-nested like its `SlotConfined` sibling and would have deleted the sole
   initializer of a field a nested body still read (#2866) — the partial-sibling
   species again, this time split along storage class rather than render context.
+- **By-ref lambda parameters require declaration evidence.** A recovered lambda
+  with any by-ref parameter carries the synthesized method's exact
+  `ref`/`out`/`in` facts and renders the entire parameter list explicitly typed;
+  unknown or misaligned ref-kind facts decline instead of defaulting to `ref`.
+  `LambdaRaisingPassTests` gates both the compiler-produced positive and the
+  emitted C# syntax.
 - **Pretty-but-wrong loses to ugly-but-correct — and it is usually free.** When
   a raise would emit prettier source but the shape is not *provably* the exact
   pattern, decline to the honest lowered scaffolding. On honest input the proof

--- a/docs/decompiler-raise-discipline.md
+++ b/docs/decompiler-raise-discipline.md
@@ -166,8 +166,10 @@ required review shape.
   with any by-ref parameter carries the synthesized method's exact
   `ref`/`out`/`in` facts and renders the entire parameter list explicitly typed;
   unknown or misaligned ref-kind facts decline instead of defaulting to `ref`.
-  `LambdaRaisingPassTests` gates both the compiler-produced positive and the
-  emitted C# syntax.
+  `ref readonly` remains distinct metadata evidence and declines until the
+  declaration model can represent it rather than being misrendered as `in`.
+  `LambdaRaisingPassTests` gates the compiler-produced positives, decline
+  boundary, and emitted C# syntax.
 - **Pretty-but-wrong loses to ugly-but-correct — and it is usually free.** When
   a raise would emit prettier source but the shape is not *provably* the exact
   pattern, decline to the honest lowered scaffolding. On honest input the proof

--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -373,8 +373,9 @@ Cloned statements retain `SourceOffset` as provenance, but semantic clones do
 not own that offset's printable label. Only the canonical surviving statement
 may render the label; `StructuringGotoScopeTests` gates the distinction so a
 clone cannot strand a later `goto` outside the clone's C# scope.
-When a later raise replaces the canonical statement, the replacement inherits
-that label ownership; `NullCoalescingAssignmentPassTests` gates this boundary.
+When a later raise replaces a statement, the replacement inherits both its
+canonical or suppressed label-ownership state; `NullCoalescingAssignmentPassTests`
+gates both boundaries.
 
 ### Shared helpers and facts
 

--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -363,10 +363,11 @@ Every pass in this layer carries these proof obligations in code review:
 actually built, not against a separate simulation of that build. It builds from
 cloned blocks, verifies that existing `break`/`continue`/retry-`leave` transfers
 retain their enclosing owner and that every internal surviving `Leave` retains
-a label owner, and rejects any lexical block that places statements after a
-terminal transfer. It then installs that candidate transactionally or declines.
-The compiler-backed and synthetic owner/decline boundaries are gated by
-`InfiniteLoopStructuringTests` and `StructuringGotoScopeTests`.
+a label owner. It also rejects an actual retained-region build that places
+another arm after a terminal retained-merge branch. It then installs that
+candidate transactionally or declines. The compiler-backed and synthetic
+owner/decline boundaries are gated by `InfiniteLoopStructuringTests` and
+`StructuringGotoScopeTests`.
 
 Cloned statements retain `SourceOffset` as provenance, but semantic clones do
 not own that offset's printable label. Only the canonical surviving statement

--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -359,6 +359,22 @@ Every pass in this layer carries these proof obligations in code review:
 6. **Honest fallback.** A rejected shape must remain visible: residual control
    flow, `UnsupportedNode`, or lowered fidelity. No success-shaped no-op fallback.
 
+`StructuringPass` checks loop-transfer ownership against the candidate tree it
+actually built, not against a separate simulation of that build. It builds from
+cloned blocks, verifies that existing `break`/`continue`/retry-`leave` transfers
+retain their enclosing owner and that every internal surviving `Leave` retains
+a label owner, and rejects any lexical block that places statements after a
+terminal transfer. It then installs that candidate transactionally or declines.
+The compiler-backed and synthetic owner/decline boundaries are gated by
+`InfiniteLoopStructuringTests` and `StructuringGotoScopeTests`.
+
+Cloned statements retain `SourceOffset` as provenance, but semantic clones do
+not own that offset's printable label. Only the canonical surviving statement
+may render the label; `StructuringGotoScopeTests` gates the distinction so a
+clone cannot strand a later `goto` outside the clone's C# scope.
+When a later raise replaces the canonical statement, the replacement inherits
+that label ownership; `NullCoalescingAssignmentPassTests` gates this boundary.
+
 ### Shared helpers and facts
 
 Prefer shared helpers over pass-local folklore:
@@ -395,16 +411,13 @@ not classify it as a jump predecessor. Nested `Leave` clone ownership has no
 executable-edge overlap; `StructuringFlowFactsTests` owns that separate contract.
 
 The pre-switch corpus also contains 12 blocks whose direct `Break` leaves the
-current block container and zero direct `Continue` blocks. A break is not a
-lexical fall-through edge, and wrapping it in a switch would capture its
-enclosing-loop owner, so switch raising declines it while the differential
-excludes `Cfg.Build`'s current default projection from the agreement claim. A
-terminal `Continue` is different: it has no successor in the section container,
-and a switch cannot capture its enclosing-loop owner, so switch raising accepts
-it as a terminating section. `Cfg.Build` still projects lexical-next
-fall-through for both structured transfers, so the differential excludes both
-from executable-edge agreement; for `Continue`, the two views actively disagree
-until the shared CFG can represent the enclosing owner. Another 45 blocks
+current block container and zero direct `Continue` blocks. Neither transfer has
+a lexical fall-through successor in that container, and `Cfg.Build` represents
+both as edge-free structured exits. Switch raising still declines `Break`
+because wrapping it in a switch would capture its enclosing-loop owner. A
+terminal `Continue` cannot be captured by the new switch, so switch raising
+accepts it as a terminating section and now agrees with `Cfg.Build`'s empty
+successor set. Another 45 blocks
 contain a conditional arm ending in `Break`; their other path has a real
 in-container fall-through edge, so the successor view continues to model that
 edge. A synthetic case where such an arm precedes `EndFinally` pins that the
@@ -440,10 +453,10 @@ containers, 48,559 resolved explicit edges, zero external explicit edges,
 terminators, zero `EndFilter` terminators, 12 direct `Break` blocks, zero direct
 `Continue` blocks, and 45 nested structured-transfer blocks with zero
 differences over the supported overlap. That evidence makes `Cfg.Build` the
-owner of flat structural edge semantics, but not yet the owner for direct
-structured transfers. Within the flat overlap, switch raising has a narrower
-acceptance domain rather than different edges; accepted structured `Continue`
-remains the explicit owner-aware exception outside that overlap.
+owner of flat structural edge semantics and direct structured-transfer
+fall-through semantics. Switch raising has a narrower acceptance domain rather
+than different edges: it declines a direct `Break` that a new switch would
+capture and accepts terminal `Continue` with the same empty successor set.
 `StructuringFlowFacts` remains a separate region-aware projection because its
 label and clone-ownership facts are not executable edges.
 

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1221,41 +1221,6 @@ public class CfgSampleClass
         }
     }
 
-    public static int SharedTailWithNestedLeave(
-        bool first,
-        bool second,
-        bool leaveTry)
-    {
-        int value = 0;
-        if (first)
-        {
-            value = 1;
-            goto Join;
-        }
-        if (second)
-        {
-            value = 2;
-            goto Join;
-        }
-        try
-        {
-            if (leaveTry)
-                goto Join;
-            value = 3;
-        }
-        finally
-        {
-            LastValue = value;
-        }
-
-    Join:
-        LastValue = value;
-        value += 4;
-        LastValue = value;
-        value -= 4;
-        return value;
-    }
-
     public static int SwitchLoopGotoDone(int value, bool repeat)
     {
         int result = 0;

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1217,7 +1217,43 @@ public class CfgSampleClass
                     goto Outer;
                 }
             }
+
         }
+    }
+
+    public static int SharedTailWithNestedLeave(
+        bool first,
+        bool second,
+        bool leaveTry)
+    {
+        int value = 0;
+        if (first)
+        {
+            value = 1;
+            goto Join;
+        }
+        if (second)
+        {
+            value = 2;
+            goto Join;
+        }
+        try
+        {
+            if (leaveTry)
+                goto Join;
+            value = 3;
+        }
+        finally
+        {
+            LastValue = value;
+        }
+
+    Join:
+        LastValue = value;
+        value += 4;
+        LastValue = value;
+        value -= 4;
+        return value;
     }
 
     public static int SwitchLoopGotoDone(int value, bool repeat)

--- a/src/ILInspector.Decompiler.Tests/CfgTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgTests.cs
@@ -69,4 +69,24 @@ public class CfgTests
         Assert.Equal([1], edges[0].Successors);
         Assert.True(edges[1].ExitsMethod);
     }
+
+    [Fact]
+    public void Build_DirectStructuredTransfers_DoNotFallThrough()
+    {
+        var blocks = new List<Block>
+        {
+            Term(0x00, new Continue()),
+            Term(0x08, new Break()),
+            Term(0x10, new Return(null)),
+        };
+
+        var edges = Cfg.Build(blocks);
+
+        Assert.Empty(edges[0].Successors);
+        Assert.Empty(edges[1].Successors);
+        Assert.False(edges[0].ExitsMethod);
+        Assert.False(edges[0].LeavesRegion);
+        Assert.False(edges[1].ExitsMethod);
+        Assert.False(edges[1].LeavesRegion);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/ControlFlowModelDifferentialTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ControlFlowModelDifferentialTests.cs
@@ -338,6 +338,26 @@ public class ControlFlowModelDifferentialTests
                 }
                 if (switchModelsBlock && terminator is Continue)
                     comparison.AcceptedTerminalContinueBlocks++;
+
+                if (terminator is Break or Continue
+                    && (cfg[from].Successors.Count > 0
+                        || cfg[from].ExternalTargets.Count > 0
+                        || cfg[from].ExitsMethod
+                        || cfg[from].LeavesRegion))
+                {
+                    AddDifference(comparison,
+                        $"{identity}: Cfg.Build models direct structured transfer block {from} "
+                            + "as executable fall-through or an unrelated exit kind");
+                }
+                if (terminator is Continue
+                    && switchModelsBlock
+                    && !switchSuccessors.Order().SequenceEqual(cfg[from].Successors.Order()))
+                {
+                    AddDifference(comparison,
+                        $"{identity}: switch successor view for direct Continue block {from} "
+                            + $"[{string.Join(",", switchSuccessors)}] disagrees with Cfg.Build "
+                            + $"[{string.Join(",", cfg[from].Successors)}]");
+                }
                 continue;
             }
             if (hasStructuredTransfer)

--- a/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DynamicCompilationSiteInventoryTests.cs
@@ -49,6 +49,7 @@ public sealed class DynamicCompilationSiteInventoryTests
             ["MemberBodyProducerExpressionBodyTests.cs"] = (1, "Product-output validity: decompiles a compiled single-switch-return member and asserts the expression-bodied rendering (#3088)."),
             ["LadderRung6GateTests.cs"] = (1, "Product-output validity: compiles synthesized rung-6 gate source."),
             ["LadderRung9GateTests.cs"] = (1, "Product-output validity: compiles synthesized rung-9 gate source with feature parse options."),
+            ["LambdaRaisingPassTests.cs"] = (1, "Product-output validity: compiles the recovered explicit ref-parameter lambda syntax."),
 
             // Malformed-input / input-matrix / semantic-model seam isolation.
             ["ClosureDiagnosticEvidenceTests.cs"] = (6, "Input matrix + semantic-model seam: many compile-error/closure sources across a Theory."),
@@ -118,9 +119,11 @@ public sealed class DynamicCompilationSiteInventoryTests
     //     replaces a same-identity dependency to gate frozen-closure reuse.
     //   #4003 adds EnumCaseLabelOrderTests.cs (1 site): recompiles the canonical
     //     alphabetical output and proves a second decompilation is identical.
-    //   Combined: 40 files, 50 sites.
-    const int ExpectedDynamicFiles = 40;
-    const int ExpectedDynamicSites = 50;
+    //   #4238 adds LambdaRaisingPassTests.cs (1 site): recompiles recovered
+    //     explicit ref-parameter lambda syntax.
+    //   Combined: 41 files, 51 sites.
+    const int ExpectedDynamicFiles = 41;
+    const int ExpectedDynamicSites = 51;
 
     // Migrated away from Dynamic in this change; must not reappear in the scan.
     static readonly string[] MigratedFiles = ["CompileBackTypeIdentityTests.cs"];

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -121,8 +121,7 @@ public class LadderRung6GateTests
 
         Assert.All(newRules.Concat(legacy), member =>
         {
-            foreach (var node in member.Function.DescendantsOutsideNestedFunctions) System.Console.WriteLine(node.ToString());
-Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
+            Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
             Assert.Null(Completeness.Residual(member.Function));
             Assert.True(member.Result.Succeeded, $"{member.Name} did not print.");
         });
@@ -723,8 +722,7 @@ Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
     {
         var member = LoadRaisedMembers(assemblyPath, typeName)
             .Single(m => m.Name == "FixedStringFirstChar");
-        foreach (var node in member.Function.DescendantsOutsideNestedFunctions) System.Console.WriteLine(node.ToString());
-Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
+        Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
         Assert.Contains("fixed (char* ", member.Body);
         Assert.Contains(" = value)", member.Body);
         Assert.DoesNotContain("pinned", member.Body);
@@ -846,8 +844,7 @@ Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
         foreach (var name in new[] { "StackallocPointerInitializer", "StackallocSpanInitializer" })
         {
             var member = members.Single(m => m.Name == name);
-            foreach (var node in member.Function.DescendantsOutsideNestedFunctions) System.Console.WriteLine(node.ToString());
-Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
+            Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
             Assert.Contains("stackalloc int[] { 1, 2, 3 }", member.Body);
             Assert.DoesNotContain("CopyBlock", member.Body);
         }
@@ -878,8 +875,7 @@ Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
             else
             {
                 Assert.Contains("Unsafe.CopyBlock", member.Body);
-                foreach (var node in member.Function.DescendantsOutsideNestedFunctions) System.Console.WriteLine(node.ToString());
-Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
+                Assert.Equal(DecompilationFidelity.Full, member.Function.Fidelity);
             }
 
             string methodHeader = name switch

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -295,6 +295,28 @@ public class LambdaRaisingPassTests
     }
 
     [Fact]
+    public void RefReadonlyLambda_StaysLoweredUntilDeclarationKindIsRepresentable()
+    {
+        using var source = MetadataSource.Open(typeof(VoidLambdaRaisingSamples).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(VoidLambdaRaisingSamples).FullName!,
+            nameof(VoidLambdaRaisingSamples.RefReadonlyVoidLambda));
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(
+            function!,
+            method => IrImporter.Import(source, method));
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+
+        var creation = Assert.Single(function!.Descendants.OfType<DelegateCreation>());
+        Assert.Equal(ParameterRefKindFacts.Known, creation.Method.ParameterRefKindsFacts);
+        Assert.True(creation.Method.HasRefReadOnlyParameters);
+        Assert.DoesNotContain("=>", result.Output);
+        Assert.Contains("new RefReadonlyCallback", result.Output);
+    }
+
+    [Fact]
     public void ByRefLambdaWithUnknownRefKind_StaysLowered()
     {
         var holder = TypeRef.Definition("Synthetic", "Samples", "Outer+<>c");
@@ -718,6 +740,7 @@ public static class VoidLambdaRaisingSamples
 {
     public delegate void VoidCallback();
     public delegate void RefCallback(ref int value);
+    public delegate void RefReadonlyCallback(ref readonly int value);
 
     // The captured parameter is also consumed by the outer body, keeping the
     // display class in a local like NLOptNet.AddLessOrEqualZeroConstraints.
@@ -763,6 +786,9 @@ public static class VoidLambdaRaisingSamples
         => async task => await task;
 
     public static RefCallback ByRefVoidLambda() => (ref int value) => System.Console.WriteLine(value);
+
+    public static RefReadonlyCallback RefReadonlyVoidLambda()
+        => (ref readonly int value) => System.Console.WriteLine(value);
 
     static int Value() => 1;
 

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -1,4 +1,6 @@
 using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -19,6 +21,27 @@ public class LambdaRaisingPassTests
         Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
         Assert.NotNull(result.Output);
         return result.Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    [Theory]
+    [InlineData("Microsoft.CodeAnalysis.CSharp.ConversionsBase", "GetExplicitTupleLiteralConversion")]
+    [InlineData("Microsoft.CodeAnalysis.CSharp.ConversionsBase", "GetImplicitTupleLiteralConversion")]
+    [InlineData("Microsoft.CodeAnalysis.CSharp.MethodTypeInferrer", "FixDependentParameters")]
+    [InlineData("Microsoft.CodeAnalysis.CSharp.MethodTypeInferrer", "FixNondependentParameters")]
+    public void RoslynCachedLambdaDiamonds_RemainFullyRaised(string typeName, string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CSharpCompilation).Assembly.Location);
+        var function = IrImporter.Import(source, typeName, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(
+            function!,
+            method => IrImporter.Import(source, method));
+
+        Assert.True(result.Succeeded, string.Join("\n", result.Diagnostics.Select(d => d.Message)));
+        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+        Assert.Contains("=>", result.Output);
+        Assert.DoesNotContain("___c", result.Output);
     }
 
     [Fact]
@@ -261,14 +284,92 @@ public class LambdaRaisingPassTests
     }
 
     [Fact]
-    public void ByRefVoidLambda_StaysLoweredUntilRefKindsCanPrint()
+    public void ByRefVoidLambda_RaisesWithExplicitRefParameter()
     {
         string output = PrintRaised(
             nameof(VoidLambdaRaisingSamples.ByRefVoidLambda),
             typeof(VoidLambdaRaisingSamples));
 
-        Assert.DoesNotContain("=>", output);
-        Assert.Contains("new RefCallback", output);
+        Assert.Equal("return (ref int value) => Console.WriteLine(value);", output);
+        AssertRefLambdaCompiles(output);
+    }
+
+    [Fact]
+    public void ByRefLambdaWithUnknownRefKind_StaysLowered()
+    {
+        var holder = TypeRef.Definition("Synthetic", "Samples", "Outer+<>c");
+        var delegateType = TypeRef.Definition("Synthetic", "Samples", "RefCallback");
+        var byRefInt = TypeRef.ByRef(s_int);
+        var lambdaMethod = new MethodRef(
+            holder,
+            "<M>b__0",
+            TypeRef.CoreLib("System", "Void"),
+            [byRefInt],
+            HasThis: true)
+        {
+            CompilerGenerated = MetadataFactState.Yes,
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+        var singleton = new LoadField(new FieldRef(holder, "<>9", holder), instance: null);
+        var hostBlock = new Block();
+        hostBlock.Add(new Return(new DelegateCreation(delegateType, lambdaMethod, isVirtual: false, singleton)));
+        var hostBody = new BlockContainer();
+        hostBody.Add(hostBlock);
+        var host = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Outer"),
+            new MethodSignature(delegateType, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            hostBody);
+
+        var lambdaBlock = new Block();
+        lambdaBlock.Add(new Return(null));
+        var lambdaContainer = new BlockContainer();
+        lambdaContainer.Add(lambdaBlock);
+        var lambdaBody = new IrFunction(
+            lambdaMethod.Name,
+            holder,
+            new MethodSignature(
+                TypeRef.CoreLib("System", "Void"),
+                [new Parameter("value", byRefInt)],
+                HasThis: true,
+                GenericParameterCount: 0),
+            [],
+            lambdaContainer);
+
+        new LambdaRaisingPass().Run(
+            host,
+            new PassContext(
+                new Stepper(enabled: false),
+                importMethodBody: _ => lambdaBody));
+
+        Assert.Empty(host.Descendants.OfType<Lambda>());
+        Assert.Single(host.Descendants.OfType<DelegateCreation>());
+    }
+
+    static void AssertRefLambdaCompiles(string body)
+    {
+        string source = $$"""
+            using System;
+            static class Gate
+            {
+                public delegate void RefCallback(ref int value);
+                public static RefCallback M()
+                {
+                    {{body}}
+                }
+            }
+            """;
+        var compilation = CSharpCompilation.Create(
+            "lambda-ref-kind-gate",
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+            RoslynTestReferences.TrustedPlatform,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var errors = compilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .Select(diagnostic => $"{diagnostic.Id}: {diagnostic.GetMessage()}")
+            .ToArray();
+        Assert.Empty(errors);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -28,6 +28,49 @@ public class NullCoalescingAssignmentPassTests
     }
 
     [Fact]
+    public void LocalNullAssignment_PreservesSurvivingGotoLabel()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var entry = new Block(0);
+        entry.Add(new Branch(0x10));
+        var then = new Block();
+        then.Add(new StoreLocal(
+            0,
+            stringType,
+            new LoadArgument(0, "fallback", stringType)));
+        var nullCheck = new IfStatement(
+            new LogicalNot(new LoadLocal(0, stringType)),
+            then,
+            elseArm: null);
+        nullCheck.SetSourceOffset(0x10);
+        var target = new Block(0x10);
+        target.Add(nullCheck);
+        target.Add(new Return(new LoadLocal(0, stringType)));
+        var body = new BlockContainer();
+        body.Add(entry);
+        body.Add(target);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(
+                stringType,
+                [new Parameter("fallback", stringType)],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [stringType],
+            body);
+
+        new NullCoalescingAssignmentPass().Run(function, PassContext.None);
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingAssignment>());
+        Assert.Equal(0x10, assignment.SourceOffset);
+        Assert.True(assignment.OwnsSourceLabel);
+        string output = CSharpPrinter.Print(function).Output ?? "";
+        Assert.Contains("goto IL_0010;", output);
+        Assert.Contains("IL_0010:", output);
+    }
+
+    [Fact]
     public void PrintRaised_RendersNullCoalescingAssignment()
     {
         var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.NullCoalescingAssignLocal))).Output;

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -61,6 +61,7 @@ public class NullCoalescingAssignmentPassTests
             body);
 
         new NullCoalescingAssignmentPass().Run(function, PassContext.None);
+        function.CheckInvariant();
 
         var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingAssignment>());
         Assert.Equal(0x10, assignment.SourceOffset);

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -72,6 +72,47 @@ public class NullCoalescingAssignmentPassTests
     }
 
     [Fact]
+    public void LocalNullAssignment_PreservesSuppressedCloneLabel()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var then = new Block();
+        then.Add(new StoreLocal(
+            0,
+            stringType,
+            new LoadArgument(0, "fallback", stringType)));
+        var nullCheck = new IfStatement(
+            new LogicalNot(new LoadLocal(0, stringType)),
+            then,
+            elseArm: null);
+        nullCheck.SetSourceOffset(0x10);
+        nullCheck.SuppressSourceLabel();
+        var body = new BlockContainer();
+        var target = new Block(0x10);
+        target.Add(nullCheck);
+        target.Add(new Return(new LoadLocal(0, stringType)));
+        body.Add(target);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(
+                stringType,
+                [new Parameter("fallback", stringType)],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [stringType],
+            body);
+
+        new NullCoalescingAssignmentPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var assignment = Assert.Single(function.Descendants.OfType<NullCoalescingAssignment>());
+        Assert.Equal(0x10, assignment.SourceOffset);
+        Assert.False(assignment.OwnsSourceLabel);
+        string output = CSharpPrinter.Print(function).Output ?? "";
+        Assert.DoesNotContain("IL_0010:", output);
+    }
+
+    [Fact]
     public void PrintRaised_RendersNullCoalescingAssignment()
     {
         var output = CSharpPrinter.Print(Raised(nameof(CfgSampleClass.NullCoalescingAssignLocal))).Output;

--- a/src/ILInspector.Decompiler.Tests/StructuringFlowFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringFlowFactsTests.cs
@@ -91,4 +91,26 @@ public class StructuringFlowFactsTests
         Assert.Equal([3], facts.ClonePredecessorIndices[0x90]);
         Assert.Equal([0x50, 0x60, 0x70, 0x80, 0x90], facts.BranchTargets.Order());
     }
+
+    [Fact]
+    public void Collect_NestedTransfersReserveCanonicalTargetLabels()
+    {
+        var nested = new Block(0x00);
+        var arm = new Block();
+        arm.Add(new Branch(0x40));
+        arm.Add(new ConditionalBranch(new Constant(true, Boolean), 0x50));
+        arm.Add(new SwitchBranch(new Constant(0, Int32), [0x60, 0x70]));
+        nested.Add(new IfStatement(new Constant(true, Boolean), arm, elseArm: null));
+
+        var facts = StructuringFlowFacts.Collect([nested]);
+
+        Assert.Equal([0x40, 0x50, 0x60, 0x70], facts.PreservedTargets.Order());
+        Assert.Equal([0], facts.ClonePredecessorIndices[0x40]);
+        Assert.Equal([0], facts.ClonePredecessorIndices[0x50]);
+        Assert.Equal([0], facts.ClonePredecessorIndices[0x60]);
+        Assert.Equal([0], facts.ClonePredecessorIndices[0x70]);
+        Assert.Empty(facts.UnconditionalTargets);
+        Assert.Empty(facts.ConditionalTargetCounts);
+        Assert.Empty(facts.JumpPredecessorIndices);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
@@ -220,7 +220,7 @@ public class StructuringGotoScopeTests
     }
 
     [Fact]
-    public void RetainedRegion_TerminalBranchBeforeAlternateArm_StaysFlat()
+    public void RetainedRegion_DoesNotAppendAlternateArmAfterTerminalBranch()
     {
         var b0 = new Block(0x00);
         b0.Add(new ConditionalBranch(Cond(), 0x54));
@@ -239,7 +239,6 @@ public class StructuringGotoScopeTests
 
         var function = Structured([b0, b1, b2, b3, b4, b5]);
 
-        Assert.Empty(function.Descendants.OfType<IfStatement>());
         Assert.All(
             function.Descendants.OfType<Block>(),
             block => Assert.DoesNotContain(

--- a/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
@@ -250,11 +250,11 @@ public class StructuringGotoScopeTests
     [Fact]
     public void CompilerSharedTailWithNestedLeave_RemainsFullyStructured()
     {
-        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        using var source = MetadataSource.Open(typeof(StructuringGotoScopeFixtures).Assembly.Location);
         var function = IrImporter.Import(
             source,
-            typeof(CfgSampleClass).FullName!,
-            nameof(CfgSampleClass.SharedTailWithNestedLeave))!;
+            typeof(StructuringGotoScopeFixtures).FullName!,
+            nameof(StructuringGotoScopeFixtures.SharedTailWithNestedLeave))!;
 
         IrPasses.Run(function);
         function.CheckInvariant();
@@ -265,5 +265,45 @@ public class StructuringGotoScopeTests
         string output = CSharpPrinter.Print(function).Output ?? "";
         Assert.DoesNotContain("goto IL_", output);
         Assert.DoesNotContain("IL_00", output);
+    }
+}
+
+static class StructuringGotoScopeFixtures
+{
+    static int _lastValue;
+
+    public static int SharedTailWithNestedLeave(
+        bool first,
+        bool second,
+        bool leaveTry)
+    {
+        int value = 0;
+        if (first)
+        {
+            value = 1;
+            goto Join;
+        }
+        if (second)
+        {
+            value = 2;
+            goto Join;
+        }
+        try
+        {
+            if (leaveTry)
+                goto Join;
+            value = 3;
+        }
+        finally
+        {
+            _lastValue = value;
+        }
+
+    Join:
+        _lastValue = value;
+        value += 4;
+        _lastValue = value;
+        value -= 4;
+        return value;
     }
 }

--- a/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
@@ -188,4 +188,83 @@ public class StructuringGotoScopeTests
         Assert.DoesNotContain("goto IL_0018;", output);
         Assert.DoesNotContain("IL_0018:", output);
     }
+
+    [Fact]
+    public void ClonedSharedTail_DoesNotStealCanonicalGotoLabel()
+    {
+        var b0 = new Block(0x00);
+        b0.Add(new ConditionalBranch(Cond(), 0x18));
+        var b1 = new Block(0x08);
+        b1.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        b1.Add(new Branch(0x40));
+        var b2 = new Block(0x18);
+        b2.Add(new ConditionalBranch(Cond(), 0x30));
+        var b3 = new Block(0x20);
+        b3.Add(new StoreLocal(0, Int32, new Constant(2, Int32)));
+        b3.Add(new Branch(0x40));
+        var b4 = new Block(0x30);
+        var survivingGoto = new Block();
+        survivingGoto.Add(new Branch(0x40));
+        b4.Add(new IfStatement(Cond(), survivingGoto, elseArm: null));
+        b4.Add(new StoreLocal(0, Int32, new Constant(3, Int32)));
+        var b5 = new Block(0x40);
+        b5.Add(new Return(new LoadLocal(0, Int32)));
+
+        var function = Structured([b0, b1, b2, b3, b4, b5]);
+        string output = CSharpPrinter.Print(function).Output ?? "";
+
+        int label = output.IndexOf("IL_0040:", StringComparison.Ordinal);
+        int finalGoto = output.LastIndexOf("goto IL_0040;", StringComparison.Ordinal);
+        Assert.True(finalGoto >= 0, output);
+        Assert.True(label > finalGoto, output);
+    }
+
+    [Fact]
+    public void RetainedRegion_TerminalBranchBeforeAlternateArm_StaysFlat()
+    {
+        var b0 = new Block(0x00);
+        b0.Add(new ConditionalBranch(Cond(), 0x54));
+        var b1 = new Block(0x27);
+        b1.Add(new ConditionalBranch(Cond(), 0x51));
+        var b2 = new Block(0x42);
+        b2.Add(new StoreLocal(0, Int32, new Constant(2, Int32)));
+        b2.Add(new Branch(0x55));
+        var b3 = new Block(0x51);
+        b3.Add(new StoreLocal(0, Int32, new Constant(0, Int32)));
+        b3.Add(new Branch(0x55));
+        var b4 = new Block(0x54);
+        b4.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        var b5 = new Block(0x55);
+        b5.Add(new Return(new LoadLocal(0, Int32)));
+
+        var function = Structured([b0, b1, b2, b3, b4, b5]);
+
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.All(
+            function.Descendants.OfType<Block>(),
+            block => Assert.DoesNotContain(
+                block.Children.Take(Math.Max(0, block.Children.Count - 1)),
+                child => child is Branch or Leave or Return or Throw
+                    or Break or Continue or EndFinally or EndFilter));
+    }
+
+    [Fact]
+    public void CompilerSharedTailWithNestedLeave_RemainsFullyStructured()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(CfgSampleClass).FullName!,
+            nameof(CfgSampleClass.SharedTailWithNestedLeave))!;
+
+        IrPasses.Run(function);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<Branch>());
+        Assert.Empty(function.Descendants.OfType<Leave>());
+
+        string output = CSharpPrinter.Print(function).Output ?? "";
+        Assert.DoesNotContain("goto IL_", output);
+        Assert.DoesNotContain("IL_00", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Cfg.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Cfg.cs
@@ -55,6 +55,8 @@ public static class Cfg
                 case Return or Throw:
                     exits = true;
                     break;
+                case Break or Continue:
+                    break;
                 case Leave or EndFinally or EndFilter:
                     leaves = true;
                     break;

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -163,6 +163,9 @@ internal sealed class CrossAssemblyTypeResolver
             ParameterRefKindsFacts = needsRefKinds && resolved.ParameterRefKinds.State != ParameterRefKindFacts.Unknown
                 ? resolved.ParameterRefKinds.State
                 : callee.ParameterRefKindsFacts,
+            HasRefReadOnlyParameters = needsRefKinds && resolved.ParameterRefKinds.State != ParameterRefKindFacts.Unknown
+                ? resolved.ParameterRefKinds.HasRefReadOnlyParameters
+                : callee.HasRefReadOnlyParameters,
             RequiresUnsafe = callee.RequiresUnsafe || (needsUnsafe && resolved.RequiresUnsafe),
             CompilerGenerated = needsGenerated ? resolved.CompilerGenerated : callee.CompilerGenerated,
             DeclaringTypeCompilerGenerated = needsGenerated ? resolved.DeclaringTypeCompilerGenerated : callee.DeclaringTypeCompilerGenerated,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -97,10 +97,12 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// Renders a recovered lambda: parameter names (the delegate type supplies
-    /// their types, so they stay unannotated), then <c>=&gt; expr</c> for an
-    /// expression body or <c>=&gt; { ... }</c> otherwise. A single parameter
-    /// drops the parentheses. Zero-local bodies reuse the current printer so
+    /// Renders a recovered lambda: ordinary parameters stay unannotated because
+    /// the delegate supplies their types; a by-ref parameter makes the whole
+    /// list explicit so its <c>ref</c>/<c>out</c>/<c>in</c> modifier is legal.
+    /// The parameter list is followed by <c>=&gt; expr</c> for an expression body
+    /// or <c>=&gt; { ... }</c> otherwise. A single ordinary parameter drops the
+    /// parentheses. Zero-local bodies reuse the current printer so
     /// capture substitutions still bind to the outer scope; local-bearing bodies
     /// are non-capturing and print through an isolated lambda scope. A block body
     /// with more than one statement expands across lines like any other
@@ -109,9 +111,14 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string LambdaText(Lambda lambda)
     {
-        string parameters = lambda.Parameters is [var single]
-            ? CSharpNaming.ContainedIdentifier(single.Name)
-            : $"({string.Join(", ", lambda.Parameters.Select(p => CSharpNaming.ContainedIdentifier(p.Name)))})";
+        bool hasByRefParameter =
+            lambda.Parameters.Any(parameter => parameter.Type.Kind == TypeRefKind.ByRef);
+        string parameters = hasByRefParameter
+            ? $"({string.Join(", ", lambda.Parameters.Select((parameter, index) =>
+                $"{ParameterTypeText(parameter, lambda.ParameterRefKinds[index])} {CSharpNaming.ContainedIdentifier(parameter.Name)}"))})"
+            : lambda.Parameters is [var single]
+                ? CSharpNaming.ContainedIdentifier(single.Name)
+                : $"({string.Join(", ", lambda.Parameters.Select(p => CSharpNaming.ContainedIdentifier(p.Name)))})";
 
         if (lambda.ExpressionBody is { } expr)
             return LambdaConversionText(lambda, $"{parameters} => {ExpressionTreeBodyText(lambda, expr)}");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -739,7 +739,8 @@ public sealed partial class CSharpPrinter
                 if (ReferenceEquals(statement, _chainStatement) || _fieldInitStores.Contains(statement))
                     continue;   // lifted to the signature initializer / field declarations
                 bool isLastStatement = ReferenceEquals(statement, lastStatementBeforeTrailingLocalFunctions);
-                bool statementOwnsLabel = statement.SourceOffset >= 0
+                bool statementOwnsLabel = statement.OwnsSourceLabel
+                    && statement.SourceOffset >= 0
                     && _labelTargets.Contains(statement.SourceOffset);
                 if (isLastStatement && !labeledReturnOnly && !statementOwnsLabel
                     && statement is Return { Value: null })
@@ -1600,7 +1601,9 @@ public sealed partial class CSharpPrinter
             return false;
         return block.Children.Skip(statement.ChildIndex + 1)
             .SelectMany(node => node.DescendantsAndSelfOutsideNestedFunctions)
-            .Any(n => n.SourceOffset >= 0 && _labelTargets.Contains(n.SourceOffset));
+            .Any(n => n.OwnsSourceLabel
+                && n.SourceOffset >= 0
+                && _labelTargets.Contains(n.SourceOffset));
     }
 
     static bool ReferencesLocal(IrNode node, int index)
@@ -1679,7 +1682,9 @@ public sealed partial class CSharpPrinter
     {
         if (store.Type.Kind == TypeRefKind.ByRef)
             return false;
-        if (store.SourceOffset >= 0 && _labelTargets.Contains(store.SourceOffset))
+        if (store.OwnsSourceLabel
+            && store.SourceOffset >= 0
+            && _labelTargets.Contains(store.SourceOffset))
             return false;
         if (storeElement.Value is not Call { Callee: { HasThis: true, Name: "ToString" } callee, Arguments: [LoadLocalAddress receiver] } call
             || receiver.Index != store.Index
@@ -2638,7 +2643,9 @@ public sealed partial class CSharpPrinter
 
     void AppendStatementLabel(StringBuilder sb, IrNode statement, int indent)
     {
-        if (statement.SourceOffset >= 0 && _labelTargets.Contains(statement.SourceOffset))
+        if (statement.OwnsSourceLabel
+            && statement.SourceOffset >= 0
+            && _labelTargets.Contains(statement.SourceOffset))
             AppendLabel(sb, new string(' ', indent * 4), statement.SourceOffset);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -2139,6 +2139,7 @@ public static class IrImporter
                     AccessorKind = MethodDefinitionFacts.ReadAccessorKind(reader, declaringType, (MethodDefinitionHandle)handle),
                     ParameterRefKinds = parameterRefKinds.Kinds,
                     ParameterRefKindsFacts = parameterRefKinds.State,
+                    HasRefReadOnlyParameters = parameterRefKinds.HasRefReadOnlyParameters,
                     RequiresUnsafe = MethodDefinitionFacts.HasRequiresUnsafeAttribute(reader, method),
                     CompilerGenerated = FactState(methodCompilerGenerated),
                     DeclaringTypeCompilerGenerated = FactState(typeCompilerGenerated),
@@ -2197,6 +2198,7 @@ public static class IrImporter
                     // otherwise be lost; recover it from the underlying MethodDef.
                     ParameterRefKinds = memberFacts.ParameterRefKinds.Kinds,
                     ParameterRefKindsFacts = memberFacts.ParameterRefKinds.State,
+                    HasRefReadOnlyParameters = memberFacts.ParameterRefKinds.HasRefReadOnlyParameters,
                     IsOperator = memberFacts.IsOperator,
                     CompilerGenerated = memberFacts.CompilerGenerated,
                     DeclaringTypeCompilerGenerated = memberFacts.DeclaringTypeCompilerGenerated,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNode.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNode.cs
@@ -33,6 +33,16 @@ public abstract class IrNode
     public void SetSourceOffset(int offset) => SourceOffset = offset;
 
     /// <summary>
+    /// Whether this node may render the label for <see cref="SourceOffset"/>.
+    /// Semantic clones retain provenance but suppress label ownership so they
+    /// cannot steal a surviving branch target from the canonical statement.
+    /// <c>StructuringGotoScopeTests</c> gates this separation.
+    /// </summary>
+    public bool OwnsSourceLabel { get; private set; } = true;
+
+    public void SuppressSourceLabel() => OwnsSourceLabel = false;
+
+    /// <summary>
     /// Best-effort provenance for a node synthesized by a pass: adopt the source
     /// offset of an existing node it derives from, but only when this node has
     /// none of its own.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNode.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNode.cs
@@ -44,13 +44,16 @@ public abstract class IrNode
 
     /// <summary>
     /// Best-effort provenance for a node synthesized by a pass: adopt the source
-    /// offset of an existing node it derives from, but only when this node has
-    /// none of its own.
+    /// offset and label-ownership state of an existing node it replaces, but only
+    /// when this node has no provenance of its own.
     /// </summary>
     public void InheritSourceOffset(IrNode from)
     {
         if (SourceOffset < 0)
+        {
             SourceOffset = from.SourceOffset;
+            OwnsSourceLabel = from.OwnsSourceLabel;
+        }
     }
 
     /// <summary>One-line description for tree dumps; no recursion into children.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -3014,6 +3014,11 @@ public sealed class Lambda : IrExpression
 
     public TypeRef DelegateType { get; }
     public ImmutableArray<Parameter> Parameters { get; }
+    /// <summary>
+    /// Ref-kind evidence for explicitly typed lambda parameters. Empty when no
+    /// parameter is by-ref. <c>LambdaRaisingPassTests</c> gates preservation.
+    /// </summary>
+    public ImmutableArray<ArgumentRefKind> ParameterRefKinds { get; init; } = [];
     public ImmutableArray<TypeRef> Locals { get; }
     public ImmutableArray<string?> LocalNames { get; }
     public bool UsesUpdatedMemorySafetyRules { get; }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -111,6 +111,14 @@ public sealed record MethodRef(
     public ParameterRefKindFacts ParameterRefKindsFacts { get; init; } = ParameterRefKindFacts.Unknown;
 
     /// <summary>
+    /// True when at least one parameter declaration is <c>ref readonly</c>.
+    /// Its call-site behavior is represented by <see cref="ArgumentRefKind.In"/>,
+    /// but declaration-producing raises must decline until their declaration
+    /// model can preserve the distinct keyword.
+    /// </summary>
+    public bool HasRefReadOnlyParameters { get; init; }
+
+    /// <summary>
     /// Per-parameter C# defaults (<c>[Optional]</c> + <c>Constant</c>), aligned
     /// 1:1 with <see cref="ParameterTypes"/>. Empty means the defaults were not
     /// resolved (the pipeline populates this only for same-assembly

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -5,7 +5,8 @@ namespace ILInspector.Decompiler.Pipeline;
 
 internal readonly record struct ParameterRefKindResult(
     ImmutableArray<ArgumentRefKind> Kinds,
-    ParameterRefKindFacts State);
+    ParameterRefKindFacts State,
+    bool HasRefReadOnlyParameters = false);
 
 internal static class MethodDefinitionFacts
 {
@@ -21,6 +22,7 @@ internal static class MethodDefinitionFacts
             return new ParameterRefKindResult([], ParameterRefKindFacts.NotRequired);
 
         var kinds = new ArgumentRefKind[parameterTypes.Length];
+        bool hasRefReadOnly = false;
         for (int i = 0; i < kinds.Length; i++)
             kinds[i] = parameterTypes[i].Kind == TypeRefKind.ByRef ? ArgumentRefKind.Ref : ArgumentRefKind.Value;
         foreach (var handle in method.GetParameters())
@@ -29,9 +31,24 @@ internal static class MethodDefinitionFacts
             int index = parameter.SequenceNumber - 1;  // sequence 0 is the return parameter
             if (index < 0 || index >= kinds.Length || parameterTypes[index].Kind != TypeRefKind.ByRef)
                 continue;
-            kinds[index] = ClassifyByRefParameter(reader, parameter);
+            if (HasAttribute(
+                reader,
+                parameter.GetCustomAttributes(),
+                "System.Runtime.CompilerServices",
+                "RequiresLocationAttribute"))
+            {
+                kinds[index] = ArgumentRefKind.In;
+                hasRefReadOnly = true;
+            }
+            else
+            {
+                kinds[index] = ClassifyByRefParameter(reader, parameter);
+            }
         }
-        return new ParameterRefKindResult(ImmutableArray.Create(kinds), ParameterRefKindFacts.Known);
+        return new ParameterRefKindResult(
+            ImmutableArray.Create(kinds),
+            ParameterRefKindFacts.Known,
+            hasRefReadOnly);
     }
 
     internal static bool HasRequiresUnsafeAttribute(MetadataReader reader, MethodDefinition method)
@@ -149,8 +166,7 @@ internal static class MethodDefinitionFacts
     }
 
     static bool HasReadOnlyRefAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
-        => HasAttribute(reader, attributes, "System.Runtime.CompilerServices", "IsReadOnlyAttribute")
-            || HasAttribute(reader, attributes, "System.Runtime.CompilerServices", "RequiresLocationAttribute");
+        => HasAttribute(reader, attributes, "System.Runtime.CompilerServices", "IsReadOnlyAttribute");
 
     static bool HasAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes, string ns, string name)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -364,7 +364,8 @@ public sealed class LambdaRaisingPass : IIrPass
         bool hasByRefParameter =
             body.Signature.Parameters.Any(parameter => parameter.Type.Kind == TypeRefKind.ByRef);
         if (hasByRefParameter
-            && (creation.Method.ParameterRefKindsFacts != ParameterRefKindFacts.Known
+            && (creation.Method.HasRefReadOnlyParameters
+                || creation.Method.ParameterRefKindsFacts != ParameterRefKindFacts.Known
                 || creation.Method.ParameterRefKinds.Length != body.Signature.Parameters.Length))
         {
             return null;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaRaisingPass.cs
@@ -30,6 +30,8 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <para>In all cases the body must carry compiler-generated metadata evidence
 /// and be a single <c>return expr;</c>, a void expression, or a simple block
 /// ending in a return.
+/// By-ref parameters require exact metadata ref-kind facts so the printer can
+/// emit an explicitly typed <c>ref</c>/<c>out</c>/<c>in</c> parameter list.
 /// Captured outer locals still keep the zero-local guard: local-bearing lambda
 /// bodies print in a nested lambda scope, where an outer local slot would be
 /// ambiguous. A no-op when the seam is absent (stage dumps, the
@@ -357,9 +359,16 @@ public sealed class LambdaRaisingPass : IIrPass
     {
         if (!allowLocals && !body.Locals.IsEmpty)
             return null;
-        if (body.RequiresAsyncBodyModifier
-            || body.Signature.Parameters.Any(parameter => parameter.Type.Kind == TypeRefKind.ByRef))
+        if (body.RequiresAsyncBodyModifier)
             return null;
+        bool hasByRefParameter =
+            body.Signature.Parameters.Any(parameter => parameter.Type.Kind == TypeRefKind.ByRef);
+        if (hasByRefParameter
+            && (creation.Method.ParameterRefKindsFacts != ParameterRefKindFacts.Known
+                || creation.Method.ParameterRefKinds.Length != body.Signature.Parameters.Length))
+        {
+            return null;
+        }
         if (body.Descendants.OfType<UnsupportedNode>().Any())
             return null;
         if (!IsPrintableBody(body, allowLocals))
@@ -393,6 +402,7 @@ public sealed class LambdaRaisingPass : IIrPass
             container)
         {
             ReturnsVoid = returnsVoid,
+            ParameterRefKinds = hasByRefParameter ? creation.Method.ParameterRefKinds : [],
         };
         lambda.InheritSourceOffset(provenance);
         return lambda;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -590,7 +590,8 @@ public sealed class LocalFunctionRaisingPass : IIrPass
 
     static bool CanPreserveParameterRefKinds(MethodRef method, int visibleParameterCount)
         => !method.ParameterTypes.Take(visibleParameterCount).Any(type => type.Kind == TypeRefKind.ByRef)
-            || method.ParameterRefKindsFacts == ParameterRefKindFacts.Known
+            || !method.HasRefReadOnlyParameters
+                && method.ParameterRefKindsFacts == ParameterRefKindFacts.Known
                 && method.ParameterRefKinds.Length == method.ParameterTypes.Length;
 
     static bool CanRewriteSelfCall(Call call)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -35,6 +35,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
             {
                 var value = (IrExpression)local.Store.DetachChildren()[0];
                 var replacement = new NullCoalescingAssignment(local.Local.Index, local.Local.Type, value);
+                replacement.InheritSourceOffset(statement);
                 context.Stepper.StepOver("raise local null check assignment to ??=", statement);
                 statement.ReplaceWith(replacement);
                 continue;
@@ -46,6 +47,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
                 var instance = field.Store.HasInstance ? (IrExpression)children[0] : null;
                 var value = (IrExpression)children[^1];
                 var replacement = new NullCoalescingFieldAssignment(field.Store.Field, instance, value);
+                replacement.InheritSourceOffset(statement);
                 context.Stepper.StepOver("raise field null check assignment to ??=", statement);
                 statement.ReplaceWith(replacement);
                 continue;
@@ -62,6 +64,7 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
                 value.Detach();
                 var replacement = new NullCoalescingPropertyAssignment(
                     property.Store.Accessor, instance, indexArguments, value, property.Store.IsVirtual);
+                replacement.InheritSourceOffset(statement);
                 context.Stepper.StepOver("raise property null check assignment to ??=", statement);
                 statement.ReplaceWith(replacement);
             }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -225,7 +225,7 @@ public sealed class StructuringPass : IIrPass
         public required HashSet<int> ScatteredReturnDispatchTargets { get; init; }
         public int? RegionExitLeaveTarget { get; init; }
         public int? RetainedMergeIndex { get; init; }
-        public bool LoopOwnershipUnsafe { get; set; }
+        public bool CandidateOwnershipUnsafe { get; set; }
 
         /// <summary>
         /// First-wins recorder for the deepest direct stop reason, populated only
@@ -403,7 +403,7 @@ public sealed class StructuringPass : IIrPass
             joinIndex: buildBlocks.Count,
             breakTarget: null,
             continueTarget: null);
-        if (buildCtx.LoopOwnershipUnsafe
+        if (buildCtx.CandidateOwnershipUnsafe
             || HasDanglingInternalLeaveTarget(
                 buildCtx,
                 structured,
@@ -478,7 +478,7 @@ public sealed class StructuringPass : IIrPass
                 joinIndex: range.Merge,
                 breakTarget: null,
                 continueTarget: null);
-            if (buildContexts[rangeIndex].LoopOwnershipUnsafe
+            if (buildContexts[rangeIndex].CandidateOwnershipUnsafe
                 || HasDanglingInternalLeaveTarget(
                     buildContexts[rangeIndex],
                     built,
@@ -689,7 +689,7 @@ public sealed class StructuringPass : IIrPass
             joinIndex: candidate.Merge,
             breakTarget: null,
             continueTarget: null);
-        return !ctx.LoopOwnershipUnsafe
+        return !ctx.CandidateOwnershipUnsafe
             && !HasDanglingInternalLeaveTarget(ctx, built, candidate.Start, candidate.Merge);
     }
 
@@ -1475,7 +1475,7 @@ public sealed class StructuringPass : IIrPass
 
         body = BuildRegion(inlineCtx, 0, 1, joinIndex: 1, breakTarget: null, continueTarget: null);
         SuppressClonedSourceLabels(body);
-        return !inlineCtx.LoopOwnershipUnsafe;
+        return !inlineCtx.CandidateOwnershipUnsafe;
     }
 
     static bool TryBuildPastRegionTarget(Ctx ctx, int target, out Block body, out int inlinedStop)
@@ -1499,7 +1499,7 @@ public sealed class StructuringPass : IIrPass
                 continue;
 
             body = BuildRegion(inlineCtx, 0, clonedBlocks.Count, joinIndex: clonedBlocks.Count, breakTarget: null, continueTarget: null);
-            if (inlineCtx.LoopOwnershipUnsafe)
+            if (inlineCtx.CandidateOwnershipUnsafe)
                 continue;
             SuppressClonedSourceLabels(body);
             inlinedStop = stop;
@@ -2066,7 +2066,7 @@ public sealed class StructuringPass : IIrPass
                     blocks[i].StartOffset,
                     breakTargetOffsets: null))
                 {
-                    ctx.LoopOwnershipUnsafe = true;
+                    ctx.CandidateOwnershipUnsafe = true;
                 }
                 ReplaceRetryLeavesWithContinues(loopBody, blocks[i].StartOffset);
                 if (fallthroughExits)
@@ -2183,7 +2183,7 @@ public sealed class StructuringPass : IIrPass
                             blocks[branchTarget].StartOffset,
                             breakTargetOffsets))
                         {
-                            ctx.LoopOwnershipUnsafe = true;
+                            ctx.CandidateOwnershipUnsafe = true;
                         }
                         ReplaceRetryLeavesWithContinues(body, blocks[branchTarget].StartOffset);
                         if (loop.ContinueAt < blocks.Count)
@@ -2207,7 +2207,7 @@ public sealed class StructuringPass : IIrPass
                     if (ctx.RetainedMergeIndex == branchTarget)
                     {
                         if (i + 1 != stop)
-                            ctx.LoopOwnershipUnsafe = true;
+                            ctx.CandidateOwnershipUnsafe = true;
                         result.Add(last);
                         i++;
                         break;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -43,6 +43,12 @@ internal sealed class StructuringFlowFacts
     public required HashSet<int> SwitchTargets { get; init; }
     /// <summary>Targets of every explicit control transfer, including descendant <see cref="Leave"/> nodes — the offsets whose labels structuring must preserve.</summary>
     public required HashSet<int> BranchTargets { get; init; }
+    /// <summary>
+    /// Targets of transfers already nested inside structured IR. Structuring
+    /// does not consume those transfers, so their target blocks cannot be
+    /// cloned as terminators or lose their canonical label owner.
+    /// </summary>
+    public required HashSet<int> PreservedTargets { get; init; }
 
     /// <summary>
     /// Collects the facts in one walk. The dispatch facts (the predecessor-index
@@ -65,58 +71,71 @@ internal sealed class StructuringFlowFacts
         var clonePredecessorIndices = new Dictionary<int, List<int>>();
         var switchTargets = new HashSet<int>();
         var branchTargets = new HashSet<int>();
+        var preservedTargets = new HashSet<int>();
         for (int blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
         {
             var block = blocks[blockIndex];
-            foreach (var child in block.Children)
+            foreach (var node in block.DescendantsOutsideNestedFunctions)
             {
-                if (child is Branch branch)
+                bool direct = ReferenceEquals(node.Parent, block);
+                if (node is Branch branch)
                 {
-                    unconditionalTargets.Add(branch.TargetOffset);
                     branchTargets.Add(branch.TargetOffset);
                     AddPredecessor(clonePredecessorIndices, branch.TargetOffset, blockIndex);
-                    if (includeDispatchFacts)
+                    if (direct)
                     {
-                        AddPredecessor(branchPredecessorIndices, branch.TargetOffset, blockIndex);
-                        AddPredecessor(jumpPredecessorIndices, branch.TargetOffset, blockIndex);
+                        unconditionalTargets.Add(branch.TargetOffset);
+                        if (includeDispatchFacts)
+                        {
+                            AddPredecessor(branchPredecessorIndices, branch.TargetOffset, blockIndex);
+                            AddPredecessor(jumpPredecessorIndices, branch.TargetOffset, blockIndex);
+                        }
                     }
+                    else
+                        preservedTargets.Add(branch.TargetOffset);
                 }
-                else if (child is Leave leave)
+                else if (node is Leave leave)
                 {
                     branchTargets.Add(leave.TargetOffset);
+                    preservedTargets.Add(leave.TargetOffset);
+                    AddPredecessor(clonePredecessorIndices, leave.TargetOffset, blockIndex);
                 }
-                else if (child is ConditionalBranch conditional)
+                else if (node is ConditionalBranch conditional)
                 {
-                    conditionalTargetCounts[conditional.TargetOffset] =
-                        conditionalTargetCounts.GetValueOrDefault(conditional.TargetOffset) + 1;
                     branchTargets.Add(conditional.TargetOffset);
                     AddPredecessor(clonePredecessorIndices, conditional.TargetOffset, blockIndex);
-                    if (includeDispatchFacts)
+                    if (direct)
                     {
-                        AddPredecessor(conditionalPredecessorIndices, conditional.TargetOffset, blockIndex);
-                        AddPredecessor(jumpPredecessorIndices, conditional.TargetOffset, blockIndex);
+                        conditionalTargetCounts[conditional.TargetOffset] =
+                            conditionalTargetCounts.GetValueOrDefault(conditional.TargetOffset) + 1;
+                        if (includeDispatchFacts)
+                        {
+                            AddPredecessor(conditionalPredecessorIndices, conditional.TargetOffset, blockIndex);
+                            AddPredecessor(jumpPredecessorIndices, conditional.TargetOffset, blockIndex);
+                        }
                     }
+                    else
+                        preservedTargets.Add(conditional.TargetOffset);
                 }
-                else if (child is SwitchBranch switchBranch)
+                else if (node is SwitchBranch switchBranch)
                 {
                     foreach (int target in switchBranch.TargetOffsets)
                     {
-                        unconditionalTargets.Add(target);
                         branchTargets.Add(target);
                         AddPredecessor(clonePredecessorIndices, target, blockIndex);
-                        if (includeDispatchFacts)
+                        if (direct)
                         {
-                            switchTargets.Add(target);
-                            AddPredecessor(jumpPredecessorIndices, target, blockIndex);
+                            unconditionalTargets.Add(target);
+                            if (includeDispatchFacts)
+                            {
+                                switchTargets.Add(target);
+                                AddPredecessor(jumpPredecessorIndices, target, blockIndex);
+                            }
                         }
+                        else
+                            preservedTargets.Add(target);
                     }
                 }
-            }
-
-            foreach (var leave in block.Descendants.OfType<Leave>())
-            {
-                branchTargets.Add(leave.TargetOffset);
-                AddPredecessor(clonePredecessorIndices, leave.TargetOffset, blockIndex);
             }
         }
 
@@ -131,6 +150,7 @@ internal sealed class StructuringFlowFacts
             ClonePredecessorIndices = clonePredecessorIndices,
             SwitchTargets = switchTargets,
             BranchTargets = branchTargets,
+            PreservedTargets = preservedTargets,
         };
     }
 
@@ -186,6 +206,13 @@ public sealed class StructuringPass : IIrPass
         public required Dictionary<int, HashSet<int>> CloneOwnerIndices { get; init; }
         public required Dictionary<int, IReadOnlyList<IrNode>> TerminatorSnapshots { get; init; }
         public required HashSet<int> FallenInto { get; init; }
+        /// <summary>
+        /// Structured transfers synthesized while building a candidate loop.
+        /// They are owned by that candidate by construction and are excluded
+        /// from the post-build ownership check.
+        /// </summary>
+        public required HashSet<IrNode> GeneratedLoopTransfers { get; init; }
+        public required HashSet<IrNode> GeneratedLoopOwners { get; init; }
         public required bool IsComparisonTree { get; init; }
         /// <summary>
         /// Return-terminator offsets reached by two or more conditional guards
@@ -198,6 +225,7 @@ public sealed class StructuringPass : IIrPass
         public required HashSet<int> ScatteredReturnDispatchTargets { get; init; }
         public int? RegionExitLeaveTarget { get; init; }
         public int? RetainedMergeIndex { get; init; }
+        public bool LoopOwnershipUnsafe { get; set; }
 
         /// <summary>
         /// First-wins recorder for the deepest direct stop reason, populated only
@@ -305,7 +333,7 @@ public sealed class StructuringPass : IIrPass
 
         var snapshots = BuildTerminatorSnapshots(
             blocks,
-            flowFacts.UnconditionalTargets,
+            NonInlinableTerminatorTargets(flowFacts),
             flowFacts.ConditionalTargetCounts,
             fallenInto,
             isComparisonTree,
@@ -337,6 +365,8 @@ public sealed class StructuringPass : IIrPass
             CloneOwnerIndices = [],
             TerminatorSnapshots = snapshots,
             FallenInto = fallenInto,
+            GeneratedLoopTransfers = [],
+            GeneratedLoopOwners = [],
             IsComparisonTree = isComparisonTree,
             ScatteredReturnDispatchTargets = scatteredReturnDispatchTargets,
             RegionExitLeaveTarget = NormalEhContinuationTarget(container),
@@ -352,8 +382,36 @@ public sealed class StructuringPass : IIrPass
             return;
         }
 
-        if (!Validate(ctx, 0, blocks.Count, joinIndex: blocks.Count, breakTarget: null, continueTarget: null))
+        var buildBlocks = blocks.Select(CloneBlock).ToList();
+        var buildCtx = CreateRetainedCtx(
+            ctx,
+            buildBlocks,
+            retainedMergeIndex: null,
+            recorder);
+        if (!Validate(buildCtx, 0, buildBlocks.Count, joinIndex: buildBlocks.Count, breakTarget: null, continueTarget: null))
         {
+            if (TryStructureRetainedRegions(container, ctx, context))
+                return;
+            context.StructuringDiagnostics?.RecordStop(recorder?.Reason ?? "unknown");
+            return;
+        }
+
+        var structured = BuildRegion(
+            buildCtx,
+            0,
+            buildBlocks.Count,
+            joinIndex: buildBlocks.Count,
+            breakTarget: null,
+            continueTarget: null);
+        if (buildCtx.LoopOwnershipUnsafe
+            || HasDanglingInternalLeaveTarget(
+                buildCtx,
+                structured,
+                start: 0,
+                stop: buildBlocks.Count)
+            || HasStatementsAfterTerminalTransfer(structured))
+        {
+            recorder?.Record("loop-changes-control-flow-owner");
             if (TryStructureRetainedRegions(container, ctx, context))
                 return;
             context.StructuringDiagnostics?.RecordStop(recorder?.Reason ?? "unknown");
@@ -366,7 +424,6 @@ public sealed class StructuringPass : IIrPass
             $"structure container at IL_{blocks[0].StartOffset:X4} ({blocks.Count} blocks) into nested if/diamond regions",
             container);
 
-        var structured = BuildRegion(ctx, 0, blocks.Count, joinIndex: blocks.Count, breakTarget: null, continueTarget: null);
         var replacement = new BlockContainer();
         replacement.Add(structured);
         container.ReplaceWith(replacement);
@@ -415,13 +472,26 @@ public sealed class StructuringPass : IIrPass
             while (cursor < range.Start)
                 replacement.Add(clonedBlocks[cursor++]);
 
-            replacement.Add(BuildRegion(
+            var built = BuildRegion(
                 buildContexts[rangeIndex],
                 range.Start,
                 range.Merge,
                 joinIndex: range.Merge,
                 breakTarget: null,
-                continueTarget: null));
+                continueTarget: null);
+            if (buildContexts[rangeIndex].LoopOwnershipUnsafe
+                || HasDanglingInternalLeaveTarget(
+                    buildContexts[rangeIndex],
+                    built,
+                    range.Start,
+                    range.Merge)
+                || HasStatementsAfterTerminalTransfer(built))
+            {
+                context.StructuringDiagnostics?.RecordRetainedDecline(
+                    "retained-loop-changes-control-flow-owner");
+                return false;
+            }
+            replacement.Add(built);
             cursor = range.Merge;
             context.StructuringDiagnostics?.RecordRetainedRegion();
         }
@@ -603,16 +673,34 @@ public sealed class StructuringPass : IIrPass
             sourceCtx,
             clonedBlocks,
             retained ? candidate.Merge : null);
-        return Validate(
+        if (!Validate(
+                ctx,
+                candidate.Start,
+                candidate.Merge,
+                joinIndex: candidate.Merge,
+                breakTarget: null,
+                continueTarget: null))
+        {
+            return false;
+        }
+
+        var built = BuildRegion(
             ctx,
             candidate.Start,
             candidate.Merge,
             joinIndex: candidate.Merge,
             breakTarget: null,
             continueTarget: null);
+        return !ctx.LoopOwnershipUnsafe
+            && !HasDanglingInternalLeaveTarget(ctx, built, candidate.Start, candidate.Merge)
+            && !HasStatementsAfterTerminalTransfer(built);
     }
 
-    static Ctx CreateRetainedCtx(Ctx sourceCtx, IReadOnlyList<Block> blocks, int? retainedMergeIndex)
+    static Ctx CreateRetainedCtx(
+        Ctx sourceCtx,
+        IReadOnlyList<Block> blocks,
+        int? retainedMergeIndex,
+        StopRecorder? recorder = null)
     {
         var flowFacts = StructuringFlowFacts.Collect(blocks);
         var fallenInto = new HashSet<int>();
@@ -622,7 +710,7 @@ public sealed class StructuringPass : IIrPass
 
         var snapshots = BuildTerminatorSnapshots(
             blocks,
-            flowFacts.UnconditionalTargets,
+            NonInlinableTerminatorTargets(flowFacts),
             flowFacts.ConditionalTargetCounts,
             fallenInto,
             sourceCtx.IsComparisonTree,
@@ -648,11 +736,13 @@ public sealed class StructuringPass : IIrPass
             CloneOwnerIndices = [],
             TerminatorSnapshots = snapshots,
             FallenInto = fallenInto,
+            GeneratedLoopTransfers = [],
+            GeneratedLoopOwners = [],
             IsComparisonTree = sourceCtx.IsComparisonTree,
             ScatteredReturnDispatchTargets = sourceCtx.ScatteredReturnDispatchTargets,
             RegionExitLeaveTarget = sourceCtx.RegionExitLeaveTarget,
             RetainedMergeIndex = retainedMergeIndex,
-            Recorder = null,
+            Recorder = recorder,
         };
     }
 
@@ -664,6 +754,8 @@ public sealed class StructuringPass : IIrPass
         CloneOwnerIndices = [],
         TerminatorSnapshots = template.TerminatorSnapshots,
         FallenInto = template.FallenInto,
+        GeneratedLoopTransfers = [],
+        GeneratedLoopOwners = [],
         IsComparisonTree = template.IsComparisonTree,
         ScatteredReturnDispatchTargets = template.ScatteredReturnDispatchTargets,
         RegionExitLeaveTarget = template.RegionExitLeaveTarget,
@@ -700,17 +792,6 @@ public sealed class StructuringPass : IIrPass
             // (continueTarget == i) so the body walk does not re-enter the loop.
             if (continueTarget != i && FindInfiniteLoopShape(ctx, i, stop) is { } latch)
             {
-                if (ProspectiveLoopOwnershipIsUnsafe(
-                    ctx,
-                    i,
-                    latch + 1,
-                    blocks[i].StartOffset,
-                    cloneContinueTarget: i,
-                    breakTargetOffsets: null))
-                {
-                    ctx.Recorder?.Record("loop-changes-control-flow-owner");
-                    return false;
-                }
                 if (!Validate(ctx, i, latch + 1, joinIndex: latch + 1, breakTarget: latch + 1, continueTarget: i))
                     return false;
                 i = latch + 1;
@@ -808,22 +889,6 @@ public sealed class StructuringPass : IIrPass
                         var loopRegionExitBreakTarget = LoopExitReachesRegionExit(ctx, loop.ContinueAt, stop)
                             ? loop.ContinueAt
                             : (int?)null;
-                        var breakTargetOffsets = new HashSet<int>();
-                        if (loop.ContinueAt < blocks.Count)
-                            breakTargetOffsets.Add(blocks[loop.ContinueAt].StartOffset);
-                        if (loopRegionExitBreakTarget is not null && ctx.RegionExitLeaveTarget is { } regionExitTarget)
-                            breakTargetOffsets.Add(regionExitTarget);
-                        if (ProspectiveLoopOwnershipIsUnsafe(
-                            ctx,
-                            i + 1,
-                            branchTarget,
-                            blocks[branchTarget].StartOffset,
-                            cloneContinueTarget: continueTarget,
-                            breakTargetOffsets))
-                        {
-                            ctx.Recorder?.Record("loop-changes-control-flow-owner");
-                            return false;
-                        }
                         if (!Validate(ctx, i + 1, branchTarget, joinIndex: branchTarget, breakTarget: loop.ContinueAt, continueTarget, loopRegionExitBreakTarget))
                             return false;
                         i = loop.ContinueAt;
@@ -978,60 +1043,8 @@ public sealed class StructuringPass : IIrPass
         return true;
     }
 
-    static bool ProspectiveLoopOwnershipIsUnsafe(
-        Ctx ctx,
-        int start,
-        int stop,
-        int retryTargetOffset,
-        int? cloneContinueTarget,
-        HashSet<int>? breakTargetOffsets)
-    {
-        var blocks = ctx.Blocks;
-        for (int index = start; index < stop; index++)
-        {
-            var root = blocks[index];
-            if (LoopBodyOwnershipIsUnsafe(root, retryTargetOffset, breakTargetOffsets))
-                return true;
-
-            if (root.Children.Count == 0
-                || root.Children[^1] is not ConditionalBranch branch
-                || !ctx.FlowFacts.OffsetToIndex.TryGetValue(branch.TargetOffset, out int target)
-                || target <= stop)
-            {
-                continue;
-            }
-
-            if (IsInlinableTerminator(ctx, target))
-            {
-                var clonedSnapshot = CloneTerminatorSnapshot(
-                    ctx,
-                    target,
-                    blocks[target].StartOffset);
-                if (LoopBodyOwnershipIsUnsafe(clonedSnapshot, retryTargetOffset, breakTargetOffsets))
-                    return true;
-                continue;
-            }
-
-            if (cloneContinueTarget is { } cloneLoopHead
-                && IsLeaveRetryLoopHead(ctx, cloneLoopHead)
-                && TryClonePastRegionTerminator(ctx, target, out var clonedTerminator))
-            {
-                if (LoopBodyOwnershipIsUnsafe(clonedTerminator, retryTargetOffset, breakTargetOffsets))
-                    return true;
-                continue;
-            }
-
-            if (TryBuildPastRegionTarget(ctx, target, out var pastRegion, out int inlinedStop)
-                && CanDuplicatePastRegionBody(ctx, target, inlinedStop, index, pastRegion)
-                && LoopBodyOwnershipIsUnsafe(pastRegion, retryTargetOffset, breakTargetOffsets))
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
     static bool LoopBodyOwnershipIsUnsafe(
+        Ctx ctx,
         IrNode root,
         int retryTargetOffset,
         HashSet<int>? breakTargetOffsets)
@@ -1040,6 +1053,8 @@ public sealed class StructuringPass : IIrPass
         {
             if (node is Continue)
             {
+                if (ctx.GeneratedLoopTransfers.Contains(node))
+                    continue;
                 if (!HasOwnerBeforeRoot(
                     node,
                     root,
@@ -1051,6 +1066,8 @@ public sealed class StructuringPass : IIrPass
             }
             if (node is Break)
             {
+                if (ctx.GeneratedLoopTransfers.Contains(node))
+                    continue;
                 if (!HasOwnerBeforeRoot(
                     node,
                     root,
@@ -1063,32 +1080,71 @@ public sealed class StructuringPass : IIrPass
             if (node is not Leave leave || !CanRaiseRetryLeave(leave))
                 continue;
 
-            if (leave.TargetOffset == retryTargetOffset
-                && HasOwnerBeforeRoot(
+            IrNode? owner = null;
+            if (leave.TargetOffset == retryTargetOffset)
+            {
+                owner = OwnerBeforeRoot(
                     leave,
                     root,
-                    static ancestor => ancestor is WhileLoop or DoWhileLoop or ForLoop or ForeachStatement))
-            {
-                return true;
+                    static ancestor => ancestor is WhileLoop or DoWhileLoop or ForLoop or ForeachStatement);
             }
-            if (breakTargetOffsets?.Contains(leave.TargetOffset) == true
-                && HasOwnerBeforeRoot(
+            else if (breakTargetOffsets?.Contains(leave.TargetOffset) == true)
+            {
+                owner = OwnerBeforeRoot(
                     leave,
                     root,
-                    static ancestor => ancestor is Switch or WhileLoop or DoWhileLoop or ForLoop or ForeachStatement))
-            {
+                    static ancestor => ancestor is Switch or WhileLoop or DoWhileLoop or ForLoop or ForeachStatement);
+            }
+            if (owner is not null && !ctx.GeneratedLoopOwners.Contains(owner))
                 return true;
+        }
+        return false;
+    }
+
+    static bool HasDanglingInternalLeaveTarget(
+        Ctx ctx,
+        IrNode root,
+        int start,
+        int stop)
+    {
+        var survivingLabels = root.DescendantsAndSelfOutsideNestedFunctions
+            .Where(static node => node.OwnsSourceLabel && node.SourceOffset >= 0)
+            .Select(static node => node.SourceOffset)
+            .ToHashSet();
+        return root.DescendantsOutsideNestedFunctions
+            .OfType<Leave>()
+            .Any(leave =>
+                ctx.FlowFacts.OffsetToIndex.TryGetValue(leave.TargetOffset, out int target)
+                && target >= start
+                && target < stop
+                && !survivingLabels.Contains(leave.TargetOffset));
+    }
+
+    static bool HasStatementsAfterTerminalTransfer(IrNode root)
+    {
+        foreach (var block in root.DescendantsAndSelfOutsideNestedFunctions.OfType<Block>())
+        {
+            for (int i = 0; i + 1 < block.Children.Count; i++)
+            {
+                if (block.Children[i] is Return or Throw or Branch or Leave
+                    or Break or Continue or EndFinally or EndFilter)
+                {
+                    return true;
+                }
             }
         }
         return false;
     }
 
     static bool HasOwnerBeforeRoot(IrNode node, IrNode root, Func<IrNode, bool> isOwner)
+        => OwnerBeforeRoot(node, root, isOwner) is not null;
+
+    static IrNode? OwnerBeforeRoot(IrNode node, IrNode root, Func<IrNode, bool> isOwner)
     {
         for (var ancestor = node.Parent; ancestor is not null && !ReferenceEquals(ancestor, root); ancestor = ancestor.Parent)
             if (isOwner(ancestor))
-                return true;
-        return false;
+                return ancestor;
+        return null;
     }
 
     /// <summary>
@@ -1437,7 +1493,8 @@ public sealed class StructuringPass : IIrPass
             return false;
 
         body = BuildRegion(inlineCtx, 0, 1, joinIndex: 1, breakTarget: null, continueTarget: null);
-        return true;
+        SuppressClonedSourceLabels(body);
+        return !inlineCtx.LoopOwnershipUnsafe;
     }
 
     static bool TryBuildPastRegionTarget(Ctx ctx, int target, out Block body, out int inlinedStop)
@@ -1461,6 +1518,9 @@ public sealed class StructuringPass : IIrPass
                 continue;
 
             body = BuildRegion(inlineCtx, 0, clonedBlocks.Count, joinIndex: clonedBlocks.Count, breakTarget: null, continueTarget: null);
+            if (inlineCtx.LoopOwnershipUnsafe)
+                continue;
+            SuppressClonedSourceLabels(body);
             inlinedStop = stop;
             return true;
         }
@@ -1525,7 +1585,7 @@ public sealed class StructuringPass : IIrPass
         var scatteredReturnDispatchTargets = new HashSet<int>();
         var snapshots = BuildTerminatorSnapshots(
             blocks,
-            flowFacts.UnconditionalTargets,
+            NonInlinableTerminatorTargets(flowFacts),
             flowFacts.ConditionalTargetCounts,
             fallenInto,
             isComparisonTree,
@@ -1539,6 +1599,8 @@ public sealed class StructuringPass : IIrPass
             CloneOwnerIndices = [],
             TerminatorSnapshots = snapshots,
             FallenInto = fallenInto,
+            GeneratedLoopTransfers = [],
+            GeneratedLoopOwners = [],
             IsComparisonTree = isComparisonTree,
             ScatteredReturnDispatchTargets = scatteredReturnDispatchTargets,
             RegionExitLeaveTarget = null,
@@ -1927,7 +1989,7 @@ public sealed class StructuringPass : IIrPass
     /// </summary>
     static Dictionary<int, IReadOnlyList<IrNode>> BuildTerminatorSnapshots(
         IReadOnlyList<Block> blocks,
-        HashSet<int> unconditionalTargets,
+        HashSet<int> nonInlinableTargets,
         Dictionary<int, int> conditionalTargetCounts,
         HashSet<int> fallenInto,
         bool isComparisonTree,
@@ -1935,9 +1997,16 @@ public sealed class StructuringPass : IIrPass
     {
         var snapshots = new Dictionary<int, IReadOnlyList<IrNode>>();
         for (int i = 0; i < blocks.Count; i++)
-            if (IsSharedTerminator(blocks[i], unconditionalTargets, conditionalTargetCounts, fallenInto, isComparisonTree, scatteredReturnDispatchTargets))
+            if (IsSharedTerminator(blocks[i], nonInlinableTargets, conditionalTargetCounts, fallenInto, isComparisonTree, scatteredReturnDispatchTargets))
                 snapshots[i] = blocks[i].Children.ToList();
         return snapshots;
+    }
+
+    static HashSet<int> NonInlinableTerminatorTargets(StructuringFlowFacts flowFacts)
+    {
+        var targets = new HashSet<int>(flowFacts.UnconditionalTargets);
+        targets.UnionWith(flowFacts.PreservedTargets);
+        return targets;
     }
 
     /// <summary>
@@ -1954,7 +2023,17 @@ public sealed class StructuringPass : IIrPass
         var clone = new Block(startOffset);
         foreach (var statement in ctx.TerminatorSnapshots[index])
             clone.Add(statement.Clone());
+        SuppressClonedSourceLabels(clone);
         return clone;
+    }
+
+    static void SuppressClonedSourceLabels(IrNode root)
+    {
+        foreach (var statement in root.DescendantsOutsideNestedFunctions
+            .Where(static node => node.Parent is Block))
+        {
+            statement.SuppressSourceLabel();
+        }
     }
 
     /// <summary>Whether control reaching the end of this block continues into its successor (vs. returning, throwing, or branching away).</summary>
@@ -2000,10 +2079,19 @@ public sealed class StructuringPass : IIrPass
                     breakTarget: latch + 1,
                     continueTarget: i,
                     suppressStartTargetLabel: true);
+                if (LoopBodyOwnershipIsUnsafe(
+                    ctx,
+                    loopBody,
+                    blocks[i].StartOffset,
+                    breakTargetOffsets: null))
+                {
+                    ctx.LoopOwnershipUnsafe = true;
+                }
                 ReplaceRetryLeavesWithContinues(loopBody, blocks[i].StartOffset);
                 if (fallthroughExits)
                     loopBody.Add(new Break());
                 var loop = new WhileLoop(TrueLiteral(), loopBody);
+                ctx.GeneratedLoopOwners.Add(loop);
                 if (ctx.FlowFacts.BranchTargets.Contains(blocks[i].StartOffset))
                     loop.SetSourceOffset(blocks[i].StartOffset);
                 result.Add(loop);
@@ -2033,6 +2121,7 @@ public sealed class StructuringPass : IIrPass
                 {
                     var next = new Break();
                     next.InheritSourceOffset(leave);
+                    ctx.GeneratedLoopTransfers.Add(next);
                     result.Add(next);
                     i++;
                     break;
@@ -2043,6 +2132,7 @@ public sealed class StructuringPass : IIrPass
                 {
                     var next = new Break();
                     next.InheritSourceOffset(leave);
+                    ctx.GeneratedLoopTransfers.Add(next);
                     result.Add(next);
                     i++;
                     break;
@@ -2053,6 +2143,7 @@ public sealed class StructuringPass : IIrPass
                 {
                     var next = new Continue();
                     next.InheritSourceOffset(leave);
+                    ctx.GeneratedLoopTransfers.Add(next);
                     result.Add(next);
                     i++;
                     break;
@@ -2079,6 +2170,7 @@ public sealed class StructuringPass : IIrPass
                     {
                         var next = new Break();
                         next.InheritSourceOffset(branch);
+                        ctx.GeneratedLoopTransfers.Add(next);
                         result.Add(next);
                         i++;
                         break;
@@ -2096,6 +2188,22 @@ public sealed class StructuringPass : IIrPass
                             ? loop.ContinueAt
                             : (int?)null;
                         var body = BuildRegion(ctx, i + 1, branchTarget, joinIndex: branchTarget, breakTarget: loop.ContinueAt, continueTarget, loopRegionExitBreakTarget);
+                        var breakTargetOffsets = new HashSet<int>();
+                        if (loop.ContinueAt < blocks.Count)
+                            breakTargetOffsets.Add(blocks[loop.ContinueAt].StartOffset);
+                        if (loopRegionExitBreakTarget is not null
+                            && ctx.RegionExitLeaveTarget is { } loopRegionExitTarget)
+                        {
+                            breakTargetOffsets.Add(loopRegionExitTarget);
+                        }
+                        if (LoopBodyOwnershipIsUnsafe(
+                            ctx,
+                            body,
+                            blocks[branchTarget].StartOffset,
+                            breakTargetOffsets))
+                        {
+                            ctx.LoopOwnershipUnsafe = true;
+                        }
                         ReplaceRetryLeavesWithContinues(body, blocks[branchTarget].StartOffset);
                         if (loop.ContinueAt < blocks.Count)
                             ReplaceRetryLeavesWithBreaks(body, blocks[loop.ContinueAt].StartOffset);
@@ -2103,6 +2211,7 @@ public sealed class StructuringPass : IIrPass
                             ReplaceRetryLeavesWithBreaks(body, regionExitTarget);
                         var condition = BuildWhileCondition(loop);
                         var whileLoop = new WhileLoop(condition, body);
+                        ctx.GeneratedLoopOwners.Add(whileLoop);
                         if (ctx.FlowFacts.BranchTargets.Contains(blocks[branchTarget].StartOffset))
                             whileLoop.SetSourceOffset(blocks[branchTarget].StartOffset);
                         result.Add(whileLoop);
@@ -2131,7 +2240,9 @@ public sealed class StructuringPass : IIrPass
                     if (breakTarget == target)
                     {
                         var breakArm = new Block(block.StartOffset);
-                        breakArm.Add(new Break());
+                        var next = new Break();
+                        ctx.GeneratedLoopTransfers.Add(next);
+                        breakArm.Add(next);
                         result.Add(new IfStatement(condition, breakArm, null));
                         i++;
                         break;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -408,8 +408,7 @@ public sealed class StructuringPass : IIrPass
                 buildCtx,
                 structured,
                 start: 0,
-                stop: buildBlocks.Count)
-            || HasStatementsAfterTerminalTransfer(structured))
+                stop: buildBlocks.Count))
         {
             recorder?.Record("loop-changes-control-flow-owner");
             if (TryStructureRetainedRegions(container, ctx, context))
@@ -484,8 +483,7 @@ public sealed class StructuringPass : IIrPass
                     buildContexts[rangeIndex],
                     built,
                     range.Start,
-                    range.Merge)
-                || HasStatementsAfterTerminalTransfer(built))
+                    range.Merge))
             {
                 context.StructuringDiagnostics?.RecordRetainedDecline(
                     "retained-loop-changes-control-flow-owner");
@@ -692,8 +690,7 @@ public sealed class StructuringPass : IIrPass
             breakTarget: null,
             continueTarget: null);
         return !ctx.LoopOwnershipUnsafe
-            && !HasDanglingInternalLeaveTarget(ctx, built, candidate.Start, candidate.Merge)
-            && !HasStatementsAfterTerminalTransfer(built);
+            && !HasDanglingInternalLeaveTarget(ctx, built, candidate.Start, candidate.Merge);
     }
 
     static Ctx CreateRetainedCtx(
@@ -1118,22 +1115,6 @@ public sealed class StructuringPass : IIrPass
                 && target >= start
                 && target < stop
                 && !survivingLabels.Contains(leave.TargetOffset));
-    }
-
-    static bool HasStatementsAfterTerminalTransfer(IrNode root)
-    {
-        foreach (var block in root.DescendantsAndSelfOutsideNestedFunctions.OfType<Block>())
-        {
-            for (int i = 0; i + 1 < block.Children.Count; i++)
-            {
-                if (block.Children[i] is Return or Throw or Branch or Leave
-                    or Break or Continue or EndFinally or EndFilter)
-                {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 
     static bool HasOwnerBeforeRoot(IrNode node, IrNode root, Func<IrNode, bool> isOwner)
@@ -2225,6 +2206,8 @@ public sealed class StructuringPass : IIrPass
                     }
                     if (ctx.RetainedMergeIndex == branchTarget)
                     {
+                        if (i + 1 != stop)
+                            ctx.LoopOwnershipUnsafe = true;
                         result.Add(last);
                         i++;
                         break;


### PR DESCRIPTION
# Restore decompiler control-flow ownership

Fixes #4238

Unblocks #4237 without changing its branch or either corpus baseline.

## Change

**Conclusion: PASS** — fixes the product defects behind all 13 pinned regressions while preserving explicit decline boundaries.

### Raise contract

| Obligation | Contract |
| --- | --- |
| Lowering shell | `StructuringPass` consumes compiler-emitted forward regions and loop transfers; `LambdaRaisingPass` consumes synthesized methods only when exact parameter ref-kind metadata is known. |
| Consumed ownership | Structuring builds from cloned blocks, validates the actual candidate, and installs it transactionally. Semantic clones retain source provenance but not the canonical printable label. |
| Control flow | Existing `break`/`continue`/retry-`leave` nodes retain their original owner; retained-merge branches cannot absorb a following alternate arm; direct structured transfers have no lexical CFG fallthrough. |
| Replacement | Canonical replacements inherit source-label ownership. By-ref lambdas render explicitly typed `ref`/`out`/`in` parameter lists. Package-wide semantic binding and the 89,065-method corpus gate validate the result. |
| Decline boundary | Unknown/misaligned lambda ref-kind facts remain lowered; unsafe loop ownership, dangling internal leaves, externally owned labels, and retained terminal/trailing-arm candidates remain flat. |
| Falsifier | Any new invalid `Full`, lost branch target, captured transfer owner, or pinned valid/fully-raised regression fails the focused gates or #4237 corpus sensor. |

### Structural review

Structural review status: Not generated — no product correspondence issuer

### Benchmark target

- `dotnet-inspect.any@0.14.0`
- `ILInspector.Decompiler.Pipeline.CSharpPrinter::EnumIntegerCast`
- Base: `3e80d62cca60935739d413722b6d3f2761454839`
- Head: `244e1896312bc01cdf3946bdaeb9e4766bdf6ac7`

### Original IL

```il
IL_002F: brfalse.s IL_0051
IL_0040: brfalse.s IL_0051
IL_004F: br.s IL_0055
IL_0051: ldc.i4.0
IL_0052: br.s IL_0055
IL_0054: ldc.i4.1
IL_0055: stloc.0
```

### Before

```csharp
if (V_3 is not null)
{
    V_4 = V_3.Value;
    if (V_4 is long)
    {
        S_0 = ((long)V_4) < ((long)0);
        goto IL_0055;
    }
}
else
{
    S_0 = false;
    goto IL_0055;
    S_0 = true;
}
negativeLiteral = S_0;
```

- Valid: False (`CS0165`)
- Correct: False
- IL fidelity: not checkable for invalid output
- Taste applied: None
- Commit: `3e80d62cca60935739d413722b6d3f2761454839`

### After

```csharp
if (V_3 is null) goto IL_0051;
V_4 = V_3.Value;
if (V_4 is not long) goto IL_0051;
S_0 = ((long)V_4) < ((long)0);
goto IL_0055;
IL_0051:
S_0 = false;
goto IL_0055;
IL_0054:
S_0 = true;
IL_0055:
negativeLiteral = S_0;
```

- Valid: True
- Correct: True; preserves the original three-way value selection
- IL fidelity: measured by changed-method corpus fidelity below
- Taste applied: None
- Commit: `244e1896312bc01cdf3946bdaeb9e4766bdf6ac7`

## Root causes fixed

- Replaced `ProspectiveLoopOwnershipIsUnsafe`'s divergent simulation with validation of the actual cloned candidate built by `BuildRegion`.
- Separated source provenance from printable label ownership so an inlined semantic clone cannot steal a surviving goto label.
- Declined retained builds that append an alternate arm after a terminal retained-merge branch.
- Preserved canonical and suppressed label ownership when later passes replace statements, including `NullCoalescingAssignmentPass` on a second pipeline run.
- Restored four Roslyn cached predicates by carrying exact by-ref parameter kinds into raised lambdas instead of blanket-declining them; `ref readonly` declarations remain a distinct, explicit decline boundary.
- Reconciled `Cfg.Build` with switch successor semantics for terminal `Break`/`Continue`.
- Removed the four debug `Console.WriteLine` sprays called out by #4101 review.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`: passed (three pre-existing nullable warnings in metadata tests).
- Decompiler `--gate fast`: passed at current head.
- `Area=Pass`: passed at current head.
- Full `ILInspector.Decompiler.Tests` suite: passed at current head; seven hand-authored IL cases skipped because `ilasm` was unavailable. The earlier `8ec65f60d` run exposed only the new shared-tail canary joining the unrelated opcode-exact corpus; fixture isolation fixed both fidelity docket gates without changing a baseline.
- Fast CLI suite: 2,786 total, 0 failed, 12 oracle/platform skips. The first CI attempt had one isolated package-source test failure; that exact test and the full fast CLI suite both passed locally, and the failed CI job was rerun.
- Package-wide semantic binding:
  - `ILInspector.Decompiler.dll`: 4,037 / 4,037 Full methods bound; neither pinned `CS0165` row remains.
  - `System.CommandLine.dll`: 523 / 523 Full methods bound; the pinned `CS0159` row is gone.
- Focused owner/label/CFG/lambda tests include compiler-produced positives and close decline boundaries.
- Markdown lint and `git diff --check`: passed.
- Full corpus: PASS over 14 assemblies / 89,065 methods; all 13 pinned rows restored, semantic defects 86 → 57, fully raised +28, no regressions.
- Changed-method fidelity: 104 / 104 current changed methods attempted: 18 exact, 12 opcode diffs, 1 operand diff, 0 NotFull/unavailable; 68 shell recompile failures and 5 generated-member context failures remain explicit. The corpus sample had no Exact→diff transition and improved five OpcodeDiff rows to Exact.

## Compatibility and boundaries

- Product paths remain SRM-only, Roslyn-free, NativeAOT-friendly, and cross-platform.
- Unknown by-ref declaration evidence still declines safely.
- No #4237 files or schema-v5 baselines changed.
- Review round 1 at `8ec65f60d`: GPT-5.6 Sol found suppressed clone-label ownership could be regained; `7b8e6169f` fixed it. Round 2 at `302587074`: GPT-5.6 Sol found `ref readonly` lambda parameters could be misrendered as `in`; `244e18963` fixed it. Round 3 at exact head `244e18963` is clean from GPT-5.6 Sol and Claude Opus 5; both rechecked the two prior fixes, transactional ownership, CFG transfers, ref-kind propagation, and decline boundaries.
