### PR TITLE
Add exact clone census demos

### DIFF
--- a/docs/design/structural-clone-analysis.md
+++ b/docs/design/structural-clone-analysis.md
@@ -200,6 +200,45 @@ semantic hazards, and the EH unsupported boundary. Exact discovery finds four
 families and rejects the close negative. Fuzzy ranking, precision/recall
 measurement, and CoreLib scale runs are later slices.
 
+## Census and demo projection
+
+`analysis-harness --clone-census` is the harness-only whole-assembly and
+seed-to-family projection. It enumerates one PE's MethodDef table, calls
+`StructuralCloneAnalysis.Discover` exactly once, and presents product-owned
+clusters, evidence, blockers, suppression, method outcomes, and receipts. It
+does not filter candidate methods, reconstruct fingerprints, compare pairs, or
+form clusters.
+
+Every projected method includes its full MethodDef token. Type and method names
+are display and selector conveniences, never identity. A `Type::Method`
+selector must resolve uniquely; overloads fail and require a token. Nested type
+display uses `Outer+Inner`.
+
+Text output is bounded, but a selected seed and at least one member of its
+exact family are always pinned. Structured output retains every cluster/member,
+suppressed bucket, non-completed method, and unresolved comparison. Elapsed
+time measures the one product discovery call and is run evidence, not a
+performance baseline.
+
+Seed status preserves discovery completeness:
+
+- `Clustered` is positive product evidence and remains valid when unrelated
+  methods make the overall run partial.
+- `Unsupported`, `LimitReached`, and `Failed` preserve the seed's production
+  disposition.
+- `Singleton` is emitted only for a completed, unsuppressed discovery run.
+- `Unresolved` replaces negative inference on partial runs.
+
+The census reports eligible methods without an emitted family in every run,
+but names that count `ExactSingletonMethods` only when discovery completed.
+Product method and candidate-comparison limits remain separate and are echoed
+in output.
+
+`StructuralCloneCensusTests` gates exact-family and close-negative seed
+behavior, unsupported and partial seed status, token selection, overload
+ambiguity, seed pinning under truncation, complete structured output,
+malformed metadata, and CLI argument/exit behavior.
+
 Clone detection is intentionally neutral about why two bodies are similar.
 Deduplication, refactoring, provenance investigation, copied-code detection,
 known-insecure-pattern remediation, and CFG stress testing are possible

--- a/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
@@ -107,6 +107,11 @@ public class StructuralCloneCensusTests
             StructuralCloneCensusSeedStatus.Unresolved,
             report.Seed!.Status);
         Assert.Equal(0, report.Receipt.ProcessedMethods);
+        string text = StructuralCloneCensus.Format(report);
+        Assert.Contains("suppressed=57", text);
+        Assert.Contains(
+            "eligible-without-emitted-family=0",
+            text);
     }
 
     [Fact]
@@ -128,6 +133,25 @@ public class StructuralCloneCensusTests
         Assert.Contains(
             "suppressed buckets",
             StructuralCloneCensus.Format(report, top: 1));
+    }
+
+    [Fact]
+    public void Run_ClusteredSeedSurvivesUnrelatedPartialWork()
+    {
+        StructuralCloneCensusReport report = StructuralCloneCensus.Run(
+            FixturePath,
+            $"{FixtureType}::{nameof(StructuralCloneFixture.ExactPositiveA)}",
+            maximumCandidateComparisons: 1);
+
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.LimitReached,
+            report.Disposition);
+        Assert.Equal(
+            StructuralCloneCensusSeedStatus.Clustered,
+            report.Seed!.Status);
+        Assert.Equal(2, report.Seed.Cluster!.Members.Length);
+        Assert.NotEmpty(report.SuppressedBuckets);
+        Assert.Null(report.ExactSingletonMethods);
     }
 
     [Fact]
@@ -286,6 +310,18 @@ public class StructuralCloneCensusTests
         Assert.Contains(
             "--top requires a positive integer.",
             invalidTop.error);
+
+        (int exitCode, string output, string error) invalidTopOtherMode =
+            await RunHarness(
+                "--precision-sample",
+                FixturePath,
+                "--top",
+                "invalid");
+        Assert.Equal(2, invalidTopOtherMode.exitCode);
+        Assert.Equal("", invalidTopOtherMode.output);
+        Assert.Contains(
+            "--top requires a positive integer.",
+            invalidTopOtherMode.error);
 
         (int exitCode, string output, string error) orphan =
             await RunHarness("--seed", "System.String::Concat");

