### PR TITLE
Preserve supplied member section authority

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -13250,6 +13250,56 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_PreResolvedAnnotatedSourceDocumentJson_NonExactSingletonUsesOrdinaryDocument()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(CommandCaretGestureFixture).FullName!,
+                AssemblyPath = TestAssemblyPath,
+                MemberFilter = [nameof(CommandCaretGestureFixture.Pump)],
+                OverloadIndex = 1,
+                IncludeSections = [SectionNames.AnnotatedSourceDocument],
+                ExactIncludeSectionsOverride = [],
+                JsonOutput = true,
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        using var document = JsonDocument.Parse(result.Output);
+        Assert.True(document.RootElement.TryGetProperty("name", out _));
+        Assert.False(document.RootElement.TryGetProperty("text", out _));
+    }
+
+    [Fact]
+    public async Task Member_PreResolvedAnnotatedSourceDocumentJson_NonExactCompositionUsesOrdinaryDocument()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(CommandCaretGestureFixture).FullName!,
+                AssemblyPath = TestAssemblyPath,
+                MemberFilter = [nameof(CommandCaretGestureFixture.Pump)],
+                OverloadIndex = 1,
+                IncludeSections =
+                [
+                    SectionNames.AnnotatedSourceDocument,
+                    SectionNames.Signature
+                ],
+                ExactIncludeSectionsOverride = [],
+                JsonOutput = true,
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        using var document = JsonDocument.Parse(result.Output);
+        Assert.True(document.RootElement.TryGetProperty("name", out _));
+        Assert.False(document.RootElement.TryGetProperty("text", out _));
+    }
+
+    [Fact]
     public async Task Member_AnnotatedSourceDocument_UsesTheSyntaxThePrinterSelected()
     {
         await AssertNodeKind(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -13200,6 +13200,56 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_PreResolvedAnnotatedSourceDocumentJson_IgnoresStaleSelector()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(CommandCaretGestureFixture).FullName!,
+                AssemblyPath = TestAssemblyPath,
+                MemberFilter = [nameof(CommandCaretGestureFixture.Pump)],
+                OverloadIndex = 1,
+                Select = [SectionNames.Methods],
+                IncludeSections = [SectionNames.AnnotatedSourceDocument],
+                JsonOutput = true,
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        using var document = JsonDocument.Parse(result.Output);
+        Assert.True(document.RootElement.TryGetProperty("text", out _));
+        Assert.False(document.RootElement.TryGetProperty("name", out _));
+    }
+
+    [Fact]
+    public async Task Member_PreResolvedAnnotatedSourceDocumentJson_RejectsAuthoritativeComposition()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(CommandCaretGestureFixture).FullName!,
+                AssemblyPath = TestAssemblyPath,
+                MemberFilter = [nameof(CommandCaretGestureFixture.Pump)],
+                OverloadIndex = 1,
+                Select = [SectionNames.Methods],
+                IncludeSections =
+                [
+                    SectionNames.AnnotatedSourceDocument,
+                    SectionNames.Signature
+                ],
+                JsonOutput = true,
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(
+            $"section '{SectionNames.AnnotatedSourceDocument}' must be the only selected section under --json.",
+            result.Error);
+    }
+
+    [Fact]
     public async Task Member_AnnotatedSourceDocument_UsesTheSyntaxThePrinterSelected()
     {
         await AssertNodeKind(

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -2,12 +2,189 @@ using DotnetInspector.Commands;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Sections;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Tests;
 
 [Collection("Console")]
 public class MemberCallGraphSectionTests
 {
+    [Fact]
+    public async Task PreResolvedSection_OverridesStaleRawSelector()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            Select = [SectionNames.Methods],
+            IncludeSections = [SectionNames.Signature],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("1", result.Output.Trim());
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public async Task EmptyPreResolvedSection_DoesNotResolveStaleRawSelector()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            Select = [SectionNames.Methods],
+            IncludeSections = [],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(CountOutput.SingleSectionRequiredMessage, result.Error);
+    }
+
+    [Fact]
+    public async Task EmptyPreResolvedSection_ValidatesBeforeAcquisition()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = "Missing.Type.Member",
+            AssemblyPath = Path.Combine(Path.GetTempPath(), "missing-member-selection.dll"),
+            Select = [SectionNames.Methods],
+            IncludeSections = [],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(CountOutput.SingleSectionRequiredMessage, result.Error);
+        Assert.DoesNotContain("not found", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task EmptyPreResolvedSection_SelectsNoDefaultSections()
+    {
+        var options = new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Detailed,
+        };
+
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(options));
+        var type = new ApiType
+        {
+            Name = "Fixture",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = nameof(MemberCallGraphFixture.RootCall),
+                    Kind = "method",
+                    MetadataToken = 0x06000001
+                }
+            ]
+        };
+        var resolvedOptions = options with { MemberSectionsPreResolved = true };
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("## ", result.Output);
+        Assert.Empty(ApiCommand.GetRequestedMemberSections(type, resolvedOptions));
+        Assert.Empty(
+            ApiOutputFormatter.BuildTypeWriterOptions(type, resolvedOptions).IncludeSections!);
+        Assert.Empty(
+            ApiMemberSectionPipelines.Create(resolvedOptions).GetDiscoverableSections(
+                type,
+                resolvedOptions.IncludeSections,
+                explicitInclude: true));
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task EmptyPreResolvedSection_SelectsNoDefaultTabularRows(
+        bool tsv,
+        bool jsonl)
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallGraphFixture).FullName!,
+                AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+                IncludeSections = [],
+                Tabular = true,
+                Tsv = tsv,
+                Jsonl = jsonl,
+                TipLevel = TipLevel.Quiet,
+                Verbosity = Verbosity.Detailed
+            }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(string.Empty, result.Output.Trim());
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public async Task PreResolvedDetailSection_IgnoresStaleAllSelectorDuringAutoSelection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            Select = [SelectResolver.AllSelector],
+            IncludeSections = [SectionNames.Signature],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("1", result.Output.Trim());
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public void PreResolvedDetailSections_IgnoreStaleAllSelectorDuringFormatting()
+    {
+        var type = new ApiType
+        {
+            Name = "Fixture",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = nameof(MemberCallGraphFixture.RootCall),
+                    Kind = "method",
+                    MetadataToken = 0x06000001,
+                    Signature = "public void RootCall()"
+                }
+            ]
+        };
+        var options = new MemberOptions
+        {
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            OverloadIndex = 1,
+            Select = [SelectResolver.AllSelector],
+            IncludeSections = [SectionNames.Signature, SectionNames.CallGraph],
+            MemberSectionsPreResolved = true,
+        };
+
+        var writerOptions = ApiOutputFormatter.BuildTypeWriterOptions(type, options);
+
+        Assert.Equal(
+            [SectionNames.Summary, SectionNames.Signature, SectionNames.CallGraph],
+            writerOptions.IncludeSections);
+    }
+
     [Fact]
     public async Task CallGraphSection_RendersEdgeTableByDefault()
     {

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -178,6 +178,29 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    public async Task PreResolvedPerformanceTriageJson_NormalizesExactSectionComparer()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallGraphFixture).FullName!,
+                AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+                MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+                OverloadIndex = 1,
+                IncludeSections = [SectionNames.PerformanceTriage],
+                ExactIncludeSectionsOverride = ["performance triage"],
+                JsonOutput = true,
+                TipLevel = TipLevel.Quiet,
+            }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(
+            "Document --json cannot represent Performance Triage analysis.",
+            result.Error);
+    }
+
+    [Fact]
     public async Task EmptyPreResolvedSection_DoesNotResolveStaleRawSelector()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -29,6 +29,155 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    public async Task TypeSuppliedSections_DoNotSuppressRawSelectorValidation()
