### PR TITLE
Project typed package graph boundaries

### DIFF
--- a/docs/design/inspection-graph-document.md
+++ b/docs/design/inspection-graph-document.md
@@ -373,9 +373,11 @@ structured data and must not be recovered from a node label.
 
 `InspectionGraphPackageBoundary` implements this boundary over realized
 workspace members. It joins an acquired assembly to its package through the
-participant's opaque acquisition registration, validates the package asset
-provenance against the exact `RealizedMemberCoordinate.Package`, and projects
-the resulting package subject as an assembly group, a package node, or both.
+participant's opaque acquisition registration, validates the package identity
+and version against package-asset provenance, and projects the resulting
+package subject as an assembly group, a package node, or both. The realized
+framework and RID remain the effective acquisition target; provenance retains
+the selected physical asset target, which may differ after compatible fallback.
 Assembly nodes retain acquisition-bound identity, so matching metadata
 identities from two acquired artifacts do not collapse. A package-only lens
 retains only portable realized package coordinates.

--- a/docs/design/inspection-graph-document.md
+++ b/docs/design/inspection-graph-document.md
@@ -371,6 +371,19 @@ they reference the same domain subject. Renderers may lower a group as a
 Mermaid subgraph, a table column, a badge, or nothing. Group membership is
 structured data and must not be recovered from a node label.
 
+`InspectionGraphPackageBoundary` implements this boundary over realized
+workspace members. It joins an acquired assembly to its package through the
+participant's opaque acquisition registration, validates the package asset
+provenance against the exact `RealizedMemberCoordinate.Package`, and projects
+the resulting package subject as an assembly group, a package node, or both.
+Assembly nodes retain acquisition-bound identity, so matching metadata
+identities from two acquired artifacts do not collapse. A package-only lens
+retains only portable realized package coordinates.
+`WorkspaceContextLoaderTests.PackageBoundary_ProjectsLoadedPackageAsGroupAndNode`
+gates the compiled package-acquisition path;
+`InspectionGraphPackageBoundaryTests.PackageGroupsLens_DoesNotCollapseMatchingAssemblyMetadata`
+gates the close acquisition-identity case.
+
 ## Relationships and occurrences
 
 ### Relationship descriptors
@@ -960,7 +973,9 @@ subject lenses it advances.
    they must not encode these values back into edge labels.
 3. **Typed groups and package boundary.** Project assembly/package ownership
    from workspace provenance and realized coordinates; render the same package
-   as a group or node without string-derived identity.
+   as a group or node without string-derived identity. Implemented by
+   `InspectionGraphPackageBoundary`; presentation lowering and integration
+   composition remain later slices.
 4. **Type/package integration projection.** Compose extension and Integrations
    evidence into the locked `IChatClient` type-outward and package-inward views
    demonstrated by #4127.

--- a/docs/design/inspection-graph-document.md
+++ b/docs/design/inspection-graph-document.md
@@ -383,6 +383,8 @@ identities from two acquired artifacts do not collapse. A package-only lens
 retains only portable realized package coordinates.
 `WorkspaceContextLoaderTests.PackageBoundary_ProjectsLoadedPackageAsGroupAndNode`
 gates the compiled package-acquisition path;
+`WorkspaceContextLoaderTests.PackageBoundary_KeepsEffectiveTargetAcrossAssetFallback`
+gates the effective/physical target distinction; and
 `InspectionGraphPackageBoundaryTests.PackageGroupsLens_DoesNotCollapseMatchingAssemblyMetadata`
 gates the close acquisition-identity case.
 

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -71,6 +71,8 @@ of repeated in every row.
 | Currency | Scope | Answers | Does not answer |
 | --- | --- | --- | --- |
 | `ApiFacetDescriptor`, `ApiTypeInventoryResult`, `ApiMemberInventoryResult` | One materialized API inventory query | Stable filter identity, labels, ordering, defaults, counts, and the selected projection | Raw metadata kind or member identity |
+| `InspectionGraphAssemblyIdentity.Acquired` | One loaded workspace context | Which acquisition registration, assembly identity, and provenance own an assembly subject in a session-bound graph | Portable artifact identity or correspondence outside that acquisition |
+| `InspectionGraphPackageIdentity.Realized` | One portable inspection-graph subject | Which exact package version, producer, framework, and RID own the package subject | Assembly membership without the workspace package-boundary projection |
 
 `ApiType.Kind` and `ApiMember.Kind` remain raw product facts. Consumers do not
 parse them or own a parallel grouping vocabulary: `ApiInventoryQuery` maps each

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -403,6 +403,12 @@ gate prerequisite activation and failure-safe opportunity composition.
 skip suppression across grouped package and single-library hosts.
 `PackageIntegrationsWorkspaceTests.LocalAcquisition_UsesOnlyValidNuspecCoordinates`
 and `RemoteAcquisition_UsesResolvedCoordinate` gate acquisition provenance.
