### PR TITLE
Preserve bare select in all-libraries mode

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -16960,6 +16960,53 @@ public partial class CommandExecutionTests
         }
     }
 
+    /// <summary>
+    /// Bare <c>-S</c> must remain the fixed overview after package inspection delegates to the
+    /// all-libraries path. The count map names the complete request, while the rendered headings
+    /// prove that the same preset reached effective-section selection and data collection.
+    /// </summary>
+    [Fact]
+    public async Task PackageCommand_AllLibraries_BareSelectCount_MapDescribesBareSelectRender()
+    {
+        var (packagePath, tempDir) = CreateLocalRefPackage("System.Text.Json");
+        try
+        {
+            var (renderExit, renderOutput, renderError) = await RunAppAsync(
+                "package", packagePath, "--all-libraries", "-S", "--tips", "q");
+            var (countExit, countOutput, countError) = await RunAppAsync(
+                "package", packagePath, "--all-libraries", "-S", "--count", "--tips", "q");
+
+            Assert.Equal(0, renderExit);
+            Assert.Equal(0, countExit);
+            Assert.DoesNotContain("Tip:", renderError);
+            Assert.DoesNotContain("Tip:", countError);
+
+            var rendered = renderOutput.ReplaceLineEndings("\n").Split('\n')
+                .Where(line => line.StartsWith("## ", StringComparison.Ordinal))
+                .Select(line =>
+                {
+                    var heading = line[3..].Trim();
+                    var provenance = heading.IndexOf(" (", StringComparison.Ordinal);
+                    return provenance >= 0 ? heading[..provenance] : heading;
+                })
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            var mapped = countOutput.ReplaceLineEndings("\n").Split('\n')
+                .Where(line => line.StartsWith("| ", StringComparison.Ordinal))
+                .Select(line => line.Split('|')[1].Trim())
+                .Where(name => name.Length > 0 && name != "Section" && !name.StartsWith('-'))
+                .ToList();
+
+            var expected = LibrarySections.CreatePipeline().BareSelectSectionNames;
+            Assert.Equal(expected.Order(), rendered.Order());
+            Assert.Equal(expected.Order(), mapped.Order());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task PackageCommand_AllLibraries_RendersLibraryInfoPerHighestTfmLibrary()
     {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -16968,7 +16968,9 @@ public partial class CommandExecutionTests
     [Fact]
     public async Task PackageCommand_AllLibraries_BareSelectCount_MapDescribesBareSelectRender()
     {
-        var (packagePath, tempDir) = CreateLocalRefPackage("System.Text.Json");
+        var (packagePath, tempDir) = CreateLocalRefPackage(
+            "System.Text.Json",
+            "System.Collections");
         try
         {
             var (renderExit, renderOutput, renderError) = await RunAppAsync(
@@ -17031,10 +17033,15 @@ public partial class CommandExecutionTests
             foreach (var section in expected)
             {
                 Assert.True(
-                    renderedCounts[section] > 0,
+                    renderedCounts.TryGetValue(
+                        section,
+                        out var renderedCount),
+                    $"{section} must render in this fixture.");
+                Assert.True(
+                    renderedCount > 0,
                     $"{section} must render rows in this fixture.");
                 Assert.Equal(
-                    renderedCounts[section],
+                    renderedCount,
                     mapped[section]);
             }
 
@@ -17064,6 +17071,29 @@ public partial class CommandExecutionTests
                     formattedError,
                     StringComparison.OrdinalIgnoreCase);
             }
+
+            var (categoryExit, categoryOutput, categoryError) =
+                await RunAppAsync(
+                    "package",
+                    packagePath,
+                    "--all-libraries",
+                    "-S",
+                    SectionCategoryNames.Library,
+                    "--count",
+                    "--tips",
+                    "q");
+
+            Assert.Equal(0, categoryExit);
+            Assert.Contains("| Section | Count |", categoryOutput);
+            foreach (var section in LibrarySections
+                         .CreatePipeline()
+                         .GetCategoryMap()[SectionCategoryNames.Library])
+            {
+                Assert.Contains($"| {section} |", categoryOutput);
+            }
+            Assert.DoesNotContain(
+                CountOutput.SingleSectionRequiredMessage,
+                categoryError);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -16993,13 +16993,77 @@ public partial class CommandExecutionTests
                 .ToList();
             var mapped = countOutput.ReplaceLineEndings("\n").Split('\n')
                 .Where(line => line.StartsWith("| ", StringComparison.Ordinal))
-                .Select(line => line.Split('|')[1].Trim())
-                .Where(name => name.Length > 0 && name != "Section" && !name.StartsWith('-'))
-                .ToList();
+                .Select(line => line.Split('|'))
+                .Where(cells => cells.Length > 2)
+                .Select(cells => (
+                    Section: cells[1].Trim(),
+                    Count: cells[2].Trim()))
+                .Where(row => row.Section.Length > 0
+                    && row.Section != "Section"
+                    && !row.Section.StartsWith('-'))
+                .ToDictionary(
+                    row => row.Section,
+                    row => int.Parse(
+                        row.Count,
+                        CultureInfo.InvariantCulture),
+                    StringComparer.OrdinalIgnoreCase);
+            var renderedCounts = CountOutput
+                .CountMarkdownTableRowsBySection(renderOutput)
+                .GroupBy(
+                    row =>
+                    {
+                        var provenance = row.Key.IndexOf(
+                            " (",
+                            StringComparison.Ordinal);
+                        return provenance >= 0
+                            ? row.Key[..provenance]
+                            : row.Key;
+                    },
+                    StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Sum(row => row.Value),
+                    StringComparer.OrdinalIgnoreCase);
 
             var expected = LibrarySections.CreatePipeline().BareSelectSectionNames;
             Assert.Equal(expected.Order(), rendered.Order());
-            Assert.Equal(expected.Order(), mapped.Order());
+            Assert.Equal(expected.Order(), mapped.Keys.Order());
+            foreach (var section in expected)
+            {
+                Assert.True(
+                    renderedCounts[section] > 0,
+                    $"{section} must render rows in this fixture.");
+                Assert.Equal(
+                    renderedCounts[section],
+                    mapped[section]);
+            }
+
+            foreach (var format in new[]
+                     {
+                         "--json",
+                         "--table",
+                         "--tsv",
+                         "--jsonl",
+                     })
+            {
+                var (formattedExit, formattedOutput, formattedError) =
+                    await RunAppAsync(
+                        "package",
+                        packagePath,
+                        "--all-libraries",
+                        "-S",
+                        "--count",
+                        format,
+                        "--tips",
+                        "q");
+
+                Assert.Equal(0, formattedExit);
+                Assert.Equal(countOutput, formattedOutput);
+                Assert.DoesNotContain(
+                    "unprojected output",
+                    formattedError,
+                    StringComparison.OrdinalIgnoreCase);
+            }
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -17107,6 +17107,9 @@ public partial class CommandExecutionTests
                     "q");
 
             Assert.Equal(0, metadataExit);
+            Assert.DoesNotContain(
+                $"| {MetadataSectionNames.Heap} |",
+                metadataOutput);
             var metadataImageRow = metadataOutput
                 .ReplaceLineEndings("\n")
                 .Split('\n')
@@ -17116,7 +17119,31 @@ public partial class CommandExecutionTests
             var metadataImageCount = int.Parse(
                 metadataImageRow.Split('|')[2].Trim(),
                 CultureInfo.InvariantCulture);
-            Assert.True(metadataImageCount > 0);
+            var (metadataImageRenderExit, metadataImageRender, _) =
+                await RunAppAsync(
+                    "package",
+                    packagePath,
+                    "--all-libraries",
+                    "-S",
+                    MetadataSectionNames.Image,
+                    "--tips",
+                    "q");
+            Assert.Equal(0, metadataImageRenderExit);
+            Assert.Equal(
+                CountOutput.CountMarkdownTableRows(
+                    metadataImageRender),
+                metadataImageCount);
+            Assert.Contains(
+                $"## {MetadataSectionNames.Image} (ref/",
+                metadataImageRender);
+            Assert.Equal(
+                2,
+                metadataImageRender
+                    .ReplaceLineEndings("\n")
+                    .Split('\n')
+                    .Count(line => line.StartsWith(
+                        $"## {MetadataSectionNames.Image} (",
+                        StringComparison.Ordinal)));
             Assert.DoesNotContain(
                 "unprojected output",
                 metadataError,

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -17094,6 +17094,57 @@ public partial class CommandExecutionTests
             Assert.DoesNotContain(
                 CountOutput.SingleSectionRequiredMessage,
                 categoryError);
+
+            var (metadataExit, metadataOutput, metadataError) =
+                await RunAppAsync(
+                    "package",
+                    packagePath,
+                    "--all-libraries",
+                    "-S",
+                    SectionCategoryNames.Metadata,
+                    "--count",
+                    "--tips",
+                    "q");
+
+            Assert.Equal(0, metadataExit);
+            var metadataImageRow = metadataOutput
+                .ReplaceLineEndings("\n")
+                .Split('\n')
+                .Single(line => line.StartsWith(
+                    $"| {MetadataSectionNames.Image} |",
+                    StringComparison.Ordinal));
+            var metadataImageCount = int.Parse(
+                metadataImageRow.Split('|')[2].Trim(),
+                CultureInfo.InvariantCulture);
+            Assert.True(metadataImageCount > 0);
+            Assert.DoesNotContain(
+                "unprojected output",
+                metadataError,
+                StringComparison.OrdinalIgnoreCase);
+
+            var (emptyExit, emptyOutput, emptyError) =
+                await RunAppAsync(
+                    "package",
+                    packagePath,
+                    "--all-libraries",
+                    "-S",
+                    $"{SectionNames.IdentifierConfusion},{SectionNames.NonNormalizedPaths}",
+                    "--count",
+                    "--json",
+                    "--tips",
+                    "q");
+
+            Assert.Equal(0, emptyExit);
+            Assert.Contains(
+                $"| {SectionNames.IdentifierConfusion} | 0 |",
+                emptyOutput);
+            Assert.Contains(
+                $"| {SectionNames.NonNormalizedPaths} | 0 |",
+                emptyOutput);
+            Assert.DoesNotContain(
+                "unprojected output",
+                emptyError,
+                StringComparison.OrdinalIgnoreCase);
         }
         finally
         {

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -228,55 +228,11 @@ public class LibraryCommand
         if (SelectOutput.WriteUnresolved(selectResult)) return 1;
         if (selectResult.Sections != null)
         {
-            const string ilCoordinateRequired =
-                "IL coordinate sections require --il-offset <token>+<offset>.";
-            var heapCoordinateRequired =
-                $"\"{MetadataSectionNames.Heap}\" requires --heap <heap>:<address>, for example --heap \"#Strings:0x1a4\".";
-            var removedILCoordinateSections = false;
-            var removedHeapSection = false;
-
-            if (selectResult.Sections.Overlaps(ILCoordinateSections)
-                && string.IsNullOrWhiteSpace(options.ILOffsetParameter))
+            if (ApplyCoordinateSectionRequirements(
+                    options,
+                    selectResult) is { } coordinateError)
             {
-                if (!selectResult.ExactSections.Overlaps(ILCoordinateSections))
-                {
-                    var count = selectResult.Sections.Count;
-                    selectResult.Sections.ExceptWith(ILCoordinateSections);
-                    removedILCoordinateSections = selectResult.Sections.Count != count;
-                }
-                else if (options.Discover == null)
-                {
-                    CommandError.Write(ilCoordinateRequired);
-                    return 1;
-                }
-            }
-
-            if (selectResult.Sections.Contains(MetadataSectionNames.Heap)
-                && string.IsNullOrWhiteSpace(options.HeapParameter))
-            {
-                // Same discipline as the IL coordinate sections above: reached through the
-                // @Metadata door the section is simply dropped, because a category selection is a
-                // request for whatever applies; reached by an exact name or compatible alias it is
-                // an error, because the caller asked for a specific section that cannot exist
-                // without its coordinate.
-                if (!selectResult.ExactSections.Contains(MetadataSectionNames.Heap))
-                {
-                    removedHeapSection = selectResult.Sections.Remove(MetadataSectionNames.Heap);
-                }
-                else if (options.Discover == null)
-                {
-                    CommandError.Write(heapCoordinateRequired);
-                    return 1;
-                }
-            }
-
-            if (selectResult.Sections.Count == 0
-                && (removedILCoordinateSections || removedHeapSection))
-            {
-                if (removedILCoordinateSections)
-                    CommandError.Write(ilCoordinateRequired);
-                else if (removedHeapSection)
-                    CommandError.Write(heapCoordinateRequired);
+                CommandError.Write(coordinateError);
                 return 1;
             }
 
@@ -1328,6 +1284,66 @@ public class LibraryCommand
         }, null);
     }
 
+    internal static string? ApplyCoordinateSectionRequirements(
+        LibraryOptions options,
+        SelectResult selectResult)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(selectResult);
+        if (selectResult.Sections is not { } sections)
+            return null;
+
+        const string ilCoordinateRequired =
+            "IL coordinate sections require --il-offset <token>+<offset>.";
+        var heapCoordinateRequired =
+            $"\"{MetadataSectionNames.Heap}\" requires --heap <heap>:<address>, for example --heap \"#Strings:0x1a4\".";
+        var removedILCoordinateSections = false;
+        var removedHeapSection = false;
+
+        if (sections.Overlaps(ILCoordinateSections)
+            && string.IsNullOrWhiteSpace(options.ILOffsetParameter))
+        {
+            if (!selectResult.ExactSections.Overlaps(ILCoordinateSections))
+            {
+                var count = sections.Count;
+                sections.ExceptWith(ILCoordinateSections);
+                removedILCoordinateSections = sections.Count != count;
+            }
+            else if (options.Discover == null)
+            {
+                return ilCoordinateRequired;
+            }
+        }
+
+        if (sections.Contains(MetadataSectionNames.Heap)
+            && string.IsNullOrWhiteSpace(options.HeapParameter))
+        {
+            // Reached through @Metadata the section is dropped because a category selects whatever
+            // applies. An exact selector is an error because the section cannot exist without its
+            // coordinate.
+            if (!selectResult.ExactSections.Contains(
+                    MetadataSectionNames.Heap))
+            {
+                removedHeapSection = sections.Remove(
+                    MetadataSectionNames.Heap);
+            }
+            else if (options.Discover == null)
+            {
+                return heapCoordinateRequired;
+            }
+        }
+
+        if (sections.Count != 0
+            || (!removedILCoordinateSections && !removedHeapSection))
+        {
+            return null;
+        }
+
+        return removedILCoordinateSections
+            ? ilCoordinateRequired
+            : heapCoordinateRequired;
+    }
+
     // Catalog-hidden set for the effective (real-assembly) -D flows. Base-category
     // members form the flat catalog; separate domains remain behind their category
     // doors even when a coordinate or other explicit input makes a member effective.
@@ -1335,13 +1351,16 @@ public class LibraryCommand
         => pipeline.GetCatalogHiddenSections();
 
     /// <summary>
-    /// Rejects rendered metadata-lens rows when a package resolved to more than one assembly.
-    /// The lens renders raw ECMA-335 tables of one image: row ids are image-relative and section
-    /// names carry no assembly, so several assemblies would emit repeated
+    /// Rejects direct-library metadata-lens rows when a package resolved to more than one assembly.
+    /// That renderer carries no per-image provenance: several assemblies would emit repeated
     /// <c>## Metadata: TypeDef</c> headings whose rows silently belong to different images and
     /// whose row numbering restarts without saying so. Aggregate counts remain safe because they
-    /// do not expose image-relative row identities; the rejection and count allowance are gated by
-    /// <c>MetadataLens_MultipleAssemblies_IsRejected</c> in dotnet-inspect.Tests.
+    /// do not expose image-relative row identities. Package <c>--all-libraries</c> is a separate
+    /// renderer that suffixes each metadata heading with the package-relative assembly path. The
+    /// direct-library rejection and count allowance are gated by
+    /// <c>MetadataLens_MultipleAssemblies_IsRejected</c> in dotnet-inspect.Tests; all-libraries
+    /// provenance is gated by
+    /// <c>PackageCommand_AllLibraries_BareSelectCount_MapDescribesBareSelectRender</c>.
     /// </summary>
     private static bool RejectMultiAssemblyMetadataSelection(
         IReadOnlyCollection<LibraryInspection> inspections, LibraryOptions options)

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -81,6 +81,27 @@ public class LibraryCommand
         }
     }
 
