### PR TITLE
Add bounded exact structural clone discovery

### DIFF
--- a/docs/design/structural-clone-analysis.md
+++ b/docs/design/structural-clone-analysis.md
@@ -5,8 +5,9 @@ body structure. The first slice answers one bounded question: are two IL method
 bodies in the same retained PE image exactly equal under the documented
 normalization?
 
-This is an internal product API. It does not discover candidate pairs or expose
-a CLI command.
+This is an internal product API. The second slice adds bounded exact discovery
+over a caller-supplied same-PE population. It does not expose a public CLI
+command.
 
 ## Result contract
 
@@ -90,6 +91,75 @@ corresponding fail-closed metadata boundaries.
 `StructuralCloneAnalysisTests` gates this policy with compiler-produced and
 synthetic close-positive/close-negative cases.
 
+## Exact discovery
+
+`StructuralCloneAnalysis.Discover` partitions a caller-supplied set of
+`MethodDefinitionHandle` values from one retained `PEReader`. It does not
+enumerate the PE or widen the population. Duplicate handles and invalid handles
+are caller errors. Method-count admission is atomic: when the population
+exceeds the method limit, no metadata or body work starts.
+
+Discovery has two bounded production passes:
+
+1. Produce each admitted method once, emit its side-free outcome and receipt,
+   calculate a compact retrieval fingerprint, and discard the full body facts.
+2. Re-produce only multi-member candidate buckets, retain one bucket at a time,
+   and partition it by exact comparisons against current group
+   representatives.
+
+The fingerprint contains only necessary exact invariants: normalized method
+signature shape and `InitLocals`; local count and an order-independent local
+type multiset; block, instruction, and edge counts; an order-independent
+multiset of per-block operation/exit fingerprints; and duplicate-preserving
+global incoming and outgoing edge-role multisets. Local slot numbers and CFG
+target identities are excluded. Offsets, body size, `MaxStack`, declared
+parameter and non-void return identities, and block order are also excluded.
+Hash collisions can add comparisons but cannot establish identity. Only the
+existing exact comparator can put two methods in one cluster.
+
+Overall discovery disposition is separate from per-method production:
+
+| Discovery disposition | Meaning |
+| --- | --- |
+| `Completed` | Every admitted candidate bucket was fully partitioned. |
+| `LimitReached` | A method, comparison, or verification budget suppressed work. |
+| `Failed` | Malformed metadata or operational body production failed. |
+
+Unsupported methods remain explicit per-method outcomes and do not downgrade
+an otherwise complete run. Failure takes precedence over a limit when both
+occur. A comparison consumes budget when attempted, so reaching the exact
+budget after the last required comparison is still complete.
+
+Every emitted cluster is complete for its candidate bucket. A cluster carries
+sorted typed method addresses and exact representative comparisons for every
+non-anchor member. If a bucket cannot be fully verified, discovery emits no
+cluster from it; instead it emits the full affected method set and a typed
+suppression reason. Completed clusters from other buckets remain visible, but
+absence from a cluster is negative evidence only when the overall disposition
+is `Completed` and there are no suppressed buckets.
+
+Cluster identity is the module MVID plus the sorted, unique full MethodDef
+tokens of its members. This is deterministic and collision-free within one
+admitted PE/population. It is not a global identity: MVIDs can be duplicated,
+and membership changes when the input population changes.
+
+The discovery receipt reports admitted and suppressed methods, per-disposition
+method counts, candidate/completed/suppressed buckets, exact/different/
+unresolved comparisons, and total body productions.
+
+`Discover_CompilerProducedPopulation_FindsClosedExactFamilies` gates realistic
+retrieval, exact families, the edge-role close negative, and unsupported
+methods. `Discover_ThreeMemberFamily_UsesRepresentativeEvidence` and
+`Discover_InputOrder_DoesNotChangeClusterIdentity` gate representative
+partitioning and deterministic identity.
+`Discover_ExactComparisonBudget_CanComplete`,
+`Discover_MidBucketBudget_EmitsNoPartialCluster`, and
+`Discover_MethodLimitAdmission_IsAtomic` gate bounded completeness and
+suppression. `Discover_DuplicateHandles_AreCallerError`,
+`Discover_InvalidLimits_AreCallerError`, and
+`Discover_MalformedModuleIdentity_ReturnsTypedFailure` gate caller and
+malformed-input boundaries.
+
 ## Correspondence and automorphisms
 
 Joint block/local refinement narrows possible correspondence classes until it
@@ -114,16 +184,21 @@ independent candidate relationships and expected outcomes. Each case records:
 - expected disposition and, separately, expected relation;
 - difficulty, intent, actionability, and tags.
 
+Schema 2 also declares the closed-world discovery population.
 `analysis-harness --clone-corpus` resolves those identities through SRM and
-grades only the public `StructuralCloneAnalysis.Compare` API. It does not own
-normalization, CFG correspondence, or verification logic.
-`StructuralCloneCorpusTests` gates ledger validity, fixture inventory coverage,
-and all committed outcomes.
+grades comparison and discovery independently. Expected exact connected
+components derive only from declared expected relations. Complete actual
+clusters must equal them, so both missed families and undeclared
+cross-component merges fail. The harness does not own retrieval,
+normalization, clustering, CFG correspondence, or verification logic.
+`StructuralCloneCorpusTests` gates ledger validity, both fixture inventory
+views, all direct outcomes, and exact closed-world clustering.
 
 The initial corpus includes authored arithmetic and metadata-operand exact
 pairs, a control-flow close negative, exact parameter-type and return-type
-semantic hazards, and the EH unsupported boundary. Candidate discovery, fuzzy
-ranking, precision/recall measurement, and CoreLib scale runs are later slices.
+semantic hazards, and the EH unsupported boundary. Exact discovery finds four
+families and rejects the close negative. Fuzzy ranking, precision/recall
+measurement, and CoreLib scale runs are later slices.
 
 Clone detection is intentionally neutral about why two bodies are similar.
 Deduplication, refactoring, provenance investigation, copied-code detection,

--- a/src/ILInspector.Analysis.Tests/StructuralCloneAnalysisTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneAnalysisTests.cs
@@ -148,6 +148,20 @@ public class StructuralCloneAnalysisTests
         Assert.Equal(2, result.Receipt.UnsupportedMethods);
         Assert.Equal(4, result.Receipt.ExactComparisons);
         Assert.Equal(1, result.Receipt.DifferentComparisons);
+        StructuralCloneMethodOutcome[] unsupported =
+        [
+            .. result.Methods.Where(static method =>
+                method.Disposition
+                    == StructuralCloneDisposition.Unsupported),
+        ];
+        Assert.Equal(2, unsupported.Length);
+        Assert.All(
+            unsupported,
+            static method => Assert.All(
+                method.Blockers,
+                static blocker => Assert.Equal(
+                    StructuralCloneDiscoveryBlockerKind.MethodUnsupported,
+                    blocker.Kind)));
 
         AssertCluster(
             result,

--- a/src/ILInspector.Analysis.Tests/StructuralCloneAnalysisTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneAnalysisTests.cs
@@ -113,6 +113,288 @@ public class StructuralCloneAnalysisTests
     }
 
     [Fact]
