### PR TITLE
Add typed package source client boundary

### DIFF
--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -560,6 +560,15 @@ The existing NuGetFetch shape is a useful base:
 - it source-scopes candidates and payload provenance; and
 - it already special-cases NuGet.org search internally.
 
+The first implementation slice establishes the typed source identity,
+credential-free descriptor, capability, runtime-client, and factory contracts
+in NuGetFetch. It adapts the existing desktop `PackageSource` input to a NuGet
+v3 client without migrating current consumers, and centralizes canonical HTTP
+producer identity so credential scope and future transports use the same key.
+Gallery and local-folder descriptors are modeled but intentionally have no
+runtime client yet. The existing NuGet.org search special case remains inside
+the v3 compatibility adapter until the Gallery client replaces it.
+
 The remaining structural problem is that `PackageSource` and `NuGetClient`
 largely equate a source with a v3 service-index URL. The implementation should:
 

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -558,7 +558,7 @@ The existing NuGetFetch shape is a useful base:
 - it resolves multiple configured sources;
 - it implements package source mapping;
 - it source-scopes candidates and payload provenance; and
-- it already special-cases NuGet.org search internally.
+- its v3 primitives already own service-index, version, and package requests.
 
 The first implementation slice establishes the typed source identity,
 credential-free descriptor, capability, runtime-client, and factory contracts
@@ -566,8 +566,18 @@ in NuGetFetch. It adapts the existing desktop `PackageSource` input to a NuGet
 v3 client without migrating current consumers, and centralizes canonical HTTP
 producer identity so credential scope and future transports use the same key.
 Gallery and local-folder descriptors are modeled but intentionally have no
-runtime client yet. The existing NuGet.org search special case remains inside
-the v3 compatibility adapter until the Gallery client replaces it.
+runtime client yet. The v3 compatibility adapter initially exposes version and
+package-payload operations only. Search remains on the existing package-layer
+service-index discovery path until that resource discovery moves into the
+typed client; the adapter does not restore the retired NuGet.org-only search
+shortcut.
+`PackageSourceClientTests.GalleryAndCanonicalV3ShareProducerIdentity`,
+`HttpProducerIdentityFoldsIdnAndPercentEscapeSpelling`,
+`LegacyPackageSourceCreatesV3Client`,
+`CanonicalNuGetOrgV3DoesNotReintroduceSearchShortcut`, and
+`LegacyLocalSourceRemainsAnExplicitUnsupportedKind` gate this first boundary.
+The existing `NuGetSearchSourcesTests` continue to gate the package-layer
+service-index search behavior and credential-scope canonicalization.
 
 The remaining structural problem is that `PackageSource` and `NuGetClient`
 largely equate a source with a v3 service-index URL. The implementation should:

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -565,12 +565,16 @@ credential-free descriptor, capability, runtime-client, and factory contracts
 in NuGetFetch. It adapts the existing desktop `PackageSource` input to a NuGet
 v3 client without migrating current consumers, and centralizes canonical HTTP
 producer identity so credential scope and future transports use the same key.
+Portable descriptors reject user information, queries, and fragments. The
+desktop compatibility adapter keeps established query-bearing signed service
+indexes as runtime-only configuration rather than admitting them into a
+portable descriptor.
 Gallery and local-folder descriptors are modeled but intentionally have no
 runtime client yet. The v3 compatibility adapter initially exposes version and
-package-payload operations only. Search remains on the existing package-layer
-service-index discovery path until that resource discovery moves into the
-typed client; the adapter does not restore the retired NuGet.org-only search
-shortcut.
+package-payload operations only, and validates package coordinates before any
+service-index or payload request. Search remains on the existing package-layer
+service-index discovery path until that resource discovery moves into the typed
+client; the adapter does not restore the retired NuGet.org-only search shortcut.
 `PackageSourceClientTests.GalleryAndCanonicalV3ShareProducerIdentity`,
 `HttpProducerIdentityFoldsIdnAndPercentEscapeSpelling`,
 `LegacyPackageSourceCreatesV3Client`,

--- a/src/DotnetInspector.Packages/NuGetCredentialScope.cs
+++ b/src/DotnetInspector.Packages/NuGetCredentialScope.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using DotnetInspector.Core;
 using InertText;
+using NuGetFetch;
 using NuGetSource = NuGetFetch.PackageSource;
 
 namespace DotnetInspector.Packages;
@@ -100,27 +101,22 @@ public static class NuGetCredentialScope
     public static string CanonicalizeEndpoint(Uri url)
     {
         ArgumentNullException.ThrowIfNull(url);
+        if (url.Scheme == Uri.UriSchemeHttp
+            || url.Scheme == Uri.UriSchemeHttps)
+        {
+            return PackageSourceIdentity.ForHttpEndpoint(url).Value;
+        }
 
-        // Scheme and host are case-insensitive by definition, so they fold. Path, query, and
-        // fragment are not, and are preserved as written apart from the percent-escape hex casing
-        // that RFC 3986 defines as equivalent. The path's trailing slash is dropped; the query's
-        // is not, because a trailing slash inside a query is a value, not a path terminator.
         var origin =
             $"{url.Scheme.ToLowerInvariant()}://{url.IdnHost.ToLowerInvariant()}:{url.Port}";
         string absolutePath = url.AbsolutePath;
-        var path = NormalizeEscapes(
+        string path = NormalizeEscapes(
             absolutePath.EndsWith("/", StringComparison.Ordinal)
                 ? absolutePath[..^1]
                 : absolutePath);
-        var query = NormalizeEscapes(url.Query);
-        var fragment = NormalizeEscapes(url.Fragment);
-        return $"{origin}{path}{query}{fragment}";
+        return $"{origin}{path}{NormalizeEscapes(url.Query)}{NormalizeEscapes(url.Fragment)}";
     }
 
-    /// <summary>
-    /// Upper-cases the hex digits of percent-escapes, which RFC 3986 defines as case-insensitive,
-    /// leaving every other character byte-for-byte intact.
-    /// </summary>
     private static string NormalizeEscapes(string value)
     {
         if (!value.Contains('%', StringComparison.Ordinal))

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -99,6 +99,29 @@ public sealed class PackageSourceClientTests
             error.Message);
     }
 
