### PR TITLE
Prepare 0.19.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,10 @@ renders its coverage as a caveat.
 
 Default output is Markdown. Use Markdown for evidence and narrative, `--table` for compact human scanning, `--tsv` for normalized tab-separated rows for agents and scripts, `--jsonl` for one JSON object per table row, and `--json` for structured object graphs. Use `--plaintext` for plain text, `--bare` for one undecorated payload without changing the selected shape, `--value` for one scalar, `--urls` for URL lists, `--paths` for path lists, `--print` to materialize one selected-section document (`--row N|first|last` chooses a displayed row), `--json-array` to emit projected rows as one JSON array, `--rows N` to cap rendered table rows (`2..10` is inclusive, `2+10` is start plus count, and `10..` is open-ended), `--count` to reduce a selected section/vector to a row count, and `--mermaid` for diagrams. On `member -S "Call Graph"`, `--tree` and `--mermaid` are standalone formats; pair `--mermaid` with `--markdown` to embed the diagram in a Markdown document. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`. Markdown and JSON can represent multi-section documents; `--table`, `--tsv`, and `--jsonl` render one table/section at a time, so pair them with a specific `-S` selection when querying sectioned output.
 
+On `find`, plain `--json` retains the typed result shape. Add `--columns` or
+`--fields` to emit projected JSON with the same selected rows and snake_case
+fields as the tabular formats.
+
 Call Graph edge rows use the machine field names `from`, `from_group`,
 `to`, `to_group`, and `label` under `--tsv` and `--jsonl`. Markdown and
 `--table` retain the human headings `From`, `From Group`, `To`, `To Group`, and
@@ -554,6 +558,7 @@ Sections and fields are queryable without a template language:
 dotnet-inspect library System.Net.Security -S "Async*"
 dotnet-inspect member JsonSerializer --package System.Text.Json -D
 dotnet-inspect member JsonSerializer --package System.Text.Json -D --schema
+dotnet-inspect find JsonSerializer --platform System.Text.Json --columns Type,Library --json
 dotnet-inspect type --package System.Text.Json --columns Kind,Name
 dotnet-inspect library System.Text.Json -S Symbols --fields "PDB*;SourceLink"
 dotnet-inspect library System.Text.Json -S @Audit

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Default output is Markdown. Use Markdown for evidence and narrative, `--table` f
 
 On `find`, plain `--json` retains the typed result shape. Add `--columns` or
 `--fields` to emit projected JSON with the same selected rows and snake_case
-fields as the tabular formats.
+fields as `--tsv` and `--jsonl`.
 
 Call Graph edge rows use the machine field names `from`, `from_group`,
 `to`, `to_group`, and `label` under `--tsv` and `--jsonl`. Markdown and

--- a/skills/decompiler/SKILL.md
+++ b/skills/decompiler/SKILL.md
@@ -73,9 +73,18 @@ the same coordinates as one-based line/column fields.
 `--readable-names` replaces compiler-style local names such as `V_0` where the
 body provides a stable readable alternative. It is independent of C# taste
 options. A tool-owned `.dotnet-inspectconfig`, discovered by walking up from the
-working directory, selects configured spellings; `--taste` requests the full
-supported taste set for one invocation. `Applied Taste` reports which choices
-actually changed the rendered body.
+working directory, selects configured spellings; `--taste` requests the
+oracle-endorsed taste set for one invocation. `Applied Taste` reports which
+choices actually changed the rendered body.
+
+Explicit local types are the default. Enable any independent `var` category
+with `csharp_style_var_for_built_in_types = true`,
+`csharp_style_var_when_type_is_apparent = true`, or
+`csharp_style_var_elsewhere = true`. These byte-neutral opt-ins are not part of
+`--taste`. Object creation is target-typed by default; set
+`csharp_style_implicit_object_creation_when_type_is_apparent = false` to retain
+the explicit constructed type. A `var` declaration keeps `new T(...)` because
+`var x = new()` has no target type.
 
 ```bash
 dnx dotnet-inspect -y -- member MyType Method:1 --library MyLib.dll \

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.18.0
+version: 0.19.0
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and version-to-version API changes.
 ---
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -36,6 +36,11 @@ Default output is Markdown. Pick a machine or compact shape when you need one:
 - `--mermaid` — a standalone diagram; combine it with `--markdown` to embed
   the diagram in a Markdown document.
 
