### PR TITLE
Preserve caller-scope output contracts

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14826,6 +14826,50 @@ public partial class CommandExecutionTests
         Assert.Equal(2, document.RootElement.GetProperty("members").GetArrayLength());
     }
 
+    [Fact]
+    public async Task Member_PreResolvedDocumentJson_IgnoresStaleCallerSelector()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallsFixture).FullName!,
+                AssemblyPath = TestAssemblyPath,
+                MemberFilter = [nameof(MemberCallsFixture.Overloaded)],
+                OverloadIndex = 1,
+                Select = [SectionNames.Callers],
+                IncludeSections = [SectionNames.Signature],
+                JsonOutput = true,
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        using var _ = JsonDocument.Parse(result.Output);
+    }
+
+    [Fact]
+    public async Task Member_PreResolvedCallerDocumentJson_IgnoresStaleNonCallerSelector()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(
+            new MemberOptions
+            {
+                TypeName = typeof(MemberCallsFixture).FullName!,
+                AssemblyPath = TestAssemblyPath,
+                MemberFilter = [nameof(MemberCallsFixture.Overloaded)],
+                OverloadIndex = 1,
+                Select = [SectionNames.Signature],
+                IncludeSections = [SectionNames.Callers],
+                JsonOutput = true,
+                TipLevel = TipLevel.Quiet
+            }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Empty(result.Output);
+        Assert.Contains(
+            $"Document --json cannot represent {SectionNames.Callers} analysis.",
+            result.Error);
+    }
+
     [Theory]
     [InlineData("Method Groups", false)]
     [InlineData("Properties", true)]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -15562,6 +15562,58 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_DeferredCallerGlobDocumentJsonFailsBeforeCallerScopeAcquisition()
+    {
+        var missingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-missing-{Guid.NewGuid():N}");
+        var (exit, output, error) = await RunAppAsync(
+            "member",
+            $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            "--library",
+            TestAssemblyPath,
+            "-S",
+            "Caller?",
+            "--bin",
+            missingDirectory,
+            "--json",
+            "--tips",
+            "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains(
+            $"Document --json cannot represent {SectionNames.Callers} analysis.",
+            error);
+        Assert.DoesNotContain("Directory not found", error);
+    }
+
+    [Fact]
+    public async Task Member_SelectedDocumentJsonDoesNotAcquireImplicitCallerScope()
+    {
+        var missingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-missing-{Guid.NewGuid():N}");
+        var (exit, output, error) = await RunAppAsync(
+            "member",
+            $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            "--library",
+            TestAssemblyPath,
+            "-S",
+            SectionNames.Signature,
+            "--bin",
+            missingDirectory,
+            "--json",
+            "--tips",
+            "q");
+
+        Assert.Equal(0, exit);
+        Assert.NotEqual(string.Empty, output.Trim());
+        using var _ = JsonDocument.Parse(output);
+        Assert.DoesNotContain("Directory not found", error);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_SelectDecompiledSource_RendersPlainCSharp()
     {
         var options = new MemberOptions

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -16169,7 +16169,7 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Member_AnnotatedSourceDocumentJson_RejectsBeforeCallerScopeAcquisition()
+    public async Task Member_AnnotatedSourceDocumentJson_DoesNotAcquireUnusedCallerScope()
     {
         string missingDirectory = Path.Combine(
             Path.GetTempPath(),
@@ -16179,10 +16179,11 @@ public partial class CommandExecutionTests
             "Pump:1", "-S", SectionNames.AnnotatedSourceDocument, "--json",
             "--bin", missingDirectory, "--tips", "q");
 
-        Assert.Equal(1, exit);
-        Assert.Empty(output);
-        Assert.Contains("must be the only selected section under --json", error);
-        Assert.DoesNotContain("Directory not found", error);
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        Assert.True(document.RootElement.TryGetProperty("text", out _));
+        Assert.False(document.RootElement.TryGetProperty("namespace", out _));
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14970,6 +14970,34 @@ public partial class CommandExecutionTests
         Assert.Contains(nameof(CallerScopeCountFixture.Root), result.Output);
     }
 
+    [Theory]
+    [InlineData(SectionNames.Callers)]
+    [InlineData(SectionNames.CallGraph)]
+    public async Task Member_DocumentJsonWithExplicitCallerAnalysis_FailsClosed(
+        string section)
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member",
+            typeof(MemberCallsFixture).FullName!,
+            "--library",
+            TestAssemblyPath,
+            $"{nameof(MemberCallsFixture.Overloaded)}:1",
+            "-S",
+            section,
+            "--bin",
+            testDirectory,
+            "--json",
+            "--tips",
+            "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains(
+            $"Document --json cannot represent {section} analysis.",
+            error);
+    }
+
     [Fact]
     public async Task Member_CallerScope_BareSelectPreservesAuthoredOverview()
     {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14552,6 +14552,49 @@ public partial class CommandExecutionTests
             row => row.GetProperty("name").GetString() == SectionNames.Callers);
     }
 