+    [Theory]
+    [InlineData("https://feed.example/v3/index.json?sig=secret")]
+    [InlineData("https://feed.example/v3/index.json#sig=secret")]
+    public void PortableDescriptorRejectsRawQueryAndFragment(string endpoint)
+    {
+        var rawEndpoint = new Uri(
+            endpoint,
+            new UriCreationOptions
+            {
+                DangerousDisablePathAndQueryCanonicalization = true,
+            });
+
+        ArgumentException error = Assert.Throws<ArgumentException>(
+            () => PackageSourceDescriptor.NuGetV3(
+                "raw",
+                "Raw",
+                rawEndpoint));
+
+        Assert.Contains(
+            "cannot contain a query or fragment",
+            error.Message);
+    }
+
     [Fact]
     public void PortableDescriptorRejectsRelativeEndpoint()
     {

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -1,0 +1,244 @@
+using System.Net;
+using System.Text;
+using NuGetFetch;
+
+namespace NuGetFetch.Tests;
+
+public sealed class PackageSourceClientTests
+{
+    private const string ServiceIndex =
+        "https://feed.example/v3/index.json";
+    private const string FlatContainer =
+        "https://feed.example/v3/flat/";
+    private const string Versions =
+        "https://feed.example/v3/flat/contoso/index.json";
+    private const string Package =
+        "https://feed.example/v3/flat/contoso/1.0.0/contoso.1.0.0.nupkg";
+
+    [Fact]
+    public void GalleryAndCanonicalV3ShareProducerIdentity()
+    {
+        PackageSourceDescriptor v3 = PackageSourceDescriptor.NuGetV3(
+            "nuget-v3",
+            "NuGet.org v3",
+            new Uri("HTTPS://API.NUGET.ORG:443/v3/index.json/"));
+
+        Assert.Equal(
+            PackageSourceDescriptor.NuGetGallery.Identity,
+            v3.Identity);
+        Assert.NotEqual(
+            PackageSourceDescriptor.NuGetGallery.Kind,
+            v3.Kind);
+        Assert.Null(PackageSourceDescriptor.NuGetGallery.Endpoint);
+    }
+
+    [Fact]
+    public void HttpProducerIdentityPreservesEndpointDistinctions()
+    {
+        PackageSourceIdentity upperPath =
+            PackageSourceIdentity.ForHttpEndpoint(
+                new Uri("https://feed.example/V3/index.json"));
+        PackageSourceIdentity lowerPath =
+            PackageSourceIdentity.ForHttpEndpoint(
+                new Uri("https://FEED.EXAMPLE:443/v3/index.json/"));
+        PackageSourceIdentity query =
+            PackageSourceIdentity.ForHttpEndpoint(
+                new Uri("https://feed.example/V3/index.json?tenant=a"));
+
+        Assert.NotEqual(upperPath, lowerPath);
+        Assert.NotEqual(upperPath, query);
+        Assert.Equal(
+            "https://feed.example:443/v3/index.json",
+            lowerPath.Value);
+    }
+
+    [Fact]
+    public void DescriptorRejectsCredentialsEmbeddedInEndpoint()
+    {
+        ArgumentException error = Assert.Throws<ArgumentException>(
+            () => PackageSourceDescriptor.NuGetV3(
+                "credentialed",
+                "Credentialed",
+                new Uri("https://user:token@feed.example/v3/index.json")));
+
+        Assert.Contains(
+            "cannot contain user information",
+            error.Message);
+    }
+
+    [Fact]
+    public void DescriptorIsCredentialFreeConfiguration()
+    {
+        PackageSourceDescriptor descriptor = PackageSourceDescriptor.NuGetV3(
+            "corporate",
+            "Corporate feed",
+            new Uri(ServiceIndex),
+            enabled: false);
+
+        Assert.Equal("corporate", descriptor.Id);
+        Assert.Equal("Corporate feed", descriptor.DisplayName);
+        Assert.Equal(PackageSourceKind.NuGetV3, descriptor.Kind);
+        Assert.False(descriptor.Enabled);
+        Assert.Null(
+            typeof(PackageSourceDescriptor).GetProperty(
+                nameof(PackageSource.Credential)));
+    }
+
+    [Fact]
+    public async Task LegacyPackageSourceCreatesV3Client()
+    {
+        var handler = new RecordingHandler
+        {
+            [ServiceIndex] = $$"""
+                {
+                  "version": "3.0.0",
+                  "resources": [
+                    {
+                      "@id": "{{FlatContainer}}",
+                      "@type": "PackageBaseAddress/3.0.0"
+                    }
+                  ]
+                }
+                """,
+            [Versions] = """{"versions":["1.0.0"]}""",
+            [Package] = "package bytes",
+        };
+        using var client = new HttpClient(handler);
+        var source = new PackageSource(
+            "corporate",
+            ServiceIndex,
+            new PackageSourceCredential("user", "token"));
+
+        IPackageSourceClient runtime =
+            PackageSourceClientFactory.Create(source, client);
+
+        Assert.Equal(PackageSourceKind.NuGetV3, runtime.Kind);
+        Assert.Equal(
+            PackageSourceCapabilities.VersionEnumeration
+                | PackageSourceCapabilities.PackagePayload,
+            runtime.Capabilities);
+        Assert.Equal(["1.0.0"], await runtime.GetVersionsAsync(
+            "contoso",
+            TestContext.Current.CancellationToken));
+        await using Stream package = await runtime.GetPackageAsync(
+            "contoso",
+            "1.0.0",
+            TestContext.Current.CancellationToken);
+        using var reader = new StreamReader(package);
+        Assert.Equal(
+            "package bytes",
+            await reader.ReadToEndAsync(
+                TestContext.Current.CancellationToken));
+        Assert.Equal(
+            ["user:token", "user:token", "user:token"],
+            handler.Authentication.Select(DecodeBasic));
+    }
+
+    [Fact]
+    public async Task UnsupportedCapabilityFailsBeforeNetworkAccess()
+    {
+        var handler = new RecordingHandler();
+        using var client = new HttpClient(handler);
+        IPackageSourceClient runtime =
+            PackageSourceClientFactory.Create(
+                new PackageSource("corporate", ServiceIndex),
+                client);
+
+        PackageSourceCapabilityException error =
+            await Assert.ThrowsAsync<PackageSourceCapabilityException>(
+                () => runtime.SearchAsync(
+                    "contoso",
+                    cancellationToken:
+                        TestContext.Current.CancellationToken));
+
+        Assert.Equal(PackageSourceKind.NuGetV3, error.Kind);
+        Assert.Equal(
+            PackageSourceCapabilities.Search,
+            error.Capability);
+        Assert.Empty(handler.Requested);
+    }
+
+    [Fact]
+    public async Task NuGetOrgSearchDoesNotSendServiceIndexCredential()
+    {
+        var handler = new RecordingHandler
+        {
+            DefaultResponse = """{"data":[]}""",
+        };
+        using var client = new HttpClient(handler);
+        IPackageSourceClient runtime =
+            PackageSourceClientFactory.Create(
+                new PackageSource(
+                    "nuget.org",
+                    PackageSourceIdentity.NuGetOrg.Value,
+                    new PackageSourceCredential("user", "token")),
+                client);
+
+        Assert.True(
+            runtime.Capabilities.HasFlag(
+                PackageSourceCapabilities.Search));
+        Assert.Empty(await runtime.SearchAsync(
+            "contoso",
+            cancellationToken:
+                TestContext.Current.CancellationToken));
+        Assert.Single(handler.Authentication);
+        Assert.Null(handler.Authentication[0]);
+    }
+
+    [Fact]
+    public void FactoryRejectsKindsWithoutAnImplementation()
+    {
+        using var client = new HttpClient(new RecordingHandler());
+
+        PackageSourceClientUnavailableException error =
+            Assert.Throws<PackageSourceClientUnavailableException>(
+                () => PackageSourceClientFactory.Create(
+                    PackageSourceDescriptor.NuGetGallery,
+                    client));
+
+        Assert.Equal(PackageSourceKind.NuGetGallery, error.Kind);
+    }
+
+    private static string? DecodeBasic(string? parameter) =>
+        parameter is null
+            ? null
+            : Encoding.UTF8.GetString(
+                Convert.FromBase64String(parameter));
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly Dictionary<string, string> _routes =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        public string this[string url] { set => _routes[url] = value; }
+
+        public string? DefaultResponse { get; init; }
+        public List<string> Requested { get; } = [];
+        public List<string?> Authentication { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string url = request.RequestUri!.AbsoluteUri;
+            Requested.Add(url);
+            Authentication.Add(
+                request.Headers.Authorization?.Parameter);
+            bool hasResponse =
+                _routes.ContainsKey(url)
+                || DefaultResponse is not null;
+            HttpStatusCode status = hasResponse
+                ? HttpStatusCode.OK
+                : HttpStatusCode.NotFound;
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(
+                    hasResponse
+                        ? _routes.GetValueOrDefault(url)
+                            ?? DefaultResponse!
+                        : ""),
+                RequestMessage = request,
+            });
+        }
+    }
+}

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -53,6 +53,23 @@ public sealed class PackageSourceClientTests
     }
 
     [Fact]
