### PR TITLE
Normalize evil pin path aliases

### DIFF
--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -72,7 +72,8 @@ if (args is ["--validate-pin", ..])
     bool anyMalformed = false;
     foreach (string candidate in candidates)
     {
-        string? problem = ValidatePinFile(candidate);
+        string path = ResolvePathIdentity(candidate);
+        string? problem = ValidatePinFile(path);
         anyMalformed |= problem is not null;
         // One line per path, in the order given, and never more than one: the reason can
         // quote the file's own bytes (a parser error echoes the text it choked on), and a
@@ -80,8 +81,8 @@ if (args is ["--validate-pin", ..])
         // like a verdict. A caller matching output to input by position rather than by
         // parsing prose is then reading what this loop decided, not what a pin file wrote.
         Console.Out.WriteLine(OneLine(problem is null
-            ? $"Pin file '{candidate}' is well formed."
-            : $"Pin file '{candidate}' {problem}."));
+            ? $"Pin file '{path}' is well formed."
+            : $"Pin file '{path}' {problem}."));
     }
 
     Environment.ExitCode = anyMalformed ? 2 : 0;
@@ -1177,6 +1178,63 @@ static PackageSweepJsonContext SweepJsonContext() =>
 // occupies one line no matter what the file it describes contains.
 static string OneLine(string text) =>
     new([.. text.Select(c => char.IsControl(c) ? ' ' : c)]);
+
+/// <summary>
+/// Returns one absolute spelling for a filesystem identity by resolving every existing
+/// symbolic-link component.
+///
+/// <para><c>Directory.GetCurrentDirectory()</c> reports the physical path on macOS, while
+/// an absolute command-line argument can retain an alias such as <c>/var</c> for
+/// <c>/private/var</c>. The validator normalizes at its path-input boundary so it and the
+/// sweep proper report the same file alike. <c>EvilPoolPinTests</c> gates this with an
+/// explicit directory alias as well as the platform temporary-directory spelling.</para>
+/// </summary>
+static string ResolvePathIdentity(string path) =>
+    ResolvePathIdentityCore(path, linksRemaining: 40);
+
+static string ResolvePathIdentityCore(string path, int linksRemaining)
+{
+    string fullPath;
+    try
+    {
+        fullPath = Path.GetFullPath(path);
+    }
+    catch (Exception ex) when (ex is ArgumentException or NotSupportedException
+        or PathTooLongException)
+    {
+        return path;
+    }
+
+    string? root = Path.GetPathRoot(fullPath);
+    if (string.IsNullOrEmpty(root))
+        return fullPath;
+
+    string resolved = root;
+    foreach (string component in fullPath[root.Length..].Split(
+        [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+        StringSplitOptions.RemoveEmptyEntries))
+    {
+        string next = Path.Combine(resolved, component);
+        FileSystemInfo entry = Directory.Exists(next)
+            ? new DirectoryInfo(next)
+            : new FileInfo(next);
+
+        try
+        {
+            FileSystemInfo? target = entry.ResolveLinkTarget(returnFinalTarget: true);
+            resolved = target is not null && linksRemaining > 0
+                ? ResolvePathIdentityCore(target.FullName, linksRemaining - 1)
+                : next;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException
+            or NotSupportedException)
+        {
+            resolved = next;
+        }
+    }
+
+    return resolved;
+}
 
 // Reading and shape-checking a pin file in one place, so --validate-pin and the sweep
 // proper cannot disagree about what a well-formed pin is. Returns null when the file

--- a/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
@@ -178,7 +178,9 @@ public class EvilPoolPinTests
                 [.. Encoding.UTF8.GetBytes(valid[..^1]), .. ",\"opaque\":\""u8, 0xFF, .. "\"}"u8]);
             written.Add(("a file that is not valid UTF-8", "encoding", notUtf8));
 
-            var verdicts = ValidateWithSweep(root, [committed, .. written.Select(w => w.Path)]);
+            var verdicts = ValidateWithSweep(root, [committed, .. written.Select(w => w.Path)])
+                .Select(verdict => verdict.Problem)
+                .ToArray();
 
             Assert.True(
                 verdicts[0] is null,
@@ -295,17 +297,37 @@ public class EvilPoolPinTests
                 writer.Write("\"}");
             }
 
-            string? validatorSaid = ValidateWithSweep(root, [oversized])[0];
-            Assert.NotNull(validatorSaid);
+            PinVerdict validator;
+            string sweepRoot = fakeRoot;
+            if (OperatingSystem.IsWindows())
+            {
+                validator = ValidateWithSweep(root, [oversized])[0];
+            }
+            else
+            {
+                string aliasRoot = Path.Combine(scratch, "root-alias");
+                Directory.CreateSymbolicLink(aliasRoot, fakeRoot);
+                string aliased = Path.Combine(
+                    aliasRoot,
+                    Path.GetRelativePath(fakeRoot, oversized));
+                var verdicts = ValidateWithSweep(root, [oversized, aliased]);
 
-            var sweep = RunSweep(root, fakeRoot, Path.Combine(scratch, "pool"));
+                Assert.Equal(verdicts[0].Path, verdicts[1].Path);
+                Assert.Equal(verdicts[0].Problem, verdicts[1].Problem);
+                validator = verdicts[1];
+                sweepRoot = aliasRoot;
+            }
+
+            Assert.NotNull(validator.Problem);
+
+            var sweep = RunSweep(root, sweepRoot, Path.Combine(scratch, "pool"));
 
             Assert.True(
                 sweep.ExitCode == 2,
                 $"the sweep exited {sweep.ExitCode} over a pin file its own validator "
-                + $"refused ({validatorSaid}); stderr was:\n{sweep.Errors}");
+                + $"refused ({validator.Problem}); stderr was:\n{sweep.Errors}");
 