+    /// <summary>
+    /// Converts bare <c>-S</c> into the library pipeline's fixed, network-free overview while
+    /// preserving explicit selectors and higher user-selected verbosity.
+    /// </summary>
+    internal static LibraryOptions NormalizeBareSelect(
+        LibraryOptions options)
+    {
+        if (options.Discover != null || !options.SelectDefault)
+            return options;
+
+        options = options with { SelectDefault = false };
+        return options.Select is null
+            && options.Verbosity == Verbosity.Minimal
+                ? options with
+                {
+                    Verbosity = Verbosity.Normal,
+                    FixedOverview = true,
+                }
+                : options;
+    }
+
     private static async Task<int> ExecuteCoreAsync(LibraryOptions options, InspectionTrace? trace)
     {
         var assemblyPath = options.AssemblyName;
@@ -162,12 +183,7 @@ public class LibraryCommand
         // the user asked for, in which case the normal curated ladder applies instead of the fixed
         // overview). Combined with an explicit selector the explicit selection wins and the marker
         // is dropped. See #3547.
-        if (options.Discover == null && options.SelectDefault)
-        {
-            options = options with { SelectDefault = false };
-            if (options.Select is null && options.Verbosity == Verbosity.Minimal)
-                options = options with { Verbosity = Verbosity.Normal, FixedOverview = true };
-        }
+        options = NormalizeBareSelect(options);
 
         bool discoveryInspection = options.Discover != null && !options.Schema && hasInputSource;
         bool fullEffectiveDiscovery = discoveryInspection && options.Effective;

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -3363,7 +3363,21 @@ public class PackageCommand
             selectDefault: libraryOptions.SelectDefault);
         if (SelectOutput.WriteUnresolved(selectResult)) return 1;
         if (selectResult.Sections != null)
