### PR TITLE
Add shared query vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | ---------- | -------- | ---------- |
 | Package inventory | `package` | Metadata, versions, TFMs, file layout, dependency tree, metadata audit, vulnerability data, custom feeds, NuGet config support. |
 | Project skills | `project` | Direct dependency `Skills` rows from package `skills/**/SKILL.md` files, plus version-resolved package README/PROJECT docs from restored projects. |
+| Query vocabulary | `vocabulary` | Product-owned stable values, operators, defaults, and applicability for rich queries, exposed as ordinary discoverable sections and shared with browser/WASM. |
 | Library audit | `library` | Assembly identity, public key token, trim/AOT metadata, unsafe/interoperability signals, OpenTelemetry support, symbols/PDBs, SourceLink and determinism audit, flat or depth-bounded tree references, resources, async method classification. |
 | API discovery | `type`, `member`, `find` | Type search, member tables, docs, overload selection, generics, obsolete-member markers, direct calls and callers, source/decompiled/IL drill-in. Add `--project` to resolve type/member queries in the project's restored dependency context. |
 | API compatibility | `diff` | Version ranges, package or platform diffs, breaking/additive/potentially-breaking classification, type and member filters, plus opt-in decompiled C#/IL/checksum-verified authored Source evidence. |
@@ -154,6 +155,7 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | `type X` | Discover types or render a single type shape. |
 | `member X` | Inspect members, docs, overloads, decompiled/lowered C#, SourceLink-backed original source, and IL. |
 | `find X` | Search for types across packages, frameworks, projects, and local assets. Add `--members` (or lead the query with `.`, e.g. `.Serialize`) to search member names instead. |
+| `vocabulary` | Discover product-owned query vocabularies; select sections such as `Accessibility` or `C# Style Choices` to enumerate their legal values. |
 | `body-shape X` | Search one library's full-fidelity bodies for an exact stable rendered-syntax kind, returning the containing member, MethodDef token, exact range, and selected text. |
 | `diff X` | Compare API surfaces by default; opt into analysis or peer decompiled C#, IL, and checksum-verified authored Source implementation evidence. |
 | `extensions X` | Find extension methods and C# extension properties for a type. |
@@ -591,6 +593,9 @@ dotnet-inspect member Command --project ./src/App -S "Member Index"
 dotnet-inspect project ./src/App -S Skills --jsonl
 dotnet-inspect project ./src/App -S Skills --paths
 dotnet-inspect project ./src/App -S Skills --print --row 1
+dotnet-inspect vocabulary -D
+dotnet-inspect vocabulary -S Accessibility --json
+dotnet-inspect vocabulary -S "C# Style Choices" --columns "ID,Title,Tier" --tsv
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --urls --json-array
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Rendering Model](design/rendering-model.md) | Historical/current rendering model notes; prefer [Progressive Disclosure](design/progressive-disclosure.md) for current agent-facing behavior. |
 | [Section Model](design/section-model.md) | Section selection design notes; use with [Progressive Disclosure](design/progressive-disclosure.md). |
 | [Schema Query](design/schema-query.md) | `-D`/`-S` schema/query implementation notes. |
+| [Query Vocabulary](design/vocabulary.md) | Shared static catalogs for legal query values across CLI and browser hosts. |
 | [Hidden-Fact Annotations](design/hidden-fact-annotations.md) | Allocation/unsafety/lifetime annotation model and the static IL pair-agreement oracle strategy. |
 | [Caret Stacking](design/caret-stacking.md) | `--focus` display model: one caret per fact extent, packed onto as few rows as fit, with the numbered fact texts listed below. |
 | [Decompiler Inspection & Oracle](design/decompiler-inspection-oracle.md) | Unifies single-method inspection (dump/stages) with the corpus-wide fidelity check oracle; product-vs-tool scoping. |

--- a/docs/design/vocabulary.md
+++ b/docs/design/vocabulary.md
@@ -1,0 +1,61 @@
+# Product Vocabulary
+
+`dotnet-inspect vocabulary` exposes the stable values accepted by product-owned
+queries. It is an inspection document, not a help-text command or an enum dump:
+sections are vocabularies, and section rows are legal values.
+
+## Data all the way down
+
+Vocabulary uses the ordinary output model:
+
+```bash
+dotnet-inspect vocabulary
+dotnet-inspect vocabulary -D
+dotnet-inspect vocabulary -S Accessibility
+dotnet-inspect vocabulary -S "C# Style Choices" --json
+dotnet-inspect vocabulary -S @Decompiler --count
+```
+
+- Bare `vocabulary` renders the `Vocabulary Sections` index.
+- `-D` discovers sections, categories, and fields.
+- `-S` selects the values to materialize.
+- `--columns`, `--fields`, `--rows`, and `--count` narrow those values.
+- Markdown, table, TSV, JSONL, and JSON use the same section and row identities.
+
+The structured document carries a schema version. Every section declares its
+stable ID, categories, accepted query inputs, field schema, legal operators, and
+typed values. A stable value ID can therefore flow from discovery or a website
+picker back into a typed query without parsing labels.
+
+## Ownership
+
+`DotnetInspector.Vocabulary` composes existing owner catalogs; it does not
+reclassify their values:
+
+- `ApiAccessibility` owns accessibility identity, order, defaults, and
+  classification.
+- `StyleOptionCatalog` owns C# style tiers, selectable choices, conflicts,
+  endorsement, and byte-divergence properties.
+
+CLI and browser/WASM consume the same `VocabularyCatalog` and
+`VocabularyJson` projection. Hosts may select a section for a purpose-specific
+control, but they do not restate its values, labels, order, defaults, or
+selection semantics.
+
+Static vocabulary answers "what may I ask?" Target-aware facets remain query
+results: they add availability, counts, or rejection reasons for one inspected
+target while retaining the static value IDs.
+
+## Current sections
+
+| Section | Stable ID | Values |
+| ------- | --------- | ------ |
+| Vocabulary Sections | `vocabulary.sections` | Available vocabulary sections |
+| Accessibility | `api.accessibility` | API accessibility facet IDs |
+| C# Style Tiers | `csharp.style-tiers` | Style fidelity/presentation tiers |
+| C# Style Choices | `csharp.style-choices` | Selectable rendering choice IDs |
+
+Body syntax kinds are deliberately not in this first slice. Their addition
+belongs with moving kind search into scoped rich queries, so vocabulary
+exposure and query consumption land together rather than preserving the
+standalone `body-shape` UX.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -108,6 +108,7 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
   discovery budgets, `-D`/`-S`, capabilities, and limiter behavior.
 - [Command transitions](design/command-transition-model.md): when source, focus, operation arity, lens, traversal, or rendering changes should switch commands versus stay within one command.
 - [Row query and ordering](design/row-query-order.md): proposed field-scoped row predicates, ordering, `--top`, and schema-discoverable defaults.
+- [Product vocabulary](design/vocabulary.md): sectioned, host-neutral legal query values shared by CLI and browser/WASM.
 - [Analysis UX scopes](design/analysis-ux-scopes.md): shared analysis vocabulary across offset, member, type, and library scopes.
 - [IL coordinate workflows](design/il-coordinate-workflows.md): prototype workflows for explaining sparse runtime coordinates from debugger, profiler, or analyzer artifacts.
 - [IL Diff canonicalization](design/il-diff-canonicalization.md): current `CanonicalIlOperation` guarantees, boundaries, and extension points.

--- a/docs/workflows/features.md
+++ b/docs/workflows/features.md
@@ -152,6 +152,7 @@
 | `--dotnet` scope | b9c3263 | 0.3.x | Default platform + extensions scope |
 | Fully qualified names | 8b1a64d | 0.5.0 | Use `System.Text.Json.JsonSerializer` as positional |
 | Multi-library package follow-up context | — | 0.8.0 | Preserve package/library context for type and member drill-in |
+| `vocabulary` command | — | 0.20.0 | Discover product-owned query-value sections shared by CLI and browser/WASM |
 
 ## Samples and Source
 

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -18,6 +18,7 @@
     <Project Path="src/DotnetInspector.ResearchQueries/DotnetInspector.ResearchQueries.csproj" />
     <Project Path="src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj" />
     <Project Path="src/DotnetInspector.Services/DotnetInspector.Services.csproj" />
+    <Project Path="src/DotnetInspector.Vocabulary/DotnetInspector.Vocabulary.csproj" />
     <Project Path="src/DotnetInspector.SourceLinkMalformedFixtures/DotnetInspector.SourceLinkMalformedFixtures.csproj" />
     <Project Path="src/DotnetInspector.SourceLinkNormalizedFixtures/DotnetInspector.SourceLinkNormalizedFixtures.csproj" />
     <Project Path="src/ILInspector.Analysis.App/ILInspector.Analysis.App.csproj" />

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -252,8 +252,8 @@ beside a product-selected compile asset).
 
 Three exports touch **no artifact at all** and say so in place: `SearchTypes`
 (ranking names the client already holds, through `TypeMatcher`),
-`PackageCacheStats`, and `ListStyleTiers`/`ListStyleOptions` (the
-`StyleOptionCatalog`).
+`PackageCacheStats`, and `ListVocabulary` (the shared product-owned vocabulary
+catalog).
 
 `QueryPackageIntegrations` groups the query's own
 `EcosystemIntegrationSignalInfo` values by the integration name the scanner
@@ -437,8 +437,9 @@ not answer report the engine's failure rather than fixture results.
 - Arrow keys or `j`/`k` navigate the type index.
 - Number keys switch the active scope's lenses when an input is not focused.
 - `share` copies the package, version, framework, type, and lens selection.
