### PR TITLE
Validate sparse switch decision partitions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SparseIntSwitchRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SparseIntSwitchRaisingTests.cs
@@ -66,6 +66,78 @@ public class SparseIntSwitchRaisingTests
         Assert.Empty(function.Descendants.OfType<ConditionalBranch>());
     }
 
+    [Theory]
+    [InlineData(ComparisonKind.GreaterThan, false, -1, 2)]
+    [InlineData(ComparisonKind.LessThanOrEqual, false, 2, -1)]
+    [InlineData(ComparisonKind.LessThan, true, -1, 2)]
+    [InlineData(ComparisonKind.GreaterThan, true, 2, -1)]
+    [Trait("Area", "Pass")]
+    public void PartitionedComparisonDispatch_RaisesSwitch(
+        ComparisonKind pivotKind,
+        bool constantOnLeft,
+        int fallthroughCase,
+        int targetCase)
+    {
+        var function = PartitionedComparisonDispatch(
+            pivotKind,
+            constantOnLeft,
+            fallthroughCase,
+            targetCase);
+
+        function.CheckInvariant();
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Single(function.Descendants.OfType<Switch>());
+        Assert.Empty(function.Descendants.OfType<ConditionalBranch>());
+    }
+
+    [Theory]
+    [InlineData(ComparisonKind.GreaterThan, 1, 2)]
+    [InlineData(ComparisonKind.LessThan, -1, 2)]
+    [Trait("Area", "Pass")]
+    public void EqualityLeafOutsidePivotPartition_DeclinesSwitchRaise(
+        ComparisonKind pivotKind,
+        int fallthroughCase,
+        int targetCase)
+    {
+        var function = PartitionedComparisonDispatch(
+            pivotKind,
+            constantOnLeft: false,
+            fallthroughCase,
+            targetCase);
+
+        function.CheckInvariant();
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<Switch>());
+        Assert.Equal(
+            3,
+            function.Descendants.OfType<ConditionalBranch>().Count());
+    }
+
+    [Fact]
+    [Trait("Area", "Pass")]
+    public void UnsignedRelationalPivot_DeclinesSwitchRaise()
+    {
+        var function = PartitionedComparisonDispatch(
+            ComparisonKind.GreaterThan,
+            constantOnLeft: false,
+            fallthroughCase: -1,
+            targetCase: 2,
+            isUnsigned: true);
+
+        function.CheckInvariant();
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<Switch>());
+        Assert.Equal(
+            3,
+            function.Descendants.OfType<ConditionalBranch>().Count());
+    }
+
     [Fact]
     [Trait("Area", "Pass")]
     public void NestedBranchEnteringSecondComparison_DeclinesSwitchRaise()
@@ -221,6 +293,65 @@ public class SparseIntSwitchRaisingTests
         }
 
         return InOuterLoop(loopBody);
+    }
+
+    static IrFunction PartitionedComparisonDispatch(
+        ComparisonKind pivotKind,
+        bool constantOnLeft,
+        int fallthroughCase,
+        int targetCase,
+        bool isUnsigned = false)
+    {
+        var body = new BlockContainer();
+        var value = new LoadArgument(0, "value", s_int);
+        var constant = new Constant(0, s_int);
+        var pivot = new Block(0x00);
+        pivot.Add(new ConditionalBranch(
+            new Comparison(
+                pivotKind,
+                isUnsigned,
+                constantOnLeft ? constant : value,
+                constantOnLeft ? value : constant),
+            0x20));
+        body.Add(pivot);
+
+        void AddEquality(int offset, int label, int target)
+        {
+            var block = new Block(offset);
+            block.Add(new ConditionalBranch(
+                new Comparison(
+                    ComparisonKind.Equal,
+                    isUnsigned: false,
+                    new LoadArgument(0, "value", s_int),
+                    new Constant(label, s_int)),
+                target));
+            body.Add(block);
+        }
+
+        AddEquality(0x10, fallthroughCase, 0x40);
+        AddEquality(0x20, targetCase, 0x50);
+
+        var dispatchDefault = new Block(0x30);
+        dispatchDefault.Add(new Branch(0x60));
+        body.Add(dispatchDefault);
+
+        foreach (int offset in new[] { 0x40, 0x50, 0x60 })
+        {
+            var section = new Block(offset);
+            section.Add(new Return(null));
+            body.Add(section);
+        }
+
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(
+                s_void,
+                [new Parameter("value", s_int)],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [],
+            body);
     }
 
     static IrFunction InOuterLoop(BlockContainer loopBody)

--- a/src/ILInspector.Decompiler.Tests/SparseIntSwitchRaisingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SparseIntSwitchRaisingTests.cs
@@ -140,6 +140,55 @@ public class SparseIntSwitchRaisingTests
 
     [Fact]
     [Trait("Area", "Pass")]