+    public void HttpProducerIdentityFoldsIdnAndPercentEscapeSpelling()
+    {
+        PackageSourceIdentity unicode =
+            PackageSourceIdentity.ForHttpEndpoint(
+                new Uri("https://bücher.example/feed/%2f?q=%2f"));
+        PackageSourceIdentity ascii =
+            PackageSourceIdentity.ForHttpEndpoint(
+                new Uri("https://xn--bcher-kva.example:443/feed/%2F?q=%2F"));
+
+        Assert.Equal(unicode, ascii);
+        Assert.Contains(
+            "xn--bcher-kva.example:443",
+            unicode.Value,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void DescriptorRejectsCredentialsEmbeddedInEndpoint()
     {
         ArgumentException error = Assert.Throws<ArgumentException>(
@@ -159,12 +176,9 @@ public sealed class PackageSourceClientTests
     }
 
     [Fact]
-    public async Task NuGetOrgSearchDoesNotSendServiceIndexCredential()
+    public async Task CanonicalNuGetOrgV3DoesNotReintroduceSearchShortcut()
     {
-        var handler = new RecordingHandler
-        {
-            DefaultResponse = """{"data":[]}""",
-        };
+        var handler = new RecordingHandler();
         using var client = new HttpClient(handler);
         IPackageSourceClient runtime =
             PackageSourceClientFactory.Create(
@@ -174,15 +188,15 @@ public sealed class PackageSourceClientTests
                     new PackageSourceCredential("user", "token")),
                 client);
 
-        Assert.True(
-            runtime.Capabilities.HasFlag(
-                PackageSourceCapabilities.Search));
-        Assert.Empty(await runtime.SearchAsync(
-            "contoso",
-            cancellationToken:
-                TestContext.Current.CancellationToken));
-        Assert.Single(handler.Authentication);
-        Assert.Null(handler.Authentication[0]);
+        Assert.False(
+            runtime.Capabilities.HasFlag(PackageSourceCapabilities.Search));
+        await Assert.ThrowsAsync<PackageSourceCapabilityException>(
+            () => runtime.SearchAsync(
+                "contoso",
+                cancellationToken:
+                    TestContext.Current.CancellationToken));
+        Assert.Empty(handler.Requested);
+        Assert.Empty(handler.Authentication);
     }
 
     [Fact]
@@ -199,6 +213,21 @@ public sealed class PackageSourceClientTests
         Assert.Equal(PackageSourceKind.NuGetGallery, error.Kind);
     }
 
+    [Fact]
+    public void LegacyLocalSourceRemainsAnExplicitUnsupportedKind()
+    {
+        using var client = new HttpClient(new RecordingHandler());
+        var source = new PackageSource(
+            "local",
+            Path.GetFullPath("packages"));
+
+        PackageSourceClientUnavailableException error =
+            Assert.Throws<PackageSourceClientUnavailableException>(
+                () => PackageSourceClientFactory.Create(source, client));
+
+        Assert.Equal(PackageSourceKind.LocalFolder, error.Kind);
+    }
+
     private static string? DecodeBasic(string? parameter) =>
         parameter is null
             ? null
@@ -212,7 +241,6 @@ public sealed class PackageSourceClientTests
 
         public string this[string url] { set => _routes[url] = value; }
 
-        public string? DefaultResponse { get; init; }
         public List<string> Requested { get; } = [];
         public List<string?> Authentication { get; } = [];
 
@@ -224,9 +252,7 @@ public sealed class PackageSourceClientTests
             Requested.Add(url);
             Authentication.Add(
                 request.Headers.Authorization?.Parameter);
-            bool hasResponse =
-                _routes.ContainsKey(url)
-                || DefaultResponse is not null;
+            bool hasResponse = _routes.ContainsKey(url);
             HttpStatusCode status = hasResponse
                 ? HttpStatusCode.OK
                 : HttpStatusCode.NotFound;
@@ -234,8 +260,7 @@ public sealed class PackageSourceClientTests
             {
                 Content = new StringContent(
                     hasResponse
-                        ? _routes.GetValueOrDefault(url)
-                            ?? DefaultResponse!
+                        ? _routes.GetValueOrDefault(url)!
                         : ""),
                 RequestMessage = request,
             });

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -83,6 +83,34 @@ public sealed class PackageSourceClientTests
             error.Message);
     }
 