+`InspectionGraphPackageBoundary` consumes those realized workspace members
+without reopening their artifacts. It validates package provenance against the
+exact realized package coordinate, retains acquisition-bound assembly subjects,
+and projects one package subject as a structured group, a package node, or
+both. `WorkspaceContextLoaderTests.PackageBoundary_ProjectsLoadedPackageAsGroupAndNode`
+gates the compiled package-acquisition path.
 `GroupedIntegrationsFailure_IsVisibleAndDeduplicated` gates diagnostic
 composition and the shared nonzero completion status used after Markdown,
 count, tabular, or JSON output.

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -404,10 +404,12 @@ skip suppression across grouped package and single-library hosts.
 `PackageIntegrationsWorkspaceTests.LocalAcquisition_UsesOnlyValidNuspecCoordinates`
 and `RemoteAcquisition_UsesResolvedCoordinate` gate acquisition provenance.
 `InspectionGraphPackageBoundary` consumes those realized workspace members
-without reopening their artifacts. It validates package provenance against the
-exact realized package coordinate, retains acquisition-bound assembly subjects,
-and projects one package subject as a structured group, a package node, or
-both. `WorkspaceContextLoaderTests.PackageBoundary_ProjectsLoadedPackageAsGroupAndNode`
+without reopening their artifacts. It validates package identity and version
+against package provenance while keeping the effective acquisition target
+distinct from the selected physical asset target, retains acquisition-bound
+assembly subjects, and projects one package subject as a structured group, a
+package node, or both.
+`WorkspaceContextLoaderTests.PackageBoundary_ProjectsLoadedPackageAsGroupAndNode`
 gates the compiled package-acquisition path.
 `GroupedIntegrationsFailure_IsVisibleAndDeduplicated` gates diagnostic
 composition and the shared nonzero completion status used after Markdown,

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -410,7 +410,9 @@ distinct from the selected physical asset target, retains acquisition-bound
 assembly subjects, and projects one package subject as a structured group, a
 package node, or both.
 `WorkspaceContextLoaderTests.PackageBoundary_ProjectsLoadedPackageAsGroupAndNode`
-gates the compiled package-acquisition path.
+gates the compiled package-acquisition path, and
+`PackageBoundary_KeepsEffectiveTargetAcrossAssetFallback` gates the
+effective/physical target distinction.
 `GroupedIntegrationsFailure_IsVisibleAndDeduplicated` gates diagnostic
 composition and the shared nonzero completion status used after Markdown,
 count, tabular, or JSON output.