-- The Taste popover and Settings page render their groups, summaries, and
-  ordering from `StyleOptionCatalog`; the browser does not restate that taxonomy.
+- The Taste popover and Settings page consume the same `C# Style Tiers` and
+  `C# Style Choices` vocabulary sections as the CLI; the browser does not
+  restate their taxonomy.
 
 ## Deploy
 

--- a/prototypes/inspect-web/engine.Tests/BrowserStyleOptionsTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserStyleOptionsTests.cs
@@ -8,23 +8,33 @@ namespace InspectWeb.Engine.Tests;
 public sealed class BrowserStyleOptionsTests
 {
     [Fact]
-    public void ListStyleOptions_ProjectsProductOwnedChoices()
+    public void ListVocabulary_ProjectsProductOwnedStyleChoices()
     {
-        BrowserStyleOption[] actual = JsonSerializer.Deserialize(
-            BrowserInspectionEngine.ListStyleOptions(),
-            BrowserJsonContext.Default.BrowserStyleOptionArray) ?? [];
+        using JsonDocument document = JsonDocument.Parse(
+            BrowserInspectionEngine.ListVocabulary());
+        JsonElement actual = document.RootElement
+            .GetProperty("sections")
+            .EnumerateArray()
+            .Single(section =>
+                section.GetProperty("id").GetString()
+                    == "csharp.style-choices")
+            .GetProperty("values");
 
-        Assert.Equal(Pipeline.StyleOptionCatalog.Choices.Count, actual.Length);
-        for (int i = 0; i < actual.Length; i++)
+        Assert.Equal(Pipeline.StyleOptionCatalog.Choices.Count, actual.GetArrayLength());
+        for (int i = 0; i < actual.GetArrayLength(); i++)
         {
             Pipeline.StyleOptionChoice expected = Pipeline.StyleOptionCatalog.Choices[i];
-            Assert.Equal(expected.Id, actual[i].Id);
-            Assert.Equal(expected.Title, actual[i].Title);
-            Assert.Equal(expected.Summary, actual[i].Summary);
-            Assert.Equal(expected.Tier.ToString(), actual[i].Tier);
-            Assert.Equal(expected.ByteDivergent, actual[i].ByteDivergent);
-            Assert.Equal(expected.OracleEndorsed, actual[i].OracleEndorsed);
-            Assert.Equal(expected.ConflictGroup, actual[i].ConflictGroup);
+            Assert.Equal(expected.Id, actual[i].GetProperty("id").GetString());
+            Assert.Equal(expected.Title, actual[i].GetProperty("title").GetString());
+            Assert.Equal(expected.Summary, actual[i].GetProperty("summary").GetString());
+            Assert.Equal(expected.Tier.ToString(), actual[i].GetProperty("tier").GetString());
+            Assert.Equal(expected.ByteDivergent, actual[i].GetProperty("byte_divergent").GetBoolean());
+            Assert.Equal(expected.OracleEndorsed, actual[i].GetProperty("oracle_endorsed").GetBoolean());
+            Assert.Equal(
+                expected.ConflictGroup,
+                actual[i].TryGetProperty("conflict_group", out JsonElement conflict)
+                    ? conflict.GetString()
+                    : null);
         }
     }
 

--- a/prototypes/inspect-web/engine/BrowserContracts.cs
+++ b/prototypes/inspect-web/engine/BrowserContracts.cs
@@ -279,22 +279,6 @@ public sealed record BrowserAnnotatedSource(
     string Provenance,
     string? ContextLimitation);
 
-public sealed record BrowserStyleOption(
-    string Id,
-    string Title,
-    string Summary,
-    string Tier,
-    bool ByteDivergent,
-    bool OracleEndorsed,
-    string? ConflictGroup);
-
-public sealed record BrowserStyleTier(
-    string Id,
-    string Title,
-    string Summary,
-    int Order,
-    bool ByteDivergent);
-
 /// <summary>
 /// Ecosystem integration evidence for one workspace, carried exactly as
 /// <c>AssemblyContextIntegrationsQuery</c> produced it: one group per package/version/framework,
@@ -424,7 +408,5 @@ public sealed record BrowserWorkspacePackage(
 [JsonSerializable(typeof(BrowserWorkspacePackage[]))]
 [JsonSerializable(typeof(BrowserTypeCandidate[]))]
 [JsonSerializable(typeof(BrowserTypeSearchHit[]))]
-[JsonSerializable(typeof(BrowserStyleOption[]))]
-[JsonSerializable(typeof(BrowserStyleTier[]))]
 [JsonSerializable(typeof(string[]))]
 internal sealed partial class BrowserJsonContext : JsonSerializerContext;

--- a/prototypes/inspect-web/engine/BrowserInspectionEngine.cs
+++ b/prototypes/inspect-web/engine/BrowserInspectionEngine.cs
@@ -928,34 +928,12 @@ public static partial class BrowserInspectionEngine
             BrowserJsonContext.Default.BrowserDependencyCoordinateMatch);
     }
 
-    // The library-owned StyleOptionCatalog is the single source of truth for the decompiler style
-    // taxonomy. These records carry its data across the Wasm boundary; the host retains no labels,
-    // summaries, or ordering of its own. Neither listing inspects an artifact.
+    // Vocabulary is product-owned static data. The browser receives the same section/field/value
+    // document as the CLI and retains no separate labels, ordering, defaults, or query semantics.
     [JSExport]
-    public static string ListStyleTiers() => JsonSerializer.Serialize(
-        Pipeline.StyleOptionCatalog.Tiers
-            .Select(tier => new BrowserStyleTier(
-                tier.Id.ToString(),
-                tier.Title,
-                tier.Summary,
-                tier.Order,
-                tier.ByteDivergent))
-            .ToArray(),
-        BrowserJsonContext.Default.BrowserStyleTierArray);
-
-    [JSExport]
-    public static string ListStyleOptions() => JsonSerializer.Serialize(
-        Pipeline.StyleOptionCatalog.Choices
-            .Select(choice => new BrowserStyleOption(
-                choice.Id,
-                choice.Title,
-                choice.Summary,
-                choice.Tier.ToString(),
-                choice.ByteDivergent,
-                choice.OracleEndorsed,
-                choice.ConflictGroup))
-            .ToArray(),
-        BrowserJsonContext.Default.BrowserStyleOptionArray);
+    public static string ListVocabulary() =>
+        DotnetInspector.Vocabulary.VocabularyJson.Serialize(
+            DotnetInspector.Vocabulary.VocabularyCatalog.Document);
 
     /// <summary>
     /// Resolves one exact package/version/framework coordinate, reuses its workspace, and returns

--- a/prototypes/inspect-web/engine/BrowserStyleOptions.cs
+++ b/prototypes/inspect-web/engine/BrowserStyleOptions.cs
@@ -9,10 +9,10 @@ namespace InspectWeb.Engine;
 /// the library-owned <see cref="Pipeline.StyleOptionCatalog"/>.
 /// </summary>
 /// <remarks>
-/// The ids are exactly the product-owned <see cref="Pipeline.StyleOptionCatalog.Choices"/> that
-/// <c>ListStyleOptions</c> handed the client. The host only decodes the transport; identity,
-/// defaults, conflicts, and selection semantics remain in the product catalog. An id the catalog
-/// does not know is a visible failure rather than a silently ignored selection.
+/// The ids are exactly the product-owned <see cref="Pipeline.StyleOptionCatalog.Choices"/> exposed
+/// in the <c>csharp.style-choices</c> vocabulary section. The host only decodes the transport;
+/// identity, defaults, conflicts, and selection semantics remain in the product catalog. An id
+/// the catalog does not know is a visible failure rather than a silently ignored selection.
 /// </remarks>
 [SupportedOSPlatform("browser")]
 internal static class BrowserStyleOptions

--- a/prototypes/inspect-web/engine/InspectWeb.Engine.csproj
+++ b/prototypes/inspect-web/engine/InspectWeb.Engine.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\..\..\src\DotnetInspector.Queries\DotnetInspector.Queries.csproj" />
     <ProjectReference Include="..\..\..\src\DotnetInspector.ResearchQueries\DotnetInspector.ResearchQueries.csproj" />
     <ProjectReference Include="..\..\..\src\DotnetInspector.Services\DotnetInspector.Services.csproj" />
+    <ProjectReference Include="..\..\..\src\DotnetInspector.Vocabulary\DotnetInspector.Vocabulary.csproj" />
     <ProjectReference Include="..\..\..\src\CSharpText\CSharpText.csproj" />
     <ProjectReference Include="..\..\..\src\ILInspector.Metadata\ILInspector.Metadata.csproj" />
     <ProjectReference Include="..\..\..\src\DotnetInspector.CSharpBodySlicer\DotnetInspector.CSharpBodySlicer.csproj" />

--- a/prototypes/inspect-web/engine/wwwroot/engine.js
+++ b/prototypes/inspect-web/engine/wwwroot/engine.js
@@ -30,8 +30,7 @@ let loadRuntimePackAssembly;
 let queryMemberDocumentation;
 let queryMemberFacts;
 let searchTypes;
-let listStyleTiers;
-let listStyleOptions;
+let listVocabulary;
 let packageCacheStats;
 let buildIdentity;
 