+    [Theory]
+    [InlineData("--count")]
+    [InlineData("--table")]
+    [InlineData("--tsv")]
+    [InlineData("--jsonl")]
+    [InlineData("--value")]
+    [InlineData("--print")]
+    public async Task Member_BareNameCallersWithCallerScope_SingleSectionOutputPreservesSelection(
+        string outputOption)
+    {
+        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallGraphFixture).FullName!, "--library", TestAssemblyPath,
+            nameof(MemberCallGraphFixture.Inner), "-S", SectionNames.Callers,
+            "--bin", testDirectory, outputOption, "--tips", "q");
+
+        if (outputOption == "--value")
+        {
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains(
+                $"section '{SectionNames.Callers}' does not expose value values.",
+                error);
+            return;
+        }
+        if (outputOption == "--print")
+        {
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains(
+                $"section '{SectionNames.Callers}' is not printable.",
+                error);
+            return;
+        }
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        if (outputOption == "--count")
+            Assert.True(int.Parse(output.Trim()) > 0);
+        else
+            Assert.Contains(nameof(MemberCallGraphFixture.Mid), output);
+    }
+
     [Fact]
     public async Task Member_NamedCallerDiscoveryRetainsCallerSection()
     {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14976,7 +14976,9 @@ public partial class CommandExecutionTests
     public async Task Member_DocumentJsonWithExplicitCallerAnalysis_FailsClosed(
         string section)
     {
-        var testDirectory = Path.GetDirectoryName(TestAssemblyPath)!;
+        var missingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-missing-{Guid.NewGuid():N}");
         var (exit, output, error) = await RunAppAsync(
             "member",
             typeof(MemberCallsFixture).FullName!,
@@ -14986,7 +14988,7 @@ public partial class CommandExecutionTests
             "-S",
             section,
             "--bin",
-            testDirectory,
+            missingDirectory,
             "--json",
             "--tips",
             "q");
@@ -14996,6 +14998,7 @@ public partial class CommandExecutionTests
         Assert.Contains(
             $"Document --json cannot represent {section} analysis.",
             error);
+        Assert.DoesNotContain("Directory not found", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14971,10 +14971,13 @@ public partial class CommandExecutionTests
     }
 
     [Theory]
-    [InlineData(SectionNames.Callers)]
-    [InlineData(SectionNames.CallGraph)]
+    [InlineData(SectionNames.Callers, SectionNames.Callers)]
+    [InlineData(SectionNames.CallGraph, SectionNames.CallGraph)]
+    [InlineData("Caller?", SectionNames.Callers)]
+    [InlineData("Call Grap?", SectionNames.CallGraph)]
     public async Task Member_DocumentJsonWithExplicitCallerAnalysis_FailsClosed(
-        string section)
+        string selector,
+        string expectedSection)
     {
         var missingDirectory = Path.Combine(
             Path.GetTempPath(),
@@ -14986,7 +14989,7 @@ public partial class CommandExecutionTests
             TestAssemblyPath,
             $"{nameof(MemberCallsFixture.Overloaded)}:1",
             "-S",
-            section,
+            selector,
             "--bin",
             missingDirectory,
             "--json",
@@ -14996,7 +14999,7 @@ public partial class CommandExecutionTests
         Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains(
-            $"Document --json cannot represent {section} analysis.",
+            $"Document --json cannot represent {expectedSection} analysis.",
             error);
         Assert.DoesNotContain("Directory not found", error);
     }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -15633,6 +15633,30 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_DeferredCallerDocumentJsonFailsBeforeSourceAcquisition()
+    {
+        string missingAssembly = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-missing-{Guid.NewGuid():N}.dll");
+        var (exit, output, error) = await RunAppAsync(
+            "System.Collections.Generic.List<>.Add",
+            "--library",
+            missingAssembly,
+            "-S",
+            SectionNames.Callers,
+            "--json",
+            "--tips",
+            "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains(
+            $"Document --json cannot represent {SectionNames.Callers} analysis.",
+            error);
+        Assert.DoesNotContain("File not found", error);
+    }
+
+    [Fact]
     public async Task Member_SelectedDocumentJsonDoesNotAcquireImplicitCallerScope()
     {
         var missingDirectory = Path.Combine(
@@ -16099,6 +16123,23 @@ public partial class CommandExecutionTests
         using var document = JsonDocument.Parse(output);
         Assert.True(document.RootElement.TryGetProperty("text", out _));
         Assert.False(document.RootElement.TryGetProperty("namespace", out _));
+    }
+
+    [Fact]
+    public async Task Member_AnnotatedSourceDocumentJson_RejectsBeforeCallerScopeAcquisition()
+    {
+        string missingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-missing-{Guid.NewGuid():N}");
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
+            "Pump:1", "-S", SectionNames.AnnotatedSourceDocument, "--json",
+            "--bin", missingDirectory, "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("must be the only selected section under --json", error);
+        Assert.DoesNotContain("Directory not found", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -599,6 +599,22 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    public async Task CallerScope_ImplicitCallers_DoesNotRequireOneOverload()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallsFixture).FullName!,
+            AssemblyPath = typeof(MemberCallsFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallsFixture.Overloaded)],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallsFixture).Assembly.Location)!],
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("requires a single selected overload", result.Error);
+    }
+
+    [Fact]
     public async Task CallerScope_DoesNotAcquireScopeForNonGraphSelection()
     {
         var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions

--- a/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs
@@ -540,6 +540,214 @@ public class MemberCallGraphSectionTests
     }
 
     [Fact]