+    [Theory]
+    [InlineData("https://feed.example/v3/index.json?sig=secret")]
+    [InlineData("https://feed.example/v3/index.json#metadata")]
+    public void PortableDescriptorRejectsQueryAndFragment(string endpoint)
+    {
+        ArgumentException error = Assert.Throws<ArgumentException>(
+            () => PackageSourceDescriptor.NuGetV3(
+                "nonportable",
+                "Nonportable",
+                new Uri(endpoint)));
+
+        Assert.Contains(
+            "cannot contain a query or fragment",
+            error.Message);
+    }
+
+    [Fact]
+    public void PortableDescriptorRejectsRelativeEndpoint()
+    {
+        ArgumentException error = Assert.Throws<ArgumentException>(
+            () => PackageSourceDescriptor.NuGetV3(
+                "relative",
+                "Relative",
+                new Uri("v3/index.json", UriKind.Relative)));
+
+        Assert.Contains("must be an absolute", error.Message);
+    }
+
     [Fact]
     public void DescriptorIsCredentialFreeConfiguration()
     {
@@ -149,6 +177,92 @@ public sealed class PackageSourceClientTests
         Assert.Equal(
             ["user:token", "user:token", "user:token"],
             handler.Authentication.Select(DecodeBasic));
+    }
+
+    [Fact]
+    public async Task LegacySignedSourceRemainsRuntimeOnlyConfiguration()
+    {
+        const string signedServiceIndex =
+            ServiceIndex + "?sig=secret";
+        var handler = new RecordingHandler
+        {
+            [signedServiceIndex] = $$"""
+                {
+                  "version": "3.0.0",
+                  "resources": [
+                    {
+                      "@id": "{{FlatContainer}}",
+                      "@type": "PackageBaseAddress/3.0.0"
+                    }
+                  ]
+                }
+                """,
+            [Versions] = """{"versions":["1.0.0"]}""",
+        };
+        using var client = new HttpClient(handler);
+        IPackageSourceClient runtime =
+            PackageSourceClientFactory.Create(
+                new PackageSource(
+                    "signed",
+                    signedServiceIndex,
+                    new PackageSourceCredential("user", "token")),
+                client);
+
+        Assert.Equal(
+            ["1.0.0"],
+            await runtime.GetVersionsAsync(
+                "contoso",
+                TestContext.Current.CancellationToken));
+        Assert.Equal(
+            [signedServiceIndex, Versions],
+            handler.Requested);
+    }
+
+    [Theory]
+    [InlineData("../admin")]
+    [InlineData("contoso/package")]
+    [InlineData(" contoso")]
+    [InlineData("")]
+    public async Task InvalidPackageIdFailsBeforeNetworkAccess(
+        string packageId)
+    {
+        var handler = new RecordingHandler();
+        using var client = new HttpClient(handler);
+        IPackageSourceClient runtime =
+            PackageSourceClientFactory.Create(
+                new PackageSource("corporate", ServiceIndex),
+                client);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => runtime.GetVersionsAsync(
+                packageId,
+                TestContext.Current.CancellationToken));
+
+        Assert.Empty(handler.Requested);
+    }
+
+    [Theory]
+    [InlineData("../1.0.0")]
+    [InlineData("1.0.0/extra")]
+    [InlineData(" 1.0.0")]
+    [InlineData("")]
+    public async Task InvalidPackageVersionFailsBeforeNetworkAccess(
+        string version)
+    {
+        var handler = new RecordingHandler();
+        using var client = new HttpClient(handler);
+        IPackageSourceClient runtime =
+            PackageSourceClientFactory.Create(
+                new PackageSource("corporate", ServiceIndex),
+                client);
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => runtime.GetPackageAsync(
+                "contoso",
+                version,
+                TestContext.Current.CancellationToken));
+
+        Assert.Empty(handler.Requested);
     }
 
     [Fact]

--- a/src/NuGetFetch/PackageSourceClients.cs
+++ b/src/NuGetFetch/PackageSourceClients.cs
@@ -195,22 +195,25 @@ public sealed record PackageSourceDescriptor
         bool enabled = true)
     {
         ArgumentNullException.ThrowIfNull(serviceIndex);
-        if (!serviceIndex.IsAbsoluteUri)
+        if (!Uri.TryCreate(
+                serviceIndex.OriginalString,
+                UriKind.Absolute,
+                out Uri? portableEndpoint))
         {
             throw new ArgumentException(
                 "A portable package source endpoint must be an absolute HTTP or HTTPS URI.",
                 nameof(serviceIndex));
         }
 
-        if (serviceIndex.UserInfo.Length > 0)
+        if (portableEndpoint.UserInfo.Length > 0)
         {
             throw new ArgumentException(
                 "A portable package source endpoint cannot contain user information.",
                 nameof(serviceIndex));
         }
 
-        if (serviceIndex.Query.Length > 0
-            || serviceIndex.Fragment.Length > 0)
+        if (portableEndpoint.Query.Length > 0
+            || portableEndpoint.Fragment.Length > 0)
         {
             throw new ArgumentException(
                 "A portable package source endpoint cannot contain a query or fragment.",
@@ -218,13 +221,13 @@ public sealed record PackageSourceDescriptor
         }
 
         PackageSourceIdentity identity =
-            PackageSourceIdentity.ForHttpEndpoint(serviceIndex);
+            PackageSourceIdentity.ForHttpEndpoint(portableEndpoint);
         return new PackageSourceDescriptor(
             id,
             displayName,
             PackageSourceKind.NuGetV3,
             identity,
-            serviceIndex,
+            portableEndpoint,
             enabled);
     }
 }

--- a/src/NuGetFetch/PackageSourceClients.cs
+++ b/src/NuGetFetch/PackageSourceClients.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using System.Text.RegularExpressions;
+using NuGet.Versioning;
 
 namespace NuGetFetch;
 
