### PR TITLE
Extract lock sugar samples from CfgSampleClass

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5494,32 +5494,3 @@ public sealed class NamedCtorArgumentOrder : NamedCtorArgumentOrderBase
 
     static int Mutate(ref int value) => value++;
 }
-
-/// <summary>Lock shapes the lock-sugar pass must raise, including static-field, instance-field, and parameter receivers.</summary>
-public sealed class LockFixtureSamples
-{
-    static readonly object s_staticRoot = new();
-    static int s_staticValue;
-    readonly object _root = new();
-    int _value;
-
-    public static void IncrementStaticUnderLock()
-    {
-        lock (s_staticRoot) { s_staticValue++; }
-    }
-
-    public void IncrementUnderLock()
-    {
-        lock (_root) { _value++; }
-    }
-
-    public int ReadUnderLock()
-    {
-        lock (_root) { return _value; }
-    }
-
-    public void LockOnParameter(object gate)
-    {
-        lock (gate) { _value = 1; }
-    }
-}

--- a/src/ILInspector.Decompiler.Tests/LockSugarSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/LockSugarSamples.cs
@@ -1,0 +1,30 @@
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>Lock shapes the lock-sugar pass must raise, including static-field, instance-field, and parameter receivers.</summary>
+public sealed class LockFixtureSamples
+{
+    static readonly object s_staticRoot = new();
+    static int s_staticValue;
+    readonly object _root = new();
+    int _value;
+
+    public static void IncrementStaticUnderLock()
+    {
+        lock (s_staticRoot) { s_staticValue++; }
+    }
+
+    public void IncrementUnderLock()
+    {
+        lock (_root) { _value++; }
+    }
+
+    public int ReadUnderLock()
+    {
+        lock (_root) { return _value; }
+    }
+
+    public void LockOnParameter(object gate)
+    {
+        lock (gate) { _value = 1; }
+    }
+}


### PR DESCRIPTION
## Summary

Moves `LockFixtureSamples` unchanged from the catch-all `CfgSampleClass.cs` fixture into the feature-focused `LockSugarSamples.cs` file beside its primary owning tests. The type name, fields, methods, comments, and declaration order remain unchanged.

Related to #3913. Leaves #3913 open for the remaining fixture groups.

## Validation

- Release solution build: passed (0 errors; 3 pre-existing nullable warnings)
- `LockSugarTests`: 4 passed
- `ConstructorChainTests`: 7 passed
- decompiler fast gate: 5,111 total, 0 failed, 8 expected Windows privilege-dependent skips
- stable-path base/head rendering comparison: 20,598 methods evaluated; 0 changed, 0 added, 0 removed