+On `find`, plain `--json` retains the typed result shape. Adding
+`--columns` or `--fields` requests projected JSON instead: the result is a
+JSON document containing the same selected rows and snake_case fields as the
+tabular formats.
+
 For `member -S "Call Graph"`, default Markdown is an edge table. Choose the
 view for the task without changing the graph or its ordered edge rows:
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -39,7 +39,7 @@ Default output is Markdown. Pick a machine or compact shape when you need one:
 On `find`, plain `--json` retains the typed result shape. Adding
 `--columns` or `--fields` requests projected JSON instead: the result is a
 JSON document containing the same selected rows and snake_case fields as the
-tabular formats.
+`--tsv` and `--jsonl` formats.
 
 For `member -S "Call Graph"`, default Markdown is an edge table. Choose the
 view for the task without changing the graph or its ordered edge rows:

--- a/skills/signals/SKILL.md
+++ b/skills/signals/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dotnet-inspect-signals
 version: 0.1.0
-description: Surface a dependency's observable signals — SourceLink, determinism, trim/AOT, license, vulnerabilities, age, dependency risk, and the unsafe/PInvoke surface — to judge how much caution it warrants. Observations, not verdicts.
+description: Surface a dependency's observable signals — provenance, compatibility, dependency risk, unsafe/PInvoke surface, artifact-text containment, and identifier confusion — to judge how much caution it warrants. Observations, not verdicts.
 ---
 
 # dotnet-inspect: dependency signals
@@ -20,7 +20,8 @@ dnx dotnet-inspect -y -- <command>
 `-S Signals` on `package` or `library` is the one-stop view. It reports
 SourceLink, determinism, trim/AOT compatibility, memory-safety metadata,
 unsafe/PInvoke surface, references, TFMs, manifest/docs, license,
-vulnerabilities, package age, and dependency risk.
+vulnerabilities, package age, dependency risk, and content-free summaries of
+artifact-text containment and identifier confusion where applicable.
 
 ```bash
 dnx dotnet-inspect -y -- package Microsoft.Extensions.AI -S Signals
@@ -29,15 +30,32 @@ dnx dotnet-inspect -y -- library System.Text.Json -S Signals
 
 ## Safety and interop surface
 
-`-S @Audit` includes `Unsafe Members` and `P/Invoke Methods` alongside library
-signals, symbols, and path audit evidence. `Switches` is a separate section;
-select it explicitly for feature-switch and trim/AOT knobs. (For unsafe
-operations inside one method, see the `correctness` skill; for what switches
-mean across versions, see `compatibility`.)
+`-S @Audit` expands the audit sections authored for the target. On libraries it
+includes `Unsafe Members`, `P/Invoke Methods`, and `Audit: Identifier
+Confusion` alongside signals, symbols, and path evidence. On packages it
+includes `Audit: Artifact Text` and `Audit: Identifier Confusion`. `Switches`
+is a separate section; select it explicitly for feature-switch and trim/AOT
+knobs. (For unsafe operations inside one method, see the `correctness` skill;
+for what switches mean across versions, see `compatibility`.)
 
 ```bash
 dnx dotnet-inspect -y -- library MyLib.dll -S "@Audit,Switches"
 dnx dotnet-inspect -y -- library MyLib.dll -S "Unsafe Members,P/Invoke Methods"