+    public async Task CallerScope_DoesNotInvalidateCallGraphCount()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.CallGraph],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(int.TryParse(result.Output.Trim(), out var count));
+        Assert.True(count > 0, "fixture must produce a non-empty graph");
+    }
+
+    [Fact]
+    public async Task CallerScope_DoesNotInvalidateCallGraphTabularOutput()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.CallGraph],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Tabular = true,
+            Tsv = true,
+            TabularExplicitlySet = true,
+            FormatExplicitlySet = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.StartsWith("from\t", result.Output, StringComparison.Ordinal);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), result.Output);
+    }
+
+    [Fact]
+    public async Task CallerScope_WithTabularOutputAndNoSelection_StillSelectsCallers()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.Inner)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Tabular = true,
+            Tsv = true,
+            TabularExplicitlySet = true,
+            FormatExplicitlySet = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.StartsWith("caller\t", result.Output, StringComparison.Ordinal);
+        Assert.Contains(nameof(MemberCallGraphFixture.Mid), result.Output);
+    }
+
+    [Fact]
+    public async Task CallerScope_DoesNotAcquireScopeForNonGraphSelection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            OverloadIndex = 1,
+            IncludeSections = [SectionNames.Signature],
+            CallerScopeDirectories = ["/definitely/not/a/caller/scope"],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("1", result.Output.Trim());
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public async Task CallerScope_DoesNotAcquireScopeForIneffectiveGraphSelection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.Data)],
+            OverloadIndex = 1,
+            IncludeSections = [SectionNames.Callers],
+            CallerScopeDirectories = ["/definitely/not/a/caller/scope"],
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("Directory not found", result.Error);
+    }
+
+    [Fact]
+    public async Task CallerScope_PreservesBroadBodyIndexSections()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.CalledTypes],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Count = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(int.TryParse(result.Output.Trim(), out var count));
+        Assert.True(count > 0, "fixture must produce called-type evidence");
+    }
+
+    [Fact]
+    public async Task CallerScope_PreservesSingleSectionValueValidation()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = $"{typeof(MemberCallGraphFixture).FullName}.{nameof(MemberCallGraphFixture.RootCall)}",
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.Calls],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Columns = ["Callee"],
+            Value = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("section 'Calls' does not expose value values.", result.Error);
+        Assert.DoesNotContain("--value requires -S/--select to match exactly one section.", result.Error);
+    }
+
+    [Fact]
+    public async Task CallerScope_DoesNotInjectUnsupportedCallersIntoBroadPipeline()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = nameof(MemberCallGraphFixture),
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            IncludeSections = [SectionNames.MethodGroups],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Method Groups", result.Output);
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
+    public async Task CallGraphTree_WithCallerScope_RendersTheSelectedGraph()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            IncludeSections = [SectionNames.CallGraph],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            Tree = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), result.Output);
+        Assert.Contains("├─", result.Output);
+    }
+
+    [Fact]
+    public async Task CallGraphMermaid_WithCallerScope_RendersTheSelectedGraph()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            IncludeSections = [SectionNames.CallGraph],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            MermaidOutput = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("graph TD", result.Output);
+        Assert.Contains(nameof(MemberCallGraphFixture.RootCall), result.Output);
+    }
+
+    [Fact]
+    public async Task EnvironmentMermaidFallback_WithCallerScope_RendersCallers()
+    {
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(MemberCallGraphFixture).FullName!,
+            AssemblyPath = typeof(MemberCallGraphFixture).Assembly.Location,
+            MemberFilter = [nameof(MemberCallGraphFixture.RootCall)],
+            CallerScopeDirectories = [Path.GetDirectoryName(typeof(MemberCallGraphFixture).Assembly.Location)!],
+            MermaidOutput = true,
+            TipLevel = TipLevel.Quiet,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Callers", result.Output);
+        Assert.DoesNotContain("graph TD", result.Output);
+        Assert.Empty(result.Error);
+    }
+
+    [Fact]
     public async Task CallGraphSection_RendersEdgeTableByDefault()
     {
         var result = await RunCallGraphAsync(
@@ -1443,6 +1651,8 @@ public class MemberCallGraphSectionTests
 
 public static class MemberCallGraphFixture
 {
+    public static int Data;
+
     public static void RootCall() => Mid();
 
     public static void Mid() => Inner();

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -554,7 +554,11 @@ public class ApiCommand
             ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
             : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         includeSections.Add(SectionNames.Callers);
-        return options with { IncludeSections = includeSections };
+        return options with
+        {
+            IncludeSections = includeSections,
+            CallerScopeSectionImplicitlySelected = true
+        };
     }
 
     private static bool HasAuthoredMemberSectionRequest(MemberOptions options)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -4241,6 +4241,19 @@ public class ApiCommand
     private static string? GetExplicitCallerAnalysisSection(
         ApiOptions options)
     {
+        if (options is MemberOptions
+            {
+                MemberSectionsPreResolved: true,
+                IncludeSections: { } authoritativeSections
+            })
+        {
+            return authoritativeSections.Contains(SectionNames.Callers)
+                ? SectionNames.Callers
+                : authoritativeSections.Contains(SectionNames.CallGraph)
+                    ? SectionNames.CallGraph
+                    : null;
+        }
+
         foreach (var selector in options.Select ?? [])
         {
             if (selector.Equals(
@@ -4277,20 +4290,7 @@ public class ApiCommand
             }
         }
 
-        if (options is not MemberOptions
-            {
-                MemberSectionsPreResolved: true,
-                IncludeSections: { } sections
-            })
-        {
-            return null;
-        }
-
-        return sections.Contains(SectionNames.Callers)
-            ? SectionNames.Callers
-            : sections.Contains(SectionNames.CallGraph)
-                ? SectionNames.CallGraph
-                : null;
+        return null;
     }
 
     private static bool ShouldRenderMemberIndex(ApiOptions options)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -4255,6 +4255,26 @@ public class ApiCommand
             }
         }
 
+        if (options is MemberOptions
+            && options.Select is { Length: > 0 })
+        {
+            var pipeline = ApiMemberSectionPipelines.Create(options);
+            var resolved = SelectResolver.ResolveSelectAsSections(
+                options.Select,
+                pipeline.SelectableSectionNames,
+                pipeline.InfoSectionNames,
+                pipeline.GetCategoryMap(),
+                options.SelectDefault);
+            if (!resolved.HasError
+                && resolved.Sections is { Count: 1 } singleton)
+            {
+                if (singleton.Contains(SectionNames.Callers))
+                    return SectionNames.Callers;
+                if (singleton.Contains(SectionNames.CallGraph))
+                    return SectionNames.CallGraph;
+            }
+        }
+
         if (options is not MemberOptions
             {
                 MemberSectionsPreResolved: true,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -2665,12 +2665,8 @@ public class ApiCommand
     {
         var sink = output ?? Console.Out;
 
-        if (IsInvalidAnnotatedSourceDocumentJsonSelection(options))
-        {
-            CommandError.Write(
-                $"section '{SectionNames.AnnotatedSourceDocument}' must be the only selected section under --json.");
+        if (RejectUnsupportedAnnotatedSourceDocumentJson(options))
             return 1;
-        }
 
         if (RejectUnsupportedCallerDocumentJson(options))
             return 1;
@@ -4173,9 +4169,11 @@ public class ApiCommand
         => options.JsonOutput
            && !options.Count
            && !IsProjectionRequested(options)
-           && options.IncludeSections is { Count: 1 } sections
-           && sections.Contains(SectionNames.AnnotatedSourceDocument)
-           && HasOnlyExplicitAnnotatedSourceDocumentSelectors(options);
+           && (options.IncludeSections is { Count: 1 } sections
+               && sections.Contains(SectionNames.AnnotatedSourceDocument)
+               && HasOnlyExplicitAnnotatedSourceDocumentSelectors(options)
+               || options.IncludeSections is null
+               && HasOnlyExplicitAnnotatedSourceDocumentSelectors(options));
 
     private static bool IsInvalidAnnotatedSourceDocumentJsonSelection(ApiOptions options)
         => options.JsonOutput
@@ -4186,6 +4184,21 @@ public class ApiCommand
            && HasExplicitAnnotatedSourceDocumentSelector(options)
            && (sections.Count != 1
                || !HasOnlyExplicitAnnotatedSourceDocumentSelectors(options));
+
+    internal static bool RejectUnsupportedAnnotatedSourceDocumentJson(
+        ApiOptions options)
+    {
+        if (!IsInvalidAnnotatedSourceDocumentJsonSelection(options)
+            && !(options is MemberOptions { HasCallerScope: true }
+                 && IsAnnotatedSourceDocumentJson(options)))
+        {
+            return false;
+        }
+
+        CommandError.Write(
+            $"section '{SectionNames.AnnotatedSourceDocument}' must be the only selected section under --json.");
+        return true;
+    }
 
     private static bool HasOnlyExplicitAnnotatedSourceDocumentSelectors(ApiOptions options)
         => options is MemberOptions { MemberSectionsPreResolved: true }

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -2673,6 +2673,9 @@ public class ApiCommand
             return 1;
         }
 
+        if (RejectUnsupportedCallerDocumentJson(options))
+            return 1;
+
         if (options is TypeOptions { ShapeOutput: true } typeOptions && !options.Count)
         {
             ApiOutputFormatter.WriteShapeOutput(
@@ -2753,15 +2756,6 @@ public class ApiCommand
                 CommandError.Write(
                     "Document --json cannot represent Body Shapes analysis. "
                     + "Use --jsonl, --tsv, or --table.");
-                return 1;
-            }
-            var unsupportedCallerSection =
-                GetExplicitCallerAnalysisSection(options);
-            if (unsupportedCallerSection is not null)
-            {
-                CommandError.Write(
-                    $"Document --json cannot represent {unsupportedCallerSection} analysis. "
-                    + "Use --jsonl, --tsv, --table, or a graph output format.");
                 return 1;
             }
             // --fields/--columns select table columns; document JSON has no column-slicing
@@ -4223,6 +4217,24 @@ public class ApiCommand
                    || selector.Equals(
                        "Optimization Opportunities",
                        StringComparison.OrdinalIgnoreCase)) == true;
+
+    internal static bool RejectUnsupportedCallerDocumentJson(
+        ApiOptions options)
+    {
+        if (!options.JsonOutput
+            || options.Count
+            || options.Discover is not null
+            || IsProjectionRequested(options)
+            || GetExplicitCallerAnalysisSection(options) is not { } section)
+        {
+            return false;
+        }
+
+        CommandError.Write(
+            $"Document --json cannot represent {section} analysis. "
+            + "Use --jsonl, --tsv, --table, or a graph output format.");
+        return true;
+    }
 
     private static string? GetExplicitCallerAnalysisSection(
         ApiOptions options)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -571,7 +571,8 @@ public class ApiCommand
            && options.HasCallerScope
            && options.IncludeSections is { } sections
            && (sections.Contains(SectionNames.Callers, StringComparer.OrdinalIgnoreCase)
-               && ApiMemberDetailSectionDescriptors.Callers.CanRender(type)
+               && (ApiMemberSectionPipelines.ShouldAggregateImplicitCallers(type, options)
+                   || ApiMemberDetailSectionDescriptors.Callers.CanRender(type))
                || sections.Contains(SectionNames.CallGraph, StringComparer.OrdinalIgnoreCase)
                && ApiMemberDetailSectionDescriptors.CallGraph.CanRender(type));
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -572,7 +572,7 @@ public class ApiCommand
            && options.HasCallerScope
            && options.IncludeSections is { } sections
            && (sections.Contains(SectionNames.Callers, StringComparer.OrdinalIgnoreCase)
-               && (ApiMemberSectionPipelines.ShouldAggregateImplicitCallers(type, options)
+               && (ApiMemberSectionPipelines.ShouldAggregateCallers(type, options)
                    || ApiMemberDetailSectionDescriptors.Callers.CanRender(type))
                || sections.Contains(SectionNames.CallGraph, StringComparer.OrdinalIgnoreCase)
                && ApiMemberDetailSectionDescriptors.CallGraph.CanRender(type));

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -610,6 +610,7 @@ public class ApiCommand
     private static bool HasAuthoredMemberSectionRequest(MemberOptions options)
         => options.MemberSectionsPreResolved
            || options.Select is { Length: > 0 }
+           || options.SelectDefault
            || options.Discover is { Length: > 0 }
            || options.BodyKindQuery.HasFilter;
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -4300,7 +4300,7 @@ public class ApiCommand
         if (options is MemberOptions
             {
                 MemberSectionsPreResolved: true,
-                IncludeSections: { } authoritativeSections
+                ExactIncludeSections: { } authoritativeSections
             })
         {
             return authoritativeSections.Contains(SectionNames.Callers)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -2756,13 +2756,7 @@ public class ApiCommand
                 return 1;
             }
             var unsupportedCallerSection =
-                options.IncludeSections?.FirstOrDefault(section =>
-                    section.Equals(
-                        SectionNames.Callers,
-                        StringComparison.OrdinalIgnoreCase)
-                    || section.Equals(
-                        SectionNames.CallGraph,
-                        StringComparison.OrdinalIgnoreCase));
+                GetExplicitCallerAnalysisSection(options);
             if (unsupportedCallerSection is not null)
             {
                 CommandError.Write(
@@ -4229,6 +4223,41 @@ public class ApiCommand
                    || selector.Equals(
                        "Optimization Opportunities",
                        StringComparison.OrdinalIgnoreCase)) == true;
+
+    private static string? GetExplicitCallerAnalysisSection(
+        ApiOptions options)
+    {
+        foreach (var selector in options.Select ?? [])
+        {
+            if (selector.Equals(
+                    SectionNames.Callers,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return SectionNames.Callers;
+            }
+            if (selector.Equals(
+                    SectionNames.CallGraph,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return SectionNames.CallGraph;
+            }
+        }
+
+        if (options is not MemberOptions
+            {
+                MemberSectionsPreResolved: true,
+                IncludeSections: { } sections
+            })
+        {
+            return null;
+        }
+
+        return sections.Contains(SectionNames.Callers)
+            ? SectionNames.Callers
+            : sections.Contains(SectionNames.CallGraph)
+                ? SectionNames.CallGraph
+                : null;
+    }
 
     private static bool ShouldRenderMemberIndex(ApiOptions options)
         => options.IncludeSections?.Contains(SectionNames.MemberIndex) == true;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -4284,7 +4284,7 @@ public class ApiCommand
 
         CommandError.Write(
             $"Document --json cannot represent {section} analysis. "
-            + "Use --jsonl, --tsv, --table, or a graph output format.");
+            + "Use --jsonl, --tsv, --table, --count, or a graph output format.");
         return true;
     }
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -564,8 +564,10 @@ public class ApiCommand
 
     private static bool HasAuthoredMemberSectionRequest(MemberOptions options)
         => options.MemberSectionsPreResolved
-           || options.HasSectionQuery
-           || options.Discover is not null;
+           || options.Select is { Length: > 0 }
+           || options.Columns is { Length: > 0 }
+           || options.Fields is { Length: > 0 }
+           || options.BodyKindQuery.HasFilter;
 
     internal static bool RequiresCallerScopeResolution(MemberOptions options, ApiType type)
         => !MemberCommand.IsWholeDocumentJson(options)
@@ -4188,12 +4190,8 @@ public class ApiCommand
     internal static bool RejectUnsupportedAnnotatedSourceDocumentJson(
         ApiOptions options)
     {
-        if (!IsInvalidAnnotatedSourceDocumentJsonSelection(options)
-            && !(options is MemberOptions { HasCallerScope: true }
-                 && IsAnnotatedSourceDocumentJson(options)))
-        {
+        if (!IsInvalidAnnotatedSourceDocumentJsonSelection(options))
             return false;
-        }
 
         CommandError.Write(
             $"section '{SectionNames.AnnotatedSourceDocument}' must be the only selected section under --json.");

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -2755,6 +2755,21 @@ public class ApiCommand
                     + "Use --jsonl, --tsv, or --table.");
                 return 1;
             }
+            var unsupportedCallerSection =
+                options.IncludeSections?.FirstOrDefault(section =>
+                    section.Equals(
+                        SectionNames.Callers,
+                        StringComparison.OrdinalIgnoreCase)
+                    || section.Equals(
+                        SectionNames.CallGraph,
+                        StringComparison.OrdinalIgnoreCase));
+            if (unsupportedCallerSection is not null)
+            {
+                CommandError.Write(
+                    $"Document --json cannot represent {unsupportedCallerSection} analysis. "
+                    + "Use --jsonl, --tsv, --table, or a graph output format.");
+                return 1;
+            }
             // --fields/--columns select table columns; document JSON has no column-slicing
             // facility, so the combination is rejected rather than silently dropped. A scalar
             // payload projection (--value/--print) does compose, and is handled above.

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -542,6 +542,8 @@ public class ApiCommand
         if (!options.HasCallerScope
             || options.Tree
             || IsStandaloneMermaid(options)
+            || options.JsonOutput
+            && options.IncludeSections is not { Count: > 0 }
             || HasAuthoredMemberSectionRequest(options)
             || !pipeline.SelectableSectionNames.Contains(
                 SectionNames.Callers,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -349,6 +349,7 @@ public class ApiCommand
             MemberPipelineDeferredToLookup = false,
             MemberSelectionDeferredToLookup = false
         };
+        resolved = IncludeCallerScopeSection(resolved, pipeline);
 
         return ValidateResolvedMemberSelection(resolved, pipeline);
     }
@@ -424,11 +425,13 @@ public class ApiCommand
         MemberOptions options,
         SectionPipeline<ApiType> pipeline)
     {
-        var resolved = options with
-        {
-            MemberPipelineDeferredToLookup = false,
-            MemberSelectionDeferredToLookup = false
-        };
+        var resolved = IncludeCallerScopeSection(
+            options with
+            {
+                MemberPipelineDeferredToLookup = false,
+                MemberSelectionDeferredToLookup = false
+            },
+            pipeline);
         return ValidateResolvedMemberSelection(resolved, pipeline);
     }
 
@@ -531,6 +534,48 @@ public class ApiCommand
 
         return resolvedSelection;
     }
+
+    private static MemberOptions IncludeCallerScopeSection(
+        MemberOptions options,
+        SectionPipeline<ApiType> pipeline)
+    {
+        if (!options.HasCallerScope
+            || options.Tree
+            || IsStandaloneMermaid(options)
+            || HasAuthoredMemberSectionRequest(options)
+            || !pipeline.SelectableSectionNames.Contains(
+                SectionNames.Callers,
+                StringComparer.OrdinalIgnoreCase))
+            return options;
+        if (options.IncludeSections?.Contains(SectionNames.Callers) == true)
+            return options;
+
+        var includeSections = options.IncludeSections is { Count: > 0 } existing
+            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        includeSections.Add(SectionNames.Callers);
+        return options with { IncludeSections = includeSections };
+    }
+
+    private static bool HasAuthoredMemberSectionRequest(MemberOptions options)
+        => options.MemberSectionsPreResolved
+           || options.HasSectionQuery
+           || options.Discover is not null;
+
+    internal static bool RequiresCallerScopeResolution(MemberOptions options, ApiType type)
+        => !MemberCommand.IsWholeDocumentJson(options)
+           && options.HasCallerScope
+           && options.IncludeSections is { } sections
+           && (sections.Contains(SectionNames.Callers, StringComparer.OrdinalIgnoreCase)
+               && ApiMemberDetailSectionDescriptors.Callers.CanRender(type)
+               || sections.Contains(SectionNames.CallGraph, StringComparer.OrdinalIgnoreCase)
+               && ApiMemberDetailSectionDescriptors.CallGraph.CanRender(type));
+
+    private static bool IsStandaloneMermaid(MemberOptions options)
+        => options.MermaidOutput
+           && (options.FormatFlagExplicitlySet
+               || options.IncludeSections is { Count: 1 } sections
+               && sections.Contains(SectionNames.CallGraph, StringComparer.OrdinalIgnoreCase));
 
     internal static int ExecuteStructuralTypeDiscovery(
         ApiOptions options,
@@ -739,7 +784,8 @@ public class ApiCommand
         var deferMemberSelection = memberPipelineRequiresLookup
             && options.IncludeSections is null
             && (options.Select is not null
-                || options.SelectDefault);
+                || options.SelectDefault
+                || options is MemberOptions { HasCallerScope: true });
         if (options is MemberOptions memberOptions && memberPipelineRequiresLookup)
         {
             options = memberOptions with
@@ -887,6 +933,12 @@ public class ApiCommand
             {
                 IncludeSections = [SectionNames.BodyShapes],
             };
+        }
+
+        if (options is MemberOptions callerScopeOptions
+            && !callerScopeOptions.MemberPipelineDeferredToLookup)
+        {
+            options = IncludeCallerScopeSection(callerScopeOptions, memberPipeline);
         }
 
         // A deferred select has no IncludeSections yet, and the preamble cannot know whether a

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -539,34 +539,78 @@ public class ApiCommand
         MemberOptions options,
         SectionPipeline<ApiType> pipeline)
     {
+        var discoveredCallerSections =
+            ResolveDiscoveredCallerScopeSections(options, pipeline);
         if (!options.HasCallerScope
             || options.Tree
             || IsStandaloneMermaid(options)
             || IsWholeDocumentJson(options)
             || HasAuthoredMemberSectionRequest(options)
-            || !pipeline.SelectableSectionNames.Contains(
-                SectionNames.Callers,
-                StringComparer.OrdinalIgnoreCase))
+                && discoveredCallerSections.Count == 0)
             return options;
-        if (options.IncludeSections?.Contains(SectionNames.Callers) == true)
+
+        if (discoveredCallerSections.Count == 0)
+        {
+            if (!pipeline.SelectableSectionNames.Contains(
+                    SectionNames.Callers,
+                    StringComparer.OrdinalIgnoreCase))
+            {
+                return options;
+            }
+
+            discoveredCallerSections.Add(SectionNames.Callers);
+        }
+
+        if (discoveredCallerSections.All(
+                section => options.IncludeSections?.Contains(
+                    section,
+                    StringComparer.OrdinalIgnoreCase) == true))
+        {
             return options;
+        }
 
         var includeSections = options.IncludeSections is { Count: > 0 } existing
             ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
             : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        includeSections.Add(SectionNames.Callers);
+        includeSections.UnionWith(discoveredCallerSections);
         return options with
         {
             IncludeSections = includeSections,
-            CallerScopeSectionImplicitlySelected = true
+            CallerScopeSectionImplicitlySelected =
+                discoveredCallerSections.Contains(SectionNames.Callers)
         };
+    }
+
+    private static HashSet<string> ResolveDiscoveredCallerScopeSections(
+        MemberOptions options,
+        SectionPipeline<ApiType> pipeline)
+    {
+        if (options.Discover is not { Length: > 0 } discover)
+            return [];
+
+        var resolved = SelectResolver.ResolveSelectAsSections(
+            discover,
+            pipeline.SelectableSectionNames,
+            pipeline.InfoSectionNames,
+            pipeline.GetCategoryMap());
+        if (resolved.HasError || resolved.Sections is not { } sections)
+            return [];
+
+        return sections
+            .Where(section =>
+                section.Equals(
+                    SectionNames.Callers,
+                    StringComparison.OrdinalIgnoreCase)
+                || section.Equals(
+                    SectionNames.CallGraph,
+                    StringComparison.OrdinalIgnoreCase))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     private static bool HasAuthoredMemberSectionRequest(MemberOptions options)
         => options.MemberSectionsPreResolved
            || options.Select is { Length: > 0 }
-           || options.Columns is { Length: > 0 }
-           || options.Fields is { Length: > 0 }
+           || options.Discover is { Length: > 0 }
            || options.BodyKindQuery.HasFilter;
 
     internal static bool RequiresCallerScopeResolution(MemberOptions options, ApiType type)

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -542,8 +542,7 @@ public class ApiCommand
         if (!options.HasCallerScope
             || options.Tree
             || IsStandaloneMermaid(options)
-            || options.JsonOutput
-            && options.IncludeSections is not { Count: > 0 }
+            || IsWholeDocumentJson(options)
             || HasAuthoredMemberSectionRequest(options)
             || !pipeline.SelectableSectionNames.Contains(
                 SectionNames.Callers,
@@ -4221,10 +4220,7 @@ public class ApiCommand
     internal static bool RejectUnsupportedCallerDocumentJson(
         ApiOptions options)
     {
-        if (!options.JsonOutput
-            || options.Count
-            || options.Discover is not null
-            || IsProjectionRequested(options)
+        if (!IsWholeDocumentJson(options)
             || GetExplicitCallerAnalysisSection(options) is not { } section)
         {
             return false;
@@ -4235,6 +4231,12 @@ public class ApiCommand
             + "Use --jsonl, --tsv, --table, or a graph output format.");
         return true;
     }
+
+    private static bool IsWholeDocumentJson(ApiOptions options)
+        => options.JsonOutput
+           && !options.Count
+           && options.Discover is null
+           && !IsProjectionRequested(options);
 
     private static string? GetExplicitCallerAnalysisSection(
         ApiOptions options)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -39,8 +39,9 @@ public static class MemberCommand
             return 1;
         if (ApiCommand.RejectRouteIndependentOptionShape(options))
             return 1;
-        if (ApiCommand.RejectUnsupportedCallerDocumentJson(options)
-            || ApiCommand.RejectUnsupportedAnnotatedSourceDocumentJson(options))
+        if (options.RouterDeferredTypeOrMember
+            && (ApiCommand.RejectUnsupportedCallerDocumentJson(options)
+                || ApiCommand.RejectUnsupportedAnnotatedSourceDocumentJson(options)))
         {
             return 1;
         }

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -949,28 +949,6 @@ public static class MemberCommand
         return sections.Count > 0;
     }
 
-    private static MemberOptions ExcludeCallersSection(MemberOptions options)
-    {
-        var includeSections = options.IncludeSections is { } existing
-            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
-            : [];
-        includeSections.Remove(SectionNames.Callers);
-        HashSet<string>? exactIncludeSections = null;
-        if (options.ExactIncludeSectionsOverride is { } exactExisting)
-        {
-            exactIncludeSections = new HashSet<string>(
-                exactExisting,
-                StringComparer.OrdinalIgnoreCase);
-            exactIncludeSections.Remove(SectionNames.Callers);
-        }
-        return options with
-        {
-            IncludeSections = includeSections,
-            ExactIncludeSectionsOverride = exactIncludeSections,
-            CallerScopeSectionImplicitlySelected = false
-        };
-    }
-
     private static bool HasAuthoredSectionRequest(MemberOptions options)
         => options.MemberSectionsPreResolved
            || options.Select is { Length: > 0 }
@@ -1084,7 +1062,20 @@ public static class MemberCommand
             ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
             : [];
         includeSections.Remove(SectionNames.Callers);
-        return options with { IncludeSections = includeSections };
+        HashSet<string>? exactIncludeSections = null;
+        if (options.ExactIncludeSectionsOverride is { } exactExisting)
+        {
+            exactIncludeSections = new HashSet<string>(
+                exactExisting,
+                StringComparer.OrdinalIgnoreCase);
+            exactIncludeSections.Remove(SectionNames.Callers);
+        }
+        return options with
+        {
+            IncludeSections = includeSections,
+            ExactIncludeSectionsOverride = exactIncludeSections,
+            CallerScopeSectionImplicitlySelected = false
+        };
     }
 
     private static MemberOptions IncludeCallersSection(MemberOptions options)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -44,6 +44,8 @@ public static class MemberCommand
             var (preamble, error) = ApiCommand.RunPreamble(options);
             if (error.HasValue) return error.Value;
             options = (MemberOptions)preamble.Options;
+            if (ApiCommand.RejectUnsupportedCallerDocumentJson(options))
+                return 1;
         }
         else if (options.Discover != null
                  && !options.EffectiveDiscovery)
@@ -211,6 +213,8 @@ public static class MemberCommand
                     PackageRangeAddress = null,
                     ProjectAssetsPath = projectAssetsPath,
                 };