-            string expected = $"Pin file '{oversized}' {validatorSaid}.";
+            string expected = $"Pin file '{validator.Path}' {validator.Problem}.";
             Assert.True(
                 sweep.Errors.Contains(expected, StringComparison.Ordinal),
                 $"the sweep and its validator do not read a pin file the same way.\n"
@@ -481,21 +503,21 @@ public class EvilPoolPinTests
 
     /// <summary>
     /// Runs the sweep's own pin validator over <paramref name="paths"/> and returns, per
-    /// path and in the same order, null when the sweep considers it well formed or the
-    /// reason it gave.
+    /// path and in the same order, the path identity and whether the sweep considers it
+    /// well formed or the reason it gave.
     ///
     /// <para>One process for every case: the sweep is a file-based app, so each launch
     /// costs a couple of seconds, and this gate runs in PR CI where <c>Speed=Slow</c> is
     /// filtered out.</para>
     ///
-    /// <para>Verdicts are matched to inputs by position, and each line must open with the
-    /// path that was asked about. A refusal quotes the file's own bytes -- a parser error
-    /// echoes the text it choked on -- so a pin file can name itself in the reason it
-    /// causes. The sweep emits exactly one line per path; reading them in order means this
-    /// harness believes the loop that made the decisions rather than prose a pin file had
-    /// a hand in writing.</para>
+    /// <para>Verdicts are matched to inputs by position. The reported path may be the
+    /// resolved identity rather than the spelling supplied by the caller. A refusal quotes
+    /// the file's own bytes -- a parser error echoes the text it choked on -- so a pin file
+    /// can name itself in the reason it causes. The sweep emits exactly one line per path;
+    /// reading them in order means this harness believes the loop that made the decisions
+    /// rather than prose a pin file had a hand in writing.</para>
     /// </summary>
-    static string?[] ValidateWithSweep(string root, string[] paths)
+    static PinVerdict[] ValidateWithSweep(string root, string[] paths)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -532,17 +554,23 @@ public class EvilPoolPinTests
             $"the sweep printed {lines.Length} verdicts for {paths.Length} pin files; "
             + $"stdout was:\n{output}\nstderr was:\n{errors}");
 
-        var verdicts = new string?[paths.Length];
+        var verdicts = new PinVerdict[paths.Length];
         for (int index = 0; index < paths.Length; index++)
         {
             string line = lines[index];
-            string prefix = $"Pin file '{paths[index]}' ";
+            const string prefix = "Pin file '";
+            int pathEnd = line.IndexOf("' ", prefix.Length, StringComparison.Ordinal);
             Assert.True(
-                line.StartsWith(prefix, StringComparison.Ordinal) && line.EndsWith('.'),
+                line.StartsWith(prefix, StringComparison.Ordinal)
+                    && pathEnd >= prefix.Length
+                    && line.EndsWith('.'),
                 $"verdict {index} does not report on '{paths[index]}': {line}");
 
-            string verdict = line[prefix.Length..^1];
-            verdicts[index] = verdict == "is well formed" ? null : verdict;
+            string reportedPath = line[prefix.Length..pathEnd];
+            string verdict = line[(pathEnd + 2)..^1];
+            verdicts[index] = new(
+                reportedPath,
+                verdict == "is well formed" ? null : verdict);
         }
 
         return verdicts;
@@ -846,4 +874,6 @@ public class EvilPoolPinTests
 
     sealed record PinnedPackage(
         string Package, string? Version, string? Tfm, string Status, string? Sha256);
+
+    sealed record PinVerdict(string Path, string? Problem);
 }


### PR DESCRIPTION
## Summary

Canonicalizes pin-validator path identity so macOS filesystem aliases such as `/var` and `/private/var` produce the same diagnostic as the package sweep.

The validator now resolves existing symbolic-link components at its path-input boundary. The parity gate exercises both the platform temporary-directory spelling and an explicit directory alias.

Closes #4256.

## Compatibility and boundaries

Windows retains direct-path coverage; no diagnostic severity or pin validation rule changes. This change affects only the path spelling used to identify the same file.

## Validation

Exact head `8fd5ab125ef38dc8381778dcbdf924bb1ea57841`:

- `dotnet build dotnet-inspect.slnx -c Release` — passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.EvilPoolPinTests` — 10 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"` — 5,037 passed, 1 platform skip