--- a/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
@@ -1,0 +1,387 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Reflection.PortableExecutable;
+using System.Text.Json;
+
+using ILInspector.Analysis.StructuralCloneFixtures;
+using ILInspector.AnalysisHarness;
+
+namespace ILInspector.Analysis.Tests;
+
+public class StructuralCloneCensusTests
+{
+    static string FixturePath =>
+        typeof(StructuralCloneFixture).Assembly.Location;
+
+    static string FixtureType =>
+        typeof(StructuralCloneFixture).FullName!;
+
+    [Fact]
+    public void Run_FixtureAssembly_ReportsExactFamiliesAndSeedFamily()
+    {
+        StructuralCloneCensusReport report = StructuralCloneCensus.Run(
+            FixturePath,
+            $"{FixtureType}::{nameof(StructuralCloneFixture.ExactPositiveA)}");
+
+        Assert.True(report.Success);
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.Completed,
+            report.Disposition);
+        Assert.True(report.Clusters >= 5);
+        Assert.True(report.ClusteredMethods >= 10);
+        Assert.True(report.ExactSingletonMethods > 0);
+        Assert.True(report.Receipt.UnsupportedMethods >= 2);
+        Assert.True(report.Receipt.ExactComparisons >= 5);
+        Assert.True(report.Receipt.DifferentComparisons >= 1);
+
+        StructuralCloneCensusSeed seed = Assert.IsType<
+            StructuralCloneCensusSeed>(report.Seed);
+        Assert.Equal(
+            StructuralCloneCensusSeedStatus.Clustered,
+            seed.Status);
+        StructuralCloneCensusCluster family = Assert.IsType<
+            StructuralCloneCensusCluster>(seed.Cluster);
+        Assert.Equal(
+            [
+                nameof(StructuralCloneFixture.ExactPositiveA),
+                nameof(StructuralCloneFixture.ExactPositiveB),
+            ],
+            family.Members.Select(static member => member.Name));
+        Assert.All(
+            family.Members,
+            static member => Assert.Equal(
+                0x06000000,
+                member.Token & unchecked((int)0xFF000000)));
+    }
+
+    [Fact]
+    public void Run_CloseNegativeSeed_IsSingletonOnlyAfterCompleteDiscovery()
+    {
+        StructuralCloneCensusReport report = StructuralCloneCensus.Run(
+            FixturePath,
+            $"{FixtureType}::{nameof(StructuralCloneFixture.EdgeRoleNegativeA)}");
+
+        Assert.Equal(
+            StructuralCloneCensusSeedStatus.Singleton,
+            report.Seed!.Status);
+        Assert.Null(report.Seed.Cluster);
+        Assert.Equal(
+            StructuralCloneDisposition.Completed,
+            report.Seed.ProductionDisposition);
+    }
+
+    [Fact]
+    public void Run_UnsupportedSeed_RemainsExplicit()
+    {
+        StructuralCloneCensusReport report = StructuralCloneCensus.Run(
+            FixturePath,
+            $"{FixtureType}::{nameof(StructuralCloneFixture.ExceptionHandlingA)}");
+
+        Assert.Equal(
+            StructuralCloneCensusSeedStatus.Unsupported,
+            report.Seed!.Status);
+        Assert.Equal(
+            StructuralCloneDisposition.Unsupported,
+            report.Seed.ProductionDisposition);
+        Assert.Contains(
+            report.Seed.Blockers,
+            static blocker =>
+                blocker.Kind
+                    == StructuralCloneDiscoveryBlockerKind.MethodUnsupported);
+    }
+
+    [Fact]
+    public void Run_MethodLimitMakesSeedUnresolvedNotSingleton()
+    {
+        StructuralCloneCensusReport report = StructuralCloneCensus.Run(
+            FixturePath,
+            $"{FixtureType}::{nameof(StructuralCloneFixture.EdgeRoleNegativeA)}",
+            maximumMethods: 1);
+
+        Assert.False(report.Success);
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.LimitReached,
+            report.Disposition);
+        Assert.Null(report.ExactSingletonMethods);
+        Assert.Equal(
+            StructuralCloneCensusSeedStatus.Unresolved,
+            report.Seed!.Status);
+        Assert.Equal(0, report.Receipt.ProcessedMethods);
+    }
+
+    [Fact]
+    public void Run_ComparisonLimitProjectsSuppressedBuckets()
+    {
+        StructuralCloneCensusReport report = StructuralCloneCensus.Run(
+            FixturePath,
+            $"{FixtureType}::{nameof(StructuralCloneFixture.MetadataOperandsA)}",
+            maximumCandidateComparisons: 1);
+
+        Assert.Equal(
+            StructuralCloneDiscoveryDisposition.LimitReached,
+            report.Disposition);
+        Assert.NotEmpty(report.SuppressedBuckets);
+        Assert.Equal(
+            StructuralCloneCensusSeedStatus.Unresolved,
+            report.Seed!.Status);
+        Assert.Null(report.ExactSingletonMethods);
+        Assert.Contains(
+            "suppressed buckets",
+            StructuralCloneCensus.Format(report, top: 1));
+    }
+
+    [Fact]
+    public void Run_MethodDefTokenRoundTripsToSameSeed()
+    {
+        StructuralCloneCensusReport named = StructuralCloneCensus.Run(
+            FixturePath,
+            $"{FixtureType}::{nameof(StructuralCloneFixture.MetadataOperandsA)}");
+        int token = named.Seed!.Method.Token;
+
+        StructuralCloneCensusReport tokenSelected =
+            StructuralCloneCensus.Run(
+                FixturePath,
+                $"0x{token:X8}");
+
+        Assert.Equal(token, tokenSelected.Seed!.Method.Token);
+        Assert.Equal(
+            StructuralCloneCensusSeedStatus.Clustered,
+            tokenSelected.Seed.Status);
+    }
+
+    [Fact]
+    public void Run_AmbiguousNameSelectorRequiresMethodDefToken()
+    {
+        InvalidDataException error = Assert.Throws<InvalidDataException>(
+            () => StructuralCloneCensus.Run(
+                typeof(object).Assembly.Location,
+                "System.String::Concat"));
+
+        Assert.Contains("is ambiguous", error.Message);
+        Assert.Contains("0x06", error.Message);
+    }
+
+    [Fact]
+    public void Run_InvalidLimitsAreCallerErrors()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => StructuralCloneCensus.Run(
+                FixturePath,
+                maximumMethods: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => StructuralCloneCensus.Run(
+                FixturePath,
+                maximumCandidateComparisons: 0));
+    }
+
+    [Fact]
+    public void Format_PinsSeedAndPeerWhenTopIsOne()
+    {
+        StructuralCloneCensusReport report = StructuralCloneCensus.Run(
+            FixturePath,
+            $"{FixtureType}::{nameof(StructuralCloneFixture.MetadataOperandsB)}");
+
+        string text = StructuralCloneCensus.Format(report, top: 1);
+
+        Assert.Contains(
+            nameof(StructuralCloneFixture.MetadataOperandsA),
+            text);
+        Assert.Contains(
+            nameof(StructuralCloneFixture.MetadataOperandsB),
+            text);
+        Assert.Contains("more families omitted", text);
+        Assert.Contains("more members omitted", text);
+    }
+
+    [Fact]
+    public void Json_ContainsAllFamiliesAndTypedReceipt()
+    {
+        StructuralCloneCensusReport report =
+            StructuralCloneCensus.Run(FixturePath);
+
+        using JsonDocument json = JsonDocument.Parse(
+            StructuralCloneCensus.ToJson(report));
+        JsonElement root = json.RootElement;
+
+        Assert.Equal(
+            report.Clusters,
+            root.GetProperty("families").GetArrayLength());
+        Assert.Equal(
+            "Completed",
+            root.GetProperty("disposition").GetString());
+        Assert.Equal(
+            report.Receipt.BodyProductions,
+            root.GetProperty("receipt")
+                .GetProperty("bodyProductions")
+                .GetInt32());
+        Assert.Equal(
+            report.Receipt.UnsupportedMethods
+                + report.Receipt.LimitReachedMethods
+                + report.Receipt.FailedMethods,
+            root.GetProperty("nonCompletedMethods").GetArrayLength());
+        Assert.Equal(
+            report.Receipt.UnresolvedComparisons,
+            root.GetProperty("unresolvedComparisons").GetArrayLength());
+    }
+
+    [Fact]
+    public void Run_RejectsMalformedManagedMetadata()
+    {
+        byte[] bytes = File.ReadAllBytes(FixturePath);
+        using (var image = new PEReader(new MemoryStream(bytes)))
+        {
+            BinaryPrimitives.WriteUInt32LittleEndian(
+                bytes.AsSpan(
+                    image.PEHeaders.CorHeaderStartOffset
+                        + 3 * sizeof(uint)),
+                uint.MaxValue);
+        }
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"structural-clone-census-malformed-{Guid.NewGuid():N}.dll");
+        try
+        {
+            File.WriteAllBytes(path, bytes);
+
+            Assert.Throws<InvalidDataException>(
+                () => StructuralCloneCensus.Run(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task Command_RejectsMissingAndInvalidCloneCensusArguments()
+    {
+        (int exitCode, string output, string error) missing =
+            await RunHarness("--clone-census");
+        Assert.Equal(2, missing.exitCode);
+        Assert.Equal("", missing.output);
+        Assert.Contains(
+            "--clone-census requires an assembly path.",
+            missing.error);
+
+        (int exitCode, string output, string error) invalid =
+            await RunHarness(
+                "--clone-census",
+                FixturePath,
+                "--max-comparisons",
+                "0");
+        Assert.Equal(2, invalid.exitCode);
+        Assert.Equal("", invalid.output);
+        Assert.Contains(
+            "--max-comparisons requires a positive integer.",
+            invalid.error);
+
+        (int exitCode, string output, string error) invalidTop =
+            await RunHarness(
+                "--clone-census",
+                FixturePath,
+                "--top",
+                "0");
+        Assert.Equal(2, invalidTop.exitCode);
+        Assert.Equal("", invalidTop.output);
+        Assert.Contains(
+            "--top requires a positive integer.",
+            invalidTop.error);
+
+        (int exitCode, string output, string error) orphan =
+            await RunHarness("--seed", "System.String::Concat");
+        Assert.Equal(2, orphan.exitCode);
+        Assert.Equal("", orphan.output);
+        Assert.Contains("require --clone-census", orphan.error);
+    }
+
+    [Fact]
+    public async Task Command_EmitsCompletedJsonDemo()
+    {
+        (int exitCode, string output, string error) result =
+            await RunHarness(
+                "--clone-census",
+                FixturePath,
+                "--seed",
+                $"{FixtureType}::{nameof(StructuralCloneFixture.ExactPositiveA)}",
+                "--top",
+                "1",
+                "--json");
+
+        Assert.Equal(0, result.exitCode);
+        Assert.Equal("", result.error);
+        using JsonDocument json = JsonDocument.Parse(result.output);
+        Assert.True(json.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal(
+            "Clustered",
+            json.RootElement
+                .GetProperty("seed")
+                .GetProperty("status")
+                .GetString());
+    }
+
+    [Fact]
+    public async Task Command_RejectsMultipleTopLevelModes()
+    {
+        (int exitCode, string output, string error) cloneConflict =
+            await RunHarness(
+                "--clone-corpus",
+                FixturePath,
+                "--clone-census",
+                FixturePath);
+        Assert.Equal(2, cloneConflict.exitCode);
+        Assert.Equal("", cloneConflict.output);
+        Assert.Contains("--clone-corpus", cloneConflict.error);
+        Assert.Contains("--clone-census", cloneConflict.error);
+
+        (int exitCode, string output, string error) historicalConflict =
+            await RunHarness(
+                "--clone-corpus",
+                FixturePath,
+                "--historical-performance-recall");
+        Assert.Equal(2, historicalConflict.exitCode);
+        Assert.Equal("", historicalConflict.output);
+        Assert.Contains("--clone-corpus", historicalConflict.error);
+        Assert.Contains(
+            "--historical-performance-recall",
+            historicalConflict.error);
+
+        (int exitCode, string output, string error) existingConflict =
+            await RunHarness(
+                "--corpus-list",
+                FixturePath,
+                "--leak-triage",
+                FixturePath);
+        Assert.Equal(2, existingConflict.exitCode);
+        Assert.Equal("", existingConflict.output);
+        Assert.Contains("--corpus-list", existingConflict.error);
+        Assert.Contains("--leak-triage", existingConflict.error);
+    }
+
+    static async Task<(int ExitCode, string Output, string Error)> RunHarness(
+        params string[] arguments)
+    {
+        var start = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        start.ArgumentList.Add(
+            typeof(StructuralCloneCensus).Assembly.Location);
+        foreach (string argument in arguments)
+            start.ArgumentList.Add(argument);
+
+        using Process process = Process.Start(start)!;
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        Task<string> standardError =
+            process.StandardError.ReadToEndAsync(cancellationToken);
+        Task<string> standardOutput =
+            process.StandardOutput.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+        return (
+            process.ExitCode,
+            await standardOutput,
+            await standardError);
+    }
+}

--- a/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
@@ -391,6 +391,16 @@ public class StructuralCloneCensusTests
         Assert.Equal("", existingConflict.output);
         Assert.Contains("--corpus-list", existingConflict.error);
         Assert.Contains("--leak-triage", existingConflict.error);
+
+        (int exitCode, string output, string error) missingOperandConflict =
+            await RunHarness(
+                "--leak-triage",
+                "--clone-census",
+                FixturePath);
+        Assert.Equal(2, missingOperandConflict.exitCode);
+        Assert.Equal("", missingOperandConflict.output);
+        Assert.Contains("--leak-triage", missingOperandConflict.error);
+        Assert.Contains("--clone-census", missingOperandConflict.error);
     }
 
     static async Task<(int ExitCode, string Output, string Error)> RunHarness(

--- a/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
@@ -401,6 +401,27 @@ public class StructuralCloneCensusTests
         Assert.Equal("", missingOperandConflict.output);
         Assert.Contains("--leak-triage", missingOperandConflict.error);
         Assert.Contains("--clone-census", missingOperandConflict.error);
+
+        (int exitCode, string output, string error) consumedModeConflict =
+            await RunHarness(
+                "--corpus-list",
+                "--historical-performance-recall");
+        Assert.Equal(2, consumedModeConflict.exitCode);
+        Assert.Equal("", consumedModeConflict.output);
+        Assert.Contains("--corpus-list", consumedModeConflict.error);
+        Assert.Contains(
+            "--historical-performance-recall",
+            consumedModeConflict.error);
+
+        (int exitCode, string output, string error) validationOrderConflict =
+            await RunHarness(
+                "--clone-census",
+                "--leak-triage",
+                FixturePath);
+        Assert.Equal(2, validationOrderConflict.exitCode);
+        Assert.Equal("", validationOrderConflict.output);
+        Assert.Contains("--clone-census", validationOrderConflict.error);
+        Assert.Contains("--leak-triage", validationOrderConflict.error);
     }
 
     static async Task<(int ExitCode, string Output, string Error)> RunHarness(

--- a/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
@@ -370,6 +370,90 @@ public class StructuralCloneCensusTests
         Assert.Contains($"{option} requires a file path.", result.error);
     }
 
+    [Theory]
+    [InlineData(
+        "--diff-corpus-baseline",
+        "--corpus-list")]
+    [InlineData(
+        "--emit-corpus-snapshot",
+        "--corpus-list")]
+    [InlineData("--reference", "--paydirt-recall")]
+    [InlineData("--max-depth", "--caller-loop-census")]
+    [InlineData("--top", "does not apply")]
+    public async Task Command_RejectsOptionsOutsideOwningMode(
+        string option,
+        string expectedError)
+    {
+        (int exitCode, string output, string error) result =
+            await RunHarness(
+                "--clone-corpus",
+                FixturePath,
+                option,
+                option is "--max-depth" or "--top"
+                    ? "1"
+                    : FixturePath);
+
+        Assert.Equal(2, result.exitCode);
+        Assert.Equal("", result.output);
+        Assert.Contains(expectedError, result.error);
+    }
+
+    [Fact]
+    public async Task Command_RejectsKeepOutsideGeneratedFixtures()
+    {
+        (int exitCode, string output, string error) result =
+            await RunHarness(
+                "--clone-corpus",
+                FixturePath,
+                "--keep");
+
+        Assert.Equal(2, result.exitCode);
+        Assert.Equal("", result.output);
+        Assert.Contains(
+            "--keep requires --generated-fixtures.",
+            result.error);
+    }
+
+    [Fact]
+    public async Task Command_RejectsEarlierMissingDuplicateValues()
+    {
+        (int exitCode, string output, string error) reference =
+            await RunHarness(
+                "--paydirt-recall",
+                FixturePath,
+                "--reference",
+                "--reference",
+                FixturePath);
+        Assert.Equal(2, reference.exitCode);
+        Assert.Equal("", reference.output);
+        Assert.Contains(
+            "--reference requires a file path.",
+            reference.error);
+
+        (int exitCode, string output, string error) mode =
+            await RunHarness(
+                "--clone-census",
+                "--clone-census",
+                FixturePath);
+        Assert.Equal(2, mode.exitCode);
+        Assert.Equal("", mode.output);
+        Assert.Contains(
+            "--clone-census requires an assembly path.",
+            mode.error);
+
+        (int exitCode, string output, string error) seed =
+            await RunHarness(
+                "--clone-census",
+                FixturePath,
+                "--seed",
+                "--seed",
+                $"{FixtureType}::"
+                    + nameof(StructuralCloneFixture.ExactPositiveA));
+        Assert.Equal(2, seed.exitCode);
+        Assert.Equal("", seed.output);
+        Assert.Contains("--seed requires a selector.", seed.error);
+    }
+
     [Fact]
     public async Task Command_RejectsMultipleTopLevelModes()
     {

--- a/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneCensusTests.cs
@@ -355,6 +355,21 @@ public class StructuralCloneCensusTests
                 .GetString());
     }
 
+    [Theory]
+    [InlineData("--diff-corpus-baseline")]
+    [InlineData("--emit-corpus-snapshot")]
+    [InlineData("--reference")]
+    public async Task Command_RejectsMissingSharedOptionValues(
+        string option)
+    {
+        (int exitCode, string output, string error) result =
+            await RunHarness(option, "--json");
+
+        Assert.Equal(2, result.exitCode);
+        Assert.Equal("", result.output);
+        Assert.Contains($"{option} requires a file path.", result.error);
+    }
+
     [Fact]
     public async Task Command_RejectsMultipleTopLevelModes()
     {
@@ -422,6 +437,26 @@ public class StructuralCloneCensusTests
         Assert.Equal("", validationOrderConflict.output);
         Assert.Contains("--clone-census", validationOrderConflict.error);
         Assert.Contains("--leak-triage", validationOrderConflict.error);
+
+        foreach (string numericOption in new[]
+                 {
+                     "--max-methods",
+                     "--max-comparisons",
+                     "--max-depth",
+                 })
+        {
+            (int exitCode, string output, string error) numericConflict =
+                await RunHarness(
+                    "--clone-census",
+                    FixturePath,
+                    "--leak-triage",
+                    FixturePath,
+                    numericOption);
+            Assert.Equal(2, numericConflict.exitCode);
+            Assert.Equal("", numericConflict.output);
+            Assert.Contains("--clone-census", numericConflict.error);
+            Assert.Contains("--leak-triage", numericConflict.error);
+        }
     }
 
     static async Task<(int ExitCode, string Output, string Error)> RunHarness(

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -36,6 +36,11 @@ const string Usage =
           committed closed-world corpus. The harness resolves typed metadata identities and does
           not reconstruct candidate retrieval, normalization, correspondence, or verification.
 
+      --clone-census <assembly> [--seed <0xMethodDef|Type::Method>] [--top N]
+          Run bounded product-owned exact discovery over every MethodDef in one assembly.
+          Reports exact families, receipts, suppression, and an optional seed-to-family drill-in.
+          --max-methods and --max-comparisons override the product admission/comparison limits.
+
       --allocation-readout <file> [--top N] [--json]
           Sweep a corpus list and aggregate allocation occurrence/opportunity metadata
           distributions: allocation, path, path confidence, post dominance, escape, shape, and
@@ -114,6 +119,14 @@ string? cloneCorpusAssembly = null;
 string? relationshipLedger = null;
 bool cloneCorpusSpecified = false;
 bool relationshipLedgerSpecified = false;
+string? cloneCensusAssembly = null;
+string? cloneCensusSeed = null;
+bool cloneCensusSpecified = false;
+bool cloneCensusSeedSpecified = false;
+bool cloneMaximumMethodsSpecified = false;
+bool cloneMaximumComparisonsSpecified = false;
+int cloneMaximumMethods = 50_000;
+int cloneMaximumComparisons = 100_000;
 string? allocationReadoutList = null;
 string? callerLoopCensusList = null;
 string? deferredCallbackCensusList = null;
@@ -129,6 +142,7 @@ string? memoryPoolLifecycleList = null;
 bool tsv = false;
 bool jsonl = false;
 int top = 20;
+bool topArgumentValid = true;
 int maxDepth = 4;
 
 for (int i = 0; i < args.Length; i++)
@@ -171,6 +185,38 @@ for (int i = 0; i < args.Length; i++)
             relationshipLedgerSpecified = true;
             relationshipLedger = NextPathValue(args, ref i);
             break;
+        case "--clone-census":
+            cloneCensusSpecified = true;
+            cloneCensusAssembly = NextPathValue(args, ref i);
+            break;
+        case "--seed":
+            cloneCensusSeedSpecified = true;
+            cloneCensusSeed = NextPathValue(args, ref i);
+            break;
+        case "--max-methods":
+            cloneMaximumMethodsSpecified = true;
+            if (NextPathValue(args, ref i) is not { } methodLimit
+                || !int.TryParse(methodLimit, out cloneMaximumMethods)
+                || cloneMaximumMethods < 1)
+            {
+                Console.Error.WriteLine(
+                    "--max-methods requires a positive integer.");
+                return 2;
+            }
+            break;
+        case "--max-comparisons":
+            cloneMaximumComparisonsSpecified = true;
+            if (NextPathValue(args, ref i) is not { } comparisonLimit
+                || !int.TryParse(
+                    comparisonLimit,
+                    out cloneMaximumComparisons)
+                || cloneMaximumComparisons < 1)
+            {
+                Console.Error.WriteLine(
+                    "--max-comparisons requires a positive integer.");
+                return 2;
+            }
+            break;
         case "--allocation-readout":
             allocationReadoutList = NextValue(args, ref i);
             break;
@@ -211,7 +257,11 @@ for (int i = 0; i < args.Length; i++)
             referenceFile = NextValue(args, ref i);
             break;
         case "--top":
-            if (NextValue(args, ref i) is { } t && int.TryParse(t, out int n)) top = n;
+            if (NextPathValue(args, ref i) is not { } t
+                || !int.TryParse(t, out top))
+            {
+                topArgumentValid = false;
+            }
             break;
         case "--max-depth":
             if (NextValue(args, ref i) is not { } depth
@@ -257,6 +307,73 @@ if (relationshipLedgerSpecified && !cloneCorpusSpecified)
         "--relationship-ledger requires --clone-corpus.");
     return 2;
 }
+if (cloneCensusSpecified && cloneCensusAssembly is null)
+{
+    Console.Error.WriteLine("--clone-census requires an assembly path.");
+    return 2;
+}
+if (cloneCensusSeedSpecified && cloneCensusSeed is null)
+{
+    Console.Error.WriteLine("--seed requires a selector.");
+    return 2;
+}
+if ((cloneCensusSeedSpecified
+        || cloneMaximumMethodsSpecified
+        || cloneMaximumComparisonsSpecified)
+    && !cloneCensusSpecified)
+{
+    Console.Error.WriteLine(
+        "--seed, --max-methods, and --max-comparisons require "
+            + "--clone-census.");
+    return 2;
+}
+if (cloneCensusSpecified && (!topArgumentValid || top < 1))
+{
+    Console.Error.WriteLine("--top requires a positive integer.");
+    return 2;
+}
+
+List<string> selectedModes = [];
+if (fixturesMode || list)
+    selectedModes.Add("--generated-fixtures");
+if (corpusList is not null)
+    selectedModes.Add("--corpus-list");
+if (recallAssembly is not null)
+    selectedModes.Add("--paydirt-recall");
+if (historicalPerformanceReference is not null)
+    selectedModes.Add("--historical-performance-recall");
+if (precisionAssembly is not null)
+    selectedModes.Add("--precision-sample");
+if (cloneCorpusSpecified)
+    selectedModes.Add("--clone-corpus");
+if (cloneCensusSpecified)
+    selectedModes.Add("--clone-census");
+if (allocationReadoutList is not null)
+    selectedModes.Add("--allocation-readout");
+if (callerLoopCensusList is not null)
+    selectedModes.Add("--caller-loop-census");
+if (deferredCallbackCensusList is not null)
+    selectedModes.Add("--deferred-callback-census");
+if (recursiveTraversalCensusList is not null)
+    selectedModes.Add("--recursive-traversal-census");
+if (allocationParityExpected is not null)
+    selectedModes.Add("--allocation-parity");
+if (annotationParityExpected is not null)
+    selectedModes.Add("--annotation-parity");
+if (leakTriageList is not null)
+    selectedModes.Add("--leak-triage");
+if (leakActionabilityList is not null)
+    selectedModes.Add("--leak-actionability");
+if (memoryPoolLifecycleList is not null)
+    selectedModes.Add("--memorypool-lifecycle");
+if (selectedModes.Count > 1)
+{
+    Console.Error.WriteLine(
+        "Analysis harness modes are mutually exclusive: "
+            + string.Join(", ", selectedModes)
+            + ".");
+    return 2;
+}
 
 // --tsv/--jsonl are tabular-format selectors for the leak cards; other modes use --json.
 // Reject them elsewhere rather than silently accepting-and-ignoring them.
@@ -278,6 +395,17 @@ if (precisionAssembly is not null)
 
 if (cloneCorpusAssembly is not null)
     return RunCloneCorpus(cloneCorpusAssembly, relationshipLedger, json);
+
+if (cloneCensusAssembly is not null)
+{
+    return RunCloneCensus(
+        cloneCensusAssembly,
+        cloneCensusSeed,
+        cloneMaximumMethods,
+        cloneMaximumComparisons,
+        top,
+        json);
+}
 
 if (allocationReadoutList is not null)
     return RunAllocationReadout(allocationReadoutList, top, json);
@@ -370,6 +498,45 @@ static int RunCloneCorpus(
             ? StructuralCloneCorpus.ToJson(report) + Environment.NewLine
             : StructuralCloneCorpus.Format(report));
     return report.Success ? 0 : 1;
+}
+
+static int RunCloneCensus(
+    string assembly,
+    string? seed,
+    int maximumMethods,
+    int maximumComparisons,
+    int top,
+    bool json)
+{
+    if (!File.Exists(assembly))
+    {
+        Console.Error.WriteLine($"Assembly not found: {assembly}");
+        return 2;
+    }
+
+    try
+    {
+        StructuralCloneCensusReport report = StructuralCloneCensus.Run(
+            assembly,
+            seed,
+            maximumMethods,
+            maximumComparisons);
+        Console.Write(
+            json
+                ? StructuralCloneCensus.ToJson(report)
+                    + Environment.NewLine
+                : StructuralCloneCensus.Format(report, top));
+        return report.Success ? 0 : 1;
+    }
+    catch (Exception ex) when (
+        ex is InvalidDataException
+            or BadImageFormatException
+            or IOException
+            or UnauthorizedAccessException)
+    {
+        Console.Error.WriteLine(ex.Message);
+        return 2;
+    }
 }
 
 static int RunAllocationReadout(string corpusList, int top, bool json)

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -145,9 +145,12 @@ string? memoryPoolLifecycleList = null;
 bool tsv = false;
 bool jsonl = false;
 int top = 20;