+                if (ApiCommand.RejectUnsupportedCallerDocumentJson(options))
+                    return 1;
             }
             var memberPipeline = ApiMemberSectionPipelines.Create(options);
 

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -296,18 +296,6 @@ public static class MemberCommand
             MemberOptions effectiveOptions = options;
             if (!options.DocsExplicitlySet && options.Verbosity >= Verbosity.Normal)
                 effectiveOptions = options with { ShowDocs = true };
-            var discoveredCallerSections =
-                GetDiscoveredCallerSections(effectiveOptions);
-            var callersImplicitlySelected = effectiveOptions.HasCallerScope
-                && !IsWholeDocumentJson(effectiveOptions)
-                && (!HasAuthoredSectionRequest(effectiveOptions)
-                    || discoveredCallerSections.Count > 0);
-            if (callersImplicitlySelected)
-            {
-                effectiveOptions = IncludeCallerScopeSections(
-                    effectiveOptions,
-                    discoveredCallerSections);
-            }
             var aggregateCallers =
                 ApiMemberSectionPipelines.ShouldAggregateCallers(
                     apiType,
@@ -362,12 +350,7 @@ public static class MemberCommand
                             detailPipeline)
                         is not { } detailOptions)
                         return 1;
-                    effectiveOptions = aggregateCallers
-                        ? IncludeCallerScopeSections(
-                            detailOptions,
-                            discoveredCallerSections,
-                            callersImplicitlySelected)
-                        : detailOptions;
+                    effectiveOptions = detailOptions;
                 }
             }
 
