### PR TITLE
Fetch dependency-tree roots as nuspecs

### DIFF
--- a/src/DotnetInspector.Packages/NuGetSourceOptions.cs
+++ b/src/DotnetInspector.Packages/NuGetSourceOptions.cs
@@ -12,5 +12,6 @@ public record NuGetSourceOptions
     public string[] AdditionalSources { get; init; } = [];
     public string? ConfigFile { get; init; }
     internal string[]? AuthorizedSourceKeys { get; init; }
+    internal NuGetFetch.PackageSource[]? ResolvedSources { get; init; }
     public static NuGetSourceOptions Default { get; } = new();
 }

--- a/src/DotnetInspector.Packages/NuGetSourceResolver.cs
+++ b/src/DotnetInspector.Packages/NuGetSourceResolver.cs
@@ -60,6 +60,22 @@ public static class NuGetSourceResolver
     }
 
     /// <summary>
+    /// Restricts follow-on metadata or payload acquisition to an already
+    /// resolved producer set without reselecting configured aliases.
+    /// </summary>
+    public static NuGetSourceOptions RestrictToResolvedSources(
+        NuGetSourceOptions? original,
+        IReadOnlyList<NuGetSource> sources)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+        return (original ?? NuGetSourceOptions.Default) with
+        {
+            AuthorizedSourceKeys = [.. SourceKeys(sources)],
+            ResolvedSources = [.. sources],
+        };
+    }
+
+    /// <summary>
     /// Restricts payload or metadata fulfillment to canonical producer identities established
     /// by an earlier package acquisition.
     /// </summary>
@@ -95,9 +111,15 @@ public static class NuGetSourceResolver
 
     internal static NuGetSourceOptions? WithoutSourceRestriction(
         NuGetSourceOptions? options)
-        => options?.AuthorizedSourceKeys is null
+        => options is null
+            || options.AuthorizedSourceKeys is null
+                && options.ResolvedSources is null
             ? options
-            : options with { AuthorizedSourceKeys = null };
+            : options with
+            {
+                AuthorizedSourceKeys = null,
+                ResolvedSources = null,
+            };
 
     /// <summary>
     /// Resolves sources and reduces them to the identities the package content
@@ -154,6 +176,8 @@ public static class NuGetSourceResolver
         {
             ValidateExplicitConfig(options.ConfigFile);
         }
+        if (options.ResolvedSources is { } resolvedSources)
+            return [.. resolvedSources];
 
         IReadOnlyList<NuGetSource> configured = SourceResolver.ResolveSources(
             explicitSource: null,

--- a/src/DotnetInspector.Services.Tests/NuspecParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/NuspecParserTests.cs
@@ -106,6 +106,25 @@ public class NuspecParserTests : IDisposable
     }
 
     [Fact]