+    public void Discover_CompilerProducedPopulation_FindsClosedExactFamilies()
+    {
+        using PEReader image = OpenFixture();
+        MetadataReader reader = image.GetMetadataReader();
+        ImmutableArray<MethodDefinitionHandle> population =
+        [
+            Method(reader, nameof(StructuralCloneFixture.ExactPositiveA)),
+            Method(reader, nameof(StructuralCloneFixture.ExactPositiveB)),
+            Method(reader, nameof(StructuralCloneFixture.EdgeRoleNegativeA)),
+            Method(reader, nameof(StructuralCloneFixture.EdgeRoleNegativeB)),
+            Method(reader, nameof(StructuralCloneFixture.SignatureHazardByte)),
+            Method(reader, nameof(StructuralCloneFixture.SignatureHazardUInt)),
+            Method(reader, nameof(StructuralCloneFixture.SignatureHazardString)),
+            Method(reader, nameof(StructuralCloneFixture.SignatureHazardObject)),
+            Method(reader, nameof(StructuralCloneFixture.MetadataOperandsA)),
+            Method(reader, nameof(StructuralCloneFixture.MetadataOperandsB)),
+            Method(reader, nameof(StructuralCloneFixture.ExceptionHandlingA)),
+            Method(reader, nameof(StructuralCloneFixture.ExceptionHandlingB)),
+        ];
+
+        StructuralCloneDiscoveryResult result =
+            StructuralCloneAnalysis.Discover(image, population);
+
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.Completed,
+            result.Disposition);
+        Assert.Empty(result.Blockers);
+        Assert.Empty(result.SuppressedBuckets);
+        Assert.Empty(result.UnresolvedComparisons);
+        Assert.Equal(4, result.Clusters.Length);
+        Assert.Equal(12, result.Receipt.ProcessedMethods);
+        Assert.Equal(10, result.Receipt.EligibleMethods);
+        Assert.Equal(2, result.Receipt.UnsupportedMethods);
+        Assert.Equal(4, result.Receipt.ExactComparisons);
+        Assert.Equal(1, result.Receipt.DifferentComparisons);
+
+        AssertCluster(
+            result,
+            Method(reader, nameof(StructuralCloneFixture.ExactPositiveA)),
+            Method(reader, nameof(StructuralCloneFixture.ExactPositiveB)));
+        AssertCluster(
+            result,
+            Method(reader, nameof(StructuralCloneFixture.SignatureHazardByte)),
+            Method(reader, nameof(StructuralCloneFixture.SignatureHazardUInt)));
+        AssertCluster(
+            result,
+            Method(reader, nameof(StructuralCloneFixture.SignatureHazardString)),
+            Method(reader, nameof(StructuralCloneFixture.SignatureHazardObject)));
+        AssertCluster(
+            result,
+            Method(reader, nameof(StructuralCloneFixture.MetadataOperandsA)),
+            Method(reader, nameof(StructuralCloneFixture.MetadataOperandsB)));
+
+        HashSet<MethodDefinitionHandle> clustered =
+        [
+            .. result.Clusters.SelectMany(static cluster =>
+                cluster.Members.Select(static member => member.Handle)),
+        ];
+        Assert.DoesNotContain(
+            Method(reader, nameof(StructuralCloneFixture.EdgeRoleNegativeA)),
+            clustered);
+        Assert.DoesNotContain(
+            Method(reader, nameof(StructuralCloneFixture.EdgeRoleNegativeB)),
+            clustered);
+    }
+
+    [Fact]
+    public void Discover_ThreeMemberFamily_UsesRepresentativeEvidence()
+    {
+        using PEReader image = OpenImage(BuildTripletAssembly([0x2A]));
+        ImmutableArray<MethodDefinitionHandle> population =
+        [
+            MetadataTokens.MethodDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(2),
+            MetadataTokens.MethodDefinitionHandle(3),
+        ];
+
+        StructuralCloneDiscoveryResult result =
+            StructuralCloneAnalysis.Discover(image, population);
+
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.Completed,
+            result.Disposition);
+        StructuralCloneCluster cluster = Assert.Single(result.Clusters);
+        Assert.Equal(3, cluster.Members.Length);
+        Assert.Equal(2, cluster.Evidence.Length);
+        Assert.All(
+            cluster.Evidence,
+            static evidence => Assert.Equal(
+                StructuralCloneRelation.Exact,
+                evidence.Relation));
+        Assert.Equal(2, result.Receipt.CandidateComparisons);
+    }
+
+    [Fact]
+    public void Discover_InputOrder_DoesNotChangeClusterIdentity()
+    {
+        using PEReader image = OpenImage(BuildTripletAssembly([0x2A]));
+        MethodDefinitionHandle first =
+            MetadataTokens.MethodDefinitionHandle(1);
+        MethodDefinitionHandle second =
+            MetadataTokens.MethodDefinitionHandle(2);
+        MethodDefinitionHandle third =
+            MetadataTokens.MethodDefinitionHandle(3);
+
+        StructuralCloneDiscoveryResult forward =
+            StructuralCloneAnalysis.Discover(
+                image,
+                [first, second, third]);
+        StructuralCloneDiscoveryResult reverse =
+            StructuralCloneAnalysis.Discover(
+                image,
+                [third, first, second]);
+
+        Assert.Equal(
+            Assert.Single(forward.Clusters).Identity,
+            Assert.Single(reverse.Clusters).Identity);
+    }
+
+    [Fact]
+    public void Discover_DuplicateHandles_AreCallerError()
+    {
+        using PEReader image = OpenImage(BuildTwinAssembly([0x2A]));
+        MethodDefinitionHandle method =
+            MetadataTokens.MethodDefinitionHandle(1);
+
+        Assert.Throws<ArgumentException>(
+            () => StructuralCloneAnalysis.Discover(
+                image,
+                [method, method]));
+    }
+
+    [Fact]
+    public void Discover_ExactComparisonBudget_CanComplete()
+    {
+        using PEReader image = OpenImage(BuildTripletAssembly([0x2A]));
+
+        StructuralCloneDiscoveryResult result =
+            StructuralCloneAnalysis.Discover(
+                image,
+                [
+                    MetadataTokens.MethodDefinitionHandle(1),
+                    MetadataTokens.MethodDefinitionHandle(2),
+                    MetadataTokens.MethodDefinitionHandle(3),
+                ],
+                new StructuralCloneDiscoveryLimits(
+                    MaximumCandidateComparisons: 2));
+
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.Completed,
+            result.Disposition);
+        Assert.Single(result.Clusters);
+        Assert.Equal(2, result.Receipt.CandidateComparisons);
+    }
+
+    [Fact]
+    public void Discover_ExhaustedBudget_SuppressesLaterBucketsBeforeReplay()
+    {
+        using PEReader image = OpenFixture();
+        MetadataReader reader = image.GetMetadataReader();
+
+        StructuralCloneDiscoveryResult result =
+            StructuralCloneAnalysis.Discover(
+                image,
+                [
+                    Method(
+                        reader,
+                        nameof(StructuralCloneFixture.ExactPositiveA)),
+                    Method(
+                        reader,
+                        nameof(StructuralCloneFixture.ExactPositiveB)),
+                    Method(
+                        reader,
+                        nameof(StructuralCloneFixture.MetadataOperandsA)),
+                    Method(
+                        reader,
+                        nameof(StructuralCloneFixture.MetadataOperandsB)),
+                ],
+                new StructuralCloneDiscoveryLimits(
+                    MaximumCandidateComparisons: 1));
+
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.LimitReached,
+            result.Disposition);
+        Assert.Single(result.Clusters);
+        Assert.Single(result.SuppressedBuckets);
+        Assert.Equal(1, result.Receipt.CandidateComparisons);
+        Assert.Equal(6, result.Receipt.BodyProductions);
+    }
+
+    [Fact]
+    public void Discover_MidBucketBudget_EmitsNoPartialCluster()
+    {
+        using PEReader image = OpenImage(BuildTripletAssembly([0x2A]));
+
+        StructuralCloneDiscoveryResult result =
+            StructuralCloneAnalysis.Discover(
+                image,
+                [
+                    MetadataTokens.MethodDefinitionHandle(1),
+                    MetadataTokens.MethodDefinitionHandle(2),
+                    MetadataTokens.MethodDefinitionHandle(3),
+                ],
+                new StructuralCloneDiscoveryLimits(
+                    MaximumCandidateComparisons: 1));
+
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.LimitReached,
+            result.Disposition);
+        Assert.Empty(result.Clusters);
+        StructuralCloneSuppressedBucket suppressed =
+            Assert.Single(result.SuppressedBuckets);
+        Assert.Equal(3, suppressed.Methods.Length);
+        Assert.Equal(
+            StructuralCloneDiscoveryBlockerKind.CandidateComparisonLimit,
+            suppressed.Reason.Kind);
+        Assert.Equal(1, result.Receipt.CandidateComparisons);
+        Assert.Equal(6, result.Receipt.BodyProductions);
+    }
+
+    [Fact]
+    public void Discover_MethodLimitAdmission_IsAtomic()
+    {
+        using PEReader image = OpenImage(BuildTwinAssembly([0x2A]));
+
+        StructuralCloneDiscoveryResult result =
+            StructuralCloneAnalysis.Discover(
+                image,
+                [
+                    MetadataTokens.MethodDefinitionHandle(1),
+                    MetadataTokens.MethodDefinitionHandle(2),
+                ],
+                new StructuralCloneDiscoveryLimits(MaximumMethods: 1));
+
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.LimitReached,
+            result.Disposition);
+        Assert.Empty(result.Methods);
+        Assert.Equal(0, result.Receipt.ProcessedMethods);
+        Assert.Equal(0, result.Receipt.BodyProductions);
+        Assert.Equal(2, result.Receipt.SuppressedMethods);
+    }
+
+    [Fact]
+    public void Discover_MalformedModuleIdentity_ReturnsTypedFailure()
+    {
+        using PEReader image = OpenImage(
+            BuildMalformedModuleIdentityTwinAssembly());
+
+        StructuralCloneDiscoveryResult result =
+            StructuralCloneAnalysis.Discover(
+                image,
+                [
+                    MetadataTokens.MethodDefinitionHandle(1),
+                    MetadataTokens.MethodDefinitionHandle(2),
+                ]);
+
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.Failed,
+            result.Disposition);
+        Assert.Empty(result.Methods);
+        StructuralCloneDiscoveryBlocker blocker =
+            Assert.Single(result.Blockers);
+        Assert.Equal(
+            StructuralCloneDiscoveryBlockerKind.MetadataReadFailure,
+            blocker.Kind);
+    }
+
+    [Fact]
+    public void Discover_InvalidLimits_AreCallerError()
+    {
+        using PEReader image = OpenImage(BuildTwinAssembly([0x2A]));
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => StructuralCloneAnalysis.Discover(
+                image,
+                [MetadataTokens.MethodDefinitionHandle(1)],
+                new StructuralCloneDiscoveryLimits(
+                    MaximumCandidateComparisons: 0)));
+    }
+
+    [Fact]
     public void Compare_SameNamedLocalsFromDifferentAssemblyIdentities_AreDifferent()
     {
         using PEReader image = OpenImage(
@@ -1670,6 +1952,23 @@ public class StructuralCloneAnalysisTests
         => new(File.OpenRead(
             typeof(StructuralCloneFixture).Assembly.Location));
 
+    static void AssertCluster(
+        StructuralCloneDiscoveryResult result,
+        params MethodDefinitionHandle[] expected)
+    {
+        int[] expectedTokens =
+        [
+            .. expected
+                .Select(static method =>
+                    MetadataTokens.GetToken(method))
+                .Order(),
+        ];
+        Assert.Single(
+            result.Clusters,
+            cluster => cluster.Identity.MethodTokens.SequenceEqual(
+                expectedTokens));
+    }
+
     static MethodDefinitionHandle Method(
         MetadataReader reader,
         string name)
@@ -2052,6 +2351,27 @@ public class StructuralCloneAnalysisTests
             secondBody,
             implementation: implementation,
             attributes: attributes);
+        return Serialize(metadata, bodies);
+    }
+
+    static byte[] BuildTripletAssembly(byte[] il)
+    {
+        MetadataBuilder metadata = AssemblyMetadata();
+        AddFixtureType(metadata);
+        var bodies = new BlobBuilder();
+        var bodyEncoder = new MethodBodyStreamEncoder(bodies);
+        AddMethod(
+            metadata,
+            "First",
+            AddBody(bodyEncoder, il, localSignature: default));
+        AddMethod(
+            metadata,
+            "Second",
+            AddBody(bodyEncoder, il, localSignature: default));
+        AddMethod(
+            metadata,
+            "Third",
+            AddBody(bodyEncoder, il, localSignature: default));
         return Serialize(metadata, bodies);
     }
 