@@ -623,7 +606,7 @@ public static class MemberCommand
             // Expand --bin/--directory, --project, and --caller-package into assemblies
             // for cross-assembly callers and Call Graph traversal, in addition to the
             // selected member's own assembly.
-            if (RequiresCallerScopeResolution(effectiveOptions))
+            if (ApiCommand.RequiresCallerScopeResolution(effectiveOptions, apiType))
             {
                 var ownAssembly = effectiveOptions.DllPath ?? runtimeAssemblyPath ?? apiDllPath;
                 callerScopeAssemblySet = await CallerScopeResolver.ResolveAsync(
@@ -936,60 +919,6 @@ public static class MemberCommand
         return sections.Count > 0;
     }
 
-    private static MemberOptions IncludeCallerScopeSections(
-        MemberOptions options,
-        IReadOnlySet<string> discoveredCallerSections,
-        bool implicitlySelected = true)
-    {
-        var includeSections = options.IncludeSections is { Count: > 0 } existing
-            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
-            : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (discoveredCallerSections.Count > 0)
-            includeSections.UnionWith(discoveredCallerSections);
-        else
-            includeSections.Add(SectionNames.Callers);
-        return options with
-        {
-            IncludeSections = includeSections,
-            CallerScopeSectionImplicitlySelected =
-                implicitlySelected
-                && includeSections.Contains(SectionNames.Callers)
-        };
-    }
-
-    private static HashSet<string> GetDiscoveredCallerSections(
-        MemberOptions options)
-    {
-        if (options.Discover is not { Length: > 0 } discover)
-            return [];
-
-        var pipeline = ApiMemberSectionPipelines.Create(options);
-        var resolved = SelectResolver.ResolveSelectAsSections(
-            discover,
-            pipeline.SelectableSectionNames,
-            pipeline.InfoSectionNames,
-            pipeline.GetCategoryMap());
-        if (resolved.HasError || resolved.Sections is not { } sections)
-            return [];
-
-        return sections
-            .Where(section =>
-                section.Equals(
-                    SectionNames.Callers,
-                    StringComparison.OrdinalIgnoreCase)
-                || section.Equals(
-                    SectionNames.CallGraph,
-                    StringComparison.OrdinalIgnoreCase))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-    }
-
-    private static bool RequiresCallerScopeResolution(MemberOptions options)
-        => !IsWholeDocumentJson(options)
-           && options.HasCallerScope
-           && options.IncludeSections is { } sections
-           && (sections.Contains(SectionNames.Callers)
-               || sections.Contains(SectionNames.CallGraph));
-
     private static MemberOptions ExcludeCallersSection(MemberOptions options)
     {
         var includeSections = options.IncludeSections is { } existing
@@ -1019,7 +948,7 @@ public static class MemberCommand
            || options.Discover is { Length: > 0 }
            || options.BodyKindQuery.HasFilter;
 
-    private static bool IsWholeDocumentJson(MemberOptions options)
+    internal static bool IsWholeDocumentJson(MemberOptions options)
         => options.JsonOutput
            && !options.Count
            && options.Discover is null

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -256,6 +256,9 @@ public static class MemberCommand
             else
                 return 1;
 
+            if (ApiCommand.RejectUnsupportedCallerDocumentJson(options))
+                return 1;
+
             if (options.BodyKindQuery.HasFilter
                 && options.IncludeSections is null
                 && options.Discover is null)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -32,10 +32,18 @@ public static class MemberCommand
             return 1;
         }
 
+        if (options.IncludeSections is not null)
+            options = options with { MemberSectionsPreResolved = true };
+
         if (ApiCommand.RejectUniversallyInvalidMemberSelect(options))
             return 1;
         if (ApiCommand.RejectRouteIndependentOptionShape(options))
             return 1;
+        if (ApiCommand.RejectUnsupportedCallerDocumentJson(options)
+            || ApiCommand.RejectUnsupportedAnnotatedSourceDocumentJson(options))
+        {
+            return 1;
+        }
 
         var unresolvedOptions = options;
         if (!options.RouterDeferredTypeOrMember)
@@ -44,8 +52,11 @@ public static class MemberCommand
             var (preamble, error) = ApiCommand.RunPreamble(options);
             if (error.HasValue) return error.Value;
             options = (MemberOptions)preamble.Options;
-            if (ApiCommand.RejectUnsupportedCallerDocumentJson(options))
+            if (ApiCommand.RejectUnsupportedCallerDocumentJson(options)
+                || ApiCommand.RejectUnsupportedAnnotatedSourceDocumentJson(options))
+            {
                 return 1;
+            }
         }
         else if (options.Discover != null
                  && !options.EffectiveDiscovery)