+    public void ParseContent_Utf8BomDecodedAsText_IsAccepted()
+    {
+        NuspecData result = NuspecParser.ParseContent(
+            "\uFEFF"
+            + """
+              <?xml version="1.0" encoding="utf-8"?>
+              <package>
+                <metadata>
+                  <id>Bom.Package</id>
+                  <version>1.0.0</version>
+                </metadata>
+              </package>
+              """);
+
+        Assert.Equal("Bom.Package", result.PackageName);
+        Assert.Equal("1.0.0", result.Version);
+    }
+
+    [Fact]
     public void Parse_ExtractsRepositoryUrl()
     {
         var nuspec = WriteNuspec("""

--- a/src/DotnetInspector.Services/NuspecParser.cs
+++ b/src/DotnetInspector.Services/NuspecParser.cs
@@ -51,6 +51,9 @@ public static class NuspecParser
     {
         try
         {
+            if (nuspecXml.Length > 0 && nuspecXml[0] == '\uFEFF')
+                nuspecXml = nuspecXml[1..];
+
             return ParseDocument(HardenedXml.ParseXDocument(nuspecXml));
         }
         catch (System.Xml.XmlException ex)

--- a/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
+++ b/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
@@ -281,6 +281,102 @@ public class DependencyGraphServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task BuildPackageDependencyTreeAsync_ReporterDoesNotReactivateDisabledAlias()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Depends.Alias.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        string flatContainer =
+            $"https://content.example.test/{suffix}/flat/";
+        Directory.CreateDirectory(_testRoot);
+        string configPath = Path.Combine(
+            _testRoot,
+            $"NuGet-{suffix}.Config");
+        File.WriteAllText(
+            configPath,
+            $$"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="active" value="{{serviceIndex}}" />
+                <add key="disabled" value="{{serviceIndex}}" />
+              </packageSources>
+              <packageSourceCredentials>
+                <disabled>
+                  <add key="Username" value="disabled-user" />
+                  <add key="ClearTextPassword" value="disabled-password" />
+                </disabled>
+              </packageSourceCredentials>
+              <packageSourceMapping>
+                <packageSource key="active">
+                  <package pattern="Depends.*" />
+                </packageSource>
+                <packageSource key="disabled">
+                  <package pattern="Depends.*" />
+                </packageSource>
+              </packageSourceMapping>
+              <disabledPackageSources>
+                <add key="disabled" value="true" />
+              </disabledPackageSources>
+            </configuration>
+            """);
+        var handler = new ManifestOnlyHandler(
+            serviceIndex,
+            flatContainer,
+            $"https://other.example.test/{suffix}/v3/index.json",
+            $"https://other-content.example.test/{suffix}/flat/",
+            packageId);
+        using var httpClient = new HttpClient(handler);
+        var logger = new VerboseLogger(enabled: false);
+        var sourceOptions =
+            new NuGetSourceOptions { ConfigFile = configPath };
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                packageId,
+                requestedTfm: null,
+                sourceOptions,
+                logger);
+
+        Assert.IsType<PackageDependencyGraphResult.Empty>(result);
+        Assert.Contains(
+            handler.Requests,
+            uri => uri.AbsolutePath.EndsWith(
+                $"/{packageId.ToLowerInvariant()}.nuspec",
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ResolvedSourceRestriction_ReleasesAmbientSources()
+    {
+        const string FeedA = "https://feed-a.example/v3/index.json";
+        const string FeedB = "https://feed-b.example/v3/index.json";
+        var original = new NuGetSourceOptions
+        {
+            Sources = [FeedA, FeedB],
+        };
+        NuGetSourceOptions restricted =
+            NuGetSourceResolver.RestrictToResolvedSources(
+                original,
+                [new NuGetFetch.PackageSource(FeedA, FeedA)]);
+
+        Assert.Equal(
+            [FeedA],
+            NuGetSourceResolver.ResolveSources(restricted)
+                .Select(source => source.Url));
+
+        NuGetSourceOptions? unrestricted =
+            NuGetSourceResolver.WithoutSourceRestriction(restricted);
+        Assert.Equal(
+            [FeedA, FeedB],
+            NuGetSourceResolver.ResolveSources(unrestricted)
+                .Select(source => source.Url));
+    }
+
+    [Fact]
     public async Task BuildPackageDependencyTreeAsync_ToolPackageUsesArchive()
     {
         string suffix = Guid.NewGuid().ToString("N");

--- a/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
+++ b/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Net;
 using DotnetInspector.Inspectors;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
@@ -91,5 +92,201 @@ public class DependencyGraphServiceTests
         {
             Directory.Delete(packageDir, recursive: true);
         }
+    }
+
+    [Fact]
+    public async Task BuildPackageDependencyTreeAsync_LocalPackageStillSupported()
+    {
+        string packageDir =
+            Directory.CreateTempSubdirectory("depends-local-package-test")
+                .FullName;
+        string packagePath =
+            Path.Combine(packageDir, "Depends.Local.1.0.0.nupkg");
+
+        try
+        {
+            using (ZipArchive archive =
+                ZipFile.Open(packagePath, ZipArchiveMode.Create))
+            {
+                ZipArchiveEntry nuspec =
+                    archive.CreateEntry("Depends.Local.nuspec");
+                await using Stream stream = nuspec.Open();
+                await using var writer = new StreamWriter(stream);
+                await writer.WriteAsync(
+                    """
+                    <?xml version="1.0"?>
+                    <package>
+                      <metadata>
+                        <id>Depends.Local</id>
+                        <version>1.0.0</version>
+                      </metadata>
+                    </package>
+                    """);
+            }
+
+            using var httpClient = new HttpClient();
+            var logger = new VerboseLogger(enabled: false);
+
+            PackageDependencyGraphResult result =
+                await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                    httpClient,
+                    packagePath,
+                    requestedTfm: null,
+                    sourceOptions: null,
+                    logger);
+
+            Assert.IsType<PackageDependencyGraphResult.Empty>(result);
+        }
+        finally
+        {
+            Directory.Delete(packageDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task BuildPackageDependencyTreeAsync_AcquiresOnlyRootNuspec()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Depends.Root.{suffix}";
+        string reportingServiceIndex =
+            $"https://reporting.example.test/{suffix}/v3/index.json";
+        string reportingFlatContainer =
+            $"https://reporting-content.example.test/{suffix}/flat/";
+        string otherServiceIndex =
+            $"https://other.example.test/{suffix}/v3/index.json";
+        string otherFlatContainer =
+            $"https://other-content.example.test/{suffix}/flat/";
+        var handler = new ManifestOnlyHandler(
+            reportingServiceIndex,
+            reportingFlatContainer,
+            otherServiceIndex,
+            otherFlatContainer,
+            packageId);
+        using var httpClient = new HttpClient(handler);
+        var logger = new VerboseLogger(enabled: false);
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                packageId,
+                requestedTfm: null,
+                new NuGetSourceOptions
+                {
+                    Sources =
+                    [
+                        otherServiceIndex,
+                        reportingServiceIndex,
+                    ],
+                },
+                logger);
+
+        Assert.IsType<PackageDependencyGraphResult.Empty>(result);
+        Assert.Contains(
+            handler.Requests,
+            uri => uri.AbsolutePath.EndsWith(
+                $"/{packageId.ToLowerInvariant()}.nuspec",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            handler.Requests,
+            uri => uri.AbsoluteUri.StartsWith(
+                    otherFlatContainer,
+                    StringComparison.Ordinal)
+                && uri.AbsolutePath.EndsWith(
+                    $"/1.0.0/{packageId.ToLowerInvariant()}.nuspec",
+                    StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            handler.Requests,
+            uri => uri.AbsolutePath.EndsWith(
+                ".nupkg",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    private sealed class ManifestOnlyHandler(
+        string reportingServiceIndex,
+        string reportingFlatContainer,
+        string otherServiceIndex,
+        string otherFlatContainer,
+        string packageId) : HttpMessageHandler
+    {
+        public List<Uri> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Uri uri = request.RequestUri!;
+            Requests.Add(uri);
+
+            if (uri.AbsoluteUri.Equals(
+                reportingServiceIndex,
+                StringComparison.Ordinal))
+            {
+                return Task.FromResult(Response(
+                    ServiceIndex(reportingFlatContainer)));
+            }
+            if (uri.AbsoluteUri.Equals(
+                otherServiceIndex,
+                StringComparison.Ordinal))
+            {
+                return Task.FromResult(Response(
+                    ServiceIndex(otherFlatContainer)));
+            }
+
+            string normalizedPackageId = packageId.ToLowerInvariant();
+            if (uri.AbsoluteUri.Equals(
+                $"{reportingFlatContainer}{normalizedPackageId}/index.json",
+                StringComparison.Ordinal))
+            {
+                return Task.FromResult(Response(
+                    """{"versions":["1.0.0"]}"""));
+            }
+            if (uri.AbsoluteUri.Equals(
+                $"{otherFlatContainer}{normalizedPackageId}/index.json",
+                StringComparison.Ordinal))
+            {
+                return Task.FromResult(Response(
+                    """{"versions":["0.9.0"]}"""));
+            }
+
+            if (uri.AbsolutePath.EndsWith(
+                $"/1.0.0/{normalizedPackageId}.nuspec",
+                StringComparison.Ordinal))
+            {
+                return Task.FromResult(Response(
+                    $$"""
+                    <?xml version="1.0"?>
+                    <package>
+                      <metadata>
+                        <id>{{packageId}}</id>
+                        <version>1.0.0</version>
+                      </metadata>
+                    </package>
+                    """));
+            }
+
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    RequestMessage = request,
+                });
+        }
+
+        private static string ServiceIndex(string flatContainer) =>
+            $$"""
+            {
+              "resources": [
+                {
+                  "@type": "PackageBaseAddress/3.0.0",
+                  "@id": "{{flatContainer}}"
+                }
+              ]
+            }
+            """;
+
+        private static HttpResponseMessage Response(string content) =>
+            new(HttpStatusCode.OK)
+            {
+                Content = new StringContent(content),
+            };
     }
 }

--- a/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
+++ b/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
@@ -7,11 +7,24 @@ using DotnetInspector.Packages;
 namespace DotnetInspector.Tests;
 
 [Collection("Console")]
-public class DependencyGraphServiceTests
+public class DependencyGraphServiceTests : IDisposable
 {
+    private readonly string _testRoot = Path.Combine(
+        Path.GetTempPath(),
+        $"dependency-graph-tests-{Guid.NewGuid():N}");
+
     public DependencyGraphServiceTests()
     {
-        NuGetCache.Initialize("dotnet-inspect");
+        NuGetCache.Initialize(
+            "dotnet-inspect-test",
+            Path.Combine(_testRoot, "cache"),
+            skipNuGetCache: true);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testRoot))
+            Directory.Delete(_testRoot, recursive: true);
     }
 
     [Fact]
@@ -144,6 +157,72 @@ public class DependencyGraphServiceTests
     }
 
     [Fact]
+    public async Task BuildPackageDependencyTreeAsync_CachedFloatingLookupTimesOutEarly()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Depends.Cached.{suffix}";
+        const string Version = "1.0.0";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        SeedCachedPackage(packageId, Version, serviceIndex);
+        var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler);
+        var logger = new VerboseLogger(enabled: false);
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                packageId,
+                requestedTfm: null,
+                new NuGetSourceOptions { Sources = [serviceIndex] },
+                logger);
+
+        var error =
+            Assert.IsType<PackageDependencyGraphResult.Error>(result);
+        Assert.Contains("lookup timed out", error.Message);
+        Assert.Contains(
+            $"Locally cached versions: {Version}",
+            error.Message);
+        Assert.Single(handler.Requests);
+    }
+
+    [Fact]
+    public async Task BuildPackageDependencyTreeAsync_MissingLocalPackageReportsError()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Depends.Missing.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        string flatContainer =
+            $"https://content.example.test/{suffix}/flat/";
+        var handler = new ManifestOnlyHandler(
+            serviceIndex,
+            flatContainer,
+            $"https://other.example.test/{suffix}/v3/index.json",
+            $"https://other-content.example.test/{suffix}/flat/",
+            packageId);
+        using var httpClient = new HttpClient(handler);
+        var logger = new VerboseLogger(enabled: false);
+        string packagePath = Path.Combine(
+            Path.GetTempPath(),
+            suffix,
+            $"{packageId}.1.0.0.nupkg");
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                packagePath,
+                requestedTfm: null,
+                new NuGetSourceOptions { Sources = [serviceIndex] },
+                logger);
+
+        var error =
+            Assert.IsType<PackageDependencyGraphResult.Error>(result);
+        Assert.Contains("File not found", error.Message);
+        Assert.Empty(handler.Requests);
+    }
+
+    [Fact]
     public async Task BuildPackageDependencyTreeAsync_AcquiresOnlyRootNuspec()
     {
         string suffix = Guid.NewGuid().ToString("N");
@@ -201,12 +280,93 @@ public class DependencyGraphServiceTests
                 StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task BuildPackageDependencyTreeAsync_ToolPackageUsesArchive()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Depends.Tool.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        var handler = new ManifestOnlyHandler(
+            serviceIndex,
+            $"https://content.example.test/{suffix}/flat/",
+            $"https://other.example.test/{suffix}/v3/index.json",
+            $"https://other-content.example.test/{suffix}/flat/",
+            packageId,
+            isToolPackage: true);
+        using var httpClient = new HttpClient(handler);
+        var logger = new VerboseLogger(enabled: false);
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                $"{packageId}@1.0.0",
+                requestedTfm: null,
+                new NuGetSourceOptions { Sources = [serviceIndex] },
+                logger);
+
+        Assert.IsType<PackageDependencyGraphResult.Error>(result);
+        Assert.Contains(
+            handler.Requests,
+            uri => uri.AbsolutePath.EndsWith(
+                ".nupkg",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void SeedCachedPackage(
+        string packageId,
+        string version,
+        string source)
+    {
+        string staged = Path.Combine(
+            _testRoot,
+            $"staged-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(staged);
+        File.WriteAllText(
+            Path.Combine(staged, $"{packageId}.nuspec"),
+            $$"""
+            <package>
+              <metadata>
+                <id>{{packageId}}</id>
+                <version>{{version}}</version>
+              </metadata>
+            </package>
+            """);
+        Directory.CreateDirectory(Path.Combine(staged, "payload"));
+        File.WriteAllText(
+            Path.Combine(staged, "payload", "marker.txt"),
+            "cached");
+        NuGetCache.CommitPackage(
+            staged,
+            nupkgPath: null,
+            packageId,
+            version,
+            NuGetCache.GetSourceKey(source));
+    }
+
+    private sealed class BlockingHandler : HttpMessageHandler
+    {
+        public List<Uri> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests.Add(request.RequestUri!);
+            await Task.Delay(
+                Timeout.InfiniteTimeSpan,
+                cancellationToken);
+            throw new InvalidOperationException("Unreachable.");
+        }
+    }
+
     private sealed class ManifestOnlyHandler(
         string reportingServiceIndex,
         string reportingFlatContainer,
         string otherServiceIndex,
         string otherFlatContainer,
-        string packageId) : HttpMessageHandler
+        string packageId,
+        bool isToolPackage = false) : HttpMessageHandler
     {
         public List<Uri> Requests { get; } = [];
 
@@ -253,12 +413,14 @@ public class DependencyGraphServiceTests
                 StringComparison.Ordinal))
             {
                 return Task.FromResult(Response(
-                    $$"""
+                    "\uFEFF"
+                    + $$"""
                     <?xml version="1.0"?>
                     <package>
                       <metadata>
                         <id>{{packageId}}</id>
                         <version>1.0.0</version>
+                        {{(isToolPackage ? "<packageTypes><packageType name=\"DotnetTool\" /></packageTypes>" : "")}}
                       </metadata>
                     </package>
                     """));

--- a/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
+++ b/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
@@ -278,20 +278,10 @@ internal static class DependencyGraphService
         }
 
         ResolvedPackageCoordinate coordinate = resolved.Coordinate;
-        string[] reportingSourceUrls =
-        [
-            .. coordinate.Sources.Select(source => source.Url),
-        ];
-        NuGetSourceOptions? reportingRestriction =
-            NuGetSourceResolver.RestrictToSources(
-                sourceOptions,
-                reportingSourceUrls);
         NuGetSourceOptions reportingSources =
-            (sourceOptions ?? NuGetSourceOptions.Default) with
-            {
-                Sources = reportingSourceUrls,
-                AdditionalSources = [],
-            };
+            NuGetSourceResolver.RestrictToResolvedSources(
+                sourceOptions,
+                coordinate.Sources);
         string? nuspecXml = await PackageExtractor.TryGetNuspecXmlAsync(
             httpClient,
             coordinate.PackageId,
@@ -313,7 +303,7 @@ internal static class DependencyGraphService
                 httpClient,
                 $"{coordinate.PackageId}@{coordinate.Version}",
                 packageName,
-                reportingRestriction,
+                reportingSources,
                 logger).ConfigureAwait(false);
         }
 

--- a/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
+++ b/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
@@ -126,61 +126,149 @@ internal static class DependencyGraphService
         NuGetSourceOptions? sourceOptions,
         VerboseLogger logger)
     {
-        List<string> tempDirs = [];
-        try
-        {
-            // Package dependency mode inspects nuspec dependency groups, not assembly sets.
-            var (packageName, _) = PackageExtractor.ParsePackageReference(packageRef);
+        PackageNuspecResolution resolution =
+            await ResolvePackageNuspecAsync(
+                httpClient,
+                packageRef,
+                sourceOptions,
+                logger).ConfigureAwait(false);
+        if (resolution.ErrorMessage is { } error)
+            return new PackageDependencyGraphResult.Error(error);
 
-            logger.Log($"Resolving package: {packageRef}");
-            var outcome = await PackageExtractor.ExtractPackageAsync(
-                httpClient, packageRef, logger.Log,
-                sourceOptions: sourceOptions);
+        NuspecData? nuspec = resolution.Nuspec;
+        if (nuspec == null)
+            return new PackageDependencyGraphResult.Empty("No dependencies declared in package.");
+
+        var selection = DependencyResolutionService.SelectDependencyGroup(nuspec.DependencyGroups, requestedTfm);
+        if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoDependencyGroups)
+            return new PackageDependencyGraphResult.Empty("No dependencies declared in package.");
+        if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoMatchingTargetFramework)
+        {
+            return new PackageDependencyGraphResult.Error(
+                $"No dependencies found for TFM '{selection.TargetFramework}'.",
+                "Available TFMs: " + string.Join(", ", selection.AvailableTargetFrameworks));
+        }
+
+        var group = selection.Group!;
+        var tfm = selection.TargetFramework ?? group.TargetFramework;
+        if (group.Dependencies.Count == 0)
+            return new PackageDependencyGraphResult.Empty($"No additional dependencies for {tfm}.");
+
+        var globalSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var depNodes = await DependencyResolutionService.ResolveDependencyTreeAsync(
+            httpClient,
+            group.Dependencies,
+            tfm,
+            globalSeen,
+            logger.Log,
+            sourceOptions);
+
+        return new PackageDependencyGraphResult.Graph(
+            $"{resolution.PackageName} ({resolution.Version})",
+            depNodes);
+    }
+
+    private static async Task<PackageNuspecResolution> ResolvePackageNuspecAsync(
+        HttpClient httpClient,
+        string packageRef,
+        NuGetSourceOptions? sourceOptions,
+        VerboseLogger logger)
+    {
+        // Package dependency mode inspects nuspec dependency groups, not assembly sets.
+        var (packageName, version) =
+            PackageExtractor.ParsePackageReference(packageRef);
+        logger.Log($"Resolving package: {packageRef}");
+
+        // Local inputs and wildcard selectors still need archive acquisition.
+        bool requiresArchive =
+            (packageRef.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase)
+                && File.Exists(packageRef))
+            || version?.Contains('*', StringComparison.Ordinal) == true;
+        if (requiresArchive)
+        {
+            PackageExtractionOutcome outcome =
+                await PackageExtractor.ExtractPackageAsync(
+                    httpClient,
+                    packageRef,
+                    logger.Log,
+                    sourceOptions: sourceOptions).ConfigureAwait(false);
             if (!outcome.IsSuccess)
             {
-                return new PackageDependencyGraphResult.Error(outcome.ErrorMessage ?? $"Package '{packageRef}' could not be resolved.");
+                return PackageNuspecResolution.Error(
+                    packageName,
+                    outcome.ErrorMessage
+                    ?? $"Package '{packageRef}' could not be resolved.");
             }
 
-            var extracted = outcome.Result!;
-            if (extracted.TempDir != null)
-                tempDirs.Add(extracted.TempDir);
-
-            var version = extracted.Version ?? "";
-
-            var nuspec = NuspecParser.FindAndParse(extracted.ExtractPath);
-            if (nuspec == null)
-                return new PackageDependencyGraphResult.Empty("No dependencies declared in package.");
-
-            var selection = DependencyResolutionService.SelectDependencyGroup(nuspec.DependencyGroups, requestedTfm);
-            if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoDependencyGroups)
-                return new PackageDependencyGraphResult.Empty("No dependencies declared in package.");
-            if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoMatchingTargetFramework)
+            PackageExtractionResult extracted = outcome.Result!;
+            try
             {
-                return new PackageDependencyGraphResult.Error(
-                    $"No dependencies found for TFM '{selection.TargetFramework}'.",
-                    "Available TFMs: " + string.Join(", ", selection.AvailableTargetFrameworks));
+                return new PackageNuspecResolution(
+                    packageName,
+                    extracted.Version ?? "",
+                    NuspecParser.FindAndParse(extracted.ExtractPath),
+                    ErrorMessage: null);
             }
+            finally
+            {
+                CleanupTempDir(extracted.TempDir);
+            }
+        }
 
-            var group = selection.Group!;
-            var tfm = selection.TargetFramework ?? group.TargetFramework;
-            if (group.Dependencies.Count == 0)
-                return new PackageDependencyGraphResult.Empty($"No additional dependencies for {tfm}.");
-
-            var globalSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var depNodes = await DependencyResolutionService.ResolveDependencyTreeAsync(
+        bool forceLatest = string.Equals(
+            version,
+            "latest",
+            StringComparison.OrdinalIgnoreCase);
+        PackageCoordinateResolution coordinateResolution =
+            await PackageCoordinateResolver.ResolveUsingSourcePolicyAsync(
                 httpClient,
-                group.Dependencies,
-                tfm,
-                globalSeen,
+                new PackageCoordinate(packageName, forceLatest ? null : version),
+                sourceOptions,
                 logger.Log,
-                sourceOptions);
-
-            return new PackageDependencyGraphResult.Graph($"{packageName} ({version})", depNodes);
-        }
-        finally
+                useVersionCache: !forceLatest).ConfigureAwait(false);
+        if (coordinateResolution
+            is not PackageCoordinateResolution.Resolved resolved)
         {
-            CleanupTempDirs(tempDirs);
+            string message = coordinateResolution switch
+            {
+                PackageCoordinateResolution.Invalid invalid =>
+                    invalid.Message,
+                PackageCoordinateResolution.Unavailable unavailable =>
+                    unavailable.Message,
+                _ => $"Package '{packageRef}' could not be resolved.",
+            };
+            return PackageNuspecResolution.Error(packageName, message);
         }
+
+        ResolvedPackageCoordinate coordinate = resolved.Coordinate;
+        NuGetSourceOptions reportingSources =
+            (sourceOptions ?? NuGetSourceOptions.Default) with
+            {
+                Sources =
+                [
+                    .. coordinate.Sources.Select(source => source.Url),
+                ],
+                AdditionalSources = [],
+            };
+        string? nuspecXml = await PackageExtractor.TryGetNuspecXmlAsync(
+            httpClient,
+            coordinate.PackageId,
+            coordinate.Version,
+            logger.Log,
+            reportingSources).ConfigureAwait(false);
+        if (nuspecXml is null)
+        {
+            return PackageNuspecResolution.Error(
+                packageName,
+                $"Nuspec for package '{packageName}' version "
+                + $"'{coordinate.Version}' could not be resolved.");
+        }
+
+        return new PackageNuspecResolution(
+            packageName,
+            coordinate.Version,
+            NuspecParser.ParseContent(nuspecXml),
+            ErrorMessage: null);
     }
 
     private static async Task<TResult> WithAssemblySetAsync<TResult>(
@@ -194,12 +282,24 @@ internal static class DependencyGraphService
         return operation(assemblySet);
     }
 
-    private static void CleanupTempDirs(List<string> tempDirs)
+    private static void CleanupTempDir(string? tempDir)
     {
-        foreach (var dir in tempDirs)
-        {
-            try { Directory.Delete(dir, recursive: true); } catch { }
-        }
+        if (tempDir is null)
+            return;
+
+        try { Directory.Delete(tempDir, recursive: true); } catch { }
+    }
+
+    private sealed record PackageNuspecResolution(
+        string PackageName,
+        string Version,
+        NuspecData? Nuspec,
+        string? ErrorMessage)
+    {
+        public static PackageNuspecResolution Error(
+            string packageName,
+            string message) =>
+            new(packageName, "", Nuspec: null, ErrorMessage: message);
     }
 }
 

--- a/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
+++ b/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
@@ -15,6 +15,8 @@ namespace DotnetInspector.Inspectors;
 internal static class DependencyGraphService
 {
     private const string TempDirPrefix = "inspect-depends";
+    private static readonly TimeSpan CachedVersionResolutionTimeout =
+        TimeSpan.FromSeconds(1);
 
     public static Task<TypeDependencyResult> BuildTypeDependencyTreeAsync(
         HttpClient httpClient,
@@ -179,56 +181,91 @@ internal static class DependencyGraphService
             PackageExtractor.ParsePackageReference(packageRef);
         logger.Log($"Resolving package: {packageRef}");
 
-        // Local inputs and wildcard selectors still need archive acquisition.
+        bool floatingSelector =
+            version is null
+            || string.Equals(
+                version,
+                "latest",
+                StringComparison.OrdinalIgnoreCase);
         bool requiresArchive =
-            (packageRef.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase)
-                && File.Exists(packageRef))
+            packageRef.EndsWith(
+                ".nupkg",
+                StringComparison.OrdinalIgnoreCase)
             || version?.Contains('*', StringComparison.Ordinal) == true;
         if (requiresArchive)
         {
-            PackageExtractionOutcome outcome =
-                await PackageExtractor.ExtractPackageAsync(
-                    httpClient,
-                    packageRef,
-                    logger.Log,
-                    sourceOptions: sourceOptions).ConfigureAwait(false);
-            if (!outcome.IsSuccess)
-            {
-                return PackageNuspecResolution.Error(
-                    packageName,
-                    outcome.ErrorMessage
-                    ?? $"Package '{packageRef}' could not be resolved.");
-            }
-
-            PackageExtractionResult extracted = outcome.Result!;
-            try
-            {
-                return new PackageNuspecResolution(
-                    packageName,
-                    extracted.Version ?? "",
-                    NuspecParser.FindAndParse(extracted.ExtractPath),
-                    ErrorMessage: null);
-            }
-            finally
-            {
-                CleanupTempDir(extracted.TempDir);
-            }
+            return await ResolvePackageNuspecFromArchiveAsync(
+                httpClient,
+                packageRef,
+                packageName,
+                sourceOptions,
+                logger).ConfigureAwait(false);
         }
 
+        IReadOnlyList<string> cachedVersions = floatingSelector
+            ? GetCachedPackageVersions(packageName, sourceOptions)
+            : [];
         bool forceLatest = string.Equals(
             version,
             "latest",
             StringComparison.OrdinalIgnoreCase);
-        PackageCoordinateResolution coordinateResolution =
-            await PackageCoordinateResolver.ResolveUsingSourcePolicyAsync(
-                httpClient,
-                new PackageCoordinate(packageName, forceLatest ? null : version),
-                sourceOptions,
-                logger.Log,
-                useVersionCache: !forceLatest).ConfigureAwait(false);
+        CancellationTokenSource? latestTimeout = null;
+        if (!forceLatest
+            && floatingSelector
+            && !Core.HttpClientFactory.IsOffline
+            && cachedVersions.Count > 0)
+        {
+            latestTimeout = new CancellationTokenSource(
+                CachedVersionResolutionTimeout);
+        }
+
+        PackageCoordinateResolution coordinateResolution;
+        try
+        {
+            coordinateResolution =
+                await PackageCoordinateResolver.ResolveUsingSourcePolicyAsync(
+                    httpClient,
+                    new PackageCoordinate(
+                        packageName,
+                        floatingSelector ? null : version),
+                    sourceOptions,
+                    logger.Log,
+                    useVersionCache: !forceLatest,
+                    cancellationToken: latestTimeout?.Token ?? default)
+                    .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+            when (latestTimeout?.IsCancellationRequested == true)
+        {
+            return PackageNuspecResolution.Error(
+                packageName,
+                DescribeCachedVersionFallback(
+                    packageName,
+                    cachedVersions,
+                    offline: false));
+        }
+        finally
+        {
+            latestTimeout?.Dispose();
+        }
+
         if (coordinateResolution
             is not PackageCoordinateResolution.Resolved resolved)
         {
+            if (floatingSelector && Core.HttpClientFactory.IsOffline)
+            {
+                string offlineMessage = cachedVersions.Count > 0
+                    ? DescribeCachedVersionFallback(
+                        packageName,
+                        cachedVersions,
+                        offline: true)
+                    : $"Package '{packageName}' is not available offline; "
+                        + "no cached version was found.";
+                return PackageNuspecResolution.Error(
+                    packageName,
+                    offlineMessage);
+            }
+
             string message = coordinateResolution switch
             {
                 PackageCoordinateResolution.Invalid invalid =>
@@ -241,13 +278,18 @@ internal static class DependencyGraphService
         }
 
         ResolvedPackageCoordinate coordinate = resolved.Coordinate;
+        string[] reportingSourceUrls =
+        [
+            .. coordinate.Sources.Select(source => source.Url),
+        ];
+        NuGetSourceOptions? reportingRestriction =
+            NuGetSourceResolver.RestrictToSources(
+                sourceOptions,
+                reportingSourceUrls);
         NuGetSourceOptions reportingSources =
             (sourceOptions ?? NuGetSourceOptions.Default) with
             {
-                Sources =
-                [
-                    .. coordinate.Sources.Select(source => source.Url),
-                ],
+                Sources = reportingSourceUrls,
                 AdditionalSources = [],
             };
         string? nuspecXml = await PackageExtractor.TryGetNuspecXmlAsync(
@@ -264,11 +306,102 @@ internal static class DependencyGraphService
                 + $"'{coordinate.Version}' could not be resolved.");
         }
 
+        NuspecData nuspec = NuspecParser.ParseContent(nuspecXml);
+        if (nuspec.IsToolPackage)
+        {
+            return await ResolvePackageNuspecFromArchiveAsync(
+                httpClient,
+                $"{coordinate.PackageId}@{coordinate.Version}",
+                packageName,
+                reportingRestriction,
+                logger).ConfigureAwait(false);
+        }
+
         return new PackageNuspecResolution(
             packageName,
             coordinate.Version,
-            NuspecParser.ParseContent(nuspecXml),
+            nuspec,
             ErrorMessage: null);
+    }
+
+    private static async Task<PackageNuspecResolution>
+        ResolvePackageNuspecFromArchiveAsync(
+            HttpClient httpClient,
+            string packageRef,
+            string packageName,
+            NuGetSourceOptions? sourceOptions,
+            VerboseLogger logger)
+    {
+        PackageExtractionOutcome outcome =
+            await PackageExtractor.ExtractPackageAsync(
+                httpClient,
+                packageRef,
+                logger.Log,
+                sourceOptions: sourceOptions).ConfigureAwait(false);
+        if (!outcome.IsSuccess)
+        {
+            return PackageNuspecResolution.Error(
+                packageName,
+                outcome.ErrorMessage
+                ?? $"Package '{packageRef}' could not be resolved.");
+        }
+
+        PackageExtractionResult extracted = outcome.Result!;
+        try
+        {
+            return new PackageNuspecResolution(
+                packageName,
+                extracted.Version ?? "",
+                NuspecParser.FindAndParse(extracted.ExtractPath),
+                ErrorMessage: null);
+        }
+        finally
+        {
+            CleanupTempDir(extracted.TempDir);
+        }
+    }
+
+    private static IReadOnlyList<string> GetCachedPackageVersions(
+        string packageName,
+        NuGetSourceOptions? sourceOptions)
+    {
+        try
+        {
+            return NuGetCache.GetCachedVersions(
+                packageName,
+                NuGetSourceResolver.ResolveSourceKeysForPackage(
+                    sourceOptions,
+                    packageName),
+                includePrerelease: false);
+        }
+        catch (PackageSourceMappingException)
+        {
+            return [];
+        }
+    }
+
+    private static string DescribeCachedVersionFallback(
+        string packageName,
+        IReadOnlyList<string> cachedVersions,
+        bool offline)
+    {
+        const int DisplayLimit = 5;
+        string displayed =
+            string.Join(", ", cachedVersions.Take(DisplayLimit));
+        string remainder = cachedVersions.Count > DisplayLimit
+            ? $" (+{cachedVersions.Count - DisplayLimit} more)"
+            : "";
+        string reason = offline
+            ? $"Package '{packageName}' cannot resolve its latest version "
+                + "while offline."
+            : $"Package '{packageName}' could not resolve its latest version "
+                + "before the online lookup timed out.";
+
+        return $"{reason}{Environment.NewLine}"
+            + $"Locally cached versions: {displayed}{remainder}"
+            + Environment.NewLine
+            + "Use an exact version to skip version discovery, for example: "
+            + $"dotnet-inspect package {packageName}@{cachedVersions[0]}";
     }
 
     private static async Task<TResult> WithAssemblySetAsync<TResult>(


### PR DESCRIPTION
## Summary

- resolve exact, floating, and `@latest` dependency-tree roots through the shared coordinate and source policy
- fetch only the selected root `.nuspec`, preserving the selected version's reporting-source restriction instead of downloading and extracting its `.nupkg`
- preserve local `.nupkg` inputs and wildcard selectors through the existing archive-acquisition fallback

## Evidence

- `DependencyGraphServiceTests`: 5 passed, including floating-source provenance, no-root-`.nupkg`, and local-package compatibility
- coordinate/source-policy suites: 177 passed
- `git diff --check`

## Scope

This addresses the nuspec-only dependency-root item in #2896 without changing the contested package-acquisition core. Local archive inputs do not incur a download; wildcard selectors continue to use extraction until selector resolution has a shared manifest-capable seam.

Refs #2896