+bool topSpecified = false;
 bool topArgumentValid = true;
 int maxDepth = 4;
+bool maxDepthSpecified = false;
 HashSet<string> selectedModes = [];
+List<string> missingValueOptions = [];
 string? numericArgumentError = null;
 
 for (int i = 0; i < args.Length; i++)
@@ -162,19 +165,35 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--corpus-list":
             selectedModes.Add("--corpus-list");
-            corpusList = NextValue(args, ref i);
+            corpusList = NextRequiredValue(
+                args,
+                ref i,
+                "--corpus-list",
+                missingValueOptions);
             break;
         case "--diff-corpus-baseline":
             diffBaselineSpecified = true;
-            diffBaseline = NextValue(args, ref i);
+            diffBaseline = NextRequiredValue(
+                args,
+                ref i,
+                "--diff-corpus-baseline",
+                missingValueOptions);
             break;
         case "--emit-corpus-snapshot":
             emitSnapshotSpecified = true;
-            emitSnapshot = NextValue(args, ref i);
+            emitSnapshot = NextRequiredValue(
+                args,
+                ref i,
+                "--emit-corpus-snapshot",
+                missingValueOptions);
             break;
         case "--paydirt-recall":
             selectedModes.Add("--paydirt-recall");
-            recallAssembly = NextValue(args, ref i);
+            recallAssembly = NextRequiredValue(
+                args,
+                ref i,
+                "--paydirt-recall",
+                missingValueOptions);
             break;
         case "--historical-performance-recall":
             selectedModes.Add("--historical-performance-recall");