+    {
+        var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            Select = ["No Such Section"],
+            IncludeSections = [SectionNames.Methods],
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains("Select value 'No Such Section' not found.", result.Error);
+    }
+
+    [Fact]
+    public async Task PreResolvedBodyShapes_ValidatesBeforeAcquisition()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = Path.Combine(Path.GetTempPath(), "missing-body-shapes.dll"),
+            Select = [SectionNames.BodyShapes],
+            IncludeSections = [SectionNames.BodyShapes],
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(
+            $"Section '{SectionNames.BodyShapes}' requires --where",
+            result.Error);
+        Assert.DoesNotContain("File not found", result.Error);
+    }
+
+    [Fact]
+    public async Task PreResolvedBodyShapes_UsesAuthoritativeExactSectionProvenance()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = Path.Combine(Path.GetTempPath(), "missing-exact-body-shapes.dll"),
+            Select = [SectionNames.Signature],
+            IncludeSections = [SectionNames.BodyShapes, SectionNames.Signature],
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(
+            $"Section '{SectionNames.BodyShapes}' requires --where",
+            result.Error);
+        Assert.DoesNotContain("File not found", result.Error);
+    }
+
+    [Fact]
+    public async Task PreResolvedBodyShapes_CategoryExpansionRemainsNonExact()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = Path.Combine(Path.GetTempPath(), "missing-category-body-shapes.dll"),
+            Select = [SelectResolver.AllSelector],
+            IncludeSections = [SectionNames.BodyShapes, SectionNames.Signature],
+            ExactIncludeSectionsOverride = [],
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains("File not found", result.Error);
+        Assert.DoesNotContain("requires --where", result.Error);
+    }
+
+    [Fact]
+    public async Task PreResolvedBodyKindQuery_RejectsAuthoritativeNonBodyShapeSelection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = Path.Combine(Path.GetTempPath(), "missing-body-kind.dll"),
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            Select = [SectionNames.Signature],
+            IncludeSections = [SectionNames.Signature],
+            BodyKindQuery = new BodyKindQueryOptions { Kind = "expression-bodied" },
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(
+            $"--where Kind=... targets section '{SectionNames.BodyShapes}'.",
+            result.Error);
+        Assert.DoesNotContain("File not found", result.Error);
+    }
+
+    [Fact]
+    public async Task PreResolvedBroadSection_IgnoresStaleRawSelectorAfterAcquisition()
+    {
+        var stale = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallGraphFixture).FullName!,
+                AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+                Select = [SectionNames.Methods, SectionNames.Properties],
+                IncludeSections = [SectionNames.Methods],
+                Count = true,
+                TipLevel = TipLevel.Quiet,
+            }));
+        var control = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallGraphFixture).FullName!,
+                AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+                IncludeSections = [SectionNames.Methods],
+                Count = true,
+                TipLevel = TipLevel.Quiet,
+            }));
+
+        Assert.Equal(0, stale.ExitCode);
+        Assert.Equal(control.Output, stale.Output);
+        Assert.Empty(stale.Error);
+    }
+
+    [Fact]
+    public async Task PreResolvedPerformanceTriageJson_IgnoresStaleRawSelector()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallGraphFixture).FullName!,
+                AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+                MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+                OverloadIndex = 1,
+                Select = [SectionNames.Methods],
+                IncludeSections = [SectionNames.PerformanceTriage],
+                JsonOutput = true,
+                TipLevel = TipLevel.Quiet,
+            }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(
+            "Document --json cannot represent Performance Triage analysis.",
+            result.Error);
+    }
+
+    [Fact]
     public async Task EmptyPreResolvedSection_DoesNotResolveStaleRawSelector()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -505,7 +505,11 @@ public class ApiCommand
                 CommandError.Write(bodyShapeError);
                 return (null!, 1);
             }