-            libraryOptions = libraryOptions with { IncludeSections = selectResult.Sections };
+        {
+            if (LibraryCommand.ApplyCoordinateSectionRequirements(
+                    libraryOptions,
+                    selectResult) is { } coordinateError)
+            {
+                CommandError.Write(coordinateError);
+                return 1;
+            }
+
+            libraryOptions = libraryOptions with
+            {
+                IncludeSections = selectResult.Sections,
+                ExactIncludeSectionsOverride = selectResult.ExactSections,
+            };
+        }
 
         if (libraryOptions.Count
             && !CountOutput.ValidateSectionsSelected(
@@ -3558,6 +3572,10 @@ public class PackageCommand
             return completionExitCode;
         }
 
+        Dictionary<string, int>? sectionCounts = libraryOptions.Count
+            ? new Dictionary<string, int>(
+                StringComparer.OrdinalIgnoreCase)
+            : null;
         var markdown = RenderAllLibrariesMarkdown(
             packageName,
             version,
@@ -3565,7 +3583,7 @@ public class PackageCommand
             sections,
             libraryOptions,
             pipeline,
-            out var sectionCounts);
+            sectionCounts);
         if (libraryOptions.Count)
         {
             var ordered = OutputFormatter.ResolveCountMapSections(
@@ -3575,7 +3593,7 @@ public class PackageCommand
             if (ordered != null)
             {
                 CountOutput.WriteCountMap(
-                    sectionCounts,
+                    sectionCounts!,
                     ordered,
                     options.OutputPath);
             }
@@ -4093,11 +4111,9 @@ public class PackageCommand
         List<string> sections,
         LibraryOptions options,
         SectionPipeline<LibraryInspection> pipeline,
-        out Dictionary<string, int> sectionCounts)
+        Dictionary<string, int>? sectionCounts)
     {
         var sb = new StringBuilder();
-        sectionCounts = new Dictionary<string, int>(
-            StringComparer.OrdinalIgnoreCase);
         var title = string.IsNullOrWhiteSpace(version) ? packageName : $"{packageName} {version}";
         AppendBlock(sb, $"# {title}");
 
@@ -4108,8 +4124,14 @@ public class PackageCommand
                 AppendAggregatedSection(sb, section, inspections, options.Rows);
             else
                 AppendPerLibrarySections(sb, section, inspections, options, pipeline);
-            sectionCounts[section] = CountOutput.CountMarkdownTableRows(
-                sb.ToString(sectionStart, sb.Length - sectionStart));
+            if (sectionCounts is not null)
+            {
+                sectionCounts[section] =
+                    CountOutput.CountMarkdownTableRows(
+                        sb.ToString(
+                            sectionStart,
+                            sb.Length - sectionStart));
+            }
         }
 
         return sb.ToString().TrimEnd();

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -3366,9 +3366,9 @@ public class PackageCommand
             libraryOptions = libraryOptions with { IncludeSections = selectResult.Sections };
 
         if (libraryOptions.Count
-            && !libraryOptions.FixedOverview
-            && !CountOutput.ValidateSingleSection(
-                libraryOptions.IncludeSections))
+            && !CountOutput.ValidateSectionsSelected(
+                libraryOptions.IncludeSections,
+                libraryOptions.FixedOverview))
             return 1;
 
         var requiredVerbosity = pipeline.GetRequiredVerbosity(libraryOptions.IncludeSections);
