### PR TITLE
Extract extension method samples from CfgSampleClass

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5523,13 +5523,3 @@ public sealed class LockFixtureSamples
         lock (gate) { _value = 1; }
     }
 }
-
-// Same-assembly samples for extension-method rendering: one genuine [Extension]
-// method and one plain static of the same call shape, to exercise the IsExtension
-// gate that decides instance-vs-static spelling.
-public static class ExtensionMethodSamples
-{
-    public static int Doubled(this int value) => value * 2;
-
-    public static int Combine(int left, int right) => left + right;
-}

--- a/src/ILInspector.Decompiler.Tests/ExtensionMethodSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/ExtensionMethodSamples.cs
@@ -1,0 +1,11 @@
+namespace ILInspector.Decompiler.Tests;
+
+// Same-assembly samples for extension-method rendering: one genuine [Extension]
+// method and one plain static of the same call shape, to exercise the IsExtension
+// gate that decides instance-vs-static spelling.
+public static class ExtensionMethodSamples
+{
+    public static int Doubled(this int value) => value * 2;
+
+    public static int Combine(int left, int right) => left + right;
+}


### PR DESCRIPTION
## Summary

Moves `ExtensionMethodSamples` unchanged from the catch-all `CfgSampleClass.cs` fixture into the feature-focused `ExtensionMethodSamples.cs` file beside its owning tests. The caller methods remain on `CfgSampleClass`, preserving their declaring type and artifact identity.

Related to #3913. Leaves #3913 open for the remaining fixture groups.

## Validation

- Release solution build: passed (0 errors; 3 pre-existing nullable warnings)
- `ExtensionMethodCallTests`: 4 passed
- decompiler fast gate: 5,069 total, 0 failed, 8 expected Windows privilege-dependent skips
- stable-path base/head rendering comparison: 20,492 methods evaluated; 0 changed, 0 added, 0 removed