### PR TITLE
Preserve implicit caller target identity

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14711,7 +14711,7 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Member_BareSelectSingleOverloadCallerScope_DoesNotAnalyzeOtherMembers()
+    public async Task Member_BareSelectSingleOverloadCallerScope_PreservesAuthoredOverview()
     {
         var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
         var (exit, output, error) = await RunAppAsync(
@@ -14720,8 +14720,9 @@ public partial class CommandExecutionTests
             "-S", "--tips", "q");
 
         Assert.Equal(0, exit);
-        Assert.Contains("## Callers", output);
-        Assert.Contains("No callers found", output);
+        Assert.Contains("## Methods", output);
+        Assert.Contains(nameof(MemberCallGraphFixture.NoCalls), output);
+        Assert.DoesNotContain("## Callers", output);
         Assert.DoesNotContain(nameof(MemberCallGraphFixture.LoopHeavyCall), output);
         Assert.Empty(error);
     }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14634,6 +14634,10 @@ public partial class CommandExecutionTests
         var all = await RunAppAsync([.. common, "-D", "--tips", "q"]);
         var named = await RunAppAsync(
             [.. common, "-D", SectionNames.Callers, "--tips", "q"]);
+        var selected = await RunAppAsync(
+            [.. common, "-S", SectionNames.Callers, "--tips", "q"]);
+        var allSelected = await RunAppAsync(
+            [.. common, "-S", SelectResolver.AllSelector, "--tips", "q"]);
 
         Assert.Equal(0, all.Exit);
         Assert.Contains(SectionNames.Callers, all.Output);
@@ -14641,6 +14645,12 @@ public partial class CommandExecutionTests
         Assert.Equal(0, named.Exit);
         Assert.NotEqual(string.Empty, named.Output.Trim());
         Assert.Empty(named.Error);
