### PR TITLE
Carry find view text through typed containment

### DIFF
--- a/docs/design/inert-text.md
+++ b/docs/design/inert-text.md
@@ -243,7 +243,7 @@ Two are known, and neither is complete on its own:
 
 | Boundary | Measured size | Tracked by |
 | -------- | ------------- | ---------- |
-| Row and view types | 359 columns across 86 row types | #3463 |
+| Row and view types | 332 columns across 78 row types, pinned by `MarkoutRowContainmentTests` | #3463 |
 | Diagnostic and log callbacks | 97 `Action<string>` sites | #3606 |
 
 Those cover the table path and the logging path. They are not exhaustive: the

--- a/src/dotnet-inspect.Tests/FindCommandTests.cs
+++ b/src/dotnet-inspect.Tests/FindCommandTests.cs
@@ -5,6 +5,7 @@ using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
+using InertText;
 using Markout;
 
 namespace DotnetInspector.Tests;
@@ -39,7 +40,7 @@ public class FindCommandTests
     }
 
     [Fact]
-    public void TableFormatter_NormalizesTabsAndNewlinesInTsvCells()
+    public void TableFormatter_VisiblyEncodesTabsAndNewlinesInTsvCells()
     {
         var results = new List<TypeFindResult>
         {
@@ -50,10 +51,91 @@ public class FindCommandTests
         var view = FindOutputFormatter.BuildView(results);
         var fields = RenderFindTable(view, tsv: true, showHeader: false).TrimEnd().Split('\t');
 
-        // "Ns Value", not "Ns  Value": containment (issue #3319) folds CRLF as a
-        // single line ending before the TSV normalizer sees it, where the
-        // normalizer alone would have replaced CR and LF with a space each.
-        Assert.Equal(["Line Break", "Ns Value", "class", "Tab Lib", "runtime"], fields);
+        Assert.Equal(
+            [@"Line\^JBreak", @"Ns\^M\^JValue", "class", @"Tab\^ILib", "runtime"],
+            fields);
+    }
+
+    [Fact]
+    public void Views_CarryConcernProvenanceAcrossMarkoutFormats()
+    {
+        const string hostile = "Name\u202E\n";
+        TextConcern expectedConcerns = TextConcern.Format | TextConcern.Control;
+        var view = FindOutputFormatter.BuildView(
+            [
+                new TypeFindResult
+                {
+                    Pattern = hostile,
+                    Match = MatchKind.Exact,
+                    Similarity = 1.0,
+                    Type = hostile,
+                    Namespace = hostile,
+                    Kind = hostile,
+                    Library = hostile,
+                    Source = hostile,
+                    SourceVersion = hostile,
+                },
+            ],
+            hostile);
+        var memberView = FindOutputFormatter.BuildMemberView(
+            [
+                new MemberFindResult
+                {
+                    Pattern = hostile,
+                    Match = MatchKind.Exact,
+                    Member = hostile,
+                    Kind = hostile,
+                    DeclaringType = hostile,
+                    Signature = hostile,
+                    Library = hostile,
+                    Source = hostile,
+                    SourceVersion = hostile,
+                },
+            ],
+            hostile);
+
+        FindRow row = Assert.Single(view.Results!);
+        FindMemberRow memberRow = Assert.Single(memberView.Results!);
+        Assert.Equal(expectedConcerns, view.TitleText.Concerns);
+        Assert.Equal(expectedConcerns, row.TypeText.Concerns);
+        Assert.Equal(expectedConcerns, row.SourceText.Concerns);
+        Assert.Equal(expectedConcerns, memberView.TitleText.Concerns);
+        Assert.Equal(expectedConcerns, memberRow.SignatureText.Concerns);
+        Assert.Equal(@"Name\u202E\^J", row.Type);
+
+        string markdown = MarkoutSerializer.Serialize(view, SearchViewContext.Default);
+        string tsv = RenderFindTable(view, tsv: true, showHeader: false);
+        string jsonl = RenderFindTable(view, tsv: false, showHeader: false, jsonl: true);
+        string json = OutputFormatter.RenderProjectedJson(
+            columns: null,
+            fields: null,
+            (writer, formatter, writerOptions) =>
+                MarkoutSerializer.Serialize(
+                    view,
+                    writer,
+                    formatter,
+                    SearchViewContext.Default,
+                    writerOptions));
+
+        Assert.DoesNotContain("\u202E", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("\u202E", tsv, StringComparison.Ordinal);
+        Assert.DoesNotContain("\u202E", jsonl, StringComparison.Ordinal);
+        Assert.Contains(@"\u202E", markdown, StringComparison.Ordinal);
+        Assert.Contains(@"\^J", markdown, StringComparison.Ordinal);
+        Assert.Contains(@"\u202E", tsv, StringComparison.Ordinal);
+        Assert.Contains(@"\^J", tsv, StringComparison.Ordinal);
+
+        using var jsonlDocument = System.Text.Json.JsonDocument.Parse(jsonl);
+        Assert.Equal(
+            @"Name\u202E\^J",
+            jsonlDocument.RootElement.GetProperty("type").GetString());
+
+        using var document = System.Text.Json.JsonDocument.Parse(json);
+        string? jsonType = document.RootElement
+            .GetProperty("results")[0]
+            .GetProperty("type")
+            .GetString();
+        Assert.Equal(@"Name\u202E\^J", jsonType);
     }
 
     [Fact]
@@ -171,7 +253,12 @@ public class FindCommandTests
         Assert.Equal("type\tsimilarity\nIsLong\t0.50\n", output.ReplaceLineEndings("\n"));
     }
 
-    private static string RenderFindTable(FindResultView view, bool tsv, bool showHeader, string[]? columns = null) =>
+    private static string RenderFindTable(
+        FindResultView view,
+        bool tsv,
+        bool showHeader,
+        string[]? columns = null,
+        bool jsonl = false) =>
         OutputFormatter.RenderTable(showHeader,
             (writer, formatter) => MarkoutSerializer.Serialize(
                 view,
@@ -184,7 +271,7 @@ public class FindCommandTests
                         Projection = OutputFormatter.BuildProjection(columns)
                     },
                     tsv,
-                    jsonl: false)));
+                    jsonl)));
 }
 
 /// <summary>