-            options = options with { IncludeSections = selectResult.Sections };
+            options = options with
+            {
+                IncludeSections = selectResult.Sections,
+                ExactIncludeSectionsOverride = selectResult.ExactSections,
+            };
         }
         if (options is
             {

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -447,8 +447,9 @@ public class ApiCommand
             return (null!, 1);
         }
 
-        // -S/--select with values: resolve as section filter for backpressure
-        if (options.IncludeSections is null)
+        // Resolve raw selectors unless member lookup already supplied the authoritative set.
+        // Both paths still enforce Body Shapes requirements before acquisition.
+        if (options is not MemberOptions { MemberSectionsPreResolved: true })
         {
             var selectResult = SelectResolver.ResolveSelectAsSections(
                 options.Select,
@@ -484,6 +485,27 @@ public class ApiCommand
                     };
                 }
             }
+        }
+        else if (options is MemberOptions { IncludeSections: { } preResolvedSections })
+        {
+            var selectResult = new SelectResult(
+                new HashSet<string>(
+                    preResolvedSections,
+                    StringComparer.OrdinalIgnoreCase),
+                [])
+            {
+                ExactSections = new HashSet<string>(
+                    options.ExactIncludeSections ?? [],
+                    StringComparer.OrdinalIgnoreCase)
+            };
+            if (ApplyBodyShapeSelectionRequirements(
+                    options,
+                    selectResult) is { } bodyShapeError)
+            {
+                CommandError.Write(bodyShapeError);
+                return (null!, 1);
+            }
+            options = options with { IncludeSections = selectResult.Sections };
         }
         if (options is
             {
@@ -626,7 +648,7 @@ public class ApiCommand
 
         const string required =
             "Section 'Body Shapes' requires --where \"Kind=<C# Body Kinds ID>\".";
-        if (TargetsBodyShapes(options, options.Select)
+        if (selectResult.ExactSections.Contains(SectionNames.BodyShapes)
             || sections.Count == 1)
         {
             return required;
@@ -3450,13 +3472,16 @@ public class ApiCommand
             StringComparison.OrdinalIgnoreCase);
 
     private static bool HasExplicitPerformanceTriageSelector(ApiOptions options)
-        => options.Select?.Any(static selector =>
-               selector.Equals(
-                   SectionNames.PerformanceTriage,
-                   StringComparison.OrdinalIgnoreCase)
-               || selector.Equals(
-                   "Optimization Opportunities",
-                   StringComparison.OrdinalIgnoreCase)) == true;
+        => options is MemberOptions { MemberSectionsPreResolved: true }
+            ? options.ExactIncludeSections?.Contains(
+                SectionNames.PerformanceTriage) == true
+            : options.Select?.Any(static selector =>
+                   selector.Equals(
+                       SectionNames.PerformanceTriage,
+                       StringComparison.OrdinalIgnoreCase)
+                   || selector.Equals(
+                       "Optimization Opportunities",
+                       StringComparison.OrdinalIgnoreCase)) == true;
 
     private static bool ShouldRenderMemberIndex(ApiOptions options)
         => options.IncludeSections?.Contains(SectionNames.MemberIndex) == true;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -356,6 +356,9 @@ public class ApiCommand
 
     internal static (PreambleResult Result, int? Error) RunPreamble(ApiOptions options)
     {
+        if (options is MemberOptions { IncludeSections: not null } preResolvedMemberOptions)
+            options = preResolvedMemberOptions with { MemberSectionsPreResolved = true };
+
         var typePipeline = ApiTypeSectionDescriptors.CreatePipeline();
         var structuralDetailOptions = options.Discover is not null
                                       && !options.EffectiveDiscovery
@@ -445,38 +448,41 @@ public class ApiCommand
         }
 
         // -S/--select with values: resolve as section filter for backpressure
-        var selectResult = SelectResolver.ResolveSelectAsSections(
-            options.Select,
-            knownSections,
-            bareSelectSections,
-            singleTypeMode ? memberPipeline.GetCategoryMap() : typePipeline.GetCategoryMap(),
-            selectDefault: options.SelectDefault);
-        if (ShouldDeferSelectToListing(options, singleTypeMode, selectResult, typePipeline))
+        if (options.IncludeSections is null)
         {
-            // `-D` advertised these names and `-S` rejected them, on the same command line: the
-            // preamble was answering for the single-type pipeline while the render is a listing.
-            // Hold the rejection rather than resolving it here, because which pipeline is right is
-            // not known until the type lookup runs.
-            options = options with { SelectDeferredToListing = true };
-        }
-        else
-        {
-            if (SelectOutput.WriteUnresolved(selectResult))
-                return (null!, 1);
-            if (ApplyBodyShapeSelectionRequirements(
-                    options,
-                    selectResult) is { } bodyShapeError)
+            var selectResult = SelectResolver.ResolveSelectAsSections(
+                options.Select,
+                knownSections,
+                bareSelectSections,
+                singleTypeMode ? memberPipeline.GetCategoryMap() : typePipeline.GetCategoryMap(),
+                selectDefault: options.SelectDefault);
+            if (ShouldDeferSelectToListing(options, singleTypeMode, selectResult, typePipeline))
             {
-                CommandError.Write(bodyShapeError);
-                return (null!, 1);
+                // `-D` advertised these names and `-S` rejected them, on the same command line: the
+                // preamble was answering for the single-type pipeline while the render is a listing.
+                // Hold the rejection rather than resolving it here, because which pipeline is right is
+                // not known until the type lookup runs.
+                options = options with { SelectDeferredToListing = true };
             }
-            if (selectResult.Sections != null)
+            else
             {
-                options = options with
+                if (SelectOutput.WriteUnresolved(selectResult))
+                    return (null!, 1);
+                if (ApplyBodyShapeSelectionRequirements(
+                        options,
+                        selectResult) is { } bodyShapeError)
                 {
-                    IncludeSections = selectResult.Sections,
-                    ExactIncludeSectionsOverride = selectResult.ExactSections,
-                };
+                    CommandError.Write(bodyShapeError);
+                    return (null!, 1);
+                }
+                if (selectResult.Sections != null)
+                {
+                    options = options with
+                    {
+                        IncludeSections = selectResult.Sections,
+                        ExactIncludeSectionsOverride = selectResult.ExactSections,
+                    };
+                }
             }
         }
         if (options is
@@ -1094,8 +1100,15 @@ public class ApiCommand
     {
         if (options.IncludeSections is not { Count: > 0 })
             return;
-        if (SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
-            || SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
+        var sectionsPreResolved = options is MemberOptions { MemberSectionsPreResolved: true };
+        if (SelectResolver.IsActiveInfoSelector(
+                options.SelectDefault,
+                options.IncludeSections,
+                sectionsPreResolved)
+            || SelectResolver.IsActiveAllSelector(
+                options.Select,
+                options.IncludeSections,
+                sectionsPreResolved))
             return;
 
         var filtered = BuildFilteredTypeForSections(type, options);
@@ -1293,8 +1306,13 @@ public class ApiCommand
     internal static HashSet<string> GetRequestedMemberSections(ApiType type, ApiOptions options)
     {
         var pipeline = ApiMemberSectionPipelines.Create(options);
+        var explicitInclude = options is MemberOptions { MemberSectionsPreResolved: true };
         var sections = new HashSet<string>(
-            pipeline.GetEffectiveSections(type, options.Verbosity, options.IncludeSections),
+            pipeline.GetEffectiveSections(
+                type,
+                options.Verbosity,
+                options.IncludeSections,
+                explicitInclude: explicitInclude),
             StringComparer.OrdinalIgnoreCase);
         if (options.Discover is { Length: > 0 } discover)
         {
@@ -2484,12 +2502,18 @@ public class ApiCommand
             }
             else
             {
-                if (SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections))
+                if (SelectResolver.IsActiveAllSelector(
+                    options.Select,
+                    options.IncludeSections,
+                    options is MemberOptions { MemberSectionsPreResolved: true }))
                 {
                     var pipeline = ApiMemberSectionPipelines.Create(options);
                     writerOptions.SectionOrder = pipeline.GetAllSelectorSections(type);
                 }
-                else if (SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections))
+                else if (SelectResolver.IsActiveInfoSelector(
+                    options.SelectDefault,
+                    options.IncludeSections,
+                    options is MemberOptions { MemberSectionsPreResolved: true }))
                 {
                     var pipeline = ApiMemberSectionPipelines.Create(options);
                     writerOptions.SectionOrder = pipeline.InfoSectionNames;
@@ -2889,7 +2913,10 @@ public class ApiCommand
     {
         var fullSchema = GetTypeDocumentSchema(options);
         var filteredType = BuildFilteredTypeForSections(apiType, options);
-        var effective = memberPipeline.GetDiscoverableSections(filteredType, options.IncludeSections);
+        var effective = memberPipeline.GetDiscoverableSections(
+            filteredType,
+            options.IncludeSections,
+            explicitInclude: options is MemberOptions { MemberSectionsPreResolved: true });
         if (!options.BodyKindQuery.HasFilter)
         {
             effective = effective
@@ -3341,7 +3368,9 @@ public class ApiCommand
                 .ToList();
 
         // -S/--select scopes JSON to the requested sections, mirroring the markdown view.
-        if (options.IncludeSections is { Count: > 0 } sections)
+        if (options.IncludeSections is { } sections
+            && (sections.Count > 0
+                || options is MemberOptions { MemberSectionsPreResolved: true }))
         {
             outputType = ProjectTypeToSections(type, members, sections);
         }
@@ -3396,7 +3425,8 @@ public class ApiCommand
            && !IsProjectionRequested(options)
            && options.IncludeSections is { Count: 1 } sections
            && sections.Contains(SectionNames.AnnotatedSourceDocument)
-           && HasOnlyExplicitAnnotatedSourceDocumentSelectors(options);
+           && (options is MemberOptions { MemberSectionsPreResolved: true }
+               || HasOnlyExplicitAnnotatedSourceDocumentSelectors(options));
 
     private static bool IsInvalidAnnotatedSourceDocumentJsonSelection(ApiOptions options)
         => options.JsonOutput
@@ -3404,9 +3434,11 @@ public class ApiCommand
            && !IsProjectionRequested(options)
            && options.IncludeSections is { Count: > 0 } sections
            && sections.Contains(SectionNames.AnnotatedSourceDocument)
-           && options.Select?.Any(IsExplicitAnnotatedSourceDocumentSelector) == true
-           && (sections.Count != 1
-               || !HasOnlyExplicitAnnotatedSourceDocumentSelectors(options));
+           && (options is MemberOptions { MemberSectionsPreResolved: true }
+               ? sections.Count != 1
+               : options.Select?.Any(IsExplicitAnnotatedSourceDocumentSelector) == true
+                 && (sections.Count != 1
+                     || !HasOnlyExplicitAnnotatedSourceDocumentSelectors(options)));
 
     private static bool HasOnlyExplicitAnnotatedSourceDocumentSelectors(ApiOptions options)
         => options.Select is { Length: > 0 } selectors

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -3451,8 +3451,7 @@ public class ApiCommand
            && !IsProjectionRequested(options)
            && options.IncludeSections is { Count: 1 } sections
            && sections.Contains(SectionNames.AnnotatedSourceDocument)
-           && (options is MemberOptions { MemberSectionsPreResolved: true }
-               || HasOnlyExplicitAnnotatedSourceDocumentSelectors(options));
+           && HasOnlyExplicitAnnotatedSourceDocumentSelectors(options);
 
     private static bool IsInvalidAnnotatedSourceDocumentJsonSelection(ApiOptions options)
         => options.JsonOutput
@@ -3460,15 +3459,22 @@ public class ApiCommand
            && !IsProjectionRequested(options)
            && options.IncludeSections is { Count: > 0 } sections
            && sections.Contains(SectionNames.AnnotatedSourceDocument)
-           && (options is MemberOptions { MemberSectionsPreResolved: true }
-               ? sections.Count != 1
-               : options.Select?.Any(IsExplicitAnnotatedSourceDocumentSelector) == true
-                 && (sections.Count != 1
-                     || !HasOnlyExplicitAnnotatedSourceDocumentSelectors(options)));
+           && HasExplicitAnnotatedSourceDocumentSelector(options)
+           && (sections.Count != 1
+               || !HasOnlyExplicitAnnotatedSourceDocumentSelectors(options));
 
     private static bool HasOnlyExplicitAnnotatedSourceDocumentSelectors(ApiOptions options)
-        => options.Select is { Length: > 0 } selectors
-           && selectors.All(IsExplicitAnnotatedSourceDocumentSelector);
+        => options is MemberOptions { MemberSectionsPreResolved: true }
+            ? options.ExactIncludeSections is { Count: 1 } exactSections
+              && exactSections.Contains(SectionNames.AnnotatedSourceDocument)
+            : options.Select is { Length: > 0 } selectors
+              && selectors.All(IsExplicitAnnotatedSourceDocumentSelector);
+
+    private static bool HasExplicitAnnotatedSourceDocumentSelector(ApiOptions options)
+        => options is MemberOptions { MemberSectionsPreResolved: true }
+            ? options.ExactIncludeSections?.Contains(
+                SectionNames.AnnotatedSourceDocument) == true
+            : options.Select?.Any(IsExplicitAnnotatedSourceDocumentSelector) == true;
 
     private static bool IsExplicitAnnotatedSourceDocumentSelector(string selector)
         => selector.Equals(

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -648,7 +648,11 @@ public class ApiCommand
 
         const string required =
             "Section 'Body Shapes' requires --where \"Kind=<C# Body Kinds ID>\".";
-        if (selectResult.ExactSections.Contains(SectionNames.BodyShapes)
+        bool explicitlyTargetsBodyShapes =
+            options is MemberOptions { MemberSectionsPreResolved: true }
+                ? selectResult.ExactSections.Contains(SectionNames.BodyShapes)
+                : TargetsBodyShapes(options, options.Select);
+        if (explicitlyTargetsBodyShapes
             || sections.Count == 1)
         {
             return required;

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -802,8 +802,9 @@ public static class MemberCommand
         if (options.IncludeSections is not { Count: > 0 } includeSections)
             return false;
         // Bare -S carries no selector value, so it cannot be recognized by inspecting Select.
-        if ((options.SelectDefault && options.Select is null)
-            || IsPureSelector(options.Select, SelectResolver.AllSelector))
+        if (!options.MemberSectionsPreResolved
+            && ((options.SelectDefault && options.Select is null)
+                || IsPureSelector(options.Select, SelectResolver.AllSelector)))
             return false;
 
         sections = SingleOverloadSectionNames

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -206,7 +206,9 @@ public static class MemberCommand
                     ProjectAssetsPath = projectAssetsPath,
                 };
             }
-            else if (options.MemberFilter.Count == 0 && options.Select is { Length: > 0 })
+            else if (!options.MemberSectionsPreResolved
+                && options.MemberFilter.Count == 0
+                && options.Select is { Length: > 0 })
             {
                 var actualPipeline = ApiMemberSectionPipelines.Create(options);
                 var actualSelect = SelectResolver.ResolveSelectAsSections(

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -312,7 +312,7 @@ public record MemberOptions : ApiOptions
     /// preamble. Retained raw selectors are provenance only and must not override that set or
     /// control later member-pipeline transitions.
     /// </summary>
-    public bool MemberSectionsPreResolved { get; init; }
+    internal bool MemberSectionsPreResolved { get; init; }
 
     public bool CtorOnly { get; init; }
     public int? OverloadIndex { get; init; }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -306,6 +306,14 @@ public record MemberOptions : ApiOptions
     internal bool RouterDeferredTypeOrMember { get; init; }
     internal string[] RouterDeferredTypeMemberValues { get; init; } = [];
     internal bool OverloadIndexExplicitlySet { get; init; }
+
+    /// <summary>
+    /// True when <see cref="ApiOptions.IncludeSections"/> was supplied before the command
+    /// preamble. Retained raw selectors are provenance only and must not override that set or
+    /// control later member-pipeline transitions.
+    /// </summary>
+    public bool MemberSectionsPreResolved { get; init; }
+
     public bool CtorOnly { get; init; }
     public int? OverloadIndex { get; init; }
     public string? MemberDigest { get; init; }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -221,9 +221,17 @@ public static class ApiOutputFormatter
         var effectiveVerbosity = options.Verbosity;
 
         var pipeline = ApiMemberSectionPipelines.Create(options);
-        var selectAll = SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections);
+        var sectionsPreResolved = options is MemberOptions { MemberSectionsPreResolved: true };
+        var selectAll = SelectResolver.IsActiveAllSelector(
+            options.Select,
+            options.IncludeSections,
+            sectionsPreResolved);
         var includeSections = pipeline.ComputeIncludeSections(
-            type, effectiveVerbosity, options.IncludeSections, selectAll);
+            type,
+            effectiveVerbosity,
+            options.IncludeSections,
+            selectAll,
+            explicitInclude: sectionsPreResolved);
         if (ShouldRenderMemberDetailContext(options) && includeSections is { Count: > 0 }
             && !includeSections.Contains(SectionNames.Summary))
             includeSections = [SectionNames.Summary, .. includeSections];
@@ -239,8 +247,14 @@ public static class ApiOutputFormatter
     internal static bool ShouldRenderMemberDetailContext(ApiOptions options) =>
         options is MemberOptions { OverloadIndex: not null }
         && options.IncludeSections is { Count: > 0 }
-        && !SelectResolver.IsActiveAllSelector(options.Select, options.IncludeSections)
-        && !SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
+        && !SelectResolver.IsActiveAllSelector(
+            options.Select,
+            options.IncludeSections,
+            options is MemberOptions { MemberSectionsPreResolved: true })
+        && !SelectResolver.IsActiveInfoSelector(
+            options.SelectDefault,
+            options.IncludeSections,
+            options is MemberOptions { MemberSectionsPreResolved: true })
         && !options.Count
         && !options.JsonOutput
         && !options.Tabular;
@@ -263,7 +277,10 @@ public static class ApiOutputFormatter
         options.Verbosity != Verbosity.Minimal
         || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options)
         || SectionRequested(options.IncludeSections, SectionNames.Methods)
-        || (!SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections)
+        || (!SelectResolver.IsActiveInfoSelector(
+                options.SelectDefault,
+                options.IncludeSections,
+                options is MemberOptions { MemberSectionsPreResolved: true })
             && (SectionRequested(options.IncludeSections, SectionNames.Operators)
                 || SectionRequested(options.IncludeSections, SectionNames.ExplicitInterfaceImplementations)
                 || SectionRequested(options.IncludeSections, SectionNames.ExtensionMethods)))
@@ -283,7 +300,10 @@ public static class ApiOutputFormatter
         options.Verbosity == Verbosity.Minimal
         && !ShouldRenderMemberRows(options)
         && (options.IncludeSections is null
-            || SelectResolver.IsActiveInfoSelector(options.SelectDefault, options.IncludeSections));
+            || SelectResolver.IsActiveInfoSelector(
+                options.SelectDefault,
+                options.IncludeSections,
+                options is MemberOptions { MemberSectionsPreResolved: true }));
 
     /// <summary>
     /// True when the type-listing tabular view must project the fixed fact table rather than type
@@ -312,6 +332,12 @@ public static class ApiOutputFormatter
 
     internal static bool ShouldRenderSectionedTabularView(ApiType type, ApiOptions options)
     {
+        if (options is MemberOptions
+            {
+                MemberSectionsPreResolved: true,
+                IncludeSections.Count: 0
+            })
+            return true;
         if (options.IncludeSections is { Count: 1 })
             return true;
         if (!ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options))

--- a/src/dotnet-inspect/Output/SelectResolver.cs
+++ b/src/dotnet-inspect/Output/SelectResolver.cs
@@ -104,12 +104,24 @@ public static class SelectResolver
     public static bool IsActiveAllSelector(string[]? select, HashSet<string>? includeSections)
         => IsAllSelector(select) && includeSections is { Count: > 1 };
 
+    public static bool IsActiveAllSelector(
+        string[]? select,
+        HashSet<string>? includeSections,
+        bool sectionsPreResolved)
+        => !sectionsPreResolved && IsActiveAllSelector(select, includeSections);
+
     /// <summary>
     /// Whether the default preset is in effect and actually resolved to something. The preset is
     /// reached only through bare <c>-S</c>; it has no selector spelling.
     /// </summary>
     public static bool IsActiveInfoSelector(bool selectDefault, HashSet<string>? includeSections)
         => selectDefault && includeSections is { Count: > 0 };
+
+    public static bool IsActiveInfoSelector(
+        bool selectDefault,
+        HashSet<string>? includeSections,
+        bool sectionsPreResolved)
+        => !sectionsPreResolved && IsActiveInfoSelector(selectDefault, includeSections);
 
     internal static bool TryResolveCategory(
         string value,

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -572,13 +572,13 @@ public sealed class SectionPipeline<TModel>
     /// filtered by verbosity and <c>-S</c>.
     /// </summary>
     public List<string> GetEffectiveSections(TModel model, Verbosity verbosity,
-        HashSet<string>? include = null, bool fixedOverview = false)
+        HashSet<string>? include = null, bool fixedOverview = false, bool explicitInclude = false)
     {
         List<string> result = [];
         for (int i = 0; i < _entries.Count; i++)
         {
             var entry = _entries[i];
-            if (!IsRequested(entry, i, verbosity, include, fixedOverview))
+            if (!IsRequested(entry, i, verbosity, include, fixedOverview, explicitInclude))
                 continue;
             if (entry.CanRender(model))
                 result.Add(entry.Name);
@@ -649,14 +649,18 @@ public sealed class SectionPipeline<TModel>
     /// structural applicability; they merely skip render probing so discovery never opens a
     /// whole-assembly index. Registration order is preserved.
     /// </summary>
-    public List<string> GetDiscoverableSections(TModel model, HashSet<string>? include = null)
+    public List<string> GetDiscoverableSections(
+        TModel model,
+        HashSet<string>? include = null,
+        bool explicitInclude = false)
     {
         List<string> result = [];
         foreach (var entry in _entries)
         {
             if (!IsSelectable(entry))
                 continue;
-            if (include is { Count: > 0 } && !include.Contains(entry.Name))
+            if ((explicitInclude || include is { Count: > 0 })
+                && include?.Contains(entry.Name) != true)
                 continue;
             if (entry.IsApplicable(model))
                 result.Add(entry.Name);
@@ -754,11 +758,12 @@ public sealed class SectionPipeline<TModel>
     /// all sections should be rendered (no filtering needed).
     /// </summary>
     public HashSet<string>? ComputeIncludeSections(TModel model, Verbosity verbosity,
-        HashSet<string>? include = null, bool allSelector = false, bool fixedOverview = false)
+        HashSet<string>? include = null, bool allSelector = false, bool fixedOverview = false,
+        bool explicitInclude = false)
     {
         var effective = allSelector
             ? GetAllSelectorSections(model)
-            : GetEffectiveSections(model, verbosity, include, fixedOverview);
+            : GetEffectiveSections(model, verbosity, include, fixedOverview, explicitInclude);
 
         if (allSelector)
             return [.. effective];
@@ -959,11 +964,11 @@ public sealed class SectionPipeline<TModel>
     }
 
     private bool IsRequested(SectionEntry<TModel> entry, int index, Verbosity verbosity,
-        HashSet<string>? include, bool fixedOverview = false)
+        HashSet<string>? include, bool fixedOverview = false, bool explicitInclude = false)
     {
         // Explicit include overrides verbosity (and is the only way to select ExplicitOnly sections)
-        if (include is { Count: > 0 })
-            return include.Contains(entry.Name);
+        if (explicitInclude || include is { Count: > 0 })
+            return include?.Contains(entry.Name) == true;
 
         // Not explicitly included: ExplicitOnly sections are never auto-selected by verbosity.
         // In the curated model this covers coordinate-gated sections (IL context) only; the old


### PR DESCRIPTION
## Summary

Treat a supplied `IncludeSections` set as authoritative, including an empty set. Retained raw selectors remain provenance and cannot overwrite the supplied set during preamble processing, formatting, discovery, JSON projection, or automatic detail selection.

This is slice 2 of 6, stacked on #4258. Residual work is metadata-resolved pipeline selection, caller-target aggregation, caller-scope contracts, and the fixed `Member Info` section.

## Validation

- Release solution build
- Full CLI suite: 3,898 tests; 4 platform skips
- 11 focused pre-resolved-section regressions
