### PR TITLE
Add portable C# structural diff document

### DIFF
--- a/docs/decompiler-raise-discipline.md
+++ b/docs/decompiler-raise-discipline.md
@@ -62,8 +62,10 @@ product documents to `DecompilerHarness --structural-review`. The decompiler
 issuer binds correspondence to the exact document revisions and the exact
 physical method body. It matches only unique product-owned IL-origin evidence,
 then feeds the full-body structural review introduced by #4092 from one
-`CSharpStructuralComparison`. Paste its Before/After caret overlays,
-structural rows, and any correspondence gaps verbatim.
+`CSharpStructuralDiffDocument` and its derived `CSharpStructuralComparison`.
+Paste its Before/After caret overlays, structural rows, and any correspondence
+gaps verbatim. Add `--json` when the revision-bound diff document itself must be
+retained or replayed; never replace it with caller-authored correspondence.
 
 Never hand-place carets or recover correspondence from equal ids, coordinates,
 text, labels, or display order. When the documents predate provenance support,

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -67,8 +67,8 @@ ambiguous nodes never become guessed additions or removals.
 overload validates the complete result against the exact documents, projects
 the mixed annotated-source documents to C# without re-parsing rendered syntax,
 and maps matches plus `NoCounterpart` nodes into the existing selected-node
-comparison. The explicit-input overload remains for already-issued legacy
-artifacts.
+comparison. The explicit-input overload is an internal construction seam for
+focused presentation tests; it is not a portable input contract.
 
 The result is one `CSharpStructuralComparison` with explicit `Added`, `Removed`,
 `Changed`, and `Moved` outcomes. Movement is orthogonal, so a node may be both
@@ -80,6 +80,33 @@ in identity. Stable kind ids and display labels come from
 Each row retains exact absolute UTF-16 spans and the smallest enclosing region
 role on both sides. Optional compile-back fidelity is separately supplied typed
 evidence, not a conclusion inferred from C# text.
+
+`CSharpStructuralDiffDocument` is the portable artifact paired with
+`AnnotatedSourceDocument`. It carries schema and methodology versions, the
+exact revision-bound `CSharpNodeCorrespondenceResult`, and optional independent
+fidelity evidence. It also retains the generated structural rows so the JSON is
+the diff artifact, not only a recipe for recreating one. Its top-level Before
+and After values are the exact C#-only projections that own those row ids and
+spans; the correspondence payload separately retains the original mixed
+annotated-source documents. Construction and strict deserialization reissue
+correspondence from those originals, derive both projections and the expected
+rows, and require exact agreement before `ToComparison` exposes them. This
+keeps the artifact product-issued rather than accepting caller-authored
+mappings, projections, or rows.
+`CSharpStructuralComparisonTests.StructuralDiffDocument_RejectsTamperedCorrespondence`
+`CSharpStructuralComparisonTests.StructuralDiffDocument_RejectsTamperedProjection`,
+and
+`StructuralDiffDocument_RejectsTamperedRows` are the non-vacuity gates for that
+replay check.
+`StructuralDiffDocument_ProjectsInterleavedIlWithoutInferringFromText` gates
+that the top-level projections own the serialized row coordinates.
+
+The C# name is intentional. `AnnotatedSourceDocument` may interleave C# and IL,
+but this artifact compares the C# node/span projection. Native IL comparison
+remains owned by `ILInspector.ILDiff` through `IlBodyDiffResult`; a future
+portable IL envelope should retain that typed result rather than manufacture a
+parallel generic structural-row hierarchy. Research remains the owner of any
+combined C# + IL implementation-diff document.
 
 `CSharpStructuralDiffPrinter` projects that one result into complete-body caret
 overlays and compact rich-diff rows. For a changed single-span node, each caret
@@ -95,12 +122,14 @@ remains rejected by the existing safety gate. It performs no correspondence.
 gates the lossless wrapped-text claim.
 DecompilerHarness `--structural-review` mode owns Markdown orchestration and
 consumes the same result for both presentations. With two documents it invokes
-the product issuer; the legacy one-file form consumes already-issued explicit
-correspondence. It reads untrusted input through Decompiler-owned
-`AnnotatedSourceJson`, so the CLI document writer and harness reader share one
-model-owned contract while retaining separate writer and strict-reader
-policies. Unsupported and ambiguous nodes remain a separate correspondence-gap
-section; an incomplete result is never reported as "no structural changes."
+the product issuer; `--json` emits the resulting
+`CSharpStructuralDiffDocument`. The one-file form accepts only that generated
+artifact, reissues its correspondence, and renders it later. Both forms read
+untrusted input through Decompiler-owned `AnnotatedSourceJson`, so the CLI
+document writer and harness reader share one model-owned contract while
+retaining separate writer and strict-reader policies. Unsupported and ambiguous
+nodes remain a separate correspondence-gap section; an incomplete result is
+never reported as "no structural changes."
 This model exists only for node/span structure that the line-oriented
 `CSharpDiffRow` cannot represent; it does not introduce another generic
 diff-row hierarchy. Ordinary indented spans reuse the annotation comment gutter

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -122,11 +122,12 @@ dotnet run --project tools/DecompilerHarness -c Release -- \
   --structural-review /tmp/before.json /tmp/after.json
 
 Paste the output verbatim. Its complete Before/After blocks and rich structural
-diff consume one CSharpStructuralComparison issued from physical-method and
-IL-origin provenance; do not manually place carets or reconstruct rows. Node ids
-remain document-local. Equal ids, coordinates, selected text, labels, and
-display order never establish correspondence. Fidelity and retained IL notes
-are independent evidence, not claims inferred from the C# transition.
+diff derive from one product-issued `CSharpStructuralDiffDocument` bound to
+physical-method and IL-origin provenance; do not manually place carets or
+reconstruct rows. Node ids remain document-local. Equal ids, coordinates,
+selected text, labels, and display order never establish correspondence.
+Fidelity and retained IL notes are independent evidence, not claims inferred
+from the C# transition.
 
 When either document lacks product provenance, the physical method identities
 differ, or the changed nodes are unsupported or ambiguous, write:

--- a/src/ILInspector.Decompiler.Tests/AnnotatedSourceJsonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedSourceJsonTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using ILInspector.Decompiler.Annotations;
 
 namespace ILInspector.Decompiler.Tests;
@@ -83,6 +84,31 @@ public class AnnotatedSourceJsonTests
         Assert.Null(Assert.Single(actual.Facts).Detail);
     }
 
+    [Fact]
+    public void StructuralDiffWriter_RoundTripsStrictReaderAndDerivedRows()
+    {
+        var expected = StructuralDiff();
+
+        string json = AnnotatedSourceJson.SerializeStructuralDiff(expected);
+        var actual = AnnotatedSourceJson.DeserializeStructuralDiff(json);
+
+        Assert.Equal(CSharpStructuralDiffDocument.CurrentSchemaVersion, actual.SchemaVersion);
+        Assert.Equal(
+            CSharpStructuralDiffDocument.CurrentMethodologyVersion,
+            actual.MethodologyVersion);
+        Assert.Equal(expected.Correspondence.BeforeRevision, actual.Correspondence.BeforeRevision);
+        Assert.Equal(expected.Correspondence.AfterRevision, actual.Correspondence.AfterRevision);
+        Assert.Equal(expected.Correspondence.Matches, actual.Correspondence.Matches);
+        Assert.Equal(expected.Before, actual.Before);
+        Assert.Equal(expected.After, actual.After);
+        Assert.Equal(expected.Rows.Length, actual.Rows.Length);
+        Assert.Equal(expected.Rows[0].Change, actual.Rows[0].Change);
+        Assert.Equal(expected.Rows[0].BeforeSpans, actual.Rows[0].BeforeSpans);
+        Assert.Equal(expected.Rows[0].AfterSpans, actual.Rows[0].AfterSpans);
+        Assert.Equal(expected.Fidelity, actual.Fidelity);
+        Assert.Single(actual.ToComparison().Rows);
+    }
+
     [Theory]
     [InlineData("\"start\":0,\"length\":7", "\"start\":0", "length")]
     [InlineData("\"medium\":\"CSharp\",", "", "medium")]