@@ -187,25 +206,45 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--precision-sample":
             selectedModes.Add("--precision-sample");
-            precisionAssembly = NextValue(args, ref i);
+            precisionAssembly = NextRequiredValue(
+                args,
+                ref i,
+                "--precision-sample",
+                missingValueOptions);
             break;
         case "--clone-corpus":
             selectedModes.Add("--clone-corpus");
             cloneCorpusSpecified = true;
-            cloneCorpusAssembly = NextPathValue(args, ref i);
+            cloneCorpusAssembly = NextRequiredValue(
+                args,
+                ref i,
+                "--clone-corpus",
+                missingValueOptions);
             break;
         case "--relationship-ledger":
             relationshipLedgerSpecified = true;
-            relationshipLedger = NextPathValue(args, ref i);
+            relationshipLedger = NextRequiredValue(
+                args,
+                ref i,
+                "--relationship-ledger",
+                missingValueOptions);
             break;
         case "--clone-census":
             selectedModes.Add("--clone-census");
             cloneCensusSpecified = true;
-            cloneCensusAssembly = NextPathValue(args, ref i);
+            cloneCensusAssembly = NextRequiredValue(
+                args,
+                ref i,
+                "--clone-census",
+                missingValueOptions);
             break;
         case "--seed":
             cloneCensusSeedSpecified = true;
-            cloneCensusSeed = NextPathValue(args, ref i);
+            cloneCensusSeed = NextRequiredValue(
+                args,
+                ref i,
+                "--seed",
+                missingValueOptions);
             break;
         case "--max-methods":
             cloneMaximumMethodsSpecified = true;
@@ -231,42 +270,90 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--allocation-readout":
             selectedModes.Add("--allocation-readout");
-            allocationReadoutList = NextValue(args, ref i);
+            allocationReadoutList = NextRequiredValue(
+                args,
+                ref i,
+                "--allocation-readout",
+                missingValueOptions);
             break;
         case "--caller-loop-census":
             selectedModes.Add("--caller-loop-census");
-            callerLoopCensusList = NextValue(args, ref i);
+            callerLoopCensusList = NextRequiredValue(
+                args,
+                ref i,
+                "--caller-loop-census",
+                missingValueOptions);
             break;
         case "--deferred-callback-census":
             selectedModes.Add("--deferred-callback-census");
-            deferredCallbackCensusList = NextValue(args, ref i);
+            deferredCallbackCensusList = NextRequiredValue(
+                args,
+                ref i,
+                "--deferred-callback-census",
+                missingValueOptions);
             break;
         case "--recursive-traversal-census":
             selectedModes.Add("--recursive-traversal-census");
-            recursiveTraversalCensusList = NextValue(args, ref i);
+            recursiveTraversalCensusList = NextRequiredValue(
+                args,
+                ref i,
+                "--recursive-traversal-census",
+                missingValueOptions);
             break;
         case "--allocation-parity":
             selectedModes.Add("--allocation-parity");
-            allocationParityExpected = NextPathValue(args, ref i);
-            allocationParityActual = NextPathValue(args, ref i);
+            allocationParityExpected = NextRequiredValue(
+                args,
+                ref i,
+                "--allocation-parity",
+                missingValueOptions);
+            allocationParityActual = NextRequiredValue(
+                args,
+                ref i,
+                "--allocation-parity",
+                missingValueOptions);
             break;
         case "--annotation-parity":
             selectedModes.Add("--annotation-parity");
-            annotationParityCategory = NextValue(args, ref i);
-            annotationParityExpected = NextPathValue(args, ref i);
-            annotationParityActual = NextPathValue(args, ref i);
+            annotationParityCategory = NextRequiredValue(
+                args,
+                ref i,
+                "--annotation-parity",
+                missingValueOptions);
+            annotationParityExpected = NextRequiredValue(
+                args,
+                ref i,
+                "--annotation-parity",
+                missingValueOptions);
+            annotationParityActual = NextRequiredValue(
+                args,
+                ref i,
+                "--annotation-parity",
+                missingValueOptions);
             break;
         case "--leak-triage":
             selectedModes.Add("--leak-triage");
-            leakTriageList = NextPathValue(args, ref i);
+            leakTriageList = NextRequiredValue(
+                args,
+                ref i,
+                "--leak-triage",
+                missingValueOptions);
             break;
         case "--leak-actionability":
             selectedModes.Add("--leak-actionability");
-            leakActionabilityList = NextPathValue(args, ref i);
+            leakActionabilityList = NextRequiredValue(
+                args,
+                ref i,
+                "--leak-actionability",
+                missingValueOptions);
             break;
         case "--memorypool-lifecycle":
             selectedModes.Add("--memorypool-lifecycle");
-            memoryPoolLifecycleList = NextPathValue(args, ref i);
+            memoryPoolLifecycleList = NextRequiredValue(
+                args,
+                ref i,
+                "--memorypool-lifecycle",
+                missingValueOptions);
             break;
         case "--tsv":
             tsv = true;
@@ -276,9 +363,14 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--reference":
             referenceFileSpecified = true;
-            referenceFile = NextValue(args, ref i);
+            referenceFile = NextRequiredValue(
+                args,
+                ref i,
+                "--reference",
+                missingValueOptions);
             break;
         case "--top":
+            topSpecified = true;
             if (NextPathValue(args, ref i) is not { } t
                 || !int.TryParse(t, out int parsedTop))
             {
@@ -290,7 +382,8 @@ for (int i = 0; i < args.Length; i++)
             }
             break;
         case "--max-depth":
-            if (NextValue(args, ref i) is not { } depth
+            maxDepthSpecified = true;
+            if (NextPathValue(args, ref i) is not { } depth
                 || !int.TryParse(depth, out maxDepth)
                 || maxDepth < 1)
             {
@@ -333,48 +426,31 @@ if (numericArgumentError is not null)
     return 2;
 }
 
-if (diffBaselineSpecified && diffBaseline is null)
+if (missingValueOptions.Count > 0)
 {
     Console.Error.WriteLine(
-        "--diff-corpus-baseline requires a file path.");
-    return 2;
-}
-if (emitSnapshotSpecified && emitSnapshot is null)
-{
-    Console.Error.WriteLine(
-        "--emit-corpus-snapshot requires a file path.");
-    return 2;
-}
-if (referenceFileSpecified && referenceFile is null)
-{
-    Console.Error.WriteLine("--reference requires a file path.");
+        MissingValueError(missingValueOptions[0]));
     return 2;
 }
 
-if (cloneCorpusSpecified && cloneCorpusAssembly is null)
+if ((diffBaselineSpecified || emitSnapshotSpecified)
+    && !selectedModes.Contains("--corpus-list"))
 {
-    Console.Error.WriteLine("--clone-corpus requires an assembly path.");
+    Console.Error.WriteLine(
+        "--diff-corpus-baseline and --emit-corpus-snapshot require "
+            + "--corpus-list.");
     return 2;
 }