@@ -3775,7 +3775,6 @@ public class PackageCommand
                 : OutputFormat.Markdown,
             Verbose = options.Verbose,
             Verbosity = options.Verbosity,
-            FixedOverview = options.FixedOverview,
             IncludeSections = options.IncludeSections,
             Discover = options.Discover,
             Tree = options.Tree,

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -4276,7 +4276,11 @@ public class PackageCommand
                 .Contains(section, StringComparer.OrdinalIgnoreCase))
                 continue;
 
-            var rendered = RenderLibrarySection(inspection, section, options);
+            var rendered = RenderLibrarySection(
+                inspection,
+                section,
+                options,
+                pipeline);
             if (rendered.Length == 0)
                 continue;
 
@@ -4284,20 +4288,25 @@ public class PackageCommand
         }
     }
 
-    private static string RenderLibrarySection(LibraryInspection inspection, string section, LibraryOptions options)
+    private static string RenderLibrarySection(
+        LibraryInspection inspection,
+        string section,
+        LibraryOptions options,
+        SectionPipeline<LibraryInspection> pipeline)
     {
         var view = new LibraryInspectionView(inspection);
         var writerOptions = new MarkoutWriterOptions
         {
             IncludeSections = [section],
             Projection = OutputFormatter.BuildProjection(options.Columns, options.Fields),
-            // Windowed here rather than over the assembled document: the heading rewrite below is
-            // the only text this path edits, and it does not touch rows.
-            RowWindow = RowWindow.ToMarkout(options.Rows)
         };
-        var output = new StringWriter { NewLine = "\n" };
-        MarkoutSerializer.Serialize(view, output, InspectionContext.Default, writerOptions);
-        var markdown = output.ToString().Trim();
+        var markdown = OutputFormatter.SerializeLibraryMarkdown(
+                view,
+                inspection,
+                writerOptions,
+                pipeline,
+                options.Rows)
+            .Trim();
         if (markdown.Length == 0)
             return "";
 

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -3349,14 +3349,26 @@ public class PackageCommand
         var queryRegistry = catalog.QueryRegistry;
         var libraryOptions = CreateLibraryOptions(assemblyName: null, packageReference, options);
 
+        libraryOptions = LibraryCommand.NormalizeBareSelect(libraryOptions);
+        libraryOptions = libraryOptions with
+        {
+            UserVerbosityOverride = libraryOptions.Verbosity,
+        };
+
         var selectResult = SelectResolver.ResolveSelectAsSections(
-            options.Select, pipeline.SelectableSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap(),
-            selectDefault: options.SelectDefault);
+            libraryOptions.Select,
+            pipeline.SelectableSectionNames,
+            pipeline.InfoSectionNames,
+            pipeline.GetCategoryMap(),
+            selectDefault: libraryOptions.SelectDefault);
         if (SelectOutput.WriteUnresolved(selectResult)) return 1;
         if (selectResult.Sections != null)
             libraryOptions = libraryOptions with { IncludeSections = selectResult.Sections };
 