@@ -213,8 +224,11 @@ public static class MemberCommand
                     PackageRangeAddress = null,
                     ProjectAssetsPath = projectAssetsPath,
                 };
-                if (ApiCommand.RejectUnsupportedCallerDocumentJson(options))
+                if (ApiCommand.RejectUnsupportedCallerDocumentJson(options)
+                    || ApiCommand.RejectUnsupportedAnnotatedSourceDocumentJson(options))
+                {
                     return 1;
+                }
             }
             var memberPipeline = ApiMemberSectionPipelines.Create(options);
 
@@ -256,8 +270,11 @@ public static class MemberCommand
             else
                 return 1;
 
-            if (ApiCommand.RejectUnsupportedCallerDocumentJson(options))
+            if (ApiCommand.RejectUnsupportedCallerDocumentJson(options)
+                || ApiCommand.RejectUnsupportedAnnotatedSourceDocumentJson(options))
+            {
                 return 1;
+            }
 
             if (options.BodyKindQuery.HasFilter
                 && options.IncludeSections is null

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -1048,6 +1048,15 @@ public static class MemberCommand
         return members;
     }
 
+    private static MemberOptions ExcludeCallersSection(MemberOptions options)
+    {
+        var includeSections = options.IncludeSections is { } existing
+            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
+            : [];
+        includeSections.Remove(SectionNames.Callers);
+        return options with { IncludeSections = includeSections };
+    }
+
     private static readonly string[] SingleOverloadSectionNames =
     [
         SectionNames.Signature,

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -369,6 +369,11 @@ public static class MemberCommand
                         OverloadIndex = autoCandidate.SelectorIndex,
                         AutoSelectedSingleOverload = true
                     };
