### PR TITLE
Prepare 0.20.0 release

### DIFF
--- a/docs/private-feeds.md
+++ b/docs/private-feeds.md
@@ -265,11 +265,14 @@ profile cannot override what you typed. A value outside the range, or one that i
 number, fails the command when given as a flag and is ignored when given as the variable: you
 typed the flag just now, but a stale variable should not make every command fail.
 
-The configured value replaces the 30 second request deadline in either direction, including
-response-body consumption and service-index discovery. Search API pagination uses an operation
-ceiling four times that value so multiple pages remain finite without silently restoring the
-default. One shared ceiling around discovery and every selected source belongs to the package
-source-client work; each request remains bounded in the meantime.
+For `package search` and package-name prefix expansion, the configured value replaces the 30
+second request deadline through service-index discovery and search-response consumption. Each
+selected source gets its own search operation ceiling four times that value so pagination remains
+finite without silently restoring the default. Discovery and multiple selected sources do not
+share one operation ceiling.
+
+This setting does not raise ordinary package-download body consumption above its existing 30
+second baseline.
 
 Fetching source content through SourceLink keeps the fixed 30 second timeout. Those URLs come
 from the package rather than from a feed you configured, so they are not covered by this setting.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.19.0
+version: 0.20.0
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and version-to-version API changes.
 ---
 

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -19,7 +19,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.19.0</VersionPrefix>
+    <VersionPrefix>0.20.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -4,21 +4,23 @@
 
 ### Inspection reliability
 