@@ -109,15 +135,15 @@ public class AnnotatedSourceJsonTests
     [InlineData(false, ",\"subject\":\"M\"", "", "subject")]
     [InlineData(true, ",\"subject\":\"M\"", "", "subject")]
     public void StrictReaders_RejectMissingNestedRequiredFields(
-        bool structuralComparison,
+        bool structuralDiff,
         string oldValue,
         string newValue,
         string expected)
     {
-        string document = TrustedCompactJson().Replace(oldValue, newValue, StringComparison.Ordinal);
-        string json = structuralComparison ? StructuralComparisonJson(document) : document;
+        string json = (structuralDiff ? StructuralDiffJson() : TrustedCompactJson())
+            .Replace(oldValue, newValue, StringComparison.Ordinal);
 
-        var error = Assert.Throws<JsonException>(() => Deserialize(structuralComparison, json));
+        var error = Assert.Throws<JsonException>(() => Deserialize(structuralDiff, json));
 
         Assert.Contains("missing required properties", error.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(expected, error.Message, StringComparison.Ordinal);
@@ -137,21 +163,21 @@ public class AnnotatedSourceJsonTests
 
     [Theory]
     [InlineData(false, "Annotated-source JSON violates the JSON contract.")]
-    [InlineData(true, "Structural comparison JSON violates the JSON contract.")]
+    [InlineData(true, "C# structural diff JSON violates the JSON contract.")]
     public void StrictReaders_DoNotRelayUnknownPropertyNames(
-        bool structuralComparison,
+        bool structuralDiff,
         string expectedMessage)
     {
         const string HostilePropertyName = "ATTACKER_TOKEN";
-        string json = (structuralComparison ? StructuralComparisonJson() : CompactJson()).Replace(
-            structuralComparison ? "\"subject\":\"test\"" : "\"text\":\"return;\"",
-            structuralComparison
-                ? $"\"subject\":\"test\",\"{HostilePropertyName}\":0"
+        string json = (structuralDiff ? StructuralDiffJson() : CompactJson()).Replace(
+            structuralDiff ? "\"schema_version\":1" : "\"text\":\"return;\"",
+            structuralDiff
+                ? $"\"schema_version\":1,\"{HostilePropertyName}\":0"
                 : $"\"text\":\"return;\",\"{HostilePropertyName}\":0",
             StringComparison.Ordinal);
 
         var error = Assert.Throws<JsonException>(
-            () => Deserialize(structuralComparison, json));
+            () => Deserialize(structuralDiff, json));
 
         Assert.Equal(expectedMessage, error.Message);
         Assert.DoesNotContain(HostilePropertyName, error.Message, StringComparison.Ordinal);
@@ -160,16 +186,16 @@ public class AnnotatedSourceJsonTests
 
     [Theory]
     [InlineData(false, "Annotated-source JSON is malformed.")]
-    [InlineData(true, "Structural comparison JSON is malformed.")]
+    [InlineData(true, "C# structural diff JSON is malformed.")]
     public void StrictReaders_DoNotRelayMalformedJsonContent(
-        bool structuralComparison,
+        bool structuralDiff,
         string expectedMessage)
     {
         const string HostileContent = "ATTACKER_TOKEN";
-        string json = $"{(structuralComparison ? StructuralComparisonJson() : CompactJson())} {HostileContent}";
+        string json = $"{(structuralDiff ? StructuralDiffJson() : CompactJson())} {HostileContent}";
 
         var error = Assert.Throws<JsonException>(
-            () => Deserialize(structuralComparison, json));
+            () => Deserialize(structuralDiff, json));
 
         Assert.Equal(expectedMessage, error.Message);
         Assert.DoesNotContain(HostileContent, error.Message, StringComparison.Ordinal);
@@ -178,21 +204,21 @@ public class AnnotatedSourceJsonTests
 
     [Theory]
     [InlineData(false, "Annotated-source JSON is malformed.")]
-    [InlineData(true, "Structural comparison JSON is malformed.")]
+    [InlineData(true, "C# structural diff JSON is malformed.")]
     public void StrictReaders_ContainRawMalformedUtf16(
-        bool structuralComparison,
+        bool structuralDiff,
         string expectedMessage)
     {
         const string RawUnpairedSurrogate = "\uD800";
-        string json = (structuralComparison ? StructuralComparisonJson() : CompactJson()).Replace(
-            structuralComparison ? "\"subject\":\"test\"" : "\"text\":\"return;\"",
-            structuralComparison
+        string json = (structuralDiff ? StructuralDiffJson() : CompactJson()).Replace(
+            structuralDiff ? "\"subject\":\"M\"" : "\"text\":\"return;\"",
+            structuralDiff
                 ? $"\"subject\":\"{RawUnpairedSurrogate}\""
                 : $"\"text\":\"{RawUnpairedSurrogate}\"",
             StringComparison.Ordinal);
 
         var error = Assert.Throws<JsonException>(
-            () => Deserialize(structuralComparison, json));
+            () => Deserialize(structuralDiff, json));
 
         Assert.Equal(expectedMessage, error.Message);
         AssertContained(error);
@@ -200,20 +226,20 @@ public class AnnotatedSourceJsonTests
 
     [Theory]
     [InlineData(false, "Annotated-source JSON is malformed.")]
-    [InlineData(true, "Structural comparison JSON violates the JSON contract.")]
+    [InlineData(true, "C# structural diff JSON violates the JSON contract.")]
     public void StrictReaders_ContainEscapedMalformedUtf16PropertyNames(
-        bool structuralComparison,
+        bool structuralDiff,
         string expectedMessage)
     {
-        string json = (structuralComparison ? StructuralComparisonJson() : CompactJson()).Replace(
-            structuralComparison ? "\"subject\":\"test\"" : "\"text\":\"return;\"",
-            structuralComparison
-                ? "\"subject\":\"test\",\"\\uD800\":0"
+        string json = (structuralDiff ? StructuralDiffJson() : CompactJson()).Replace(
+            structuralDiff ? "\"schema_version\":1" : "\"text\":\"return;\"",
+            structuralDiff
+                ? "\"schema_version\":1,\"\\uD800\":0"
                 : "\"text\":\"return;\",\"\\uD800\":0",
             StringComparison.Ordinal);
 
         var error = Assert.Throws<JsonException>(
-            () => Deserialize(structuralComparison, json));
+            () => Deserialize(structuralDiff, json));
 
         Assert.Equal(expectedMessage, error.Message);
         AssertContained(error);
@@ -238,33 +264,19 @@ public class AnnotatedSourceJsonTests
     }
 
     [Theory]
-    [InlineData("subject")]
+    [InlineData("schema_version")]
+    [InlineData("methodology_version")]
+    [InlineData("correspondence")]
     [InlineData("before")]
     [InlineData("after")]
-    [InlineData("before_node_ids")]
-    [InlineData("after_node_ids")]
-    [InlineData("correspondences")]
-    public void StrictStructuralReader_RejectsNullRequiredFields(string propertyName)
+    [InlineData("rows")]
+    public void StrictStructuralDiffReader_RejectsNullRequiredFields(string propertyName)
     {
-        string json = StructuralComparisonJson();
-        string oldValue = propertyName switch
-        {
-            "subject" => "\"subject\":\"test\"",
-            "before" => $"\"before\":{CompactJson()}",
-            "after" => $"\"after\":{CompactJson()}",
-            "before_node_ids" => "\"before_node_ids\":[0]",
-            "after_node_ids" => "\"after_node_ids\":[0]",
-            "correspondences" =>
-                "\"correspondences\":[{\"before_node_id\":0,\"after_node_id\":0}]",
-            _ => throw new ArgumentOutOfRangeException(nameof(propertyName)),
-        };
-        string jsonWithNull = json.Replace(
-            oldValue,
-            $"\"{propertyName}\":null",
-            StringComparison.Ordinal);
+        var root = JsonNode.Parse(StructuralDiffJson())!.AsObject();
+        root[propertyName] = null;
 
         var error = Assert.Throws<JsonException>(
-            () => AnnotatedSourceJson.DeserializeStructuralComparison(jsonWithNull));
+            () => AnnotatedSourceJson.DeserializeStructuralDiff(root.ToJsonString()));
 
         Assert.Contains("null required properties", error.Message, StringComparison.Ordinal);
         Assert.Contains(propertyName, error.Message, StringComparison.Ordinal);
@@ -272,17 +284,106 @@ public class AnnotatedSourceJsonTests
     }
 
     [Fact]
-    public void StrictStructuralReader_RejectsNullCorrespondence()
+    public void StrictStructuralDiffReader_RejectsNullMatch()
     {
-        string json = StructuralComparisonJson().Replace(
-            """{"before_node_id":0,"after_node_id":0}""",
-            "null",
+        string json = StructuralDiffJson().Replace(
+            "\"matches\":[{",
+            "\"matches\":[null,{",
             StringComparison.Ordinal);
 
         var error = Assert.Throws<JsonException>(
-            () => AnnotatedSourceJson.DeserializeStructuralComparison(json));
+            () => AnnotatedSourceJson.DeserializeStructuralDiff(json));
 
-        Assert.Equal("correspondences must contain JSON objects.", error.Message);
+        Assert.Equal("correspondence.matches must contain JSON objects.", error.Message);
+        AssertContained(error);
+    }
+
+    [Theory]
+    [InlineData("\"provenance\":\"IlOriginSet\"", "\"provenance\":\"iloriginset\"", "node-match provenance")]
+    [InlineData("\"reason\":\"NoCounterpart\"", "\"reason\":0", "unmatched-node reason")]
+    [InlineData("\"before\":\"OpcodeDiff\"", "\"before\":\"Exact, OpcodeDiff\"", "IL body-diff outcome")]
+    [InlineData("\"change\":\"Changed\"", "\"change\":\"Added, Removed\"", "structural change kind")]
+    public void StrictStructuralDiffReader_RequiresExactDeclaredEnumNames(
+        string oldValue,
+        string newValue,
+        string expected)
+    {
+        string json = StructuralDiffJson(includeUnmatched: true)
+            .Replace(oldValue, newValue, StringComparison.Ordinal);
+
+        var error = Assert.Throws<JsonException>(
+            () => AnnotatedSourceJson.DeserializeStructuralDiff(json));
+
+        Assert.Contains(expected, error.Message, StringComparison.OrdinalIgnoreCase);
+        AssertContained(error);
+    }
+
+    [Theory]
+    [InlineData("schema_version")]
+    [InlineData("methodology_version")]
+    public void StrictStructuralDiffReader_RejectsUnsupportedVersions(string propertyName)
+    {
+        string json = StructuralDiffJson().Replace(
+            $"\"{propertyName}\":1",
+            $"\"{propertyName}\":999",
+            StringComparison.Ordinal);
+
+        var error = Assert.Throws<JsonException>(
+            () => AnnotatedSourceJson.DeserializeStructuralDiff(json));
+
+        Assert.Equal(
+            "C# structural diff JSON violates the product-issued model contract.",
+            error.Message);
+        AssertContained(error);
+    }
+
+    [Fact]
+    public void StrictStructuralDiffReader_RejectsTamperedRevision()
+    {
+        var document = StructuralDiff();
+        string json = AnnotatedSourceJson.SerializeStructuralDiff(document, indented: false).Replace(
+            document.Correspondence.BeforeRevision.Sha256,
+            new string('F', 64),
+            StringComparison.Ordinal);
+
+        var error = Assert.Throws<JsonException>(
+            () => AnnotatedSourceJson.DeserializeStructuralDiff(json));
+
+        Assert.Equal(
+            "C# structural diff JSON violates the product-issued model contract.",
+            error.Message);
+        AssertContained(error);
+    }
+
+    [Fact]
+    public void StrictStructuralDiffReader_RejectsTamperedRows()
+    {
+        string json = StructuralDiffJson().Replace(
+            "\"change\":\"Changed\"",
+            "\"change\":\"Moved\"",
+            StringComparison.Ordinal);
+
+        var error = Assert.Throws<JsonException>(
+            () => AnnotatedSourceJson.DeserializeStructuralDiff(json));
+
+        Assert.Equal(
+            "C# structural diff JSON violates the product-issued model contract.",
+            error.Message);
+        AssertContained(error);
+    }
+
+    [Fact]
+    public void StrictStructuralDiffReader_RejectsTamperedProjection()
+    {
+        var root = JsonNode.Parse(StructuralDiffJson())!.AsObject();
+        root["before"] = root["after"]!.DeepClone();
+
+        var error = Assert.Throws<JsonException>(
+            () => AnnotatedSourceJson.DeserializeStructuralDiff(root.ToJsonString()));
+
+        Assert.Equal(
+            "C# structural diff JSON violates the product-issued model contract.",
+            error.Message);
         AssertContained(error);
     }
 
@@ -346,14 +447,10 @@ public class AnnotatedSourceJsonTests
             Document(),
             AnnotatedSourceDocumentCompactJsonContext.Default.AnnotatedSourceDocument);
 
-    static string StructuralComparisonJson()
-        => StructuralComparisonJson(CompactJson());
-
-    static string StructuralComparisonJson(string document)
-    {
-        return
-            $$"""{"subject":"test","before":{{document}},"after":{{document}},"before_node_ids":[0],"after_node_ids":[0],"correspondences":[{"before_node_id":0,"after_node_id":0}]}""";
-    }
+    static string StructuralDiffJson(bool includeUnmatched = false)
+        => AnnotatedSourceJson.SerializeStructuralDiff(
+            StructuralDiff(includeUnmatched),
+            indented: false);
 
     static string TrustedCompactJson()
         => JsonSerializer.Serialize(
@@ -378,10 +475,10 @@ public class AnnotatedSourceJsonTests
                     "M")),
             AnnotatedSourceDocumentCompactJsonContext.Default.AnnotatedSourceDocument);
 