-        if (libraryOptions.Count && !CountOutput.ValidateSingleSection(libraryOptions.IncludeSections))
+        if (libraryOptions.Count
+            && !libraryOptions.FixedOverview
+            && !CountOutput.ValidateSingleSection(
+                libraryOptions.IncludeSections))
             return 1;
 
         var requiredVerbosity = pipeline.GetRequiredVerbosity(libraryOptions.IncludeSections);
@@ -3373,13 +3385,17 @@ public class PackageCommand
                 candidates.Contains(SectionNames.IdentifierConfusion),
         };
 
-        var scanners = pipeline.GetRequiredScanners(libraryOptions.Verbosity, libraryOptions.IncludeSections);
+        var scanners = pipeline.GetRequiredScanners(
+            libraryOptions.Verbosity,
+            libraryOptions.IncludeSections,
+            libraryOptions.FixedOverview);
         List<(string Reason, InspectionQueryDefinition Query)> commandQueryDemand = [];
         if (libraryOptions.CollectReferenceTree)
             commandQueryDemand.Add(("reference tree", AssemblyReferencesQuery.Definition));
         var queries = pipeline.GetRequiredQueries(
             libraryOptions.Verbosity,
             libraryOptions.IncludeSections,
+            libraryOptions.FixedOverview,
             commandDemand: commandQueryDemand);
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
@@ -3527,7 +3543,25 @@ public class PackageCommand
 
         var markdown = RenderAllLibrariesMarkdown(packageName, version, inspections, sections, libraryOptions, pipeline);
         if (libraryOptions.Count)