--- a/src/ILInspector.Analysis.Tests/StructuralCloneCorpusTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneCorpusTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Reflection.PortableExecutable;
 using System.Text.Json;
 
+using ILInspector.Analysis;
 using ILInspector.Analysis.StructuralCloneFixtures;
 using ILInspector.AnalysisHarness;
 
@@ -24,6 +25,12 @@ public class StructuralCloneCorpusTests
             report.Success,
             StructuralCloneCorpus.Format(report));
         Assert.Equal(6, report.Total);
+        Assert.True(report.Discovery.Passed);
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.Completed,
+            report.Discovery.Disposition);
+        Assert.Equal(4, report.Discovery.ExpectedClusters.Length);
+        Assert.Equal(4, report.Discovery.ActualClusters.Length);
     }
 
     [Fact]
@@ -84,6 +91,65 @@ public class StructuralCloneCorpusTests
         ];
 
         Assert.Equal(fixtureMethods, corpusMethods);
+        string[] discoveryMethods =
+        [
+            .. corpus.Discovery.Population
+                .Select(static method =>
+                    $"{method.Type}.{method.Method}")
+                .Order(StringComparer.Ordinal),
+        ];
+        Assert.Equal(fixtureMethods, discoveryMethods);
+    }
+
+    [Fact]
+    public void Run_ClosedWorldDiscoveryRejectsUndeclaredMerge()
+    {
+        StructuralCloneCorpusDocument corpus = LoadCorpus();
+        StructuralCloneCorpusCase exact = corpus.Cases.Single(
+            static item => item.Id == "banal.authored.exact");
+        StructuralCloneCorpusDocument altered = corpus with
+        {
+            Cases = corpus.Cases.Replace(
+                exact,
+                exact with
+                {
+                    ExpectedRelation = StructuralCloneRelation.Different,
+                }),
+        };
+
+        StructuralCloneCorpusReport report = StructuralCloneCorpus.Run(
+            typeof(StructuralCloneFixture).Assembly.Location,
+            altered);
+
+        Assert.False(report.Discovery.Passed);
+        Assert.Equal(3, report.Discovery.ExpectedClusters.Length);
+        Assert.Equal(4, report.Discovery.ActualClusters.Length);
+    }
+
+    [Fact]
+    public void Run_ClosedWorldDiscoveryRejectsMissedFamily()
+    {
+        StructuralCloneCorpusDocument corpus = LoadCorpus();
+        StructuralCloneCorpusCase different = corpus.Cases.Single(
+            static item =>
+                item.Id == "challenging.edge-role.negative");
+        StructuralCloneCorpusDocument altered = corpus with
+        {
+            Cases = corpus.Cases.Replace(
+                different,
+                different with
+                {
+                    ExpectedRelation = StructuralCloneRelation.Exact,
+                }),
+        };
+
+        StructuralCloneCorpusReport report = StructuralCloneCorpus.Run(
+            typeof(StructuralCloneFixture).Assembly.Location,
+            altered);
+
+        Assert.False(report.Discovery.Passed);
+        Assert.Equal(5, report.Discovery.ExpectedClusters.Length);
+        Assert.Equal(4, report.Discovery.ActualClusters.Length);
     }
 
     [Fact]
@@ -92,7 +158,7 @@ public class StructuralCloneCorpusTests
         const string Invalid =
             """
             {
-              "schemaVersion": 1,
+              "schemaVersion": 2,
               "cases": [{
                 "id": "invalid",
                 "left": { "type": "T", "method": "A" },
@@ -103,7 +169,13 @@ public class StructuralCloneCorpusTests
                 "intent": "unsupported-boundary",
                 "actionability": "none",
                 "tags": []
-              }]
+              }],
+              "discovery": {
+                "population": [
+                  { "type": "T", "method": "A" },
+                  { "type": "T", "method": "B" }
+                ]
+              }
             }
             """;
 

--- a/src/ILInspector.Analysis/StructuralCloneAnalysis.cs
+++ b/src/ILInspector.Analysis/StructuralCloneAnalysis.cs
@@ -222,8 +222,8 @@ public sealed record StructuralCloneComparison
 }
 
 /// <summary>
-/// Exact normalized structural comparison over two method bodies in one
-/// retained PE image.
+/// Exact normalized structural comparison and bounded discovery over method
+/// bodies in one retained PE image.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -242,7 +242,7 @@ public sealed record StructuralCloneComparison
 /// Nops and redundant branches are retained rather than normalized away.
 /// </para>
 /// </remarks>
-public static class StructuralCloneAnalysis
+public static partial class StructuralCloneAnalysis
 {
     internal const byte HasThisSignatureFlag = 0x20;
     internal const byte ExplicitThisSignatureFlag = 0x40;
@@ -261,77 +261,33 @@ public static class StructuralCloneAnalysis
             new(Guid.Empty, left);
         MetadataMethodAddress rightAddress =
             new(Guid.Empty, right);
-        bool hasMetadata;
-        try
-        {
-            hasMetadata = image.HasMetadata;
-        }
-        catch (Exception ex) when (
-            ex is BadImageFormatException
-                or ArgumentException
-                or ArgumentOutOfRangeException
-                or InvalidOperationException and not ObjectDisposedException
-                or OverflowException)
+        if (!TryGetMetadataReader(
+                image,
+                out MetadataReader reader,
+                out StructuralCloneMetadataFailure metadataFailure))
         {
             return MetadataReadFailure(
                 leftAddress,
                 rightAddress,
-                "metadata directory",
-                ex);
-        }
-        if (!hasMetadata)
-        {
-            throw new ArgumentException(
-                "Structural clone comparison requires a managed metadata image.",
-                nameof(image));
-        }
-
-        MetadataReader reader;
-        try
-        {
-            reader = image.GetMetadataReader();
-        }
-        catch (Exception ex) when (
-            ex is BadImageFormatException
-                or ArgumentException
-                or ArgumentOutOfRangeException
-                or InvalidOperationException
-                or OverflowException)
-        {
-            return MetadataReadFailure(
-                leftAddress,
-                rightAddress,
-                "metadata root",
-                ex);
+                metadataFailure.Subject,
+                metadataFailure.Exception);
         }
 
         ValidateHandle(reader, left, nameof(left));
         ValidateHandle(reader, right, nameof(right));
-        try
-        {
-            ModuleDefinition module = reader.GetModuleDefinition();
-            if (module.Mvid.IsNil)
-            {
-                throw new BadImageFormatException(
-                    "The module has no version identifier.");
-            }
-            Guid moduleVersionId = reader.GetGuid(module.Mvid);
-            leftAddress = new(moduleVersionId, left);
-            rightAddress = new(moduleVersionId, right);
-        }
-        catch (Exception ex) when (
-            ex is BadImageFormatException
-                or ArgumentException
-                or ArgumentOutOfRangeException
-                or InvalidOperationException
-                or OverflowException)
+        if (!TryGetModuleVersionId(
+                reader,
+                out Guid moduleVersionId,
+                out metadataFailure))
         {
             return MetadataReadFailure(
                 leftAddress,
                 rightAddress,
-                "module identity",
-                ex);
+                metadataFailure.Subject,
+                metadataFailure.Exception);
         }
+        leftAddress = new(moduleVersionId, left);
+        rightAddress = new(moduleVersionId, right);
         BodyProduction leftBody =
             Produce(image, reader, leftAddress, StructuralCloneSide.Left, limits);
         BodyProduction rightBody =