@@ -193,10 +195,25 @@ public sealed record PackageSourceDescriptor
         bool enabled = true)
     {
         ArgumentNullException.ThrowIfNull(serviceIndex);
+        if (!serviceIndex.IsAbsoluteUri)
+        {
+            throw new ArgumentException(
+                "A portable package source endpoint must be an absolute HTTP or HTTPS URI.",
+                nameof(serviceIndex));
+        }
+
         if (serviceIndex.UserInfo.Length > 0)
         {
             throw new ArgumentException(
                 "A portable package source endpoint cannot contain user information.",
+                nameof(serviceIndex));
+        }
+
+        if (serviceIndex.Query.Length > 0
+            || serviceIndex.Fragment.Length > 0)
+        {
+            throw new ArgumentException(
+                "A portable package source endpoint cannot contain a query or fragment.",
                 nameof(serviceIndex));
         }
 
@@ -293,6 +310,7 @@ public static class PackageSourceClientFactory
         NuGetFetchOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(client);
         if (!Uri.TryCreate(source.Url, UriKind.Absolute, out Uri? endpoint)
             || endpoint.IsFile)
         {
@@ -300,14 +318,11 @@ public static class PackageSourceClientFactory
                 PackageSourceKind.LocalFolder);
         }
 
-        PackageSourceDescriptor descriptor = PackageSourceDescriptor.NuGetV3(
-            source.Name,
-            source.Name,
-            endpoint);
-        return Create(
-            descriptor,
+        return new NuGetV3PackageSourceClient(
+            PackageSourceIdentity.ForHttpEndpoint(endpoint),
+            endpoint,
             client,
-            options,
+            options ?? new NuGetFetchOptions(),
             source.Credential);
     }
 
@@ -341,7 +356,8 @@ public static class PackageSourceClientFactory
 
 internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
 {
-    private readonly PackageSourceDescriptor _descriptor;
+    private readonly PackageSourceIdentity _identity;
+    private readonly Uri _endpoint;
     private readonly PackageSourceCredential? _credential;
     private readonly NuGetClient _nuget;
 
@@ -350,13 +366,29 @@ internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
         HttpClient client,
         NuGetFetchOptions options,
         PackageSourceCredential? credential)
+        : this(
+            descriptor.Identity,
+            descriptor.Endpoint!,
+            client,
+            options,
+            credential)
     {
-        _descriptor = descriptor;
+    }
+
+    public NuGetV3PackageSourceClient(
+        PackageSourceIdentity identity,
+        Uri endpoint,
+        HttpClient client,
+        NuGetFetchOptions options,
+        PackageSourceCredential? credential)
+    {
+        _identity = identity;
+        _endpoint = endpoint;
         _credential = credential;
         _nuget = new NuGetClient(client, options);
     }
 
-    public PackageSourceIdentity Identity => _descriptor.Identity;
+    public PackageSourceIdentity Identity => _identity;
     public PackageSourceKind Kind => PackageSourceKind.NuGetV3;
     public PackageSourceCapabilities Capabilities =>
         PackageSourceCapabilities.VersionEnumeration
@@ -373,23 +405,37 @@ internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
 
     public async Task<IReadOnlyList<string>> GetVersionsAsync(
         string packageId,
-        CancellationToken cancellationToken = default) =>
-        await _nuget.GetVersionsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        PackageCoordinateValidation.ValidatePackageId(
             packageId,
-            _descriptor.Endpoint!.AbsoluteUri,
+            nameof(packageId));
+        return await _nuget.GetVersionsAsync(
+            packageId,
+            _endpoint.AbsoluteUri,
             _credential,
             cancellationToken).ConfigureAwait(false);
+    }
 
     public async Task<Stream> GetPackageAsync(
         string packageId,
         string version,
-        CancellationToken cancellationToken = default) =>
-        await _nuget.DownloadAsync(
+        CancellationToken cancellationToken = default)
+    {
+        PackageCoordinateValidation.ValidatePackageId(
             packageId,
-            version,
-            _descriptor.Endpoint!.AbsoluteUri,
+            nameof(packageId));
+        string normalizedVersion =
+            PackageCoordinateValidation.NormalizeVersion(
+                version,
+                nameof(version));
+        return await _nuget.DownloadAsync(
+            packageId,
+            normalizedVersion,
+            _endpoint.AbsoluteUri,
             _credential,
             cancellationToken).ConfigureAwait(false);
+    }
 
     public Task<Stream?> TryGetSymbolsAsync(
         string packageId,
@@ -399,4 +445,48 @@ internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
             Kind,
             PackageSourceCapabilities.SymbolPayload);
 