--- a/src/DotnetInspector.Queries.Tests/InspectionGraphPackageBoundaryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionGraphPackageBoundaryTests.cs
@@ -1,0 +1,279 @@
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class InspectionGraphPackageBoundaryTests
+{
+    [Fact]
+    public void MixedLens_UsesOneTypedPackageAsNodeAndGroup()
+    {
+        RealizedMemberCoordinate.Package package =
+            Package("sample.package", "feed-a");
+        WorkspaceContextMember first =
+            PackageMember(package, "Sample.First");
+        WorkspaceContextMember second =
+            PackageMember(package, "Sample.Second");
+
+        InspectionGraphPackageBoundary boundary =
+            InspectionGraphPackageBoundary.Create([first, second]);
+        InspectionGraphDocument document = boundary.Project(
+            InspectionGraphPackageBoundaryLens.Mixed);
+
+        Assert.Equal(InspectionGraphDocumentScope.SessionBound, document.Scope);
+        Assert.Equal(3, document.Nodes.Length);
+        InspectionGraphGroup group = Assert.Single(document.Groups);
+        Assert.Same(document.Nodes[0].Subject, group.Subject);
+        Assert.IsType<InspectionGraphSubject.PackageSubject>(
+            document.Nodes[0].Subject);
+        Assert.All(
+            document.Nodes.Skip(1),
+            node =>
+            {
+                Assert.Equal([group.Id], node.GroupIds);
+                var subject =
+                    Assert.IsType<InspectionGraphSubject.AssemblySubject>(
+                        node.Subject);
+                Assert.IsType<InspectionGraphAssemblyIdentity.Acquired>(
+                    subject.Identity);
+            });
+
+        Assert.True(
+            boundary.TryGetPackageSubject(
+                first.Participant.Assembly.Registration,
+                out InspectionGraphSubject.PackageSubject? firstOwner));
+        Assert.True(
+            boundary.TryGetPackageSubject(
+                second.Participant.Assembly.Registration,
+                out InspectionGraphSubject.PackageSubject? secondOwner));
+        Assert.Same(group.Subject, firstOwner);
+        Assert.Same(firstOwner, secondOwner);
+    }
+
+    [Fact]
+    public void PackageNodesLens_IsPortableAndPreservesProducerIdentity()
+    {
+        RealizedMemberCoordinate.Package firstPackage =
+            Package("sample.package", "feed-a");
+        RealizedMemberCoordinate.Package secondPackage =
+            Package("sample.package", "feed-b");
+
+        InspectionGraphDocument document =
+            InspectionGraphPackageBoundary.Create(
+                [
+                    PackageMember(
+                        firstPackage,
+                        "Sample",
+                        assemblyVersion: new Version(1, 0)),
+                    PackageMember(
+                        secondPackage,
+                        "Sample",
+                        assemblyVersion: new Version(1, 0)),
+                ])
+            .Project(InspectionGraphPackageBoundaryLens.PackageNodes);
+
+        Assert.Equal(InspectionGraphDocumentScope.Portable, document.Scope);
+        Assert.Equal(2, document.Nodes.Length);
+        Assert.Empty(document.Groups);
+        Assert.NotEqual(
+            document.Nodes[0].Subject,
+            document.Nodes[1].Subject);
+        Assert.All(
+            document.Nodes,
+            node => Assert.True(node.Subject.IsPortable));
+    }
+
+    [Fact]
+    public void PackageGroupsLens_DoesNotCollapseMatchingAssemblyMetadata()
+    {
+        RealizedMemberCoordinate.Package firstPackage =
+            Package("sample.package", "feed-a");
+        RealizedMemberCoordinate.Package secondPackage =
+            Package("sample.package", "feed-b");
+
+        InspectionGraphDocument document =
+            InspectionGraphPackageBoundary.Create(
+                [
+                    PackageMember(firstPackage, "Sample"),
+                    PackageMember(secondPackage, "Sample"),
+                ])
+            .Project(InspectionGraphPackageBoundaryLens.PackageGroups);
+
+        Assert.Equal(2, document.Nodes.Length);
+        Assert.Equal(2, document.Groups.Length);
+        Assert.NotEqual(
+            document.Nodes[0].Subject,
+            document.Nodes[1].Subject);
+        Assert.Equal([0], document.Nodes[0].GroupIds);
+        Assert.Equal([1], document.Nodes[1].GroupIds);
+    }
+
+    [Fact]
+    public void PackageGroupsLens_KeepsNonPackageArtifactsUngrouped()
+    {
+        RealizedMemberCoordinate.Package package =
+            Package("sample.package", "feed-a");
+        WorkspaceContextMember embedded = EmbeddedMember("Embedded.Sample");
+
+        InspectionGraphPackageBoundary boundary =
+            InspectionGraphPackageBoundary.Create(
+                [PackageMember(package, "Package.Sample"), embedded]);
+        InspectionGraphDocument document = boundary.Project(
+            InspectionGraphPackageBoundaryLens.PackageGroups);
+
+        Assert.Equal(2, document.Nodes.Length);
+        Assert.Single(document.Groups);
+        Assert.Equal([0], document.Nodes[0].GroupIds);
+        Assert.Empty(document.Nodes[1].GroupIds);
+        Assert.False(
+            boundary.TryGetPackageSubject(
+                embedded.Participant.Assembly.Registration,
+                out _));
+    }
+
+    [Theory]
+    [InlineData("other.package", "1.0.0", "net11.0", null)]
+    [InlineData("sample.package", "2.0.0", "net11.0", null)]
+    [InlineData("sample.package", "1.0.0", "net10.0", null)]
+    [InlineData("sample.package", "1.0.0", "net11.0", "linux-x64")]
+    public void Create_RejectsPackageCoordinateThatConflictsWithProvenance(
+        string packageId,
+        string version,
+        string framework,
+        string? runtimeIdentifier)
+    {
+        RealizedMemberCoordinate.Package package =
+            Package("sample.package", "feed-a");
+        WorkspaceContextMember member = PackageMember(
+            package,
+            "Sample",
+            provenancePackageId: packageId,
+            provenanceVersion: version,
+            provenanceFramework: framework,
+            provenanceRuntimeIdentifier: runtimeIdentifier);
+
+        Assert.Throws<ArgumentException>(
+            () => InspectionGraphPackageBoundary.Create([member]));
+    }
+
+    [Fact]
+    public void Create_RejectsConflictingOwnershipForOneAcquisition()
+    {
+        RealizedMemberCoordinate.Package firstPackage =
+            Package("sample.package", "feed-a");
+        WorkspaceContextMember first =
+            PackageMember(firstPackage, "Sample");
+        RealizedMemberCoordinate.Package secondPackage =
+            Package("other.package", "feed-a");
+        var second = new WorkspaceContextMember(
+            WorkspaceMemberCoordinate.Package(
+                secondPackage.PackageId,
+                secondPackage.Version,
+                secondPackage.Framework),
+            secondPackage,
+            first.Participant);
+
+        Assert.Throws<ArgumentException>(
+            () => InspectionGraphPackageBoundary.Create([first, second]));
+    }
+
+    [Fact]
+    public void Create_RejectsLoadedContextThatOmitsAParticipant()
+    {
+        RealizedMemberCoordinate.Package package =
+            Package("sample.package", "feed-a");
+        WorkspaceContextMember first =
+            PackageMember(package, "Sample.First");
+        WorkspaceContextMember second =
+            PackageMember(package, "Sample.Second");
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [first.Participant, second.Participant]);
+        var loaded = new WorkspaceContextLoadOutcome.Loaded(
+            group,
+            [first],
+            package.Framework,
+            package.RuntimeIdentifier);
+
+        Assert.Throws<ArgumentException>(
+            () => InspectionGraphPackageBoundary.Create(loaded));
+    }
+
+    static RealizedMemberCoordinate.Package Package(
+        string packageId,
+        string producer) =>
+        new(
+            packageId,
+            "1.0.0",
+            producer,
+            "net11.0",
+            null);
+
+    static WorkspaceContextMember PackageMember(
+        RealizedMemberCoordinate.Package package,
+        string assemblyName,
+        Version? assemblyVersion = null,
+        string? provenancePackageId = null,
+        string? provenanceVersion = null,
+        string? provenanceFramework = null,
+        string? provenanceRuntimeIdentifier = null)
+    {
+        ResolvedAssemblyReference assembly =
+            ResolvedAssemblyReference.Create(
+                new AssemblyReferenceIdentity(
+                    assemblyName,
+                    assemblyVersion ?? new Version(1, 0),
+                    null,
+                    null),
+                path: null,
+                static () => new MemoryStream([]),
+                AssemblyResolutionProvenance.Package(
+                    provenancePackageId ?? package.PackageId,
+                    provenanceVersion ?? package.Version,
+                    provenanceFramework ?? package.Framework,
+                    provenanceRuntimeIdentifier
+                        ?? package.RuntimeIdentifier));
+        return new WorkspaceContextMember(
+            WorkspaceMemberCoordinate.Package(
+                package.PackageId,
+                package.Version,
+                package.Framework,
+                package.RuntimeIdentifier),
+            package,
+            new AssemblyContextParticipant(
+                assembly,
+                NoResolverAssemblyBindingPolicy.Instance));
+    }
+
+    static WorkspaceContextMember EmbeddedMember(string assemblyName)
+    {
+        const string ContentRef = "fixtures/embedded.dll";
+        const string Digest =
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        ResolvedAssemblyReference assembly =
+            ResolvedAssemblyReference.Create(
+                new AssemblyReferenceIdentity(
+                    assemblyName,
+                    new Version(1, 0),
+                    null,
+                    null),
+                path: null,
+                static () => new MemoryStream([]),
+                AssemblyResolutionProvenance.Embedded(
+                    ContentRef,
+                    Digest,
+                    assemblyName));
+        return new WorkspaceContextMember(
+            WorkspaceMemberCoordinate.Embedded(
+                ContentRef,
+                Digest,
+                assemblyName),
+            new RealizedMemberCoordinate.Embedded(
+                ContentRef,
+                Digest,
+                assemblyName),
+            new AssemblyContextParticipant(
+                assembly,
+                NoResolverAssemblyBindingPolicy.Instance));
+    }
+}