+```
+
+`Signals` stays summary-only and never repeats a concerning value. Package
+`Artifact text containment` names the Unicode concern kinds found in
+package-model fields; its focused audit lists content-free field locations and
+concern kinds. Package and library `Identifier confusion` summarizes
+non-ASCII identifiers and reserved-prefix homoglyphs; its focused audit adds
+content-free locations, classifications, similarity, and code points. The
+explicit library audit resolves the transitive reference closure, while the
+Signals row stays bounded to the selected assembly and direct references.
+
+```bash
+dnx dotnet-inspect -y -- package MyPackage -S "Signals,Audit: Artifact Text"
+dnx dotnet-inspect -y -- package MyPackage -S "Signals,Audit: Identifier Confusion"
+dnx dotnet-inspect -y -- library MyLib.dll -S "Signals,Audit: Identifier Confusion"
 ```
 
 ## SourceLink provenance

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -19,7 +19,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.18.0</VersionPrefix>
+    <VersionPrefix>0.19.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -18,6 +18,9 @@
   retain full extraction (#4175).
 - Static and instance call-graph members now have distinct opaque selectors, so
   close signatures no longer collide during remapping (#4219).
+- Call-graph projection now retains physical call-site receipts behind each
+  logical edge, preserving exact loop evidence and disclosing incomplete
+  occurrence sets instead of fabricating complete aggregates (#4193).
 
 ### Safety and acquisition
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -6,9 +6,12 @@
 
 - `find --json` now composes with `--columns` and `--fields`, emitting a
   projected JSON document with the same rows, windows, compactness, and
-  snake_case field vocabulary as the tabular formats. Invalid, duplicate, and
-  overlapping projections fail before command execution instead of producing
-  lossy output (#3536).
+  snake_case field vocabulary as TSV and JSONL output (#3536).
+- **Breaking:** Explicit empty projection values and duplicate
+  `--columns`/`--fields` entries are now rejected at parse time for every
+  command and format. Overlapping wildcard patterns resolve each source column
+  once, while a name matching no column continues to fail closed during
+  rendering (#3536).
 - Multi-package inspection now renders and counts `Signature`, package fields,
   and file projections consistently across Markdown, count, TSV, and JSONL
   output, including global row windows and empty package rows (#4004).
@@ -24,11 +27,15 @@
 
 ### Safety and acquisition
 
-- Package `Signals` and `Audit: Artifact Text` now identify package-model fields
-  containing control, format, surrogate, line-separator, or paragraph-separator
-  text without echoing the artifact content (#4090).
-- Package and library `Signals` and `Audit: Identifier Confusion` now report
-  non-ASCII identifiers and reserved-prefix homoglyphs with content-free
+- Package presentation now carries containment evidence across every package
+  text source through a typed boundary. Aggregate projections report whether
+  containment was required while explicit document payloads remain
+  byte-preserving (#3831).
+- Package `Signals` now summarizes the Unicode concern kinds found in
+  package-model text. `Audit: Artifact Text` adds content-free field locations
+  and concern kinds without echoing the artifact content (#4090).
+- Package and library `Signals` now summarize non-ASCII identifiers and
+  reserved-prefix homoglyphs. `Audit: Identifier Confusion` adds content-free
   locations, classifications, similarity, and code points (#4090).
 - PDB and SourceLink acquisition now handles pathless and content-shaped
   responses while preserving visible diagnostics for rejected evidence
@@ -43,8 +50,8 @@
 ### Experimental decompilation
 
 - Adds complete opt-in `var` spelling and a configurable
-  explicit-versus-target-typed object-creation style, with byte-divergence
-  disclosure in annotated output (#4220, #4252).
+  explicit-versus-target-typed object-creation style. Both choices are
+  byte-neutral (#4220, #4252).
 - Expands whole-member compile-back coverage for constructors, properties, and
   events; recovers variable-less `using` statements; preserves local-function
   argument ref kinds; and fixes several control-flow ownership, stack-merge,
@@ -181,9 +188,7 @@
 - Carries untrusted artifact text through typed inert-text boundaries and
   contains metadata and package-authored text before rendering. Malformed
   nuspec XML now produces a one-line location diagnostic, and descriptions
-  cannot impersonate tool headings or tables. Package projections expose
-  aggregate containment evidence while explicit document payloads remain
-  byte-preserving (#3679, #3772).
+  cannot impersonate tool headings or tables (#3679, #3772).
 - **Breaking:** removes the hidden `--oneline` compatibility alias and
   `DOTNET_INSPECT_FORMAT=oneline`/`one-line`; use `--table`.
 - Builds Native AOT packages with `OptimizationPreference=Speed`, worth a

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,53 @@
 # Release Notes
 
+## v0.19.0
+
+### Inspection and output
+
+- `find --json` now composes with `--columns` and `--fields`, emitting a
+  projected JSON document with the same rows, windows, compactness, and
+  snake_case field vocabulary as the tabular formats. Invalid, duplicate, and
+  overlapping projections fail before command execution instead of producing
+  lossy output (#3536).
+- Multi-package inspection now renders and counts `Signature`, package fields,
+  and file projections consistently across Markdown, count, TSV, and JSONL
+  output, including global row windows and empty package rows (#4004).
+- Quiet .NET platform type listings use a compact shared-runtime metadata path,
+  avoiding full extraction while preserving forwarded type and extension method
+  counts. Rich, ASP.NET Core, pinned reference-pack, and structured output paths
+  retain full extraction (#4175).
+- Static and instance call-graph members now have distinct opaque selectors, so
+  close signatures no longer collide during remapping (#4219).
+
+### Safety and acquisition
+
+- Package `Signals` and `Audit: Artifact Text` now identify package-model fields
+  containing control, format, surrogate, line-separator, or paragraph-separator
+  text without echoing the artifact content (#4090).
+- Package and library `Signals` and `Audit: Identifier Confusion` now report
+  non-ASCII identifiers and reserved-prefix homoglyphs with content-free
+  locations, classifications, similarity, and code points (#4090).
+- PDB and SourceLink acquisition now handles pathless and content-shaped
+  responses while preserving visible diagnostics for rejected evidence
+  (#4138).
+- NuGet metadata acquisition now bounds response bodies, attributes failures to
+  their source, and reports malformed service indexes and version metadata
+  instead of silently treating them as absent (#4134, #4247).
+- Signature decoding and classification now enforce cumulative work budgets,
+  keeping deeply nested or broadly repeated metadata from multiplying
+  inspection cost without bound (#4170, #4188).
+
+### Experimental decompilation
+
+- Adds complete opt-in `var` spelling and a configurable
+  explicit-versus-target-typed object-creation style, with byte-divergence
+  disclosure in annotated output (#4220, #4252).
+- Expands whole-member compile-back coverage for constructors, properties, and
+  events; recovers variable-less `using` statements; preserves local-function
+  argument ref kinds; and fixes several control-flow ownership, stack-merge,
+  and structuring fidelity failures (#4070, #4198, #4244, #4113, #4204, #4192,
+  #4101, #4255).
+
 ## v0.18.0
 
 ### Inspection correctness
@@ -133,19 +181,6 @@
   cannot impersonate tool headings or tables. Package projections expose
   aggregate containment evidence while explicit document payloads remain
   byte-preserving (#3679, #3772).
-- Reports that package aggregate in `Signals` as
-  `Artifact text containment`, with category-only evidence for control,
-  format/bidi, unpaired-surrogate, line-separator, and paragraph-separator
-  concerns. Literal backslashes do not trigger the concern.
-- Adds the explicit `Audit: Artifact Text` package section under `@Audit`,
-  listing package-model field locations and concern kinds without echoing
-  artifact values.
-- Adds an `Identifier confusion` Signal for package IDs, dependency IDs,
-  assembly names, and direct assembly references. Explicit package and library
-  audit sections report content-free locations, classifications, similarity,
-  and code points, including bounded Greek/Cyrillic homoglyph checks for
-  `System`, `Microsoft`, and `Azure`; the explicit library audit additionally
-  resolves the transitive reference closure.
 - **Breaking:** removes the hidden `--oneline` compatibility alias and
   `DOTNET_INSPECT_FORMAT=oneline`/`one-line`; use `--table`.
 - Builds Native AOT packages with `OptimizationPreference=Speed`, worth a


### PR DESCRIPTION
## Summary

- bump the tool and embedded base skill to 0.19.0
- add 0.19.0 release notes covering projected `find` JSON, multi-package correctness, call-site evidence, inspection hardening, audits, and experimental decompiler improvements
- update the packed README and owning query, Signals, and decompiler skills for new 0.19.0 workflows

The README and every shipped skill were audited against changes since v0.18.0. Review identified missing discovery guidance for the new audit and `var` capabilities; both owning skills now teach those workflows.

## Evidence

Exact head `d9690a566317590ce3e3d0aa275f298572d958ed`:

- markdownlint passes for every changed Markdown file
- Release product build succeeds with activated `ilasm`/`ildasm`/`mdv`
- focused embedded-skill suite: 23 passed
- built local pointer, managed fallback, and Linux Native AOT packages; installed `0.19.0+d9690a5` in an isolated tool home and verified version, the packed skill updates, projected `find` JSON, and two-package `Signature` JSON

The preceding candidate also passed the full CLI (3,879), Analysis (664), and Queries (277) suites before review-only documentation fixes moved the head. Current-head CI is the fixed-head full-suite gate.

## Candidate

`main` advanced while the first candidate was being validated. Base tip `3c1d7d4799cbb7d9fb1f3a793d1b928661981b03` was integrated by merge commit `0aae6f01bdc1b5e40027f7556a080e9c4e5fb6e1`; release notes were reconciled with that call-graph change before freezing the candidate. Adversarial review round 1 findings on `a184aee1` were resolved by `d9690a56`; the PR comment records the reconciliation.

## Boundary

This PR prepares but does not publish 0.19.0. Publication remains an explicit post-merge workflow dispatch backed by fresh release certification.
