### PR TITLE
Correlate performance triage with allocation traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,11 @@ The compact `Performance:* --jsonl` table intentionally carries only the tight
 human-facing columns and therefore cannot support an exact trace join.
 `runfaster` reports those rows as not runtime-correlatable rather than treating
 them as negative workload evidence.
+For filtered triage exports, allocation-stack correlation stops at the first
+frame in the represented assembly. If that method has no exported row, the
+allocation remains unattributed rather than being credited to an outer caller.
+When the same site arrives from both `--library` and `--triage`, the
+shape-compatible triage row supplies the richer single attribution.
 
 `CallerLoop`, `CallerLoopDepth`, and `CallerLoopWitness` expose a separate
 cross-method repetition fact. `CallerLoop=direct` means a resolved invocation

--- a/README.md
+++ b/README.md
@@ -353,7 +353,8 @@ For filtered triage exports, allocation-stack correlation stops at the first
 frame in the represented assembly. If that method has no exported row, the
 allocation remains unattributed rather than being credited to an outer caller.
 When the same site arrives from both `--library` and `--triage`, the
-shape-compatible triage row supplies the richer single attribution.
+shape-compatible triage row supplies the richer single attribution; the raw
+library row is marked `superseded-by-triage`, not workload-cold.
 
 `CallerLoop`, `CallerLoopDepth`, and `CallerLoopWitness` expose a separate
 cross-method repetition fact. `CallerLoop=direct` means a resolved invocation

--- a/README.md
+++ b/README.md
@@ -298,8 +298,9 @@ the single `Performance Triage` lens.
 
 The tight markdown columns carry the ranked, human-facing fields, including a
 static `Priority` that is separate from evidence/rewrite `Confidence`; the full