--- a/src/DotnetInspector.Queries.Tests/InspectionGraphPackageBoundaryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionGraphPackageBoundaryTests.cs
@@ -131,15 +131,11 @@ public sealed class InspectionGraphPackageBoundaryTests
     }
 
     [Theory]
-    [InlineData("other.package", "1.0.0", "net11.0", null)]
-    [InlineData("sample.package", "2.0.0", "net11.0", null)]
-    [InlineData("sample.package", "1.0.0", "net10.0", null)]
-    [InlineData("sample.package", "1.0.0", "net11.0", "linux-x64")]
+    [InlineData("other.package", "1.0.0")]
+    [InlineData("sample.package", "2.0.0")]
     public void Create_RejectsPackageCoordinateThatConflictsWithProvenance(
         string packageId,
-        string version,
-        string framework,
-        string? runtimeIdentifier)
+        string version)
     {
         RealizedMemberCoordinate.Package package =
             Package("sample.package", "feed-a");
@@ -147,12 +143,44 @@ public sealed class InspectionGraphPackageBoundaryTests
             package,
             "Sample",
             provenancePackageId: packageId,
-            provenanceVersion: version,
-            provenanceFramework: framework,
-            provenanceRuntimeIdentifier: runtimeIdentifier);
+            provenanceVersion: version);
 
         Assert.Throws<ArgumentException>(
             () => InspectionGraphPackageBoundary.Create([member]));