-if (relationshipLedgerSpecified && relationshipLedger is null)
+if (referenceFileSpecified
+    && !selectedModes.Contains("--paydirt-recall"))
 {
-    Console.Error.WriteLine("--relationship-ledger requires a file path.");
+    Console.Error.WriteLine("--reference requires --paydirt-recall.");
     return 2;
 }
 if (relationshipLedgerSpecified && !cloneCorpusSpecified)
 {
     Console.Error.WriteLine(
         "--relationship-ledger requires --clone-corpus.");
-    return 2;
-}
-if (cloneCensusSpecified && cloneCensusAssembly is null)
-{
-    Console.Error.WriteLine("--clone-census requires an assembly path.");
-    return 2;
-}
-if (cloneCensusSeedSpecified && cloneCensusSeed is null)
-{
-    Console.Error.WriteLine("--seed requires a selector.");
     return 2;
 }
 if ((cloneCensusSeedSpecified
@@ -387,15 +463,50 @@ if ((cloneCensusSeedSpecified
             + "--clone-census.");
     return 2;
 }
+if (maxDepthSpecified
+    && !selectedModes.Contains("--caller-loop-census")
+    && !selectedModes.Contains("--deferred-callback-census")
+    && !selectedModes.Contains("--recursive-traversal-census"))
+{
+    Console.Error.WriteLine(
+        "--max-depth requires --caller-loop-census, "
+            + "--deferred-callback-census, or "
+            + "--recursive-traversal-census.");
+    return 2;
+}
+if (topSpecified
+    && !selectedModes.Contains("--precision-sample")
+    && !selectedModes.Contains("--clone-census")
+    && !selectedModes.Contains("--allocation-readout")
+    && !selectedModes.Contains("--caller-loop-census")
+    && !selectedModes.Contains("--deferred-callback-census")
+    && !selectedModes.Contains("--recursive-traversal-census")
+    && !selectedModes.Contains("--leak-triage")
+    && !selectedModes.Contains("--leak-actionability")
+    && !selectedModes.Contains("--memorypool-lifecycle"))
+{
+    Console.Error.WriteLine(
+        "--top does not apply to the selected mode.");
+    return 2;
+}
 if (!topArgumentValid || top < 1)
 {
     Console.Error.WriteLine("--top requires a positive integer.");
     return 2;
 }
+if (keep && !selectedModes.Contains("--generated-fixtures"))
+{
+    Console.Error.WriteLine(
+        "--keep requires --generated-fixtures.");
+    return 2;
+}
 
 // --tsv/--jsonl are tabular-format selectors for the leak cards; other modes use --json.
 // Reject them elsewhere rather than silently accepting-and-ignoring them.
-if ((tsv || jsonl) && leakTriageList is null && leakActionabilityList is null && memoryPoolLifecycleList is null)
+if ((tsv || jsonl)
+    && !selectedModes.Contains("--leak-triage")
+    && !selectedModes.Contains("--leak-actionability")
+    && !selectedModes.Contains("--memorypool-lifecycle"))
 {
     Console.Error.WriteLine("--tsv and --jsonl apply only to --leak-triage / --leak-actionability / --memorypool-lifecycle; other modes use --json.");
     return 2;
@@ -846,8 +957,31 @@ static int RunCorpus(string corpusList, string? diffBaseline, string? emitSnapsh
     return diff.HasRegression ? 1 : 0;
 }
 
-static string? NextValue(string[] args, ref int i)
-    => NextPathValue(args, ref i);
+static string? NextRequiredValue(
+    string[] args,
+    ref int i,
+    string option,
+    List<string> missingValueOptions)
+{
+    string? value = NextPathValue(args, ref i);
+    if (value is null && !missingValueOptions.Contains(option))
+        missingValueOptions.Add(option);
+    return value;
+}
+
+static string MissingValueError(string option) =>
+    option switch
+    {
+        "--clone-corpus" or "--clone-census" or "--paydirt-recall"
+            or "--precision-sample"
+            => $"{option} requires an assembly path.",
+        "--seed" => "--seed requires a selector.",
+        "--allocation-parity" =>
+            "--allocation-parity requires expected and actual files.",
+        "--annotation-parity" =>
+            "--annotation-parity requires a category and expected/actual files.",
+        _ => $"{option} requires a file path.",
+    };
 
 static string? NextPathValue(string[] args, ref int i)
     => i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal)

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -258,9 +258,13 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--top":
             if (NextPathValue(args, ref i) is not { } t
-                || !int.TryParse(t, out top))
+                || !int.TryParse(t, out int parsedTop))
             {
                 topArgumentValid = false;
+            }
+            else
+            {
+                top = parsedTop;
             }
             break;
         case "--max-depth":
@@ -327,7 +331,7 @@ if ((cloneCensusSeedSpecified
             + "--clone-census.");
     return 2;
 }
-if (cloneCensusSpecified && (!topArgumentValid || top < 1))
+if (!topArgumentValid || top < 1)
 {
     Console.Error.WriteLine("--top requires a positive integer.");
     return 2;

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -144,17 +144,20 @@ bool jsonl = false;
 int top = 20;
 bool topArgumentValid = true;
 int maxDepth = 4;
+HashSet<string> selectedModes = [];
 
 for (int i = 0; i < args.Length; i++)
 {
     switch (args[i])
     {
         case "--generated-fixtures":
+            selectedModes.Add("--generated-fixtures");
             fixturesMode = true;
             if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
                 fixtureSelector = args[++i];
             break;
         case "--corpus-list":
+            selectedModes.Add("--corpus-list");
             corpusList = NextValue(args, ref i);
             break;
         case "--diff-corpus-baseline":
@@ -164,9 +167,11 @@ for (int i = 0; i < args.Length; i++)
             emitSnapshot = NextValue(args, ref i);
             break;
         case "--paydirt-recall":
+            selectedModes.Add("--paydirt-recall");
             recallAssembly = NextValue(args, ref i);
             break;
         case "--historical-performance-recall":
+            selectedModes.Add("--historical-performance-recall");
             historicalPerformanceReference =
                 NextPathValue(args, ref i)
                 ?? Path.Combine(
@@ -175,9 +180,11 @@ for (int i = 0; i < args.Length; i++)
                     "historical-performance-reference.json");
             break;
         case "--precision-sample":
+            selectedModes.Add("--precision-sample");
             precisionAssembly = NextValue(args, ref i);
             break;
         case "--clone-corpus":
+            selectedModes.Add("--clone-corpus");
             cloneCorpusSpecified = true;
             cloneCorpusAssembly = NextPathValue(args, ref i);
             break;
@@ -186,6 +193,7 @@ for (int i = 0; i < args.Length; i++)
             relationshipLedger = NextPathValue(args, ref i);
             break;
         case "--clone-census":
+            selectedModes.Add("--clone-census");
             cloneCensusSpecified = true;
             cloneCensusAssembly = NextPathValue(args, ref i);
             break;
@@ -218,33 +226,42 @@ for (int i = 0; i < args.Length; i++)
             }
             break;
         case "--allocation-readout":
+            selectedModes.Add("--allocation-readout");
             allocationReadoutList = NextValue(args, ref i);
             break;
         case "--caller-loop-census":
+            selectedModes.Add("--caller-loop-census");
             callerLoopCensusList = NextValue(args, ref i);
             break;
         case "--deferred-callback-census":
+            selectedModes.Add("--deferred-callback-census");
             deferredCallbackCensusList = NextValue(args, ref i);
             break;
         case "--recursive-traversal-census":
+            selectedModes.Add("--recursive-traversal-census");
             recursiveTraversalCensusList = NextValue(args, ref i);
             break;
         case "--allocation-parity":
+            selectedModes.Add("--allocation-parity");
             allocationParityExpected = NextPathValue(args, ref i);
             allocationParityActual = NextPathValue(args, ref i);
             break;
         case "--annotation-parity":
+            selectedModes.Add("--annotation-parity");
             annotationParityCategory = NextValue(args, ref i);
             annotationParityExpected = NextPathValue(args, ref i);
             annotationParityActual = NextPathValue(args, ref i);
             break;
         case "--leak-triage":
+            selectedModes.Add("--leak-triage");
             leakTriageList = NextPathValue(args, ref i);
             break;
         case "--leak-actionability":
+            selectedModes.Add("--leak-actionability");
             leakActionabilityList = NextPathValue(args, ref i);
             break;
         case "--memorypool-lifecycle":
+            selectedModes.Add("--memorypool-lifecycle");
             memoryPoolLifecycleList = NextPathValue(args, ref i);
             break;
         case "--tsv":
@@ -277,6 +294,7 @@ for (int i = 0; i < args.Length; i++)
             }
             break;
         case "list":
+            selectedModes.Add("--generated-fixtures");
             list = true;
             break;
         case "--json":
@@ -337,39 +355,6 @@ if (!topArgumentValid || top < 1)
     return 2;
 }
 
-List<string> selectedModes = [];
-if (fixturesMode || list)
-    selectedModes.Add("--generated-fixtures");
-if (corpusList is not null)
-    selectedModes.Add("--corpus-list");
-if (recallAssembly is not null)
-    selectedModes.Add("--paydirt-recall");
-if (historicalPerformanceReference is not null)
-    selectedModes.Add("--historical-performance-recall");
-if (precisionAssembly is not null)
-    selectedModes.Add("--precision-sample");
-if (cloneCorpusSpecified)
-    selectedModes.Add("--clone-corpus");
-if (cloneCensusSpecified)
-    selectedModes.Add("--clone-census");
-if (allocationReadoutList is not null)
-    selectedModes.Add("--allocation-readout");
-if (callerLoopCensusList is not null)
-    selectedModes.Add("--caller-loop-census");
-if (deferredCallbackCensusList is not null)
-    selectedModes.Add("--deferred-callback-census");
-if (recursiveTraversalCensusList is not null)
-    selectedModes.Add("--recursive-traversal-census");
-if (allocationParityExpected is not null)
-    selectedModes.Add("--allocation-parity");
-if (annotationParityExpected is not null)
-    selectedModes.Add("--annotation-parity");
-if (leakTriageList is not null)
-    selectedModes.Add("--leak-triage");
-if (leakActionabilityList is not null)
-    selectedModes.Add("--leak-actionability");
-if (memoryPoolLifecycleList is not null)
-    selectedModes.Add("--memorypool-lifecycle");
 if (selectedModes.Count > 1)
 {
     Console.Error.WriteLine(

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -108,12 +108,15 @@ bool fixturesMode = false;
 string? corpusList = null;
 string? diffBaseline = null;
 string? emitSnapshot = null;
+bool diffBaselineSpecified = false;
+bool emitSnapshotSpecified = false;
 bool json = false;
 bool keep = false;
 bool list = false;
 string? recallAssembly = null;
 string? historicalPerformanceReference = null;
 string? referenceFile = null;
+bool referenceFileSpecified = false;
 string? precisionAssembly = null;
 string? cloneCorpusAssembly = null;
 string? relationshipLedger = null;
@@ -145,6 +148,7 @@ int top = 20;
 bool topArgumentValid = true;
 int maxDepth = 4;
 HashSet<string> selectedModes = [];
+string? numericArgumentError = null;
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -161,9 +165,11 @@ for (int i = 0; i < args.Length; i++)
             corpusList = NextValue(args, ref i);
             break;
         case "--diff-corpus-baseline":
+            diffBaselineSpecified = true;
             diffBaseline = NextValue(args, ref i);
             break;
         case "--emit-corpus-snapshot":
+            emitSnapshotSpecified = true;
             emitSnapshot = NextValue(args, ref i);
             break;
         case "--paydirt-recall":
@@ -207,9 +213,8 @@ for (int i = 0; i < args.Length; i++)
                 || !int.TryParse(methodLimit, out cloneMaximumMethods)
                 || cloneMaximumMethods < 1)
             {
-                Console.Error.WriteLine(
-                    "--max-methods requires a positive integer.");
-                return 2;
+                numericArgumentError ??=
+                    "--max-methods requires a positive integer.";
             }
             break;
         case "--max-comparisons":
@@ -220,9 +225,8 @@ for (int i = 0; i < args.Length; i++)
                     out cloneMaximumComparisons)
                 || cloneMaximumComparisons < 1)
             {
-                Console.Error.WriteLine(
-                    "--max-comparisons requires a positive integer.");
-                return 2;
+                numericArgumentError ??=
+                    "--max-comparisons requires a positive integer.";
             }
             break;
         case "--allocation-readout":
@@ -271,6 +275,7 @@ for (int i = 0; i < args.Length; i++)
             jsonl = true;
             break;
         case "--reference":
+            referenceFileSpecified = true;
             referenceFile = NextValue(args, ref i);
             break;
         case "--top":
@@ -289,8 +294,8 @@ for (int i = 0; i < args.Length; i++)
                 || !int.TryParse(depth, out maxDepth)
                 || maxDepth < 1)
             {
-                Console.Error.WriteLine("--max-depth requires a positive integer.");
-                return 2;
+                numericArgumentError ??=
+                    "--max-depth requires a positive integer.";
             }
             break;
         case "list":
@@ -319,6 +324,30 @@ if (selectedModes.Count > 1)
         "Analysis harness modes are mutually exclusive: "
             + string.Join(", ", selectedModes)
             + ".");
+    return 2;
+}
+
+if (numericArgumentError is not null)
+{
+    Console.Error.WriteLine(numericArgumentError);
+    return 2;
+}
+
+if (diffBaselineSpecified && diffBaseline is null)
+{
+    Console.Error.WriteLine(
+        "--diff-corpus-baseline requires a file path.");
+    return 2;
+}
+if (emitSnapshotSpecified && emitSnapshot is null)
+{
+    Console.Error.WriteLine(
+        "--emit-corpus-snapshot requires a file path.");
+    return 2;
+}
+if (referenceFileSpecified && referenceFile is null)
+{
+    Console.Error.WriteLine("--reference requires a file path.");
     return 2;
 }
 

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -313,6 +313,15 @@ for (int i = 0; i < args.Length; i++)
     }
 }
 