-    static void Deserialize(bool structuralComparison, string json)
+    static void Deserialize(bool structuralDiff, string json)
     {
-        if (structuralComparison)
-            _ = AnnotatedSourceJson.DeserializeStructuralComparison(json);
+        if (structuralDiff)
+            _ = AnnotatedSourceJson.DeserializeStructuralDiff(json);
         else
             _ = AnnotatedSourceJson.DeserializeDocument(json);
     }
@@ -420,4 +517,60 @@ public class AnnotatedSourceJsonTests
                     AnnotatedSourceFactOrigin.Body),
             ],
             [new AnnotatedSourceTarget(0, 0)]);
+
+    static CSharpStructuralDiffDocument StructuralDiff(bool includeUnmatched = false)
+    {
+        var source = new AnnotatedSourceDocumentSource(
+            "Tests",
+            new Guid("00112233-4455-6677-8899-AABBCCDDEEFF"),
+            0x06000001,
+            new string('A', 64),
+            "M");
+        var before = TrustedDocument(
+            "return;",
+            "ReturnStatement",
+            [0],
+            source);
+        var after = TrustedDocument(
+            includeUnmatched ? "break; Call();" : "break;",
+            "BreakStatement",
+            [0],
+            source,
+            includeUnmatched
+                ? new AnnotatedSourceNode(
+                    1,
+                    "InvocationExpression",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(7, 6)],
+                    Provenance: new AnnotatedSourceNodeProvenance([1]))
+                : null);
+        return CSharpStructuralDiffDocument.Create(
+            before,
+            after,
+            new CSharpStructuralFidelityEvidence(
+                ILInspector.Instructions.IlBodyDiffOutcome.OpcodeDiff,
+                ILInspector.Instructions.IlBodyDiffOutcome.Exact,
+                "terminal IL_0000: ret"));
+    }
+
+    static AnnotatedSourceDocument TrustedDocument(
+        string text,
+        string kind,
+        IReadOnlyList<int> provenance,
+        AnnotatedSourceDocumentSource source,
+        AnnotatedSourceNode? additionalNode = null)
+    {
+        var nodes = new List<AnnotatedSourceNode>
+        {
+            new(
+                0,
+                kind,
+                SourceLineKind.CSharp,
+                [new AnnotatedSourceSpan(0, kind == "ReturnStatement" ? 7 : 6)],
+                Provenance: new AnnotatedSourceNodeProvenance(provenance))
+        };
+        if (additionalNode is not null)
+            nodes.Add(additionalNode);
+        return new AnnotatedSourceDocument(text, nodes, [], [], [], source);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/AuthoredCorpusHarnessProcessTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredCorpusHarnessProcessTests.cs
@@ -2,6 +2,7 @@ using ILInspector.Decompiler;
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.DecompilerHarness;
+using ILInspector.Instructions;
 using ILInspector.Research;
 using System.Diagnostics;
 using System.Reflection;
@@ -55,7 +56,7 @@ public class AuthoredCorpusHarnessProcessTests
     }
 
     [Fact]
-    public void Harness_RendersStructuralReviewFromOwnerIssuedComparison()
+    public void Harness_RendersStructuralReviewFromProductDiffDocument()
     {
         string path = Path.Combine(Path.GetTempPath(), $"structural-review-{Guid.NewGuid():N}.json");
         File.WriteAllText(path, StructuralReviewJson("break;", "BreakStatement", 6));
@@ -154,6 +155,58 @@ public class AuthoredCorpusHarnessProcessTests
         {
             File.Delete(beforePath);
             File.Delete(afterPath);
+        }
+    }
+
+    [Fact]
+    public void Harness_EmitsAndReplaysProductStructuralDiffDocument()
+    {
+        string beforePath = Path.Combine(Path.GetTempPath(), $"structural-before-{Guid.NewGuid():N}.json");
+        string afterPath = Path.Combine(Path.GetTempPath(), $"structural-after-{Guid.NewGuid():N}.json");
+        string diffPath = Path.Combine(Path.GetTempPath(), $"structural-diff-{Guid.NewGuid():N}.json");
+        var source = new AnnotatedSourceDocumentSource(
+            "Fixture",
+            new Guid("11111111-2222-3333-4444-555555555555"),
+            0x06000001,
+            new string('A', 64),
+            "Fixture.M");
+        var before = StructuralDocument("return;", "ReturnStatement", 7, source);
+        var after = StructuralDocument("break;", "BreakStatement", 6, source);
+        File.WriteAllText(
+            beforePath,
+            JsonSerializer.Serialize(
+                before,
+                AnnotatedSourceDocumentJsonContext.Default.AnnotatedSourceDocument));
+        File.WriteAllText(
+            afterPath,
+            JsonSerializer.Serialize(
+                after,
+                AnnotatedSourceDocumentJsonContext.Default.AnnotatedSourceDocument));
+
+        try
+        {
+            var emitted = RunHarness(
+                "--structural-review",
+                beforePath,
+                afterPath,
+                "--json");
+
+            Assert.Equal(0, emitted.ExitCode);
+            var document = AnnotatedSourceJson.DeserializeStructuralDiff(emitted.Output);
+            Assert.Single(document.Correspondence.Matches);
+            Assert.Single(document.ToComparison().Rows);
+
+            File.WriteAllText(diffPath, emitted.Output);
+            var replayed = RunHarness("--structural-review", diffPath);
+
+            Assert.Equal(0, replayed.ExitCode);
+            Assert.Contains("Return -&gt; Break", replayed.Output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(beforePath);
+            File.Delete(afterPath);
+            File.Delete(diffPath);
         }
     }
 
@@ -268,11 +321,11 @@ public class AuthoredCorpusHarnessProcessTests
     }
 
     [Fact]