@@ -372,6 +328,83 @@ public static class StructuralCloneAnalysis
             ],
             new StructuralCloneVerificationReceipt(
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false, false));
+
+    static bool TryGetMetadataReader(
+        PEReader image,
+        out MetadataReader reader,
+        out StructuralCloneMetadataFailure failure)
+    {
+        bool hasMetadata;
+        try
+        {
+            hasMetadata = image.HasMetadata;
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentException
+                or ArgumentOutOfRangeException
+                or InvalidOperationException and not ObjectDisposedException
+                or OverflowException)
+        {
+            reader = null!;
+            failure = new("metadata directory", ex);
+            return false;
+        }
+        if (!hasMetadata)
+        {
+            throw new ArgumentException(
+                "Structural clone analysis requires a managed metadata image.",
+                nameof(image));
+        }
+
+        try
+        {
+            reader = image.GetMetadataReader();
+            failure = default;
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentException
+                or ArgumentOutOfRangeException
+                or InvalidOperationException
+                or OverflowException)
+        {
+            reader = null!;
+            failure = new("metadata root", ex);
+            return false;
+        }
+    }
+
+    static bool TryGetModuleVersionId(
+        MetadataReader reader,
+        out Guid moduleVersionId,
+        out StructuralCloneMetadataFailure failure)
+    {
+        try
+        {
+            ModuleDefinition module = reader.GetModuleDefinition();
+            if (module.Mvid.IsNil)
+            {
+                throw new BadImageFormatException(
+                    "The module has no version identifier.");
+            }
+            moduleVersionId = reader.GetGuid(module.Mvid);
+            failure = default;
+            return true;
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentException
+                or ArgumentOutOfRangeException
+                or InvalidOperationException
+                or OverflowException)
+        {
+            moduleVersionId = Guid.Empty;
+            failure = new("module identity", ex);
+            return false;
+        }
+    }
 
     internal static StructuralCloneComparison Compare(
         StructuralCloneBodyFacts left,

--- a/src/ILInspector.Analysis/StructuralCloneDiscovery.cs
+++ b/src/ILInspector.Analysis/StructuralCloneDiscovery.cs
@@ -1,0 +1,863 @@
+using System.Buffers.Binary;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Security.Cryptography;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Analysis;
+
+/// <summary>The execution disposition of one structural-clone discovery run.</summary>
+public enum StructuralCloneDiscoveryDisposition
+{
+    Completed,
+    LimitReached,
+    Failed,
+}
+
+/// <summary>Typed reasons why structural-clone discovery did not complete.</summary>
+public enum StructuralCloneDiscoveryBlockerKind
+{
+    MetadataReadFailure,
+    MethodLimit,
+    MethodProductionLimit,
+    MethodProductionFailure,
+    CandidateComparisonLimit,
+    CandidateVerificationLimit,
+    CandidateVerificationFailure,
+    CandidateReproductionFailure,
+}
+
+/// <summary>One visible discovery failure or limit.</summary>
+public sealed record StructuralCloneDiscoveryBlocker(
+    StructuralCloneDiscoveryBlockerKind Kind,
+    string Detail);
+
+/// <summary>Bounded production receipt for one method.</summary>
+public sealed record StructuralCloneMethodReceipt(
+    int BodyBytes,
+    int Instructions,
+    int Blocks,
+    int Edges,
+    int Locals);
+
+/// <summary>Side-free production outcome for one admitted method.</summary>
+public sealed record StructuralCloneMethodOutcome(
+    MetadataMethodAddress Method,
+    StructuralCloneDisposition Disposition,
+    ImmutableArray<StructuralCloneDiscoveryBlocker> Blockers,
+    StructuralCloneMethodReceipt Receipt);
+
+/// <summary>
+/// Deterministic exact-cluster identity within one admitted PE and population.
+/// </summary>
+public sealed class StructuralCloneClusterIdentity
+    : IEquatable<StructuralCloneClusterIdentity>
+{
+    internal StructuralCloneClusterIdentity(
+        Guid moduleVersionId,
+        ImmutableArray<int> methodTokens)
+    {
+        ModuleVersionId = moduleVersionId;
+        MethodTokens = methodTokens;
+    }
+
+    public Guid ModuleVersionId { get; }
+    public ImmutableArray<int> MethodTokens { get; }
+
+    public bool Equals(StructuralCloneClusterIdentity? other)
+        => other is not null
+            && ModuleVersionId == other.ModuleVersionId
+            && MethodTokens.AsSpan().SequenceEqual(
+                other.MethodTokens.AsSpan());
+
+    public override bool Equals(object? obj)
+        => obj is StructuralCloneClusterIdentity other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(ModuleVersionId);
+        foreach (int token in MethodTokens)
+            hash.Add(token);
+        return hash.ToHashCode();
+    }
+
+    public override string ToString()
+        => $"{ModuleVersionId:N}/"
+            + string.Join(
+                ",",
+                MethodTokens.Select(static token => $"{token:X8}"));
+}
+
+/// <summary>
+/// One completely verified exact cluster. Evidence compares every non-anchor
+/// member with the first member.
+/// </summary>
+public sealed record StructuralCloneCluster(
+    StructuralCloneClusterIdentity Identity,
+    ImmutableArray<MetadataMethodAddress> Members,
+    ImmutableArray<StructuralCloneComparison> Evidence);
+
+/// <summary>
+/// One candidate bucket that discovery could not completely partition.
+/// Absence from a cluster is not negative evidence for these methods.
+/// </summary>
+public sealed record StructuralCloneSuppressedBucket(
+    ImmutableArray<MetadataMethodAddress> Methods,
+    StructuralCloneDiscoveryBlocker Reason);
+
+/// <summary>Bounded-work receipt for one discovery run.</summary>
+public sealed record StructuralCloneDiscoveryReceipt(
+    int InputMethods,
+    int ProcessedMethods,
+    int SuppressedMethods,
+    int EligibleMethods,
+    int UnsupportedMethods,
+    int LimitReachedMethods,
+    int FailedMethods,
+    int CandidateBuckets,
+    int CompletedCandidateBuckets,
+    int SuppressedCandidateBuckets,
+    int CandidateComparisons,
+    int ExactComparisons,
+    int DifferentComparisons,
+    int UnresolvedComparisons,
+    int BodyProductions);
+
+/// <summary>Resource limits for exact structural-clone discovery.</summary>
+public sealed record StructuralCloneDiscoveryLimits(
+    int MaximumMethods = 50_000,
+    int MaximumCandidateComparisons = 100_000,
+    StructuralCloneComparisonLimits? ComparisonLimits = null);
+
+/// <summary>Product-owned result for one bounded A-vs-A discovery run.</summary>
+public sealed record StructuralCloneDiscoveryResult
+{
+    internal StructuralCloneDiscoveryResult(
+        StructuralCloneDiscoveryDisposition disposition,
+        ImmutableArray<StructuralCloneCluster> clusters,
+        ImmutableArray<StructuralCloneMethodOutcome> methods,
+        ImmutableArray<StructuralCloneSuppressedBucket> suppressedBuckets,
+        ImmutableArray<StructuralCloneComparison> unresolvedComparisons,
+        ImmutableArray<StructuralCloneDiscoveryBlocker> blockers,
+        StructuralCloneDiscoveryReceipt receipt)
+    {
+        if (disposition == StructuralCloneDiscoveryDisposition.Completed
+            && (!blockers.IsEmpty
+                || !suppressedBuckets.IsEmpty
+                || !unresolvedComparisons.IsEmpty))
+        {
+            throw new ArgumentException(
+                "Completed discovery cannot carry blockers or suppressed work.");
+        }
+        if (disposition != StructuralCloneDiscoveryDisposition.Completed
+            && blockers.IsEmpty)
+        {
+            throw new ArgumentException(
+                "Non-completed discovery requires a blocker.",
+                nameof(blockers));
+        }
+
+        Disposition = disposition;
+        Clusters = clusters;
+        Methods = methods;
+        SuppressedBuckets = suppressedBuckets;
+        UnresolvedComparisons = unresolvedComparisons;
+        Blockers = blockers;
+        Receipt = receipt;
+    }
+
+    public StructuralCloneDiscoveryDisposition Disposition { get; }
+    public ImmutableArray<StructuralCloneCluster> Clusters { get; }
+    public ImmutableArray<StructuralCloneMethodOutcome> Methods { get; }
+    public ImmutableArray<StructuralCloneSuppressedBucket> SuppressedBuckets
+    {
+        get;
+    }
+    public ImmutableArray<StructuralCloneComparison> UnresolvedComparisons
+    {
+        get;
+    }
+    public ImmutableArray<StructuralCloneDiscoveryBlocker> Blockers { get; }
+    public StructuralCloneDiscoveryReceipt Receipt { get; }
+}
+
+public static partial class StructuralCloneAnalysis
+{
+    /// <summary>
+    /// Discovers completely verified exact clusters in one retained PE image.
+    /// Retrieval fingerprints only select candidates; they never establish
+    /// cluster identity or relation.
+    /// </summary>
+    public static StructuralCloneDiscoveryResult Discover(
+        PEReader image,
+        ImmutableArray<MethodDefinitionHandle> methods,
+        StructuralCloneDiscoveryLimits? limits = null)
+    {
+        ArgumentNullException.ThrowIfNull(image);
+        if (methods.IsDefault)
+        {
+            throw new ArgumentException(
+                "The discovery population must be initialized.",
+                nameof(methods));
+        }
+
+        limits ??= new StructuralCloneDiscoveryLimits();
+        ValidateDiscoveryLimits(limits);
+        StructuralCloneComparisonLimits comparisonLimits =
+            limits.ComparisonLimits
+            ?? new StructuralCloneComparisonLimits();
+        ValidateLimits(comparisonLimits);
+
+        if (methods.Length > limits.MaximumMethods)
+        {
+            StructuralCloneDiscoveryBlocker blocker = new(
+                StructuralCloneDiscoveryBlockerKind.MethodLimit,
+                $"Method population {methods.Length} exceeds "
+                    + $"{limits.MaximumMethods}.");
+            return new StructuralCloneDiscoveryResult(
+                StructuralCloneDiscoveryDisposition.LimitReached,
+                [],
+                [],
+                [],
+                [],
+                [blocker],
+                EmptyDiscoveryReceipt(
+                    methods.Length,
+                    suppressedMethods: methods.Length));
+        }
+
+        MethodDefinitionHandle[] orderedMethods =
+        [
+            .. methods.OrderBy(static method =>
+                MetadataTokens.GetRowNumber(method)),
+        ];
+        for (int index = 1; index < orderedMethods.Length; index++)
+        {
+            if (orderedMethods[index] == orderedMethods[index - 1])
+            {
+                throw new ArgumentException(
+                    "The discovery population cannot contain duplicate handles.",
+                    nameof(methods));
+            }
+        }
+
+        if (!TryGetMetadataReader(
+                image,
+                out MetadataReader reader,
+                out StructuralCloneMetadataFailure metadataFailure))
+        {
+            return FailedDiscovery(
+                methods.Length,
+                metadataFailure);
+        }
+        foreach (MethodDefinitionHandle method in orderedMethods)
+            ValidateHandle(reader, method, nameof(methods));
+        if (!TryGetModuleVersionId(
+                reader,
+                out Guid moduleVersionId,
+                out metadataFailure))
+        {
+            return FailedDiscovery(
+                methods.Length,
+                metadataFailure);
+        }
+
+        var buckets =
+            new Dictionary<StructuralCloneCandidateKey,
+                List<MethodDefinitionHandle>>();
+        ImmutableArray<StructuralCloneMethodOutcome>.Builder methodOutcomes =
+            ImmutableArray.CreateBuilder<StructuralCloneMethodOutcome>(
+                orderedMethods.Length);
+        ImmutableArray<StructuralCloneDiscoveryBlocker>.Builder blockers =
+            ImmutableArray.CreateBuilder<StructuralCloneDiscoveryBlocker>();
+        int eligibleMethods = 0;
+        int unsupportedMethods = 0;
+        int limitReachedMethods = 0;
+        int failedMethods = 0;
+        int bodyProductions = 0;
+
+        foreach (MethodDefinitionHandle handle in orderedMethods)
+        {
+            MetadataMethodAddress address = new(moduleVersionId, handle);
+            BodyProduction production = Produce(
+                image,
+                reader,
+                address,
+                StructuralCloneSide.Both,
+                comparisonLimits);
+            bodyProductions++;
+            methodOutcomes.Add(MethodOutcome(address, production));
+            switch (production.Disposition)
+            {
+                case StructuralCloneDisposition.Completed:
+                    eligibleMethods++;
+                    StructuralCloneCandidateKey key =
+                        StructuralCloneCandidateKey.Create(
+                            production.Facts!);
+                    if (!buckets.TryGetValue(key, out List<MethodDefinitionHandle>? bucket))
+                    {
+                        bucket = [];
+                        buckets.Add(key, bucket);
+                    }
+                    bucket.Add(handle);
+                    break;
+                case StructuralCloneDisposition.Unsupported:
+                    unsupportedMethods++;
+                    break;
+                case StructuralCloneDisposition.LimitReached:
+                    limitReachedMethods++;
+                    break;
+                case StructuralCloneDisposition.Failed:
+                    failedMethods++;
+                    break;
+            }
+        }
+
+        if (limitReachedMethods > 0)
+        {
+            blockers.Add(
+                new StructuralCloneDiscoveryBlocker(
+                    StructuralCloneDiscoveryBlockerKind.MethodProductionLimit,
+                    $"{limitReachedMethods} methods exceeded comparison "
+                        + "production limits."));
+        }
+        if (failedMethods > 0)
+        {
+            blockers.Add(
+                new StructuralCloneDiscoveryBlocker(
+                    StructuralCloneDiscoveryBlockerKind.MethodProductionFailure,
+                    $"{failedMethods} methods failed body production."));
+        }
+
+        List<List<MethodDefinitionHandle>> candidateBuckets =
+        [
+            .. buckets.Values
+                .Where(static bucket => bucket.Count > 1)
+                .OrderBy(static bucket =>
+                    MetadataTokens.GetRowNumber(bucket[0])),
+        ];
+        ImmutableArray<StructuralCloneCluster>.Builder clusters =
+            ImmutableArray.CreateBuilder<StructuralCloneCluster>();
+        ImmutableArray<StructuralCloneSuppressedBucket>.Builder suppressed =
+            ImmutableArray.CreateBuilder<StructuralCloneSuppressedBucket>();
+        ImmutableArray<StructuralCloneComparison>.Builder unresolved =
+            ImmutableArray.CreateBuilder<StructuralCloneComparison>();
+        int completedBuckets = 0;
+        int comparisons = 0;
+        int exactComparisons = 0;
+        int differentComparisons = 0;
+        bool comparisonBudgetExhausted = false;
+        bool verificationFailed = false;
+
+        for (int bucketIndex = 0;
+            bucketIndex < candidateBuckets.Count;
+            bucketIndex++)
+        {
+            List<MethodDefinitionHandle> bucket = candidateBuckets[bucketIndex];
+            if (comparisonBudgetExhausted
+                || comparisons >= limits.MaximumCandidateComparisons)
+            {
+                StructuralCloneDiscoveryBlocker reason = new(
+                    StructuralCloneDiscoveryBlockerKind
+                        .CandidateComparisonLimit,
+                    "The global candidate-comparison budget was exhausted.");
+                SuppressRemainingBuckets(
+                    candidateBuckets,
+                    bucketIndex,
+                    moduleVersionId,
+                    reason,
+                    suppressed);
+                blockers.Add(reason);
+                break;
+            }
+
+            List<StructuralCloneBodyFacts> facts = [];
+            StructuralCloneDiscoveryBlocker? bucketBlocker = null;
+            foreach (MethodDefinitionHandle handle in bucket)
+            {
+                MetadataMethodAddress address = new(moduleVersionId, handle);
+                BodyProduction production = Produce(
+                    image,
+                    reader,
+                    address,
+                    StructuralCloneSide.Both,
+                    comparisonLimits);
+                bodyProductions++;
+                if (production.Disposition
+                    != StructuralCloneDisposition.Completed)
+                {
+                    bucketBlocker = new(
+                        StructuralCloneDiscoveryBlockerKind
+                            .CandidateReproductionFailure,
+                        $"Candidate method 0x{MetadataTokens.GetToken(handle):X8} "
+                            + $"re-produced as {production.Disposition}.");
+                    if (production.Disposition
+                        == StructuralCloneDisposition.LimitReached)
+                    {
+                        bucketBlocker = new(
+                            StructuralCloneDiscoveryBlockerKind
+                                .CandidateVerificationLimit,
+                            $"Candidate method 0x{MetadataTokens.GetToken(handle):X8} "
+                                + "exceeded a limit when re-produced.");
+                    }
+                    else
+                    {
+                        verificationFailed = true;
+                    }
+                    break;
+                }
+                facts.Add(production.Facts!);
+            }
+            if (bucketBlocker is not null)
+            {
+                suppressed.Add(
+                    SuppressedBucket(
+                        bucket,
+                        moduleVersionId,
+                        bucketBlocker));
+                blockers.Add(bucketBlocker);
+                continue;
+            }
+
+            List<StructuralCloneDiscoveryGroup> groups = [];
+            bool bucketComplete = true;
+            foreach (StructuralCloneBodyFacts candidate in facts)
+            {
+                bool matched = false;
+                foreach (StructuralCloneDiscoveryGroup group in groups)
+                {
+                    if (comparisons
+                        >= limits.MaximumCandidateComparisons)
+                    {
+                        comparisonBudgetExhausted = true;
+                        bucketComplete = false;
+                        bucketBlocker = new(
+                            StructuralCloneDiscoveryBlockerKind
+                                .CandidateComparisonLimit,
+                            $"Candidate comparison count {comparisons} reached "
+                                + $"{limits.MaximumCandidateComparisons}.");
+                        break;
+                    }
+
+                    StructuralCloneComparison comparison = Compare(
+                        group.Representative,
+                        candidate,
+                        comparisonLimits);
+                    comparisons++;
+                    if (comparison.Disposition
+                        != StructuralCloneDisposition.Completed)
+                    {
+                        unresolved.Add(comparison);
+                        bucketComplete = false;
+                        if (comparison.Disposition
+                            == StructuralCloneDisposition.Failed)
+                        {
+                            verificationFailed = true;
+                            bucketBlocker = new(
+                                StructuralCloneDiscoveryBlockerKind
+                                    .CandidateVerificationFailure,
+                                "An exact candidate comparison failed.");
+                        }
+                        else
+                        {
+                            bucketBlocker = new(
+                                StructuralCloneDiscoveryBlockerKind
+                                    .CandidateVerificationLimit,
+                                "An exact candidate comparison did not "
+                                    + $"complete: {comparison.Disposition}.");
+                        }
+                        break;
+                    }
+                    if (comparison.Relation
+                        == StructuralCloneRelation.Exact)
+                    {
+                        group.Members.Add(candidate.Method);
+                        group.Evidence.Add(comparison);
+                        exactComparisons++;
+                        matched = true;
+                        break;
+                    }
+                    differentComparisons++;
+                }
+                if (!bucketComplete)
+                    break;
+                if (!matched)
+                    groups.Add(new StructuralCloneDiscoveryGroup(candidate));
+            }
+
+            if (!bucketComplete)
+            {
+                StructuralCloneDiscoveryBlocker reason =
+                    bucketBlocker
+                    ?? throw new InvalidOperationException(
+                        "Incomplete discovery bucket has no blocker.");
+                suppressed.Add(
+                    SuppressedBucket(
+                        bucket,
+                        moduleVersionId,
+                        reason));
+                blockers.Add(reason);
+                continue;
+            }
+
+            completedBuckets++;
+            foreach (StructuralCloneDiscoveryGroup group in groups)
+            {
+                if (group.Members.Count < 2)
+                    continue;
+                ImmutableArray<MetadataMethodAddress> members =
+                [
+                    .. group.Members.OrderBy(static member =>
+                        MetadataTokens.GetRowNumber(member.Handle)),
+                ];
+                clusters.Add(
+                    new StructuralCloneCluster(
+                        new StructuralCloneClusterIdentity(
+                            moduleVersionId,
+                            [
+                                .. members.Select(static member =>
+                                    MetadataTokens.GetToken(member.Handle)),
+                            ]),
+                        members,
+                        [.. group.Evidence]));
+            }
+        }
+
+        StructuralCloneDiscoveryDisposition disposition =
+            failedMethods > 0 || verificationFailed
+                ? StructuralCloneDiscoveryDisposition.Failed
+                : limitReachedMethods > 0
+                    || suppressed.Count > 0
+                    || unresolved.Count > 0
+                    ? StructuralCloneDiscoveryDisposition.LimitReached
+                    : StructuralCloneDiscoveryDisposition.Completed;
+        ImmutableArray<StructuralCloneDiscoveryBlocker> resultBlockers =
+            disposition == StructuralCloneDiscoveryDisposition.Completed
+                ? []
+                : blockers
+                    .Distinct()
+                    .ToImmutableArray();
+
+        return new StructuralCloneDiscoveryResult(
+            disposition,
+            [
+                .. clusters.OrderBy(static cluster =>
+                    cluster.Identity.MethodTokens[0]),
+            ],
+            methodOutcomes.ToImmutable(),
+            suppressed.ToImmutable(),
+            unresolved.ToImmutable(),
+            resultBlockers,
+            new StructuralCloneDiscoveryReceipt(
+                methods.Length,
+                methods.Length,
+                SuppressedMethods(suppressed),
+                eligibleMethods,
+                unsupportedMethods,
+                limitReachedMethods,
+                failedMethods,
+                candidateBuckets.Count,
+                completedBuckets,
+                suppressed.Count,
+                comparisons,
+                exactComparisons,
+                differentComparisons,
+                unresolved.Count,
+                bodyProductions));
+    }
+
+    static void ValidateDiscoveryLimits(
+        StructuralCloneDiscoveryLimits limits)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            limits.MaximumMethods,
+            1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            limits.MaximumCandidateComparisons,
+            1);
+    }
+
+    static StructuralCloneDiscoveryResult FailedDiscovery(
+        int inputMethods,
+        StructuralCloneMetadataFailure failure)
+    {
+        StructuralCloneDiscoveryBlocker blocker = new(
+            StructuralCloneDiscoveryBlockerKind.MetadataReadFailure,
+            $"The {failure.Subject} is invalid: "
+                + $"{failure.Exception.GetType().Name}: "
+                + failure.Exception.Message);
+        return new StructuralCloneDiscoveryResult(
+            StructuralCloneDiscoveryDisposition.Failed,
+            [],
+            [],
+            [],
+            [],
+            [blocker],
+            EmptyDiscoveryReceipt(inputMethods));
+    }
+
+    static StructuralCloneDiscoveryReceipt EmptyDiscoveryReceipt(
+        int inputMethods,
+        int suppressedMethods = 0)
+        => new(
+            inputMethods,
+            ProcessedMethods: 0,
+            suppressedMethods,
+            EligibleMethods: 0,
+            UnsupportedMethods: 0,
+            LimitReachedMethods: 0,
+            FailedMethods: 0,
+            CandidateBuckets: 0,
+            CompletedCandidateBuckets: 0,
+            SuppressedCandidateBuckets: 0,
+            CandidateComparisons: 0,
+            ExactComparisons: 0,
+            DifferentComparisons: 0,
+            UnresolvedComparisons: 0,
+            BodyProductions: 0);
+
+    static StructuralCloneMethodOutcome MethodOutcome(
+        MetadataMethodAddress address,
+        BodyProduction production)
+        => new(
+            address,
+            production.Disposition,
+            [
+                .. production.Blockers.Select(static blocker =>
+                    new StructuralCloneDiscoveryBlocker(
+                        blocker.Kind switch
+                        {
+                            StructuralCloneBlockerKind.BodySizeLimit
+                                or StructuralCloneBlockerKind.InstructionLimit
+                                or StructuralCloneBlockerKind.BlockLimit
+                                or StructuralCloneBlockerKind.EdgeLimit
+                                or StructuralCloneBlockerKind.LocalLimit
+                                or StructuralCloneBlockerKind
+                                    .VerificationStepLimit =>
+                                    StructuralCloneDiscoveryBlockerKind
+                                        .MethodProductionLimit,
+                            _ => StructuralCloneDiscoveryBlockerKind
+                                .MethodProductionFailure,
+                        },
+                        $"{blocker.Kind}: {blocker.Detail}")),
+            ],
+            new StructuralCloneMethodReceipt(
+                production.Measurements.BodyBytes,
+                production.Measurements.InstructionCount,
+                production.Measurements.BlockCount,
+                production.Measurements.EdgeCount,
+                production.Measurements.LocalCount));
+
+    static StructuralCloneSuppressedBucket SuppressedBucket(
+        IEnumerable<MethodDefinitionHandle> methods,
+        Guid moduleVersionId,
+        StructuralCloneDiscoveryBlocker reason)
+        => new(
+            [
+                .. methods
+                    .OrderBy(static method =>
+                        MetadataTokens.GetRowNumber(method))
+                    .Select(method =>
+                        new MetadataMethodAddress(moduleVersionId, method)),
+            ],
+            reason);
+
+    static void SuppressRemainingBuckets(
+        IReadOnlyList<List<MethodDefinitionHandle>> buckets,
+        int start,
+        Guid moduleVersionId,
+        StructuralCloneDiscoveryBlocker reason,
+        ImmutableArray<StructuralCloneSuppressedBucket>.Builder suppressed)
+    {
+        for (int index = start; index < buckets.Count; index++)
+        {
+            suppressed.Add(
+                SuppressedBucket(
+                    buckets[index],
+                    moduleVersionId,
+                    reason));
+        }
+    }
+
+    static int SuppressedMethods(
+        ImmutableArray<StructuralCloneSuppressedBucket>.Builder suppressed)
+    {
+        HashSet<MetadataMethodAddress> methods = [];
+        foreach (StructuralCloneSuppressedBucket bucket in suppressed)
+            methods.UnionWith(bucket.Methods);
+        return methods.Count;
+    }
+
+    sealed class StructuralCloneDiscoveryGroup(
+        StructuralCloneBodyFacts representative)
+    {
+        public StructuralCloneBodyFacts Representative { get; } =
+            representative;
+        public List<MetadataMethodAddress> Members { get; } =
+            [representative.Method];
+        public List<StructuralCloneComparison> Evidence { get; } = [];
+    }
+
+    sealed class StructuralCloneCandidateKey
+        : IEquatable<StructuralCloneCandidateKey>
+    {
+        StructuralCloneCandidateKey(
+            StructuralCloneMethodSignature signature,
+            bool initLocals,
+            int localCount,
+            int blockCount,
+            int instructionCount,
+            int edgeCount,
+            ImmutableArray<byte> fingerprint)
+        {
+            Signature = signature;
+            InitLocals = initLocals;
+            LocalCount = localCount;
+            BlockCount = blockCount;
+            InstructionCount = instructionCount;
+            EdgeCount = edgeCount;
+            Fingerprint = fingerprint;
+        }
+
+        StructuralCloneMethodSignature Signature { get; }
+        bool InitLocals { get; }
+        int LocalCount { get; }
+        int BlockCount { get; }
+        int InstructionCount { get; }
+        int EdgeCount { get; }
+        ImmutableArray<byte> Fingerprint { get; }
+
+        public static StructuralCloneCandidateKey Create(
+            StructuralCloneBodyFacts facts)
+        {
+            List<byte[]> blockHashes =
+            [
+                .. facts.Graph.Blocks.Select(BlockHash),
+            ];
+            blockHashes.Sort(ByteArrayComparer.Instance);
+            int[] localHashes =
+            [
+                .. facts.Locals
+                    .Select(static local => local.GetHashCode())
+                    .Order(),
+            ];
+
+            using var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream);
+            writer.Write(localHashes.Length);
+            foreach (int hash in localHashes)
+                writer.Write(hash);
+            writer.Write(blockHashes.Count);
+            foreach (byte[] hash in blockHashes)
+                writer.Write(hash);
+            WriteRoles(
+                writer,
+                facts.Graph.Blocks.SelectMany(static block =>
+                    block.Outgoing.Select(static edge => edge.Role)));
+            WriteRoles(
+                writer,
+                facts.Graph.Blocks.SelectMany(static block =>
+                    block.Incoming.Select(static edge => edge.Role)));
+            writer.Flush();
+
+            return new StructuralCloneCandidateKey(
+                facts.Signature,
+                facts.InitLocals,
+                facts.Locals.Length,
+                facts.Graph.Blocks.Length,
+                facts.InstructionCount,
+                facts.Graph.Blocks.Sum(
+                    static block => block.Outgoing.Length),
+                SHA256.HashData(stream.GetBuffer().AsSpan(
+                    0,
+                    checked((int)stream.Length))).ToImmutableArray());
+        }
+
+        public bool Equals(StructuralCloneCandidateKey? other)
+            => other is not null
+                && Signature == other.Signature
+                && InitLocals == other.InitLocals
+                && LocalCount == other.LocalCount
+                && BlockCount == other.BlockCount
+                && InstructionCount == other.InstructionCount
+                && EdgeCount == other.EdgeCount
+                && Fingerprint.AsSpan().SequenceEqual(
+                    other.Fingerprint.AsSpan());
+
+        public override bool Equals(object? obj)
+            => obj is StructuralCloneCandidateKey other && Equals(other);
+
+        public override int GetHashCode()
+            => HashCode.Combine(
+                Signature,
+                InitLocals,
+                LocalCount,
+                BlockCount,
+                InstructionCount,
+                EdgeCount,
+                BinaryPrimitives.ReadInt32LittleEndian(
+                    Fingerprint.AsSpan()));
+
+        static byte[] BlockHash(StructuralCloneBlock block)
+        {
+            using var stream = new MemoryStream();
+            using var writer = new BinaryWriter(stream);
+            writer.Write(block.ExitsMethod);
+            writer.Write(block.Operations.Length);
+            foreach (StructuralCloneOperation operation in block.Operations)
+            {
+                writer.Write((int)operation.OpCode);
+                writer.Write((int)operation.OperandKind);
+                writer.Write(
+                    operation.OperandKind == StructuralCloneOperandKind.Local
+                        ? 0
+                        : operation.Value);
+            }
+            writer.Flush();
+            return SHA256.HashData(stream.GetBuffer().AsSpan(
+                0,
+                checked((int)stream.Length)));
+        }
+
+        static void WriteRoles(
+            BinaryWriter writer,
+            IEnumerable<StructuralCloneEdgeRole> edgeRoles)
+        {
+            StructuralCloneEdgeRole[] roles =
+            [
+                .. edgeRoles
+                    .OrderBy(static role => role.Kind)
+                    .ThenBy(static role => role.Ordinal),
+            ];
+            writer.Write(roles.Length);
+            foreach (StructuralCloneEdgeRole role in roles)
+            {
+                writer.Write((int)role.Kind);
+                writer.Write(role.Ordinal);
+            }
+        }
+    }
+
+    sealed class ByteArrayComparer : IComparer<byte[]>
+    {
+        public static ByteArrayComparer Instance { get; } = new();
+
+        public int Compare(byte[]? left, byte[]? right)
+        {
+            if (ReferenceEquals(left, right))
+                return 0;
+            if (left is null)
+                return -1;
+            if (right is null)
+                return 1;
+            return left.AsSpan().SequenceCompareTo(right);
+        }
+    }
+}
+
+readonly record struct StructuralCloneMetadataFailure(
+    string Subject,
+    Exception Exception);