+        Assert.Equal(0, selected.Exit);
+        Assert.Contains($"## {SectionNames.Callers}", selected.Output);
+        Assert.Empty(selected.Error);
+        Assert.Equal(0, allSelected.Exit);
+        Assert.Contains($"## {SectionNames.Callers}", allSelected.Output);
+        Assert.Empty(allSelected.Error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14689,6 +14689,28 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_BareSolePropertyNameCallerScope_AggregatesAccessorOverloads()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberOnlyPropertyCallsFixture).FullName!,
+            "--library", TestAssemblyPath,
+            nameof(MemberOnlyPropertyCallsFixture.Solo),
+            "--bin", testDirectory,
+            "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains(
+            nameof(MemberOnlyPropertyCallerFixture.CallsSolo),
+            output);
+        Assert.Contains(
+            nameof(MemberOnlyPropertyCallerFixture.WritesSolo),
+            output);
+        Assert.Contains("## Callers", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
     public async Task Member_BareSelectSingleOverloadCallerScope_DoesNotAnalyzeOtherMembers()
     {
         var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3249,6 +3249,32 @@ public partial class CommandExecutionTests
         Assert.Contains("| Source | Platform |", factOutput, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("System.Collections.Frozen.FrozenDictionary`2.AlternateLookup`1")]
+    [InlineData("System.Collections.Frozen.FrozenDictionary<TKey,TValue>.AlternateLookup<TAlternateKey>")]
+    public async Task BareNestedGenericPlatformType_RoutesToWholeType(string typeName)
+    {
+        var (exit, output, error) = await RunAppAsync(typeName, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("System.Collections.Frozen.FrozenDictionary", output);
+        Assert.Contains("AlternateLookup", output);
+    }
+
+    [Fact]
+    public async Task BareForwardedNestedGenericPlatformType_RoutesToDeclaringType()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.Collections.Generic.List`1.Enumerator",
+            "--markdown", "-v", "m", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains(".Enumerator", output);
+        Assert.Contains("Kind: struct", output);
+    }
+
     /// <summary>
     /// A dotted prefix that does not resolve to a type enters the preamble looking like a single
     /// type -- so its sections are validated against the single-type pipeline -- but renders a
@@ -8060,6 +8086,20 @@ public partial class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains("public void Run(", output);
+    }
+
+    [Fact]
+    public async Task BareQualifiedAspNetCoreGenericMember_RoutesAcrossPlatformFrameworks()
+    {
+        SkipUnlessAspNetCoreAvailable();
+
+        var (exit, output, error) = await RunAppAsync(
+            "member", "Microsoft.AspNetCore.Components.EventCallback<T>.InvokeAsync",
+            "-S", "Methods", "--count", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.True(int.Parse(output.Trim(), CultureInfo.InvariantCulture) > 0);
+        Assert.Empty(error);
     }
 
     [Fact]
@@ -14557,18 +14597,170 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Member_BareNameCallerScope_AmbiguousOverloadReportsSelectorHint()
+    public async Task Member_BareNameCallerScope_AggregatesAmbiguousOverloads()
     {
         var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
         var (exit, output, error) = await RunAppAsync(
             "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
             nameof(MemberCallsFixture.Overloaded), "--bin", testDirectory, "--tips", "q");
 
-        Assert.Equal(1, exit);
-        Assert.Empty(output);
-        Assert.Contains("section 'Callers' requires a single selected overload", error);
-        Assert.Contains("Overloaded~<digest>", error);
-        Assert.Contains("Overloaded:1 through Overloaded:2", error);
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            2,
+            output.Split(
+                nameof(MemberCallsFixture.CallsOverloaded),
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("## Callers", output);
+        Assert.Contains($"# {typeof(MemberCallsFixture).FullName}", output);
+        Assert.Empty(error);
+        Assert.DoesNotContain("requires a single selected overload", error);
+    }
+
+    [Fact]
+    public async Task Member_BareNameCallerScope_EmptyAggregateRendersEmptyState()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallsFixture.UnusedOverloaded), "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Callers", output);
+        Assert.Contains("No callers found", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_BarePropertyNameCallerScope_AggregatesAccessorOverloads()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberPropertyCallsFixture).FullName!, "--library", TestAssemblyPath,
+            "Item", "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            2,
+            output.Split(
+                nameof(MemberPropertyCallsFixture.CallsIndexers),
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("## Callers", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_BareSelectSingleOverloadCallerScope_DoesNotAnalyzeOtherMembers()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallGraphFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallGraphFixture.NoCalls), "--bin", testDirectory,
+            "-S", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Callers", output);
+        Assert.Contains("No callers found", output);
+        Assert.DoesNotContain(nameof(MemberCallGraphFixture.LoopHeavyCall), output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_MultipleNamesCallerScope_AnalyzesOnlySelectedMembers()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallGraphFixture).FullName!, "--library", TestAssemblyPath,
+            "-m", nameof(MemberCallGraphFixture.Mid),
+            "-m", nameof(MemberCallGraphFixture.NoCalls),
+            "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Callers", output);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), output);
+        Assert.DoesNotContain(nameof(MemberCallGraphFixture.LoopHeavyCall), output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_AbstractMethodFamilyCallerScope_IncludesAbstractOverloads()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberAbstractCallsFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberAbstractCallsFixture.Mixed), "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            2,
+            output.Split(
+                nameof(MemberAbstractCallsFixture.CallsMixed),
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("## Callers", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_AbstractPropertyFamilyCallerScope_IncludesAbstractAccessors()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberAbstractPropertyCallsFixture).FullName!,
+            "--library", TestAssemblyPath,
+            "Item", "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            2,
+            output.Split(
+                nameof(MemberAbstractPropertyCallsFixture.CallsIndexers),
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("## Callers", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_FilteredSolePropertyCallerScope_DoesNotReintroduceItsAccessors()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberOnlyPropertyCallsFixture).FullName!,
+            "--library", TestAssemblyPath,
+            "Solo", "-k", "method", "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("## Callers", output);
+        Assert.DoesNotContain(nameof(MemberOnlyPropertyCallerFixture.CallsSolo), output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_ForwardedTypeCallerScope_UsesImplementationAssembly()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.String", "IndexOf", "--platform", "System.Runtime",
+            "--bin", testDirectory, "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("## Callers", output);
+        Assert.Contains("| `System.", output);
+        Assert.DoesNotContain("No callers found", output);
+        Assert.Empty(error);
+    }
+
+    [Fact]
+    public async Task Member_DocumentJsonWithCallerScope_PreservesOverloadInventory()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallsFixture.Overloaded), "--bin", testDirectory,
+            "--json", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        Assert.Equal(2, document.RootElement.GetProperty("members").GetArrayLength());
     }
 
     [Theory]