+    public void FinalDispatchComparisonWithoutFallthrough_DeclinesSwitchRaise()
+    {
+        var body = new BlockContainer();
+
+        void AddComparison(int offset, ComparisonKind kind, int constant, int target)
+        {
+            var block = new Block(offset);
+            block.Add(new ConditionalBranch(
+                new Comparison(
+                    kind,
+                    isUnsigned: false,
+                    new LoadArgument(0, "value", s_int),
+                    new Constant(constant, s_int)),
+                target));
+            body.Add(block);
+        }
+
+        AddComparison(0x00, ComparisonKind.GreaterThan, 0, 0x20);
+
+        var explicitDefault = new Block(0x10);
+        explicitDefault.Add(new Branch(0x80));
+        body.Add(explicitDefault);
+
+        AddComparison(0x20, ComparisonKind.Equal, 1, 0x90);
+        AddComparison(0x30, ComparisonKind.Equal, 2, 0xA0);
+
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(
+                s_void,
+                [new Parameter("value", s_int)],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [],
+            body);
+
+        function.CheckInvariant();
+        new SwitchRaisingPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Empty(function.Descendants.OfType<Switch>());
+        Assert.Equal(
+            3,
+            function.Descendants.OfType<ConditionalBranch>().Count());
+    }
+
+    [Fact]
+    [Trait("Area", "Pass")]
     public void NestedBranchEnteringSecondComparison_DeclinesSwitchRaise()
     {
         var body = new BlockContainer();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -2014,6 +2014,8 @@ public sealed class SwitchRaisingPass : IIrPass
                     index++;
                     continue;
                 }
+                if (dispatchEnd + 1 >= blocks.Count)
+                    return false;
                 outcome = blocks[dispatchEnd + 1].StartOffset;
                 break;
             }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SwitchRaisingPass.cs
@@ -1779,7 +1779,12 @@ public sealed class SwitchRaisingPass : IIrPass
         // temp) and ends in a comparison against it — an equality test (a case) or
         // a relational pivot.
         if (blocks[s].Children is not [.., ConditionalBranch firstBranch]
-            || !TryIntComparison(firstBranch.Condition, out var value, out _, out _))
+            || !TryIntComparison(
+                firstBranch.Condition,
+                out var value,
+                out _,
+                out _,
+                out _))
             return false;
 
         var caseLabels = new List<Constant>();