@@ -70,8 +69,7 @@ export async function initializeEngine(onStatus = () => {}) {
   queryMemberDocumentation = exports.BrowserInspectionEngine.QueryMemberDocumentation;
   queryMemberFacts = exports.BrowserInspectionEngine.QueryMemberFacts;
   searchTypes = exports.BrowserInspectionEngine.SearchTypes;
-  listStyleTiers = exports.BrowserInspectionEngine.ListStyleTiers;
-  listStyleOptions = exports.BrowserInspectionEngine.ListStyleOptions;
+  listVocabulary = exports.BrowserInspectionEngine.ListVocabulary;
   packageCacheStats = exports.BrowserInspectionEngine.PackageCacheStats;
   buildIdentity = exports.BrowserInspectionEngine.BuildIdentity;
   await runtime.runMain();
@@ -307,14 +305,9 @@ export async function inspectTypeSource(request) {
   return JSON.parse(json);
 }
 
-export async function inspectListStyleOptions() {
-  if (!listStyleOptions) throw new Error("The browser inspection engine is not initialized.");
-  return JSON.parse(await listStyleOptions());
-}
-
-export async function inspectListStyleTiers() {
-  if (!listStyleTiers) throw new Error("The browser inspection engine is not initialized.");
-  return JSON.parse(await listStyleTiers());
+export async function inspectVocabulary() {
+  if (!listVocabulary) throw new Error("The browser inspection engine is not initialized.");
+  return JSON.parse(await listVocabulary());
 }
 
 export function inspectPackageCacheStats() {

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -42,8 +42,7 @@ import { loadPlatformIndex } from "/src/platform-index.js";
 let initializeEngine;
 let inspectBuildIdentity;
 let inspectExpandPlatformCallGraph;
-let inspectListStyleOptions;
-let inspectListStyleTiers;
+let inspectVocabulary;
 let inspectLoadRuntimePack;
 let inspectLoadRuntimePackAssembly;
 let inspectMemberAnnotatedSource;
@@ -80,8 +79,7 @@ async function loadEngineModule() {
     initializeEngine,
     inspectBuildIdentity,
     inspectExpandPlatformCallGraph,
-    inspectListStyleOptions,
-    inspectListStyleTiers,
+    inspectVocabulary,
     inspectLoadRuntimePack,
     inspectLoadRuntimePackAssembly,
     inspectMemberAnnotatedSource,
@@ -7477,14 +7475,14 @@ function styleCatalogGroupsHtml() {
       <div class="taste-group">
         <div class="taste-group-head">
           <div class="taste-group-title">${escapeHtml(tier.title)}</div>
-          ${tier.byteDivergent ? '<em class="taste-badge divergent">byte-divergent</em>' : ""}
+          ${tier.byte_divergent ? '<em class="taste-badge divergent">byte-divergent</em>' : ""}
         </div>
         <div class="taste-group-summary">${escapeHtml(tier.summary)}</div>
         ${options.filter(option => option.tier === tier.id).map(option => `
           <label class="taste-item">
             <input type="checkbox" data-taste="${escapeHtml(option.id)}" ${state.taste.includes(option.id) ? "checked" : ""} />
             <span class="taste-item-text">
-              <span class="taste-item-title">${escapeHtml(option.title)}${option.oracleEndorsed ? '<em class="taste-badge oracle">oracle</em>' : ""}</span>
+              <span class="taste-item-title">${escapeHtml(option.title)}${option.oracle_endorsed ? '<em class="taste-badge oracle">oracle</em>' : ""}</span>
               <span class="taste-item-summary">${escapeHtml(option.summary)}</span>
             </span>
           </label>`).join("")}
@@ -7532,9 +7530,9 @@ function toggleTaste(id) {
   if (state.taste.includes(id)) {
     state.taste = state.taste.filter(item => item !== id);
   } else {
-    if (option?.conflictGroup) {
+    if (option?.conflict_group) {
       const groupIds = (state.styleOptions || [])
-        .filter(item => item.conflictGroup === option.conflictGroup)
+        .filter(item => item.conflict_group === option.conflict_group)
         .map(item => item.id);
       state.taste = state.taste.filter(item => !groupIds.includes(item));
     }
@@ -8301,10 +8299,10 @@ async function bootstrap() {
     state.buildIdentity = inspectBuildIdentity();
     const tEngine = performance.now();
     try {
-      [state.styleTiers, state.styleOptions] = await Promise.all([
-        inspectListStyleTiers(),
-        inspectListStyleOptions()
-      ]);
+      const vocabulary = await inspectVocabulary();
+      const sections = vocabulary?.sections || [];
+      state.styleTiers = sections.find(section => section.id === "csharp.style-tiers")?.values || [];
+      state.styleOptions = sections.find(section => section.id === "csharp.style-choices")?.values || [];
     } catch (error) {
       state.styleTiers = [];
       state.styleOptions = [];

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -22,6 +22,7 @@ dnx dotnet-inspect -y -- <command>
 | Inspect a type | `type Type --package Foo`; add `--all` for non-public/hidden members. |
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
+| Discover legal query values | `vocabulary -D`; select values with `vocabulary -S Accessibility` or `-S "C# Style Choices" --json`. |
 | Find rendered body syntax | `body-shape ObjectCreationExpression --library path/to.dll`; load `skill decompiler` for stable kinds and coordinates. |
 | Compare APIs | `diff --package Foo@old..new --breaking` (`--additive` new APIs); `--alloc-regressions` for perf regressions (allocations up, hot first). |
 | Trace API evolution | `timeline --package Foo@old..new --type Type --members --at all`; omit `--at` to inspect the vector without acquiring packages. |

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -32,8 +32,7 @@ dnx dotnet-inspect -y -- <command>
 
 ## Member lookup
 
-Run `find Name` when scope is unknown, inspect the type, then `-S "Member Index"` to list overloads.
-Select with `Name:N` (1-based) or `Name~digest` (stable). A selected overload
+Run `find Name` when scope is unknown, inspect the type, then `-S "Member Index"` to list overloads. Select with `Name:N` (1-based) or `Name~digest` (stable). A selected overload
 defaults to `Signature`. A fully-qualified `Namespace.Type.Member` needs no scope.
 
 ```bash

--- a/src/DotnetInspector.Queries/AssemblyContextApiSurfaceQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextApiSurfaceQuery.cs
@@ -73,6 +73,13 @@ public static class ApiAccessibility
     static readonly ApiAccessibilityBucket PrivateBucket =
         new("private", "private", 3, IsDefault: false, Count: 0);
 
+    /// <summary>
+    /// Every product-owned accessibility value in query and presentation order, without
+    /// target-specific counts.
+    /// </summary>
+    public static ImmutableArray<ApiAccessibilityBucket> Values { get; } =
+        [PublicBucket, ProtectedBucket, InternalBucket, PrivateBucket];
+
     /// <summary>The bucket one accessibility spelling belongs to, with a zero count.</summary>
     public static ApiAccessibilityBucket Classify(string? accessibility)
     {
@@ -106,7 +113,7 @@ public static class ApiAccessibility
 
         return
         [
-            .. new[] { PublicBucket, ProtectedBucket, InternalBucket, PrivateBucket }
+            .. Values
                 .Where(bucket => bucket.IsDefault || counts.ContainsKey(bucket.Id))
                 .Select(bucket => bucket with
                 {

--- a/src/DotnetInspector.Vocabulary/DotnetInspector.Vocabulary.csproj
+++ b/src/DotnetInspector.Vocabulary/DotnetInspector.Vocabulary.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Richard Lander</Authors>
+    <Description>Product-owned query vocabularies for dotnet-inspect consumers</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotnetInspector.Queries\DotnetInspector.Queries.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler\ILInspector.Decompiler.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/DotnetInspector.Vocabulary/VocabularyCatalog.cs
+++ b/src/DotnetInspector.Vocabulary/VocabularyCatalog.cs
@@ -206,24 +206,29 @@ public static class VocabularyCatalog
             TextListField("accepted_by", "Accepted By", "Typed query inputs that consume these values.", VocabularyOperator.Contains),
             IntegerField("values", "Values", "Number of legal values.", VocabularyOperator.Equals, VocabularyOperator.LessThan, VocabularyOperator.GreaterThan),
         ];
-        ImmutableArray<VocabularyRow> rows =
-        [
-            .. sections.Select(section => new VocabularyRow(
-                ("id", VocabularyValue.FromText(section.Id)),
-                ("section", VocabularyValue.FromText(section.Name)),
-                ("summary", VocabularyValue.FromText(section.Summary)),
-                ("categories", VocabularyValue.FromTextList(section.Categories)),
-                ("accepted_by", VocabularyValue.FromTextList(section.AcceptedBy)),
-                ("values", VocabularyValue.FromInteger(section.Values.Length)))),
-        ];
-        return new(
+        var definition = new VocabularySection(
             "vocabulary.sections",
             SectionsSection,
             "Product-owned vocabularies available as rich-query inputs.",
             ["@Vocabulary"],
             ["vocabulary"],
             fields,
-            rows);
+            []);
+        ImmutableArray<VocabularySection> indexedSections = [definition, .. sections];
+        ImmutableArray<VocabularyRow> rows =
+        [
+            .. indexedSections.Select(section => new VocabularyRow(
+                ("id", VocabularyValue.FromText(section.Id)),
+                ("section", VocabularyValue.FromText(section.Name)),
+                ("summary", VocabularyValue.FromText(section.Summary)),
+                ("categories", VocabularyValue.FromTextList(section.Categories)),
+                ("accepted_by", VocabularyValue.FromTextList(section.AcceptedBy)),
+                ("values", VocabularyValue.FromInteger(
+                    ReferenceEquals(section, definition)
+                        ? indexedSections.Length
+                        : section.Values.Length)))),
+        ];
+        return definition with { Values = rows };
     }
 
     private static VocabularySection CreateAccessibility()

--- a/src/DotnetInspector.Vocabulary/VocabularyCatalog.cs
+++ b/src/DotnetInspector.Vocabulary/VocabularyCatalog.cs
@@ -1,0 +1,398 @@
+using System.Collections.Immutable;
+using System.Globalization;
+
+using DotnetInspector.Queries;
+using ILInspector.Decompiler.Pipeline;
+
+namespace DotnetInspector.Vocabulary;
+
+/// <summary>The primitive shape of one vocabulary field.</summary>
+public enum VocabularyValueKind
+{
+    /// <summary>One text value.</summary>
+    Text,
+
+    /// <summary>One integer value.</summary>
+    Integer,
+
+    /// <summary>One Boolean value.</summary>
+    Boolean,
+
+    /// <summary>An ordered list of text values.</summary>
+    TextList,
+}
+
+/// <summary>An operator a rich query may apply to a vocabulary field.</summary>
+public enum VocabularyOperator
+{
+    /// <summary>Exact equality.</summary>
+    Equals,
+
+    /// <summary>Exact inequality.</summary>
+    NotEquals,
+
+    /// <summary>Membership in a set.</summary>
+    In,
+
+    /// <summary>Ordered less-than comparison.</summary>
+    LessThan,
+
+    /// <summary>Ordered greater-than comparison.</summary>
+    GreaterThan,
+
+    /// <summary>String glob matching.</summary>
+    Glob,
+
+    /// <summary>Membership of one value in a list-valued field.</summary>
+    Contains,
+}
+
+/// <summary>The discoverable contract of one field in a vocabulary section.</summary>
+public sealed record VocabularyField(
+    string Id,
+    string Label,
+    string Summary,
+    VocabularyValueKind Kind,
+    ImmutableArray<VocabularyOperator> Operators);
+
+/// <summary>One typed cell in a vocabulary value row.</summary>
+public readonly record struct VocabularyValue
+{
+    private VocabularyValue(
+        VocabularyValueKind kind,
+        string? text,
+        int integer,
+        bool boolean,
+        ImmutableArray<string> textList)
+    {
+        Kind = kind;
+        Text = text;
+        Integer = integer;
+        Boolean = boolean;
+        TextList = textList;
+    }
+
+    /// <summary>The cell's primitive shape.</summary>
+    public VocabularyValueKind Kind { get; }
+
+    /// <summary>The text payload when <see cref="Kind"/> is <see cref="VocabularyValueKind.Text"/>.</summary>
+    public string? Text { get; }
+
+    /// <summary>The integer payload when <see cref="Kind"/> is <see cref="VocabularyValueKind.Integer"/>.</summary>
+    public int Integer { get; }
+
+    /// <summary>The Boolean payload when <see cref="Kind"/> is <see cref="VocabularyValueKind.Boolean"/>.</summary>
+    public bool Boolean { get; }
+
+    /// <summary>The list payload when <see cref="Kind"/> is <see cref="VocabularyValueKind.TextList"/>.</summary>
+    public ImmutableArray<string> TextList { get; }
+
+    /// <summary>Creates a text value.</summary>
+    public static VocabularyValue FromText(string value) =>
+        new(VocabularyValueKind.Text, value, 0, false, []);
+
+    /// <summary>Creates an integer value.</summary>
+    public static VocabularyValue FromInteger(int value) =>
+        new(VocabularyValueKind.Integer, null, value, false, []);
+
+    /// <summary>Creates a Boolean value.</summary>
+    public static VocabularyValue FromBoolean(bool value) =>
+        new(VocabularyValueKind.Boolean, null, 0, value, []);
+
+    /// <summary>Creates an ordered text-list value.</summary>
+    public static VocabularyValue FromTextList(IEnumerable<string> values) =>
+        new(VocabularyValueKind.TextList, null, 0, false, [.. values]);
+
+    /// <summary>Formats the value for a tabular projection.</summary>
+    public string ToDisplayString() => Kind switch
+    {
+        VocabularyValueKind.Text => Text ?? "",
+        VocabularyValueKind.Integer => Integer.ToString(CultureInfo.InvariantCulture),
+        VocabularyValueKind.Boolean => Boolean ? "true" : "false",
+        VocabularyValueKind.TextList => string.Join(", ", TextList),
+        _ => throw new InvalidOperationException($"Unsupported vocabulary value kind '{Kind}'."),
+    };
+}
+
+/// <summary>One stable query value and its data fields.</summary>
+public sealed record VocabularyRow
+{
+    private readonly IReadOnlyDictionary<string, VocabularyValue> _values;
+
+    /// <summary>Creates one row from unique field/value cells.</summary>
+    public VocabularyRow(params (string Field, VocabularyValue Value)[] values)
+    {
+        var cells = new Dictionary<string, VocabularyValue>(StringComparer.Ordinal);
+        foreach ((string field, VocabularyValue value) in values)
+        {
+            if (!cells.TryAdd(field, value))
+                throw new ArgumentException($"Vocabulary field '{field}' occurs more than once.", nameof(values));
+        }
+        _values = cells;
+    }
+
+    /// <summary>Returns whether this row carries <paramref name="field"/>.</summary>
+    public bool TryGetValue(string field, out VocabularyValue value) =>
+        _values.TryGetValue(field, out value);
+
+    /// <summary>Returns one required field value.</summary>
+    public VocabularyValue GetRequired(string field) =>
+        _values.TryGetValue(field, out VocabularyValue value)
+            ? value
+            : throw new InvalidOperationException($"Vocabulary row does not define required field '{field}'.");
+}
+
+/// <summary>One discoverable vocabulary section whose rows are legal query values.</summary>
+public sealed record VocabularySection(
+    string Id,
+    string Name,
+    string Summary,
+    ImmutableArray<string> Categories,
+    ImmutableArray<string> AcceptedBy,
+    ImmutableArray<VocabularyField> Fields,
+    ImmutableArray<VocabularyRow> Values);
+
+/// <summary>The complete static product-owned vocabulary document.</summary>
+public sealed record VocabularyDocument(
+    int SchemaVersion,
+    ImmutableArray<VocabularySection> Sections);
+
+/// <summary>Composes product-owned query vocabularies without reclassifying their values.</summary>
+public static class VocabularyCatalog
+{
+    /// <summary>The section that describes the vocabulary sections themselves.</summary>
+    public const string SectionsSection = "Vocabulary Sections";
+
+    /// <summary>The API accessibility vocabulary section.</summary>
+    public const string AccessibilitySection = "Accessibility";
+
+    /// <summary>The C# style-tier vocabulary section.</summary>
+    public const string StyleTiersSection = "C# Style Tiers";
+
+    /// <summary>The selectable C# style-choice vocabulary section.</summary>
+    public const string StyleChoicesSection = "C# Style Choices";
+
+    /// <summary>The current static vocabulary document.</summary>
+    public static VocabularyDocument Document { get; } = CreateDocument();
+
+    /// <summary>Returns the section with the exact stable <paramref name="id"/>.</summary>
+    public static VocabularySection GetById(string id) =>
+        Document.Sections.FirstOrDefault(section => section.Id == id)
+        ?? throw new ArgumentException($"Unknown vocabulary section ID '{id}'.", nameof(id));
+
+    private static VocabularyDocument CreateDocument()
+    {
+        ImmutableArray<VocabularySection> values =
+        [
+            CreateAccessibility(),
+            CreateStyleTiers(),
+            CreateStyleChoices(),
+        ];
+        VocabularySection index = CreateSectionIndex(values);
+        var document = new VocabularyDocument(1, [index, .. values]);
+        Validate(document);
+        return document;
+    }
+
+    private static VocabularySection CreateSectionIndex(
+        ImmutableArray<VocabularySection> sections)
+    {
+        ImmutableArray<VocabularyField> fields =
+        [
+            TextField("id", "ID", "Stable section identity.", VocabularyOperator.Equals, VocabularyOperator.NotEquals, VocabularyOperator.In),
+            TextField("section", "Section", "Human-facing section name.", VocabularyOperator.Equals, VocabularyOperator.NotEquals, VocabularyOperator.Glob),
+            TextField("summary", "Summary", "What the vocabulary values control.", VocabularyOperator.Glob),
+            TextListField("categories", "Categories", "Section categories.", VocabularyOperator.Contains),
+            TextListField("accepted_by", "Accepted By", "Typed query inputs that consume these values.", VocabularyOperator.Contains),
+            IntegerField("values", "Values", "Number of legal values.", VocabularyOperator.Equals, VocabularyOperator.LessThan, VocabularyOperator.GreaterThan),
+        ];
+        ImmutableArray<VocabularyRow> rows =
+        [
+            .. sections.Select(section => new VocabularyRow(
+                ("id", VocabularyValue.FromText(section.Id)),
+                ("section", VocabularyValue.FromText(section.Name)),
+                ("summary", VocabularyValue.FromText(section.Summary)),
+                ("categories", VocabularyValue.FromTextList(section.Categories)),
+                ("accepted_by", VocabularyValue.FromTextList(section.AcceptedBy)),
+                ("values", VocabularyValue.FromInteger(section.Values.Length)))),
+        ];
+        return new(
+            "vocabulary.sections",
+            SectionsSection,
+            "Product-owned vocabularies available as rich-query inputs.",
+            ["@Vocabulary"],
+            ["vocabulary"],
+            fields,
+            rows);
+    }
+
+    private static VocabularySection CreateAccessibility()
+    {
+        ImmutableArray<VocabularyField> fields =
+        [
+            TextField("id", "ID", "Stable accessibility selection identity.", VocabularyOperator.Equals, VocabularyOperator.NotEquals, VocabularyOperator.In),
+            TextField("label", "Label", "Product-owned display label.", VocabularyOperator.Equals, VocabularyOperator.Glob),
+            IntegerField("order", "Order", "Product-owned presentation order.", VocabularyOperator.Equals, VocabularyOperator.LessThan, VocabularyOperator.GreaterThan),
+            BooleanField("default", "Default", "Whether this value participates without an explicit selection."),
+        ];
+        ImmutableArray<VocabularyRow> rows =
+        [
+            .. ApiAccessibility.Values.Select(bucket => new VocabularyRow(
+                ("id", VocabularyValue.FromText(bucket.Id)),
+                ("label", VocabularyValue.FromText(bucket.Label)),
+                ("order", VocabularyValue.FromInteger(bucket.Order)),
+                ("default", VocabularyValue.FromBoolean(bucket.IsDefault)))),
+        ];
+        return new(
+            "api.accessibility",
+            AccessibilitySection,
+            "Accessibility facets accepted by API type and member inventory queries.",
+            ["@Vocabulary", "@API"],
+            ["api.type-inventory", "api.member-inventory"],
+            fields,
+            rows);
+    }
+
+    private static VocabularySection CreateStyleTiers()
+    {
+        ImmutableArray<VocabularyField> fields =
+        [
+            TextField("id", "ID", "Stable style-tier identity.", VocabularyOperator.Equals, VocabularyOperator.NotEquals, VocabularyOperator.In),
+            TextField("title", "Title", "Product-owned tier title.", VocabularyOperator.Equals, VocabularyOperator.Glob),
+            TextField("summary", "Summary", "The fidelity contract of this tier.", VocabularyOperator.Glob),
+            IntegerField("order", "Order", "Product-owned presentation order.", VocabularyOperator.Equals, VocabularyOperator.LessThan, VocabularyOperator.GreaterThan),
+            BooleanField("byte_divergent", "Byte Divergent", "Whether every choice in the tier may change emitted IL bytes."),
+        ];
+        ImmutableArray<VocabularyRow> rows =
+        [
+            .. StyleOptionCatalog.Tiers.Select(tier => new VocabularyRow(
+                ("id", VocabularyValue.FromText(tier.Id.ToString())),
+                ("title", VocabularyValue.FromText(tier.Title)),
+                ("summary", VocabularyValue.FromText(tier.Summary)),
+                ("order", VocabularyValue.FromInteger(tier.Order)),
+                ("byte_divergent", VocabularyValue.FromBoolean(tier.ByteDivergent)))),
+        ];
+        return new(
+            "csharp.style-tiers",
+            StyleTiersSection,
+            "Fidelity and presentation tiers used to group C# style choices.",
+            ["@Vocabulary", "@Decompiler"],
+            ["decompiler.style-picker"],
+            fields,
+            rows);
+    }
+
+    private static VocabularySection CreateStyleChoices()
+    {
+        ImmutableArray<VocabularyField> fields =
+        [
+            TextField("id", "ID", "Stable selectable style-choice identity.", VocabularyOperator.Equals, VocabularyOperator.NotEquals, VocabularyOperator.In),
+            TextField("option", "Option", "Owning style option identity.", VocabularyOperator.Equals, VocabularyOperator.NotEquals, VocabularyOperator.In),
+            TextField("value", "Value", "Selected value token on the owning option axis.", VocabularyOperator.Equals, VocabularyOperator.NotEquals, VocabularyOperator.In),
+            TextField("title", "Title", "Product-owned picker label.", VocabularyOperator.Equals, VocabularyOperator.Glob),
+            TextField("summary", "Summary", "What the choice changes.", VocabularyOperator.Glob),
+            TextField("tier", "Tier", "Owning fidelity/presentation tier.", VocabularyOperator.Equals, VocabularyOperator.NotEquals, VocabularyOperator.In),
+            BooleanField("byte_divergent", "Byte Divergent", "Whether this choice may change emitted IL bytes."),
+            BooleanField("oracle_endorsed", "Oracle Endorsed", "Whether the declared runtime style oracle endorses this choice."),
+            BooleanField("corpus_endorsed", "Corpus Endorsed", "Whether the runtime source corpus endorses this choice."),
+            TextField("conflict_group", "Conflict Group", "Product-owned mutually-exclusive selection group.", VocabularyOperator.Equals, VocabularyOperator.NotEquals, VocabularyOperator.In),
+        ];
+        ImmutableArray<VocabularyRow> rows =
+        [
+            .. StyleOptionCatalog.Choices.Select(choice =>
+            {
+                var values = new List<(string, VocabularyValue)>
+                {
+                    ("id", VocabularyValue.FromText(choice.Id)),
+                    ("option", VocabularyValue.FromText(choice.OptionId)),
+                    ("value", VocabularyValue.FromText(choice.ValueToken)),
+                    ("title", VocabularyValue.FromText(choice.Title)),
+                    ("summary", VocabularyValue.FromText(choice.Summary)),
+                    ("tier", VocabularyValue.FromText(choice.Tier.ToString())),
+                    ("byte_divergent", VocabularyValue.FromBoolean(choice.ByteDivergent)),
+                    ("oracle_endorsed", VocabularyValue.FromBoolean(choice.OracleEndorsed)),
+                    ("corpus_endorsed", VocabularyValue.FromBoolean(choice.CorpusEndorsed)),
+                };
+                if (choice.ConflictGroup is not null)
+                    values.Add(("conflict_group", VocabularyValue.FromText(choice.ConflictGroup)));
+                return new VocabularyRow([.. values]);
+            }),
+        ];
+        return new(
+            "csharp.style-choices",
+            StyleChoicesSection,
+            "Selectable product-owned C# rendering choices.",
+            ["@Vocabulary", "@Decompiler"],
+            ["decompiler.style-picker", "decompiler.render"],
+            fields,
+            rows);
+    }
+
+    private static VocabularyField TextField(
+        string id,
+        string label,
+        string summary,
+        params VocabularyOperator[] operators) =>
+        new(id, label, summary, VocabularyValueKind.Text, [.. operators]);
+
+    private static VocabularyField IntegerField(
+        string id,
+        string label,
+        string summary,
+        params VocabularyOperator[] operators) =>
+        new(id, label, summary, VocabularyValueKind.Integer, [.. operators]);
+
+    private static VocabularyField BooleanField(
+        string id,
+        string label,
+        string summary) =>
+        new(
+            id,
+            label,
+            summary,
+            VocabularyValueKind.Boolean,
+            [VocabularyOperator.Equals, VocabularyOperator.NotEquals]);
+
+    private static VocabularyField TextListField(
+        string id,
+        string label,
+        string summary,
+        params VocabularyOperator[] operators) =>
+        new(id, label, summary, VocabularyValueKind.TextList, [.. operators]);
+
+    private static void Validate(VocabularyDocument document)
+    {
+        var sectionIds = new HashSet<string>(StringComparer.Ordinal);
+        var sectionNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (VocabularySection section in document.Sections)
+        {
+            if (!sectionIds.Add(section.Id))
+                throw new InvalidOperationException($"Vocabulary section ID '{section.Id}' occurs more than once.");
+            if (!sectionNames.Add(section.Name))
+                throw new InvalidOperationException($"Vocabulary section name '{section.Name}' occurs more than once.");
+
+            var fields = section.Fields.ToDictionary(field => field.Id, StringComparer.Ordinal);
+            if (!fields.ContainsKey("id"))
+                throw new InvalidOperationException($"Vocabulary section '{section.Id}' has no identity field.");
+
+            var valueIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (VocabularyRow row in section.Values)
+            {
+                foreach (VocabularyField field in section.Fields)
+                {
+                    if (!row.TryGetValue(field.Id, out VocabularyValue value))
+                        continue;
+                    if (value.Kind != field.Kind)
+                    {
+                        throw new InvalidOperationException(
+                            $"Vocabulary section '{section.Id}' field '{field.Id}' expects {field.Kind} but received {value.Kind}.");
+                    }
+                }
+
+                VocabularyValue id = row.GetRequired("id");
+                if (id.Kind != VocabularyValueKind.Text || !valueIds.Add(id.Text!))
+                    throw new InvalidOperationException($"Vocabulary section '{section.Id}' has a duplicate or non-text value ID.");
+            }
+        }
+    }
+}

--- a/src/DotnetInspector.Vocabulary/VocabularyJson.cs
+++ b/src/DotnetInspector.Vocabulary/VocabularyJson.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using System.Text.Json;
+
+namespace DotnetInspector.Vocabulary;
+
+/// <summary>NativeAOT-safe JSON projection for vocabulary documents.</summary>
+public static class VocabularyJson
+{
+    /// <summary>Serializes the selected vocabulary sections as one structured document.</summary>
+    public static string Serialize(
+        VocabularyDocument document,
+        IEnumerable<VocabularySection>? sections = null,
+        bool indented = true)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(
+            stream,
+            new JsonWriterOptions { Indented = indented }))
+        {
+            Write(writer, document, sections ?? document.Sections);
+        }
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    /// <summary>Writes the selected vocabulary sections as one structured document.</summary>
+    public static void Write(
+        Utf8JsonWriter writer,
+        VocabularyDocument document,
+        IEnumerable<VocabularySection> sections)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(sections);
+
+        writer.WriteStartObject();
+        writer.WriteNumber("schema_version", document.SchemaVersion);
+        writer.WriteStartArray("sections");
+        foreach (VocabularySection section in sections)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("id", section.Id);
+            writer.WriteString("name", section.Name);
+            writer.WriteString("summary", section.Summary);
+            WriteStrings(writer, "categories", section.Categories);
+            WriteStrings(writer, "accepted_by", section.AcceptedBy);
+
+            writer.WriteStartArray("fields");
+            foreach (VocabularyField field in section.Fields)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("id", field.Id);
+                writer.WriteString("label", field.Label);
+                writer.WriteString("summary", field.Summary);
+                writer.WriteString("type", Name(field.Kind));
+                writer.WriteStartArray("operators");
+                foreach (VocabularyOperator value in field.Operators)
+                    writer.WriteStringValue(Name(value));
+                writer.WriteEndArray();
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+
+            writer.WriteStartArray("values");
+            foreach (VocabularyRow row in section.Values)
+            {
+                writer.WriteStartObject();
+                foreach (VocabularyField field in section.Fields)
+                {
+                    if (!row.TryGetValue(field.Id, out VocabularyValue value))
+                        continue;
+                    writer.WritePropertyName(field.Id);
+                    WriteValue(writer, value);
+                }
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+
+    private static void WriteValue(Utf8JsonWriter writer, VocabularyValue value)
+    {
+        switch (value.Kind)
+        {
+            case VocabularyValueKind.Text:
+                writer.WriteStringValue(value.Text);
+                break;
+            case VocabularyValueKind.Integer:
+                writer.WriteNumberValue(value.Integer);
+                break;
+            case VocabularyValueKind.Boolean:
+                writer.WriteBooleanValue(value.Boolean);
+                break;
+            case VocabularyValueKind.TextList:
+                writer.WriteStartArray();
+                foreach (string item in value.TextList)
+                    writer.WriteStringValue(item);
+                writer.WriteEndArray();
+                break;
+            default:
+                throw new InvalidOperationException($"Unsupported vocabulary value kind '{value.Kind}'.");
+        }
+    }
+
+    private static void WriteStrings(
+        Utf8JsonWriter writer,
+        string property,
+        IEnumerable<string> values)
+    {
+        writer.WriteStartArray(property);
+        foreach (string value in values)
+            writer.WriteStringValue(value);
+        writer.WriteEndArray();
+    }
+
+    private static string Name(VocabularyValueKind value) => value switch
+    {
+        VocabularyValueKind.Text => "text",
+        VocabularyValueKind.Integer => "integer",
+        VocabularyValueKind.Boolean => "boolean",
+        VocabularyValueKind.TextList => "text-list",
+        _ => throw new InvalidOperationException($"Unsupported vocabulary value kind '{value}'."),
+    };
+
+    private static string Name(VocabularyOperator value) => value switch
+    {
+        VocabularyOperator.Equals => "equals",
+        VocabularyOperator.NotEquals => "not-equals",
+        VocabularyOperator.In => "in",
+        VocabularyOperator.LessThan => "less-than",
+        VocabularyOperator.GreaterThan => "greater-than",
+        VocabularyOperator.Glob => "glob",
+        VocabularyOperator.Contains => "contains",
+        _ => throw new InvalidOperationException($"Unsupported vocabulary operator '{value}'."),
+    };
+}

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -112,6 +112,15 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void VocabularyCommand_AcceptsSectionSelection()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(
+            ["vocabulary", "-S", "Accessibility", "--json"]);
+
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void BodyShapeCommand_RejectsUnknownOrCaseVariantKind()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(

--- a/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
+++ b/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
@@ -14,6 +14,15 @@ public sealed class VocabularyCommandTests
     [Fact]
     public void Catalog_ProjectsOwnerValuesWithoutChangingIdentityOrOrder()
     {
+        VocabularySection index =
+            VocabularyCatalog.GetById("vocabulary.sections");
+        Assert.Equal(
+            VocabularyCatalog.Document.Sections.Select(section => section.Id),
+            index.Values.Select(ValueId));
+        Assert.Equal(
+            VocabularyCatalog.Document.Sections.Length,
+            index.Values[0].GetRequired("values").Integer);
+
         VocabularySection accessibility =
             VocabularyCatalog.GetById("api.accessibility");
         Assert.Equal(
@@ -171,6 +180,52 @@ public sealed class VocabularyCommandTests
             | C# Style Choices | {choices.Values.Length} |
             """,
             result.Output.Trim());
+    }
+
+    [Fact]
+    public async Task Command_StableSectionIdsRoundTripThroughSelectionAndDiscovery()
+    {
+        var selected = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select = ["api.accessibility"],
+                JsonOutput = true,
+            })));
+        var discovered = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Discover = ["csharp.style-choices"],
+            })));
+
+        Assert.Equal(0, selected.ExitCode);
+        Assert.Empty(selected.Error);
+        using JsonDocument document = JsonDocument.Parse(selected.Output);
+        Assert.Equal(
+            "api.accessibility",
+            Assert.Single(document.RootElement.GetProperty("sections").EnumerateArray())
+                .GetProperty("id")
+                .GetString());
+
+        Assert.Equal(0, discovered.ExitCode);
+        Assert.Empty(discovered.Error);
+        Assert.Contains("| ID | column |", discovered.Output);
+        Assert.Contains("| Conflict Group | column |", discovered.Output);
+    }
+
+    [Fact]
+    public async Task Command_AllCountIncludesEveryVocabularySection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select = [SelectResolver.AllSelector],
+                Count = true,
+            })));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        foreach (VocabularySection section in VocabularyCatalog.Document.Sections)
+            Assert.Contains($"| {section.Name} | {section.Values.Length} |", result.Output);
     }
 
     private static string ValueId(VocabularyRow row) =>

--- a/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
+++ b/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
@@ -126,6 +126,53 @@ public sealed class VocabularyCommandTests
         Assert.Equal("4", counted.Output.Trim());
     }
 
+    [Fact]
+    public async Task Command_FieldsProjectsTableColumns()
+    {
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select = [VocabularyCatalog.StyleChoicesSection],
+                Tabular = true,
+                Tsv = true,
+                Fields = ["ID", "Tier"],
+                Rows = RowWindow.Range(1, 1),
+            })));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        string[] lines = result.Output.Split(
+            '\n',
+            StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        Assert.Equal("id\ttier", lines[0]);
+        Assert.Equal(2, lines[1].Split('\t').Length);
+    }
+
+    [Fact]
+    public async Task Command_CategoryCountRendersPerSectionMap()
+    {
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select = ["@Decompiler"],
+                Count = true,
+            })));
+        VocabularySection tiers = VocabularyCatalog.GetById("csharp.style-tiers");
+        VocabularySection choices = VocabularyCatalog.GetById("csharp.style-choices");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Equal(
+            $"""
+            | Section | Count |
+            | ------- | ----- |
+            | C# Style Tiers | {tiers.Values.Length} |
+            | C# Style Choices | {choices.Values.Length} |
+            """,
+            result.Output.Trim());
+    }
+
     private static string ValueId(VocabularyRow row) =>
         row.GetRequired("id").Text!;
 }

--- a/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
+++ b/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Queries;
+using DotnetInspector.Vocabulary;
+using ILInspector.Decompiler.Pipeline;
+
+namespace DotnetInspector.Tests;
+
+public sealed class VocabularyCommandTests
+{
+    [Fact]
+    public void Catalog_ProjectsOwnerValuesWithoutChangingIdentityOrOrder()
+    {
+        VocabularySection accessibility =
+            VocabularyCatalog.GetById("api.accessibility");
+        Assert.Equal(
+            ApiAccessibility.Values.Select(value => value.Id),
+            accessibility.Values.Select(ValueId));
+
+        VocabularySection tiers =
+            VocabularyCatalog.GetById("csharp.style-tiers");
+        Assert.Equal(
+            StyleOptionCatalog.Tiers.Select(value => value.Id.ToString()),
+            tiers.Values.Select(ValueId));
+
+        VocabularySection choices =
+            VocabularyCatalog.GetById("csharp.style-choices");
+        Assert.Equal(
+            StyleOptionCatalog.Choices.Select(value => value.Id),
+            choices.Values.Select(ValueId));
+    }
+
+    [Fact]
+    public async Task Command_DefaultRendersTheSelfDescribingSectionIndex()
+    {
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions())));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Contains("# Vocabulary", result.Output);
+        Assert.Contains("## Vocabulary Sections", result.Output);
+        Assert.Contains("csharp.style-choices", result.Output);
+        Assert.DoesNotContain("## C# Style Choices", result.Output);
+    }
+
+    [Fact]
+    public async Task Command_DiscoveryListsSectionsAndCategories()
+    {
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Discover = [],
+            })));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Contains("| Accessibility | section |", result.Output);
+        Assert.Contains("| @Decompiler | category |", result.Output);
+        Assert.Contains("| @Vocabulary | category |", result.Output);
+    }
+
+    [Fact]
+    public async Task Command_JsonCarriesTypedSchemaAndValues()
+    {
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select = [VocabularyCatalog.AccessibilitySection],
+                JsonOutput = true,
+            })));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        using JsonDocument document = JsonDocument.Parse(result.Output);
+        JsonElement section = Assert.Single(
+            document.RootElement.GetProperty("sections").EnumerateArray());
+        Assert.Equal("api.accessibility", section.GetProperty("id").GetString());
+        JsonElement values = section.GetProperty("values");
+        Assert.Equal(4, values.GetArrayLength());
+        Assert.True(values[0].GetProperty("default").GetBoolean());
+        Assert.Equal(JsonValueKind.Number, values[0].GetProperty("order").ValueKind);
+
+        JsonElement defaultField = section.GetProperty("fields")
+            .EnumerateArray()
+            .Single(field => field.GetProperty("id").GetString() == "default");
+        Assert.Equal("boolean", defaultField.GetProperty("type").GetString());
+        Assert.Contains(
+            defaultField.GetProperty("operators").EnumerateArray(),
+            value => value.GetString() == "equals");
+    }
+
+    [Fact]
+    public async Task Command_TsvProjectionAndCountUseSectionRows()
+    {
+        var projected = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select = [VocabularyCatalog.StyleChoicesSection],
+                Tabular = true,
+                Tsv = true,
+                Columns = ["ID", "Tier"],
+                Rows = RowWindow.Range(1, 2),
+            })));
+        var counted = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select = [VocabularyCatalog.AccessibilitySection],
+                Count = true,
+            })));
+
+        Assert.Equal(0, projected.ExitCode);
+        Assert.Empty(projected.Error);
+        Assert.Equal(
+            3,
+            projected.Output.Split(
+                '\n',
+                StringSplitOptions.RemoveEmptyEntries).Length);
+        Assert.StartsWith("id\ttier", projected.Output);
+
+        Assert.Equal(0, counted.ExitCode);
+        Assert.Empty(counted.Error);
+        Assert.Equal("4", counted.Output.Trim());
+    }
+
+    private static string ValueId(VocabularyRow row) =>
+        row.GetRequired("id").Text!;
+}

--- a/src/dotnet-inspect/CommandLine/Commands/VocabularyCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/VocabularyCommandDefinitions.cs
@@ -1,0 +1,43 @@
+using System.CommandLine;
+
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.CommandLine;
+
+public static class VocabularyCommandDefinitions
+{
+    public static Command CreateVocabularyCommand(SharedOptions opts)
+    {
+        var command = new Command(
+            VocabularyCommand.Name,
+            "Inspect product-owned values accepted by rich queries");
+        opts.AddJsonOptionTo(command);
+        opts.AddTableOptionsTo(command);
+        opts.AddOutputOptionsTo(command);
+        opts.AddSectionOptionsTo(command);
+        opts.AddCountOptionTo(command);
+
+        command.SetAction((parseResult) => VocabularyCommand.Execute(
+            new VocabularyOptions
+            {
+                Discover = opts.ParseDiscover(parseResult),
+                Select = opts.ParseSelect(parseResult),
+                SelectDefault = opts.ParseSelectDefault(parseResult),
+                Columns = opts.ParseColumns(parseResult),
+                Fields = opts.ParseFields(parseResult),
+                Schema = opts.ParseSchema(parseResult),
+                Tree = opts.ParseTree(parseResult),
+                Count = parseResult.GetValue(opts.Count),
+                Rows = opts.ParseRows(parseResult),
+                JsonOutput = opts.ResolveFormat(parseResult) == OutputFormat.Json,
+                Tabular = opts.ResolveTabular(parseResult),
+                Tsv = opts.ResolveTsv(parseResult),
+                Jsonl = opts.ResolveJsonl(parseResult),
+                NoHeader = parseResult.GetValue(opts.NoHeaders),
+            }));
+
+        return command;
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -104,7 +104,7 @@ public static class ArgumentPreprocessor
     public static readonly HashSet<string> KnownCommands = new(StringComparer.OrdinalIgnoreCase)
     {
         "audit", // removed command, reserved so it is not treated as an implicit package target
-        "package", "project", "library", "api", "type", "member", "diff", "timeline", "find", "body-shape", "source", "list", "ls", "skill", "extensions", "implements", "depends", "cache", "help", "--help", "-h", "-?", "--version", "--flavor"
+        "package", "project", "library", "api", "type", "member", "diff", "timeline", "find", "vocabulary", "body-shape", "source", "list", "ls", "skill", "extensions", "implements", "depends", "cache", "help", "--help", "-h", "-?", "--version", "--flavor"
     };
 
     /// <summary>

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -187,6 +187,9 @@ public static class CommandLineBuilder
         // Find command
         rootCommand.Subcommands.Add(SearchCommandDefinitions.CreateFindCommand(opts));
 
+        // Product-owned query vocabulary
+        rootCommand.Subcommands.Add(VocabularyCommandDefinitions.CreateVocabularyCommand(opts));
+
         // Body shape command
         rootCommand.Subcommands.Add(SearchCommandDefinitions.CreateBodyShapeCommand(opts));
 

--- a/src/dotnet-inspect/Commands/VocabularyCommand.cs
+++ b/src/dotnet-inspect/Commands/VocabularyCommand.cs
@@ -17,6 +17,8 @@ public static class VocabularyCommand
         IReadOnlyDictionary<string, string[]> categoryMap = CreateCategoryMap(document);
         DocumentSchema schema = CreateSchema(document);
         string[]? projectedColumns = ResolveProjectedColumns(options);
+        string[]? discover = NormalizeSectionIds(options.Discover, document);
+        string[]? select = NormalizeSectionIds(options.Select, document);
 
         if (options.Schema && options.Discover is null)
         {
@@ -27,7 +29,7 @@ public static class VocabularyCommand
         if (options.Discover is not null)
         {
             return DiscoverOutput.Execute(
-                options.Discover,
+                discover,
                 schema,
                 projection: options,
                 tree: options.Tree,
@@ -39,7 +41,7 @@ public static class VocabularyCommand
         }
 
         SelectResult selection = SelectResolver.ResolveSelectAsSections(
-            options.Select,
+            select,
             sectionNames,
             infoSections: [VocabularyCatalog.SectionsSection],
             categoryMap,
@@ -216,10 +218,28 @@ public static class VocabularyCommand
                 members.Add(section.Name);
             }
         }
+        categories[SelectResolver.AllSelector] =
+            [.. document.Sections.Select(section => section.Name)];
         return categories.ToDictionary(
             pair => pair.Key,
             pair => pair.Value.ToArray(),
             StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string[]? NormalizeSectionIds(
+        string[]? values,
+        VocabularyDocument document)
+    {
+        if (values is null)
+            return null;
+
+        return
+        [
+            .. values.Select(value =>
+                document.Sections.FirstOrDefault(section =>
+                    section.Id.Equals(value, StringComparison.OrdinalIgnoreCase))?.Name
+                ?? value),
+        ];
     }
 
     private static string[]? ResolveProjectedColumns(VocabularyOptions options)

--- a/src/dotnet-inspect/Commands/VocabularyCommand.cs
+++ b/src/dotnet-inspect/Commands/VocabularyCommand.cs
@@ -1,0 +1,213 @@
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Vocabulary;
+using Markout;
+
+namespace DotnetInspector.Commands;
+
+/// <summary>Renders product-owned query vocabularies as ordinary sections.</summary>
+public static class VocabularyCommand
+{
+    public const string Name = "vocabulary";
+
+    public static int Execute(VocabularyOptions options)
+    {
+        VocabularyDocument document = VocabularyCatalog.Document;
+        string[] sectionNames = [.. document.Sections.Select(section => section.Name)];
+        IReadOnlyDictionary<string, string[]> categoryMap = CreateCategoryMap(document);
+        DocumentSchema schema = CreateSchema(document);
+
+        if (options.Schema && options.Discover is null)
+        {
+            CommandError.Write("--schema requires -D/--discover.");
+            return 1;
+        }
+
+        if (options.Discover is not null)
+        {
+            return DiscoverOutput.Execute(
+                options.Discover,
+                schema,
+                projection: options,
+                tree: options.Tree,
+                json: options.JsonOutput,
+                tsv: options.Tsv,
+                jsonl: options.Jsonl,
+                markdown: !options.Tabular && !options.JsonOutput,
+                sectionCategories: categoryMap);
+        }
+
+        SelectResult selection = SelectResolver.ResolveSelectAsSections(
+            options.Select,
+            sectionNames,
+            infoSections: [VocabularyCatalog.SectionsSection],
+            categoryMap,
+            selectDefault: options.SelectDefault);
+        if (SelectOutput.WriteUnresolved(selection))
+            return 1;
+
+        HashSet<string> selectedNames = selection.Sections
+            ?? new HashSet<string>(
+                [VocabularyCatalog.SectionsSection],
+                StringComparer.OrdinalIgnoreCase);
+        VocabularySection[] sections =
+        [
+            .. document.Sections.Where(section => selectedNames.Contains(section.Name)),
+        ];
+
+        if (!ProjectionDiagnostics.ValidateProjection(
+                schema,
+                selectedNames,
+                options.Columns,
+                options.Fields))
+        {
+            return 1;
+        }
+
+        if (options.Count)
+        {
+            if (!CountOutput.ValidateSingleSection(selectedNames))
+                return 1;
+            CountOutput.WriteCount(RowWindow.Apply(options.Rows, sections[0].Values).Count);
+            return 0;
+        }
+
+        if (options.Tabular && sections.Length != 1)
+        {
+            CommandError.Write(
+                "Tabular vocabulary output requires exactly one selected section; "
+                + "use -S <section>.");
+            return 1;
+        }
+
+        if (options.JsonOutput)
+        {
+            if (options.Columns is { Length: > 0 }
+                || options.Fields is { Length: > 0 })
+            {
+                OutputFormatter.WriteProjectedJson(
+                    Console.Out,
+                    options.Columns,
+                    options.Fields,
+                    (writer, formatter, writerOptions) =>
+                        WriteSections(
+                            new MarkoutWriter(writer, formatter, writerOptions),
+                            sections,
+                            includeDocumentHeading: true),
+                    maxRows: options.Rows);
+            }
+            else
+            {
+                VocabularySection[] windowed =
+                [
+                    .. sections.Select(section => section with
+                    {
+                        Values = [.. RowWindow.Apply(options.Rows, section.Values)],
+                    }),
+                ];
+                Console.WriteLine(VocabularyJson.Serialize(document, windowed));
+            }
+            return 0;
+        }
+
+        if (options.Tabular)
+        {
+            VocabularySection section = sections[0];
+            OutputFormatter.WriteProjectedTable(
+                Console.Out,
+                showHeader: !options.NoHeader,
+                options.Tsv,
+                options.Jsonl,
+                options.Columns,
+                options.Fields,
+                (writer, formatter, writerOptions) =>
+                {
+                    var markout = new MarkoutWriter(writer, formatter, writerOptions);
+                    WriteTable(markout, section);
+                    markout.Flush();
+                },
+                options.Rows);
+            return 0;
+        }
+
+        var markdownOptions = OutputFormatter.CreateProjectedWriterOptions(
+            options.Columns,
+            options.Fields,
+            options.Rows);
+        var markdown = new MarkoutWriter(
+            Console.Out,
+            new MarkdownFormatter(),
+            markdownOptions);
+        WriteSections(markdown, sections, includeDocumentHeading: true);
+        markdown.Flush();
+        return 0;
+    }
+
+    private static void WriteSections(
+        MarkoutWriter writer,
+        IEnumerable<VocabularySection> sections,
+        bool includeDocumentHeading)
+    {
+        if (includeDocumentHeading)
+            writer.WriteHeading(1, "Vocabulary");
+        foreach (VocabularySection section in sections)
+        {
+            writer.WriteHeading(2, section.Name);
+            writer.WriteParagraph(section.Summary);
+            WriteTable(writer, section);
+        }
+    }
+
+    private static void WriteTable(
+        MarkoutWriter writer,
+        VocabularySection section)
+    {
+        string[] labels = [.. section.Fields.Select(field => field.Label)];
+        string[] ids = [.. section.Fields.Select(field => field.Id)];
+        string[][] rows =
+        [
+            .. section.Values.Select(row =>
+                section.Fields.Select(field =>
+                    row.TryGetValue(field.Id, out VocabularyValue value)
+                        ? value.ToDisplayString()
+                        : "").ToArray()),
+        ];
+        writer.WriteTable(labels, ids, rows);
+    }
+
+    private static DocumentSchema CreateSchema(VocabularyDocument document)
+    {
+        var schema = new DocumentSchema();
+        foreach (VocabularySection section in document.Sections)
+        {
+            schema.Add(
+                section.Name,
+                "column",
+                [.. section.Fields.Select(field => field.Label)]);
+        }
+        return schema;
+    }
+
+    private static IReadOnlyDictionary<string, string[]> CreateCategoryMap(
+        VocabularyDocument document)
+    {
+        var categories = new Dictionary<string, List<string>>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (VocabularySection section in document.Sections)
+        {
+            foreach (string category in section.Categories)
+            {
+                if (!categories.TryGetValue(category, out List<string>? members))
+                {
+                    members = [];
+                    categories.Add(category, members);
+                }
+                members.Add(section.Name);
+            }
+        }
+        return categories.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.ToArray(),
+            StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/dotnet-inspect/Commands/VocabularyCommand.cs
+++ b/src/dotnet-inspect/Commands/VocabularyCommand.cs
@@ -16,6 +16,7 @@ public static class VocabularyCommand
         string[] sectionNames = [.. document.Sections.Select(section => section.Name)];
         IReadOnlyDictionary<string, string[]> categoryMap = CreateCategoryMap(document);
         DocumentSchema schema = CreateSchema(document);
+        string[]? projectedColumns = ResolveProjectedColumns(options);
 
         if (options.Schema && options.Discover is null)
         {
@@ -58,17 +59,28 @@ public static class VocabularyCommand
         if (!ProjectionDiagnostics.ValidateProjection(
                 schema,
                 selectedNames,
-                options.Columns,
-                options.Fields))
+                fields: options.Fields,
+                columns: options.Columns))
         {
             return 1;
         }
 
         if (options.Count)
         {
-            if (!CountOutput.ValidateSingleSection(selectedNames))
-                return 1;
-            CountOutput.WriteCount(RowWindow.Apply(options.Rows, sections[0].Values).Count);
+            if (sections.Length == 1)
+            {
+                CountOutput.WriteCount(RowWindow.Apply(options.Rows, sections[0].Values).Count);
+            }
+            else
+            {
+                Dictionary<string, int> counts = sections.ToDictionary(
+                    section => section.Name,
+                    section => RowWindow.Apply(options.Rows, section.Values).Count,
+                    StringComparer.Ordinal);
+                CountOutput.WriteCountMap(
+                    counts,
+                    [.. sections.Select(section => section.Name)]);
+            }
             return 0;
         }
 
@@ -82,13 +94,12 @@ public static class VocabularyCommand
 
         if (options.JsonOutput)
         {
-            if (options.Columns is { Length: > 0 }
-                || options.Fields is { Length: > 0 })
+            if (projectedColumns is { Length: > 0 })
             {
                 OutputFormatter.WriteProjectedJson(
                     Console.Out,
-                    options.Columns,
-                    options.Fields,
+                    projectedColumns,
+                    fields: null,
                     (writer, formatter, writerOptions) =>
                         WriteSections(
                             new MarkoutWriter(writer, formatter, writerOptions),
@@ -118,8 +129,8 @@ public static class VocabularyCommand
                 showHeader: !options.NoHeader,
                 options.Tsv,
                 options.Jsonl,
-                options.Columns,
-                options.Fields,
+                projectedColumns,
+                fields: null,
                 (writer, formatter, writerOptions) =>
                 {
                     var markout = new MarkoutWriter(writer, formatter, writerOptions);
@@ -131,8 +142,8 @@ public static class VocabularyCommand
         }
 
         var markdownOptions = OutputFormatter.CreateProjectedWriterOptions(
-            options.Columns,
-            options.Fields,
+            projectedColumns,
+            fields: null,
             options.Rows);
         var markdown = new MarkoutWriter(
             Console.Out,
@@ -209,5 +220,20 @@ public static class VocabularyCommand
             pair => pair.Key,
             pair => pair.Value.ToArray(),
             StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string[]? ResolveProjectedColumns(VocabularyOptions options)
+    {
+        if (options.Columns is not { Length: > 0 })
+            return options.Fields is { Length: > 0 } ? options.Fields : null;
+        if (options.Fields is not { Length: > 0 })
+            return options.Columns;
+
+        return
+        [
+            .. options.Columns
+                .Concat(options.Fields)
+                .Distinct(StringComparer.OrdinalIgnoreCase),
+        ];
     }
 }

--- a/src/dotnet-inspect/Options/VocabularyOptions.cs
+++ b/src/dotnet-inspect/Options/VocabularyOptions.cs
@@ -1,0 +1,22 @@
+using DotnetInspector.Output;
+
+namespace DotnetInspector.Options;
+
+/// <summary>Configuration for the sectioned product vocabulary document.</summary>
+public sealed record VocabularyOptions : IProjectionOptions
+{
+    public string[]? Discover { get; init; }
+    public string[]? Select { get; init; }
+    public bool SelectDefault { get; init; }
+    public string[]? Columns { get; init; }
+    public string[]? Fields { get; init; }
+    public bool Schema { get; init; }
+    public bool Tree { get; init; }
+    public bool Count { get; init; }
+    public RowWindow? Rows { get; init; }
+    public bool JsonOutput { get; init; }
+    public bool Tabular { get; init; }
+    public bool Tsv { get; init; }
+    public bool Jsonl { get; init; }
+    public bool NoHeader { get; init; }
+}

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -98,6 +98,7 @@
     <ProjectReference Include="..\DotnetInspector.ResearchQueries\DotnetInspector.ResearchQueries.csproj" />
     <ProjectReference Include="..\DotnetInspector.MetadataRendering\DotnetInspector.MetadataRendering.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
+    <ProjectReference Include="..\DotnetInspector.Vocabulary\DotnetInspector.Vocabulary.csproj" />
     <ProjectReference Include="..\InertText\InertText.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- add a shared, host-neutral vocabulary catalog with typed fields, legal operators, stable values, and self-describing sections
- add the sectioned `vocabulary` CLI command with discovery, projections, row windows, counts, and structured output
- replace the browser's style-specific exports with one generic vocabulary document consumed by the style picker
- document the static-vocabulary/effective-facet split and defer body-kind vocabulary until scoped kind search resumes

## Validation

- `dotnet build src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release --no-restore`
- `VocabularyCommandTests` (5 passed)
- `CommandLineTests` (195 passed)
- `AssemblyContextApiSurfaceQueryTests` (25 passed)
- `BrowserStyleOptionsTests` (2 passed)
- inspect-web JavaScript style/taste tests (4 passed)
- browser WASM `dotnet publish`
- changed Markdown lint and `git diff --check`

Fixes #4307
