### PR TITLE
Make source-location discovery test hermetic

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -27,6 +27,10 @@ using ILInspector.Findings;
 using ILInspector.Metadata;
 using ILInspector.Research;
 using Markout;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Text;
 
 namespace DotnetInspector.Tests;
 
@@ -627,6 +631,69 @@ public partial class CommandExecutionTests
         var packagePath = Path.Combine(tempDir, "Test.MultiLib.1.0.0.nupkg");
         ZipFile.CreateFromDirectory(packageRoot, packagePath);
         return (packagePath, tempDir);
+    }
+
+    private static (string AssemblyPath, string FixtureDir) CreateNoSourceLinkDiscoveryAssembly()
+    {
+        const string source =
+            """
+            namespace DiscoveryFixtures;
+
+            public static class NoSourceLink
+            {
+                public static int Overloaded(int value) => value;
+                public static string Overloaded(string value) => value;
+            }
+            """;
+
+        var fixtureDir = Path.Combine(
+            AppContext.BaseDirectory,
+            $"no-sourcelink-discovery-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(fixtureDir);
+
+        try
+        {
+            var assemblyPath = Path.Combine(fixtureDir, "NoSourceLinkDiscovery.dll");
+            var pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
+            var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+                .Split(Path.PathSeparator)
+                .Select(path => MetadataReference.CreateFromFile(path));
+            var compilation = CSharpCompilation.Create(
+                "NoSourceLinkDiscovery",
+                [
+                    CSharpSyntaxTree.ParseText(
+                        SourceText.From(source, Encoding.UTF8),
+                        new CSharpParseOptions(LanguageVersion.Preview),
+                        path: "/_/NoSourceLinkDiscovery.cs")
+                ],
+                references,
+                new CSharpCompilationOptions(
+                    OutputKind.DynamicallyLinkedLibrary,
+                    optimizationLevel: OptimizationLevel.Release,
+                    deterministic: true));
+
+            using (var assembly = File.Create(assemblyPath))
+            using (var pdb = File.Create(pdbPath))
+            {
+                var result = compilation.Emit(
+                    assembly,
+                    pdbStream: pdb,
+                    options: new EmitOptions(
+                        debugInformationFormat: DebugInformationFormat.PortablePdb,
+                        pdbFilePath: Path.GetFileName(pdbPath)));
+                Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+            }
+
+            using var sourceLink = SourceLinkService.Open(assemblyPath);
+            Assert.True(sourceLink.HasPdb);
+            Assert.False(sourceLink.HasSourceLink);
+            return (assemblyPath, fixtureDir);
+        }
+        catch
+        {
+            Directory.Delete(fixtureDir, recursive: true);
+            throw;
+        }
     }
 
     private static (string PackagePath, string TempDir)
@@ -12705,6 +12772,8 @@ public partial class CommandExecutionTests
     public async Task CliDiscoverySections_AreSelectable()
     {
         var (packagePath, tempDir) = CreateLocalRefPackage("System.Runtime");
+        var (noSourceLinkAssemblyPath, noSourceLinkFixtureDir) =
+            CreateNoSourceLinkDiscoveryAssembly();
         try
         {
             var diffV1 = FixtureCatalog.DiffPair.OldAssemblyPath();
@@ -12716,7 +12785,7 @@ public partial class CommandExecutionTests
                 ["type", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath],
                 ["type", typeof(EmptyDiscoveryFixture).FullName!, "--library", TestAssemblyPath],
                 ["member", typeof(MemberCallsFixture).FullName!, nameof(MemberCallsFixture.CallsInterfaceItem), "--library", TestAssemblyPath],
-                ["member", typeof(MemberCallsFixture).FullName!, nameof(MemberCallsFixture.Overloaded), "--library", TestAssemblyPath],
+                ["member", "DiscoveryFixtures.NoSourceLink", "Overloaded", "--library", noSourceLinkAssemblyPath],
                 ["package", packagePath],
                 ["diff", "--library", $"{diffV1}..{diffV2}", "-t", "DiffFixtureSample.DiffSample"]
             ];
@@ -12733,6 +12802,8 @@ public partial class CommandExecutionTests
                     .ToArray();
                 if (!IsNoMemberTypeDiscoveryCommand(command))
                     Assert.NotEmpty(sections);
+                if (command.Contains(noSourceLinkAssemblyPath, StringComparer.Ordinal))
+                    Assert.Contains(SectionNames.SourceLocations, sections);
 
                 foreach (var section in sections)
                 {
@@ -12742,6 +12813,11 @@ public partial class CommandExecutionTests
                         || IsSourceIntegrityStatusResult(command, section, selectExit, selectOutput);
                     Assert.True(selectionSucceeded,
                         $"{command[0]} -S '{section}' failed after being listed by -D. Discovery stderr: {discoverError}. Selection stderr: {selectError}");
+                    if (command.Contains(noSourceLinkAssemblyPath, StringComparer.Ordinal)
+                        && section == SectionNames.SourceLocations)
+                    {
+                        Assert.True(string.IsNullOrWhiteSpace(selectOutput));
+                    }
                     if (RequiresNonEmptyDiscoveryResult(command, section))
                     {
                         Assert.False(string.IsNullOrWhiteSpace(selectOutput),
@@ -12755,6 +12831,7 @@ public partial class CommandExecutionTests
         finally
         {
             Directory.Delete(tempDir, recursive: true);
+            Directory.Delete(noSourceLinkFixtureDir, recursive: true);
         }
     }
 
@@ -12787,7 +12864,9 @@ public partial class CommandExecutionTests
     {
         // ProbeEffectiveness=false deliberately allows -D to list a structurally applicable
         // section whose -S result is empty. Derive that exemption from the same pipeline
-        // declaration while preserving the non-empty guard for probed sections.
+        // declaration while preserving the non-empty guard for probed sections. The generated
+        // no-SourceLink overload fixture gates this distinction without depending on checkout
+        // source acquisition (#3464).
         if (IsNoMemberTypeDiscoveryCommand(command))
             return !TypeUnprobedDiscoverySections.Contains(section);
 


### PR DESCRIPTION
## Summary

Makes the section-selectability gate deterministic by exercising `Source Locations` with a generated portable-PDB assembly that deliberately has no SourceLink map.

The fixture proves the intended section contract directly: structural discovery lists the unprobed section, explicit selection succeeds, and an empty result is legitimate when source acquisition is unavailable. The test no longer depends on the checkout assembly's SourceLink state.

Closes #3464.

## Compatibility and boundaries

This is a test-harness correction; product discovery and rendering behavior are unchanged. The existing non-empty guard remains in force for probed sections.

## Validation

Exact head `c484d99acbaf122ad43276bac9519b6d48b8b289`:

- `dotnet build dotnet-inspect.slnx -c Release` — passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method '*CliDiscoverySections_AreSelectable*'` — passed
- fast CLI suite — 2,768 passed, 13 skipped; 7 package-version tests failed because NuGet.org did not answer service-index/version requests