+if (selectedModes.Count > 1)
+{
+    Console.Error.WriteLine(
+        "Analysis harness modes are mutually exclusive: "
+            + string.Join(", ", selectedModes)
+            + ".");
+    return 2;
+}
+
 if (cloneCorpusSpecified && cloneCorpusAssembly is null)
 {
     Console.Error.WriteLine("--clone-corpus requires an assembly path.");
@@ -352,15 +361,6 @@ if ((cloneCensusSeedSpecified
 if (!topArgumentValid || top < 1)
 {
     Console.Error.WriteLine("--top requires a positive integer.");
-    return 2;
-}
-
-if (selectedModes.Count > 1)
-{
-    Console.Error.WriteLine(
-        "Analysis harness modes are mutually exclusive: "
-            + string.Join(", ", selectedModes)
-            + ".");
     return 2;
 }
 
@@ -818,7 +818,7 @@ static int RunCorpus(string corpusList, string? diffBaseline, string? emitSnapsh
 }
 
 static string? NextValue(string[] args, ref int i)
-    => i + 1 < args.Length ? args[++i] : null;
+    => NextPathValue(args, ref i);
 
 static string? NextPathValue(string[] args, ref int i)
     => i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal)

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -24,6 +24,10 @@ dotnet "$DLL" --generated-fixtures alloc --json  # grade a subset (id/prefix/tag
 dotnet "$DLL" --generated-fixtures exception.unsuffixed.external --keep  # keep temp projects
 ```
 
+Top-level harness modes are mutually exclusive. Supplying more than one names
+the conflicting flags and exits 2 instead of silently running the first
+dispatch branch.
+
 The structural clone corpus is a separate product/harness boundary and the
 first exact-discovery demo:
 
@@ -71,6 +75,54 @@ a file; it never falls back to the committed corpus.
 `StructuralCloneCorpusTests` also requires every public method in the dedicated
 fixture type to appear in both ledger views, preventing fixture, relationship,
 or discovery-population drift.
+
+The whole-assembly census is the scale and seed-to-family demo:
+
+```bash
+dotnet "$DLL" --clone-census ILInspector.Analysis.Fixtures.dll \
+  --seed ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture::ExactPositiveA
+
+dotnet "$DLL" --clone-census System.Private.CoreLib.dll \
+  --seed System.Reflection.EventInfo::op_Equality --top 8
+dotnet "$DLL" --clone-census System.Private.CoreLib.dll \
+  --seed 0x0600873D --json
+```
+
+The harness enumerates every MethodDef once and calls
+`StructuralCloneAnalysis.Discover`; it owns no fingerprint, verification, or
+clustering logic. Every projected method carries its full MethodDef token.
+`Type::Method` is a convenience selector only: overloads fail as ambiguous and
+list the tokens callers can use instead. Nested type names use `Outer+Inner`.
+
+Text output bounds families and members with `--top`, but always pins the
+selected seed and at least one exact peer. JSON contains every family, family
+member, suppressed bucket, non-completed method, and unresolved comparison.
+Both formats expose the effective method/candidate-comparison limits and the
+complete product receipt.
+`--max-methods` changes atomic population admission;
+`--max-comparisons` changes candidate comparisons, not total body work.
+
+A clustered seed is positive evidence even if unrelated methods make the
+overall census partial. `Singleton` is reported only when discovery is
+`Completed`; otherwise an eligible seed without an emitted family is
+`Unresolved`, and the exact-singleton count is absent. `Unsupported`,
+`LimitReached`, and `Failed` seed production remain distinct. The command exits
+0 only for completed discovery, 1 for a visible product limit/failure, and 2
+for invalid arguments or input.
+
+The 2026-08-16 CoreLib canary used
+`System.Private.CoreLib.dll` from .NET
+`11.0.0-preview.7.26381.103`, SHA-256
+`6c14b54d28c604613aef5a690fa10aa768e584556e90a736b506f40022f8afea`,
+MVID `82790b72-6139-4dc6-8bd5-0d6b13d1c5e8`, and the second command above.
+The default limits processed all 44,801 methods: 41,498 were eligible, 3,296
+unsupported, and seven exceeded the 128-block body limit. All 940 candidate
+buckets completed, producing 938 exact families over 10,146 methods from 9,210
+comparisons. The overall disposition was therefore `LimitReached`, with no
+singleton inference. The selected `EventInfo::op_Equality` seed still carried
+positive evidence as one member of a nine-method reflection equality family.
+There is no performance baseline; elapsed time and memory remain
+machine-specific run evidence.
 
 Each fixture builds in isolation: a consumer assembly (the inspected one) plus, when the
 fixture is cross-assembly, a referenced external assembly (with an extern alias for the

--- a/tools/AnalysisHarness/StructuralCloneCensus.cs
+++ b/tools/AnalysisHarness/StructuralCloneCensus.cs
@@ -283,6 +283,8 @@ public static class StructuralCloneCensus
         output.Append(report.Receipt.InputMethods);
         output.Append(" processed=");
         output.Append(report.Receipt.ProcessedMethods);
+        output.Append(" suppressed=");
+        output.Append(report.Receipt.SuppressedMethods);
         output.Append(" eligible=");
         output.Append(report.Receipt.EligibleMethods);
         output.Append(" unsupported=");
@@ -299,6 +301,8 @@ public static class StructuralCloneCensus
         output.Append(report.ClusteredMethods);
         output.Append(" largest=");
         output.Append(report.LargestCluster);
+        output.Append(" eligible-without-emitted-family=");
+        output.Append(report.EligibleWithoutEmittedCluster);
         output.Append(" exact-singletons=");
         output.AppendLine(
             report.ExactSingletonMethods?.ToString(

--- a/tools/AnalysisHarness/StructuralCloneCensus.cs
+++ b/tools/AnalysisHarness/StructuralCloneCensus.cs
@@ -1,0 +1,736 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.AnalysisHarness;
+
+public enum StructuralCloneCensusSeedStatus
+{
+    Clustered,
+    Singleton,
+    Unsupported,
+    LimitReached,
+    Failed,
+    Unresolved,
+}
+
+public sealed record StructuralCloneCensusMethod(
+    int Token,
+    string Type,
+    string Name);
+
+public sealed record StructuralCloneCensusCluster(
+    string Identity,
+    ImmutableArray<StructuralCloneCensusMethod> Members,
+    int UniqueCorrespondences,
+    int AmbiguousCorrespondences);
+
+public sealed record StructuralCloneCensusSuppressedBucket(
+    ImmutableArray<StructuralCloneCensusMethod> Methods,
+    StructuralCloneDiscoveryBlocker Reason);
+
+public sealed record StructuralCloneCensusMethodOutcome(
+    StructuralCloneCensusMethod Method,
+    StructuralCloneDisposition Disposition,
+    ImmutableArray<StructuralCloneDiscoveryBlocker> Blockers,
+    StructuralCloneMethodReceipt Receipt);
+
+public sealed record StructuralCloneCensusUnresolvedComparison(
+    StructuralCloneCensusMethod Left,
+    StructuralCloneCensusMethod Right,
+    StructuralCloneDisposition Disposition,
+    ImmutableArray<StructuralCloneBlocker> Blockers,
+    StructuralCloneVerificationReceipt Receipt);
+
+public sealed record StructuralCloneCensusSeed(
+    string Selector,
+    StructuralCloneCensusMethod Method,
+    StructuralCloneCensusSeedStatus Status,
+    StructuralCloneDisposition? ProductionDisposition,
+    ImmutableArray<StructuralCloneDiscoveryBlocker> Blockers,
+    StructuralCloneCensusCluster? Cluster);
+
+public sealed record StructuralCloneCensusReport(
+    string Assembly,
+    Guid? ModuleVersionId,
+    int MaximumMethods,
+    int MaximumCandidateComparisons,
+    StructuralCloneDiscoveryDisposition Disposition,
+    ImmutableArray<StructuralCloneDiscoveryBlocker> Blockers,
+    StructuralCloneDiscoveryReceipt Receipt,
+    IReadOnlyDictionary<string, int> MethodDispositionCounts,
+    IReadOnlyDictionary<string, int> MethodBlockerCounts,
+    ImmutableArray<StructuralCloneCensusMethodOutcome> NonCompletedMethods,
+    ImmutableArray<StructuralCloneCensusUnresolvedComparison>
+        UnresolvedComparisons,
+    int Clusters,
+    int ClusteredMethods,
+    int EligibleWithoutEmittedCluster,
+    int? ExactSingletonMethods,
+    int LargestCluster,
+    ImmutableArray<StructuralCloneCensusCluster> Families,
+    ImmutableArray<StructuralCloneCensusSuppressedBucket> SuppressedBuckets,
+    StructuralCloneCensusSeed? Seed,
+    long DiscoveryElapsedMilliseconds)
+{
+    public bool Success =>
+        Disposition == StructuralCloneDiscoveryDisposition.Completed;
+}
+
+public static class StructuralCloneCensus
+{
+    static readonly JsonSerializerOptions s_json = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        Converters =
+        {
+            new JsonStringEnumConverter(
+                namingPolicy: null,
+                allowIntegerValues: false),
+        },
+    };
+
+    public static StructuralCloneCensusReport Run(
+        string assemblyPath,
+        string? seedSelector = null,
+        int maximumMethods = 50_000,
+        int maximumCandidateComparisons = 100_000)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyPath);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumMethods, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(
+            maximumCandidateComparisons,
+            1);
+
+        string fullPath = Path.GetFullPath(assemblyPath);
+        using var stream = File.OpenRead(fullPath);
+        using var image = new PEReader(stream);
+        MetadataReader reader = GetMetadataReader(image, fullPath);
+        ImmutableArray<MethodDefinitionHandle> population =
+            ImmutableArray.CreateRange(reader.MethodDefinitions);
+        MethodDefinitionHandle? seed = seedSelector is null
+            ? null
+            : ResolveSeed(reader, seedSelector);
+
+        var limits = new StructuralCloneDiscoveryLimits(
+            maximumMethods,
+            maximumCandidateComparisons);
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        StructuralCloneDiscoveryResult discovery =
+            StructuralCloneAnalysis.Discover(image, population, limits);
+        stopwatch.Stop();
+
+        var methodCache =
+            new Dictionary<MethodDefinitionHandle, StructuralCloneCensusMethod>();
+        StructuralCloneCensusMethod Project(MethodDefinitionHandle handle)
+        {
+            if (methodCache.TryGetValue(
+                    handle,
+                    out StructuralCloneCensusMethod? method))
+            {
+                return method;
+            }
+            MethodDefinition definition = reader.GetMethodDefinition(handle);
+            method = new StructuralCloneCensusMethod(
+                MetadataTokens.GetToken(handle),
+                TypeName(reader, definition.GetDeclaringType()),
+                reader.GetString(definition.Name));
+            methodCache.Add(handle, method);
+            return method;
+        }
+
+        ImmutableArray<StructuralCloneCensusCluster> families =
+        [
+            .. discovery.Clusters
+                .Select(cluster =>
+                    new StructuralCloneCensusCluster(
+                        cluster.Identity.ToString(),
+                        [
+                            .. cluster.Members.Select(member =>
+                                Project(member.Handle)),
+                        ],
+                        cluster.Evidence.Count(static comparison =>
+                            comparison.Correspondence?.Kind
+                                == StructuralCloneCorrespondenceKind.Unique),
+                        cluster.Evidence.Count(static comparison =>
+                            comparison.Correspondence?.Kind
+                                == StructuralCloneCorrespondenceKind.Ambiguous)))
+                .OrderByDescending(static cluster => cluster.Members.Length)
+                .ThenBy(static cluster => cluster.Members[0].Token),
+        ];
+        ImmutableArray<StructuralCloneCensusSuppressedBucket>
+            suppressedBuckets =
+        [
+            .. discovery.SuppressedBuckets.Select(bucket =>
+                new StructuralCloneCensusSuppressedBucket(
+                    [
+                        .. bucket.Methods.Select(method =>
+                            Project(method.Handle)),
+                    ],
+                    bucket.Reason)),
+        ];
+        ImmutableArray<StructuralCloneCensusMethodOutcome>
+            nonCompletedMethods =
+        [
+            .. discovery.Methods
+                .Where(static method =>
+                    method.Disposition
+                        != StructuralCloneDisposition.Completed)
+                .Select(method =>
+                    new StructuralCloneCensusMethodOutcome(
+                        Project(method.Method.Handle),
+                        method.Disposition,
+                        method.Blockers,
+                        method.Receipt))
+                .OrderBy(static method =>
+                    NonCompletedOrder(method.Disposition))
+                .ThenBy(static method => method.Method.Token),
+        ];
+        ImmutableArray<StructuralCloneCensusUnresolvedComparison>
+            unresolvedComparisons =
+        [
+            .. discovery.UnresolvedComparisons
+                .Select(comparison =>
+                    new StructuralCloneCensusUnresolvedComparison(
+                        Project(comparison.Left.Handle),
+                        Project(comparison.Right.Handle),
+                        comparison.Disposition,
+                        comparison.Blockers,
+                        comparison.Receipt))
+                .OrderBy(static comparison => comparison.Left.Token)
+                .ThenBy(static comparison => comparison.Right.Token),
+        ];
+        int clusteredMethods = families.Sum(static cluster =>
+            cluster.Members.Length);
+        int eligibleWithoutCluster =
+            discovery.Receipt.EligibleMethods - clusteredMethods;
+        StructuralCloneCensusSeed? seedResult = seed is { } seedHandle
+            ? ProjectSeed(
+                seedSelector!,
+                seedHandle,
+                Project(seedHandle),
+                discovery,
+                families)
+            : null;
+        Guid? moduleVersionId =
+            discovery.Methods.IsEmpty
+                ? families.IsEmpty
+                    ? null
+                    : discovery.Clusters[0].Identity.ModuleVersionId
+                : discovery.Methods[0].Method.ModuleVersionId;
+
+        return new StructuralCloneCensusReport(
+            fullPath,
+            moduleVersionId,
+            maximumMethods,
+            maximumCandidateComparisons,
+            discovery.Disposition,
+            discovery.Blockers,
+            discovery.Receipt,
+            Counts(
+                discovery.Methods,
+                static method => method.Disposition.ToString()),
+            Counts(
+                discovery.Methods.SelectMany(static method =>
+                    method.Blockers),
+                static blocker => blocker.Kind.ToString()),
+            nonCompletedMethods,
+            unresolvedComparisons,
+            families.Length,
+            clusteredMethods,
+            eligibleWithoutCluster,
+            discovery.Disposition
+                == StructuralCloneDiscoveryDisposition.Completed
+                ? eligibleWithoutCluster
+                : null,
+            families.IsEmpty ? 0 : families[0].Members.Length,
+            families,
+            suppressedBuckets,
+            seedResult,
+            stopwatch.ElapsedMilliseconds);
+    }
+
+    public static string ToJson(StructuralCloneCensusReport report)
+        => JsonSerializer.Serialize(report, s_json);
+
+    public static string Format(
+        StructuralCloneCensusReport report,
+        int top = 20)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(top, 1);
+
+        StringBuilder output = new();
+        output.Append("EXACT CLONE CENSUS: ");
+        output.Append(report.Disposition);
+        output.Append(' ');
+        output.AppendLine(Path.GetFileName(report.Assembly));
+        output.Append("  limits: methods=");
+        output.Append(report.MaximumMethods);
+        output.Append(" candidate-comparisons=");
+        output.AppendLine(
+            report.MaximumCandidateComparisons.ToString(
+                CultureInfo.InvariantCulture));
+        output.Append("  methods: input=");
+        output.Append(report.Receipt.InputMethods);
+        output.Append(" processed=");
+        output.Append(report.Receipt.ProcessedMethods);
+        output.Append(" eligible=");
+        output.Append(report.Receipt.EligibleMethods);
+        output.Append(" unsupported=");
+        output.Append(report.Receipt.UnsupportedMethods);
+        output.Append(" limited=");
+        output.Append(report.Receipt.LimitReachedMethods);
+        output.Append(" failed=");
+        output.AppendLine(
+            report.Receipt.FailedMethods.ToString(
+                CultureInfo.InvariantCulture));
+        output.Append("  families: clusters=");
+        output.Append(report.Clusters);
+        output.Append(" clustered-methods=");
+        output.Append(report.ClusteredMethods);
+        output.Append(" largest=");
+        output.Append(report.LargestCluster);
+        output.Append(" exact-singletons=");
+        output.AppendLine(
+            report.ExactSingletonMethods?.ToString(
+                CultureInfo.InvariantCulture)
+            ?? "<unresolved>");
+        output.Append("  candidates: buckets=");
+        output.Append(report.Receipt.CandidateBuckets);
+        output.Append(" completed=");
+        output.Append(report.Receipt.CompletedCandidateBuckets);
+        output.Append(" suppressed=");
+        output.Append(report.Receipt.SuppressedCandidateBuckets);
+        output.Append(" comparisons=");
+        output.Append(report.Receipt.CandidateComparisons);
+        output.Append(" exact=");
+        output.Append(report.Receipt.ExactComparisons);
+        output.Append(" different=");
+        output.Append(report.Receipt.DifferentComparisons);
+        output.Append(" unresolved=");
+        output.AppendLine(
+            report.Receipt.UnresolvedComparisons.ToString(
+                CultureInfo.InvariantCulture));
+        output.Append("  body-productions=");
+        output.Append(report.Receipt.BodyProductions);
+        output.Append(" elapsed-ms=");
+        output.AppendLine(
+            report.DiscoveryElapsedMilliseconds.ToString(
+                CultureInfo.InvariantCulture));
+
+        foreach (StructuralCloneDiscoveryBlocker blocker in report.Blockers)
+        {
+            output.Append("  blocker: ");
+            output.Append(blocker.Kind);
+            output.Append(": ");
+            output.AppendLine(blocker.Detail);
+        }
+
+        foreach (IGrouping<StructuralCloneDisposition,
+            StructuralCloneCensusMethodOutcome> group
+            in report.NonCompletedMethods.GroupBy(static method =>
+                method.Disposition))
+        {
+            output.Append("  ");
+            output.Append(group.Key);
+            output.Append(" methods (top ");
+            output.Append(top);
+            output.AppendLine("):");
+            foreach (StructuralCloneCensusMethodOutcome method
+                in group.Take(top))
+            {
+                output.Append("    ");
+                output.AppendLine(MethodDisplay(method.Method));
+                foreach (StructuralCloneDiscoveryBlocker blocker
+                    in method.Blockers)
+                {
+                    output.Append("      ");
+                    output.Append(blocker.Kind);
+                    output.Append(": ");
+                    output.AppendLine(blocker.Detail);
+                }
+            }
+            int omittedMethods =
+                group.Count() - Math.Min(group.Count(), top);
+            if (omittedMethods > 0)
+            {
+                output.Append("    ... ");
+                output.Append(omittedMethods);
+                output.AppendLine(" more methods omitted");
+            }
+        }
+
+        if (!report.UnresolvedComparisons.IsEmpty)
+        {
+            output.Append("  unresolved comparisons (top ");
+            output.Append(top);
+            output.AppendLine("):");
+            foreach (StructuralCloneCensusUnresolvedComparison comparison
+                in report.UnresolvedComparisons.Take(top))
+            {
+                output.Append("    ");
+                output.Append(MethodDisplay(comparison.Left));
+                output.Append(" <> ");
+                output.AppendLine(MethodDisplay(comparison.Right));
+                foreach (StructuralCloneBlocker blocker
+                    in comparison.Blockers)
+                {
+                    output.Append("      ");
+                    output.Append(blocker.Kind);
+                    output.Append(": ");
+                    output.AppendLine(blocker.Detail);
+                }
+            }
+            int omittedComparisons =
+                report.UnresolvedComparisons.Length
+                    - Math.Min(report.UnresolvedComparisons.Length, top);
+            if (omittedComparisons > 0)
+            {
+                output.Append("    ... ");
+                output.Append(omittedComparisons);
+                output.AppendLine(" more comparisons omitted");
+            }
+        }
+
+        if (!report.SuppressedBuckets.IsEmpty)
+        {
+            output.Append("  suppressed buckets (top ");
+            output.Append(top);
+            output.AppendLine("):");
+            foreach (StructuralCloneCensusSuppressedBucket bucket
+                in report.SuppressedBuckets.Take(top))
+            {
+                output.Append("    ");
+                output.Append(bucket.Reason.Kind);
+                output.Append(": ");
+                output.AppendLine(bucket.Reason.Detail);
+                foreach (StructuralCloneCensusMethod method
+                    in bucket.Methods.Take(top))
+                {
+                    output.Append("      ");
+                    output.AppendLine(MethodDisplay(method));
+                }
+                int omittedMethods =
+                    bucket.Methods.Length
+                        - Math.Min(bucket.Methods.Length, top);
+                if (omittedMethods > 0)
+                {
+                    output.Append("      ... ");
+                    output.Append(omittedMethods);
+                    output.AppendLine(" more methods omitted");
+                }
+            }
+            int omittedBuckets =
+                report.SuppressedBuckets.Length
+                    - Math.Min(report.SuppressedBuckets.Length, top);
+            if (omittedBuckets > 0)
+            {
+                output.Append("    ... ");
+                output.Append(omittedBuckets);
+                output.AppendLine(" more buckets omitted");
+            }
+        }
+
+        if (report.Seed is { } seed)
+        {
+            output.Append("  seed ");
+            output.Append(seed.Status);
+            output.Append(": ");
+            output.AppendLine(MethodDisplay(seed.Method));
+            foreach (StructuralCloneDiscoveryBlocker blocker
+                in seed.Blockers)
+            {
+                output.Append("    ");
+                output.Append(blocker.Kind);
+                output.Append(": ");
+                output.AppendLine(blocker.Detail);
+            }
+            if (seed.Cluster is { } family)
+            {
+                output.AppendLine("    exact family:");
+                AppendFamily(
+                    output,
+                    family,
+                    top,
+                    "      ",
+                    seed.Method);
+            }
+        }
+
+        output.Append("  exact families (top ");
+        output.Append(top);
+        output.AppendLine("):");
+        HashSet<string> emitted = [];
+        if (report.Seed?.Cluster is { } seedFamily)
+            emitted.Add(seedFamily.Identity);
+        int familyCount = 0;
+        foreach (StructuralCloneCensusCluster family in report.Families)
+        {
+            if (emitted.Contains(family.Identity))
+                continue;
+            if (familyCount == top)
+                break;
+            AppendFamily(output, family, top, "    ");
+            emitted.Add(family.Identity);
+            familyCount++;
+        }
+        int omitted = report.Families.Length - emitted.Count;
+        if (omitted > 0)
+        {
+            output.Append("    ... ");
+            output.Append(omitted);
+            output.AppendLine(" more families omitted");
+        }
+        return output.ToString();
+    }
+
+    static MetadataReader GetMetadataReader(
+        PEReader image,
+        string assemblyPath)
+    {
+        try
+        {
+            if (!image.HasMetadata)
+            {
+                throw new InvalidDataException(
+                    $"The clone census target is not a managed assembly: "
+                        + assemblyPath);
+            }
+            return image.GetMetadataReader();
+        }
+        catch (Exception ex) when (
+            ex is BadImageFormatException
+                or ArgumentException
+                or ArgumentOutOfRangeException
+                or InvalidOperationException
+                or OverflowException)
+        {
+            throw new InvalidDataException(
+                $"The clone census target has invalid managed metadata: "
+                    + assemblyPath,
+                ex);
+        }
+    }
+
+    static MethodDefinitionHandle ResolveSeed(
+        MetadataReader reader,
+        string selector)
+    {
+        if (string.IsNullOrWhiteSpace(selector))
+        {
+            throw new InvalidDataException(
+                "A clone census seed selector cannot be empty.");
+        }
+
+        if (selector.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!int.TryParse(
+                    selector.AsSpan(2),
+                    NumberStyles.AllowHexSpecifier,
+                    CultureInfo.InvariantCulture,
+                    out int token)
+                || (token & unchecked((int)0xFF000000))
+                    != 0x06000000)
+            {
+                throw InvalidSeed(selector);
+            }
+            int row = token & 0x00FFFFFF;
+            if (row < 1
+                || row > reader.GetTableRowCount(TableIndex.MethodDef))
+            {
+                throw InvalidSeed(selector);
+            }
+            return MetadataTokens.MethodDefinitionHandle(row);
+        }
+
+        int separator = selector.LastIndexOf(
+            "::",
+            StringComparison.Ordinal);
+        if (separator <= 0 || separator == selector.Length - 2)
+            throw InvalidSeed(selector);
+        string typeName = selector[..separator];
+        string methodName = selector[(separator + 2)..];
+        MethodDefinitionHandle[] matches =
+        [
+            .. reader.MethodDefinitions.Where(handle =>
+            {
+                MethodDefinition method =
+                    reader.GetMethodDefinition(handle);
+                return StringComparer.Ordinal.Equals(
+                        reader.GetString(method.Name),
+                        methodName)
+                    && StringComparer.Ordinal.Equals(
+                        TypeName(reader, method.GetDeclaringType()),
+                        typeName);
+            }),
+        ];
+        if (matches.Length == 1)
+            return matches[0];
+        if (matches.Length == 0)
+            throw InvalidSeed(selector);
+
+        string tokens = string.Join(
+            ", ",
+            matches.Select(static handle =>
+                $"0x{MetadataTokens.GetToken(handle):X8}"));
+        throw new InvalidDataException(
+            $"Clone census seed '{selector}' is ambiguous; "
+                + $"use one of these MethodDef tokens: {tokens}.");
+    }
+
+    static StructuralCloneCensusSeed ProjectSeed(
+        string selector,
+        MethodDefinitionHandle seed,
+        StructuralCloneCensusMethod method,
+        StructuralCloneDiscoveryResult discovery,
+        ImmutableArray<StructuralCloneCensusCluster> families)
+    {
+        StructuralCloneCensusCluster? family =
+            families.FirstOrDefault(cluster =>
+                cluster.Members.Any(member =>
+                    member.Token == MetadataTokens.GetToken(seed)));
+        StructuralCloneMethodOutcome? outcome =
+            discovery.Methods.FirstOrDefault(item =>
+                item.Method.Handle == seed);
+        StructuralCloneCensusSeedStatus status =
+            family is not null
+                ? StructuralCloneCensusSeedStatus.Clustered
+                : outcome?.Disposition switch
+                {
+                    StructuralCloneDisposition.Unsupported =>
+                        StructuralCloneCensusSeedStatus.Unsupported,
+                    StructuralCloneDisposition.LimitReached =>
+                        StructuralCloneCensusSeedStatus.LimitReached,
+                    StructuralCloneDisposition.Failed =>
+                        StructuralCloneCensusSeedStatus.Failed,
+                    StructuralCloneDisposition.Completed
+                        when discovery.Disposition
+                            == StructuralCloneDiscoveryDisposition.Completed =>
+                        StructuralCloneCensusSeedStatus.Singleton,
+                    _ => StructuralCloneCensusSeedStatus.Unresolved,
+                };
+        return new StructuralCloneCensusSeed(
+            selector,
+            method,
+            status,
+            outcome?.Disposition,
+            outcome?.Blockers
+                ?? ImmutableArray<StructuralCloneDiscoveryBlocker>.Empty,
+            family);
+    }
+
+    static string TypeName(
+        MetadataReader reader,
+        TypeDefinitionHandle handle)
+    {
+        List<string> segments = [];
+        string @namespace = "";
+        int remaining = reader.GetTableRowCount(TableIndex.TypeDef) + 1;
+        while (!handle.IsNil && remaining-- > 0)
+        {
+            TypeDefinition type = reader.GetTypeDefinition(handle);
+            segments.Add(reader.GetString(type.Name));
+            TypeDefinitionHandle declaringType = type.GetDeclaringType();
+            if (declaringType.IsNil)
+                @namespace = reader.GetString(type.Namespace);
+            handle = declaringType;
+        }
+        if (!handle.IsNil)
+        {
+            throw new BadImageFormatException(
+                "A nested type declaration cycle was detected.");
+        }
+        segments.Reverse();
+        string name = string.Join("+", segments);
+        return string.IsNullOrEmpty(@namespace)
+            ? name
+            : $"{@namespace}.{name}";
+    }
+
+    static InvalidDataException InvalidSeed(string selector)
+        => new(
+            $"Could not resolve clone census seed '{selector}'. "
+                + "Use 0x followed by a full MethodDef token, or a unique "
+                + "Type::Method selector.");
+
+    static IReadOnlyDictionary<string, int> Counts<T>(
+        IEnumerable<T> values,
+        Func<T, string> key)
+        => values
+            .GroupBy(key, StringComparer.Ordinal)
+            .OrderBy(static group => group.Key, StringComparer.Ordinal)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.Count(),
+                StringComparer.Ordinal);
+
+    static int NonCompletedOrder(StructuralCloneDisposition disposition)
+        => disposition switch
+        {
+            StructuralCloneDisposition.Failed => 0,
+            StructuralCloneDisposition.LimitReached => 1,
+            _ => 2,
+        };
+
+    static void AppendFamily(
+        StringBuilder output,
+        StructuralCloneCensusCluster family,
+        int top,
+        string indent,
+        StructuralCloneCensusMethod? pinnedSeed = null)
+    {
+        output.Append(indent);
+        output.Append("family size=");
+        output.Append(family.Members.Length);
+        output.Append(" anchor=0x");
+        output.Append(family.Members[0].Token.ToString(
+            "X8",
+            CultureInfo.InvariantCulture));
+        output.Append(" correspondence=");
+        output.Append(family.UniqueCorrespondences);
+        output.Append(" unique/");
+        output.Append(family.AmbiguousCorrespondences);
+        output.AppendLine(" ambiguous");
+        IEnumerable<StructuralCloneCensusMethod> members =
+            pinnedSeed is null
+                ? family.Members
+                :
+                [
+                    pinnedSeed,
+                    .. family.Members.Where(member =>
+                        member.Token != pinnedSeed.Token),
+                ];
+        int memberLimit = pinnedSeed is null
+            ? top
+            : Math.Max(top, Math.Min(2, family.Members.Length));
+        foreach (StructuralCloneCensusMethod member
+            in members.Take(memberLimit))
+        {
+            output.Append(indent);
+            output.Append("  ");
+            output.AppendLine(MethodDisplay(member));
+        }
+        int omitted = family.Members.Length - Math.Min(
+            family.Members.Length,
+            memberLimit);
+        if (omitted > 0)
+        {
+            output.Append(indent);
+            output.Append("  ... ");
+            output.Append(omitted);
+            output.AppendLine(" more members omitted");
+        }
+    }
+
+    static string MethodDisplay(StructuralCloneCensusMethod method)
+        => $"0x{method.Token:X8} {method.Type}::{method.Name}";
+}


### PR DESCRIPTION
## Summary

Adds a harness-only whole-assembly exact clone census and seed-to-family drill-in
over `StructuralCloneAnalysis.Discover`. The harness enumerates MethodDefs and
projects product-owned clusters, evidence, outcomes, suppression, unresolved
comparisons, and receipts; it owns no candidate or verification logic.

Every method is token-bearing. Name selectors must resolve uniquely, partial
runs never claim singleton status, selected seed evidence stays visible under
text truncation, and JSON retains every family and non-completed detail.

Also closes the pre-existing harness dispatch gap: multiple top-level modes now
fail with a named conflict instead of silently selecting one.

## Fixture demo

```bash
dotnet run --project tools/AnalysisHarness -c Release --no-build -- \
  --clone-census \
  artifacts/bin/ILInspector.Analysis.Fixtures/release/ILInspector.Analysis.Fixtures.dll \
  --seed ILInspector.Analysis.StructuralCloneFixtures.StructuralCloneFixture::ExactPositiveA \
  --top 4
```

```text
EXACT CLONE CENSUS: Completed ILInspector.Analysis.Fixtures.dll
  methods: input=57 processed=57 eligible=53 unsupported=4 limited=0 failed=0
  families: clusters=9 clustered-methods=27 largest=8 exact-singletons=26
  candidates: buckets=10 completed=10 suppressed=0 comparisons=19 exact=18 different=1 unresolved=0
  seed Clustered: 0x06000001 ...StructuralCloneFixture::ExactPositiveA
```

The existing `--clone-corpus` demo independently retains the edge-role close
negative and exact correspondence oracle.

## CoreLib demo

Pinned input: .NET `11.0.0-preview.7.26381.103`
`System.Private.CoreLib.dll`, SHA-256
`6c14b54d28c604613aef5a690fa10aa768e584556e90a736b506f40022f8afea`,
MVID `82790b72-6139-4dc6-8bd5-0d6b13d1c5e8`.

```bash
dotnet run --project tools/AnalysisHarness -c Release --no-build -- \
  --clone-census System.Private.CoreLib.dll \
  --seed System.Reflection.EventInfo::op_Equality --top 8
```

The default limits processed all 44,801 methods and completed all 940 candidate
buckets: 938 exact families covered 10,146 methods from 9,210 comparisons.
Seven methods exceeded the 128-block body limit, so the overall disposition is
honestly `LimitReached` and singleton counts remain unresolved. The selected
seed still has valid positive evidence in a nine-member reflection equality
family.

## Evidence

- Focused census and corpus gates: 24/24
- Fixture text and JSON demos: passed
- Pinned CoreLib JSON canary: passed
- Markdown lint and diff checks: clean

## Boundaries

No product discovery changes, fuzzy/near matching, source/decompiler
participation, public product command, or actionability/provenance inference.

Closes #4290
Closes #4274