-    public void Harness_RejectsMissingRequiredStructuralCorrespondenceField()
+    public void Harness_RejectsMissingRequiredStructuralDiffField()
     {
         string path = Path.Combine(Path.GetTempPath(), $"structural-review-{Guid.NewGuid():N}.json");
         string json = StructuralReviewJson("break;", "BreakStatement", 6)
-            .Replace("\"after_node_id\": 0, ", "", StringComparison.Ordinal);
+            .Replace("\"provenance\": \"IlOriginSet\",", "", StringComparison.Ordinal);
         File.WriteAllText(path, json);
 
         try
@@ -281,6 +334,7 @@ public class AuthoredCorpusHarnessProcessTests
 
             Assert.Equal(1, run.ExitCode);
             Assert.Contains("missing required properties", run.Output, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("provenance", run.Output, StringComparison.Ordinal);
         }
         finally
         {
@@ -292,15 +346,11 @@ public class AuthoredCorpusHarnessProcessTests
     public void Harness_ContainsUntrustedStructuralMarkdownCells()
     {
         string path = Path.Combine(Path.GetTempPath(), $"structural-review-{Guid.NewGuid():N}.json");
-        string json = StructuralReviewJson("break;", "BreakStatement", 6)
-            .Replace(
-                "\"kind\": \"BreakStatement\"",
-                "\"kind\": \"Break | ![remote](https://example.test/image)\"",
-                StringComparison.Ordinal)
-            .Replace(
-                "\"note\": \"terminal IL_0072: ret\"",
-                "\"note\": \"retained | ![remote](https://example.test/image)\"",
-                StringComparison.Ordinal);
+        string json = StructuralReviewJson(
+            "break;",
+            "Break | ![remote](https://example.test/image)",
+            6,
+            note: "retained | ![remote](https://example.test/image)");
         File.WriteAllText(path, json);
 
         try
@@ -349,19 +399,12 @@ public class AuthoredCorpusHarnessProcessTests
     public void Harness_ContainsStructuralTerminalControls()
     {
         string path = Path.Combine(Path.GetTempPath(), $"structural-review-{Guid.NewGuid():N}.json");
-        string json = StructuralReviewJson("break;", "BreakStatement", 6)
-            .Replace(
-                "\"subject\": \"M\"",
-                "\"subject\": \"M\\u001B[31m\"",
-                StringComparison.Ordinal)
-            .Replace(
-                "\"kind\": \"BreakStatement\"",
-                "\"kind\": \"Break\\u001B[31m\"",
-                StringComparison.Ordinal)
-            .Replace(
-                "\"note\": \"terminal IL_0072: ret\"",
-                "\"note\": \"retained\\u001B[31m\"",
-                StringComparison.Ordinal);
+        string json = StructuralReviewJson(
+            "break;",
+            "Break\u001B[31m",
+            6,
+            subject: "M\u001B[31m",
+            note: "retained\u001B[31m");
         File.WriteAllText(path, json);
 
         try
@@ -461,7 +504,7 @@ public class AuthoredCorpusHarnessProcessTests
             var run = RunHarness("--structural-review", path);
 
             Assert.Equal(1, run.ExitCode);
-            Assert.Contains("Structural comparison JSON", run.Output, StringComparison.Ordinal);
+            Assert.Contains("structural diff JSON", run.Output, StringComparison.Ordinal);
             Assert.DoesNotContain("Unhandled exception", run.Output, StringComparison.Ordinal);
             Assert.DoesNotContain("InvalidOperationException", run.Output, StringComparison.Ordinal);
         }
@@ -472,8 +515,8 @@ public class AuthoredCorpusHarnessProcessTests
     }
 
     [Theory]
-    [InlineData("\"start\": 0, ", "", "start")]
-    [InlineData("\"start\": 0, \"length\": 7", "\"start\": 0", "length")]
+    [InlineData("\"start\": 0", "\"discarded_start\": 0", "start")]
+    [InlineData("\"length\": 7", "\"discarded_length\": 7", "length")]
     public void Harness_RejectsMissingStructuralSpanField(
         string oldValue,
         string newValue,
@@ -565,6 +608,37 @@ public class AuthoredCorpusHarnessProcessTests
             Assert.Equal(1, run.ExitCode);
             Assert.Contains("missing required properties", run.Output, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("node_id", run.Output, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Harness_RejectsLegacyCallerAuthoredComparisonInput()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"legacy-structural-review-{Guid.NewGuid():N}.json");
+        File.WriteAllText(
+            path,
+            """
+            {
+              "subject": "M",
+              "before": {},
+              "after": {},
+              "before_node_ids": [],
+              "after_node_ids": [],
+              "correspondences": []
+            }
+            """);
+
+        try
+        {
+            var run = RunHarness("--structural-review", path);
+
+            Assert.Equal(1, run.ExitCode);
+            Assert.Contains("missing required properties", run.Output, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("schema_version", run.Output, StringComparison.Ordinal);
         }
         finally
         {
@@ -916,60 +990,52 @@ public class AuthoredCorpusHarnessProcessTests
     /// </summary>
     const string UnusedOutputPath = "/does-not-exist/unused-output.json";
 
-    static string StructuralReviewJson(string afterText, string afterKind, int afterLength)
-        => $$"""
-            {
-              "subject": "M",
-              "before": {
-                "text": "return;",
-                "nodes": [
-                  {
-                    "id": 0,
-                    "kind": "ReturnStatement",
-                    "medium": "CSharp",
-                    "spans": [ { "start": 0, "length": 7 } ]
-                  }
-                ],
-                "regions": [
-                  {
-                    "role": "Case",
-                    "spans": [ { "start": 0, "length": 7 } ]
-                  }
-                ],
-                "facts": [],
-                "targets": []
-              },
-              "after": {
-                "text": "{{afterText}}",
-                "nodes": [
-                  {
-                    "id": 0,
-                    "kind": "{{afterKind}}",
-                    "medium": "CSharp",
-                    "spans": [ { "start": 0, "length": {{afterLength}} } ]
-                  }
-                ],
-                "regions": [
-                  {
-                    "role": "Case",
-                    "spans": [ { "start": 0, "length": {{afterLength}} } ]
-                  }
-                ],
-                "facts": [],
-                "targets": []
-              },
-              "before_node_ids": [ 0 ],
-              "after_node_ids": [ 0 ],
-              "correspondences": [
-                { "before_node_id": 0, "after_node_id": 0, "moved": false }
-              ],
-              "fidelity": {
-                "before": "OpcodeDiff",
-                "after": "Exact",
-                "note": "terminal IL_0072: ret"
-              }
-            }
-            """;
+    static string StructuralReviewJson(
+        string afterText,
+        string afterKind,
+        int afterLength,
+        string subject = "M",
+        string note = "terminal IL_0072: ret")
+    {
+        var source = new AnnotatedSourceDocumentSource(
+            "Fixture",
+            new Guid("11111111-2222-3333-4444-555555555555"),
+            0x06000001,
+            new string('A', 64),
+            subject);
+        var document = CSharpStructuralDiffDocument.Create(
+            StructuralDocument("return;", "ReturnStatement", 7, source),
+            StructuralDocument(afterText, afterKind, afterLength, source),
+            new CSharpStructuralFidelityEvidence(
+                IlBodyDiffOutcome.OpcodeDiff,
+                IlBodyDiffOutcome.Exact,
+                note));
+        return AnnotatedSourceJson.SerializeStructuralDiff(document);
+    }
+
+    static AnnotatedSourceDocument StructuralDocument(
+        string text,
+        string kind,
+        int length,
+        AnnotatedSourceDocumentSource source)
+        => new(
+            text,
+            [
+                new AnnotatedSourceNode(
+                    0,
+                    kind,
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(0, length)],
+                    Provenance: new AnnotatedSourceNodeProvenance([0x10]))
+            ],
+            [
+                new AnnotatedSourceRegion(
+                    PrintedRegionRole.Case,
+                    [new AnnotatedSourceSpan(0, length)])
+            ],
+            [],
+            [],
+            source);
 
     /// <summary>
     /// A requested <c>--ratchet-baseline</c> must reach the benchmark.

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -904,6 +904,141 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void StructuralDiffDocument_ReissuesCorrespondenceAndDerivesRows()
+    {
+        var before = TrustedDocument(
+            "return;",
+            new NodeSpec("ReturnStatement", "return;", [0x10]));
+        var after = TrustedDocument(
+            "break;",
+            new NodeSpec("BreakStatement", "break;", [0x10]));
+
+        var document = CSharpStructuralDiffDocument.Create(before, after);
+
+        Assert.Equal(CSharpStructuralDiffDocument.CurrentSchemaVersion, document.SchemaVersion);
+        Assert.Equal(
+            CSharpStructuralDiffDocument.CurrentMethodologyVersion,
+            document.MethodologyVersion);
+        Assert.Single(document.Rows);
+        var row = Assert.Single(document.ToComparison().Rows);
+        Assert.Equal(CSharpStructuralChangeKind.Changed, row.Change);
+        Assert.Equal("ReturnStatement", row.BeforeKind);
+        Assert.Equal("BreakStatement", row.AfterKind);
+    }
+
+    [Fact]
+    public void StructuralDiffDocument_RejectsTamperedCorrespondence()
+    {
+        var before = TrustedDocument(
+            "return;",
+            new NodeSpec("ReturnStatement", "return;", [0x10]));
+        var after = TrustedDocument(
+            "break;",
+            new NodeSpec("BreakStatement", "break;", [0x10]));
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+        var comparison = CSharpBodyDiff.CompareStructure(issued);
+
+        Assert.Throws<ArgumentException>(() => new CSharpStructuralDiffDocument(
+            CSharpStructuralDiffDocument.CurrentSchemaVersion,
+            CSharpStructuralDiffDocument.CurrentMethodologyVersion,
+            issued with
+            {
+                BeforeRevision = new CSharpDocumentRevision(new string('B', 64))
+            },
+            comparison.Before,
+            comparison.After,
+            comparison.Rows));
+    }
+
+    [Theory]
+    [InlineData(0, CSharpStructuralDiffDocument.CurrentMethodologyVersion)]
+    [InlineData(CSharpStructuralDiffDocument.CurrentSchemaVersion, 0)]
+    public void StructuralDiffDocument_RejectsUnsupportedVersions(
+        int schemaVersion,
+        int methodologyVersion)
+    {
+        var document = TrustedDocument(
+            "return;",
+            new NodeSpec("ReturnStatement", "return;", [0x10]));
+        var issued = CSharpBodyDiff.IssueCorrespondence(document, document);
+        var comparison = CSharpBodyDiff.CompareStructure(issued);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CSharpStructuralDiffDocument(
+            schemaVersion,
+            methodologyVersion,
+            issued,
+            comparison.Before,
+            comparison.After,
+            comparison.Rows));
+    }
+
+    [Fact]
+    public void StructuralDiffDocument_RejectsMalformedFidelityNote()
+    {
+        var document = TrustedDocument(
+            "return;",
+            new NodeSpec("ReturnStatement", "return;", [0x10]));
+        var issued = CSharpBodyDiff.IssueCorrespondence(document, document);
+        var comparison = CSharpBodyDiff.CompareStructure(issued);
+
+        Assert.Throws<ArgumentException>(() => new CSharpStructuralDiffDocument(
+            CSharpStructuralDiffDocument.CurrentSchemaVersion,
+            CSharpStructuralDiffDocument.CurrentMethodologyVersion,
+            issued,
+            comparison.Before,
+            comparison.After,
+            comparison.Rows,
+            new CSharpStructuralFidelityEvidence(
+                IlBodyDiffOutcome.Exact,
+                IlBodyDiffOutcome.Exact,
+                "\uD800")));
+    }
+
+    [Fact]
+    public void StructuralDiffDocument_RejectsTamperedRows()
+    {
+        var before = TrustedDocument(
+            "return;",
+            new NodeSpec("ReturnStatement", "return;", [0x10]));
+        var after = TrustedDocument(
+            "break;",
+            new NodeSpec("BreakStatement", "break;", [0x10]));
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+        var comparison = CSharpBodyDiff.CompareStructure(issued);
+
+        Assert.Throws<ArgumentException>(() => new CSharpStructuralDiffDocument(
+            CSharpStructuralDiffDocument.CurrentSchemaVersion,
+            CSharpStructuralDiffDocument.CurrentMethodologyVersion,
+            issued,
+            comparison.Before,
+            comparison.After,
+            comparison.Rows.SetItem(
+                0,
+                comparison.Rows[0] with { Change = CSharpStructuralChangeKind.Moved })));
+    }
+
+    [Fact]
+    public void StructuralDiffDocument_RejectsTamperedProjection()
+    {
+        var before = TrustedDocument(
+            "return;",
+            new NodeSpec("ReturnStatement", "return;", [0x10]));
+        var after = TrustedDocument(
+            "break;",
+            new NodeSpec("BreakStatement", "break;", [0x10]));
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+        var comparison = CSharpBodyDiff.CompareStructure(issued);
+
+        Assert.Throws<ArgumentException>(() => new CSharpStructuralDiffDocument(
+            CSharpStructuralDiffDocument.CurrentSchemaVersion,
+            CSharpStructuralDiffDocument.CurrentMethodologyVersion,
+            issued,
+            comparison.After,
+            comparison.After,
+            comparison.Rows));
+    }
+
+    [Fact]
     public void IssueCorrespondence_RequiresEqualPhysicalMethodProvenance()
     {
         var withoutSource = Document("return;", "ReturnStatement", "return;");
@@ -1101,7 +1236,7 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
-    public void IssuedComparison_ProjectsInterleavedIlWithoutInferringFromText()
+    public void StructuralDiffDocument_ProjectsInterleavedIlWithoutInferringFromText()
     {
         const string beforeText = "return;\nIL_0000: ret";
         const string afterText = "break;\nIL_0000: ret";
@@ -1128,9 +1263,13 @@ public class CSharpStructuralComparisonTests
             [],
             source);
 
-        var comparison = CSharpBodyDiff.CompareStructure(
-            CSharpBodyDiff.IssueCorrespondence(before, after));
+        var document = CSharpStructuralDiffDocument.Create(before, after);
+        var comparison = document.ToComparison();
 
+        Assert.Equal("return;\n", document.Before.Text);
+        Assert.Equal("break;\n", document.After.Text);
+        Assert.Equal(document.Before, comparison.Before);
+        Assert.Equal(document.After, comparison.After);
         Assert.Equal("return;\n", comparison.Before.Text);
         Assert.Equal("break;\n", comparison.After.Text);
         Assert.Single(comparison.Rows);

--- a/src/ILInspector.Decompiler/AnnotatedSourceDocumentJsonContext.cs
+++ b/src/ILInspector.Decompiler/AnnotatedSourceDocumentJsonContext.cs
@@ -21,6 +21,7 @@ namespace ILInspector.Decompiler;
     UseStringEnumConverter = true)]
 [JsonSerializable(typeof(AnnotatedSourceDocument))]
 [JsonSerializable(typeof(CSharpNodeCorrespondenceResult))]
+[JsonSerializable(typeof(CSharpStructuralDiffDocument))]
 public partial class AnnotatedSourceDocumentJsonContext : JsonSerializerContext;
 
 /// <inheritdoc cref="AnnotatedSourceDocumentJsonContext"/>
@@ -31,4 +32,5 @@ public partial class AnnotatedSourceDocumentJsonContext : JsonSerializerContext;
     UseStringEnumConverter = true)]
 [JsonSerializable(typeof(AnnotatedSourceDocument))]
 [JsonSerializable(typeof(CSharpNodeCorrespondenceResult))]
+[JsonSerializable(typeof(CSharpStructuralDiffDocument))]
 public partial class AnnotatedSourceDocumentCompactJsonContext : JsonSerializerContext;

--- a/src/ILInspector.Decompiler/AnnotatedSourceJson.cs
+++ b/src/ILInspector.Decompiler/AnnotatedSourceJson.cs
@@ -6,15 +6,15 @@ using ILInspector.Instructions;
 namespace ILInspector.Decompiler;
 
 /// <summary>
-/// JSON contracts for <see cref="AnnotatedSourceDocument"/> and structural
-/// comparison input.
+/// JSON contracts for <see cref="AnnotatedSourceDocument"/> and
+/// <see cref="CSharpStructuralDiffDocument"/>.
 /// </summary>
 public static class AnnotatedSourceJson
 {
     const string DocumentJsonContractError =
         "Annotated-source JSON violates the JSON contract.";
-    const string StructuralComparisonJsonContractError =
-        "Structural comparison JSON violates the JSON contract.";
+    const string StructuralDiffJsonContractError =
+        "C# structural diff JSON violates the JSON contract.";
 
     /// <summary>
     /// Reads one annotated-source document from an untrusted JSON payload.
@@ -50,22 +50,40 @@ public static class AnnotatedSourceJson
     }
 
     /// <summary>
-    /// Reads one owner-issued structural comparison from an untrusted JSON
-    /// payload under the same strict annotated-source contract.
+    /// Serializes one product-issued structural diff using the owned wire
+    /// contract.
     /// </summary>
-    public static CSharpStructuralComparisonInput DeserializeStructuralComparison(string json)
+    public static string SerializeStructuralDiff(
+        CSharpStructuralDiffDocument document,
+        bool indented = true)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        return indented
+            ? JsonSerializer.Serialize(
+                document,
+                AnnotatedSourceDocumentJsonContext.Default.CSharpStructuralDiffDocument)
+            : JsonSerializer.Serialize(
+                document,
+                AnnotatedSourceDocumentCompactJsonContext.Default.CSharpStructuralDiffDocument);
+    }
+
+    /// <summary>
+    /// Reads one product-issued structural diff from an untrusted JSON payload,
+    /// then reissues correspondence from its exact embedded documents.
+    /// </summary>
+    public static CSharpStructuralDiffDocument DeserializeStructuralDiff(string json)
     {
         ArgumentNullException.ThrowIfNull(json);
         Validate(
             json,
-            ValidateStructuralComparison,
-            "Structural comparison JSON is malformed.");
+            ValidateStructuralDiff,
+            "C# structural diff JSON is malformed.");
         try
         {
             return JsonSerializer.Deserialize(
                 json,
-                AnnotatedSourceStrictJsonContext.Default.CSharpStructuralComparisonInput)
-                ?? throw new JsonException("Structural comparison input is null.");
+                AnnotatedSourceStrictJsonContext.Default.CSharpStructuralDiffDocument)
+                ?? throw new JsonException("C# structural diff document is null.");
         }
         catch (AnnotatedSourceContractJsonException error)
         {
@@ -73,11 +91,12 @@ public static class AnnotatedSourceJson
         }
         catch (JsonException)
         {
-            throw new JsonException(StructuralComparisonJsonContractError);
+            throw new JsonException(StructuralDiffJsonContractError);
         }
         catch (ArgumentException)
         {
-            throw new JsonException("Structural comparison JSON violates the owned model contract.");
+            throw new JsonException(
+                "C# structural diff JSON violates the product-issued model contract.");
         }
     }
 