@@ -27103,6 +27295,19 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_OverflowingGenericArity_DoesNotBroadenSelection()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.String", "ToString`999999999999999999999:1",
+            "--platform", "System.Private.CoreLib",
+            "-S", SectionNames.Signature, "--count", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("No members matched filter", error);
+    }
+
+    [Fact]
     public async Task Member_GenericMethodSelector_MemberIndexSelectorRoundTrips()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -27187,9 +27392,8 @@ public partial class CommandExecutionTests
     public async Task Member_DottedImpliedMemberWithDistinctGenericSelector_IsRejected()
     {
         var (exit, output, error) = await RunAppAsync(
-            "member", "System.MemoryExtensions.Contains",
-            "--platform", "System.Memory",
-            "-m", "AsSpan<T>", "--tips", "q");
+            "member", "System.MemoryExtensions.Contains", "--platform", "System.Memory",
+            "-m", "AsSpan<T>", "-S", "Methods", "--count", "--tips", "q");
 
         Assert.Equal(1, exit);
         Assert.Empty(output);

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14617,6 +14617,33 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_BareNameCallerScope_EffectiveDiscoveryIncludesAggregatedCallers()
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        string[] common =
+        [
+            "member",
+            typeof(MemberCallsFixture).FullName!,
+            nameof(MemberCallsFixture.Overloaded),
+            "--library",
+            TestAssemblyPath,
+            "--bin",
+            testDirectory
+        ];
+
+        var all = await RunAppAsync([.. common, "-D", "--tips", "q"]);
+        var named = await RunAppAsync(
+            [.. common, "-D", SectionNames.Callers, "--tips", "q"]);
+
+        Assert.Equal(0, all.Exit);
+        Assert.Contains(SectionNames.Callers, all.Output);
+        Assert.Empty(all.Error);
+        Assert.Equal(0, named.Exit);
+        Assert.NotEqual(string.Empty, named.Output.Trim());
+        Assert.Empty(named.Error);
+    }
+
+    [Fact]
     public async Task Member_BareNameCallerScope_EmptyAggregateRendersEmptyState()
     {
         var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14568,18 +14568,21 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Member_BareNameCallersWithCallerScope_AmbiguousOverloadReportsSelectorHint()
+    public async Task Member_BareNameCallersWithCallerScope_AggregatesAmbiguousOverloads()
     {
         var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
         var (exit, output, error) = await RunAppAsync(
             "member", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath,
             nameof(MemberCallsFixture.Overloaded), "-S", "Callers", "--bin", testDirectory, "--tips", "q");
 
-        Assert.Equal(1, exit);
-        Assert.Empty(output);
-        Assert.Contains("section 'Callers' requires a single selected overload", error);
-        Assert.Contains("Overloaded~<digest>", error);
-        Assert.Contains("Overloaded:1 through Overloaded:2", error);
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            2,
+            output.Split(
+                nameof(MemberCallsFixture.CallsOverloaded),
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains("## Callers", output);
+        Assert.Empty(error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -292,12 +292,14 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
-    public async Task PipelineIndependentMultiSectionSelection_ValidatesBeforeAcquisition()
+    public async Task PipelineIndependentMultiSectionCount_ReachesAcquisition()
     {
+        string missingAssembly =
+            Path.Combine(Path.GetTempPath(), "missing-member-selection.dll");
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
             TypeName = "Missing.Type.Member",
-            AssemblyPath = Path.Combine(Path.GetTempPath(), "missing-member-selection.dll"),
+            AssemblyPath = missingAssembly,
             Select = [SectionNames.DecompiledSource, SectionNames.PdbSource],
             Count = true,
             TipLevel = TipLevel.Quiet,
@@ -305,8 +307,8 @@ public class MemberCallGraphSectionTests
 
         Assert.Equal(1, result.ExitCode);
         Assert.Empty(result.Output);
-        Assert.Contains(CountOutput.SingleSectionRequiredMessage, result.Error);
-        Assert.DoesNotContain("not found", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains($"File not found: {missingAssembly}", result.Error);
+        Assert.DoesNotContain(CountOutput.SingleSectionRequiredMessage, result.Error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -515,7 +515,7 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
-    public async Task ImplicitCallers_DoesNotInvalidateAuthoredInventorySection()
+    public async Task CallerScope_DoesNotMutateAuthoredInventorySection()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
             new MemberOptions
@@ -534,7 +534,7 @@ public class MemberCallGraphSectionTests
         Assert.Equal(0, result.ExitCode);
         Assert.Empty(result.Error);
         Assert.Contains($"## {SectionNames.MemberIndex}", result.Output);
-        Assert.Contains($"## {SectionNames.Callers}", result.Output);
+        Assert.DoesNotContain($"## {SectionNames.Callers}", result.Output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -292,6 +292,24 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    public async Task PipelineIndependentMultiSectionSelection_ValidatesBeforeAcquisition()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = "Missing.Type.Member",
+            AssemblyPath = Path.Combine(Path.GetTempPath(), "missing-member-selection.dll"),
+            Select = [SectionNames.DecompiledSource, SectionNames.OriginalSource],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(CountOutput.SingleSectionRequiredMessage, result.Error);
+        Assert.DoesNotContain("not found", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task EmptyPreResolvedSection_SelectsNoDefaultSections()
     {
         var options = new MemberOptions
@@ -446,6 +464,77 @@ public class MemberCallGraphSectionTests
         Assert.Equal(0, result.ExitCode);
         Assert.NotEqual(string.Empty, result.Output.Trim());
         Assert.Empty(result.Error);
+    }
+
+    [Theory]
+    [InlineData("count")]
+    [InlineData("table")]
+    [InlineData("tsv")]
+    [InlineData("jsonl")]
+    [InlineData("tree")]
+    [InlineData("mermaid")]
+    public async Task AutoSelectedDetail_WithCallerScope_ValidatesTheAuthoredSelection(
+        string format)
+    {
+        var options = new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            IncludeSections =
+            [
+                format is "tree" or "mermaid"
+                    ? SectionNames.CallGraph
+                    : SectionNames.Signature
+            ],
+            CallerScopeDirectories =
+            [
+                Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!
+            ],
+            Count = format == "count",
+            Tabular = format is "table" or "tsv" or "jsonl",
+            Tsv = format == "tsv",
+            Jsonl = format == "jsonl",
+            TabularExplicitlySet = format is "table" or "tsv" or "jsonl",
+            FormatExplicitlySet = format is "table" or "tsv" or "jsonl",
+            Tree = format == "tree",
+            MermaidOutput = format == "mermaid",
+            TipLevel = TipLevel.Quiet,
+        };
+
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotEqual(string.Empty, result.Output.Trim());
+        Assert.DoesNotContain("Error:", result.Error);
+        if (format is "table" or "tsv" or "jsonl")
+        {
+            Assert.Contains("signature", result.Output, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("caller", result.Output, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task ImplicitCallers_DoesNotInvalidateAuthoredInventorySection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallGraphFixture).FullName!,
+                AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+                MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+                IncludeSections = [SectionNames.MemberIndex],
+                CallerScopeDirectories =
+                [
+                    Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!
+                ],
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Contains($"## {SectionNames.MemberIndex}", result.Output);
+        Assert.Contains($"## {SectionNames.Callers}", result.Output);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -298,7 +298,7 @@ public class MemberCallGraphSectionTests
         {
             TypeName = "Missing.Type.Member",
             AssemblyPath = Path.Combine(Path.GetTempPath(), "missing-member-selection.dll"),
-            Select = [SectionNames.DecompiledSource, SectionNames.OriginalSource],
+            Select = [SectionNames.DecompiledSource, SectionNames.PdbSource],
             Count = true,
             TipLevel = TipLevel.Quiet,
         }));

--- a/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
@@ -96,7 +96,7 @@ public class MemberCallsSectionTests
         var type = SolePropertyType();
         var options = ImplicitCallerOptions();
 
-        Assert.False(ApiMemberSectionPipelines.ShouldAggregateImplicitCallers(type, options));
+        Assert.False(ApiMemberSectionPipelines.ShouldAggregateCallers(type, options));
     }
 
     static ApiType SolePropertyType()

--- a/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
@@ -258,10 +258,13 @@ public abstract class MemberAbstractPropertyCallsFixture
 
 public static class MemberOnlyPropertyCallsFixture
 {
-    public static int Solo => 1;
+    public static int Solo { get; set; }
 }
 
 public static class MemberOnlyPropertyCallerFixture
 {
     public static int CallsSolo() => MemberOnlyPropertyCallsFixture.Solo;
+
+    public static void WritesSolo() =>
+        MemberOnlyPropertyCallsFixture.Solo = 1;
 }

--- a/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
@@ -122,7 +122,7 @@ public class MemberCallsSectionTests
         {
             CallerScopeSectionImplicitlySelected = true,
             IncludeSections = [SectionNames.Callers],
-            ImplicitCallerMemberTokens = new HashSet<int>()
+            AggregatedCallerMemberTokens = new HashSet<int>()
         };
 
     static Task<(int ExitCode, string Output, string Error)> RunMemberCallsAsync(string memberName, bool tsv = false, bool discover = false, int? overloadIndex = null)

--- a/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
@@ -1,6 +1,8 @@
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 using DotnetInspector.Sections;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Tests;
 
@@ -76,6 +78,53 @@ public class MemberCallsSectionTests
         Assert.Contains("Calls\tsection", result.Output);
     }
 
+    [Fact]
+    public void EmptyImplicitCallerTokenScope_DoesNotResolveSolePropertyAccessor()
+    {
+        var type = SolePropertyType();
+        var options = ImplicitCallerOptions();
+
+        var methods = ApiOutputFormatter.ResolveBodyMethods(
+            type, new HashSet<string> { SectionNames.Callers }, options);
+
+        Assert.Empty(methods);
+    }
+
+    [Fact]
+    public void EmptyImplicitCallerTokenScope_DoesNotMakeCallersEffective()
+    {
+        var type = SolePropertyType();
+        var options = ImplicitCallerOptions();
+
+        Assert.False(ApiMemberSectionPipelines.ShouldAggregateImplicitCallers(type, options));
+    }
+
+    static ApiType SolePropertyType()
+        => new()
+        {
+            Namespace = "Samples",
+            Name = "Properties",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Solo",
+                    Kind = "property",
+                    ReturnType = "int",
+                    GetterToken = 0x06000001
+                }
+            ]
+        };
+
+    static MemberOptions ImplicitCallerOptions()
+        => new()
+        {
+            CallerScopeSectionImplicitlySelected = true,
+            IncludeSections = [SectionNames.Callers],
+            ImplicitCallerMemberTokens = new HashSet<int>()
+        };
+
     static Task<(int ExitCode, string Output, string Error)> RunMemberCallsAsync(string memberName, bool tsv = false, bool discover = false, int? overloadIndex = null)
         => ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
@@ -132,6 +181,20 @@ public static class MemberCallsFixture
         Console.WriteLine(value);
     }
 
+    public static void CallsOverloaded()
+    {
+        Overloaded(1);
+        Overloaded("value");
+    }
+
+    public static void UnusedOverloaded(int value)
+    {
+    }
+
+    public static void UnusedOverloaded(string value)
+    {
+    }
+
     // Non-public member: only selectable under --all. Regression coverage for #1323,
     // where the body-load path counted overloads public-only and so reported "no IL body"
     // for a method that the Calls/IL index reads fine.
@@ -155,4 +218,50 @@ public static class MemberAbstractCallerUseFixture
         target.Invoke();
         _ = target.Value;
     }
+}
+public sealed class MemberPropertyCallsFixture
+{
+    public int this[int index] => index;
+    public int this[string key] => key.Length;
+
+    public static void CallsIndexers()
+    {
+        var fixture = new MemberPropertyCallsFixture();
+        _ = fixture[1];
+        _ = fixture["one"];
+    }
+}
+
+public abstract class MemberAbstractCallsFixture
+{
+    public abstract void Mixed(int value);
+    public void Mixed(string value) { }
+
+    public static void CallsMixed(MemberAbstractCallsFixture fixture)
+    {
+        fixture.Mixed(1);
+        fixture.Mixed("one");
+    }
+}
+
+public abstract class MemberAbstractPropertyCallsFixture
+{
+    public abstract int this[int index] { get; }
+    public abstract int this[string key] { get; }
+
+    public static void CallsIndexers(MemberAbstractPropertyCallsFixture fixture)
+    {
+        _ = fixture[1];
+        _ = fixture["one"];
+    }
+}
+
+public static class MemberOnlyPropertyCallsFixture
+{
+    public static int Solo => 1;
+}
+
+public static class MemberOnlyPropertyCallerFixture
+{
+    public static int CallsSolo() => MemberOnlyPropertyCallsFixture.Solo;
 }

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -3565,6 +3565,15 @@ public class ApiCommand
             filteredType,
             options.IncludeSections,
             explicitInclude: options is MemberOptions { MemberSectionsPreResolved: true });
+        if (ApiMemberSectionPipelines.ShouldAggregateImplicitCallers(
+                filteredType,
+                options)
+            && !effective.Contains(
+                SectionNames.Callers,
+                StringComparer.OrdinalIgnoreCase))
+        {
+            effective.Add(SectionNames.Callers);
+        }
         if (!options.BodyKindQuery.HasFilter)
         {
             effective = effective

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -3565,7 +3565,7 @@ public class ApiCommand
             filteredType,
             options.IncludeSections,
             explicitInclude: options is MemberOptions { MemberSectionsPreResolved: true });
-        if (ApiMemberSectionPipelines.ShouldAggregateImplicitCallers(
+        if (ApiMemberSectionPipelines.ShouldAggregateCallers(
                 filteredType,
                 options)
             && !effective.Contains(

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -989,7 +989,11 @@ public static class MemberCommand
             ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
             : [];
         includeSections.Remove(SectionNames.Callers);
-        return options with { IncludeSections = includeSections };
+        return options with
+        {
+            IncludeSections = includeSections,
+            CallerScopeSectionImplicitlySelected = false
+        };
     }
 
     private static bool RequiresCallerScopeResolution(MemberOptions options)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -983,19 +983,6 @@ public static class MemberCommand
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
-    private static MemberOptions ExcludeCallersSection(MemberOptions options)
-    {
-        var includeSections = options.IncludeSections is { } existing
-            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
-            : [];
-        includeSections.Remove(SectionNames.Callers);
-        return options with
-        {
-            IncludeSections = includeSections,
-            CallerScopeSectionImplicitlySelected = false
-        };
-    }
-
     private static bool RequiresCallerScopeResolution(MemberOptions options)
         => !IsWholeDocumentJson(options)
            && options.HasCallerScope

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -362,7 +362,12 @@ public static class MemberCommand
                             detailPipeline)
                         is not { } detailOptions)
                         return 1;
-                    effectiveOptions = detailOptions;
+                    effectiveOptions = aggregateCallers
+                        ? IncludeCallerScopeSections(
+                            detailOptions,
+                            discoveredCallerSections,
+                            callersImplicitlySelected)
+                        : detailOptions;
                 }
             }
 
@@ -933,7 +938,8 @@ public static class MemberCommand
 
     private static MemberOptions IncludeCallerScopeSections(
         MemberOptions options,
-        IReadOnlySet<string> discoveredCallerSections)
+        IReadOnlySet<string> discoveredCallerSections,
+        bool implicitlySelected = true)
     {
         var includeSections = options.IncludeSections is { Count: > 0 } existing
             ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
@@ -946,7 +952,8 @@ public static class MemberCommand
         {
             IncludeSections = includeSections,
             CallerScopeSectionImplicitlySelected =
-                includeSections.Contains(SectionNames.Callers)
+                implicitlySelected
+                && includeSections.Contains(SectionNames.Callers)
         };
     }
 

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -308,7 +308,13 @@ public static class MemberCommand
                     effectiveOptions,
                     discoveredCallerSections);
             }
-            var authoredSelection = effectiveOptions;
+            var aggregateCallers =
+                ApiMemberSectionPipelines.ShouldAggregateCallers(
+                    apiType,
+                    effectiveOptions);
+            var authoredSelection = aggregateCallers
+                ? ExcludeCallersSection(effectiveOptions)
+                : effectiveOptions;
 
             // Keep member-name lookups as overload inventories. Only auto-select the lone
             // overload when the user explicitly asks for a selected-overload detail section.
@@ -968,6 +974,15 @@ public static class MemberCommand
                     SectionNames.CallGraph,
                     StringComparison.OrdinalIgnoreCase))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static MemberOptions ExcludeCallersSection(MemberOptions options)
+    {
+        var includeSections = options.IncludeSections is { } existing
+            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
+            : [];
+        includeSections.Remove(SectionNames.Callers);
+        return options with { IncludeSections = includeSections };
     }
 
     private static bool RequiresCallerScopeResolution(MemberOptions options)


### PR DESCRIPTION
## Summary

Make implicit caller aggregation authoritative over the selected overload family. Method declarations, abstract declarations, properties/events through accessors, filtered names, generic arity, and forwarded implementation assemblies retain exact MethodDef target identity; an authoritative empty target set stays empty.

This is slice 4 of 6, stacked on #4260. Its product tree equals #4108's reviewed product tree; the old PR's unrelated Windows timeout edit is intentionally excluded. Residual work is caller-scope output contracts in #4109 and the fixed `Member Info` section in #4038.

## Validation

- Release solution build
- Full CLI suite: 3,954 tests; 4 platform skips
- 58 member caller/call-graph tests
- 44 caller-scope command tests; 2 platform skips