+    }
+
+    [Fact]
+    public void Create_KeepsEffectiveAndPhysicalPackageTargetsDistinct()
+    {
+        var package = new RealizedMemberCoordinate.Package(
+            "sample.package",
+            "1.0.0",
+            "feed-a",
+            "net11.0",
+            "linux-x64");
+        WorkspaceContextMember member = PackageMember(
+            package,
+            "Sample",
+            provenanceFramework: "net10.0",
+            provenanceRuntimeIdentifier: "linux-musl-x64");
+
+        InspectionGraphPackageBoundary boundary =
+            InspectionGraphPackageBoundary.Create([member]);
+        InspectionGraphDocument document = boundary.Project(
+            InspectionGraphPackageBoundaryLens.PackageNodes);
+
+        var subject =
+            Assert.IsType<InspectionGraphSubject.PackageSubject>(
+                Assert.Single(document.Nodes).Subject);
+        var identity =
+            Assert.IsType<InspectionGraphPackageIdentity.Realized>(
+                subject.Identity);
+        Assert.Same(package, identity.Package);
+        var provenance =
+            Assert.IsType<AssemblyResolutionProvenance.PackageAsset>(
+                member.Participant.Assembly.Provenance);
+        Assert.Equal("net10.0", provenance.Tfm);
+        Assert.Equal("linux-musl-x64", provenance.Rid);
     }
 
     [Fact]

--- a/src/DotnetInspector.Queries.Tests/WorkspaceContextLoaderTests.cs
+++ b/src/DotnetInspector.Queries.Tests/WorkspaceContextLoaderTests.cs
@@ -101,6 +101,50 @@ public sealed class WorkspaceContextLoaderTests
     }
 
     [Fact]
+    public async Task PackageBoundary_ProjectsLoadedPackageAsGroupAndNode()
+    {
+        using var workspace = new InspectionWorkspace();
+        IPackageStore store = await CachedStoreAsync(
+            Version,
+            LibraryPackage());
+        using var client = new HttpClient(new FailingHandler());
+
+        var loaded = Loaded(
+            await WorkspaceContextLoader.LoadAsync(
+                workspace,
+                new WorkspaceContextInput
+                {
+                    Framework = Framework,
+                    Members = [PackageMember(Version)],
+                },
+                Options(client, store),
+                TestContext.Current.CancellationToken));
+
+        InspectionGraphPackageBoundary boundary =
+            InspectionGraphPackageBoundary.Create(loaded);
+        InspectionGraphDocument document = boundary.Project(
+            InspectionGraphPackageBoundaryLens.Mixed);
+
+        Assert.Equal(3, document.Nodes.Length);
+        InspectionGraphGroup packageGroup =
+            Assert.Single(document.Groups);
+        Assert.Same(document.Nodes[0].Subject, packageGroup.Subject);
+        Assert.All(
+            document.Nodes.Skip(1),
+            node => Assert.Equal([packageGroup.Id], node.GroupIds));
+        Assert.All(
+            loaded.Members,
+            member =>
+            {
+                Assert.True(
+                    boundary.TryGetPackageSubject(
+                        member.Participant.Assembly.Registration,
+                        out InspectionGraphSubject.PackageSubject? owner));
+                Assert.Same(packageGroup.Subject, owner);
+            });
+    }
+
+    [Fact]
     public async Task Group_BindsAnInContextReferenceToItsOwnDescriptor()
     {
         using var workspace = new InspectionWorkspace();

--- a/src/DotnetInspector.Queries.Tests/WorkspaceContextLoaderTests.cs
+++ b/src/DotnetInspector.Queries.Tests/WorkspaceContextLoaderTests.cs
@@ -145,6 +145,51 @@ public sealed class WorkspaceContextLoaderTests
     }
 
     [Fact]