@@ -1800,10 +1805,15 @@ public sealed class SwitchRaisingPass : IIrPass
                 : (children is [ConditionalBranch] or [Branch] ? children[0] : null);
 
             if (term is ConditionalBranch cb
-                && TryIntComparison(cb.Condition, out var testValue, out int constant, out bool isEqual)
+                && TryIntComparison(
+                    cb.Condition,
+                    out var testValue,
+                    out int constant,
+                    out ComparisonKind kind,
+                    out _)
                 && PlaceIdentity.SameVariable(value, testValue))
             {
-                if (isEqual)
+                if (kind == ComparisonKind.Equal)
                 {
                     // C# forbids duplicate case labels (CS0152); a repeated constant is
                     // not a source switch. Decline rather than emit an uncompilable
@@ -1849,8 +1859,173 @@ public sealed class SwitchRaisingPass : IIrPass
             defaultOffset = blocks[dispatchEnd + 1].StartOffset;
         }
 
+        if (!IsValidSparseIntDecisionGraph(
+                blocks,
+                s,
+                dispatchEnd,
+                value,
+                caseTargetOffsets,
+                defaultOffset.Value))
+        {
+            return false;
+        }
+
         return FinishSwitchRaise(container, s, dispatchEnd, value, caseTargetOffsets,
             caseLabels, defaultOffset.Value, leaveTargets, stepper);
+    }
+
+    static bool IsValidSparseIntDecisionGraph(
+        IReadOnlyList<Block> blocks,
+        int start,
+        int dispatchEnd,
+        IrExpression value,
+        IReadOnlyCollection<int> caseTargets,
+        int defaultTarget)
+    {
+        var dispatchByOffset = Enumerable.Range(start, dispatchEnd - start + 1)
+            .ToDictionary(index => blocks[index].StartOffset);
+        if (dispatchByOffset.ContainsKey(defaultTarget)
+            || caseTargets.Any(dispatchByOffset.ContainsKey))
+        {
+            return false;
+        }
+
+        int count = dispatchEnd - start + 1;
+        var terms = new IrNode[count];
+        var cases = new Dictionary<int, int>();
+        var witnesses = new HashSet<int> { int.MinValue, int.MaxValue };
+
+        void AddWitnesses(int constant)
+        {
+            witnesses.Add(constant);
+            if (constant > int.MinValue)
+                witnesses.Add(constant - 1);
+            if (constant < int.MaxValue)
+                witnesses.Add(constant + 1);
+        }
+
+        for (int index = start; index <= dispatchEnd; index++)
+        {
+            var children = blocks[index].Children;
+            IrNode? term = index == start
+                ? (children is [.., ConditionalBranch or Branch]
+                    ? children[^1]
+                    : null)
+                : (children is [ConditionalBranch] or [Branch]
+                    ? children[0]
+                    : null);
+            if (term is null)
+                return false;
+            terms[index - start] = term;
+
+            if (term is Branch branch)
+            {
+                if (branch.TargetOffset != defaultTarget)
+                    return false;
+                continue;
+            }
+            if (term is not ConditionalBranch conditional
+                || !TryIntComparison(
+                    conditional.Condition,
+                    out var testValue,
+                    out int constant,
+                    out ComparisonKind kind,
+                    out bool isUnsigned)
+                || !PlaceIdentity.SameVariable(value, testValue)
+                || isUnsigned && kind != ComparisonKind.Equal)
+            {
+                return false;
+            }
+
+            AddWitnesses(constant);
+            if (kind == ComparisonKind.Equal)
+            {
+                if (!caseTargets.Contains(conditional.TargetOffset)
+                    || !cases.TryAdd(constant, conditional.TargetOffset))
+                {
+                    return false;
+                }
+            }
+            else if (!dispatchByOffset.ContainsKey(conditional.TargetOffset))
+            {
+                return false;
+            }
+        }
+
+        // Signed integer comparison outcomes change only at a comparison
+        // constant or immediately beside it. Traversing those boundary
+        // representatives proves every integer partition without expanding
+        // every path through compiler DAG joins. SparseIntSwitchRaisingTests
+        // gates valid joins, infeasible case leaves, and cyclic dispatch.
+        var reached = new bool[count];
+        foreach (int witness in witnesses)
+        {
+            var path = new bool[count];
+            int index = start;
+            int outcome;
+            while (true)
+            {
+                int localIndex = index - start;
+                if (localIndex < 0
+                    || localIndex >= count
+                    || path[localIndex])
+                {
+                    return false;
+                }
+                path[localIndex] = true;
+                reached[localIndex] = true;
+
+                if (terms[localIndex] is Branch branch)
+                {
+                    outcome = branch.TargetOffset;
+                    break;
+                }
+
+                var conditional = (ConditionalBranch)terms[localIndex];
+                _ = TryIntComparison(
+                    conditional.Condition,
+                    out _,
+                    out int constant,
+                    out ComparisonKind kind,
+                    out _);
+                bool takeBranch = kind switch
+                {
+                    ComparisonKind.Equal => witness == constant,
+                    ComparisonKind.LessThan => witness < constant,
+                    ComparisonKind.LessThanOrEqual => witness <= constant,
+                    ComparisonKind.GreaterThan => witness > constant,
+                    ComparisonKind.GreaterThanOrEqual => witness >= constant,
+                    _ => false,
+                };
+
+                if (takeBranch)
+                {
+                    if (kind == ComparisonKind.Equal)
+                    {
+                        outcome = conditional.TargetOffset;
+                        break;
+                    }
+                    index = dispatchByOffset[conditional.TargetOffset];
+                    continue;
+                }
+
+                if (index < dispatchEnd)
+                {
+                    index++;
+                    continue;
+                }
+                outcome = blocks[dispatchEnd + 1].StartOffset;
+                break;
+            }
+
+            int expected = cases.TryGetValue(witness, out int caseTarget)
+                ? caseTarget
+                : defaultTarget;
+            if (outcome != expected)
+                return false;
+        }
+
+        return reached.All(static value => value);
     }
 
     /// <summary>
@@ -2038,30 +2213,38 @@ public sealed class SwitchRaisingPass : IIrPass
     /// <summary>
     /// An integer comparison <c>v &lt;op&gt; const</c> (in either operand order)
     /// against an <c>int</c> constant — the equality leaves and relational pivots
-    /// of csc's sparse switch dispatch. <paramref name="isEqual"/> distinguishes a
-    /// case test (<c>==</c>) from a range pivot.
+    /// of csc's sparse switch dispatch. Comparisons with the constant on the left
+    /// are mirrored so <paramref name="kind"/> always describes
+    /// <c>value &lt;op&gt; constant</c>.
     /// </summary>