--- a/src/ILInspector.Analysis/StructuralCloneDiscovery.cs
+++ b/src/ILInspector.Analysis/StructuralCloneDiscovery.cs
@@ -21,6 +21,7 @@ public enum StructuralCloneDiscoveryBlockerKind
 {
     MetadataReadFailure,
     MethodLimit,
+    MethodUnsupported,
     MethodProductionLimit,
     MethodProductionFailure,
     CandidateComparisonLimit,
@@ -626,21 +627,22 @@ public static partial class StructuralCloneAnalysis
             address,
             production.Disposition,
             [
-                .. production.Blockers.Select(static blocker =>
+                .. production.Blockers.Select(blocker =>
                     new StructuralCloneDiscoveryBlocker(
-                        blocker.Kind switch
+                        production.Disposition switch
                         {
-                            StructuralCloneBlockerKind.BodySizeLimit
-                                or StructuralCloneBlockerKind.InstructionLimit
-                                or StructuralCloneBlockerKind.BlockLimit
-                                or StructuralCloneBlockerKind.EdgeLimit
-                                or StructuralCloneBlockerKind.LocalLimit
-                                or StructuralCloneBlockerKind
-                                    .VerificationStepLimit =>
-                                    StructuralCloneDiscoveryBlockerKind
-                                        .MethodProductionLimit,
-                            _ => StructuralCloneDiscoveryBlockerKind
-                                .MethodProductionFailure,
+                            StructuralCloneDisposition.Unsupported =>
+                                StructuralCloneDiscoveryBlockerKind
+                                    .MethodUnsupported,
+                            StructuralCloneDisposition.LimitReached =>
+                                StructuralCloneDiscoveryBlockerKind
+                                    .MethodProductionLimit,
+                            StructuralCloneDisposition.Failed =>
+                                StructuralCloneDiscoveryBlockerKind
+                                    .MethodProductionFailure,
+                            _ => throw new InvalidOperationException(
+                                "Completed method production cannot have "
+                                    + "blockers."),
                         },
                         $"{blocker.Kind}: {blocker.Detail}")),
             ],

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -32,9 +32,9 @@ const string Usage =
           true/false-positive judgement. No automatic oracle.
 
       --clone-corpus <assembly> [--relationship-ledger <file>] [--json]
-          Grade the product-owned structural clone comparator against the committed relationship
-          corpus. The ledger owns candidate pairs and expected disposition/relation; the harness
-          resolves typed metadata identities and does not reconstruct normalization or verification.
+          Grade product-owned structural clone comparison and exact discovery against the
+          committed closed-world corpus. The harness resolves typed metadata identities and does
+          not reconstruct candidate retrieval, normalization, correspondence, or verification.
 
       --allocation-readout <file> [--top N] [--json]
           Sweep a corpus list and aggregate allocation occurrence/opportunity metadata

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -24,29 +24,53 @@ dotnet "$DLL" --generated-fixtures alloc --json  # grade a subset (id/prefix/tag
 dotnet "$DLL" --generated-fixtures exception.unsuffixed.external --keep  # keep temp projects
 ```
 
-The structural clone relationship corpus is a separate product/harness
-boundary:
+The structural clone corpus is a separate product/harness boundary and the
+first exact-discovery demo:
 
 ```bash
 dotnet "$DLL" --clone-corpus ILInspector.Analysis.Fixtures.dll
 dotnet "$DLL" --clone-corpus ILInspector.Analysis.Fixtures.dll --json
 ```
 
+The text demo reports direct comparison and discovery independently:
+
+```text
+Structural clone relationship corpus: 6/6 passed
+PASS banal.authored.exact: expected Completed/Exact, actual Completed/Exact (Unique correspondence)
+...
+PASS closed-world exact discovery: expected 4 clusters, actual 4 clusters, disposition Completed
+  ...::ExactPositiveA = ...::ExactPositiveB
+  ...::MetadataOperandsA = ...::MetadataOperandsB
+  ...::SignatureHazardByte = ...::SignatureHazardUInt
+  ...::SignatureHazardObject = ...::SignatureHazardString
+```
+
 The committed
-`corpus/structural-clone-relationships.json` ledger supplies candidate pairs
-and separately expected disposition/relation. It also records orthogonal
-difficulty, intent, actionability, and tag axes. The harness resolves the
-declared type and method names to SRM handles, then grades only
-`StructuralCloneAnalysis.Compare`; it owns no clone normalization,
-correspondence, or verification logic.
+`corpus/structural-clone-relationships.json` ledger supplies candidate pairs,
+separate expected disposition/relation, and an explicit closed-world discovery
+population. It also records orthogonal difficulty, intent, actionability, and
+tag axes. The harness derives expected exact connected components only from
+the ledger's expected relations. It then resolves the declared identities to
+SRM handles, grades `StructuralCloneAnalysis.Compare`, runs
+`StructuralCloneAnalysis.Discover`, and requires the complete discovered
+clusters to equal those components. A missed family or an undeclared
+cross-component merge fails the discovery card.
+
+The harness owns no candidate fingerprint, clone normalization,
+correspondence, clustering, or verification logic. Negative cluster membership
+is graded only after discovery reports `Completed` with no suppressed buckets.
+Unsupported direct-comparison cases remain visible direct gates and do not
+downgrade an otherwise complete discovery pass.
 
 The ledger is strict: missing or unknown fields, integer enum values, schema
 versions, duplicate IDs, unknown axis values, incomplete identities, and
 relation/disposition contradictions fail instead of silently shrinking
-coverage. An explicitly supplied `--relationship-ledger` must name a file;
-it never falls back to the committed corpus. `StructuralCloneCorpusTests` also
-requires every public method in the dedicated fixture type to appear in the
-ledger, preventing fixture or relationship inventory drift.
+coverage. The discovery population must contain each distinct relationship
+method exactly once. An explicitly supplied `--relationship-ledger` must name
+a file; it never falls back to the committed corpus.
+`StructuralCloneCorpusTests` also requires every public method in the dedicated
+fixture type to appear in both ledger views, preventing fixture, relationship,
+or discovery-population drift.
 
 Each fixture builds in isolation: a consumer assembly (the inspected one) plus, when the
 fixture is cross-assembly, a referenced external assembly (with an extern alias for the

--- a/tools/AnalysisHarness/StructuralCloneCorpus.cs
+++ b/tools/AnalysisHarness/StructuralCloneCorpus.cs
@@ -11,7 +11,12 @@ namespace ILInspector.AnalysisHarness;
 
 public sealed record StructuralCloneCorpusDocument(
     [property: JsonRequired] int SchemaVersion,
-    [property: JsonRequired] ImmutableArray<StructuralCloneCorpusCase> Cases);
+    [property: JsonRequired] ImmutableArray<StructuralCloneCorpusCase> Cases,
+    [property: JsonRequired] StructuralCloneCorpusDiscovery Discovery);
+
+public sealed record StructuralCloneCorpusDiscovery(
+    [property: JsonRequired]
+    ImmutableArray<StructuralCloneCorpusMethod> Population);
 
 public sealed record StructuralCloneCorpusCase(
     [property: JsonRequired] string Id,
@@ -41,13 +46,29 @@ public sealed record StructuralCloneCorpusCaseResult(
     StructuralCloneVerificationReceipt Receipt,
     bool Passed);
 
+public sealed record StructuralCloneCorpusCluster(
+    ImmutableArray<StructuralCloneCorpusMethod> Members);
+
+public sealed record StructuralCloneCorpusDiscoveryResult(
+    StructuralCloneDiscoveryDisposition Disposition,
+    ImmutableArray<StructuralCloneCorpusCluster> ExpectedClusters,
+    ImmutableArray<StructuralCloneCorpusCluster> ActualClusters,
+    ImmutableArray<StructuralCloneSuppressedBucket> SuppressedBuckets,
+    ImmutableArray<StructuralCloneDiscoveryBlocker> Blockers,
+    StructuralCloneDiscoveryReceipt Receipt,
+    bool Passed);
+
 public sealed record StructuralCloneCorpusReport(
     string Assembly,
     int Total,
     int Passed,
-    ImmutableArray<StructuralCloneCorpusCaseResult> Cases)
+    ImmutableArray<StructuralCloneCorpusCaseResult> Cases,
+    StructuralCloneCorpusDiscoveryResult Discovery)
 {
-    public bool Success => Total > 0 && Passed == Total;
+    public bool Success =>
+        Total > 0
+        && Passed == Total
+        && Discovery.Passed;
 }
 
 public static class StructuralCloneCorpus
@@ -157,13 +178,62 @@ public static class StructuralCloneCorpus
                     passed));
         }
 
+        var methodsByHandle =
+            new Dictionary<MethodDefinitionHandle, StructuralCloneCorpusMethod>();
+        ImmutableArray<MethodDefinitionHandle>.Builder population =
+            ImmutableArray.CreateBuilder<MethodDefinitionHandle>(
+                corpus.Discovery.Population.Length);
+        foreach (StructuralCloneCorpusMethod method
+            in corpus.Discovery.Population)
+        {
+            MethodDefinitionHandle handle = Resolve(reader, method);
+            methodsByHandle.Add(handle, method);
+            population.Add(handle);
+        }
+        StructuralCloneDiscoveryResult discovery =
+            StructuralCloneAnalysis.Discover(
+                image,
+                population.ToImmutable());
+        ImmutableArray<StructuralCloneCorpusCluster> expectedClusters =
+            ExpectedClusters(corpus);
+        ImmutableArray<StructuralCloneCorpusCluster> actualClusters =
+        [
+            .. discovery.Clusters
+                .Select(cluster =>
+                    new StructuralCloneCorpusCluster(
+                        [
+                            .. cluster.Members
+                                .Select(member =>
+                                    methodsByHandle[member.Handle])
+                                .OrderBy(MethodKey, StringComparer.Ordinal),
+                        ]))
+                .OrderBy(ClusterKey, StringComparer.Ordinal),
+        ];
+        bool discoveryPassed =
+            discovery.Disposition
+                == StructuralCloneDiscoveryDisposition.Completed
+            && discovery.SuppressedBuckets.IsEmpty
+            && expectedClusters
+                .Select(ClusterKey)
+                .SequenceEqual(
+                    actualClusters.Select(ClusterKey),
+                    StringComparer.Ordinal);
+
         ImmutableArray<StructuralCloneCorpusCaseResult> cases =
             results.ToImmutable();
         return new StructuralCloneCorpusReport(
             Path.GetFullPath(assemblyPath),
             cases.Length,
             cases.Count(static item => item.Passed),
-            cases);
+            cases,
+            new StructuralCloneCorpusDiscoveryResult(
+                discovery.Disposition,
+                expectedClusters,
+                actualClusters,
+                discovery.SuppressedBuckets,
+                discovery.Blockers,
+                discovery.Receipt,
+                discoveryPassed));
     }
 
     public static string ToJson(StructuralCloneCorpusReport report)
@@ -196,21 +266,44 @@ public static class StructuralCloneCorpus
             }
             output.AppendLine();
         }
+        output.Append(report.Discovery.Passed ? "PASS " : "FAIL ");
+        output.Append("closed-world exact discovery: expected ");
+        output.Append(report.Discovery.ExpectedClusters.Length);
+        output.Append(" clusters, actual ");
+        output.Append(report.Discovery.ActualClusters.Length);
+        output.Append(" clusters, disposition ");
+        output.AppendLine(report.Discovery.Disposition.ToString());
+        foreach (StructuralCloneCorpusCluster cluster
+            in report.Discovery.ActualClusters)
+        {
+            output.Append("  ");
+            output.AppendLine(string.Join(
+                " = ",
+                cluster.Members.Select(static member =>
+                    $"{member.Type}::{member.Method}")));
+        }
         return output.ToString();
     }
 
     static void Validate(StructuralCloneCorpusDocument document)
     {
-        if (document.SchemaVersion != 1)
+        if (document.SchemaVersion != 2)
         {
             throw new InvalidDataException(
-                $"Unsupported structural clone corpus schema {document.SchemaVersion}; expected 1.");
+                $"Unsupported structural clone corpus schema {document.SchemaVersion}; expected 2.");
         }
         if (document.Cases.IsDefaultOrEmpty)
             throw new InvalidDataException(
                 "The structural clone relationship ledger has no cases.");
+        if (document.Discovery is null
+            || document.Discovery.Population.IsDefaultOrEmpty)
+        {
+            throw new InvalidDataException(
+                "The structural clone relationship ledger has no closed-world discovery population.");
+        }
 
         HashSet<string> ids = new(StringComparer.Ordinal);
+        HashSet<string> caseMethods = new(StringComparer.Ordinal);
         foreach (StructuralCloneCorpusCase item in document.Cases)
         {
             if (string.IsNullOrWhiteSpace(item.Id) || !ids.Add(item.Id))
@@ -218,6 +311,8 @@ public static class StructuralCloneCorpus
                     $"Corpus case ids must be non-empty and unique: '{item.Id}'.");
             ValidateMethod(item.Id, "left", item.Left);
             ValidateMethod(item.Id, "right", item.Right);
+            caseMethods.Add(MethodKey(item.Left));
+            caseMethods.Add(MethodKey(item.Right));
             if (item.ExpectedDisposition == StructuralCloneDisposition.Completed
                 ^ item.ExpectedRelation is not null)
             {
@@ -237,7 +332,97 @@ public static class StructuralCloneCorpus
                 throw new InvalidDataException(
                     $"Corpus case '{item.Id}' must declare a tags array.");
         }
+
+        HashSet<string> population = new(StringComparer.Ordinal);
+        foreach (StructuralCloneCorpusMethod method
+            in document.Discovery.Population)
+        {
+            ValidateMethod("discovery", "population", method);
+            if (!population.Add(MethodKey(method)))
+            {
+                throw new InvalidDataException(
+                    $"Discovery population method '{method.Type}::{method.Method}' is duplicated.");
+            }
+        }
+        if (!caseMethods.SetEquals(population))
+        {
+            throw new InvalidDataException(
+                "The closed-world discovery population must equal the distinct methods declared by relationship cases.");
+        }
     }
+
+    static ImmutableArray<StructuralCloneCorpusCluster> ExpectedClusters(
+        StructuralCloneCorpusDocument corpus)
+    {
+        Dictionary<string, string> parent =
+            corpus.Discovery.Population.ToDictionary(
+                MethodKey,
+                MethodKey,
+                StringComparer.Ordinal);
+
+        foreach (StructuralCloneCorpusCase item in corpus.Cases)
+        {
+            if (item.ExpectedDisposition
+                    == StructuralCloneDisposition.Completed
+                && item.ExpectedRelation == StructuralCloneRelation.Exact)
+            {
+                Union(
+                    parent,
+                    MethodKey(item.Left),
+                    MethodKey(item.Right));
+            }
+        }
+
+        return
+        [
+            .. corpus.Discovery.Population
+                .GroupBy(
+                    method => Find(parent, MethodKey(method)),
+                    StringComparer.Ordinal)
+                .Where(static group => group.Count() > 1)
+                .Select(group =>
+                    new StructuralCloneCorpusCluster(
+                        [
+                            .. group.OrderBy(
+                                MethodKey,
+                                StringComparer.Ordinal),
+                        ]))
+                .OrderBy(ClusterKey, StringComparer.Ordinal),
+        ];
+    }
+
+    static void Union(
+        Dictionary<string, string> parent,
+        string left,
+        string right)
+    {
+        string leftRoot = Find(parent, left);
+        string rightRoot = Find(parent, right);
+        if (!StringComparer.Ordinal.Equals(leftRoot, rightRoot))
+            parent[rightRoot] = leftRoot;
+    }
+
+    static string Find(
+        Dictionary<string, string> parent,
+        string member)
+    {
+        string root = member;
+        while (!StringComparer.Ordinal.Equals(root, parent[root]))
+            root = parent[root];
+        while (!StringComparer.Ordinal.Equals(member, root))
+        {
+            string next = parent[member];
+            parent[member] = root;
+            member = next;
+        }
+        return root;
+    }
+
+    static string ClusterKey(StructuralCloneCorpusCluster cluster)
+        => string.Join("\n", cluster.Members.Select(MethodKey));
+
+    static string MethodKey(StructuralCloneCorpusMethod method)
+        => $"{method.Type}\0{method.Method}";
 
     static MethodDefinitionHandle Resolve(
         MetadataReader reader,

--- a/tools/AnalysisHarness/corpus/structural-clone-relationships.json
+++ b/tools/AnalysisHarness/corpus/structural-clone-relationships.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "cases": [
     {
       "id": "banal.authored.exact",
@@ -123,5 +123,57 @@
         "exception-handling"
       ]
     }
-  ]
+  ],
+  "discovery": {
+    "population": [
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "ExactPositiveA"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "ExactPositiveB"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "EdgeRoleNegativeA"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "EdgeRoleNegativeB"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "SignatureHazardByte"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "SignatureHazardUInt"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "SignatureHazardString"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "SignatureHazardObject"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "MetadataOperandsA"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "MetadataOperandsB"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "ExceptionHandlingA"
+      },
+      {
+        "type": "ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture",
+        "method": "ExceptionHandlingB"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Adds bounded, same-PE exact structural clone discovery over an explicit method
population. Retrieval fingerprints select candidates only; the existing exact
comparator remains the sole authority for cluster membership and supplies
representative correspondence evidence.

Discovery reports deterministic typed cluster identities, per-method production
outcomes, complete receipts, unresolved comparisons, and full suppressed
buckets. It never emits a partial cluster from an incomplete bucket, and
negative membership is valid only after a completed, unsuppressed run.

The relationship corpus is now a strict closed-world discovery oracle. It
derives expected components only from declared relations and independently
fails missed families or undeclared cross-component merges.

## Demo

```bash
dotnet run --project tools/AnalysisHarness -c Release -- \
  --clone-corpus \
  artifacts/bin/ILInspector.Analysis.Fixtures/release/ILInspector.Analysis.Fixtures.dll
```

```text
Structural clone relationship corpus: 6/6 passed
PASS banal.authored.exact: expected Completed/Exact, actual Completed/Exact (Unique correspondence)
PASS challenging.edge-role.negative: expected Completed/Different, actual Completed/Different
PASS challenging.signature.semantic-hazard: expected Completed/Exact, actual Completed/Exact (Unique correspondence)
PASS challenging.return-type.semantic-hazard: expected Completed/Exact, actual Completed/Exact (Unique correspondence)
PASS banal.metadata-operands.exact: expected Completed/Exact, actual Completed/Exact (Unique correspondence)
PASS banal.exception-handling.unsupported: expected Unsupported, actual Unsupported
PASS closed-world exact discovery: expected 4 clusters, actual 4 clusters, disposition Completed
  ...::ExactPositiveA = ...::ExactPositiveB
  ...::MetadataOperandsA = ...::MetadataOperandsB
  ...::SignatureHazardByte = ...::SignatureHazardUInt
  ...::SignatureHazardObject = ...::SignatureHazardString
```

## Evidence

- Focused discovery and corpus gates: 20/20
- Exact-head Analysis suite: 813/813
- Exact-head solution build: succeeded
- Markdown lint: clean
- Text and structured JSON demos: completed, 4/4 clusters
- GPT-5.6 Sol and Claude Opus 5 exact-head reviews: clean
- `ci-required`: succeeded

## Boundaries

No fuzzy/near ranking, cross-PE matching, source/decompiler participation,
public clone command, or actionability/provenance inference.

Closes #4278