+    public async Task PackageBoundary_KeepsEffectiveTargetAcrossAssetFallback()
+    {
+        const string RequestedFramework = "net11.0";
+        using var workspace = new InspectionWorkspace();
+        IPackageStore store = await CachedStoreAsync(
+            Version,
+            Archive(
+                ($"lib/{Framework}/{Path.GetFileName(TargetPath)}",
+                    File.ReadAllBytes(TargetPath))));
+        using var client = new HttpClient(new FailingHandler());
+
+        var loaded = Loaded(
+            await WorkspaceContextLoader.LoadAsync(
+                workspace,
+                new WorkspaceContextInput
+                {
+                    Framework = RequestedFramework,
+                    Members = [PackageMember(Version)],
+                },
+                Options(client, store),
+                TestContext.Current.CancellationToken));
+
+        WorkspaceContextMember member = Assert.Single(loaded.Members);
+        var package =
+            Assert.IsType<RealizedMemberCoordinate.Package>(
+                member.Realized);
+        var provenance =
+            Assert.IsType<AssemblyResolutionProvenance.PackageAsset>(
+                member.Participant.Assembly.Provenance);
+        Assert.Equal(RequestedFramework, package.Framework);
+        Assert.Equal(Framework, provenance.Tfm);
+
+        InspectionGraphDocument document =
+            InspectionGraphPackageBoundary.Create(loaded)
+                .Project(InspectionGraphPackageBoundaryLens.PackageNodes);
+        var subject =
+            Assert.IsType<InspectionGraphSubject.PackageSubject>(
+                Assert.Single(document.Nodes).Subject);
+        Assert.Equal(
+            package,
+            Assert.IsType<InspectionGraphPackageIdentity.Realized>(
+                subject.Identity).Package);
+    }
+
+    [Fact]
     public async Task Group_BindsAnInContextReferenceToItsOwnDescriptor()
     {
         using var workspace = new InspectionWorkspace();

--- a/src/DotnetInspector.Queries/InspectionGraphDocument.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphDocument.cs
@@ -45,6 +45,30 @@ public abstract record InspectionGraphAssemblyIdentity
 
     public abstract bool IsPortable { get; }
 
+    /// <summary>
+    /// One assembly participant while its acquisition registration remains
+    /// authoritative.
+    /// </summary>
+    /// <remarks>
+    /// <c>InspectionGraphPackageBoundaryTests.PackageGroupsLens_DoesNotCollapseMatchingAssemblyMetadata</c>
+    /// gates acquisition-distinct identity.
+    /// </remarks>
+    public sealed record Acquired : InspectionGraphAssemblyIdentity
+    {
+        internal Acquired(ResolvedAssemblyReference assembly)
+        {
+            ArgumentNullException.ThrowIfNull(assembly);
+            Registration = assembly.Registration;
+            Assembly = assembly.Identity;
+            Provenance = assembly.Provenance;
+        }
+
+        public AssemblyAcquisitionRegistration Registration { get; }
+        public AssemblyReferenceIdentity Assembly { get; }
+        public AssemblyResolutionProvenance Provenance { get; }
+        public override bool IsPortable => false;
+    }
+
     public sealed record Metadata : InspectionGraphAssemblyIdentity
     {
         public Metadata(AssemblyReferenceIdentity assembly)
@@ -107,6 +131,10 @@ public abstract record InspectionGraphSubject
     public static InspectionGraphSubject ForAssembly(
         InspectionGraphAssemblyIdentity identity) =>
         new AssemblySubject(identity);
+
+    public static InspectionGraphSubject ForAcquiredAssembly(
+        ResolvedAssemblyReference assembly) =>
+        ForAssembly(new InspectionGraphAssemblyIdentity.Acquired(assembly));
 
     public static InspectionGraphSubject ForMetadataAssembly(
         AssemblyReferenceIdentity assembly) =>

--- a/src/DotnetInspector.Queries/InspectionGraphPackageBoundary.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphPackageBoundary.cs
@@ -1,0 +1,285 @@
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+
+using ILInspector.Metadata;
+using NuGet.Versioning;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// The subject lens used to project workspace package ownership.
+/// </summary>
+public enum InspectionGraphPackageBoundaryLens
+{
+    PackageGroups,
+    PackageNodes,
+    Mixed,
+}
+
+/// <summary>
+/// Typed package ownership retained from realized workspace members.
+/// </summary>
+/// <remarks>
+/// <c>WorkspaceContextLoaderTests.PackageBoundary_ProjectsLoadedPackageAsGroupAndNode</c>
+/// gates the real package-acquisition path.
+/// </remarks>
+public sealed class InspectionGraphPackageBoundary
+{
+    readonly ImmutableArray<Artifact> _artifacts;
+    readonly ImmutableArray<Package> _packages;
+    readonly IReadOnlyDictionary<
+        AssemblyAcquisitionRegistration,
+        InspectionGraphSubject.PackageSubject> _packagesByRegistration;
+
+    InspectionGraphPackageBoundary(
+        ImmutableArray<Artifact> artifacts,
+        ImmutableArray<Package> packages,
+        IReadOnlyDictionary<
+            AssemblyAcquisitionRegistration,
+            InspectionGraphSubject.PackageSubject> packagesByRegistration)
+    {
+        _artifacts = artifacts;
+        _packages = packages;
+        _packagesByRegistration = packagesByRegistration;
+    }
+
+    /// <summary>
+    /// Captures package ownership from one loaded workspace context.
+    /// </summary>
+    public static InspectionGraphPackageBoundary Create(
+        WorkspaceContextLoadOutcome.Loaded context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var groupRegistrations = context.Group.Participants
+            .Select(static participant =>
+                participant.Assembly.Registration)
+            .ToHashSet();
+        var memberRegistrations = context.Members
+            .Select(static member =>
+                member.Participant.Assembly.Registration)
+            .ToHashSet();
+        if (!groupRegistrations.SetEquals(memberRegistrations))
+        {
+            throw new ArgumentException(
+                "Package ownership requires every participant in the loaded workspace context.",
+                nameof(context));
+        }
+
+        return Create(context.Members);
+    }
+
+    internal static InspectionGraphPackageBoundary Create(
+        IEnumerable<WorkspaceContextMember> members)
+    {
+        ArgumentNullException.ThrowIfNull(members);
+
+        var artifacts = ImmutableArray.CreateBuilder<Artifact>();
+        var artifactsByRegistration =
+            new Dictionary<AssemblyAcquisitionRegistration, Artifact>();
+        var packages = ImmutableArray.CreateBuilder<Package>();
+        var packagesByCoordinate =
+            new Dictionary<RealizedMemberCoordinate.Package, Package>();
+        var packagesByRegistration = new Dictionary<
+            AssemblyAcquisitionRegistration,
+            InspectionGraphSubject.PackageSubject>();
+
+        foreach (WorkspaceContextMember member in members)
+        {
+            ArgumentNullException.ThrowIfNull(member);
+            ResolvedAssemblyReference assembly =
+                member.Participant.Assembly;
+            AssemblyAcquisitionRegistration registration =
+                assembly.Registration;
+
+            if (artifactsByRegistration.TryGetValue(
+                    registration,
+                    out Artifact? existing))
+            {
+                if (existing.Realized != member.Realized)
+                {
+                    throw new ArgumentException(
+                        "One acquired assembly cannot belong to more than one realized workspace member.",
+                        nameof(members));
+                }
+
+                continue;
+            }
+
+            InspectionGraphSubject.PackageSubject? packageSubject = null;
+            if (member.Realized
+                is RealizedMemberCoordinate.Package packageCoordinate)
+            {
+                ValidatePackageProvenance(
+                    packageCoordinate,
+                    assembly.Provenance,
+                    nameof(members));
+                if (!packagesByCoordinate.TryGetValue(
+                        packageCoordinate,
+                        out Package? package))
+                {
+                    packageSubject = (InspectionGraphSubject.PackageSubject)
+                        InspectionGraphSubject.ForRealizedPackage(
+                            packageCoordinate);
+                    package = new Package(
+                        packageCoordinate,
+                        packageSubject);
+                    packagesByCoordinate.Add(packageCoordinate, package);
+                    packages.Add(package);
+                }
+                else
+                {
+                    packageSubject = package.Subject;
+                }
+
+                packagesByRegistration.Add(
+                    registration,
+                    packageSubject);
+            }
+            else if (assembly.Provenance
+                is AssemblyResolutionProvenance.PackageAsset)
+            {
+                throw new ArgumentException(
+                    "Package assembly provenance requires a realized package coordinate.",
+                    nameof(members));
+            }
+
+            var artifact = new Artifact(
+                member.Realized,
+                (InspectionGraphSubject.AssemblySubject)
+                    InspectionGraphSubject.ForAcquiredAssembly(assembly),
+                packageSubject);
+            artifactsByRegistration.Add(registration, artifact);
+            artifacts.Add(artifact);
+        }
+
+        return new InspectionGraphPackageBoundary(
+            artifacts.ToImmutable(),
+            packages.ToImmutable(),
+            packagesByRegistration);
+    }
+
+    /// <summary>
+    /// Gets the realized package that owns one acquired assembly.
+    /// </summary>
+    public bool TryGetPackageSubject(
+        AssemblyAcquisitionRegistration registration,
+        [NotNullWhen(true)]
+        out InspectionGraphSubject.PackageSubject? package)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        return _packagesByRegistration.TryGetValue(
+            registration,
+            out package);
+    }
+
+    /// <summary>
+    /// Projects package ownership as structured groups, package nodes, or both.
+    /// </summary>
+    public InspectionGraphDocument Project(
+        InspectionGraphPackageBoundaryLens lens)
+    {
+        InspectionGraphCollections.RequireDefined(lens, nameof(lens));
+
+        bool includeArtifacts =
+            lens is InspectionGraphPackageBoundaryLens.PackageGroups
+                or InspectionGraphPackageBoundaryLens.Mixed;
+        bool includePackageNodes =
+            lens is InspectionGraphPackageBoundaryLens.PackageNodes
+                or InspectionGraphPackageBoundaryLens.Mixed;
+
+        var groups = includeArtifacts
+            ? _packages
+                .Select((package, id) =>
+                    new InspectionGraphGroup(
+                        id,
+                        package.Subject,
+                        parentId: null))
+                .ToImmutableArray()
+            : [];
+        Dictionary<InspectionGraphSubject.PackageSubject, int> groupIds =
+            groups.ToDictionary(
+                group => (InspectionGraphSubject.PackageSubject)
+                    group.Subject,
+                static group => group.Id);
+
+        var nodes = ImmutableArray.CreateBuilder<InspectionGraphNode>();
+        if (includePackageNodes)
+        {
+            foreach (Package package in _packages)
+            {
+                nodes.Add(
+                    new InspectionGraphNode(
+                        nodes.Count,
+                        package.Subject,
+                        InspectionGraphNodeRole.Ordinary,
+                        []));
+            }
+        }
+
+        if (includeArtifacts)
+        {
+            foreach (Artifact artifact in _artifacts)
+            {
+                nodes.Add(
+                    new InspectionGraphNode(
+                        nodes.Count,
+                        artifact.Subject,
+                        InspectionGraphNodeRole.Ordinary,
+                        artifact.Package is null
+                            ? []
+                            : [groupIds[artifact.Package]]));
+            }
+        }
+
+        return new InspectionGraphDocument(
+            includeArtifacts
+                ? InspectionGraphDocumentScope.SessionBound
+                : InspectionGraphDocumentScope.Portable,
+            nodes,
+            groups,
+            [],
+            [],
+            [],
+            [],
+            [],
+            []);
+    }
+
+    static void ValidatePackageProvenance(
+        RealizedMemberCoordinate.Package coordinate,
+        AssemblyResolutionProvenance provenance,
+        string parameterName)
+    {
+        if (provenance
+                is not AssemblyResolutionProvenance.PackageAsset package
+            || !StringComparer.OrdinalIgnoreCase.Equals(
+                coordinate.PackageId,
+                package.PackageId)
+            || !NuGetVersion.TryParse(
+                package.PackageVersion,
+                out NuGetVersion? version)
+            || !StringComparer.Ordinal.Equals(
+                coordinate.Version,
+                version.ToNormalizedString().ToLowerInvariant())
+            || !StringComparer.OrdinalIgnoreCase.Equals(
+                coordinate.Framework,
+                package.Tfm)
+            || !StringComparer.OrdinalIgnoreCase.Equals(
+                coordinate.RuntimeIdentifier,
+                package.Rid))
+        {
+            throw new ArgumentException(
+                "A realized package coordinate must match its assembly provenance.",
+                parameterName);
+        }
+    }
+
+    sealed record Artifact(
+        RealizedMemberCoordinate Realized,
+        InspectionGraphSubject.AssemblySubject Subject,
+        InspectionGraphSubject.PackageSubject? Package);
+
+    sealed record Package(
+        RealizedMemberCoordinate.Package Coordinate,
+        InspectionGraphSubject.PackageSubject Subject);
+}

--- a/src/DotnetInspector.Queries/InspectionGraphPackageBoundary.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphPackageBoundary.cs
@@ -260,16 +260,10 @@ public sealed class InspectionGraphPackageBoundary
                 out NuGetVersion? version)
             || !StringComparer.Ordinal.Equals(
                 coordinate.Version,
-                version.ToNormalizedString().ToLowerInvariant())
-            || !StringComparer.OrdinalIgnoreCase.Equals(
-                coordinate.Framework,
-                package.Tfm)
-            || !StringComparer.OrdinalIgnoreCase.Equals(
-                coordinate.RuntimeIdentifier,
-                package.Rid))
+                version.ToNormalizedString().ToLowerInvariant()))
         {
             throw new ArgumentException(
-                "A realized package coordinate must match its assembly provenance.",
+                "A realized package coordinate's package identity and version must match its assembly provenance.",
                 parameterName);
         }
     }


