### PR TITLE
Use product rendering for finalizers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Fixtures;
 using DotnetInspector.Services;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.DecompilerHarness;
@@ -270,6 +271,99 @@ public class FidelityCheckGeneratedFilterTests
         {
             DeleteFixture(assemblyPath);
         }
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void Evaluate_UsesProductWholeMemberForFinalizer()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class FinalizerWholeMemberFixture
+            {
+                private static bool _finalized;
+
+                ~FinalizerWholeMemberFixture() => _finalized = true;
+            }
+            """);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(assemblyPath));
+            var reader = pe.GetMetadataReader();
+            var type = reader.GetTypeDefinition(Assert.Single(
+                reader.TypeDefinitions,
+                handle => reader.GetString(reader.GetTypeDefinition(handle).Name)
+                    == "FinalizerWholeMemberFixture"));
+            var finalizer = Assert.Single(
+                type.GetMethods(),
+                handle => reader.GetString(reader.GetMethodDefinition(handle).Name) == "Finalize");
+
+            using var source = MetadataSource.Open(assemblyPath);
+            var wholeMember = FidelityCheck.TryRenderTargetMember(
+                pe,
+                source,
+                finalizer,
+                targeted: true,
+                isPrimaryConstructor: false);
+
+            Assert.NotNull(wholeMember);
+            Assert.IsType<Microsoft.CodeAnalysis.CSharp.Syntax.DestructorDeclarationSyntax>(
+                Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ParseMemberDeclaration(
+                    wholeMember.Value.Text));
+
+            var result = Assert.Single(
+                FidelityCheck.Evaluate(
+                    assemblyPath,
+                    typeName => typeName == "FinalizerWholeMemberFixture",
+                    method => method.Method == "Finalize"));
+            Assert.True(result.UsedProductWholeMember);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+
+            var batchResult = Assert.Single(
+                FidelityCheck.Evaluate(
+                    assemblyPath,
+                    typeName => typeName == "FinalizerWholeMemberFixture"),
+                candidate => candidate.Method == "Finalize");
+            Assert.True(batchResult.UsedProductWholeMember);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, batchResult.Status);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void Evaluate_DeclinesProductLiteralWholeMemberForVbFinalizer()
+    {
+        string assemblyPath = FixtureCatalog.DecompilerVbFinalizer.AssemblyPath();
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        var reader = pe.GetMetadataReader();
+        var type = reader.GetTypeDefinition(Assert.Single(
+            reader.TypeDefinitions,
+            handle => reader.GetString(reader.GetTypeDefinition(handle).Name) == "Handle"));
+        var finalizer = Assert.Single(
+            type.GetMethods(),
+            handle => reader.GetString(reader.GetMethodDefinition(handle).Name) == "Finalize");
+
+        using var source = MetadataSource.Open(assemblyPath);
+        var wholeMember = FidelityCheck.TryRenderTargetMember(
+            pe,
+            source,
+            finalizer,
+            targeted: true,
+            isPrimaryConstructor: false);
+
+        Assert.Null(wholeMember);
+
+        var result = Assert.Single(
+            FidelityCheck.Evaluate(
+                assemblyPath,
+                typeName => typeName == "Handle",
+                method => method.Method == "Finalize"));
+        Assert.False(result.UsedProductWholeMember);
+        Assert.Equal(FidelityCheck.CompileBackStatus.RecompileFail, result.Status);
+        Assert.Contains("CS0250", result.Detail);
     }
 
     [Fact]

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -3989,11 +3989,13 @@ static class FidelityCheck
     /// <summary>
     /// The product's whole-member render for a target method — the CSharp-owned
     /// signature (from Metadata's model) composed with the decompiler body —
-    /// replacing the harness's self-spelled signature. Ordinary constructors and
-    /// properties, and custom events are safe to migrate because the scaffold already applies the
+    /// replacing the harness's self-spelled signature. Ordinary constructors,
+    /// recovered destructors, properties, and custom events are safe to migrate
+    /// because the scaffold already applies the
     /// decompiler's separately captured lifted field initializers to reconstructed
     /// fields, while property and event renders own both accessor declarations and bodies.
-    /// Field-like and explicit-interface events remain on their existing fallback paths.
+    /// Field-like and explicit-interface events, and finalizers that cannot be
+    /// recovered as destructors, remain on their existing fallback paths.
     /// Non-essential custom attributes are omitted because the skeleton does not
     /// reproduce arbitrary attribute inheritance; compilation-required attributes
     /// such as <c>SkipLocalsInit</c> remain.
@@ -4013,7 +4015,7 @@ static class FidelityCheck
         if (!TargetApiIndex(pe).TryGetValue(token, out var entry))
             return null;
         if (isPrimaryConstructor
-            || entry.Member.Kind is not ("method" or "operator" or "constructor" or "property" or "event"))
+            || entry.Member.Kind is not ("method" or "operator" or "constructor" or "finalizer" or "property" or "event"))
             return null;
         if (entry.Member.Kind == "property"
             && entry.Type.Kind == "struct"
@@ -4039,6 +4041,12 @@ static class FidelityCheck
         if (entry.Member.Kind == "constructor"
             && SyntaxFactory.ParseMemberDeclaration(result.Text)
                 is not ConstructorDeclarationSyntax)
+        {
+            return null;
+        }
+        if (entry.Member.Kind == "finalizer"
+            && SyntaxFactory.ParseMemberDeclaration(result.Text)
+                is not DestructorDeclarationSyntax)
         {
             return null;
         }


### PR DESCRIPTION
Advances #2996

## Change

**Conclusion: PASS** — canonical C# finalizers remain compile-back Exact while their destructor declaration now comes from the Metadata/CSharp/Decompiler whole-member path instead of the harness's name/signature spelling heuristic.

- Admits Metadata-classified `finalizer` members only when the product emits a complete `DestructorDeclarationSyntax`.
- Exercises both targeted and batch rendering and records product whole-member provenance.
- Keeps noncanonical VB finalizers on visible legacy fallback: the product's faithful literal `void Finalize()` contains `base.Finalize()`, which C# compile-back rejects with `CS0250`.

## Scope and safety

- **Product impact:** none; product finalizer rendering is unchanged.
- **Compile-back impact:** decreases harness-owned C# spelling for recovered destructors without broadening acceptance to non-destructor shapes.
- **RTS boundary:** canonical C# finalizers stay Exact; this is an ownership/provenance improvement, not a bucket-count rescue. VB finalizers remain `RecompileFail CS0250`.

## Evidence

| Check | Result |
| --- | --- |
| Product build | `dotnet build dotnet-inspect.slnx -c Release` passed |
| Focused tests | `FidelityCheckGeneratedFilterTests` passed, 38/38 |
| Decompiler suite | passed, 5,311/5,311 |
| C# finalizer | targeted and batch `Exact`, `UsedProductWholeMember = true` |
| VB finalizer | product whole member declined; legacy `RecompileFail CS0250` preserved |

Validated at `e80dfa41ac84d60d99fd3dc7a5128bdfdbb26ccd`, integrating `main` tip `c969548544896c11738ae9c2a838ae5aa2f18e9b`.