@@ -109,36 +128,136 @@ public static class AnnotatedSourceJson
         }
     }
 
-    static void ValidateStructuralComparison(JsonElement root)
+    static void ValidateStructuralDiff(JsonElement root)
     {
         RequireProperties(
             root,
-            "subject",
+            "schema_version",
+            "methodology_version",
+            "correspondence",
             "before",
             "after",
-            "before_node_ids",
-            "after_node_ids",
-            "correspondences");
+            "rows");
 
         if (root.ValueKind != JsonValueKind.Object)
             return;
 
+        if (root.TryGetProperty("correspondence", out var correspondence))
+            ValidateCorrespondence(correspondence);
         if (root.TryGetProperty("before", out var before))
             ValidateDocument(before, "before");
         if (root.TryGetProperty("after", out var after))
             ValidateDocument(after, "after");
-        if (root.TryGetProperty("correspondences", out var correspondences))
-        {
-            ValidateObjectArray(
-                correspondences,
-                "correspondences",
-                "before_node_id",
-                "after_node_id");
-        }
+        if (root.TryGetProperty("rows", out var rows))
+            ValidateStructuralRows(rows);
         if (root.TryGetProperty("fidelity", out var fidelity)
             && fidelity.ValueKind != JsonValueKind.Null)
         {
-            RequireProperties(fidelity, "before", "after");
+            RequireProperties(fidelity, ["before", "after"], "fidelity");
+        }
+
+        static void ValidateStructuralRows(JsonElement rows)
+        {
+            ValidateObjectArray(rows, "rows", "change", "before_spans", "after_spans");
+            if (rows.ValueKind != JsonValueKind.Array)
+                return;
+
+            foreach (var row in rows.EnumerateArray())
+            {
+                if (row.ValueKind != JsonValueKind.Object)
+                    continue;
+                if (row.TryGetProperty("before_spans", out var beforeSpans))
+                    ValidateObjectArray(beforeSpans, "rows.before_spans", "start", "length");
+                if (row.TryGetProperty("after_spans", out var afterSpans))
+                    ValidateObjectArray(afterSpans, "rows.after_spans", "start", "length");
+            }
+        }
+    }
+
+    static void ValidateCorrespondence(JsonElement correspondence)
+    {
+        RequireProperties(
+            correspondence,
+            [
+                "subject",
+                "before",
+                "after",
+                "before_revision",
+                "after_revision",
+                "matches",
+                "unmatched_before",
+                "unmatched_after",
+            ],
+            "correspondence");
+        if (correspondence.ValueKind != JsonValueKind.Object)
+            return;
+
+        if (correspondence.TryGetProperty("before", out var before))
+            ValidateDocument(before, "correspondence.before");
+        if (correspondence.TryGetProperty("after", out var after))
+            ValidateDocument(after, "correspondence.after");
+        if (correspondence.TryGetProperty("before_revision", out var beforeRevision))
+            RequireProperties(beforeRevision, ["sha256"], "correspondence.before_revision");
+        if (correspondence.TryGetProperty("after_revision", out var afterRevision))
+            RequireProperties(afterRevision, ["sha256"], "correspondence.after_revision");
+        if (correspondence.TryGetProperty("matches", out var matches))
+        {
+            ValidateObjectArray(
+                matches,
+                "correspondence.matches",
+                "before",
+                "after",
+                "provenance",
+                "evidence",
+                "moved");
+            if (matches.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var match in matches.EnumerateArray())
+                {
+                    if (match.ValueKind != JsonValueKind.Object)
+                        continue;
+                    if (match.TryGetProperty("before", out var matchBefore))
+                        ValidateDocumentNodeIdentity(matchBefore, "correspondence.matches.before");
+                    if (match.TryGetProperty("after", out var matchAfter))
+                        ValidateDocumentNodeIdentity(matchAfter, "correspondence.matches.after");
+                    if (match.TryGetProperty("evidence", out var evidence))
+                        RequireProperties(evidence, ["il_offsets"], "correspondence.matches.evidence");
+                }
+            }
+        }
+        if (correspondence.TryGetProperty("unmatched_before", out var unmatchedBefore))
+            ValidateUnmatched(unmatchedBefore, "correspondence.unmatched_before");
+        if (correspondence.TryGetProperty("unmatched_after", out var unmatchedAfter))
+            ValidateUnmatched(unmatchedAfter, "correspondence.unmatched_after");
+    }
+
+    static void ValidateUnmatched(JsonElement values, string name)
+    {
+        ValidateObjectArray(values, name, "node", "reason");
+        if (values.ValueKind != JsonValueKind.Array)
+            return;
+
+        foreach (var unmatched in values.EnumerateArray())
+        {
+            if (unmatched.ValueKind != JsonValueKind.Object)
+                continue;
+            if (unmatched.TryGetProperty("node", out var node))
+                ValidateDocumentNodeIdentity(node, $"{name}.node");
+            if (unmatched.TryGetProperty("evidence", out var evidence)
+                && evidence.ValueKind != JsonValueKind.Null)
+            {
+                RequireProperties(evidence, ["il_offsets"], $"{name}.evidence");
+            }
+        }
+    }
+
+    static void ValidateDocumentNodeIdentity(JsonElement identity, string name)
+    {
+        RequireProperties(identity, ["document", "node_id"], name);
+        if (identity.ValueKind == JsonValueKind.Object
+            && identity.TryGetProperty("document", out var revision))
+        {
+            RequireProperties(revision, ["sha256"], $"{name}.document");
         }
     }
 