--- a/src/dotnet-inspect.Tests/JsonSectionFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/JsonSectionFormatterTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using DotnetInspector.Output;
 using DotnetInspector.Views;
+using InertText;
 using Markout;
 
 namespace DotnetInspector.Tests;
@@ -11,15 +12,16 @@ namespace DotnetInspector.Tests;
 /// </summary>
 public class JsonSectionFormatterTests
 {
-    private static FindResultView BuildView() => new()
+    private static FindResultView BuildView() => new(Field("Find: Cache"))
     {
-        Title = "Find: Cache",
         Results =
         [
-            new FindRow("Cache", "MemoryCache", "System.Runtime.Caching", "class", "System.Runtime.Caching", "runtime", "Exact", "1.00"),
-            new FindRow("Cache", "HybridCache", "Microsoft.Extensions.Caching.Hybrid", "class", "Microsoft.Extensions.Caching.Abstractions", "nuget", "Partial", "0.80"),
+            new FindRow(Field("Cache"), Field("MemoryCache"), Field("System.Runtime.Caching"), Field("class"), Field("System.Runtime.Caching"), Field("runtime"), Field("Exact"), Field("1.00")),
+            new FindRow(Field("Cache"), Field("HybridCache"), Field("Microsoft.Extensions.Caching.Hybrid"), Field("class"), Field("Microsoft.Extensions.Caching.Abstractions"), Field("nuget"), Field("Partial"), Field("0.80")),
         ],
     };
+
+    private static InertString Field(string value) => new(TextPolicy.Field, value);
 
     private static string Render(MarkoutWriterOptions options)
     {

--- a/src/dotnet-inspect.Tests/MarkoutRowContainmentTests.cs
+++ b/src/dotnet-inspect.Tests/MarkoutRowContainmentTests.cs
@@ -58,8 +58,8 @@ namespace DotnetInspector.Tests;
 /// had to be corrected for. It is the exact complement of the set that contains
 /// <i>in the row</i>. Membership is a fact about which idiom a column uses; some
 /// entries are producer-contained and correct as they stand, and the remainder
-/// are the residual tracked by issue #3463 -- which this measures at 359 members
-/// across 86 types, where the estimate had been "roughly 290."</para>
+/// are the residual tracked by issue #3463 -- which this measures at 332 members
+/// across 78 types after the Find view boundary moved to typed inert text.</para>
 ///
 /// <para>Asserting it as a set is what makes the weaker property still bite. A
 /// column cannot leave the self-containing set without failing here, which is
@@ -270,25 +270,6 @@ public class MarkoutRowContainmentTests
         "FieldSummaryRow.Decode",
         "FieldSummaryRow.Name",
         "FieldSummaryRow.ReturnType",
-        "FindMemberRow.Kind",
-        "FindMemberRow.Library",
-        "FindMemberRow.Member",
-        "FindMemberRow.Pattern",
-        "FindMemberRow.Signature",
-        "FindMemberRow.Source",
-        "FindMemberRow.Type",
-        "FindMembersResultView.Description",
-        "FindMembersResultView.Title",
-        "FindResultView.Description",
-        "FindResultView.Title",
-        "FindRow.Kind",
-        "FindRow.Library",
-        "FindRow.Match",
-        "FindRow.Namespace",
-        "FindRow.Pattern",
-        "FindRow.Similarity",
-        "FindRow.Source",
-        "FindRow.Type",
         "FindingTransitionRow.Finding",
         "FindingTransitionRow.New",
         "FindingTransitionRow.Old",

--- a/src/dotnet-inspect/Output/FindOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/FindOutputFormatter.cs
@@ -1,6 +1,6 @@
 using DotnetInspector.Models;
 using DotnetInspector.Views;
-using ILInspector.CSharp;
+using InertText;
 
 namespace DotnetInspector.Output;
 
@@ -18,20 +18,20 @@ public static class FindOutputFormatter
     {
         var matchCount = results.Count(r => r.Match != MatchKind.NotFound);
 
-        return new FindResultView
+        return new FindResultView(
+            Field(title ?? "Find Results"),
+            matchCount == 0 ? Prose("No types found matching the pattern.") : null)
         {
-            Title = CSharpIdentifier.ContainRenderedText(title ?? "Find Results"),
             Matches = matchCount,
-            Description = matchCount == 0 ? "No types found matching the pattern." : null,
             Results = matchCount == 0 ? null : results.Select(r => new FindRow(
-                CSharpIdentifier.ContainRenderedText(r.Pattern),
-                r.Match == MatchKind.NotFound ? "-" : CSharpIdentifier.ContainRenderedText(r.Type),
-                r.Match == MatchKind.NotFound ? "-" : CSharpIdentifier.ContainRenderedText(r.Namespace ?? ""),
-                r.Match == MatchKind.NotFound ? "-" : r.Kind,
-                r.Match == MatchKind.NotFound ? "-" : CSharpIdentifier.ContainRenderedText(r.Library),
-                r.Match == MatchKind.NotFound ? "-" : SourceColumn.Format(r.Source, r.SourceVersion),
-                r.Match.ToString().ToLowerInvariant(),
-                r.Similarity.HasValue ? r.Similarity.Value.ToString("0.00") : "-"
+                Field(r.Pattern),
+                Field(r.Match == MatchKind.NotFound ? "-" : r.Type),
+                Field(r.Match == MatchKind.NotFound ? "-" : r.Namespace ?? ""),
+                Field(r.Match == MatchKind.NotFound ? "-" : r.Kind),
+                Field(r.Match == MatchKind.NotFound ? "-" : r.Library),
+                r.Match == MatchKind.NotFound ? Field("-") : Source(r.Source, r.SourceVersion),
+                Field(r.Match.ToString().ToLowerInvariant()),
+                Field(r.Similarity.HasValue ? r.Similarity.Value.ToString("0.00") : "-")
             )).ToList()
         };
     }
@@ -44,22 +44,31 @@ public static class FindOutputFormatter
         List<MemberFindResult> results,
         string? title = null)
     {
-        return new FindMembersResultView
+        return new FindMembersResultView(
+            Field(title ?? "Find Members"),
+            results.Count == 0 ? Prose("No members found matching the pattern.") : null)
         {
-            Title = CSharpIdentifier.ContainRenderedText(title ?? "Find Members"),
             Matches = results.Count,
-            Description = results.Count == 0 ? "No members found matching the pattern." : null,
             Results = results.Count == 0 ? null : results.Select(r => new FindMemberRow(
-                CSharpIdentifier.ContainRenderedText(r.Pattern),
-                CSharpIdentifier.ContainRenderedText(r.Member),
-                r.Kind,
-                CSharpIdentifier.ContainRenderedText(r.DeclaringType),
+                Field(r.Pattern),
+                Field(r.Member),
+                Field(r.Kind),
+                Field(r.DeclaringType),
                 // The signature is composed from type names, so it carries a
                 // hostile type spelling even when the member name is benign.
-                CSharpIdentifier.ContainRenderedText(r.Signature ?? ""),
-                CSharpIdentifier.ContainRenderedText(r.Library),
-                SourceColumn.Format(r.Source, r.SourceVersion)
+                Field(r.Signature ?? ""),
+                Field(r.Library),
+                Source(r.Source, r.SourceVersion)
             )).ToList()
         };
     }
+
+    private static InertString Field(string value) => new(TextPolicy.Field, value);
+
+    private static InertString Prose(string value) => new(TextPolicy.Prose, value);
+
+    private static InertString Source(string? source, string? version)
+        => string.IsNullOrEmpty(version)
+            ? Field(source ?? "")
+            : InertString.Format(TextPolicy.Field, $"{source}@{version}");
 }