-            CountOutput.WriteCountFromMarkdown(markdown, options.OutputPath);
+        {
+            var ordered = OutputFormatter.ResolveCountMapSections(
+                pipeline,
+                libraryOptions.IncludeSections,
+                libraryOptions.FixedOverview);
+            if (ordered != null)
+            {
+                CountOutput.WriteCountMapFromMarkdown(
+                    markdown,
+                    ordered,
+                    options.OutputPath);
+            }
+            else
+            {
+                CountOutput.WriteCountFromMarkdown(
+                    markdown,
+                    options.OutputPath);
+            }
+        }
         else
             OutputFormatter.WriteLfLine(Console.Out, markdown);
         return completionExitCode;
@@ -3717,6 +3751,7 @@ public class PackageCommand
                 : OutputFormat.Markdown,
             Verbose = options.Verbose,
             Verbosity = options.Verbosity,
+            FixedOverview = options.FixedOverview,
             IncludeSections = options.IncludeSections,
             Discover = options.Discover,
             Tree = options.Tree,
@@ -3814,7 +3849,11 @@ public class PackageCommand
         {
             var sections = selectAll
                 ? pipeline.GetAllSelectorSections(inspection)
-                : pipeline.GetEffectiveSections(inspection, options.Verbosity, options.IncludeSections);
+                : pipeline.GetEffectiveSections(
+                    inspection,
+                    options.Verbosity,
+                    options.IncludeSections,
+                    options.FixedOverview);
             foreach (var section in sections)
             {
                 if (!union.Contains(section, StringComparer.OrdinalIgnoreCase))
@@ -4200,7 +4239,12 @@ public class PackageCommand
     {
         foreach (var inspection in inspections)
         {
-            if (!pipeline.GetEffectiveSections(inspection, options.Verbosity, options.IncludeSections).Contains(section, StringComparer.OrdinalIgnoreCase))
+            if (!pipeline.GetEffectiveSections(
+                    inspection,
+                    options.Verbosity,
+                    options.IncludeSections,
+                    options.FixedOverview)
+                .Contains(section, StringComparer.OrdinalIgnoreCase))
                 continue;
 
             var rendered = RenderLibrarySection(inspection, section, options);

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -3517,7 +3517,7 @@ public class PackageCommand
             return 1;
         }
 
-        if (libraryOptions.JsonOutput)
+        if (libraryOptions.JsonOutput && !libraryOptions.Count)
         {
             Console.WriteLine(JsonSerializer.Serialize(inspections.ToArray(), JsonContext.Default.LibraryInspectionArray));
             return completionExitCode;
@@ -3530,18 +3530,42 @@ public class PackageCommand
             // An empty match is still an answer to --count, and returning without projecting
             // would report the absence as unprojected output.
             if (libraryOptions.Count)
-                CountOutput.WriteCount(0, options.OutputPath);
+            {
+                var ordered = OutputFormatter.ResolveCountMapSections(
+                    pipeline,
+                    libraryOptions.IncludeSections,
+                    libraryOptions.FixedOverview);
+                if (ordered != null)
+                {
+                    CountOutput.WriteCountMap(
+                        new Dictionary<string, int>(
+                            StringComparer.OrdinalIgnoreCase),
+                        ordered,
+                        options.OutputPath);
+                }
+                else
+                {
+                    CountOutput.WriteCount(0, options.OutputPath);
+                }
+            }
             return completionExitCode;
         }
 
-        if (libraryOptions.TabularExplicitlySet)
+        if (libraryOptions.TabularExplicitlySet && !libraryOptions.Count)
         {
             if (!WriteAllLibrariesTable(packageName, version, inspections, sections, libraryOptions))
                 return 1;
             return completionExitCode;
         }
 
-        var markdown = RenderAllLibrariesMarkdown(packageName, version, inspections, sections, libraryOptions, pipeline);
+        var markdown = RenderAllLibrariesMarkdown(
+            packageName,
+            version,
+            inspections,
+            sections,
+            libraryOptions,
+            pipeline,
+            out var sectionCounts);
         if (libraryOptions.Count)
         {
             var ordered = OutputFormatter.ResolveCountMapSections(
@@ -3550,8 +3574,8 @@ public class PackageCommand
                 libraryOptions.FixedOverview);
             if (ordered != null)
             {
-                CountOutput.WriteCountMapFromMarkdown(
-                    markdown,
+                CountOutput.WriteCountMap(
+                    sectionCounts,
                     ordered,
                     options.OutputPath);
             }
@@ -4069,18 +4093,24 @@ public class PackageCommand
         List<LibraryInspection> inspections,
         List<string> sections,
         LibraryOptions options,
-        SectionPipeline<LibraryInspection> pipeline)
+        SectionPipeline<LibraryInspection> pipeline,
+        out Dictionary<string, int> sectionCounts)
     {
         var sb = new StringBuilder();
+        sectionCounts = new Dictionary<string, int>(
+            StringComparer.OrdinalIgnoreCase);
         var title = string.IsNullOrWhiteSpace(version) ? packageName : $"{packageName} {version}";
         AppendBlock(sb, $"# {title}");
 
         foreach (var section in sections)
         {
+            var sectionStart = sb.Length;
             if (IsAggregatedAllLibrariesSection(section))
                 AppendAggregatedSection(sb, section, inspections, options.Rows);
             else
                 AppendPerLibrarySections(sb, section, inspections, options, pipeline);
+            sectionCounts[section] = CountOutput.CountMarkdownTableRows(
+                sb.ToString(sectionStart, sb.Length - sectionStart));
         }
 
         return sb.ToString().TrimEnd();

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -567,7 +567,7 @@ public static class OutputFormatter
     /// *prose*, which has no serializer-model expression. See #3619 (the migration) and #3620
     /// (the prose gap, which blocks it).
     /// </summary>
-    private static string SerializeLibraryMarkdown(
+    internal static string SerializeLibraryMarkdown(
         LibraryInspectionView auditView,
         LibraryInspection inspection,
         MarkoutWriterOptions writerOpts,


### PR DESCRIPTION
`package --all-libraries -S` now preserves the library pipeline's fixed overview through option normalization, producer demand, effective-section selection, and per-library rendering. Adding `--count` emits the same per-section map as the rendered overview instead of collapsing `Library Info` into one scalar.

The direct `library` and delegated package routes share one bare-select normalizer, preventing their selection semantics from drifting again. Explicit single-section all-libraries counts retain their existing scalar behavior.

## Demo

Previously, the overview count collapsed to a single `27`. It now reports the complete fixed overview:

```console
$ dotnet-inspect package System.Text.Json@10.0.0 --all-libraries -S --count --tips q
Using TFM: net10.0
| Section | Count |
| ------- | ----- |
| Library Info | 27 |
| Signals | 16 |
| Symbols | 4 |
```

The same command without `--count` renders those three sections per library; selecting one concrete section still returns a scalar count.

Validation:
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method 'DotnetInspector.Tests.CommandExecutionTests.PackageCommand_AllLibraries_BareSelectCount_MapDescribesBareSelectRender' -method 'DotnetInspector.Tests.CommandExecutionTests.Library_BareSelectCount_EmitsFixedOverviewMap' -method 'DotnetInspector.Tests.CommandExecutionTests.Library_BareSelectCount_MapDescribesTheBareSelectRender' -method 'DotnetInspector.Tests.CommandExecutionTests.PackageCommand_AllLibraries_RendersLibraryInfoPerHighestTfmLibrary' -method 'DotnetInspector.Tests.CommandExecutionTests.Package_Count_WritesEmbeddedLibraryAndMultiPackageRoutesToOutputFiles'`
- `git diff --check`