@@ -282,11 +401,14 @@ public static class AnnotatedSourceJson
         typeof(StrictAnnotationConditionalityJsonConverter),
         typeof(StrictAnnotatedSourceFactOriginJsonConverter),
         typeof(StrictIlBodyDiffOutcomeJsonConverter),
+        typeof(StrictCSharpNodeMatchProvenanceJsonConverter),
+        typeof(StrictCSharpUnmatchedNodeReasonJsonConverter),
+        typeof(StrictCSharpStructuralChangeKindJsonConverter),
     ],
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
     UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow)]
 [JsonSerializable(typeof(AnnotatedSourceDocument))]
-[JsonSerializable(typeof(CSharpStructuralComparisonInput))]
+[JsonSerializable(typeof(CSharpStructuralDiffDocument))]
 internal sealed partial class AnnotatedSourceStrictJsonContext : JsonSerializerContext;
 
 internal sealed class AnnotatedSourceContractJsonException(string message)
@@ -469,7 +591,7 @@ internal sealed class StrictIlBodyDiffOutcomeJsonConverter
     : StrictStringEnumJsonConverter<IlBodyDiffOutcome>
 {
     protected override string ErrorMessage
-        => "Structural comparison JSON contains an unknown IL body-diff outcome.";
+        => "C# structural diff JSON contains an unknown IL body-diff outcome.";
 
     protected override bool TryParse(string name, out IlBodyDiffOutcome value)
     {
@@ -494,6 +616,98 @@ internal sealed class StrictIlBodyDiffOutcomeJsonConverter
             IlBodyDiffOutcome.Exact => nameof(IlBodyDiffOutcome.Exact),
             IlBodyDiffOutcome.OperandDiff => nameof(IlBodyDiffOutcome.OperandDiff),
             IlBodyDiffOutcome.OpcodeDiff => nameof(IlBodyDiffOutcome.OpcodeDiff),
+            _ => null,
+        };
+}
+
+internal sealed class StrictCSharpNodeMatchProvenanceJsonConverter
+    : StrictStringEnumJsonConverter<CSharpNodeMatchProvenance>
+{
+    protected override string ErrorMessage
+        => "C# structural diff JSON contains an unknown node-match provenance.";
+
+    protected override bool TryParse(string name, out CSharpNodeMatchProvenance value)
+    {
+        if (name == nameof(CSharpNodeMatchProvenance.IlOriginSet))
+        {
+            value = CSharpNodeMatchProvenance.IlOriginSet;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    protected override string? GetName(CSharpNodeMatchProvenance value)
+        => value == CSharpNodeMatchProvenance.IlOriginSet
+            ? nameof(CSharpNodeMatchProvenance.IlOriginSet)
+            : null;
+}
+
+internal sealed class StrictCSharpUnmatchedNodeReasonJsonConverter
+    : StrictStringEnumJsonConverter<CSharpUnmatchedNodeReason>
+{
+    protected override string ErrorMessage
+        => "C# structural diff JSON contains an unknown unmatched-node reason.";
+
+    protected override bool TryParse(string name, out CSharpUnmatchedNodeReason value)
+    {
+        value = name switch
+        {
+            nameof(CSharpUnmatchedNodeReason.Unsupported) => CSharpUnmatchedNodeReason.Unsupported,
+            nameof(CSharpUnmatchedNodeReason.Ambiguous) => CSharpUnmatchedNodeReason.Ambiguous,
+            nameof(CSharpUnmatchedNodeReason.NoCounterpart) => CSharpUnmatchedNodeReason.NoCounterpart,
+            _ => default,
+        };
+        return name is nameof(CSharpUnmatchedNodeReason.Unsupported)
+            or nameof(CSharpUnmatchedNodeReason.Ambiguous)
+            or nameof(CSharpUnmatchedNodeReason.NoCounterpart);
+    }
+
+    protected override string? GetName(CSharpUnmatchedNodeReason value)
+        => value switch
+        {
+            CSharpUnmatchedNodeReason.Unsupported => nameof(CSharpUnmatchedNodeReason.Unsupported),
+            CSharpUnmatchedNodeReason.Ambiguous => nameof(CSharpUnmatchedNodeReason.Ambiguous),
+            CSharpUnmatchedNodeReason.NoCounterpart => nameof(CSharpUnmatchedNodeReason.NoCounterpart),
+            _ => null,
+        };
+}
+
+internal sealed class StrictCSharpStructuralChangeKindJsonConverter
+    : StrictStringEnumJsonConverter<CSharpStructuralChangeKind>
+{
+    protected override string ErrorMessage
+        => "C# structural diff JSON contains an unknown structural change kind.";
+
+    protected override bool TryParse(string name, out CSharpStructuralChangeKind value)
+    {
+        value = name switch
+        {
+            nameof(CSharpStructuralChangeKind.Added) => CSharpStructuralChangeKind.Added,
+            nameof(CSharpStructuralChangeKind.Removed) => CSharpStructuralChangeKind.Removed,
+            nameof(CSharpStructuralChangeKind.Changed) => CSharpStructuralChangeKind.Changed,
+            nameof(CSharpStructuralChangeKind.Moved) => CSharpStructuralChangeKind.Moved,
+            "Changed, Moved" =>
+                CSharpStructuralChangeKind.Changed | CSharpStructuralChangeKind.Moved,
+            _ => default,
+        };
+        return name is nameof(CSharpStructuralChangeKind.Added)
+            or nameof(CSharpStructuralChangeKind.Removed)
+            or nameof(CSharpStructuralChangeKind.Changed)
+            or nameof(CSharpStructuralChangeKind.Moved)
+            or "Changed, Moved";
+    }
+
+    protected override string? GetName(CSharpStructuralChangeKind value)
+        => value switch
+        {
+            CSharpStructuralChangeKind.Added => nameof(CSharpStructuralChangeKind.Added),
+            CSharpStructuralChangeKind.Removed => nameof(CSharpStructuralChangeKind.Removed),
+            CSharpStructuralChangeKind.Changed => nameof(CSharpStructuralChangeKind.Changed),
+            CSharpStructuralChangeKind.Moved => nameof(CSharpStructuralChangeKind.Moved),
+            CSharpStructuralChangeKind.Changed | CSharpStructuralChangeKind.Moved =>
+                "Changed, Moved",
             _ => null,
         };
 }

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -31,7 +31,7 @@ public enum CSharpStructuralChangeKind
 /// Whether the correspondence owner determined that the logical node moved.
 /// Coordinates are not used to infer this relationship.
 /// </param>
-public sealed record CSharpNodeCorrespondence(
+internal sealed record CSharpNodeCorrespondence(
     int BeforeNodeId,
     int AfterNodeId,
     bool Moved = false);
@@ -145,7 +145,7 @@ public sealed record CSharpStructuralFidelityEvidence(
 /// nodes become removed or added rows.
 /// </param>
 /// <param name="Fidelity">Optional independent compile-back evidence.</param>
-public sealed record CSharpStructuralComparisonInput(
+internal sealed record CSharpStructuralComparisonInput(
     string Subject,
     AnnotatedSourceDocument Before,
     AnnotatedSourceDocument After,
@@ -421,7 +421,7 @@ public static partial class CSharpBodyDiff
     /// correspondence. Node ids are dereferenced only within the document that
     /// minted them; coordinates and display text never establish identity.
     /// </summary>
-    public static CSharpStructuralComparison CompareStructure(
+    internal static CSharpStructuralComparison CompareStructure(
         CSharpStructuralComparisonInput input)
     {
         ArgumentNullException.ThrowIfNull(input);

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffDocument.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffDocument.cs
@@ -1,0 +1,157 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Decompiler;
+
+/// <summary>
+/// Portable, product-issued structural C# diff over two exact annotated-source
+/// document revisions.
+/// </summary>
+/// <remarks>
+/// The serialized artifact retains both correspondence evidence and generated
+/// structural rows. Construction reissues correspondence from the embedded
+/// documents and requires exact agreement with those rows before
+/// <see cref="ToComparison"/> exposes them.
+/// <c>CSharpStructuralComparisonTests.StructuralDiffDocument_RejectsTamperedCorrespondence</c>
+/// <c>StructuralDiffDocument_RejectsTamperedProjection</c>, and
+/// <c>StructuralDiffDocument_RejectsTamperedRows</c> are the non-vacuity gates
+/// for that replay check.
+/// <c>StructuralDiffDocument_ProjectsInterleavedIlWithoutInferringFromText</c>
+/// gates that the top-level projections own the serialized row coordinates.
+/// </remarks>
+public sealed record CSharpStructuralDiffDocument
+{
+    /// <summary>Current JSON shape version.</summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>Current correspondence and structural-comparison methodology.</summary>
+    public const int CurrentMethodologyVersion = 1;
+
+    /// <summary>Creates and validates one portable structural diff.</summary>
+    public CSharpStructuralDiffDocument(
+        int SchemaVersion,
+        int MethodologyVersion,
+        CSharpNodeCorrespondenceResult Correspondence,
+        AnnotatedSourceDocument Before,
+        AnnotatedSourceDocument After,
+        ImmutableArray<CSharpStructuralDiffRow> Rows,
+        CSharpStructuralFidelityEvidence? Fidelity = null)
+    {
+        if (SchemaVersion != CurrentSchemaVersion)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(SchemaVersion),
+                "Structural diff schema version is unsupported.");
+        }
+        if (MethodologyVersion != CurrentMethodologyVersion)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MethodologyVersion),
+                "Structural diff methodology version is unsupported.");
+        }
+        ArgumentNullException.ThrowIfNull(Correspondence);
+        ArgumentNullException.ThrowIfNull(Before);
+        ArgumentNullException.ThrowIfNull(After);
+        if (Rows.IsDefault)
+            throw new ArgumentException("Structural diff rows must be initialized.", nameof(Rows));
+        if (Fidelity?.Note is { } note)
+        {
+            AnnotatedSourceText.ValidateWellFormedUtf16(
+                note,
+                nameof(Fidelity),
+                "Structural fidelity note");
+        }
+
+        var comparison = CSharpBodyDiff.CompareStructure(Correspondence, Fidelity);
+        if (Before != comparison.Before
+            || After != comparison.After
+            || !RowsEqual(Rows, comparison.Rows))
+        {
+            throw new ArgumentException(
+                "Structural diff projection or rows do not match the product-issued comparison.");
+        }
+
+        this.SchemaVersion = SchemaVersion;
+        this.MethodologyVersion = MethodologyVersion;
+        this.Correspondence = Correspondence;
+        this.Before = Before;
+        this.After = After;
+        this.Rows = Rows;
+        this.Fidelity = Fidelity;
+    }
+
+    /// <summary>JSON shape version.</summary>
+    public int SchemaVersion { get; }
+
+    /// <summary>Correspondence and structural-comparison methodology version.</summary>
+    public int MethodologyVersion { get; }
+
+    /// <summary>Exact documents, revisions, matches, and unmatched nodes.</summary>
+    public CSharpNodeCorrespondenceResult Correspondence { get; }
+
+    /// <summary>C#-only Before projection that owns Before row ids and spans.</summary>
+    public AnnotatedSourceDocument Before { get; }
+
+    /// <summary>C#-only After projection that owns After row ids and spans.</summary>
+    public AnnotatedSourceDocument After { get; }
+
+    /// <summary>Product-generated structural rows over the exact document revisions.</summary>
+    public ImmutableArray<CSharpStructuralDiffRow> Rows { get; }
+
+    /// <summary>Optional independently measured compile-back evidence.</summary>
+    public CSharpStructuralFidelityEvidence? Fidelity { get; }
+
+    /// <summary>Issues a structural diff from two exact product documents.</summary>
+    public static CSharpStructuralDiffDocument Create(
+        AnnotatedSourceDocument before,
+        AnnotatedSourceDocument after,
+        CSharpStructuralFidelityEvidence? fidelity = null)
+    {
+        var correspondence = CSharpBodyDiff.IssueCorrespondence(before, after);
+        var comparison = CSharpBodyDiff.CompareStructure(correspondence, fidelity);
+        return new(
+            CurrentSchemaVersion,
+            CurrentMethodologyVersion,
+            correspondence,
+            comparison.Before,
+            comparison.After,
+            comparison.Rows,
+            fidelity);
+    }
+
+    /// <summary>
+    /// Revalidates the embedded product correspondence and derives presentation
+    /// rows over the exact document revisions.
+    /// </summary>
+    public CSharpStructuralComparison ToComparison()
+        => CSharpBodyDiff.CompareStructure(Correspondence, Fidelity);
+
+    static bool RowsEqual(
+        ImmutableArray<CSharpStructuralDiffRow> left,
+        ImmutableArray<CSharpStructuralDiffRow> right)
+    {
+        if (left.Length != right.Length)
+            return false;
+
+        for (int index = 0; index < left.Length; index++)
+        {
+            var leftRow = left[index];
+            var rightRow = right[index];
+            if (leftRow.Change != rightRow.Change
+                || leftRow.BeforeNodeId != rightRow.BeforeNodeId
+                || leftRow.AfterNodeId != rightRow.AfterNodeId
+                || leftRow.BeforeKind != rightRow.BeforeKind
+                || leftRow.AfterKind != rightRow.AfterKind
+                || leftRow.BeforeLabel != rightRow.BeforeLabel
+                || leftRow.AfterLabel != rightRow.AfterLabel
+                || leftRow.BeforeRegion != rightRow.BeforeRegion
+                || leftRow.AfterRegion != rightRow.AfterRegion
+                || !leftRow.BeforeSpans.SequenceEqual(rightRow.BeforeSpans)
+                || !leftRow.AfterSpans.SequenceEqual(rightRow.AfterSpans))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -450,8 +450,8 @@ static class Program
         }
         if (structuralReview is not null
             && (!string.Equals(args[0], "--structural-review", StringComparison.Ordinal)
-                || !((args.Length == 2 && inputs.Count == 0)
-                    || (args.Length == 3 && inputs.Count == 1))))
+                || inputs.Count > 1
+                || args.Length != 2 + inputs.Count + (json ? 1 : 0)))
         {
             return Fail("--structural-review is an exclusive mode and cannot be combined with other flags or inputs.");
         }
@@ -476,10 +476,11 @@ static class Program
         if (structuralReview is not null)
         {
             if (inputs.Count > 1 || packages.Count > 0)
-                return Fail("--structural-review reads product documents or a legacy comparison artifact; do not pass assembly or package inputs.");
+                return Fail("--structural-review reads product documents or a structural diff document; do not pass assembly or package inputs.");
             return StructuralReview.Run(
                 structuralReview,
-                inputs.Count == 1 ? inputs[0] : null);
+                inputs.Count == 1 ? inputs[0] : null,
+                json);
         }
 
         if (fixtureSourceInventory)
@@ -2152,9 +2153,9 @@ static class Program
                                 AnnotatedSourceDocument values, then render
                                 full-body carets and a rich diff. The documents
                                 must carry equal physical method provenance.
-                                The legacy one-file
-                                CSharpStructuralComparisonInput form remains
-                                accepted for existing artifacts.
+                                Add --json to emit the product-issued
+                                CSharpStructuralDiffDocument. Pass one such diff
+                                document to validate and render it later.
           --return-to-sender      prototype fact-planned compile-back harness:
                                 build module/type shells for the first property
                                 getter in each assembly, compile, and compare IL

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -57,13 +57,16 @@ labels, and display order never establish identity. Other nodes remain explicit
 unsupported and ambiguous rows appear under **Correspondence gaps** rather than
 being guessed as additions or removals.
 
-The legacy one-file `CSharpStructuralComparisonInput` form remains accepted for
-existing artifacts. It carries two C#-only documents, explicit selected node
-ids, and owner-issued one-to-one correspondence. Node ids remain local to the
-document that minted them; the comparison never matches by coordinates,
-selected text, or display labels. Its optional `fidelity` retains independently
-measured `OpcodeDiff -> Exact`-style evidence; correspondence does not infer
-fidelity.
+Add `--json` to emit a `CSharpStructuralDiffDocument`. That product-issued
+artifact carries schema and methodology versions, both exact documents and
+revision identities, matches, unmatched nodes, generated structural rows, and
+optional independently measured fidelity. Strict reading reissues
+correspondence from the embedded mixed documents, derives the C#-only
+Before/After projections that own the row ids and spans, and requires exact
+agreement with those projections and the serialized rows. Pass one diff
+document instead of two source documents to validate and render a previously
+emitted artifact. The retired `CSharpStructuralComparisonInput` wire format is
+not accepted.
 
 Both forms reject missing required fields, duplicate and unknown properties,
 numeric, composite, case-variant, or otherwise undeclared enum tokens,
@@ -76,6 +79,13 @@ assembly/package input with it.
 ```bash
 dotnet run --project tools/DecompilerHarness -c Release -- \
   --structural-review /tmp/before.json /tmp/after.json
+
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  --structural-review /tmp/before.json /tmp/after.json --json \
+  > /tmp/structural-diff.json
+
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  --structural-review /tmp/structural-diff.json
 ```
 
 **Inverse ledger regeneration** (`--emit-inverse-ledger <path>`): evaluates `[InverseOf]` and `[NotInverted]` attributes on the decompiler's node schema and renders the Markdown representation to the specified path. Use this command to update the single-source-of-truth document at `docs/design/inverse-ledger.generated.md` after adding or changing inverse annotations in the IR types. A drift-gate test enforces that the committed file matches this command's output.

--- a/tools/DecompilerHarness/StructuralReview.cs
+++ b/tools/DecompilerHarness/StructuralReview.cs
@@ -6,23 +6,18 @@ namespace ILInspector.DecompilerHarness;
 
 internal static class StructuralReview
 {
-    public static int Run(string path, string? afterPath = null)
+    public static int Run(string path, string? afterPath, bool json)
     {
         try
         {
-            if (afterPath is not null)
-            {
-                var before = ReadDocument(path);
-                var after = ReadDocument(afterPath);
-                var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
-                Console.Write(RenderMarkdown(CSharpBodyDiff.CompareStructure(issued)));
-                return 0;
-            }
-
-            string json = File.ReadAllText(path);
-            var input = AnnotatedSourceJson.DeserializeStructuralComparison(json);
-            var comparison = CSharpBodyDiff.CompareStructure(input);
-            Console.Write(RenderMarkdown(comparison));
+            var document = afterPath is null
+                ? AnnotatedSourceJson.DeserializeStructuralDiff(File.ReadAllText(path))
+                : CSharpStructuralDiffDocument.Create(
+                    ReadDocument(path),
+                    ReadDocument(afterPath));
+            Console.Write(json
+                ? AnnotatedSourceJson.SerializeStructuralDiff(document)
+                : RenderMarkdown(document.ToComparison()));
             return 0;
         }
         catch (Exception ex) when (ex is IOException
@@ -33,7 +28,7 @@ internal static class StructuralReview
         {
             Console.Error.WriteLine(CSharpText.CSharpIdentifier.ContainRenderedText(
                 afterPath is null
-                    ? $"Error: Could not render structural review '{path}': {ex.Message}"
+                    ? $"Error: Could not render structural diff '{path}': {ex.Message}"
                     : $"Error: Could not render structural review '{path}' and '{afterPath}': {ex.Message}"));
             return 1;
         }


### PR DESCRIPTION
## Summary

- add a schema- and methodology-versioned `CSharpStructuralDiffDocument` that retains product-issued correspondence, exact C# projections, generated rows, and optional independent fidelity evidence
- strictly validate replay by reissuing correspondence and re-deriving projections and rows before exposing the presentation model
- emit and replay the canonical artifact from DecompilerHarness, retiring the caller-authored legacy comparison JSON while leaving native IL diff ownership unchanged

## Demo

Generate a portable artifact from two exact annotated-source documents, then replay that artifact later:

```bash
dotnet run --project tools/DecompilerHarness -c Release -- \
  --structural-review /tmp/before.json /tmp/after.json --json \
  > /tmp/structural-diff.json

dotnet run --project tools/DecompilerHarness -c Release -- \
  --structural-review /tmp/structural-diff.json
```

### Simple changed-node case

For a product document changing `return;` to `break;`, replay includes the presentation row:

```markdown
| Change | Structure | Region | Before spans | After spans | Fidelity |
| --- | --- | --- | --- | --- | --- |
| Changed | Return -&gt; Break | Case | [0..7) | [0..6) | |
```

`Return -&gt; Break` is presentation only. The corresponding canonical JSON row stores each structural dimension independently:

```json
{
  "change": "Changed",
  "before_node_id": 0,
  "after_node_id": 0,
  "before_kind": "ReturnStatement",
  "after_kind": "BreakStatement",
  "before_label": "Return",
  "after_label": "Break",
  "before_region": "Case",
  "after_region": "Case",
  "before_spans": [
    { "start": 0, "length": 7 }
  ],
  "after_spans": [
    { "start": 0, "length": 6 }
  ]
}
```

That makes structural queries field-based rather than text parsing:

```bash
jq '.rows[]
  | select(.before_kind == "ReturnStatement"
      and .after_kind == "BreakStatement")
  | {change, before_node_id, after_node_id, before_region, after_region}' \
  /tmp/structural-diff.json
```

### Full outcome range

| Scenario | Issued evidence | Artifact result |
| --- | --- | --- |
| Changed | One unique origin set on both sides; kind changes | `Changed` row |
| Moved | One unique origin set on both sides; order changes | `Moved` row |
| Changed and moved | Both conditions hold for the same match | `Changed, Moved` row |
| Added | Unique after-only origin set | `unmatched_after: NoCounterpart` plus an `Added` row |
| Removed | Unique before-only origin set | `unmatched_before: NoCounterpart` plus a `Removed` row |
| Ambiguous | Origin evidence is non-unique on either side | Correspondence gap; no guessed row |
| Unsupported | A node has no supported provenance | Correspondence gap; no guessed row |
| Split or merge | One-to-many or many-to-one evidence is non-unique | Usually `Ambiguous`; no fabricated pairing |

Representative `rows` shapes show that every queryable dimension remains separate. The values below are illustrative; an emitted artifact derives them from its embedded documents and correspondence. Null-side scalar fields are omitted, while the required span array for that side is empty:

```json
[
  {
    "change": "Moved",
    "before_node_id": 1,
    "after_node_id": 4,
    "before_kind": "InvocationExpression",
    "after_kind": "InvocationExpression",
    "before_label": "InvocationExpression",
    "after_label": "InvocationExpression",
    "before_region": "Body",
    "after_region": "Body",
    "before_spans": [{ "start": 12, "length": 6 }],
    "after_spans": [{ "start": 0, "length": 6 }]
  },
  {
    "change": "Changed, Moved",
    "before_node_id": 2,
    "after_node_id": 5,
    "before_kind": "ReturnStatement",
    "after_kind": "BreakStatement",
    "before_label": "Return",
    "after_label": "Break",
    "before_region": "Case",
    "after_region": "Body",
    "before_spans": [
      { "start": 24, "length": 3 },
      { "start": 31, "length": 4 }
    ],
    "after_spans": [{ "start": 8, "length": 6 }]
  },
  {
    "change": "Added",
    "after_node_id": 6,
    "after_kind": "InvocationExpression",
    "after_label": "InvocationExpression",
    "after_region": "Body",
    "before_spans": [],
    "after_spans": [{ "start": 20, "length": 8 }]
  },
  {
    "change": "Removed",
    "before_node_id": 3,
    "before_kind": "InvocationExpression",
    "before_label": "InvocationExpression",
    "before_region": "Body",
    "before_spans": [{ "start": 40, "length": 8 }],
    "after_spans": []
  }
]
```

`Ambiguous` and `Unsupported` are intentionally not row kinds. They remain explicit under `correspondence.unmatched_before` / `unmatched_after` (revision hashes shortened here only for readability):

```json
{
  "unmatched_before": [
    {
      "node": {
        "document": { "sha256": "<before revision>" },
        "node_id": 8
      },
      "reason": "Ambiguous",
      "evidence": { "il_offsets": [16] }
    }
  ],
  "unmatched_after": [
    {
      "node": {
        "document": { "sha256": "<after revision>" },
        "node_id": 9
      },
      "reason": "Unsupported"
    }
  ]
}
```

Multi-span nodes use multiple `{start, length}` entries, as in the changed-and-moved example. For original documents that interleave C# and IL, `correspondence.before` / `correspondence.after` retain the mixed documents, while the top-level `before` / `after` are exact C#-only projections that own every row node ID and span. The artifact therefore never asks a query consumer to infer coordinate ownership from rendered text.

The complete JSON retains the original correspondence and revision identities plus those exact projections. Replay reissues and re-derives correspondence, projections, and rows before rendering; it does not accept caller-authored values for them.

## Validation

- Release build of `ILInspector.Decompiler.Tests`: 0 warnings, 0 errors
- `AnnotatedSourceJsonTests`: 45 passed
- `CSharpStructuralComparisonTests`: 39 passed
- `AuthoredCorpusHarnessProcessTests`: 177 passed
- Markdown lint and `git diff --check`

## Compatibility boundary

The existing two-document Markdown review flow remains available. The retired one-file `CSharpStructuralComparisonInput` wire format is intentionally rejected. IL comparison remains represented by `IlBodyDiffResult`; this PR does not introduce a parallel generic IL row hierarchy.

Fixes #4295