-- Resource Triage now reports incomplete method analysis as a typed inspection
-  failure instead of returning fewer rows or success-shaped empty output.
-  Instruction decoding, method and catch resolution, metadata validation,
-  method-body acquisition, and control-flow analysis retain stable failure
-  phases across Markdown, JSON, exact-section, count, multi-assembly, and
-  `package --all-libraries` projections. Legal native method bodies are no
+- **Breaking:** `library` and `package --all-libraries` now return a non-zero
+  exit status when an explicitly selected section is empty because its
+  inspection failed. Resource Triage reports incomplete method analysis as a
+  typed inspection failure instead of returning fewer rows or success-shaped
+  empty output. Instruction decoding, method and catch resolution, metadata
+  validation, method-body acquisition, and control-flow analysis retain stable
+  failure phases across Markdown, JSON, exact-section, count, multi-assembly,
+  and `package --all-libraries` projections. Legal native method bodies are no
   longer decoded as IL (#4273).
 - Classified-method facts now come from one bounded typed query shared by
   `Library Info`, P/Invoke Methods, Async Methods, and Signals. Existing output
   remains compatible while failures and raw artifact identity stay typed until
   presentation (#4195).
-- Inspection graphs can project exact package ownership and provenance without
-  reconstructing identity from assembly names or display labels. Incomplete or
-  conflicting package membership fails visibly rather than producing a smaller
-  graph (#4269).
+- Internal inspection-graph composition now has a typed package boundary that
+  preserves exact ownership and provenance without reconstructing identity
+  from assembly names or display labels. Presentation and CLI integration are
+  unchanged (#4269).
 
 ### Experimental analysis and decompilation
 
@@ -39,12 +41,12 @@
 
 ### Engineering and validation
 
-- IL diff ownership now has a dedicated assembly boundary, and Windows CI runs
-  the restored IL toolchain so round-trip coverage is no longer Linux-only
+- IL diff ownership now has a dedicated assembly boundary. Windows CI restores
+  `ilasm` and `ildasm` so oracle-backed Windows tests no longer skip
   (#4201, #4186).
-- Structural clone discovery, decompiler structural comparison, and compiler
-  fixture coverage were expanded while preserving bounded work and
-  deterministic evidence (#4114, #4251, #4280, #4286, #4293).
+- Structural clone comparison and same-assembly discovery gained
+  compiler-produced and corpus coverage while preserving bounded work and
+  deterministic evidence (#4114, #4280).
 
 ## v0.19.0
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,51 @@
 # Release Notes
 
+## v0.20.0
+
+### Inspection reliability
+
+- Resource Triage now reports incomplete method analysis as a typed inspection
+  failure instead of returning fewer rows or success-shaped empty output.
+  Instruction decoding, method and catch resolution, metadata validation,
+  method-body acquisition, and control-flow analysis retain stable failure
+  phases across Markdown, JSON, exact-section, count, multi-assembly, and
+  `package --all-libraries` projections. Legal native method bodies are no
+  longer decoded as IL (#4273).
+- Classified-method facts now come from one bounded typed query shared by
+  `Library Info`, P/Invoke Methods, Async Methods, and Signals. Existing output
+  remains compatible while failures and raw artifact identity stay typed until
+  presentation (#4195).
+- Inspection graphs can project exact package ownership and provenance without
+  reconstructing identity from assembly names or display labels. Incomplete or
+  conflicting package membership fails visibly rather than producing a smaller
+  graph (#4269).
+
+### Experimental analysis and decompilation
+
+- Adds bounded exact structural clone comparison and same-assembly discovery.
+  Exact normalized IL/control-flow witnesses remain distinct from unsupported,
+  failed, limited, ambiguous, and different outcomes; incomplete candidate
+  buckets never emit partial clusters (#4114, #4280).
+- Annotated-source and structural-review JSON now use strict decompiler-owned
+  readers and writers. Missing, duplicate, unknown, malformed, or topologically
+  invalid input is rejected without echoing artifact-provided values (#4203).
+- Structural decompiler review can consume product-issued cross-document node
+  correspondence backed by exact physical-method provenance, document
+  revisions, and IL-origin evidence. Unsupported and ambiguous nodes remain
+  explicit gaps rather than guessed additions or removals (#4254).
+- Retry-loop recognition and adjacent control-flow scans now stay inside their
+  owning local-function or lambda scope, preventing nested-function facts from
+  inventing or reshaping outer loops (#4253).
+
+### Engineering and validation
+
+- IL diff ownership now has a dedicated assembly boundary, and Windows CI runs
+  the restored IL toolchain so round-trip coverage is no longer Linux-only
+  (#4201, #4186).
+- Structural clone discovery, decompiler structural comparison, and compiler
+  fixture coverage were expanded while preserving bounded work and
+  deterministic evidence (#4114, #4251, #4280, #4286, #4293).
+
 ## v0.19.0
 
 ### Inspection and output

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -24,13 +24,11 @@
 
 ### NuGet acquisition
 
-- **Breaking:** NuGet timeout failures now use stable tool-owned diagnostics
-  instead of runtime-specific message text. Request deadlines cover
-  service-index discovery, response-body and package-stream consumption, while
-  search pagination has a separate operation ceiling. `--http-timeout` sets
-  each request deadline and a search ceiling four times that value. Configured
-  source credentials authenticate the service index and same-origin discovered
-  endpoints but are withheld from cross-origin resources (#4243).
+- **Breaking:** Package-search timeout failures now use stable tool-owned
+  diagnostics instead of runtime-specific message text. `--http-timeout` now
+  bounds service-index discovery and response-body consumption for
+  `package search` and package-prefix expansion. Each source's search
+  pagination has a separate operation ceiling four times that value (#4243).
 
 ### Experimental analysis and decompilation
 

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -22,6 +22,16 @@
   from assembly names or display labels. Presentation and CLI integration are
   unchanged (#4269).
 
+### NuGet acquisition
+
+- **Breaking:** NuGet timeout failures now use stable tool-owned diagnostics
+  instead of runtime-specific message text. Request deadlines cover
+  service-index discovery, response-body and package-stream consumption, while
+  search pagination has a separate operation ceiling. `--http-timeout` sets
+  each request deadline and a search ceiling four times that value. Configured
+  source credentials authenticate the service index and same-origin discovered
+  endpoints but are withheld from cross-origin resources (#4243).
+
 ### Experimental analysis and decompilation
 
 - Adds bounded exact structural clone comparison and same-assembly discovery.


### PR DESCRIPTION
## Summary

Prepares dotnet-inspect 0.20.0 from `main`.

- advances the tool and embedded router skill version to 0.20.0
- adds shipped release notes for Resource Triage failure visibility, typed inspection/query boundaries, exact structural clone discovery, strict annotated-source JSON, and decompiler correctness work since v0.19.0
- records the compatibility boundary: malformed or incomplete Resource Triage evidence now fails visibly; well-formed findings and unrelated selected sections retain their prior behavior

## Shipped documentation checkpoint

- `README.md`: reviewed against the post-v0.19.0 command surface; no update needed because this release adds no new public command or flag and the existing experimental-analysis guidance remains accurate.
- Embedded skills: reviewed all changes since v0.19.0; no capability text update needed. The router skill version is advanced to 0.20.0, and registry/resource equality remains green.

## Validation

- `markdownlint` passed for changed Markdown
- `PackagingSurfaceTests`: 6 passed
- `FocusedSkillFilesRegistryAndEmbeddedResourcesAgree`: 1 passed
- NuGet version probe: `dotnet-inspect` 0.20.0 returned HTTP 404 and is available for publication
- `git diff --check` passed

Full CI will validate the release candidate.