-per-row diagnostics (shape, provenance, candidate id, native `Finding`, metadata
-`Token`, IL offset, allocation `Weight`, path/loop evidence, and the fix
+per-row diagnostics (shape, provenance, candidate id, native `Finding`,
+declaring `Assembly` and `MethodToken`, operation-operand metadata `Token`, IL
+offset, allocation `Weight`, path/loop evidence, and the fix
 sentence) are preserved in the nested `performance` object of `--json`.
 Allocation rows carry `Weight`, a coarse size x multiplicity x reach static
 prior that you can query or sort when choosing pre-profile instrumentation
@@ -307,7 +308,9 @@ targets. Exact allocation and call-site rows also retain a `Candidate` id, their
 native `Finding` descriptor, `Provenance=exact`, `Operation`, and metadata
 `Token`. Aggregate rows are marked `Provenance=aggregate`; `unmatched`
 identifies an instruction-level row that could not be joined to a producer
-occurrence. Those fields let trace and version-diff tooling join a triage row to
+occurrence. `Assembly` + `MethodToken` + `IL` form the runtime allocation-trace coordinate;
+`Token` is the operand of the reported IL operation and must not be used as the
+declaring method token. Those fields let trace and version-diff tooling join a triage row to
 `analysis.allocation` or `analysis.call-site` evidence without parsing
 `Evidence` prose. Use `--top`, `--loop`, `--min-confidence`, and
 `--triage-shape` to ask the tool for the curated pay-dirt rows directly instead
@@ -332,6 +335,20 @@ When `--bin`, `--project`, or `--caller-package` supplies an assembly scope,
 retains its narrower inbound-only scan.
 Ranking rows carry a copyable `Stable` selector, `Visibility`, and `Selector`;
 add `--all` to drill non-public members.
+
+Export nested JSON when runtime correlation is the next step, then give that
+document and the matching allocation trace to `runfaster`:
+
+```bash
+dotnet-inspect library MyLib.dll -S "Performance:*" \
+  --where "Priority>=high" --json > triage.json
+runfaster correlate --triage triage.json --trace workload.nettrace
+```
+
+The compact `Performance:* --jsonl` table intentionally carries only the tight
+human-facing columns and therefore cannot support an exact trace join.
+`runfaster` reports those rows as not runtime-correlatable rather than treating
+them as negative workload evidence.
 
 `CallerLoop`, `CallerLoopDepth`, and `CallerLoopWitness` expose a separate
 cross-method repetition fact. `CallerLoop=direct` means a resolved invocation

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -145,6 +145,10 @@ runfaster correlate --triage triage.json --trace workload.nettrace
 Compact `Performance:* --jsonl` rows omit deep provenance and cannot support an
 exact trace join. `runfaster` keeps their operation `Token` separate from the
 declaring `MethodToken` and reports missing runtime coordinates explicitly.
+For a filtered export, the trace join stops at the first frame in the
+represented assembly; it does not walk past an unexported in-assembly callee
+and credit an outer caller. If `--library` and `--triage` name the same physical
+site, the shape-compatible triage row supplies the single attribution.
 
 ## Select direct caller-loop repetition
 

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -149,6 +149,7 @@ For a filtered export, the trace join stops at the first frame in the
 represented assembly; it does not walk past an unexported in-assembly callee
 and credit an outer caller. If `--library` and `--triage` name the same physical
 site, the shape-compatible triage row supplies the single attribution.
+The raw library row is marked `superseded-by-triage`, not workload-cold.
 
 ## Select direct caller-loop repetition
 

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -113,7 +113,9 @@ Exact rows retain machine-readable provenance from the native Analysis
 producer in structured JSON:
 `Candidate`, `Finding` (`analysis.allocation` or `analysis.call-site`),
 `Provenance=exact`,
-`Operation`, `Token`, and `IL`. Use these fields for runtime/static joins or to
+`Assembly`, `MethodToken`, `Operation`, `Token`, and `IL`.
+`Assembly` + `MethodToken` + `IL` form the runtime allocation-trace coordinate;
+`Token` is the operand of `Operation`. Use these fields for runtime/static joins or to
 carry one triage row into the matching `diff`/`timeline` confirmation workflow
 without parsing `Evidence` text:
 
@@ -128,6 +130,21 @@ Aggregate rows such as `allocation-hotspot` use `Provenance=aggregate` and have
 a `pt~` candidate id but no exact source Finding, operation, or token.
 `Provenance=unmatched` flags an instruction-level row that did not join to the
 expected producer census.
+
+## Correlate triage with an allocation trace
+
+Export nested JSON, whose deep rows carry the declaring method coordinate, then
+pass it to `runfaster` with a trace captured from the same assembly build:
+
+```bash
+dnx dotnet-inspect -y -- library MyLib.dll -S "Performance:*" \
+  --where "Priority>=high" --json > triage.json
+runfaster correlate --triage triage.json --trace workload.nettrace
+```
+
+Compact `Performance:* --jsonl` rows omit deep provenance and cannot support an
+exact trace join. `runfaster` keeps their operation `Token` separate from the
+declaring `MethodToken` and reports missing runtime coordinates explicitly.
 
 ## Select direct caller-loop repetition
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1596,6 +1596,8 @@ public partial class CommandExecutionTests
         Assert.Contains("\"finding\": \"analysis.allocation\"", output);
         Assert.Contains("\"provenance\": \"exact\"", output);
         Assert.Contains("\"operation\": \"box\"", output);
+        Assert.Contains("\"assembly\": \"", output);
+        Assert.Contains("\"method_token\": \"0x06", output);
         Assert.Contains("\"token\": \"0x", output);
     }
 

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -1504,6 +1504,9 @@ internal static class LibraryMetadataService
                 .Select(opportunity => new OptimizationOpportunitySummary
                 {
                     Member = FormatMethod(opportunity.Method),
+                    Assembly = opportunity.Method.AssemblyName,
+                    MethodToken = FormatToken(
+                        opportunity.Method.MetadataToken),
                     Candidate = opportunity.CandidateId,
                     Finding = opportunity.SourceFinding,
                     Provenance = FormatProvenance(opportunity.Provenance),

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -1199,6 +1199,10 @@ public record class OptimizationOpportunitySummary
 {
     public string Member { get; init; } = "";
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Assembly { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? MethodToken { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Candidate { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Finding { get; init; }

--- a/src/runfaster.Tests/E2EFixtureTests.cs
+++ b/src/runfaster.Tests/E2EFixtureTests.cs
@@ -320,6 +320,39 @@ public class E2EFixtureTests
         }
     }
 
+    [Fact]
+    public void Correlate_RejectsAllocationKindAsRootDiscriminator()
+    {
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                """
+                {"method":"RunFaster.AllocationFixture.Program.AllocateOne()","allocationKind":"Telemetry","assembly":"RunFaster.AllocationFixture","method_token":"0x06000002","il":"IL_0000","allocation":"System.Object"}
+                """);
+
+            var result = RunCorrelate(
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation.AssetPath(
+                    "fixture.nettrace"));
+
+            Assert.Equal(1, result.ExitCode);
+            Assert.Contains(
+                "contains no Performance Triage rows",
+                result.Error);
+            Assert.Empty(result.Output);
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
     [Theory]
     [InlineData("Wrong.Assembly", "System.Object")]
     [InlineData("RunFaster.AllocationFixture", "Other.Namespace.Object")]

--- a/src/runfaster.Tests/E2EFixtureTests.cs
+++ b/src/runfaster.Tests/E2EFixtureTests.cs
@@ -85,9 +85,7 @@ public class E2EFixtureTests
                 triagePath,
                 $$"""
                 {
-                  "assembly_info": {
-                    "assembly_name": "{{occurrence.Method.AssemblyName}}"
-                  },
+                  "assembly_info": null,
                   "performance": {
                     "arrays": [
                       {
@@ -165,7 +163,7 @@ public class E2EFixtureTests
             File.WriteAllText(
                 triagePath,
                 """
-                {"kind":"Arrays","member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","shape":"fixture-object","token":"0x06000002","il":"IL_0000","allocation":"System.Object"}
+                {"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","method_token":"0x0A000001","token":"0x06000002","il":"IL_0000","evidence":"new object","allocation":"Fixture.Unseen","reach":"1","priority":"high","confidence":"high"}
                 """);
 
             var result = RunCorrelate(
@@ -182,9 +180,106 @@ public class E2EFixtureTests
             Assert.Contains(
                 "lack a complete declaring assembly + method token + IL offset",
                 result.Output);
+            Assert.Contains(
+                "not-runtime-correlatable",
+                result.Output);
             Assert.DoesNotContain(
                 "joined to a single nearest-preceding static allocation site",
                 result.Output);
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Fact]
+    public void Correlate_AcceptsRealSingleKindPerformanceJsonl()
+    {
+        string inspectDll =
+            Path.Combine(AppContext.BaseDirectory, "dotnet-inspect.dll");
+        var produced = RunTool(
+            inspectDll,
+            "library",
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "ILInspector.Analysis.dll"),
+            "-S",
+            "Performance:*",
+            "--top",
+            "1",
+            "--jsonl",
+            "--tips",
+            "q");
+        Assert.Equal(0, produced.ExitCode);
+        Assert.Empty(produced.Error);
+        using (var row = JsonDocument.Parse(produced.Output))
+        {
+            Assert.False(row.RootElement.TryGetProperty("kind", out _));
+            Assert.False(row.RootElement.TryGetProperty("shape", out _));
+            Assert.True(row.RootElement.TryGetProperty("priority", out _));
+        }
+
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.jsonl");
+        try
+        {
+            File.WriteAllText(triagePath, produced.Output);
+            var result = RunCorrelate(
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation.AssetPath(
+                    "fixture.nettrace"),
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            using var output = JsonDocument.Parse(result.Output);
+            Assert.Equal(
+                1,
+                output.RootElement.GetProperty(
+                    "staticCandidates").GetInt32());
+            var candidate = Assert.Single(
+                output.RootElement.GetProperty(
+                    "candidates").EnumerateArray());
+            Assert.Equal(
+                "not-runtime-correlatable",
+                candidate.GetProperty("status").GetString());
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Fact]
+    public void Correlate_RejectsNonPerformanceJsonDocument()
+    {
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                """
+                {"unrelated":{"rows":[{"method":"Other.Component.Work()","kind":"Telemetry","assembly":"Other","method_token":"0x06000001","il":"IL_0000"}]}}
+                """);
+
+            var result = RunCorrelate(
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation.AssetPath(
+                    "fixture.nettrace"));
+
+            Assert.Equal(1, result.ExitCode);
+            Assert.Contains(
+                "contains no Performance Triage rows",
+                result.Error);
+            Assert.Empty(result.Output);
         }
         finally
         {
@@ -197,6 +292,15 @@ public class E2EFixtureTests
     {
         string runfasterDll =
             Path.Combine(AppContext.BaseDirectory, "runfaster.dll");
+        return RunTool(
+            runfasterDll,
+            ["correlate", .. arguments]);
+    }
+
+    static (int ExitCode, string Output, string Error) RunTool(
+        string toolDll,
+        params string[] arguments)
+    {
         var startInfo = new ProcessStartInfo
         {
             FileName = "dotnet",
@@ -205,8 +309,7 @@ public class E2EFixtureTests
             RedirectStandardError = true,
         };
         startInfo.ArgumentList.Add("exec");
-        startInfo.ArgumentList.Add(runfasterDll);
-        startInfo.ArgumentList.Add("correlate");
+        startInfo.ArgumentList.Add(toolDll);
         foreach (string argument in arguments)
             startInfo.ArgumentList.Add(argument);
 

--- a/src/runfaster.Tests/E2EFixtureTests.cs
+++ b/src/runfaster.Tests/E2EFixtureTests.cs
@@ -42,7 +42,7 @@ public class E2EFixtureTests
 
         string observedAllocateOneRow = RowContaining(
             output,
-            "il-offset-hot",
+            "shape-hot",
             "RunFaster.AllocationFixture.Program.AllocateOne()");
         Assert.Contains("Object", observedAllocateOneRow); // AllocationKind
         Assert.Contains("Return", observedAllocateOneRow); // EscapeKind
@@ -288,7 +288,7 @@ public class E2EFixtureTests
     }
 
     [Fact]
-    public void Correlate_FilteredTriage_DoesNotCreditUnexportedCalleeToCaller()
+    public void Correlate_RejectsNonPerformanceRootRow()
     {
         string triagePath = Path.Combine(
             Path.GetTempPath(),
@@ -298,7 +298,54 @@ public class E2EFixtureTests
             File.WriteAllText(
                 triagePath,
                 """
-                {"performance":{"boxing":[{"member":"RunFaster.AllocationFixture.Program.Main()","assembly":"RunFaster.AllocationFixture","method_token":"0x06000001","shape":"box-value-type","il":"IL_0000","allocation":"boxed System.Int32"}]}}
+                {"method":"RunFaster.AllocationFixture.Program.AllocateOne()","kind":"Telemetry","assembly":"RunFaster.AllocationFixture","method_token":"0x06000002","il":"IL_0000","allocation":"System.Object"}
+                """);
+
+            var result = RunCorrelate(
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation.AssetPath(
+                    "fixture.nettrace"));
+
+            Assert.Equal(1, result.ExitCode);
+            Assert.Contains(
+                "contains no Performance Triage rows",
+                result.Error);
+            Assert.Empty(result.Output);
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Theory]
+    [InlineData("Wrong.Assembly", "System.Object")]
+    [InlineData("RunFaster.AllocationFixture", "Other.Namespace.Object")]
+    public void Correlate_RequiresMatchingAssemblyAndAllocatedType(
+        string assembly,
+        string allocatedType)
+    {
+        string assemblyPath =
+            FixtureCatalog.RunFasterAllocation.AssemblyPath();
+        var allocateOne =
+            typeof(RunFaster.AllocationFixture.Program).GetMethod(
+                "AllocateOne",
+                BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(allocateOne);
+        var occurrence = Assert.Single(
+            LibraryBodyIndex.Open(assemblyPath)
+                .GetAllocationOccurrences()[allocateOne.MetadataToken]);
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                $$$"""
+                {"performance":{"arrays":[{"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"{{{assembly}}}","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","shape":"fixture-object","il":"IL_{{{occurrence.ILOffset:X4}}}","allocation":"{{{allocatedType}}}"}]}}
                 """);
 
             var result = RunCorrelate(
@@ -320,7 +367,49 @@ public class E2EFixtureTests
                 output.RootElement.GetProperty(
                     "candidates").EnumerateArray());
             Assert.Equal(
-                "cold-for-this-workload",
+                0,
+                candidate.GetProperty("allocationBytes").GetInt64());
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Fact]
+    public void Correlate_FilteredTriage_DoesNotCreditUnexportedCalleeToCaller()
+    {
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                """
+                {"performance":{"objects":[{"member":"RunFaster.AllocationFixture.Program.Main()","assembly":"RunFaster.AllocationFixture","method_token":"0x06000001","shape":"object-allocation","il":"IL_0000","allocation":"System.Object"}]}}
+                """);
+
+            var result = RunCorrelate(
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation.AssetPath(
+                    "fixture.nettrace"),
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            using var output = JsonDocument.Parse(result.Output);
+            Assert.Equal(
+                0,
+                output.RootElement.GetProperty(
+                    "observedCandidates").GetInt32());
+            var candidate = Assert.Single(
+                output.RootElement.GetProperty(
+                    "candidates").EnumerateArray());
+            Assert.Equal(
+                "type-hot",
                 candidate.GetProperty("status").GetString());
             Assert.Equal(
                 0,
@@ -399,6 +488,26 @@ public class E2EFixtureTests
             Assert.Equal(
                 0,
                 library.GetProperty("allocationBytes").GetInt64());
+            Assert.Equal(
+                "superseded-by-triage",
+                library.GetProperty("status").GetString());
+
+            var markdown = RunCorrelate(
+                "--library",
+                assemblyPath,
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation.AssetPath(
+                    "fixture.nettrace"));
+            Assert.Equal(0, markdown.ExitCode);
+            Assert.Empty(markdown.Error);
+            Assert.Contains(
+                "1 static candidate row(s) were not observed",
+                markdown.Output);
+            Assert.DoesNotContain(
+                "2 static candidate row(s) were not observed",
+                markdown.Output);
         }
         finally
         {

--- a/src/runfaster.Tests/E2EFixtureTests.cs
+++ b/src/runfaster.Tests/E2EFixtureTests.cs
@@ -2,7 +2,9 @@ using System;
 using System.IO;
 using System.Diagnostics;
 using System.Reflection;
+using System.Text.Json;
 using DotnetInspector.Fixtures;
+using ILInspector.Analysis;
 using Xunit;
 
 namespace runfaster.Tests;
@@ -56,6 +58,164 @@ public class E2EFixtureTests
 
         // Assert it shows negative evidence for the unexercised row
         Assert.Contains("1 static candidate row(s) were not observed", output);
+    }
+
+    [Fact]
+    public void Correlate_WithNestedTriageJson_JoinsByDeclaringMethodCoordinate()
+    {
+        string tracePath =
+            FixtureCatalog.RunFasterAllocation.AssetPath("fixture.nettrace");
+        string assemblyPath =
+            FixtureCatalog.RunFasterAllocation.AssemblyPath();
+        var allocateOne =
+            typeof(RunFaster.AllocationFixture.Program).GetMethod(
+                "AllocateOne",
+                BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(allocateOne);
+
+        var index = LibraryBodyIndex.Open(assemblyPath);
+        var occurrence = Assert.Single(
+            index.GetAllocationOccurrences()[allocateOne.MetadataToken]);
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                $$"""
+                {
+                  "assembly_info": {
+                    "assembly_name": "{{occurrence.Method.AssemblyName}}"
+                  },
+                  "performance": {
+                    "arrays": [
+                      {
+                        "member": "RunFaster.AllocationFixture.Program.AllocateOne()",
+                        "assembly": "{{occurrence.Method.AssemblyName}}",
+                        "method_token": "0x{{allocateOne.MetadataToken:X8}}",
+                        "shape": "fixture-object",
+                        "operation": "newobj",
+                        "token": "0x0A000001",
+                        "il": "IL_{{occurrence.ILOffset:X4}}",
+                        "allocation": "System.Object",
+                        "provenance": "exact"
+                      }
+                    ]
+                  }
+                }
+                """);
+
+            var result = RunCorrelate(
+                "--triage",
+                triagePath,
+                "--trace",
+                tracePath,
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            using var output = JsonDocument.Parse(result.Output);
+            Assert.Equal(
+                1,
+                output.RootElement.GetProperty(
+                    "observedCandidates").GetInt32());
+            var triageInput = Assert.Single(
+                output.RootElement.GetProperty(
+                    "triageInputs").EnumerateArray());
+            Assert.Equal(
+                1,
+                triageInput.GetProperty(
+                    "correlatableRows").GetInt32());
+            var candidate = Assert.Single(
+                output.RootElement.GetProperty(
+                    "candidates").EnumerateArray());
+            Assert.True(
+                candidate.GetProperty(
+                    "runtimeCorrelatable").GetBoolean());
+            Assert.Equal(
+                allocateOne.MetadataToken,
+                candidate.GetProperty("methodToken").GetInt32());
+            Assert.Equal(
+                0x0A000001,
+                candidate.GetProperty("operandToken").GetInt32());
+            Assert.True(
+                candidate.GetProperty(
+                    "ilOffsetJoinObserved").GetBoolean());
+            Assert.True(
+                candidate.GetProperty(
+                    "unambiguousIlOffsetJoinObserved").GetBoolean());
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Fact]
+    public void Correlate_WithCompactTriageJsonl_DoesNotTreatOperandAsMethodToken()
+    {
+        string tracePath =
+            FixtureCatalog.RunFasterAllocation.AssetPath("fixture.nettrace");
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.jsonl");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                """
+                {"kind":"Arrays","member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","shape":"fixture-object","token":"0x06000002","il":"IL_0000","allocation":"System.Object"}
+                """);
+
+            var result = RunCorrelate(
+                "--triage",
+                triagePath,
+                "--trace",
+                tracePath);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            Assert.Contains(
+                "Runtime-correlatable triage rows: 0/1",
+                result.Output);
+            Assert.Contains(
+                "lack a complete declaring assembly + method token + IL offset",
+                result.Output);
+            Assert.DoesNotContain(
+                "joined to a single nearest-preceding static allocation site",
+                result.Output);
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    static (int ExitCode, string Output, string Error) RunCorrelate(
+        params string[] arguments)
+    {
+        string runfasterDll =
+            Path.Combine(AppContext.BaseDirectory, "runfaster.dll");
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add(runfasterDll);
+        startInfo.ArgumentList.Add("correlate");
+        foreach (string argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        using var correlate = Process.Start(startInfo);
+        Assert.NotNull(correlate);
+        string output = correlate.StandardOutput.ReadToEnd();
+        string error = correlate.StandardError.ReadToEnd();
+        correlate.WaitForExit();
+        return (correlate.ExitCode, output, error);
     }
 
     static string RowContaining(string output, params string[] fragments)

--- a/src/runfaster.Tests/E2EFixtureTests.cs
+++ b/src/runfaster.Tests/E2EFixtureTests.cs
@@ -287,6 +287,125 @@ public class E2EFixtureTests
         }
     }
 
+    [Fact]
+    public void Correlate_FilteredTriage_DoesNotCreditUnexportedCalleeToCaller()
+    {
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                """
+                {"performance":{"boxing":[{"member":"RunFaster.AllocationFixture.Program.Main()","assembly":"RunFaster.AllocationFixture","method_token":"0x06000001","shape":"box-value-type","il":"IL_0000","allocation":"boxed System.Int32"}]}}
+                """);
+
+            var result = RunCorrelate(
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation.AssetPath(
+                    "fixture.nettrace"),
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            using var output = JsonDocument.Parse(result.Output);
+            Assert.Equal(
+                0,
+                output.RootElement.GetProperty(
+                    "observedCandidates").GetInt32());
+            var candidate = Assert.Single(
+                output.RootElement.GetProperty(
+                    "candidates").EnumerateArray());
+            Assert.Equal(
+                "cold-for-this-workload",
+                candidate.GetProperty("status").GetString());
+            Assert.Equal(
+                0,
+                candidate.GetProperty("allocationHits").GetInt32());
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Fact]
+    public void Correlate_LibraryAndTriageSameSite_PrefersTriageWithoutSplittingBytes()
+    {
+        string assemblyPath =
+            FixtureCatalog.RunFasterAllocation.AssemblyPath();
+        var allocateOne =
+            typeof(RunFaster.AllocationFixture.Program).GetMethod(
+                "AllocateOne",
+                BindingFlags.Public | BindingFlags.Static);
+        Assert.NotNull(allocateOne);
+        var occurrence = Assert.Single(
+            LibraryBodyIndex.Open(assemblyPath)
+                .GetAllocationOccurrences()[allocateOne.MetadataToken]);
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                $$$"""
+                {"performance":{"arrays":[{"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","shape":"fixture-object","operation":"newobj","token":"0x0A000001","il":"IL_{{{occurrence.ILOffset:X4}}}","allocation":"System.Object","provenance":"exact"}]}}
+                """);
+
+            var result = RunCorrelate(
+                "--library",
+                assemblyPath,
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation.AssetPath(
+                    "fixture.nettrace"),
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            using var output = JsonDocument.Parse(result.Output);
+            var sameMethod = output.RootElement
+                .GetProperty("candidates")
+                .EnumerateArray()
+                .Where(candidate => candidate
+                    .GetProperty("method")
+                    .GetString()!
+                    .EndsWith(
+                        ".AllocateOne()",
+                        StringComparison.Ordinal))
+                .ToArray();
+            Assert.Equal(2, sameMethod.Length);
+            var triage = Assert.Single(
+                sameMethod,
+                candidate => candidate
+                    .GetProperty("source")
+                    .GetString() == "triage");
+            var library = Assert.Single(
+                sameMethod,
+                candidate => candidate
+                    .GetProperty("source")
+                    .GetString() == "library");
+            Assert.Equal(
+                1_167_872,
+                triage.GetProperty("allocationBytes").GetInt64());
+            Assert.False(
+                triage.GetProperty(
+                    "ambiguousIlOffsetJoin").GetBoolean());
+            Assert.Equal(
+                0,
+                library.GetProperty("allocationBytes").GetInt64());
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
     static (int ExitCode, string Output, string Error) RunCorrelate(
         params string[] arguments)
     {

--- a/src/runfaster.Tests/TypeConfirmationTests.cs
+++ b/src/runfaster.Tests/TypeConfirmationTests.cs
@@ -104,6 +104,39 @@ public class TypeConfirmationTests
         Assert.NotEqual(a, b);
     }
 
+    [Theory]
+    [InlineData(
+        "System.Func<System.Int32>",
+        "System.Func`1[System.Int32]",
+        true)]
+    [InlineData(
+        "System.Func<System.Int32>",
+        "System.Func`1[System.String]",
+        false)]
+    [InlineData(
+        "display class (N.C+<>c__DisplayClass1_0)",
+        "N.C+<>c__DisplayClass1_0",
+        true)]
+    [InlineData(
+        "state machine (N.C+<M>d__1)",
+        "N.C+<M>d__1",
+        true)]
+    public void AllocationTypeMatch_PreservesExactTypeIdentity(
+        string staticType,
+        string runtimeType,
+        bool expected)
+    {
+        var candidate = CandidateWithType(
+            1,
+            "Fixture.A.M()",
+            staticType,
+            detail: "delegate allocation");
+
+        Assert.Equal(
+            expected,
+            candidate.MatchesAllocatedType(runtimeType));
+    }
+
     [Fact]
     public void ApplyTypeConfirmation_MarksUnobservedCandidate_WhenPredictedTypeIsRealizedHot()
     {
@@ -339,7 +372,11 @@ public class TypeConfirmationTests
         Assert.All(result.Candidates, c => Assert.False(c.TypeConfirmed));
     }
 
-    static AllocationCandidate CandidateWithType(int id, string method, string predictedType)
+    static AllocationCandidate CandidateWithType(
+        int id,
+        string method,
+        string predictedType,
+        string? detail = null)
     {
         string methodKey = method[..method.IndexOf('(')];
         int lastDot = methodKey.LastIndexOf('.');
@@ -357,7 +394,7 @@ public class TypeConfirmationTests
             stackKey,
             "Delegate",
             predictedType,
-            null,
+            detail,
             false,
             "Always",
             "Escapes",

--- a/src/runfaster.Tests/TypeConfirmationTests.cs
+++ b/src/runfaster.Tests/TypeConfirmationTests.cs
@@ -154,6 +154,30 @@ public class TypeConfirmationTests
         Assert.Equal("type-hot", candidate.Status);
     }
 
+    [Theory]
+    [InlineData("state machine (N.C+<M>d__1)", "N.C+<M>d__1")]
+    [InlineData(
+        "display class (N.C+<>c__DisplayClass1_0)",
+        "N.C+<>c__DisplayClass1_0")]
+    public void ApplyTypeConfirmation_UnwrapsProducerType(
+        string predictedType,
+        string runtimeType)
+    {
+        var candidate = CandidateWithType(
+            1,
+            "Fixture.A.M()",
+            predictedType);
+        var result = new CorrelationResult();
+        result.Candidates.Add(candidate);
+        result.RecordTypeVolume(
+            runtimeType,
+            ProgramSupport.TypeConfirmMinBytes);
+
+        ProgramSupport.ApplyTypeConfirmation(result);
+
+        Assert.True(candidate.TypeConfirmed);
+    }
+
     [Fact]
     public void ApplyTypeConfirmation_MarksAmbiguous_WhenMultipleSitesSharePredictedType()
     {
@@ -339,6 +363,30 @@ public class TypeConfirmationTests
         result.Candidates.Add(observed);
         result.Candidates.Add(cold);
         result.RecordTypeVolume("System.String", 900_000_000);
+
+        ProgramSupport.ApplyTypeConfirmation(result);
+
+        Assert.False(cold.TypeConfirmed);
+        Assert.Equal("cold-for-this-workload", cold.Status);
+    }
+
+    [Fact]
+    public void ApplyTypeConfirmation_WrappedObservedTypeExplainsRuntimeVolume()
+    {
+        var observed = CandidateWithType(
+            1,
+            "Fixture.Hot.M()",
+            "boxed System.Int32");
+        observed.AllocationHits = 1;
+        observed.AllocationBytes = 900_000_000;
+        var cold = CandidateWithType(
+            2,
+            "Fixture.Cold.M()",
+            "System.Int32");
+        var result = new CorrelationResult();
+        result.Candidates.Add(observed);
+        result.Candidates.Add(cold);
+        result.RecordTypeVolume("System.Int32", 900_000_000);
 
         ProgramSupport.ApplyTypeConfirmation(result);
 

--- a/src/runfaster.Tests/runfaster.Tests.csproj
+++ b/src/runfaster.Tests/runfaster.Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\runfaster\runfaster.csproj" />
+    <ProjectReference Include="..\dotnet-inspect\dotnet-inspect.csproj" />
     <ProjectReference Include="Fixtures\RunFaster.AllocationFixture\RunFaster.AllocationFixture.csproj" ReferenceOutputAssembly="true" />
     <ProjectReference Include="..\..\tests\DotnetInspector.Fixtures\DotnetInspector.Fixtures.csproj" />
   </ItemGroup>

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -45,7 +45,7 @@ static Command CreateCorrelateCommand()
 
     var triageOption = new Option<string[]>("--triage")
     {
-        Description = "dotnet-inspect Performance Triage JSONL rows to include as static candidates",
+        Description = "dotnet-inspect Performance Triage JSON or JSONL to include as static candidates",
         Arity = ArgumentArity.ZeroOrMore,
         AllowMultipleArgumentsPerToken = true
     };
@@ -385,42 +385,212 @@ static bool TryLoadTriageFile(string triageFile, CorrelationResult result, out i
         return false;
     }
 
-    int rows = 0;
     try
     {
-        foreach (var line in File.ReadLines(path))
+        int rows = 0;
+        int candidatesBefore = result.Candidates.Count;
+        try
         {
-            if (string.IsNullOrWhiteSpace(line))
-                continue;
+            using var document = JsonDocument.Parse(File.ReadAllBytes(path));
+            string? assembly = FindDocumentAssembly(document.RootElement);
+            AddTriageDocumentCandidates(
+                document.RootElement,
+                path,
+                assembly,
+                result.Candidates,
+                ref rows);
+        }
+        catch (JsonException)
+        {
+            foreach (var line in File.ReadLines(path))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
 
-            rows++;
-            using var document = JsonDocument.Parse(line);
-            if (TryCreateCandidateFromJson(result.Candidates.Count, path, document.RootElement, out var candidate))
-                result.Candidates.Add(candidate);
+                using var document = JsonDocument.Parse(line);
+                AddTriageCandidates(
+                    document.RootElement,
+                    path,
+                    defaultAssembly: null,
+                    result.Candidates,
+                    ref rows);
+            }
         }
 
-        result.TriageInputs.Add(new TriageInput(path, rows));
+        int loaded = result.Candidates.Count - candidatesBefore;
+        if (rows == 0)
+        {
+            Console.Error.WriteLine(
+                $"Error: triage input contains no Performance Triage rows: "
+                + $"{triageFile}");
+            exitCode = 1;
+            return false;
+        }
+
+        int correlatable = result.Candidates
+            .Skip(candidatesBefore)
+            .Count(static candidate => candidate.HasRuntimeCoordinate);
+        result.TriageInputs.Add(
+            new TriageInput(path, rows, loaded, correlatable));
         return true;
     }
     catch (Exception ex) when (ex is JsonException or IOException)
     {
-        Console.Error.WriteLine($"Error: cannot read triage JSONL '{triageFile}': {ex.Message}");
+        Console.Error.WriteLine($"Error: cannot read triage JSON/JSONL '{triageFile}': {ex.Message}");
         exitCode = 1;
         return false;
     }
 }
 
-static bool TryCreateCandidateFromJson(int id, string path, JsonElement element, out AllocationCandidate candidate)
+static void AddTriageDocumentCandidates(
+    JsonElement root,
+    string path,
+    string? defaultAssembly,
+    List<AllocationCandidate> candidates,
+    ref int rows)
+{
+    if (root.ValueKind == JsonValueKind.Object
+        && (root.TryGetProperty("performance", out var performance)
+            || root.TryGetProperty("Performance", out performance)))
+    {
+        AddTriageCandidates(
+            performance,
+            path,
+            defaultAssembly,
+            candidates,
+            ref rows);
+        return;
+    }
+
+    AddTriageCandidates(
+        root,
+        path,
+        defaultAssembly,
+        candidates,
+        ref rows);
+}
+
+static void AddTriageCandidates(
+    JsonElement element,
+    string path,
+    string? defaultAssembly,
+    List<AllocationCandidate> candidates,
+    ref int rows)
+{
+    if (element.ValueKind == JsonValueKind.Object)
+    {
+        if (LooksLikeTriageRow(element))
+        {
+            rows++;
+            if (TryCreateCandidateFromJson(
+                    candidates.Count,
+                    path,
+                    defaultAssembly,
+                    element,
+                    out var candidate))
+            {
+                candidates.Add(candidate);
+            }
+            return;
+        }
+
+        foreach (var property in element.EnumerateObject())
+            AddTriageCandidates(
+                property.Value,
+                path,
+                defaultAssembly,
+                candidates,
+                ref rows);
+        return;
+    }
+
+    if (element.ValueKind != JsonValueKind.Array)
+        return;
+
+    foreach (var item in element.EnumerateArray())
+        AddTriageCandidates(
+            item,
+            path,
+            defaultAssembly,
+            candidates,
+            ref rows);
+}
+
+static bool LooksLikeTriageRow(JsonElement element)
+    => GetJsonString(
+            element,
+            "Method",
+            "method",
+            "Member",
+            "member") is not null
+        && GetJsonString(
+            element,
+            "Shape",
+            "shape",
+            "Kind",
+            "kind",
+            "AllocationKind",
+            "allocationKind") is not null;
+
+static string? FindDocumentAssembly(JsonElement root)
+{
+    if (GetJsonString(root, "Assembly", "assembly") is { Length: > 0 } assembly)
+        return assembly;
+
+    if (root.ValueKind == JsonValueKind.Object
+        && (root.TryGetProperty("assembly_info", out var info)
+            || root.TryGetProperty("assemblyInfo", out info))
+        && GetJsonString(
+            info,
+            "assembly_name",
+            "assemblyName",
+            "AssemblyName") is { Length: > 0 } assemblyName)
+    {
+        return assemblyName;
+    }
+
+    return null;
+}
+
+static bool TryCreateCandidateFromJson(
+    int id,
+    string path,
+    string? defaultAssembly,
+    JsonElement element,
+    out AllocationCandidate candidate)
 {
     candidate = default!;
     string? method = GetJsonString(element, "Method", "method", "Member", "member", "Selector", "selector", "Stable", "stable");
-    string? tokenText = GetJsonString(element, "MetadataToken", "metadataToken", "Token", "token", "MethodToken", "methodToken");
+    string? methodTokenText = GetJsonString(
+        element,
+        "Method Token",
+        "method_token",
+        "MethodToken",
+        "methodToken");
+    string? operandTokenText = GetJsonString(
+        element,
+        "MetadataToken",
+        "metadataToken",
+        "Token",
+        "token",
+        "OperandToken",
+        "operandToken",
+        "operand_token");
     string? offsetText = GetJsonString(element, "ILOffset", "ilOffset", "IL Offset", "il", "IL", "Offset", "offset");
 
-    int token = TryParseFlexibleInt(tokenText, out var parsedToken) ? parsedToken : 0;
+    int methodToken = TryParseFlexibleInt(
+        methodTokenText,
+        out var parsedMethodToken)
+        ? parsedMethodToken
+        : 0;
+    int? operandToken = TryParseFlexibleInt(
+        operandTokenText,
+        out var parsedOperandToken)
+        ? parsedOperandToken
+        : null;
     int offset = TryParseFlexibleInt(offsetText, out var parsedOffset) ? parsedOffset : -1;
 
-    if (method is null && token == 0)
+    if (method is null && methodToken == 0)
         return false;
 
     string kind = GetJsonString(element, "Shape", "shape", "Kind", "kind", "AllocationKind", "allocationKind") ?? "triage";
@@ -431,11 +601,13 @@ static bool TryCreateCandidateFromJson(int id, string path, JsonElement element,
         id,
         "triage",
         path,
-        GetJsonString(element, "Assembly", "assembly") ?? "",
+        GetJsonString(element, "Assembly", "assembly")
+            ?? defaultAssembly
+            ?? "",
         null,
-        token,
+        methodToken,
         offset,
-        method ?? DisplayHelpers.FormatToken(token),
+        method ?? DisplayHelpers.FormatToken(methodToken),
         DisplayHelpers.MethodKeyFromText(method),
         DisplayHelpers.MethodStackKeyFromText(method),
         kind,
@@ -449,7 +621,11 @@ static bool TryCreateCandidateFromJson(int id, string path, JsonElement element,
         GetJsonString(element, "Root Reach", "root_reach", "rootReach"),
         GetJsonString(element, "Path", "path"),
         GetJsonString(element, "Path Confidence", "path_confidence", "pathConfidence"),
-        GetJsonString(element, "Post Dominance", "post_dominance", "postDominance"));
+        GetJsonString(element, "Post Dominance", "post_dominance", "postDominance"),
+        candidateId: GetJsonString(element, "Candidate", "candidate"),
+        provenance: GetJsonString(element, "Provenance", "provenance"),
+        operation: GetJsonString(element, "Operation", "operation"),
+        operandToken: operandToken);
     return true;
 }
 
@@ -1139,7 +1315,14 @@ static IEnumerable<AllocationCandidate> SelectCandidates(IReadOnlyList<Allocatio
 static void RenderMarkdown(CorrelationResult result, IReadOnlyList<AllocationCandidate> candidates, CorrelateOptions options)
 {
     var observed = candidates.Where(c => c.IsObserved).ToArray();
-    var cold = result.Candidates.Where(c => !c.IsObserved).ToArray();
+    var cold = result.Candidates
+        .Where(c => !c.IsObserved
+            && !c.TypeConfirmed
+            && c.HasRuntimeCoordinate)
+        .ToArray();
+    var unjoinable = result.Candidates
+        .Where(c => !c.IsObserved && !c.HasRuntimeCoordinate)
+        .ToArray();
     var counterObservations = result.DiagnosticInputs
         .Where(static i => string.Equals(i.Kind, "counters", StringComparison.OrdinalIgnoreCase))
         .SelectMany(static i => i.Observations)
@@ -1183,13 +1366,44 @@ static void RenderMarkdown(CorrelationResult result, IReadOnlyList<AllocationCan
     Console.WriteLine();
     Console.WriteLine($"Static candidates: {result.Candidates.Count.ToString(CultureInfo.InvariantCulture)}");
     Console.WriteLine($"Runtime-observed candidates: {result.Candidates.Count(c => c.IsObserved).ToString(CultureInfo.InvariantCulture)}");
+    if (result.TriageInputs.Count > 0)
+    {
+        Console.WriteLine(
+            $"Runtime-correlatable triage rows: "
+            + $"{result.TriageInputs.Sum(static input => input.CorrelatableRows).ToString(CultureInfo.InvariantCulture)}"
+            + $"/{result.TriageInputs.Sum(static input => input.LoadedRows).ToString(CultureInfo.InvariantCulture)}");
+    }
     Console.WriteLine();
 
     Console.WriteLine("## Conclusion");
     Console.WriteLine();
     if (observedGroups.Length == 0)
     {
-        Console.WriteLine("No static performance candidate was observed in the supplied runtime diagnostics. Treat the selected workload as a negative confirmation, not as proof the code is never hot.");
+        int typeConfirmedCount = result.Candidates.Count(
+            static candidate => candidate.TypeConfirmed);
+        if (typeConfirmedCount > 0)
+        {
+            Console.WriteLine(
+                $"No exact allocation site joined, but runtime type volume confirmed "
+                + $"{typeConfirmedCount.ToString(CultureInfo.InvariantCulture)} static "
+                + "candidate type(s). Treat that as type-level prioritization, not exact "
+                + "site attribution.");
+        }
+        else if (result.Candidates.Count > 0
+            && result.Candidates.All(static candidate =>
+                !candidate.HasRuntimeCoordinate
+                && !candidate.TypeConfirmed))
+        {
+            Console.WriteLine(
+                "No exact runtime join was possible because the supplied triage rows lack "
+                + "declaring assembly, method token, and IL offset coordinates. Export the "
+                + "nested Performance Triage document with `--json`; compact `--jsonl` rows "
+                + "do not carry deep provenance.");
+        }
+        else
+        {
+            Console.WriteLine("No static performance candidate was observed in the supplied runtime diagnostics. Treat the selected workload as a negative confirmation, not as proof the code is never hot.");
+        }
     }
     else
     {
@@ -1363,6 +1577,16 @@ static void RenderMarkdown(CorrelationResult result, IReadOnlyList<AllocationCan
             Console.WriteLine($"| {Escape(shape.Key)} | {shape.Count().ToString(CultureInfo.InvariantCulture)} |");
         }
     }
+    if (unjoinable.Length > 0)
+    {
+        Console.WriteLine();
+        Console.WriteLine("## Not runtime-correlatable");
+        Console.WriteLine();
+        Console.WriteLine(
+            $"{unjoinable.Length.ToString(CultureInfo.InvariantCulture)} static candidate "
+            + "row(s) lack a complete declaring assembly + method token + IL offset "
+            + "coordinate. They are not negative runtime evidence.");
+    }
     Console.WriteLine();
     Console.WriteLine("## Reading this report");
     Console.WriteLine();
@@ -1459,6 +1683,18 @@ static void RenderJson(CorrelationResult result, IReadOnlyList<AllocationCandida
     writer.WriteStartObject();
     writer.WriteNumber("staticCandidates", result.Candidates.Count);
     writer.WriteNumber("observedCandidates", result.Candidates.Count(c => c.IsObserved));
+    writer.WritePropertyName("triageInputs");
+    writer.WriteStartArray();
+    foreach (var input in result.TriageInputs)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("path", input.Path);
+        writer.WriteNumber("rows", input.Rows);
+        writer.WriteNumber("loadedRows", input.LoadedRows);
+        writer.WriteNumber("correlatableRows", input.CorrelatableRows);
+        writer.WriteEndObject();
+    }
+    writer.WriteEndArray();
     writer.WritePropertyName("inputs");
     writer.WriteStartArray();
     foreach (var input in result.DiagnosticInputs)
@@ -1502,9 +1738,20 @@ static void WriteCandidateJsonObject(Utf8JsonWriter writer, AllocationCandidate 
     writer.WriteString("library", candidate.LibraryPath);
     writer.WriteString("assembly", candidate.AssemblyName);
     writer.WriteString("method", candidate.Method);
+    writer.WriteBoolean(
+        "runtimeCorrelatable",
+        candidate.HasRuntimeCoordinate);
     writer.WriteString("tokenIl", candidate.TokenAndOffset);
     writer.WriteNumber("methodToken", candidate.MethodToken);
     writer.WriteNumber("ilOffset", candidate.IlOffset);
+    if (candidate.CandidateId is not null)
+        writer.WriteString("candidate", candidate.CandidateId);
+    if (candidate.Provenance is not null)
+        writer.WriteString("provenance", candidate.Provenance);
+    if (candidate.Operation is not null)
+        writer.WriteString("operation", candidate.Operation);
+    if (candidate.OperandToken is int operandToken)
+        writer.WriteNumber("operandToken", operandToken);
     writer.WriteString("kind", candidate.AllocationKind);
     if (candidate.EscapeKind is not null)
         writer.WriteString("escapeKind", candidate.EscapeKind);
@@ -1672,7 +1919,11 @@ sealed record DiagnosticInput(string Kind, string Path);
 
 sealed record LibraryInput(string Path, int StaticCandidates, string? Error);
 
-sealed record TriageInput(string Path, int Rows);
+sealed record TriageInput(
+    string Path,
+    int Rows,
+    int LoadedRows,
+    int CorrelatableRows);
 
 sealed class DiagnosticInputSummary(
     string kind,
@@ -1794,7 +2045,11 @@ sealed class AllocationCandidate(
     string? escapeKind = null,
     string? churnedType = null,
     string? runtimeAllocationType = null,
-    string? multiplicity = null)
+    string? multiplicity = null,
+    string? candidateId = null,
+    string? provenance = null,
+    string? operation = null,
+    int? operandToken = null)
 {
     public int Id { get; } = id;
     public string Source { get; } = source;
@@ -1803,6 +2058,10 @@ sealed class AllocationCandidate(
     public Guid? ModuleVersionId { get; } = moduleVersionId;
     public int MethodToken { get; } = methodToken;
     public int IlOffset { get; } = ilOffset;
+    public string? CandidateId { get; } = candidateId;
+    public string? Provenance { get; } = provenance;
+    public string? Operation { get; } = operation;
+    public int? OperandToken { get; } = operandToken;
     public string Method { get; } = method;
     public string MethodKey { get; } = methodKey;
     public string MethodStackKey { get; } = methodStackKey;
@@ -1908,6 +2167,10 @@ sealed class AllocationCandidate(
     }
     public double CostWeight => EffectiveObservedBytes * PromotionFactor;
     public bool IsObserved => RuntimeHits > 0 || AllocationHits > 0;
+    public bool HasRuntimeCoordinate =>
+        AssemblyName.Length > 0
+        && MethodToken != 0
+        && IlOffset >= 0;
     public string TokenAndOffset => $"{DisplayHelpers.FormatToken(MethodToken)}+{DisplayHelpers.FormatOffset(IlOffset)}";
     public string Status => ShapeMatched
         ? RowAmbiguous ? "shape-hot-ambiguous" : "shape-hot"

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -449,25 +449,43 @@ static void AddTriageDocumentCandidates(
     List<AllocationCandidate> candidates,
     ref int rows)
 {
-    if (root.ValueKind == JsonValueKind.Object
-        && (root.TryGetProperty("performance", out var performance)
-            || root.TryGetProperty("Performance", out performance)))
+    if (root.ValueKind == JsonValueKind.Object)
+    {
+        if (LooksLikeTriageRow(root))
+        {
+            AddTriageCandidates(
+                root,
+                path,
+                defaultAssembly,
+                candidates,
+                ref rows);
+        }
+        else if (root.TryGetProperty(
+                     "performance",
+                     out var performance)
+                 || root.TryGetProperty(
+                     "Performance",
+                     out performance))
+        {
+            AddTriageCandidates(
+                performance,
+                path,
+                defaultAssembly,
+                candidates,
+                ref rows);
+        }
+        return;
+    }
+
+    if (root.ValueKind == JsonValueKind.Array)
     {
         AddTriageCandidates(
-            performance,
+            root,
             path,
             defaultAssembly,
             candidates,
             ref rows);
-        return;
     }
-
-    AddTriageCandidates(
-        root,
-        path,
-        defaultAssembly,
-        candidates,
-        ref rows);
 }
 
 static void AddTriageCandidates(
@@ -517,13 +535,17 @@ static void AddTriageCandidates(
 }
 
 static bool LooksLikeTriageRow(JsonElement element)
-    => GetJsonString(
+{
+    if (element.ValueKind != JsonValueKind.Object)
+        return false;
+
+    bool hasMember = GetJsonString(
             element,
             "Method",
             "method",
             "Member",
-            "member") is not null
-        && GetJsonString(
+            "member") is not null;
+    bool hasKind = GetJsonString(
             element,
             "Shape",
             "shape",
@@ -531,15 +553,25 @@ static bool LooksLikeTriageRow(JsonElement element)
             "kind",
             "AllocationKind",
             "allocationKind") is not null;
+    bool hasCompactPerformanceSchema =
+        GetJsonString(element, "Evidence", "evidence") is not null
+        && GetJsonString(element, "Priority", "priority") is not null
+        && GetJsonString(element, "Confidence", "confidence") is not null
+        && GetJsonString(element, "Reach", "reach") is not null;
+    return hasMember && (hasKind || hasCompactPerformanceSchema);
+}
 
 static string? FindDocumentAssembly(JsonElement root)
 {
+    if (root.ValueKind != JsonValueKind.Object)
+        return null;
+
     if (GetJsonString(root, "Assembly", "assembly") is { Length: > 0 } assembly)
         return assembly;
 
-    if (root.ValueKind == JsonValueKind.Object
-        && (root.TryGetProperty("assembly_info", out var info)
+    if ((root.TryGetProperty("assembly_info", out var info)
             || root.TryGetProperty("assemblyInfo", out info))
+        && info.ValueKind == JsonValueKind.Object
         && GetJsonString(
             info,
             "assembly_name",
@@ -631,6 +663,9 @@ static bool TryCreateCandidateFromJson(
 
 static string? GetJsonString(JsonElement element, params string[] names)
 {
+    if (element.ValueKind != JsonValueKind.Object)
+        return null;
+
     foreach (var name in names)
     {
         if (!element.TryGetProperty(name, out var value))
@@ -2169,7 +2204,8 @@ sealed class AllocationCandidate(
     public bool IsObserved => RuntimeHits > 0 || AllocationHits > 0;
     public bool HasRuntimeCoordinate =>
         AssemblyName.Length > 0
-        && MethodToken != 0
+        && (MethodToken & unchecked((int)0xFF000000)) == 0x06000000
+        && (MethodToken & 0x00FFFFFF) != 0
         && IlOffset >= 0;
     public string TokenAndOffset => $"{DisplayHelpers.FormatToken(MethodToken)}+{DisplayHelpers.FormatOffset(IlOffset)}";
     public string Status => ShapeMatched
@@ -2178,7 +2214,13 @@ sealed class AllocationCandidate(
         : AllocationHits > 0
             ? "allocation-hot"
             : RuntimeHits == 0
-        ? TypeConfirmedBytes > 0 ? (TypeConfirmedAmbiguous ? "type-hot-ambiguous" : "type-hot") : "cold-for-this-workload"
+        ? TypeConfirmedBytes > 0
+            ? TypeConfirmedAmbiguous
+                ? "type-hot-ambiguous"
+                : "type-hot"
+            : !HasRuntimeCoordinate
+                ? "not-runtime-correlatable"
+                : "cold-for-this-workload"
         : ExactOffsetObserved ? "confirmed-hot" : "method-hot";
 
     public bool MatchesAllocatedType(string allocatedType)

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -549,8 +549,6 @@ static bool LooksLikeTriageRow(JsonElement element)
             element,
             "Shape",
             "shape",
-            "Kind",
-            "kind",
             "AllocationKind",
             "allocationKind") is not null;
     bool hasCompactPerformanceSchema =
@@ -823,8 +821,9 @@ static bool TryCorrelateNetTrace(
             while (stack != null)
             {
                 TraceCodeAddress address = stack.CodeAddress;
-                matchedCandidates = lookup
-                    .FindNearestByCodeAddress(address)
+                var coordinateCandidates = lookup
+                    .FindNearestByCodeAddress(address);
+                matchedCandidates = coordinateCandidates
                     .Where(candidate =>
                         !string.Equals(
                             candidate.Source,
@@ -839,6 +838,16 @@ static bool TryCorrelateNetTrace(
                             "triage",
                             StringComparison.Ordinal)))
                 {
+                    foreach (var candidate in coordinateCandidates.Where(candidate =>
+                                 string.Equals(
+                                     candidate.Source,
+                                     "library",
+                                     StringComparison.Ordinal)
+                                 && candidate.MatchesAllocatedType(
+                                     data.TypeName)))
+                    {
+                        candidate.SupersededByTriage = true;
+                    }
                     matchedCandidates = matchedCandidates
                         .Where(candidate => string.Equals(
                             candidate.Source,
@@ -1380,6 +1389,7 @@ static void RenderMarkdown(CorrelationResult result, IReadOnlyList<AllocationCan
     var cold = result.Candidates
         .Where(c => !c.IsObserved
             && !c.TypeConfirmed
+            && !c.SupersededByTriage
             && c.HasRuntimeCoordinate)
         .ToArray();
     var unjoinable = result.Candidates
@@ -1656,6 +1666,7 @@ static void RenderMarkdown(CorrelationResult result, IReadOnlyList<AllocationCan
     Console.WriteLine("- Runtime weight comes from the supplied diagnostics artifact. `.nettrace` allocation ticks stop at the first frame in a represented assembly and join only that method token and nearest-preceding IL offset; an unexported in-assembly callee is not attributed to its caller.");
     Console.WriteLine("- The kind-first table ranks realized allocation volume by static `AllocationKind`; `EscapeKind` is the static promotion prior for that hot site.");
     Console.WriteLine("- `method-hot` means the runtime artifact observed the method. `il-offset-hot` means a `.nettrace` allocation tick joined to a single nearest-preceding static IL allocation site. `allocation-hot` means raw allocation events occurred with the method on-stack. `shape-hot` means the allocated type matched the static allocation shape. `shape-hot-ambiguous` means multiple same-shape static rows share that evidence. `confirmed-hot` means an exact token+IL coordinate was observed.");
+    Console.WriteLine("- `superseded-by-triage` means the same physical site was observed through a richer shape-compatible triage row; it is not workload-cold.");
 }
 
 static void RenderPlainText(CorrelationResult result, IReadOnlyList<AllocationCandidate> candidates)
@@ -2173,6 +2184,7 @@ sealed class AllocationCandidate(
     public int TypeConfirmedSiteCount { get; set; }
     public bool TypeConfirmed => TypeConfirmedBytes > 0 && !IsObserved;
     public bool TypeConfirmedAmbiguous => TypeConfirmedSiteCount > 1;
+    public bool SupersededByTriage { get; set; }
     public bool RowAmbiguous => AmbiguousIlOffsetJoin || (ShapeMatched && SameMethodShapeRows > 1 && !ExactOffsetObserved);
     public bool UnambiguousIlOffsetJoinObserved => IlOffsetJoinObserved && !AmbiguousIlOffsetJoin;
     public HashSet<string> ObservedSources { get; } = new(StringComparer.Ordinal);
@@ -2196,7 +2208,7 @@ sealed class AllocationCandidate(
     // the Loop/Once split is a static prior the trace does not verify. "Seen" here means the site was
     // observed directly OR its type was realized-hot via type-confirmation (#2264); a type-confirmed
     // loop site is therefore hot, not cold (it would otherwise be mislabeled "not exercised").
-    bool SeenHot => IsObserved || TypeConfirmed;
+    bool SeenHot => IsObserved || TypeConfirmed || SupersededByTriage;
     public string? MultiplicityCheck
     {
         get
@@ -2235,7 +2247,9 @@ sealed class AllocationCandidate(
         && (MethodToken & 0x00FFFFFF) != 0
         && IlOffset >= 0;
     public string TokenAndOffset => $"{DisplayHelpers.FormatToken(MethodToken)}+{DisplayHelpers.FormatOffset(IlOffset)}";
-    public string Status => ShapeMatched
+    public string Status => SupersededByTriage
+        ? "superseded-by-triage"
+        : ShapeMatched
         ? RowAmbiguous ? "shape-hot-ambiguous" : "shape-hot"
         : UnambiguousIlOffsetJoinObserved ? "il-offset-hot"
         : AllocationHits > 0
@@ -2294,23 +2308,42 @@ sealed class AllocationCandidate(
     {
         left = NormalizeTypeName(left);
         right = NormalizeTypeName(right);
-        return string.Equals(left, right, StringComparison.Ordinal)
-            || string.Equals(LeafTypeName(left), LeafTypeName(right), StringComparison.Ordinal);
+        return string.Equals(
+            ProgramSupport.CanonicalTypeSignature(left),
+            ProgramSupport.CanonicalTypeSignature(right, reflection: true),
+            StringComparison.Ordinal);
     }
 
     static string NormalizeTypeName(string value)
-        => value.Replace("class ", "", StringComparison.Ordinal)
-            .Replace("value class ", "", StringComparison.Ordinal)
-            .Replace("valuetype ", "", StringComparison.Ordinal)
-            .Trim();
-
-    static string LeafTypeName(string value)
     {
-        int generic = value.IndexOf('<');
-        if (generic >= 0)
-            value = value[..generic];
-        int dot = value.LastIndexOf('.');
-        return dot >= 0 ? value[(dot + 1)..] : value;
+        value = value.Trim();
+                 bool stripped;
+                 do
+                 {
+                     stripped = false;
+                     foreach (string prefix in new[]
+                              {
+                                  "boxed ",
+                                  "value class ",
+                                  "valuetype ",
+                                  "class "
+                              })
+            {
+                         if (!value.StartsWith(
+                                 prefix,
+                                 StringComparison.OrdinalIgnoreCase))
+                         {
+                             continue;
+                         }
+
+                         value = value[prefix.Length..].Trim();
+                         stripped = true;
+                         break;
+                     }
+                 }
+                 while (stripped);
+
+                 return value;
     }
 
     public static AllocationCandidate FromOccurrence(int id, string path, AllocationOccurrence occurrence) => new(
@@ -2505,7 +2538,10 @@ sealed class CandidateLookup
         if (token == 0)
             return [];
 
-        var moduleCandidates = ModuleLookupKeys(modulePath, moduleName)
+        var moduleKeys = ModuleLookupKeys(modulePath, moduleName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var moduleCandidates = moduleKeys
             .SelectMany(moduleKey => _byModuleMethodToken.TryGetValue((moduleKey, token), out var candidates) ? candidates : [])
             .DistinctBy(static candidate => candidate.Id)
             .ToArray();
@@ -2513,7 +2549,9 @@ sealed class CandidateLookup
         var search = moduleCandidates
             .Where(candidate => candidate.IlOffset <= ilOffset)
             .ToArray();
-        if (search.Length == 0 && !string.IsNullOrWhiteSpace(methodName))
+        if (search.Length == 0
+            && moduleKeys.Length == 0
+            && !string.IsNullOrWhiteSpace(methodName))
         {
             search = _byModuleMethodToken
                 .Where(pair => pair.Key.Token == token)
@@ -2545,10 +2583,16 @@ sealed class CandidateLookup
     {
         if (NormalizeModuleKey(candidate.AssemblyName) is { Length: > 0 } assembly)
             yield return assembly;
-        if (NormalizeModuleKey(candidate.LibraryPath) is { Length: > 0 } path)
-            yield return path;
-        if (NormalizeModuleKey(Path.GetFileName(candidate.LibraryPath)) is { Length: > 0 } file)
-            yield return file;
+        if (string.Equals(
+                candidate.Source,
+                "library",
+                StringComparison.Ordinal))
+        {
+            if (NormalizeModuleKey(candidate.LibraryPath) is { Length: > 0 } path)
+                yield return path;
+            if (NormalizeModuleKey(Path.GetFileName(candidate.LibraryPath)) is { Length: > 0 } file)
+                yield return file;
+        }
     }
 
     static IEnumerable<string> ModuleLookupKeys(string? modulePath, string? moduleName)
@@ -2733,7 +2777,9 @@ internal static class ProgramSupport
         var byCanon = new Dictionary<string, List<AllocationCandidate>>(StringComparer.Ordinal);
         foreach (var candidate in result.Candidates)
         {
-            if (candidate.IsObserved || candidate.PredictedType is not { Length: > 0 } type)
+            if (candidate.IsObserved
+                || candidate.SupersededByTriage
+                || candidate.PredictedType is not { Length: > 0 } type)
                 continue;
             var canon = CanonicalTypeSignature(type);
             if (canon.Length == 0 || observedCanons.Contains(canon))

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -2299,63 +2299,12 @@ sealed class AllocationCandidate(
 
     static bool TypeNamesEquivalent(string left, string right)
     {
-        left = NormalizeTypeName(left);
-        right = NormalizeTypeName(right);
+        left = ProgramSupport.NormalizeProducerTypeName(left);
+        right = ProgramSupport.NormalizeProducerTypeName(right);
         return string.Equals(
             ProgramSupport.CanonicalTypeSignature(left),
             ProgramSupport.CanonicalTypeSignature(right, reflection: true),
             StringComparison.Ordinal);
-    }
-
-    static string NormalizeTypeName(string value)
-    {
-        value = value.Trim();
-                 bool stripped;
-                 do
-                 {
-                     stripped = false;
-                     foreach (string prefix in new[]
-                              {
-                                  "boxed ",
-                                  "value class ",
-                                  "valuetype ",
-                                  "class "
-                              })
-            {
-                         if (!value.StartsWith(
-                                 prefix,
-                                 StringComparison.OrdinalIgnoreCase))
-                         {
-                             continue;
-                         }
-
-                         value = value[prefix.Length..].Trim();
-                         stripped = true;
-                         break;
-                     }
-
-                     foreach (string wrapper in new[]
-                              {
-                                  "display class (",
-                                  "state machine ("
-                              })
-                     {
-                         if (!value.StartsWith(
-                                 wrapper,
-                                 StringComparison.OrdinalIgnoreCase)
-                             || !value.EndsWith(')'))
-                         {
-                             continue;
-                         }
-
-                         value = value[wrapper.Length..^1].Trim();
-                         stripped = true;
-                         break;
-                     }
-                 }
-                 while (stripped);
-
-                 return value;
     }
 
     public static AllocationCandidate FromOccurrence(int id, string path, AllocationOccurrence occurrence) => new(
@@ -2706,6 +2655,57 @@ static partial class Patterns
 
 internal static class ProgramSupport
 {
+    public static string NormalizeProducerTypeName(string value)
+    {
+        value = value.Trim();
+        bool stripped;
+        do
+        {
+            stripped = false;
+            foreach (string prefix in new[]
+                     {
+                         "boxed ",
+                         "value class ",
+                         "valuetype ",
+                         "class "
+                     })
+            {
+                if (!value.StartsWith(
+                        prefix,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                value = value[prefix.Length..].Trim();
+                stripped = true;
+                break;
+            }
+
+            foreach (string wrapper in new[]
+                     {
+                         "display class (",
+                         "state machine ("
+                     })
+            {
+                if (!value.StartsWith(
+                        wrapper,
+                        StringComparison.OrdinalIgnoreCase)
+                    || !value.EndsWith(')'))
+                {
+                    continue;
+                }
+
+                value = value[wrapper.Length..^1].Trim();
+                stripped = true;
+                break;
+            }
+        }
+        while (stripped);
+
+        return value;
+    }
+
     public static void MarkAllocationHitForTest(
         AllocationCandidate candidate,
         HashSet<int> matchedIds,
@@ -2781,7 +2781,8 @@ internal static class ProgramSupport
         {
             if (!candidate.IsObserved || candidate.PredictedType is not { Length: > 0 } type)
                 continue;
-            var canon = CanonicalTypeSignature(type);
+            var canon = CanonicalTypeSignature(
+                NormalizeProducerTypeName(type));
             if (canon.Length != 0)
                 observedCanons.Add(canon);
         }
@@ -2793,7 +2794,8 @@ internal static class ProgramSupport
                 || candidate.SupersededByTriage
                 || candidate.PredictedType is not { Length: > 0 } type)
                 continue;
-            var canon = CanonicalTypeSignature(type);
+            var canon = CanonicalTypeSignature(
+                NormalizeProducerTypeName(type));
             if (canon.Length == 0 || observedCanons.Contains(canon))
                 continue;
             if (!byCanon.TryGetValue(canon, out var list))

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -548,9 +548,7 @@ static bool LooksLikeTriageRow(JsonElement element)
     bool hasKind = GetJsonString(
             element,
             "Shape",
-            "shape",
-            "AllocationKind",
-            "allocationKind") is not null;
+            "shape") is not null;
     bool hasCompactPerformanceSchema =
         GetJsonString(element, "Evidence", "evidence") is not null
         && GetJsonString(element, "Priority", "priority") is not null
@@ -2296,11 +2294,6 @@ sealed class AllocationCandidate(
                 || string.Equals(allocatedType, "System.Text.StringBuilder", StringComparison.Ordinal)
                 || string.Equals(allocatedType, "System.Char[]", StringComparison.Ordinal);
 
-        if (AllocationKind.Contains("delegate", StringComparison.OrdinalIgnoreCase))
-            return allocatedType.Contains("Func`", StringComparison.Ordinal)
-                || allocatedType.Contains("Action`", StringComparison.Ordinal)
-                || allocatedType.EndsWith("Delegate", StringComparison.Ordinal);
-
         return false;
     }
 
@@ -2337,6 +2330,25 @@ sealed class AllocationCandidate(
                          }
 
                          value = value[prefix.Length..].Trim();
+                         stripped = true;
+                         break;
+                     }
+
+                     foreach (string wrapper in new[]
+                              {
+                                  "display class (",
+                                  "state machine ("
+                              })
+                     {
+                         if (!value.StartsWith(
+                                 wrapper,
+                                 StringComparison.OrdinalIgnoreCase)
+                             || !value.EndsWith(')'))
+                         {
+                             continue;
+                         }
+
+                         value = value[wrapper.Length..^1].Trim();
                          stripped = true;
                          break;
                      }

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -822,12 +822,39 @@ static bool TryCorrelateNetTrace(
             IReadOnlyList<AllocationCandidate> matchedCandidates = [];
             while (stack != null)
             {
-                matchedCandidates = lookup.FindNearestByCodeAddress(stack.CodeAddress);
+                TraceCodeAddress address = stack.CodeAddress;
+                matchedCandidates = lookup
+                    .FindNearestByCodeAddress(address)
+                    .Where(candidate =>
+                        !string.Equals(
+                            candidate.Source,
+                            "triage",
+                            StringComparison.Ordinal)
+                        || candidate.MatchesAllocatedType(
+                            data.TypeName))
+                    .ToArray();
+                if (matchedCandidates.Any(candidate =>
+                        string.Equals(
+                            candidate.Source,
+                            "triage",
+                            StringComparison.Ordinal)))
+                {
+                    matchedCandidates = matchedCandidates
+                        .Where(candidate => string.Equals(
+                            candidate.Source,
+                            "triage",
+                            StringComparison.Ordinal))
+                        .ToArray();
+                }
+
                 if (matchedCandidates.Count > 0)
                 {
-                    matchedAddress = stack.CodeAddress;
+                    matchedAddress = address;
                     break;
                 }
+
+                if (lookup.IsCandidateModule(address))
+                    break;
 
                 stack = stack.Caller;
             }
@@ -1626,7 +1653,7 @@ static void RenderMarkdown(CorrelationResult result, IReadOnlyList<AllocationCan
     Console.WriteLine("## Reading this report");
     Console.WriteLine();
     Console.WriteLine("- Static rows are IL-visible candidates from dotnet-inspect Performance Triage.");
-    Console.WriteLine("- Runtime weight comes from the supplied diagnostics artifact. `.nettrace` allocation ticks use the innermost stack frame whose method token and IL offset can join to a static allocation site by nearest-preceding IL offset.");
+    Console.WriteLine("- Runtime weight comes from the supplied diagnostics artifact. `.nettrace` allocation ticks stop at the first frame in a represented assembly and join only that method token and nearest-preceding IL offset; an unexported in-assembly callee is not attributed to its caller.");
     Console.WriteLine("- The kind-first table ranks realized allocation volume by static `AllocationKind`; `EscapeKind` is the static promotion prior for that hot site.");
     Console.WriteLine("- `method-hot` means the runtime artifact observed the method. `il-offset-hot` means a `.nettrace` allocation tick joined to a single nearest-preceding static IL allocation site. `allocation-hot` means raw allocation events occurred with the method on-stack. `shape-hot` means the allocated type matched the static allocation shape. `shape-hot-ambiguous` means multiple same-shape static rows share that evidence. `confirmed-hot` means an exact token+IL coordinate was observed.");
 }
@@ -2351,15 +2378,18 @@ sealed class CandidateLookup
 {
     readonly Dictionary<(int Token, int Offset), List<AllocationCandidate>> _byTokenOffset;
     readonly Dictionary<(string Module, int Token), List<AllocationCandidate>> _byModuleMethodToken;
+    readonly HashSet<string> _candidateModules;
     readonly List<(string Fragment, AllocationCandidate Candidate)> _methodFragments;
 
     CandidateLookup(
         Dictionary<(int Token, int Offset), List<AllocationCandidate>> byTokenOffset,
         Dictionary<(string Module, int Token), List<AllocationCandidate>> byModuleMethodToken,
+        HashSet<string> candidateModules,
         List<(string Fragment, AllocationCandidate Candidate)> methodFragments)
     {
         _byTokenOffset = byTokenOffset;
         _byModuleMethodToken = byModuleMethodToken;
+        _candidateModules = candidateModules;
         _methodFragments = methodFragments;
     }
 
@@ -2409,7 +2439,11 @@ sealed class CandidateLookup
         foreach (var tokenList in byModuleMethodToken.Values)
             tokenList.Sort(static (left, right) => left.IlOffset.CompareTo(right.IlOffset));
 
-        return new CandidateLookup(byTokenOffset, byModuleMethodToken, fragments);
+        return new CandidateLookup(
+            byTokenOffset,
+            byModuleMethodToken,
+            [.. byModuleMethodToken.Keys.Select(static key => key.Module)],
+            fragments);
 
         void AddFragment(string value, AllocationCandidate candidate)
         {
@@ -2451,6 +2485,12 @@ sealed class CandidateLookup
             address.ModuleName,
             address.FullMethodName);
     }
+
+    public bool IsCandidateModule(TraceCodeAddress address)
+        => ModuleLookupKeys(
+                address.ModuleFilePath,
+                address.ModuleName)
+            .Any(_candidateModules.Contains);
 
     public IReadOnlyList<AllocationCandidate> FindNearestByTokenOffset(
         int token,


### PR DESCRIPTION
## Outcome

`runfaster` can now conservatively correlate curated Performance Triage rows with `.nettrace` allocation events by declaring assembly, MethodDef token, IL offset, and predicted allocation shape. It stops at unexported in-assembly callees instead of falsely crediting outer callers.

## Changes

- Add `Assembly` and `MethodToken` to nested Performance Triage JSON while preserving the operation operand as `Token`.
- Accept nested Performance Triage JSON and compact JSONL in `runfaster`; inspect only the known performance projection.
- Surface runtime-correlatable row counts and separate unjoinable rows from workload-negative evidence.
- Require predicted/runtime allocation-type compatibility for exact attribution.
- Stop filtered stack walks at the first frame in an assembly represented by the candidate set.
- Prefer a matching triage candidate when `--library` and `--triage` describe the same physical site, avoiding split sampled bytes and false ambiguity.
- Document the static-to-runtime workflow and its precision boundaries.

## Evidence

- `runfaster.Tests`: 64 passed, including real checked-in `.nettrace` tests for exact coordinates, operand-token separation, real compact producer JSONL, unrelated-document rejection, filtered-caller non-attribution, and duplicate-source handling.
- Focused CLI structured-coordinate producer contract test passed.
- `markdownlint` passed for README and the shipped performance skill; `git diff --check` passed.
- Conservative self-analysis dogfood: 14 curated candidates produced 1 exact `shape-hot`, 1 type-level confirmation, 10 workload-cold rows, and 2 not runtime-correlatable aggregate rows. This replaces the earlier unsafe 7/14 result that walked past unexported same-assembly callees.

## Compatibility

Compact `Performance:* --jsonl` remains the tight tabular shape and is accepted for type-level correlation, but exact trace joins require nested `--json`. GC allocation-tick bytes remain sampling-weighted estimates, not exact object-byte counts.