-    static bool TryIntComparison(IrExpression condition, out IrExpression value, out int constant, out bool isEqual)
+    static bool TryIntComparison(
+        IrExpression condition,
+        out IrExpression value,
+        out int constant,
+        out ComparisonKind kind,
+        out bool isUnsigned)
     {
         value = null!;
         constant = 0;
-        isEqual = false;
+        kind = default;
+        isUnsigned = false;
         if (condition is not Comparison cmp
             || cmp.Kind is not (ComparisonKind.Equal or ComparisonKind.LessThan or ComparisonKind.LessThanOrEqual
                                 or ComparisonKind.GreaterThan or ComparisonKind.GreaterThanOrEqual))
             return false;
+        isUnsigned = cmp.IsUnsigned;
         if (cmp.Right is Constant { Value: int right })
         {
             value = cmp.Left;
             constant = right;
-            isEqual = cmp.Kind == ComparisonKind.Equal;
+            kind = cmp.Kind;
             return true;
         }
         if (cmp.Left is Constant { Value: int left })
         {
             value = cmp.Right;
             constant = left;
-            isEqual = cmp.Kind == ComparisonKind.Equal;
+            kind = Conditions.Mirror(cmp.Kind);
             return true;
         }
         return false;


### PR DESCRIPTION
- Fixes #4147
- Declines sparse integer switch raising unless the comparison dispatch is behaviorally equivalent to the emitted value switch.
- Candidate: `eb17a74266d156d79af819de25dfce7093fc2389`
- Integrated base: `e8f38075afca8bcb1d33aec4b3be3c8d7790e54d`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the pass now proves every signed-integer partition
before consuming a sparse comparison dispatch; compiler-produced switch DAGs
still raise, while infeasible equality leaves, cycles, and unsigned relational
pivots decline.

### Raise contract

| Obligation | Contract |
| --- | --- |
| Lowering shell | Release C# sparse integer switches lowered to contiguous equality tests and signed relational pivots over one governing value. Compiler-produced `ClassifyMode` and `ClassifyWide` pin the real single- and multi-level DAGs. |
| Consumed ownership | Existing dispatch/body ownership checks remain unchanged. The new proof evaluates only the already identified contiguous dispatch and requires every dispatch block to be reachable by at least one signed-integer partition. |
| Control flow | For every comparison boundary partition, traversal from the dispatch root must terminate at the case target for that exact label or at the shared default. A repeated node on one path declines as cyclic. |
| Replacement | The replacement remains the existing `switch (value)` raise. Raised and lowered fidelity gates already pin `ClassifyMode` and `ClassifyWide` Exact. |
| Decline boundary | Equality labels routed outside their pivot partition, self/back-edge cycles, external entry, sibling-region entry, missing final fallthrough, and unsigned relational pivots remain flat. Valid compiler DAG joins remain accepted. |
| Falsifier | Any signed `int` for which the flat comparison graph reaches a different case/default target than the emitted value switch disproves the raise. |

### Structural review

Structural review status: Not generated — the compiler-produced witnesses
render identically before and after. This is a soundness guard over adversarial
flat IR, not a rendered-C# improvement; manufacturing correspondence for the
synthetic graph would not be product-issued evidence.

### Unsound shape before this guard

```text
B0: if (v > 0) goto B2
B1: if (v == 1) goto Case1
B2: if (v == 2) goto Case2
B3: goto Default
```

For `v == 1`, the flat graph reaches `Default`, but the old raise emitted a
value switch that reached `Case1`.

### After

The shape above remains flat. Valid compiler output such as `ClassifyMode` and
`ClassifyWide` still raises to the same switch and remains pinned Exact.

### Fully raised

Valid compiler-produced sparse switch decision DAGs remain fully raised.
Irregular graphs remain honestly lowered.

## Evidence

| Check | Result |
| --- | --- |
| Exact-head test-project build | Pass, 0 warnings / 0 errors |
| `SparseIntSwitchRaisingTests` | Pass, 16/16 |
| Compiler-produced positives | `ClassifyMode` and `ClassifyWide` raise |
| Accepted boundary | Signed relational pivots in both operand orientations, including a valid DAG join |
| Decline boundaries | Infeasible equality leaves, unsigned relational pivot, external/sibling entry, cyclic dispatch, and a final comparison with no fallthrough block |
| Raised/lowered Exact fidelity | Pass, 11/11 `FidelityGateTests` and `LoweredFidelityGateTests` |
| Decompiler fast suite | 5,137/5,138 passed; one unrelated evil-pool sweep timed out, then passed alone in 12.4s |
| Full solution build | Pass, 0 warnings / 0 errors |
| Review | GPT-5.6 Sol and Claude Opus 5 clean at `eb17a742` |

## Scope boundary

This does not add an unsigned-domain model. Unsigned relational pivots decline
rather than being interpreted with signed ordering.