+                    if (aggregateCallers
+                        && !effectiveOptions.CallerScopeSectionImplicitlySelected)
+                    {
+                        inventorySections = IncludeCallersSection(inventorySections);
+                    }
                     var detailPipeline = ApiMemberSectionPipelines.Create(inventorySections);
                     if (ApiCommand.FinalizeResolvedMemberSelection(
                             inventorySections,
@@ -1079,6 +1084,15 @@ public static class MemberCommand
             ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
             : [];
         includeSections.Remove(SectionNames.Callers);
+        return options with { IncludeSections = includeSections };
+    }
+
+    private static MemberOptions IncludeCallersSection(MemberOptions options)
+    {
+        var includeSections = options.IncludeSections is { } existing
+            ? new HashSet<string>(existing, StringComparer.OrdinalIgnoreCase)
+            : [];
+        includeSections.Add(SectionNames.Callers);
         return options with { IncludeSections = includeSections };
     }
 


### PR DESCRIPTION
## Summary

Make caller scope an input to the resolved member pipeline without changing the requested output shape. `Callers` is injected only where the pipeline publishes it and only when the selected format permits a companion section.

External directories, projects, and packages are acquired only when effective `Callers` or `Call Graph` output can render. Local assembly setup remains available to broad body-index sections, and count, TSV, value, tree, and Mermaid retain their cardinality contracts.

## Stack

Slice 5 of 6. This PR targets #4261. It replaces #4109 because GitHub would not retarget that PR's frozen stacked base.

Residual work:

- Slice 6: explicit broad-member `Member Info` census.

The restack from `e8559b83b` to `e4457f3a3` preserved all four commits exactly (`git range-diff` reported `=` for each).

## Validation

- Release solution build
- Full CLI Release suite passed before the base-only restack
- 46 focused member call-graph and caller-scope tests passed