### PR DESCRIPTION
# Summary

Projects exact workspace package ownership into the typed inspection graph
without deriving identity from assembly names or display labels.

- Adds acquisition-bound assembly subjects keyed by the workspace's opaque
  acquisition registration.
- Validates each package participant's identity/version provenance while
  preserving the distinction between effective and physical asset targets.
- Projects one package subject as a structured package group, a package node,
  or both.
- Keeps package-only projections portable while assembly-bearing projections
  remain honestly session-bound.
- Rejects incomplete context membership, conflicting ownership, and
  provenance drift instead of returning a smaller success-shaped graph.

## Compatibility boundary

This is inspection-graph delivery slice 3. It adds an L1 package-boundary
projection and does not change existing CLI output, package acquisition,
Integrations scanning, or rendering. Type/package Integration relationships
and the locked `IChatClient` dual-lens view remain delivery slice 4.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — 0 warnings, 0 errors
- Focused package-boundary unit gates — 9 passed
- Compiled package-acquisition gates — 2 passed
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build`
  — 288 passed
- CLI suite with `ilasm`/`ildasm`/`mdv` activated — 3,879 passed; 4
  platform-specific skips
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release` —
  36 passed
- Browser/Wasm publish of `InspectWeb.Engine` succeeded
- `markdownlint` over all three changed design documents
- `git diff --check`