--- a/src/dotnet-inspect/Views/FindViews.cs
+++ b/src/dotnet-inspect/Views/FindViews.cs
@@ -1,3 +1,4 @@
+using InertText;
 using Markout;
 
 namespace DotnetInspector.Views;
@@ -8,8 +9,16 @@ namespace DotnetInspector.Views;
     FieldLayout = FieldLayout.Table)]
 public class FindResultView
 {
-    [MarkoutIgnore] public string Title { get; set; } = "";
-    [MarkoutIgnore] [MarkoutSkipNull] public string? Description { get; set; }
+    public FindResultView(InertString titleText, InertString? descriptionText = null)
+    {
+        TitleText = titleText;
+        DescriptionText = descriptionText;
+    }
+
+    [MarkoutIgnore] public InertString TitleText { get; }
+    [MarkoutIgnore] public InertString? DescriptionText { get; }
+    [MarkoutIgnore] public string Title => TitleText.ToString();
+    [MarkoutIgnore] [MarkoutSkipNull] public string? Description => DescriptionText?.ToString();
     [MarkoutIgnore] public int Matches { get; set; }
 
     [MarkoutSection(Name = "Results")]
@@ -30,14 +39,25 @@ public class FindResultView
 
 [MarkoutSerializable]
 public record FindRow(
-    string Pattern,
-    string Type,
-    string Namespace,
-    string Kind,
-    string Library,
-    string Source,
-    string Match,
-    [property: MarkoutPropertyName("Sim")] string Similarity);
+    [property: MarkoutIgnore] InertString PatternText,
+    [property: MarkoutIgnore] InertString TypeText,
+    [property: MarkoutIgnore] InertString NamespaceText,
+    [property: MarkoutIgnore] InertString KindText,
+    [property: MarkoutIgnore] InertString LibraryText,
+    [property: MarkoutIgnore] InertString SourceText,
+    [property: MarkoutIgnore] InertString MatchText,
+    [property: MarkoutIgnore] InertString SimilarityText)
+{
+    public string Pattern => PatternText.ToString();
+    public string Type => TypeText.ToString();
+    public string Namespace => NamespaceText.ToString();
+    public string Kind => KindText.ToString();
+    public string Library => LibraryText.ToString();
+    public string Source => SourceText.ToString();
+    public string Match => MatchText.ToString();
+    [MarkoutPropertyName("Sim")]
+    public string Similarity => SimilarityText.ToString();
+}
 
 [MarkoutSerializable(
     TitleProperty = nameof(Title),
@@ -45,8 +65,16 @@ public record FindRow(
     FieldLayout = FieldLayout.Table)]
 public class FindMembersResultView
 {
-    [MarkoutIgnore] public string Title { get; set; } = "";
-    [MarkoutIgnore] [MarkoutSkipNull] public string? Description { get; set; }
+    public FindMembersResultView(InertString titleText, InertString? descriptionText = null)
+    {
+        TitleText = titleText;
+        DescriptionText = descriptionText;
+    }
+
+    [MarkoutIgnore] public InertString TitleText { get; }
+    [MarkoutIgnore] public InertString? DescriptionText { get; }
+    [MarkoutIgnore] public string Title => TitleText.ToString();
+    [MarkoutIgnore] [MarkoutSkipNull] public string? Description => DescriptionText?.ToString();
     [MarkoutIgnore] public int Matches { get; set; }
 
     [MarkoutSection(Name = "Members")]
@@ -63,13 +91,22 @@ public class FindMembersResultView
 
 [MarkoutSerializable]
 public record FindMemberRow(
-    string Pattern,
-    string Member,
-    string Kind,
-    string Type,
-    string Signature,
-    string Library,
-    string Source);
+    [property: MarkoutIgnore] InertString PatternText,
+    [property: MarkoutIgnore] InertString MemberText,
+    [property: MarkoutIgnore] InertString KindText,
+    [property: MarkoutIgnore] InertString TypeText,
+    [property: MarkoutIgnore] InertString SignatureText,
+    [property: MarkoutIgnore] InertString LibraryText,
+    [property: MarkoutIgnore] InertString SourceText)
+{
+    public string Pattern => PatternText.ToString();
+    public string Member => MemberText.ToString();
+    public string Kind => KindText.ToString();
+    public string Type => TypeText.ToString();
+    public string Signature => SignatureText.ToString();
+    public string Library => LibraryText.ToString();
+    public string Source => SourceText.ToString();
+}
 
 [MarkoutContextOptions(SuppressTableWarnings = true)]
 [MarkoutContext(typeof(FindResultView))]

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -37,6 +37,9 @@
 - Package and library `Signals` now summarize non-ASCII identifiers and
   reserved-prefix homoglyphs. `Audit: Identifier Confusion` adds content-free
   locations, classifications, similarity, and code points (#4090).
+- Find-result views now carry titles, descriptions, type and member identities,
+  source provenance, and row values through typed inert-text boundaries before
+  Markout-backed Markdown, TSV, JSONL, and projected JSON rendering (#3463).
 - PDB and SourceLink acquisition now handles pathless and content-shaped
   responses while preserving visible diagnostics for rejected evidence
   (#4138).


### PR DESCRIPTION
## Summary

- carries find and find-member titles, descriptions, identities, source provenance, and row values as `InertString` until their Markout sink getters
- preserves benign output while replacing lossy hostile line/control folding with lossless visible encoding and retained `TextConcern` provenance
- reduces the #3463 residual from 351 members across 82 view types to 332 members across 78 types

## Compatibility

This changes only Markout-backed Markdown, TSV, JSONL, and projected JSON views. Plain typed `find --json` retains its existing raw-model contract, and this slice does not claim a global trust-axis signal while other view families remain untyped.

## Validation

Candidate `068ceaad5773837bd0fae9ba008e086f3d6ace7b` on base `2b4f7900f81b119e7d9736d270d839ffc65e3a9f`:

- Release CLI test-project build: 0 warnings, 0 errors
- 36 focused `FindCommandTests`, `JsonSectionFormatterTests`, and `MarkoutRowContainmentTests`: all passed
- changed Markdown passed `markdownlint`; `git diff --check` passed

Advances #3463.