+}
+
+internal static partial class PackageCoordinateValidation
+{
+    public static bool IsValidPackageId(string? packageId) =>
+        packageId is { Length: > 0 and <= 100 }
+        && PackageIdPattern().IsMatch(packageId);
+
+    public static bool IsValidPackageVersion(string? version) =>
+        version is not null
+        && version.AsSpan().Trim().Length == version.Length
+        && NuGetVersion.TryParse(version, out _);
+
+    public static void ValidatePackageId(
+        string? packageId,
+        string parameterName)
+    {
+        if (!IsValidPackageId(packageId))
+        {
+            throw new ArgumentException(
+                "A package ID must use the NuGet package ID grammar.",
+                parameterName);
+        }
+    }
+
+    public static string NormalizeVersion(
+        string? version,
+        string parameterName)
+    {
+        if (!IsValidPackageVersion(version)
+            || !NuGetVersion.TryParse(version, out NuGetVersion? parsed))
+        {
+            throw new ArgumentException(
+                "A package version must be a valid NuGet version without surrounding whitespace.",
+                parameterName);
+        }
+
+        return parsed.ToNormalizedString().ToLowerInvariant();
+    }
+
+    [GeneratedRegex(
+        @"^\w+(?:[.-]\w+)*\z",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex PackageIdPattern();
 }

--- a/src/NuGetFetch/PackageSourceClients.cs
+++ b/src/NuGetFetch/PackageSourceClients.cs
@@ -7,8 +7,13 @@ namespace NuGetFetch;
 /// </summary>
 public enum PackageSourceKind
 {
+    /// <summary>A standard NuGet v3 service-index source.</summary>
     NuGetV3,
+
+    /// <summary>The built-in NuGet Gallery browser transport.</summary>
     NuGetGallery,
+
+    /// <summary>A package source backed by a local directory.</summary>
     LocalFolder,
 }
 
@@ -18,10 +23,19 @@ public enum PackageSourceKind
 [Flags]
 public enum PackageSourceCapabilities
 {
+    /// <summary>No package operations are supported.</summary>
     None = 0,
+
+    /// <summary>Keyword or package-identity search.</summary>
     Search = 1 << 0,
+
+    /// <summary>Version enumeration for a package ID.</summary>
     VersionEnumeration = 1 << 1,
+
+    /// <summary>Exact package payload acquisition.</summary>
     PackagePayload = 1 << 2,
+
+    /// <summary>Exact symbol-package payload acquisition.</summary>
     SymbolPayload = 1 << 3,
 }
 
@@ -203,25 +217,34 @@ public sealed record PackageSourceDescriptor
 /// </summary>
 public interface IPackageSourceClient
 {
+    /// <summary>Gets the producer represented by this transport.</summary>
     PackageSourceIdentity Identity { get; }
+
+    /// <summary>Gets the transport family.</summary>
     PackageSourceKind Kind { get; }
+
+    /// <summary>Gets the operations implemented by this runtime client.</summary>
     PackageSourceCapabilities Capabilities { get; }
 
+    /// <summary>Searches for packages.</summary>
     Task<IReadOnlyList<SearchResult>> SearchAsync(
         string query,
         int take = 20,
         bool prerelease = false,
         CancellationToken cancellationToken = default);
 
+    /// <summary>Gets the versions reported for a package ID.</summary>
     Task<IReadOnlyList<string>> GetVersionsAsync(
         string packageId,
         CancellationToken cancellationToken = default);
 
+    /// <summary>Gets an exact package payload owned by the returned stream.</summary>
     Task<Stream> GetPackageAsync(
         string packageId,
         string version,
         CancellationToken cancellationToken = default);
 
+    /// <summary>Gets an exact symbol-package payload when supported and available.</summary>
     Task<Stream?> TryGetSymbolsAsync(
         string packageId,
         string version,
@@ -237,7 +260,10 @@ public sealed class PackageSourceCapabilityException(
     : NotSupportedException(
         $"Package source kind '{kind}' does not support capability '{capability}'.")
 {
+    /// <summary>Gets the source kind that rejected the operation.</summary>
     public PackageSourceKind Kind { get; } = kind;
+
+    /// <summary>Gets the unsupported operation.</summary>
     public PackageSourceCapabilities Capability { get; } = capability;
 }
 
@@ -249,6 +275,7 @@ public sealed class PackageSourceClientUnavailableException(
     : NotSupportedException(
         $"Package source kind '{kind}' does not have a runtime client implementation.")
 {
+    /// <summary>Gets the source kind without a runtime implementation.</summary>
     public PackageSourceKind Kind { get; } = kind;
 }
 
@@ -257,6 +284,9 @@ public sealed class PackageSourceClientUnavailableException(
 /// </summary>
 public static class PackageSourceClientFactory
 {
+    /// <summary>
+    /// Adapts the existing desktop source model to a typed runtime client.
+    /// </summary>
     public static IPackageSourceClient Create(
         PackageSource source,
         HttpClient client,
@@ -281,6 +311,10 @@ public static class PackageSourceClientFactory
             source.Credential);
     }
 
+    /// <summary>
+    /// Creates a runtime client from credential-free configuration and optional
+    /// ephemeral credentials.
+    /// </summary>
     public static IPackageSourceClient Create(
         PackageSourceDescriptor descriptor,
         HttpClient client,
@@ -310,7 +344,6 @@ internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
     private readonly PackageSourceDescriptor _descriptor;
     private readonly PackageSourceCredential? _credential;
     private readonly NuGetClient _nuget;
-    private readonly SearchService? _search;
 
     public NuGetV3PackageSourceClient(
         PackageSourceDescriptor descriptor,
@@ -321,44 +354,22 @@ internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
         _descriptor = descriptor;
         _credential = credential;
         _nuget = new NuGetClient(client, options);
-        if (descriptor.Identity == PackageSourceIdentity.NuGetOrg)
-        {
-            _search = new SearchService(
-                client,
-                NuGetClient.NuGetOrgSearchUrl,
-                options);
-        }
     }
 
     public PackageSourceIdentity Identity => _descriptor.Identity;
     public PackageSourceKind Kind => PackageSourceKind.NuGetV3;
     public PackageSourceCapabilities Capabilities =>
         PackageSourceCapabilities.VersionEnumeration
-        | PackageSourceCapabilities.PackagePayload
-        | (_search is null
-            ? PackageSourceCapabilities.None
-            : PackageSourceCapabilities.Search);
+        | PackageSourceCapabilities.PackagePayload;
 
-    public async Task<IReadOnlyList<SearchResult>> SearchAsync(
+    public Task<IReadOnlyList<SearchResult>> SearchAsync(
         string query,
         int take = 20,
         bool prerelease = false,
-        CancellationToken cancellationToken = default)
-    {
-        if (_search is null)
-        {
-            throw new PackageSourceCapabilityException(
-                Kind,
-                PackageSourceCapabilities.Search);
-        }
-
-        return await _search.SearchAsync(
-            query,
-            take,
-            prerelease,
-            auth: null,
-            cancellationToken).ConfigureAwait(false);
-    }
+        CancellationToken cancellationToken = default) =>
+        throw new PackageSourceCapabilityException(
+            Kind,
+            PackageSourceCapabilities.Search);
 
     public async Task<IReadOnlyList<string>> GetVersionsAsync(
         string packageId,

--- a/src/NuGetFetch/PackageSourceClients.cs
+++ b/src/NuGetFetch/PackageSourceClients.cs
@@ -1,0 +1,391 @@
+using System.Text;
+
+namespace NuGetFetch;
+
+/// <summary>
+/// Identifies the transport family used by a package source.
+/// </summary>
+public enum PackageSourceKind
+{
+    NuGetV3,
+    NuGetGallery,
+    LocalFolder,
+}
+
+/// <summary>
+/// Operations a package source client can perform.
+/// </summary>
+[Flags]
+public enum PackageSourceCapabilities
+{
+    None = 0,
+    Search = 1 << 0,
+    VersionEnumeration = 1 << 1,
+    PackagePayload = 1 << 2,
+    SymbolPayload = 1 << 3,
+}
+
+/// <summary>
+/// Stable producer identity shared by every transport that represents one source.
+/// </summary>
+public sealed record PackageSourceIdentity
+{
+    private PackageSourceIdentity(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Gets the canonical producer key.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Gets the canonical NuGet.org producer identity.
+    /// </summary>
+    public static PackageSourceIdentity NuGetOrg { get; } =
+        ForHttpEndpoint(new Uri("https://api.nuget.org/v3/index.json"));
+
+    /// <summary>
+    /// Creates an identity for an absolute HTTP or HTTPS source endpoint.
+    /// </summary>
+    public static PackageSourceIdentity ForHttpEndpoint(Uri endpoint)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        if (!endpoint.IsAbsoluteUri
+            || (endpoint.Scheme != Uri.UriSchemeHttp
+                && endpoint.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException(
+                "A package source endpoint must be an absolute HTTP or HTTPS URI.",
+                nameof(endpoint));
+        }
+
+        var origin =
+            $"{endpoint.Scheme.ToLowerInvariant()}://{endpoint.IdnHost.ToLowerInvariant()}:{endpoint.Port}";
+        string absolutePath = endpoint.AbsolutePath;
+        string path = NormalizeEscapes(
+            absolutePath.EndsWith("/", StringComparison.Ordinal)
+                ? absolutePath[..^1]
+                : absolutePath);
+        return new PackageSourceIdentity(
+            $"{origin}{path}{NormalizeEscapes(endpoint.Query)}{NormalizeEscapes(endpoint.Fragment)}");
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => Value;
+
+    private static string NormalizeEscapes(string value)
+    {
+        if (!value.Contains('%', StringComparison.Ordinal))
+            return value;
+
+        var builder = new StringBuilder(value.Length);
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (value[i] == '%'
+                && i + 2 < value.Length
+                && Uri.IsHexDigit(value[i + 1])
+                && Uri.IsHexDigit(value[i + 2]))
+            {
+                builder.Append('%')
+                    .Append(char.ToUpperInvariant(value[i + 1]))
+                    .Append(char.ToUpperInvariant(value[i + 2]));
+                i += 2;
+            }
+            else
+            {
+                builder.Append(value[i]);
+            }
+        }
+
+        return builder.ToString();
+    }
+}
+
+/// <summary>
+/// Credential-free configuration for one registered package source.
+/// </summary>
+public sealed record PackageSourceDescriptor
+{
+    private PackageSourceDescriptor(
+        string id,
+        string displayName,
+        PackageSourceKind kind,
+        PackageSourceIdentity identity,
+        Uri? endpoint,
+        bool enabled)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        Id = id;
+        DisplayName = displayName;
+        Kind = kind;
+        Identity = identity;
+        Endpoint = endpoint;
+        Enabled = enabled;
+    }
+
+    /// <summary>
+    /// Gets the source registry identifier.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Gets the user-facing source name.
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// Gets the transport family.
+    /// </summary>
+    public PackageSourceKind Kind { get; }
+
+    /// <summary>
+    /// Gets the producer identity shared across transports.
+    /// </summary>
+    public PackageSourceIdentity Identity { get; }
+
+    /// <summary>
+    /// Gets the transport endpoint, when the source kind requires one.
+    /// </summary>
+    public Uri? Endpoint { get; }
+
+    /// <summary>
+    /// Gets whether the source is enabled in portable configuration.
+    /// </summary>
+    public bool Enabled { get; init; }
+
+    /// <summary>
+    /// Gets the built-in Gallery descriptor. Its producer identity is NuGet.org,
+    /// but it has no configurable v3 endpoint.
+    /// </summary>
+    public static PackageSourceDescriptor NuGetGallery { get; } =
+        new(
+            "nuget-gallery",
+            "NuGet Gallery",
+            PackageSourceKind.NuGetGallery,
+            PackageSourceIdentity.NuGetOrg,
+            endpoint: null,
+            enabled: true);
+
+    /// <summary>
+    /// Creates a standard NuGet v3 source descriptor.
+    /// </summary>
+    public static PackageSourceDescriptor NuGetV3(
+        string id,
+        string displayName,
+        Uri serviceIndex,
+        bool enabled = true)
+    {
+        ArgumentNullException.ThrowIfNull(serviceIndex);
+        if (serviceIndex.UserInfo.Length > 0)
+        {
+            throw new ArgumentException(
+                "A portable package source endpoint cannot contain user information.",
+                nameof(serviceIndex));
+        }
+
+        PackageSourceIdentity identity =
+            PackageSourceIdentity.ForHttpEndpoint(serviceIndex);
+        return new PackageSourceDescriptor(
+            id,
+            displayName,
+            PackageSourceKind.NuGetV3,
+            identity,
+            serviceIndex,
+            enabled);
+    }
+}
+
+/// <summary>
+/// Protocol-independent package source operations.
+/// </summary>
+public interface IPackageSourceClient
+{
+    PackageSourceIdentity Identity { get; }
+    PackageSourceKind Kind { get; }
+    PackageSourceCapabilities Capabilities { get; }
+
+    Task<IReadOnlyList<SearchResult>> SearchAsync(
+        string query,
+        int take = 20,
+        bool prerelease = false,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<string>> GetVersionsAsync(
+        string packageId,
+        CancellationToken cancellationToken = default);
+
+    Task<Stream> GetPackageAsync(
+        string packageId,
+        string version,
+        CancellationToken cancellationToken = default);
+
+    Task<Stream?> TryGetSymbolsAsync(
+        string packageId,
+        string version,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Raised when a source client is asked to perform an operation it does not advertise.
+/// </summary>
+public sealed class PackageSourceCapabilityException(
+    PackageSourceKind kind,
+    PackageSourceCapabilities capability)
+    : NotSupportedException(
+        $"Package source kind '{kind}' does not support capability '{capability}'.")
+{
+    public PackageSourceKind Kind { get; } = kind;
+    public PackageSourceCapabilities Capability { get; } = capability;
+}
+
+/// <summary>
+/// Raised when a registered source kind has no runtime client implementation.
+/// </summary>
+public sealed class PackageSourceClientUnavailableException(
+    PackageSourceKind kind)
+    : NotSupportedException(
+        $"Package source kind '{kind}' does not have a runtime client implementation.")
+{
+    public PackageSourceKind Kind { get; } = kind;
+}
+
+/// <summary>
+/// Creates runtime clients without exposing transport construction to consumers.
+/// </summary>
+public static class PackageSourceClientFactory
+{
+    public static IPackageSourceClient Create(
+        PackageSource source,
+        HttpClient client,
+        NuGetFetchOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        if (!Uri.TryCreate(source.Url, UriKind.Absolute, out Uri? endpoint)
+            || endpoint.IsFile)
+        {
+            throw new PackageSourceClientUnavailableException(
+                PackageSourceKind.LocalFolder);
+        }
+
+        PackageSourceDescriptor descriptor = PackageSourceDescriptor.NuGetV3(
+            source.Name,
+            source.Name,
+            endpoint);
+        return Create(
+            descriptor,
+            client,
+            options,
+            source.Credential);
+    }
+
+    public static IPackageSourceClient Create(
+        PackageSourceDescriptor descriptor,
+        HttpClient client,
+        NuGetFetchOptions? options = null,
+        PackageSourceCredential? credential = null)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        ArgumentNullException.ThrowIfNull(client);
+        options ??= new NuGetFetchOptions();
+
+        return descriptor.Kind switch
+        {
+            PackageSourceKind.NuGetV3 when descriptor.Endpoint is not null =>
+                new NuGetV3PackageSourceClient(
+                    descriptor,
+                    client,
+                    options,
+                    credential),
+            _ => throw new PackageSourceClientUnavailableException(
+                descriptor.Kind),
+        };
+    }
+}
+
+internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
+{
+    private readonly PackageSourceDescriptor _descriptor;
+    private readonly PackageSourceCredential? _credential;
+    private readonly NuGetClient _nuget;
+    private readonly SearchService? _search;
+
+    public NuGetV3PackageSourceClient(
+        PackageSourceDescriptor descriptor,
+        HttpClient client,
+        NuGetFetchOptions options,
+        PackageSourceCredential? credential)
+    {
+        _descriptor = descriptor;
+        _credential = credential;
+        _nuget = new NuGetClient(client, options);
+        if (descriptor.Identity == PackageSourceIdentity.NuGetOrg)
+        {
+            _search = new SearchService(
+                client,
+                NuGetClient.NuGetOrgSearchUrl,
+                options);
+        }
+    }
+
+    public PackageSourceIdentity Identity => _descriptor.Identity;
+    public PackageSourceKind Kind => PackageSourceKind.NuGetV3;
+    public PackageSourceCapabilities Capabilities =>
+        PackageSourceCapabilities.VersionEnumeration
+        | PackageSourceCapabilities.PackagePayload
+        | (_search is null
+            ? PackageSourceCapabilities.None
+            : PackageSourceCapabilities.Search);
+
+    public async Task<IReadOnlyList<SearchResult>> SearchAsync(
+        string query,
+        int take = 20,
+        bool prerelease = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (_search is null)
+        {
+            throw new PackageSourceCapabilityException(
+                Kind,
+                PackageSourceCapabilities.Search);
+        }
+
+        return await _search.SearchAsync(
+            query,
+            take,
+            prerelease,
+            auth: null,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<string>> GetVersionsAsync(
+        string packageId,
+        CancellationToken cancellationToken = default) =>
+        await _nuget.GetVersionsAsync(
+            packageId,
+            _descriptor.Endpoint!.AbsoluteUri,
+            _credential,
+            cancellationToken).ConfigureAwait(false);
+
+    public async Task<Stream> GetPackageAsync(
+        string packageId,
+        string version,
+        CancellationToken cancellationToken = default) =>
+        await _nuget.DownloadAsync(
+            packageId,
+            version,
+            _descriptor.Endpoint!.AbsoluteUri,
+            _credential,
+            cancellationToken).ConfigureAwait(false);
+
+    public Task<Stream?> TryGetSymbolsAsync(
+        string packageId,
+        string version,
+        CancellationToken cancellationToken = default) =>
+        throw new PackageSourceCapabilityException(
+            Kind,
+            PackageSourceCapabilities.SymbolPayload);
+
+}

--- a/src/NuGetFetch/SearchService.cs
+++ b/src/NuGetFetch/SearchService.cs
@@ -1,14 +1,12 @@
 using System.Globalization;
 using System.Net.Http.Headers;
-using System.Text.RegularExpressions;
-using NuGet.Versioning;
 
 namespace NuGetFetch;
 
 /// <summary>
 /// Searches the NuGet Search API for packages by keyword or prefix.
 /// </summary>
-public partial class SearchService
+public class SearchService
 {
     private const int PrefixSearchPageSize = 100;
     private const int MaxPrefixSearchPages = 32;
@@ -156,8 +154,9 @@ public partial class SearchService
         NuGetOperationDeadline operation)
     {
         if (result is null
-            || !IsValidPackageId(result.Id)
-            || !IsValidPackageVersion(result.Version))
+            || !PackageCoordinateValidation.IsValidPackageId(result.Id)
+            || !PackageCoordinateValidation.IsValidPackageVersion(
+                result.Version))
         {
             return false;
         }
@@ -169,7 +168,8 @@ public partial class SearchService
         {
             operation.ThrowIfExpired();
             if (version is null
-                || !IsValidPackageVersion(version.Version))
+                || !PackageCoordinateValidation.IsValidPackageVersion(
+                    version.Version))
             {
                 return false;
             }
@@ -177,20 +177,6 @@ public partial class SearchService
 
         return true;
     }
-
-    private static bool IsValidPackageId(string? packageId) =>
-        packageId is { Length: > 0 and <= 100 }
-        && PackageIdPattern().IsMatch(packageId);
-
-    private static bool IsValidPackageVersion(string? version) =>
-        version is not null
-        && version.AsSpan().Trim().Length == version.Length
-        && NuGetVersion.TryParse(version, out _);
-
-    [GeneratedRegex(
-        @"^\w+(?:[.-]\w+)*\z",
-        RegexOptions.CultureInvariant)]
-    private static partial Regex PackageIdPattern();
 
     /// <summary>
     /// Searches NuGet for packages whose ID starts with the given prefix.


### PR DESCRIPTION
## Summary

- Add typed producer identity, source kind, capability, credential-free descriptor, runtime-client, and factory contracts in NuGetFetch.
- Adapt existing desktop `PackageSource` inputs to a NuGet v3 runtime client for version enumeration and package payload acquisition while preserving ephemeral credential flow and library-owned deadlines.
- Centralize canonical HTTP producer identity so credential scoping and future Gallery/v3 transports share one key.

## Behavioral claim

This slice introduces the source-client boundary without changing current desktop consumers. Canonical NuGet.org v3 and the built-in Gallery descriptor share one producer identity; local and Gallery runtime clients remain explicitly unavailable; and the v3 adapter does not restore the retired NuGet.org-only search shortcut from before #4155.

## Evidence

- `PackageSourceClientTests`: 10/10
- `NuGetSearchSourcesTests`: 114/114
- `markdownlint docs/design/browser-package-sources.md`: clean
- Exact candidate: `be8df0de6ad963501c7c817400979e6de91c4374`
- Base: `f49b30736df0dfa63d4770709ad5a761e852f11c`

## Non-action boundary

This PR does not migrate existing consumers, move service-index search discovery into the typed client, implement Gallery/local-folder clients, or add candidate/availability/provenance result contracts. Those remain follow-up slices under #4239.

Closes no issue; advances #4239.
