### PR TITLE
Tighten adversarial review round discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,9 @@ change ready to merge.
   behavior passes, commit and push promptly. Keep that head fixed while broader
   local validation, CI, and eligible fixed-head review run concurrently,
   subject to the per-round CI and conflict gates under
-  [Adversarial review](#adversarial-review).
+  [Adversarial review](#adversarial-review). Conflict recovery is the exception:
+  push its resolution head immediately, then run required local validation in
+  parallel with review and CI as described above.
 - Do not fetch or integrate the base again merely because it advances, because
   another PR is expected to land, or because later integration would make the
   branch look newer. Base movement alone does not invalidate a candidate. A
@@ -480,18 +482,19 @@ npx markdownlint-cli <file>
 ### Lock the head, review it, then fix it
 
 An ordinary review round may begin only after the candidate head is pushed,
-settled, and locally includes the effective base recorded at candidate
-formation. Its focused pre-push gate must pass before dispatch, except that a
-settled documentation-only first round may run concurrently with Markdown
-linting. The first round starts without waiting for CI. A conflict-recovery
-round starts immediately after its resolution head is pushed while required
-post-push local validation runs. An ordinary subsequent round additionally
-requires zero merge conflicts and green current-head `ci-required`.
+settled, locally includes the effective base recorded at candidate formation,
+and has passed its focused pre-push gate. The first attempt at round 1 starts
+without waiting for CI. A conflict-recovery round starts immediately after its
+resolution head is pushed while required post-push local validation runs. A
+round restarted after failed-gate recovery and every ordinary subsequent round
+additionally require zero merge conflicts and green current-head
+`ci-required`.
 
 Review is a locked-head feedback loop: freeze and push one exact head, review
 that head, reconcile the feedback, make any resulting fixes, and freeze the
-replacement head. Do not edit a head while its round is running. The fixed
-replacement is a new candidate and its review is a new round.
+replacement head. Do not edit a head while its head lock is held. The lock ends
+when both reviewers have returned and their feedback has been reconciled for
+action. The fixed replacement is a new candidate and its review is a new round.
 
 A known conflict, known failing current-head required check, or known failing
 required local gate blocks an ordinary round. Resolve an actual conflict first,
@@ -513,11 +516,10 @@ moving](#clean-reviews-are-not-spent-by-main-moving), which preserves the clean
 reviews and does not open another round.
 
 Documentation-only PRs follow the same sequencing. Their focused pre-push gate
-is Markdown linting, and a clean exact-head first-round review may run
-concurrently with that gate when the candidate is already settled. Lint must
-still pass before merge, and an ordinary subsequent round requires a
-current-head status check confirming zero merge conflicts and green
-`ci-required`.
+is Markdown linting, which must pass before the candidate is committed, pushed,
+or sent to reviewers. The first round does not wait for CI after that push. An
+ordinary subsequent round requires a current-head status check confirming zero
+merge conflicts and green `ci-required`.
 
 Adversarial review is scarce, but serial wall-clock time is also a cost. Spend
 review only on a named frozen head with focused local evidence, then accept the
@@ -548,9 +550,9 @@ so again before every subsequent round:
   [Clean reviews are not spent by main
   moving](#clean-reviews-are-not-spent-by-main-moving).
 - **Before merge, the PR is mergeable and green** — two questions, one
-  consolidated status query. The first and conflict-recovery rounds do not wait
-  for this result, but an ordinary subsequent round and merge readiness do. Use
-  a single
+  consolidated status query. The first attempt at round 1 and conflict-recovery
+  rounds do not wait for this result, but a failed-gate restart, an ordinary
+  subsequent round, and merge readiness do. Use a single
   `gh api graphql` request that returns the PR's
   `headRefOid`, `mergeable`, `mergeStateStatus`, `statusCheckRollup` state and
   contexts with `pageInfo`, and the query's `rateLimit` cost, remaining quota,
@@ -595,10 +597,14 @@ so again before every subsequent round:
     before starting that round.
   - If `mergeable` is `UNKNOWN`, it does not satisfy the zero-conflict gate. If
     current-head `ci-required` is already green, use the REST fallback above;
-    a null result follows its five-minute recovery cadence. If CI is also
-    pending, schedule the documentation-only follow-up for at least 10 minutes
-    plus small random jitter after the five-minute check, or the
-    non-documentation follow-up for the expected 35-minute completion point.
+    a null result follows its five-minute recovery cadence. If `ci-required` is
+    pending or missing, schedule the documentation-only follow-up for at least
+    10 minutes plus small random jitter after the five-minute check, or the
+    non-documentation follow-up for the expected 35-minute completion point. If
+    both mergeability and CI remain unresolved at that follow-up, continue with
+    at least 10 minutes plus small random jitter between aggregate queries.
+    Switch to the five-minute REST-backed recovery cadence once `ci-required`
+    is green and mergeability is the only unknown.
   - If `mergeable` is `MERGEABLE` and the PR is documentation-only, use that
     five-minute result as the expected CI completion check. Do not schedule a
     longer planned wait; documentation CI should be complete by then. If it is
@@ -631,15 +637,18 @@ so again before every subsequent round:
   not only the slice under review. A known-conflicted or known-red parent blocks
   review of everything above it. A pending parent does not block a slice's
   first or conflict-recovery round, provided each layer has a settled pushed
-  head and passed focused local evidence. Before any ordinary subsequent round,
-  a current-head aggregate check for every open stack layer must confirm zero
-  merge conflicts and green `ci-required`. A slice rebases onto its parent,
-  never onto `main`: only the stack's bottom open slice takes `origin/main` as
-  its base, and rebasing an upper slice onto `main` pulls in work its parent has
-  not landed and makes the slice's diff report its parent's changes as its own.
-  `ci.yml` applies no base-branch filter, so every non-documentation slice
-  schedules the same CI wherever it targets; a non-documentation slice
-  reporting *no* checks is therefore not green.
+  head and passed focused local evidence. A conflict-recovery round is scoped
+  to the recovered slice and may start while that slice's post-push local
+  validation and affected descendant restacks are pending; do not review an
+  upper slice until its own conflicts are recovered. Before any ordinary
+  subsequent round, a current-head aggregate check for every open stack layer
+  must confirm zero merge conflicts and green `ci-required`. A slice rebases
+  onto its parent, never onto `main`: only the stack's bottom open slice takes
+  `origin/main` as its base, and rebasing an upper slice onto `main` pulls in
+  work its parent has not landed and makes the slice's diff report its parent's
+  changes as its own. `ci.yml` applies no base-branch filter, so every
+  non-documentation slice schedules the same CI wherever it targets; a
+  non-documentation slice reporting *no* checks is therefore not green.
   Re-query after the registration window, following the status-discovery
   cadence above, and verify the current head; if no matching workflow run
   appears, that is a scheduling bug to investigate, since a PR that triggers no
@@ -678,10 +687,13 @@ forward without another round. Record the reviewed head, old and new main tips,
 the non-interaction analysis, and the user's decision on the PR.
 
 If the range can affect the change, report that the carry-forward path is not
-available and keep the reviewed head. Do not integrate merely because the base
-moved, and do not open another round unless an actual conflict, review-driven
-fix, author change, or explicit user workflow adjustment creates a replacement
-candidate.
+available and keep the reviewed head. The PR is not merge-ready in that state:
+do not post `Ready to merge`. Do not integrate merely because the base moved,
+and do not open another round unless an actual conflict, review-driven fix,
+author change, or explicit user workflow adjustment creates a replacement
+candidate. Ask the user whether to make a workflow adjustment that integrates
+the base and re-validates and re-reviews the replacement head, or to leave the
+PR blocked.
 
 The carry-forward continuation is the sole exception to the fixed-head review
 rule. It does not authorize carrying reviews across author changes,
@@ -776,7 +788,9 @@ the resulting fixes are committed and pushed as the replacement candidate and
 the public reconciliation is posted. A conflict- or failed-gate-superseded
 attempt is incomplete: it does not consume a round number, does not receive a
 completion report, and restarts with the same number after its applicable
-recovery gate.
+recovery gate. Record every finding returned before supersession, carry it into
+the restarted round, and disposition it in that round's public reconciliation;
+supersession never retires a finding.
 
 After every completed round and before starting the next one, emit this report
 as the assistant's visible user-facing response in the terminal, filling every
@@ -899,11 +913,14 @@ until it is unreviewable, and over parallel PRs that race in the same files.
 - **Review depth is per-slice, by that slice's own risk**, not the stack's size.
 - **Review-start readiness is checked stack-wide before any slice's round.**
   Every layer must have a settled pushed head, focused local evidence, and no
-  known failure or conflict. Pending CI is allowed only for a slice's first or
-  conflict-recovery round. Before any ordinary subsequent round, a current-head
-  aggregate check for every open stack layer must confirm zero merge conflicts
-  and green `ci-required`. Merge readiness still requires every layer to be
-  green and mergeable — see [Adversarial review](#adversarial-review).
+  known failure or conflict. A slice's first round may start with pending CI.
+  A conflict-recovery round may start while the recovered slice's required
+  post-push local validation, CI, and affected descendant restacks are pending;
+  upper-slice review remains blocked until that slice is conflict-free. Before
+  any ordinary subsequent round, a current-head aggregate check for every open
+  stack layer must confirm zero merge conflicts and green `ci-required`. Merge
+  readiness still requires every layer to be green and mergeable — see
+  [Adversarial review](#adversarial-review).
 - **A moved head — including one moved by a restack — needs a clean round at
   the new head**, and a restack never retires an open finding.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -757,8 +757,8 @@ conflict-superseded attempt is incomplete: it does not consume a round number,
 does not receive a completion report, and restarts with the same number after
 conflict recovery.
 
-After every completed round and before starting the next one, post this report
-on the PR, filling every field and choosing exactly one feedback
+After every completed round and before starting the next one, print this report
+in the terminal, filling every field and choosing exactly one feedback
 classification:
 
 ```text
@@ -775,7 +775,9 @@ Fix description: <prose description of changes made in response to the round>.
 Use `Fix description` to state the concrete review-driven changes. For a clean
 round, say that no fixes were required and that the locked head remained
 unchanged. Do not integrate the base after that clean result except through the
-approved carry-forward path.
+approved carry-forward path. The same report may also be posted on the PR; the
+public reconciliation may include more detail when the findings or fixes
+warrant it.
 
 ### Keep review proportional to the contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,17 @@ change ready to merge.
   `main`; never detach its HEAD or develop in it.
 - Before starting a change, run `git fetch origin main` from the primary
   checkout, then create a descriptive branch and linked worktree with
-  `git worktree add -b <branch> <path> origin/main`. Make all edits, builds,
-  tests, and commits in the worktree, not the primary checkout. A slice in a
-  stack branches from its parent slice's branch instead — see
+  `git worktree add -b <branch> <repo>/.worktrees/<slug> origin/main`. Make all
+  edits, builds, tests, and commits in the worktree, not the primary checkout.
+  Do not create worktrees as direct children of the user's home directory. A
+  slice in a stack branches from its parent slice's branch instead — see
   [Stacked PRs for multi-slice issues](#stacked-prs-for-multi-slice-issues).
 - Use one development worktree per PR, plus temporary worktrees for independent
-  reviews. Do not reuse a worktree across unrelated changes.
+  reviews. Development worktrees belong under the primary checkout's
+  `.worktrees/` directory. Reviewer worktrees belong there or under an
+  operating-system temporary directory; they are also prohibited at the root
+  of the user's home directory. Do not reuse a worktree across unrelated
+  changes.
 - Never amend commits; create follow-up commits.
 - **Conflict recovery is the first priority for an open PR.** When GitHub
   reports a merge conflict, stop tests, reviews, lower-stack restacks, and
@@ -62,9 +67,13 @@ change ready to merge.
   conflict resolution starts at once on the pushed head; do not wait for CI
   before sending it to reviewers. Run required local validation against that
   exact pushed head in parallel with CI, and schedule the post-push status
-  check described below. This changes sequencing only, and the PR remains
-  unready until local validation, CI, and required review are clean. Recover a
-  stack bottom-up so every child rests on a conflict-free parent.
+  check described below. A confirmed conflict supersedes any review attempt
+  already in progress and releases its head lock. That incomplete attempt does
+  not consume a round number or require a completion report; restart the same
+  numbered round on the conflict-resolution head. This changes sequencing only,
+  and the PR remains unready until local validation, CI, and required review
+  are clean. Recover a stack bottom-up so every child rests on a conflict-free
+  parent.
 - Form one frozen candidate for each review round. Immediately before focused
   local validation, fetch and integrate the effective base and record that base
   tip. Once the smallest local test, lint, or build gate covering the authored
@@ -358,8 +367,9 @@ Match evidence to the claim and use the smallest existing check that proves it:
   change crosses boundaries or focused results expose broader risk.
 - Do not serialize independent evidence. After the focused pre-push gate is
   green, start broader local suites, current-head CI, and eligible fixed-head
-  review concurrently. A long suite is not a reason to delay an independent
-  gate.
+  review concurrently. Eligibility includes the per-round CI and conflict
+  rules under [Adversarial review](#adversarial-review). A long suite is not a
+  reason to delay an independent gate.
 - Run broad local suites once per authored head, not once per elapsed base
   update. After a conflict-free base-only merge, inspect the integrated range
   and rerun the focused gates for files, contracts, and behavior that can
@@ -460,11 +470,14 @@ npx markdownlint-cli <file>
 
 ### Lock the head, review it, then fix it
 
-**A review round begins as soon as the candidate head is pushed, settled,
-locally includes the effective base recorded at candidate formation, and has
-passed its focused pre-push gate.** The first round and a round formed by merge
-conflict resolution start without waiting for CI. Run those reviews in
-parallel with broader local validation and CI.
+An ordinary review round may begin only after the candidate head is pushed,
+settled, locally includes the effective base recorded at candidate formation,
+and has passed its focused pre-push gate. The first round starts at that point
+without waiting for CI. A settled documentation-only first round may run
+concurrently with Markdown linting, and a conflict-recovery round starts
+immediately after its resolution head is pushed while required post-push local
+validation runs. An ordinary subsequent round additionally requires zero merge
+conflicts and green current-head `ci-required`.
 
 Review is a locked-head feedback loop: freeze and push one exact head, review
 that head, reconcile the feedback, make any resulting fixes, and freeze the
@@ -475,8 +488,7 @@ A known conflict, known failing current-head required check, or known failing
 required local gate blocks an ordinary round. Resolve an actual conflict first,
 push the resolution, and then start its conflict-recovery round immediately.
 Pending CI or GitHub mergeability computation does not block the first round or
-that conflict-recovery round. Every other subsequent round must wait until its
-candidate has zero merge conflicts and current-head `ci-required` is green.
+that conflict-recovery round.
 
 Absent an actual conflict, a round that produces no review-driven fix and then
 integrates newer `main` to create another round is a failed round: the review
@@ -505,7 +517,8 @@ so again before every subsequent round:
 - **The head is pushed, named, and settled.** Reviewers get an exact base and
   head, not a branch that moves under them. Finish your own edits first, and do
   not push again until both reviewers have returned and their feedback has been
-  reconciled.
+  reconciled. A confirmed merge conflict is the exception: it supersedes the
+  incomplete attempt, releases the lock, and requires immediate recovery.
 - **The candidate includes its effective base.** Immediately before focused
   validation, fetch and integrate the effective base and record the integrated
   tip. The resulting head is the candidate: keep it fixed through broader
@@ -520,8 +533,9 @@ so again before every subsequent round:
   [Clean reviews are not spent by main
   moving](#clean-reviews-are-not-spent-by-main-moving).
 - **Before merge, the PR is mergeable and green** — two questions, one
-  consolidated status query. Review does not wait for this result, but
-  readiness does. Use a single
+  consolidated status query. The first and conflict-recovery rounds do not wait
+  for this result, but an ordinary subsequent round and merge readiness do. Use
+  a single
   `gh api graphql` request that returns the PR's
   `headRefOid`, `mergeable`, `mergeStateStatus`, `statusCheckRollup` state and
   contexts with `pageInfo`, and the query's `rateLimit` cost, remaining quota,
@@ -560,18 +574,24 @@ so again before every subsequent round:
   synchronous shell or agent turn open with `sleep`. The first check verifies
   the expected head and detects merge conflicts early:
 
-  - If the PR is conflicting, integrate the effective base, resolve the
+  - If `mergeable` is `CONFLICTING`, integrate the effective base, resolve the
     conflict, push the replacement head, start its conflict-recovery review
     round immediately, and schedule a new five-minute check. Do not wait for CI
     before starting that round.
-  - If the PR is not conflicting and is documentation-only, use that
+  - If `mergeable` is `UNKNOWN`, it does not satisfy the zero-conflict gate. If
+    current-head `ci-required` is already green, use the REST fallback above;
+    a null result follows its five-minute recovery cadence. If CI is also
+    pending, schedule the documentation-only follow-up at 10 minutes plus small
+    random jitter, or the non-documentation follow-up for the expected
+    35-minute completion point.
+  - If `mergeable` is `MERGEABLE` and the PR is documentation-only, use that
     five-minute result as the expected CI completion check. Do not schedule a
     longer planned wait; documentation CI should be complete by then. If it is
     unexpectedly pending or `ci-required` is missing, wait at least 10 minutes
     plus small random jitter before querying again.
-  - If the PR is not conflicting and is not documentation-only, expect CI to
-    take about 35 minutes from the push. Schedule the next status check for
-    about 30 minutes after the five-minute conflict check. If CI is still
+  - If `mergeable` is `MERGEABLE` and the PR is not documentation-only, expect
+    CI to take about 35 minutes from the push. Schedule the next status check
+    for about 30 minutes after the five-minute conflict check. If CI is still
     pending or `ci-required` is missing, wait at least 10 minutes plus small
     random jitter before querying again.
 
@@ -634,20 +654,22 @@ conflict a textual merge would resolve silently but wrongly. Say plainly when
 the answer is that nothing in the range interacts with this change — that is the
 common case and it is the most useful thing you can report.
 
-The user decides which continuation the evidence warrants:
+If the range is non-interacting, the user may direct you to integrate main,
+re-run the claimed validation and current-head CI, and carry the clean reviews
+forward without another round. Record the reviewed head, old and new main tips,
+the non-interaction analysis, and the user's decision on the PR.
 
-- If the range is non-interacting, the user may direct you to integrate main,
-  re-run the claimed validation and current-head CI, and carry the clean reviews
-  forward without another round. Record the reviewed head, old and new main
-  tips, the non-interaction analysis, and the user's decision on the PR.
-- If the range can affect the change, integrate main and run a new round at the
-  resulting head.
+If the range can affect the change, report that the carry-forward path is not
+available and keep the reviewed head. Do not integrate merely because the base
+moved, and do not open another round unless an actual conflict, review-driven
+fix, author change, or explicit user workflow adjustment creates a replacement
+candidate.
 
-The first continuation is the sole exception to the fixed-head review rule; it
-does not authorize carrying reviews across author changes, conflict-resolution
-changes, or a restack that occurred after the recorded reviewed head.
-It is also the sole path that permits integrating the base without a
-review-driven fix or an actual merge conflict.
+The carry-forward continuation is the sole exception to the fixed-head review
+rule. It does not authorize carrying reviews across author changes,
+conflict-resolution changes, or a restack that occurred after the recorded
+reviewed head. It is also the sole default path that permits integrating the
+base without a review-driven fix or an actual merge conflict.
 
 This is the one place the settled-branch rule yields, and it has to, or the
 budget is unbounded: on a busy `main`, a round takes longer than the interval
@@ -713,9 +735,11 @@ locked until both reviewers return and their feedback is reconciled.
 
 Give each reviewer the same self-contained prompt: exact base and head, design
 intent, relevant diff, concrete attack points, and required real-run evidence.
-Isolate every reviewer in a separate linked review worktree; never detach the
-primary checkout for review. Require scratch work under `/tmp/` and prohibit
-`git reset`, `git add`, and commits in review trees. Before acting on a blocking
+Isolate every reviewer in a separate linked review worktree under the primary
+checkout's `.worktrees/` directory or an operating-system temporary directory;
+never place it at the root of the user's home directory or detach the primary
+checkout for review. Require scratch work under `/tmp/` and prohibit `git
+reset`, `git add`, and commits in review trees. Before acting on a blocking
 finding, reproduce it on a clean exact-head review worktree.
 
 Reconcile the reviews publicly on the PR: attribute findings, state what was
@@ -726,8 +750,16 @@ zero-conflict and green-CI gate unless it is a conflict-recovery round, and
 re-review it as the next numbered round. Do not mark the PR ready until every
 required fixed-head review is clean.
 
-After every round, post this report on the PR, filling every field and choosing
-exactly one feedback classification:
+A round starts when its reviewers are dispatched. A clean round ends when its
+feedback is reconciled and posted. A round with actionable findings ends when
+the resulting fixes are committed and pushed as the replacement candidate. A
+conflict-superseded attempt is incomplete: it does not consume a round number,
+does not receive a completion report, and restarts with the same number after
+conflict recovery.
+
+After every completed round and before starting the next one, post this report
+on the PR, filling every field and choosing exactly one feedback
+classification:
 
 ```text
 Round <n> is complete for PR <number>.
@@ -737,7 +769,7 @@ Round <n> is complete for PR <number>.
 - Round end: <datetime>.
 - Round duration: <hours:minutes>
 
-Fix description: <prose description of changes made for the round>.
+Fix description: <prose description of changes made in response to the round>.
 ```
 
 Use `Fix description` to state the concrete review-driven changes. For a clean
@@ -790,7 +822,8 @@ dismissed, before spending another block.
 - Keep concurrent agents modest and avoid unnecessary churn in central files.
 - Treat CI as confirmation, not discovery: run the smallest relevant local gate
   first, then push the frozen candidate promptly. Run broader local validation,
-  CI, and fixed-head review concurrently.
+  CI, and eligible fixed-head review concurrently, subject to the per-round CI
+  and conflict gates above.
 - A settled candidate should spend wall-clock time in parallel. If an hour
   passes without an authored change while an eligible independent gate has not
   started, stop and correct the sequencing or record the concrete blocker. Do
@@ -841,9 +874,12 @@ until it is unreviewable, and over parallel PRs that race in the same files.
 - **Review depth is per-slice, by that slice's own risk**, not the stack's size.
 - **Review-start readiness is checked stack-wide before any slice's round.**
   Every layer must have a settled pushed head, focused local evidence, and no
-  known failure or conflict; pending CI is allowed. Merge readiness still
-  requires every layer to be green and mergeable — see
-  [Adversarial review](#adversarial-review).
+  known failure or conflict. Pending CI is allowed only for a slice's first or
+  conflict-recovery round. An ordinary subsequent round requires zero
+  conflicts and green current-head `ci-required` for its candidate and every
+  stack layer whose head moved to form that candidate. Merge readiness still
+  requires every layer to be green and mergeable — see [Adversarial
+  review](#adversarial-review).
 - **A moved head — including one moved by a restack — needs a clean round at
   the new head**, and a restack never retires an open finding.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,17 +63,17 @@ change ready to merge.
   reports a merge conflict, stop tests, reviews, lower-stack restacks, and
   unrelated follow-up work on that PR. Integrate the effective base, resolve
   the conflict, re-read these instructions and the task-relevant docs, and push
-  the replacement head immediately so CI starts. A review round formed by that
-  conflict resolution starts at once on the pushed head; do not wait for CI
-  before sending it to reviewers. Run required local validation against that
-  exact pushed head in parallel with CI, and schedule the post-push status
-  check described below. A confirmed conflict supersedes any review attempt
-  already in progress and releases its head lock. That incomplete attempt does
-  not consume a round number or require a completion report; restart the same
-  numbered round on the conflict-resolution head. This changes sequencing only,
-  and the PR remains unready until local validation, CI, and required review
-  are clean. Recover a stack bottom-up so every child rests on a conflict-free
-  parent.
+  the   replacement head immediately so CI starts. Subject to the six-round approval
+  boundary below, a review round formed by that conflict resolution starts at
+  once on the pushed head; do not wait for CI before sending it to reviewers.
+  Run required local validation against that exact pushed head in parallel with
+  CI, and schedule the post-push status check described below. A confirmed
+  conflict supersedes any review attempt already in progress and releases its
+  head lock. That incomplete attempt does not consume a round number or require
+  a completion report; restart the same numbered round on the
+  conflict-resolution head. This changes sequencing only, and the PR remains
+  unready until local validation, CI, and required review are clean. Recover a
+  stack bottom-up so every child rests on a conflict-free parent.
 - A confirmed failing current-head required check or required local gate that
   requires an author change also supersedes any review attempt in progress and
   releases its head lock. The incomplete attempt does not consume a round
@@ -485,10 +485,11 @@ An ordinary review round may begin only after the candidate head is pushed,
 settled, locally includes the effective base recorded at candidate formation,
 and has passed its focused pre-push gate. The first attempt at round 1 starts
 without waiting for CI. A conflict-recovery round starts immediately after its
-resolution head is pushed while required post-push local validation runs. A
-round restarted after failed-gate recovery and every ordinary subsequent round
-additionally require zero merge conflicts and green current-head
-`ci-required`.
+resolution head is pushed while required post-push local validation runs,
+provided its round number is authorized under [Stop after six
+rounds](#stop-after-six-rounds). A round restarted after failed-gate recovery
+and every ordinary subsequent round additionally require zero merge conflicts
+and green current-head `ci-required`.
 
 Review is a locked-head feedback loop: freeze and push one exact head, review
 that head, reconcile the feedback, make any resulting fixes, and freeze the
@@ -499,27 +500,33 @@ action. The fixed replacement is a new candidate and its review is a new round.
 A known conflict, known failing current-head required check, or known failing
 required local gate blocks an ordinary round. Resolve an actual conflict first,
 push the resolution, and then start its conflict-recovery round immediately.
-Pending CI or GitHub mergeability computation does not block the first round or
-that conflict-recovery round. If a required check or local gate fails after
-reviewers were dispatched and requires an author change, end the incomplete
-attempt, push the fix, satisfy the ordinary subsequent-round status gate, and
-restart the same numbered round.
+Pending CI or GitHub mergeability computation does not block the first attempt
+at round 1 or that conflict-recovery round. If a required check or local gate
+fails after reviewers were dispatched and requires an author change, end the
+incomplete attempt, push the fix, satisfy the ordinary subsequent-round status
+gate, and restart the same numbered round.
 
 Absent an actual conflict, a round that produces no review-driven fix and then
-integrates newer `main` to create another round is a failed round: the review
-produced no change and the integration discarded the value of the locked-head
-result. A clean round ends adversarial review; do not move the head merely to
-buy another pass. The sole permitted base-only integration after clean reviews
-is the explicitly approved carry-forward path in
+integrates newer `main` to create another round on the agent's own initiative
+is a failed round: the review produced no change and the integration discarded
+the value of the locked-head result. A clean round ends adversarial review; do
+not move the head merely to buy another pass. The sole default base-only
+integration after clean reviews is the explicitly approved carry-forward path
+in
 [Clean reviews are not spent by main
 moving](#clean-reviews-are-not-spent-by-main-moving), which preserves the clean
-reviews and does not open another round.
+reviews and does not open another round. An explicit user workflow adjustment
+may instead authorize interacting-base integration followed by validation and
+a new review round.
 
 Documentation-only PRs follow the same sequencing. Their focused pre-push gate
-is Markdown linting, which must pass before the candidate is committed, pushed,
-or sent to reviewers. The first round does not wait for CI after that push. An
-ordinary subsequent round requires a current-head status check confirming zero
-merge conflicts and green `ci-required`.
+is Markdown linting, which must pass before an ordinary candidate is committed,
+pushed, or sent to reviewers. Conflict recovery is the exception: push the
+resolution head and start its authorized round immediately, then run Markdown
+linting in parallel with review and CI. A lint failure follows failed-gate
+recovery and supersedes that attempt. The first attempt at round 1 does not wait
+for CI after its push. An ordinary subsequent round requires a current-head
+status check confirming zero merge conflicts and green `ci-required`.
 
 Adversarial review is scarce, but serial wall-clock time is also a cost. Spend
 review only on a named frozen head with focused local evidence, then accept the
@@ -554,15 +561,19 @@ so again before every subsequent round:
   rounds do not wait for this result, but a failed-gate restart, an ordinary
   subsequent round, and merge readiness do. Use a single
   `gh api graphql` request that returns the PR's
-  `headRefOid`, `mergeable`, `mergeStateStatus`, `statusCheckRollup` state and
-  contexts with `pageInfo`, and the query's `rateLimit` cost, remaining quota,
-  and reset time. Request enough contexts for the normal check matrix; if
+  `headRefOid`, `isDraft`, `mergeable`, `mergeStateStatus`,
+  `statusCheckRollup` state and contexts with `pageInfo`, and the query's
+  `rateLimit` cost, remaining quota, and reset time. Request enough contexts for
+  the normal check matrix; if
   `pageInfo.hasNextPage` is true and `ci-required` is absent, fetch the
   remaining context pages before concluding that it is missing. Confirm that
-  `headRefOid` is the pushed head, `mergeable` is `MERGEABLE`, and the current
-  head's `ci-required` check run completed successfully. A `CONFLICTING`
-  mergeability result blocks, and `UNKNOWN` means GitHub has not finished
-  computing the merge. When the exact head's `ci-required` is already
+  `headRefOid` is the pushed head, `isDraft` is false, `mergeable` is
+  `MERGEABLE`, and the current head's `ci-required` check run completed
+  successfully. Treat `mergeStateStatus` values `BLOCKED` and `DRAFT` as
+  independent readiness blockers: identify and clear the blocker before
+  posting `Ready to merge`. A `CONFLICTING` mergeability result blocks, and
+  `UNKNOWN` means GitHub has not finished computing the merge. When the exact
+  head's `ci-required` is already
   `SUCCESS` and mergeability is the only unknown, immediately make one REST
   `GET /repos/{owner}/{repo}/pulls/{number}` request for `head.sha`,
   `mergeable`, and `mergeable_state`. That endpoint triggers GitHub's
@@ -593,8 +604,9 @@ so again before every subsequent round:
 
   - If `mergeable` is `CONFLICTING`, integrate the effective base, resolve the
     conflict, push the replacement head, start its conflict-recovery review
-    round immediately, and schedule a new five-minute check. Do not wait for CI
-    before starting that round.
+    round immediately if its round number is authorized, and schedule a new
+    five-minute check. Do not wait for CI before starting an authorized
+    conflict-recovery round.
   - If `mergeable` is `UNKNOWN`, it does not satisfy the zero-conflict gate. If
     current-head `ci-required` is already green, use the REST fallback above;
     a null result follows its five-minute recovery cadence. If `ci-required` is
@@ -661,7 +673,8 @@ change, review fix, or conflict requires a replacement candidate, say so on the
 PR and name the base tip and merge commit, so the next review reads as a
 confirmation rather than an unexplained second full pass. Do not form a
 replacement candidate from base movement alone unless the user approved the
-clean-review carry-forward path.
+clean-review carry-forward path or explicitly adjusted the workflow to
+integrate and re-review an interacting range.
 
 ### Clean reviews are not spent by main moving
 
@@ -695,13 +708,13 @@ candidate. Ask the user whether to make a workflow adjustment that integrates
 the base and re-validates and re-reviews the replacement head, or to leave the
 PR blocked.
 
-The carry-forward continuation is the sole exception to the fixed-head review
-rule. It does not authorize carrying reviews across author changes,
-conflict-resolution changes, or a restack that occurred after the recorded
-reviewed head. It is also the sole default path that permits integrating the
-base when no actual conflict, review-driven fix, author change, current-head
-merge-path failure, or explicit user workflow adjustment has ended the
-candidate.
+The carry-forward continuation is the sole exception that carries clean reviews
+across a base integration without opening another round. It does not authorize
+carrying reviews across author changes, conflict-resolution changes, or a
+restack that occurred after the recorded reviewed head. It is also the sole
+default path that permits integrating the base when no actual conflict,
+review-driven fix, author change, current-head merge-path failure, or explicit
+user workflow adjustment has ended the candidate.
 
 This is the one place the settled-branch rule yields, and it has to, or the
 budget is unbounded: on a busy `main`, a round takes longer than the interval
@@ -788,9 +801,10 @@ the resulting fixes are committed and pushed as the replacement candidate and
 the public reconciliation is posted. A conflict- or failed-gate-superseded
 attempt is incomplete: it does not consume a round number, does not receive a
 completion report, and restarts with the same number after its applicable
-recovery gate. Record every finding returned before supersession, carry it into
-the restarted round, and disposition it in that round's public reconciliation;
-supersession never retires a finding.
+recovery gate. Let in-flight reviewers finish or cancel them explicitly. Record
+every finding returned by the superseded attempt whenever it arrives, carry it
+into the restarted round, and disposition it in that round's public
+reconciliation; supersession never retires a finding.
 
 After every completed round and before starting the next one, emit this report
 as the assistant's visible user-facing response in the terminal, filling every
@@ -844,6 +858,11 @@ Do not begin a seventh review round without explicit user approval. Each
 approval authorizes one new block of up to six rounds: rounds 7-12, then 13-18,
 and so on. Stop as soon as review converges; approval is a ceiling, not a
 requirement to spend the full block.
+
+Conflict recovery does not waive this approval boundary. Resolve and push a
+conflict immediately so CI starts, but if its review would begin a new
+unauthorized block, request approval before dispatching reviewers. Once
+approved, start that conflict-recovery round without waiting for CI.
 
 Before requesting each six-round block, present an analysis of why the prior
 six rounds did not converge. In particular, determine whether the repeated
@@ -913,14 +932,15 @@ until it is unreviewable, and over parallel PRs that race in the same files.
 - **Review depth is per-slice, by that slice's own risk**, not the stack's size.
 - **Review-start readiness is checked stack-wide before any slice's round.**
   Every layer must have a settled pushed head, focused local evidence, and no
-  known failure or conflict. A slice's first round may start with pending CI.
-  A conflict-recovery round may start while the recovered slice's required
-  post-push local validation, CI, and affected descendant restacks are pending;
-  upper-slice review remains blocked until that slice is conflict-free. Before
-  any ordinary subsequent round, a current-head aggregate check for every open
-  stack layer must confirm zero merge conflicts and green `ci-required`. Merge
-  readiness still requires every layer to be green and mergeable — see
-  [Adversarial review](#adversarial-review).
+  known failure or conflict. A slice's first attempt at round 1 may start with
+  pending CI. An authorized conflict-recovery round may start while the
+  recovered slice's required post-push local validation, CI, and affected
+  descendant restacks are pending; upper-slice review remains blocked until
+  that slice is conflict-free. Before any ordinary subsequent round, a
+  current-head aggregate check for every open stack layer must confirm zero
+  merge conflicts and green `ci-required`. Merge readiness still requires every
+  layer to be green and mergeable — see [Adversarial
+  review](#adversarial-review).
 - **A moved head — including one moved by a restack — needs a clean round at
   the new head**, and a restack never retires an open finding.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -474,9 +474,9 @@ Review is a locked-head feedback loop: freeze and push one exact head, review
 that head, reconcile the feedback, make any resulting fixes, and freeze the
 replacement head. Do not edit a head while its head lock is held. The lock ends
 when both reviewers have returned, their feedback has been reconciled for
-action, and every required current-head check and local gate allowed to run
-concurrently has succeeded. The fixed replacement is a new candidate and its
-review is a new round.
+action, current-head zero-conflict evidence is confirmed, and every required
+current-head check and local gate allowed to run concurrently has succeeded.
+The fixed replacement is a new candidate and its review is a new round.
 
 A fixed-head review is **review-clean** when its public reconciliation leaves no
 finding unresolved **and the reviewed head did not move in response to that
@@ -803,11 +803,11 @@ head is review-clean.
 
 A round starts when its reviewers are dispatched. It ends when all current and
 carried feedback is publicly reconciled, every resulting fix is committed and
-pushed, and every required current-head check and post-push local gate for that
-round has completed successfully. A no-fix round with publicly justified
-dismissals can therefore end review-clean; a round that pushes fixes is
-complete but not review-clean, and its replacement head still requires the next
-numbered review.
+pushed, current-head zero-conflict evidence is confirmed, and every required
+current-head check and post-push local gate for that round has completed
+successfully. A no-fix round with publicly justified dismissals can therefore
+end review-clean; a round that pushes fixes is complete but not review-clean,
+and its replacement head still requires the next numbered review.
 
 Superseded attempts follow [Canonical round flow](#canonical-round-flow);
 supersession never retires a finding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -765,9 +765,11 @@ the public reconciliation is posted. A conflict-superseded attempt is
 incomplete: it does not consume a round number, does not receive a completion
 report, and restarts with the same number after conflict recovery.
 
-After every completed round and before starting the next one, print this report
-in the terminal, filling every field and choosing exactly one feedback
-classification:
+After every completed round and before starting the next one, emit this report
+as the assistant's visible user-facing response in the terminal, filling every
+field and choosing exactly one feedback classification. Do not emit it through
+a shell command such as `printf`, leave it only in tool output, collapse it
+behind a tool-call summary, or replace it with a shorter completion summary:
 
 ```text
 Round <n> is complete for PR <number>.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,53 +61,11 @@ change ready to merge.
   of the user's home directory. Do not reuse a worktree across unrelated
   changes.
 - Never amend commits; create follow-up commits.
-- **Conflict recovery is the first priority for an open PR.** When GitHub
-  reports a merge conflict, stop tests, reviews, lower-stack restacks, and
-  unrelated follow-up work on that PR. Integrate the effective base, resolve
-  the conflict, re-read these instructions and the task-relevant docs, and push
-  the replacement head immediately so CI starts. Subject to the six-round approval
-  boundary below, a review round formed by that conflict resolution starts at
-  once on the pushed head; do not wait for CI before sending it to reviewers.
-  Run required local validation against that exact pushed head in parallel with
-  CI, and schedule the post-push status check described below. A confirmed
-  conflict supersedes any review attempt already in progress and releases its
-  head lock. That incomplete attempt does not consume a round number or require
-  a completion report; restart the same numbered round on the
-  conflict-resolution head. This changes sequencing only, and the PR remains
-  unready until local validation, CI, and required review are clean. Recover a
-  stack bottom-up so every child rests on a conflict-free parent.
-- A confirmed failing current-head required check or required local gate that
-  requires an author change also supersedes an attempt while its head lock is
-  held and releases that lock. The incomplete attempt does not consume a round
-  number or require a completion report. Make and push the required fix, wait
-  for the replacement head's zero-conflict and green-CI gate, and restart the
-  same numbered round. Unlike conflict recovery, failed-gate recovery does not
-  start review while CI is pending.
-- A confirmed failing current-head required check that needs no author change
-  does not supersede the attempt or release its head lock. For a cancelled job
-  or evidenced transient infrastructure failure, re-run the failed check on the
-  unchanged head. If it passes, continue the same attempt. If it fails again,
-  inspect the current-head failure and either repeat only with concrete
-  transient evidence or classify the failure as requiring an author change,
-  which hands the attempt to failed-gate recovery above and releases the lock.
-  Absent that classification, never continue or complete the attempt while a
-  required check remains red.
-- Form one frozen candidate for each review round. Immediately before focused
-  local validation, fetch and integrate the effective base and record that base
-  tip. Once the smallest local test, lint, or build gate covering the authored
-  behavior passes, commit and push promptly. Keep that head fixed while broader
-  local validation, CI, and eligible fixed-head review run concurrently,
-  subject to the per-round CI and conflict gates under
-  [Adversarial review](#adversarial-review). Conflict recovery is the exception:
-  push its resolution head immediately, then run required local validation in
-  parallel with review and CI as described above.
-- Do not fetch or integrate the base again merely because it advances, because
-  another PR is expected to land, or because later integration would make the
-  branch look newer. Base movement alone does not invalidate a candidate. A
-  conflict, an author change, a review fix, a current-head merge-path failure
-  that requires code changes, a required restack onto a moved parent slice, or
-  an explicit user direction ends it. Integrate the then-current effective base
-  only when forming that replacement.
+- For an open PR, the candidate, lock, CI, conflict, failed-gate, base-movement,
+  and round-restart rules have one source of truth: [Canonical round
+  flow](#canonical-round-flow). **Conflict recovery remains the first
+  priority**; apply that flow before tests, reviews, restacks, or unrelated
+  follow-up work.
 - Rebase only before the branch's first push. Once a branch is public or under
   review, merge `origin/main`; never amend, rebase, or force-push reviewed
   history. A slice in a stack is the standing exception: restacking rebases and
@@ -119,13 +77,13 @@ change ready to merge.
 - Do not mix unrelated changes into one commit or sweep another contributor's
   working-tree changes into your work.
 - Treat worktrees as temporary. Remove a reviewer worktree after that reviewer
-  has returned and any required reproduction there is complete. Remove the
-  development worktree only after the exact reviewed head is pushed, its head
-  lock has ended with all required concurrent gates successful, and every
-  required fixed-head review at that head is review-clean — or after merge, for
-  a change that needs no adversarial review. Do not retain inactive worktrees
-  in case more work appears; recreate one for the branch if follow-up work is
-  needed.
+  has returned or its cancellation is acknowledged and any required
+  reproduction there is complete. Remove the development worktree only after
+  the exact reviewed head is pushed, its head lock has ended with all required
+  concurrent gates successful, and every required fixed-head review at that
+  head is review-clean — or after merge, for a change that needs no adversarial
+  review. Do not retain inactive worktrees in case more work appears; recreate
+  one for the branch if follow-up work is needed.
 
 ## Task-specific guidance
 
@@ -494,17 +452,23 @@ npx markdownlint-cli <file>
 
 ## Adversarial review
 
-### Lock the head, review it, then fix it
+### Canonical round flow
 
-An ordinary review round may begin only after the candidate head is pushed,
-settled, locally includes the effective base recorded at candidate formation,
-and has passed its focused pre-push gate. The first attempt at round 1 starts
-without waiting for CI. A conflict-recovery round starts immediately after its
-resolution head is pushed while required post-push local validation runs,
-provided its round number is authorized under [Stop after six
-rounds](#stop-after-six-rounds). A round restarted after failed-gate recovery
-and every ordinary subsequent round additionally require zero merge conflicts
-and green current-head `ci-required`.
+This section is the sole source of truth for candidate formation, round
+eligibility, head locking, supersession, and recovery. Other sections add
+reviewer, stack, or readiness detail without redefining these transitions.
+
+| Attempt | Required before reviewer dispatch | May remain pending |
+| --- | --- | --- |
+| First attempt at round 1 | Pushed settled head, recorded effective base, focused gate | CI and mergeability |
+| Ordinary subsequent round | First-attempt requirements, zero conflicts, green current-head `ci-required` | Nothing required |
+| Conflict-recovery attempt | Resolution head pushed, round number authorized | Post-push local gates, CI, mergeability |
+| Failed-gate restart | Required fix pushed, zero conflicts, green current-head `ci-required` | Nothing required |
+
+Documentation-only ordinary candidates use Markdown linting as their focused
+gate. A documentation conflict-recovery attempt instead lints after the
+resolution push; it may start review immediately, but cannot reconcile or
+complete until lint succeeds.
 
 Review is a locked-head feedback loop: freeze and push one exact head, review
 that head, reconcile the feedback, make any resulting fixes, and freeze the
@@ -522,15 +486,25 @@ review-clean; only the replacement head can earn that status. The report
 classification `clean` is narrower: use it only when the reviewers returned no
 findings.
 
-A known conflict, known failing current-head required check, or known failing
-required local gate blocks an ordinary round. Resolve an actual conflict first,
-push the resolution, and then start its conflict-recovery round immediately.
-Pending CI or GitHub mergeability computation does not block the first attempt
-at round 1 or that conflict-recovery round. If a required check or local gate
-fails while the head lock is held and requires an author change, end the
-incomplete attempt, push the fix, satisfy the ordinary subsequent-round status
-gate, and restart the same numbered round. If the failure needs no author
-change, keep the lock and follow the unchanged-head re-run path above.
+Apply one transition when the locked head becomes invalid:
+
+- **Conflict:** supersede the attempt, release the lock, integrate and resolve
+  the effective base, push immediately, and restart the same numbered round
+  without waiting for CI. The six-round approval boundary still applies.
+- **Failure requiring an author change:** supersede the attempt, release the
+  lock, push the fix, satisfy the failed-gate restart row, and restart the same
+  numbered round.
+- **Cancelled or evidenced transient failure:** keep the unchanged head and its
+  lock, re-run the failed check, and continue if it passes. After another
+  failure, repeat only with concrete transient evidence or classify it as
+  requiring an author change. Never continue or complete while a required check
+  remains red.
+
+A superseded attempt consumes no round number and receives no completion
+report. Let its reviewers finish or cancel them explicitly. Before completing
+the restarted round, wait for every superseded reviewer to finish or have its
+cancellation acknowledged, carry forward every returned finding, and
+disposition each one publicly.
 
 Absent an actual conflict, a round that produces no review-driven fix and then
 integrates newer `main` to create another round on the agent's own initiative
@@ -544,17 +518,6 @@ moving](#clean-reviews-are-not-spent-by-main-moving), which preserves the clean
 reviews and does not open another round. An explicit user workflow adjustment
 may instead authorize interacting-base integration followed by validation and
 a new review round.
-
-Documentation-only PRs follow the same sequencing. Their focused pre-push gate
-is Markdown linting, which must pass before an ordinary candidate is committed,
-pushed, or sent to reviewers. Conflict recovery is the exception: push the
-resolution head and start its authorized round immediately, then run Markdown
-linting in parallel with review and CI. A lint failure follows failed-gate
-recovery and supersedes that attempt. Do not reconcile or complete the
-conflict-recovery round until lint finishes successfully. The first attempt at
-round 1 does not wait for CI after its push. An ordinary subsequent round
-requires a current-head status check confirming zero merge conflicts and green
-`ci-required`.
 
 Adversarial review is scarce, but serial wall-clock time is also a cost. Spend
 review only on a named frozen head with focused local evidence, then accept the
@@ -846,14 +809,8 @@ dismissals can therefore end review-clean; a round that pushes fixes is
 complete but not review-clean, and its replacement head still requires the next
 numbered review.
 
-A conflict- or failed-gate-superseded attempt is incomplete: it does not consume
-a round number, does not receive a completion report, and restarts with the
-same number after its applicable recovery gate. Let in-flight reviewers finish
-or cancel them explicitly. Do not reconcile or complete the restarted round
-until every superseded reviewer has finished or its cancellation is
-acknowledged. Record every finding returned by the superseded attempt whenever
-it arrives, carry it into the restarted round, and disposition it in that
-round's public reconciliation; supersession never retires a finding.
+Superseded attempts follow [Canonical round flow](#canonical-round-flow);
+supersession never retires a finding.
 
 After every completed round and before starting the next one, emit this report
 as the assistant's visible user-facing response in the terminal, filling every
@@ -991,17 +948,13 @@ until it is unreviewable, and over parallel PRs that race in the same files.
   slice above. Use `--force-with-lease`, restack only your own slices, and post
   a `range-diff` proving the restack changed the base and nothing else.
 - **Review depth is per-slice, by that slice's own risk**, not the stack's size.
-- **Review-start readiness is checked stack-wide before any slice's round.**
-  Every layer must have a settled pushed head, focused local evidence, and no
-  known failure or conflict. A slice's first attempt at round 1 may start with
-  pending CI. An authorized conflict-recovery round may start while the
-  recovered slice's required post-push local validation, CI, and affected
-  descendant restacks are pending; upper-slice review remains blocked until
-  that slice is conflict-free. Before any ordinary subsequent round, a
-  current-head aggregate check for every open stack layer must confirm zero
-  merge conflicts and green `ci-required`. Merge readiness still requires every
-  layer to be green and mergeable — see [Adversarial
-  review](#adversarial-review).
+- **Apply the canonical eligibility table stack-wide.** Before an ordinary
+  subsequent round, every open layer must have a settled pushed head, focused
+  evidence, zero conflicts, and green current-head `ci-required`. A first
+  attempt may retain pending CI. A conflict-recovery attempt is scoped to the
+  recovered slice and may retain the pending work allowed by its table row;
+  upper-slice review remains blocked until that slice is conflict-free. Merge
+  readiness still requires every layer to be green and mergeable.
 - **A moved head — including one moved by a restack — needs a review-clean round
   at the new head**, and a restack never retires an open finding.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,13 @@ change ready to merge.
   and the PR remains unready until local validation, CI, and required review
   are clean. Recover a stack bottom-up so every child rests on a conflict-free
   parent.
+- A confirmed failing current-head required check or required local gate that
+  requires an author change also supersedes any review attempt in progress and
+  releases its head lock. The incomplete attempt does not consume a round
+  number or require a completion report. Make and push the required fix, wait
+  for the replacement head's zero-conflict and green-CI gate, and restart the
+  same numbered round. Unlike conflict recovery, failed-gate recovery does not
+  start review while CI is pending.
 - Form one frozen candidate for each review round. Immediately before focused
   local validation, fetch and integrate the effective base and record that base
   tip. Once the smallest local test, lint, or build gate covering the authored
@@ -473,13 +480,13 @@ npx markdownlint-cli <file>
 ### Lock the head, review it, then fix it
 
 An ordinary review round may begin only after the candidate head is pushed,
-settled, locally includes the effective base recorded at candidate formation,
-and has passed its focused pre-push gate. The first round starts at that point
-without waiting for CI. A settled documentation-only first round may run
-concurrently with Markdown linting, and a conflict-recovery round starts
-immediately after its resolution head is pushed while required post-push local
-validation runs. An ordinary subsequent round additionally requires zero merge
-conflicts and green current-head `ci-required`.
+settled, and locally includes the effective base recorded at candidate
+formation. Its focused pre-push gate must pass before dispatch, except that a
+settled documentation-only first round may run concurrently with Markdown
+linting. The first round starts without waiting for CI. A conflict-recovery
+round starts immediately after its resolution head is pushed while required
+post-push local validation runs. An ordinary subsequent round additionally
+requires zero merge conflicts and green current-head `ci-required`.
 
 Review is a locked-head feedback loop: freeze and push one exact head, review
 that head, reconcile the feedback, make any resulting fixes, and freeze the
@@ -490,7 +497,10 @@ A known conflict, known failing current-head required check, or known failing
 required local gate blocks an ordinary round. Resolve an actual conflict first,
 push the resolution, and then start its conflict-recovery round immediately.
 Pending CI or GitHub mergeability computation does not block the first round or
-that conflict-recovery round.
+that conflict-recovery round. If a required check or local gate fails after
+reviewers were dispatched and requires an author change, end the incomplete
+attempt, push the fix, satisfy the ordinary subsequent-round status gate, and
+restart the same numbered round.
 
 Absent an actual conflict, a round that produces no review-driven fix and then
 integrates newer `main` to create another round is a failed round: the review
@@ -520,8 +530,10 @@ so again before every subsequent round:
 - **The head is pushed, named, and settled.** Reviewers get an exact base and
   head, not a branch that moves under them. Finish your own edits first, and do
   not push again until both reviewers have returned and their feedback has been
-  reconciled. A confirmed merge conflict is the exception: it supersedes the
-  incomplete attempt, releases the lock, and requires immediate recovery.
+  reconciled. A confirmed merge conflict or failing required gate that requires
+  an author change is the exception: it supersedes the incomplete attempt and
+  releases the lock. Conflict recovery pushes immediately; failed-gate recovery
+  pushes the fix and waits for the ordinary subsequent-round status gate.
 - **The candidate includes its effective base.** Immediately before focused
   validation, fetch and integrate the effective base and record the integrated
   tip. The resulting head is the candidate: keep it fixed through broader
@@ -619,15 +631,15 @@ so again before every subsequent round:
   not only the slice under review. A known-conflicted or known-red parent blocks
   review of everything above it. A pending parent does not block a slice's
   first or conflict-recovery round, provided each layer has a settled pushed
-  head and passed focused local evidence. An ordinary subsequent round requires
-  green current-head `ci-required` for every stack layer whose head moved to
-  form the candidate. A slice rebases onto its parent, never onto `main`: only
-  the stack's bottom open slice takes `origin/main` as its base, and rebasing an
-  upper slice onto `main` pulls in work its parent has not landed and makes the
-  slice's diff report its parent's changes as its own. `ci.yml` applies no base-
-  branch filter, so every non-documentation slice schedules the same CI
-  wherever it targets; a non-documentation slice reporting *no* checks is
-  therefore not green.
+  head and passed focused local evidence. Before any ordinary subsequent round,
+  a current-head aggregate check for every open stack layer must confirm zero
+  merge conflicts and green `ci-required`. A slice rebases onto its parent,
+  never onto `main`: only the stack's bottom open slice takes `origin/main` as
+  its base, and rebasing an upper slice onto `main` pulls in work its parent has
+  not landed and makes the slice's diff report its parent's changes as its own.
+  `ci.yml` applies no base-branch filter, so every non-documentation slice
+  schedules the same CI wherever it targets; a non-documentation slice
+  reporting *no* checks is therefore not green.
   Re-query after the registration window, following the status-discovery
   cadence above, and verify the current head; if no matching workflow run
   appears, that is a scheduling bug to investigate, since a PR that triggers no
@@ -761,9 +773,10 @@ required fixed-head review is clean.
 A round starts when its reviewers are dispatched. A clean round ends when its
 feedback is reconciled and posted. A round with actionable findings ends when
 the resulting fixes are committed and pushed as the replacement candidate and
-the public reconciliation is posted. A conflict-superseded attempt is
-incomplete: it does not consume a round number, does not receive a completion
-report, and restarts with the same number after conflict recovery.
+the public reconciliation is posted. A conflict- or failed-gate-superseded
+attempt is incomplete: it does not consume a round number, does not receive a
+completion report, and restarts with the same number after its applicable
+recovery gate.
 
 After every completed round and before starting the next one, emit this report
 as the assistant's visible user-facing response in the terminal, filling every
@@ -887,11 +900,10 @@ until it is unreviewable, and over parallel PRs that race in the same files.
 - **Review-start readiness is checked stack-wide before any slice's round.**
   Every layer must have a settled pushed head, focused local evidence, and no
   known failure or conflict. Pending CI is allowed only for a slice's first or
-  conflict-recovery round. An ordinary subsequent round requires zero
-  conflicts and green current-head `ci-required` for its candidate and every
-  stack layer whose head moved to form that candidate. Merge readiness still
-  requires every layer to be green and mergeable — see [Adversarial
-  review](#adversarial-review).
+  conflict-recovery round. Before any ordinary subsequent round, a current-head
+  aggregate check for every open stack layer must confirm zero merge conflicts
+  and green `ci-required`. Merge readiness still requires every layer to be
+  green and mergeable — see [Adversarial review](#adversarial-review).
 - **A moved head — including one moved by a restack — needs a clean round at
   the new head**, and a restack never retires an open finding.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,10 @@ change ready to merge.
   `git worktree add -b <branch> <repo>/.worktrees/<slug> origin/main`. Make all
   edits, builds, tests, and commits in the worktree, not the primary checkout.
   Do not create worktrees as direct children of the user's home directory. A
-  slice in a stack branches from its parent slice's branch instead — see
-  [Stacked PRs for multi-slice issues](#stacked-prs-for-multi-slice-issues).
+  slice in a stack branches from its parent slice's branch instead. If a GitHub
+  outage prevents the fetch, the outage exception under [Stacked PRs for
+  multi-slice issues](#stacked-prs-for-multi-slice-issues) permits a new slice
+  to use its recorded last-known local base or parent until service recovers.
 - Use one development worktree per PR, plus temporary worktrees for independent
   reviews. Development worktrees belong under the primary checkout's
   `.worktrees/` directory. Reviewer worktrees belong there or under an
@@ -63,7 +65,7 @@ change ready to merge.
   reports a merge conflict, stop tests, reviews, lower-stack restacks, and
   unrelated follow-up work on that PR. Integrate the effective base, resolve
   the conflict, re-read these instructions and the task-relevant docs, and push
-  the   replacement head immediately so CI starts. Subject to the six-round approval
+  the replacement head immediately so CI starts. Subject to the six-round approval
   boundary below, a review round formed by that conflict resolution starts at
   once on the pushed head; do not wait for CI before sending it to reviewers.
   Run required local validation against that exact pushed head in parallel with
@@ -75,8 +77,8 @@ change ready to merge.
   unready until local validation, CI, and required review are clean. Recover a
   stack bottom-up so every child rests on a conflict-free parent.
 - A confirmed failing current-head required check or required local gate that
-  requires an author change also supersedes any review attempt in progress and
-  releases its head lock. The incomplete attempt does not consume a round
+  requires an author change also supersedes an attempt while its head lock is
+  held and releases that lock. The incomplete attempt does not consume a round
   number or require a completion report. Make and push the required fix, wait
   for the replacement head's zero-conflict and green-CI gate, and restart the
   same numbered round. Unlike conflict recovery, failed-gate recovery does not
@@ -495,20 +497,25 @@ and green current-head `ci-required`.
 Review is a locked-head feedback loop: freeze and push one exact head, review
 that head, reconcile the feedback, make any resulting fixes, and freeze the
 replacement head. Do not edit a head while its head lock is held. The lock ends
-when both reviewers have returned and their feedback has been reconciled for
-action. The fixed replacement is a new candidate and its review is a new round.
+when both reviewers have returned, their feedback has been reconciled for
+action, and every required current-head check and local gate allowed to run
+concurrently has succeeded. The fixed replacement is a new candidate and its
+review is a new round.
 
 A fixed-head review is **review-clean** when its public reconciliation leaves no
-finding unresolved. A justified dismissal counts as a resolution only when the
-reason is recorded publicly. The report classification `clean` is narrower: use
-it only when the reviewers returned no findings.
+finding unresolved **and the reviewed head did not move in response to that
+round**. A justified dismissal counts as a resolution only when the reason is
+recorded publicly. A round that pushes a fix is complete but is not
+review-clean; only the replacement head can earn that status. The report
+classification `clean` is narrower: use it only when the reviewers returned no
+findings.
 
 A known conflict, known failing current-head required check, or known failing
 required local gate blocks an ordinary round. Resolve an actual conflict first,
 push the resolution, and then start its conflict-recovery round immediately.
 Pending CI or GitHub mergeability computation does not block the first attempt
 at round 1 or that conflict-recovery round. If a required check or local gate
-fails after reviewers were dispatched and requires an author change, end the
+fails while the head lock is held and requires an author change, end the
 incomplete attempt, push the fix, satisfy the ordinary subsequent-round status
 gate, and restart the same numbered round.
 
@@ -569,7 +576,7 @@ so again before every subsequent round:
   rounds do not wait for this result, but a failed-gate restart, an ordinary
   subsequent round, and merge readiness do. Use a single
   `gh api graphql` request that returns the PR's
-  `headRefOid`, `isDraft`, `mergeable`, `mergeStateStatus`,
+  `headRefOid`, `baseRefOid`, `isDraft`, `mergeable`, `mergeStateStatus`,
   `statusCheckRollup` state and contexts with `pageInfo`, and the query's
   `rateLimit` cost, remaining quota, and reset time. Request enough contexts for
   the normal check matrix; if
@@ -675,15 +682,19 @@ so again before every subsequent round:
   workflow leaves `ci-required` nothing to block on and displays as MERGEABLE
   and CLEAN (#3706).
 
-Do not fetch or integrate the base after the candidate is formed, including
-while validation or CI runs or while a reviewer is mid-read. When an author
-change, review fix, or conflict requires a replacement candidate, say so on the
-PR and name the base tip and merge commit, so the next review reads as a
+Do not fetch or integrate the base after the candidate is formed while
+validation, CI, or review is in progress. After a review-clean result, the
+consolidated status query's `baseRefOid` may reveal that the effective base
+moved; at that point a non-mutating fetch is permitted solely to inspect the
+exact landed range for the carry-forward decision below. Do not integrate
+unless that decision or another candidate-ending trigger authorizes it. When an
+author change, review fix, or conflict requires a replacement candidate, say so
+on the PR and name the base tip and merge commit, so the next review reads as a
 confirmation rather than an unexplained second full pass. Do not form a
 replacement candidate from base movement alone unless the user approved the
-clean-review carry-forward path, explicitly adjusted the workflow to
-integrate and re-review an interacting range, or the slice requires a
-cascading restack onto its moved parent.
+clean-review carry-forward path, explicitly adjusted the workflow to integrate
+and re-review an interacting range, or the slice requires a cascading restack
+onto its moved parent.
 
 ### Clean reviews are not spent by main moving
 
@@ -696,6 +707,11 @@ does not disqualify it. If a finding remains unresolved, or the head changed
 after that review-clean result because of an author change, conflict resolution,
 or restack, the exception does not apply: resolve or restack, integrate the
 effective base, and review the new head normally.
+
+Detect movement by comparing the candidate's recorded base tip with
+`baseRefOid` from the consolidated status query. If they differ after the
+review-clean result, fetch the effective base without integrating it, then
+analyze the exact old-to-new range.
 
 Ask with an analysis of what actually landed: which commits touch files this
 change touches, which behavior this change relies on that they alter, and any
@@ -802,15 +818,16 @@ verified or dismissed, and link resolution commits or explain explicit
 non-actions. Address actionable findings only after the locked-head reviews
 finish. If fixes move the head, push the replacement candidate, wait for its
 zero-conflict and green-CI gate, and re-review it as the next numbered round.
-Do not mark the PR ready until every required fixed-head review is
-review-clean.
+Do not mark the PR ready until every required fixed-head review at the current
+head is review-clean.
 
 A round starts when its reviewers are dispatched. It ends when all current and
 carried feedback is publicly reconciled, every resulting fix is committed and
-pushed, and every required post-push local gate for that round has completed
-successfully. A no-fix round with publicly justified dismissals can therefore
-end review-clean; a round that pushes fixes is complete, but its replacement
-head still requires the next numbered review.
+pushed, and every required current-head check and post-push local gate for that
+round has completed successfully. A no-fix round with publicly justified
+dismissals can therefore end review-clean; a round that pushes fixes is
+complete but not review-clean, and its replacement head still requires the next
+numbered review.
 
 A conflict- or failed-gate-superseded attempt is incomplete: it does not consume
 a round number, does not receive a completion report, and restarts with the
@@ -944,9 +961,11 @@ until it is unreviewable, and over parallel PRs that race in the same files.
   targeted at the parent branch (`gh pr create --base <parent-branch>`).
 - **During a GitHub outage, use stacked branches for new coherent slices** so
   local work can continue without pretending remote evidence exists. Branch
-  each new slice from its local parent slice, create its worktree under
-  `.worktrees/`, and keep its commits isolated. When GitHub recovers, push and
-  open the stack bottom-up, then run each slice's required CI, status, and
+  each new slice from its recorded last-known local base or parent slice, create
+  its worktree under `.worktrees/`, record that base SHA, and keep its commits
+  isolated. When GitHub recovers, fetch the effective base, update the bottom
+  slice, cascade required restacks and focused validation through the stack,
+  then push and open it bottom-up. Run each slice's required CI, status, and
   review gates before treating it as ready.
 - **Merge bottom-up, one at a time**, then confirm the next PR retargeted and
   still shows only its own slice.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,9 @@ change ready to merge.
   another PR is expected to land, or because later integration would make the
   branch look newer. Base movement alone does not invalidate a candidate. A
   conflict, an author change, a review fix, a current-head merge-path failure
-  that requires code changes, or an explicit user direction ends it. Integrate
-  the then-current effective base only when forming that replacement.
+  that requires code changes, a required restack onto a moved parent slice, or
+  an explicit user direction ends it. Integrate the then-current effective base
+  only when forming that replacement.
 - Rebase only before the branch's first push. Once a branch is public or under
   review, merge `origin/main`; never amend, rebase, or force-push reviewed
   history. A slice in a stack is the standing exception: restacking rebases and
@@ -497,6 +498,11 @@ replacement head. Do not edit a head while its head lock is held. The lock ends
 when both reviewers have returned and their feedback has been reconciled for
 action. The fixed replacement is a new candidate and its review is a new round.
 
+A fixed-head review is **review-clean** when its public reconciliation leaves no
+finding unresolved. A justified dismissal counts as a resolution only when the
+reason is recorded publicly. The report classification `clean` is narrower: use
+it only when the reviewers returned no findings.
+
 A known conflict, known failing current-head required check, or known failing
 required local gate blocks an ordinary round. Resolve an actual conflict first,
 push the resolution, and then start its conflict-recovery round immediately.
@@ -509,10 +515,10 @@ gate, and restart the same numbered round.
 Absent an actual conflict, a round that produces no review-driven fix and then
 integrates newer `main` to create another round on the agent's own initiative
 is a failed round: the review produced no change and the integration discarded
-the value of the locked-head result. A clean round ends adversarial review; do
-not move the head merely to buy another pass. The sole default base-only
-integration after clean reviews is the explicitly approved carry-forward path
-in
+the value of the locked-head result. A review-clean round ends adversarial
+review; do not move the head merely to buy another pass. The sole default
+base-only integration after clean reviews is the explicitly approved
+carry-forward path in
 [Clean reviews are not spent by main
 moving](#clean-reviews-are-not-spent-by-main-moving), which preserves the clean
 reviews and does not open another round. An explicit user workflow adjustment
@@ -524,9 +530,11 @@ is Markdown linting, which must pass before an ordinary candidate is committed,
 pushed, or sent to reviewers. Conflict recovery is the exception: push the
 resolution head and start its authorized round immediately, then run Markdown
 linting in parallel with review and CI. A lint failure follows failed-gate
-recovery and supersedes that attempt. The first attempt at round 1 does not wait
-for CI after its push. An ordinary subsequent round requires a current-head
-status check confirming zero merge conflicts and green `ci-required`.
+recovery and supersedes that attempt. Do not reconcile or complete the
+conflict-recovery round until lint finishes successfully. The first attempt at
+round 1 does not wait for CI after its push. An ordinary subsequent round
+requires a current-head status check confirming zero merge conflicts and green
+`ci-required`.
 
 Adversarial review is scarce, but serial wall-clock time is also a cost. Spend
 review only on a named frozen head with focused local evidence, then accept the
@@ -673,20 +681,21 @@ change, review fix, or conflict requires a replacement candidate, say so on the
 PR and name the base tip and merge commit, so the next review reads as a
 confirmation rather than an unexplained second full pass. Do not form a
 replacement candidate from base movement alone unless the user approved the
-clean-review carry-forward path or explicitly adjusted the workflow to
-integrate and re-review an interacting range.
+clean-review carry-forward path, explicitly adjusted the workflow to
+integrate and re-review an interacting range, or the slice requires a
+cascading restack onto its moved parent.
 
 ### Clean reviews are not spent by main moving
 
-For a PR that targets `main` — including the bottom slice of a stack — when
-every reviewer the tier requires has come back clean at the current head and
-`origin/main` has since moved, **stop and ask.** Do not integrate main, and do
-not open another round on your own initiative. Evaluate this from the latest
-clean result: an earlier finding that was fixed and then reviewed clean does not
-disqualify it. If a finding remains unresolved, or the head changed after that
-clean result because of an author change, conflict resolution, or restack, the
-exception does not apply: resolve or restack, integrate the effective base, and
-review the new head normally.
+For a PR that targets `main` — including the bottom slice of a stack — when its
+required fixed-head review is review-clean at the current head and `origin/main`
+has since moved, **stop and ask.** Do not integrate main, and do not open
+another round on your own initiative. Evaluate this from the latest
+review-clean result: an earlier finding that was fixed and then reviewed clean
+does not disqualify it. If a finding remains unresolved, or the head changed
+after that review-clean result because of an author change, conflict resolution,
+or restack, the exception does not apply: resolve or restack, integrate the
+effective base, and review the new head normally.
 
 Ask with an analysis of what actually landed: which commits touch files this
 change touches, which behavior this change relies on that they alter, and any
@@ -714,7 +723,8 @@ carrying reviews across author changes, conflict-resolution changes, or a
 restack that occurred after the recorded reviewed head. It is also the sole
 default path that permits integrating the base when no actual conflict,
 review-driven fix, author change, current-head merge-path failure, or explicit
-user workflow adjustment has ended the candidate.
+user workflow adjustment has ended the candidate and no required cascading
+restack has moved its effective base.
 
 This is the one place the settled-branch rule yields, and it has to, or the
 budget is unbounded: on a busy `main`, a round takes longer than the interval
@@ -791,20 +801,25 @@ Reconcile the reviews publicly on the PR: attribute findings, state what was
 verified or dismissed, and link resolution commits or explain explicit
 non-actions. Address actionable findings only after the locked-head reviews
 finish. If fixes move the head, push the replacement candidate, wait for its
-zero-conflict and green-CI gate unless it is a conflict-recovery round, and
-re-review it as the next numbered round. Do not mark the PR ready until every
-required fixed-head review is clean.
+zero-conflict and green-CI gate, and re-review it as the next numbered round.
+Do not mark the PR ready until every required fixed-head review is
+review-clean.
 
-A round starts when its reviewers are dispatched. A clean round ends when its
-feedback is reconciled and posted. A round with actionable findings ends when
-the resulting fixes are committed and pushed as the replacement candidate and
-the public reconciliation is posted. A conflict- or failed-gate-superseded
-attempt is incomplete: it does not consume a round number, does not receive a
-completion report, and restarts with the same number after its applicable
-recovery gate. Let in-flight reviewers finish or cancel them explicitly. Record
-every finding returned by the superseded attempt whenever it arrives, carry it
-into the restarted round, and disposition it in that round's public
-reconciliation; supersession never retires a finding.
+A round starts when its reviewers are dispatched. It ends when all current and
+carried feedback is publicly reconciled, every resulting fix is committed and
+pushed, and every required post-push local gate for that round has completed
+successfully. A no-fix round with publicly justified dismissals can therefore
+end review-clean; a round that pushes fixes is complete, but its replacement
+head still requires the next numbered review.
+
+A conflict- or failed-gate-superseded attempt is incomplete: it does not consume
+a round number, does not receive a completion report, and restarts with the
+same number after its applicable recovery gate. Let in-flight reviewers finish
+or cancel them explicitly. Do not reconcile or complete the restarted round
+until every superseded reviewer has finished or its cancellation is
+acknowledged. Record every finding returned by the superseded attempt whenever
+it arrives, carry it into the restarted round, and disposition it in that
+round's public reconciliation; supersession never retires a finding.
 
 After every completed round and before starting the next one, emit this report
 as the assistant's visible user-facing response in the terminal, filling every
@@ -824,11 +839,15 @@ Fix description: <prose description of changes made in response to the round>.
 ```
 
 Use `Fix description` to state the concrete review-driven changes. For a clean
-round, say that no fixes were required and that the locked head remained
-unchanged. Do not integrate the base after that clean result except through the
-approved carry-forward path. The same report may also be posted on the PR; the
-public reconciliation may include more detail when the findings or fixes
-warrant it.
+classification, say that no findings or fixes were produced and that the locked
+head remained unchanged. For a no-fix round with dismissed findings, use
+`converging`, `diverging`, or `neutral` and explain the dismissals in the public
+reconciliation. Do not integrate the base after a review-clean result except
+through the approved carry-forward path or when a conflict, author change,
+current-head merge-path failure, required cascading restack, or explicit user
+workflow adjustment ends the candidate. The same report may also be posted on
+the PR; the public reconciliation may include more detail when the findings or
+fixes warrant it.
 
 ### Keep review proportional to the contract
 
@@ -923,6 +942,12 @@ until it is unreviewable, and over parallel PRs that race in the same files.
   `ci.yml` applies no base-branch filter, so a PR runs CI whatever it targets.
 - **One branch and one worktree per slice**, branched from the parent slice, and
   targeted at the parent branch (`gh pr create --base <parent-branch>`).
+- **During a GitHub outage, use stacked branches for new coherent slices** so
+  local work can continue without pretending remote evidence exists. Branch
+  each new slice from its local parent slice, create its worktree under
+  `.worktrees/`, and keep its commits isolated. When GitHub recovers, push and
+  open the stack bottom-up, then run each slice's required CI, status, and
+  review gates before treating it as ready.
 - **Merge bottom-up, one at a time**, then confirm the next PR retargeted and
   still shows only its own slice.
 - **Restacking rebases and force-pushes a public branch by design** — the
@@ -941,7 +966,7 @@ until it is unreviewable, and over parallel PRs that race in the same files.
   merge conflicts and green `ci-required`. Merge readiness still requires every
   layer to be green and mergeable — see [Adversarial
   review](#adversarial-review).
-- **A moved head — including one moved by a restack — needs a clean round at
-  the new head**, and a restack never retires an open finding.
+- **A moved head — including one moved by a restack — needs a review-clean round
+  at the new head**, and a restack never retires an open finding.
 - **Stop stacking when a slice would exist only to continue the stack.** CI cost
   is per PR; three coherent slices beat ten mechanical ones.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,10 @@ change ready to merge.
   or evidenced transient infrastructure failure, re-run the failed check on the
   unchanged head. If it passes, continue the same attempt. If it fails again,
   inspect the current-head failure and either repeat only with concrete
-  transient evidence or classify the failure as requiring an author change;
-  never release the lock while a required check remains red.
+  transient evidence or classify the failure as requiring an author change,
+  which hands the attempt to failed-gate recovery above and releases the lock.
+  Absent that classification, never continue or complete the attempt while a
+  required check remains red.
 - Form one frozen candidate for each review round. Immediately before focused
   local validation, fetch and integrate the effective base and record that base
   tip. Once the smallest local test, lint, or build gate covering the authored
@@ -116,11 +118,14 @@ change ready to merge.
   task-relevant docs before continuing.
 - Do not mix unrelated changes into one commit or sweep another contributor's
   working-tree changes into your work.
-- Treat worktrees as temporary. Confirm the exact reviewed head is pushed, then
-  `git worktree remove <path>` as soon as every required fixed-head review is
-  clean — or after merge, for a change that needs no adversarial review. Do not
-  retain inactive worktrees in case more work appears; recreate one for the
-  branch if follow-up work is needed.
+- Treat worktrees as temporary. Remove a reviewer worktree after that reviewer
+  has returned and any required reproduction there is complete. Remove the
+  development worktree only after the exact reviewed head is pushed, its head
+  lock has ended with all required concurrent gates successful, and every
+  required fixed-head review at that head is review-clean — or after merge, for
+  a change that needs no adversarial review. Do not retain inactive worktrees
+  in case more work appears; recreate one for the branch if follow-up work is
+  needed.
 
 ## Task-specific guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,9 @@ change ready to merge.
   local validation, fetch and integrate the effective base and record that base
   tip. Once the smallest local test, lint, or build gate covering the authored
   behavior passes, commit and push promptly. Keep that head fixed while broader
-  local validation, CI, and review run concurrently.
+  local validation, CI, and eligible fixed-head review run concurrently,
+  subject to the per-round CI and conflict gates under
+  [Adversarial review](#adversarial-review).
 - Do not fetch or integrate the base again merely because it advances, because
   another PR is expected to land, or because later integration would make the
   branch look newer. Base movement alone does not invalidate a candidate. A
@@ -501,10 +503,11 @@ moving](#clean-reviews-are-not-spent-by-main-moving), which preserves the clean
 reviews and does not open another round.
 
 Documentation-only PRs follow the same sequencing. Their focused pre-push gate
-is Markdown linting, and a clean exact-head review may run concurrently with
-that gate when the candidate is already settled. Lint must still pass before
-merge, and an ordinary subsequent round still requires the five-minute
-current-head status check described below.
+is Markdown linting, and a clean exact-head first-round review may run
+concurrently with that gate when the candidate is already settled. Lint must
+still pass before merge, and an ordinary subsequent round requires a
+current-head status check confirming zero merge conflicts and green
+`ci-required`.
 
 Adversarial review is scarce, but serial wall-clock time is also a cost. Spend
 review only on a named frozen head with focused local evidence, then accept the
@@ -581,9 +584,9 @@ so again before every subsequent round:
   - If `mergeable` is `UNKNOWN`, it does not satisfy the zero-conflict gate. If
     current-head `ci-required` is already green, use the REST fallback above;
     a null result follows its five-minute recovery cadence. If CI is also
-    pending, schedule the documentation-only follow-up at 10 minutes plus small
-    random jitter, or the non-documentation follow-up for the expected
-    35-minute completion point.
+    pending, schedule the documentation-only follow-up for at least 10 minutes
+    plus small random jitter after the five-minute check, or the
+    non-documentation follow-up for the expected 35-minute completion point.
   - If `mergeable` is `MERGEABLE` and the PR is documentation-only, use that
     five-minute result as the expected CI completion check. Do not schedule a
     longer planned wait; documentation CI should be complete by then. If it is
@@ -614,14 +617,17 @@ so again before every subsequent round:
   decision depends on an immediate result.
 - **Before merge, every PR in a stack meets the applicable conditions above**,
   not only the slice under review. A known-conflicted or known-red parent blocks
-  review of everything above it; a pending parent does not, provided each layer
-  has a settled pushed head and passed focused local evidence. A slice rebases
-  onto its parent, never onto `main`: only the stack's bottom open slice takes
-  `origin/main` as its base, and rebasing an upper slice onto `main` pulls in
-  work its parent has not landed and makes the slice's diff report its parent's
-  changes as its own. `ci.yml` applies no base-branch filter, so every
-  non-documentation slice schedules the same CI wherever it targets; a
-  non-documentation slice reporting *no* checks is therefore not green.
+  review of everything above it. A pending parent does not block a slice's
+  first or conflict-recovery round, provided each layer has a settled pushed
+  head and passed focused local evidence. An ordinary subsequent round requires
+  green current-head `ci-required` for every stack layer whose head moved to
+  form the candidate. A slice rebases onto its parent, never onto `main`: only
+  the stack's bottom open slice takes `origin/main` as its base, and rebasing an
+  upper slice onto `main` pulls in work its parent has not landed and makes the
+  slice's diff report its parent's changes as its own. `ci.yml` applies no base-
+  branch filter, so every non-documentation slice schedules the same CI
+  wherever it targets; a non-documentation slice reporting *no* checks is
+  therefore not green.
   Re-query after the registration window, following the status-discovery
   cadence above, and verify the current head; if no matching workflow run
   appears, that is a scheduling bug to investigate, since a PR that triggers no
@@ -669,7 +675,9 @@ The carry-forward continuation is the sole exception to the fixed-head review
 rule. It does not authorize carrying reviews across author changes,
 conflict-resolution changes, or a restack that occurred after the recorded
 reviewed head. It is also the sole default path that permits integrating the
-base without a review-driven fix or an actual merge conflict.
+base when no actual conflict, review-driven fix, author change, current-head
+merge-path failure, or explicit user workflow adjustment has ended the
+candidate.
 
 This is the one place the settled-branch rule yields, and it has to, or the
 budget is unbounded: on a busy `main`, a round takes longer than the interval
@@ -752,10 +760,10 @@ required fixed-head review is clean.
 
 A round starts when its reviewers are dispatched. A clean round ends when its
 feedback is reconciled and posted. A round with actionable findings ends when
-the resulting fixes are committed and pushed as the replacement candidate. A
-conflict-superseded attempt is incomplete: it does not consume a round number,
-does not receive a completion report, and restarts with the same number after
-conflict recovery.
+the resulting fixes are committed and pushed as the replacement candidate and
+the public reconciliation is posted. A conflict-superseded attempt is
+incomplete: it does not consume a round number, does not receive a completion
+report, and restarts with the same number after conflict recovery.
 
 After every completed round and before starting the next one, print this report
 in the terminal, filling every field and choosing exactly one feedback

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,13 @@ change ready to merge.
   for the replacement head's zero-conflict and green-CI gate, and restart the
   same numbered round. Unlike conflict recovery, failed-gate recovery does not
   start review while CI is pending.
+- A confirmed failing current-head required check that needs no author change
+  does not supersede the attempt or release its head lock. For a cancelled job
+  or evidenced transient infrastructure failure, re-run the failed check on the
+  unchanged head. If it passes, continue the same attempt. If it fails again,
+  inspect the current-head failure and either repeat only with concrete
+  transient evidence or classify the failure as requiring an author change;
+  never release the lock while a required check remains red.
 - Form one frozen candidate for each review round. Immediately before focused
   local validation, fetch and integrate the effective base and record that base
   tip. Once the smallest local test, lint, or build gate covering the authored
@@ -517,7 +524,8 @@ Pending CI or GitHub mergeability computation does not block the first attempt
 at round 1 or that conflict-recovery round. If a required check or local gate
 fails while the head lock is held and requires an author change, end the
 incomplete attempt, push the fix, satisfy the ordinary subsequent-round status
-gate, and restart the same numbered round.
+gate, and restart the same numbered round. If the failure needs no author
+change, keep the lock and follow the unchanged-head re-run path above.
 
 Absent an actual conflict, a round that produces no review-driven fix and then
 integrates newer `main` to create another round on the agent's own initiative
@@ -576,10 +584,10 @@ so again before every subsequent round:
   rounds do not wait for this result, but a failed-gate restart, an ordinary
   subsequent round, and merge readiness do. Use a single
   `gh api graphql` request that returns the PR's
-  `headRefOid`, `baseRefOid`, `isDraft`, `mergeable`, `mergeStateStatus`,
-  `statusCheckRollup` state and contexts with `pageInfo`, and the query's
-  `rateLimit` cost, remaining quota, and reset time. Request enough contexts for
-  the normal check matrix; if
+  `headRefOid`, `baseRefOid`, `baseRef { target { oid } }`, `isDraft`,
+  `mergeable`, `mergeStateStatus`, `statusCheckRollup` state and contexts with
+  `pageInfo`, and the query's `rateLimit` cost, remaining quota, and reset time.
+  Request enough contexts for the normal check matrix; if
   `pageInfo.hasNextPage` is true and `ci-required` is absent, fetch the
   remaining context pages before concluding that it is missing. Confirm that
   `headRefOid` is the pushed head, `isDraft` is false, `mergeable` is
@@ -684,17 +692,18 @@ so again before every subsequent round:
 
 Do not fetch or integrate the base after the candidate is formed while
 validation, CI, or review is in progress. After a review-clean result, the
-consolidated status query's `baseRefOid` may reveal that the effective base
-moved; at that point a non-mutating fetch is permitted solely to inspect the
-exact landed range for the carry-forward decision below. Do not integrate
-unless that decision or another candidate-ending trigger authorizes it. When an
-author change, review fix, or conflict requires a replacement candidate, say so
-on the PR and name the base tip and merge commit, so the next review reads as a
-confirmation rather than an unexplained second full pass. Do not form a
-replacement candidate from base movement alone unless the user approved the
-clean-review carry-forward path, explicitly adjusted the workflow to integrate
-and re-review an interacting range, or the slice requires a cascading restack
-onto its moved parent.
+consolidated status query's `baseRef.target.oid` may reveal that the effective
+base moved; `baseRefOid` identifies the base commit recorded for the PR and is
+not the live branch tip. At that point a non-mutating fetch is permitted solely
+to inspect the exact landed range for the carry-forward decision below. Do not
+integrate unless that decision or another candidate-ending trigger authorizes
+it. When an author change, review fix, or conflict requires a replacement
+candidate, say so on the PR and name the base tip and merge commit, so the next
+review reads as a confirmation rather than an unexplained second full pass. Do
+not form a replacement candidate from base movement alone unless the user
+approved the clean-review carry-forward path, explicitly adjusted the workflow
+to integrate and re-review an interacting range, or the slice requires a
+cascading restack onto its moved parent.
 
 ### Clean reviews are not spent by main moving
 
@@ -708,10 +717,10 @@ after that review-clean result because of an author change, conflict resolution,
 or restack, the exception does not apply: resolve or restack, integrate the
 effective base, and review the new head normally.
 
-Detect movement by comparing the candidate's recorded base tip with
-`baseRefOid` from the consolidated status query. If they differ after the
-review-clean result, fetch the effective base without integrating it, then
-analyze the exact old-to-new range.
+Detect movement by comparing the candidate's recorded base tip with the live
+tip in `baseRef.target.oid` from the consolidated status query. If they differ
+after the review-clean result, record that live tip, fetch the effective base
+without integrating it, and analyze the exact old-to-new range.
 
 Ask with an analysis of what actually landed: which commits touch files this
 change touches, which behavior this change relies on that they alter, and any
@@ -719,10 +728,13 @@ conflict a textual merge would resolve silently but wrongly. Say plainly when
 the answer is that nothing in the range interacts with this change — that is the
 common case and it is the most useful thing you can report.
 
-If the range is non-interacting, the user may direct you to integrate main,
-re-run the claimed validation and current-head CI, and carry the clean reviews
-forward without another round. Record the reviewed head, old and new main tips,
-the non-interaction analysis, and the user's decision on the PR.
+If the range is non-interacting, the user may direct you to integrate the
+approved base tip, re-run the claimed validation and current-head CI, and carry
+the clean reviews forward without another round. Integrate that exact analyzed
+tip by SHA, not a moving branch ref. If the live base tip changes before
+integration, analyze the additional range and obtain renewed approval before
+carrying the reviews forward. Record the reviewed head, old and approved new
+main tips, the non-interaction analysis, and the user's decision on the PR.
 
 If the range can affect the change, report that the carry-forward path is not
 available and keep the reviewed head. The PR is not merge-ready in that state:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -801,7 +801,7 @@ behind a tool-call summary, or replace it with a shorter completion summary:
 ```text
 Round <n> is complete for PR <number>.
 - Review models <model-a> and <model-b> were used for adversarial review.
-- Review feedback is: [converging, diverging, neutral].
+- Review feedback is: [converging, diverging, neutral, clean].
 - Round start: <datetime>.
 - Round end: <datetime>.
 - Round duration: <hours:minutes>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,11 +58,13 @@ change ready to merge.
   reports a merge conflict, stop tests, reviews, lower-stack restacks, and
   unrelated follow-up work on that PR. Integrate the effective base, resolve
   the conflict, re-read these instructions and the task-relevant docs, and push
-  the replacement head immediately so CI starts. Run required local validation
-  against that exact pushed head in parallel with CI. This changes sequencing
-  only, and the PR remains unready until local validation, CI, and required
-  review are clean. Recover a stack bottom-up so every child rests on a
-  conflict-free parent.
+  the replacement head immediately so CI starts. A review round formed by that
+  conflict resolution starts at once on the pushed head; do not wait for CI
+  before sending it to reviewers. Run required local validation against that
+  exact pushed head in parallel with CI, and schedule the post-push status
+  check described below. This changes sequencing only, and the PR remains
+  unready until local validation, CI, and required review are clean. Recover a
+  stack bottom-up so every child rests on a conflict-free parent.
 - Form one frozen candidate for each review round. Immediately before focused
   local validation, fetch and integrate the effective base and record that base
   tip. Once the smallest local test, lint, or build gate covering the authored
@@ -456,24 +458,41 @@ npx markdownlint-cli <file>
 
 ## Adversarial review
 
-### Start a settled round without waiting for CI
+### Lock the head, review it, then fix it
 
 **A review round begins as soon as the candidate head is pushed, settled,
 locally includes the effective base recorded at candidate formation, and has
-passed its focused pre-push gate.** Run review in parallel with broader local
-validation and CI by default. Do not wait for every check to complete before
-using an independent reviewer.
+passed its focused pre-push gate.** The first round and a round formed by merge
+conflict resolution start without waiting for CI. Run those reviews in
+parallel with broader local validation and CI.
+
+Review is a locked-head feedback loop: freeze and push one exact head, review
+that head, reconcile the feedback, make any resulting fixes, and freeze the
+replacement head. Do not edit a head while its round is running. The fixed
+replacement is a new candidate and its review is a new round.
 
 A known conflict, known failing current-head required check, or known failing
-required local gate blocks the round. Pending CI or GitHub mergeability
-computation does not. If later evidence reveals a conflict or requires an
-author change, the round is superseded; if every check passes without moving
-the head, its clean reviews remain exact-head evidence.
+required local gate blocks an ordinary round. Resolve an actual conflict first,
+push the resolution, and then start its conflict-recovery round immediately.
+Pending CI or GitHub mergeability computation does not block the first round or
+that conflict-recovery round. Every other subsequent round must wait until its
+candidate has zero merge conflicts and current-head `ci-required` is green.
+
+Absent an actual conflict, a round that produces no review-driven fix and then
+integrates newer `main` to create another round is a failed round: the review
+produced no change and the integration discarded the value of the locked-head
+result. A clean round ends adversarial review; do not move the head merely to
+buy another pass. The sole permitted base-only integration after clean reviews
+is the explicitly approved carry-forward path in
+[Clean reviews are not spent by main
+moving](#clean-reviews-are-not-spent-by-main-moving), which preserves the clean
+reviews and does not open another round.
 
 Documentation-only PRs follow the same sequencing. Their focused pre-push gate
 is Markdown linting, and a clean exact-head review may run concurrently with
-that gate when the candidate is already settled; lint must still pass before
-merge.
+that gate when the candidate is already settled. Lint must still pass before
+merge, and an ordinary subsequent round still requires the five-minute
+current-head status check described below.
 
 Adversarial review is scarce, but serial wall-clock time is also a cost. Spend
 review only on a named frozen head with focused local evidence, then accept the
@@ -484,7 +503,9 @@ am I reviewing?" Form and freeze one candidate before the first round, and do
 so again before every subsequent round:
 
 - **The head is pushed, named, and settled.** Reviewers get an exact base and
-  head, not a branch that moves under them. Finish your own edits first.
+  head, not a branch that moves under them. Finish your own edits first, and do
+  not push again until both reviewers have returned and their feedback has been
+  reconciled.
 - **The candidate includes its effective base.** Immediately before focused
   validation, fetch and integrate the effective base and record the integrated
   tip. The resulting head is the candidate: keep it fixed through broader
@@ -534,14 +555,32 @@ so again before every subsequent round:
   a skipped job as validation, and if a change should have triggered a job
   that skipped, the path filter is the bug.
 
-  Status discovery must conserve the shared GitHub API budget. After a push,
-  wait at least 15 minutes before the first status query; use 20 minutes for
-  lanes known to run longer. After pending checks or a missing `ci-required`,
-  wait at least 10 minutes plus small random jitter before querying again.
-  Apply the short REST-backed recovery above when mergeability is the only
-  unknown. Yield the session or schedule a delayed wake-up; do not hold a
-  synchronous shell or agent turn open with `sleep`. Do not use `gh run watch`,
-  `gh pr checks --watch`, or a polling loop for long-running PR checks.
+  Status discovery must conserve the shared GitHub API budget. After every
+  push, schedule one status check for five minutes later; do not hold a
+  synchronous shell or agent turn open with `sleep`. The first check verifies
+  the expected head and detects merge conflicts early:
+
+  - If the PR is conflicting, integrate the effective base, resolve the
+    conflict, push the replacement head, start its conflict-recovery review
+    round immediately, and schedule a new five-minute check. Do not wait for CI
+    before starting that round.
+  - If the PR is not conflicting and is documentation-only, use that
+    five-minute result as the expected CI completion check. Do not schedule a
+    longer planned wait; documentation CI should be complete by then. If it is
+    unexpectedly pending or `ci-required` is missing, wait at least 10 minutes
+    plus small random jitter before querying again.
+  - If the PR is not conflicting and is not documentation-only, expect CI to
+    take about 35 minutes from the push. Schedule the next status check for
+    about 30 minutes after the five-minute conflict check. If CI is still
+    pending or `ci-required` is missing, wait at least 10 minutes plus small
+    random jitter before querying again.
+
+  An ordinary subsequent round cannot start until one of these checks confirms
+  both zero merge conflicts and green current-head `ci-required`. Apply the
+  short REST-backed recovery above when mergeability is the only unknown.
+  Yield the session or schedule a delayed wake-up between checks. Do not use
+  `gh run watch`, `gh pr checks --watch`, or a polling loop for long-running PR
+  checks.
 
   Every status check must re-query the PR aggregate and compare its current
   `headRefOid`; a run or check identifier is pinned to one commit and cannot
@@ -573,7 +612,9 @@ Do not fetch or integrate the base after the candidate is formed, including
 while validation or CI runs or while a reviewer is mid-read. When an author
 change, review fix, or conflict requires a replacement candidate, say so on the
 PR and name the base tip and merge commit, so the next review reads as a
-confirmation rather than an unexplained second full pass.
+confirmation rather than an unexplained second full pass. Do not form a
+replacement candidate from base movement alone unless the user approved the
+clean-review carry-forward path.
 
 ### Clean reviews are not spent by main moving
 
@@ -605,6 +646,8 @@ The user decides which continuation the evidence warrants:
 The first continuation is the sole exception to the fixed-head review rule; it
 does not authorize carrying reviews across author changes, conflict-resolution
 changes, or a restack that occurred after the recorded reviewed head.
+It is also the sole path that permits integrating the base without a
+review-driven fix or an actual merge conflict.
 
 This is the one place the settled-branch rule yields, and it has to, or the
 budget is unbounded: on a busy `main`, a round takes longer than the interval
@@ -663,7 +706,8 @@ every missing seat from the user. An out-of-roster model may provide a quick
 read but does not fill a seat.
 
 A **round** evaluates one settled head with every reviewer its tier requires.
-Two reviewers in the same round count as one round, not two.
+Two reviewers in the same round count as one round, not two. The round remains
+locked until both reviewers return and their feedback is reconciled.
 
 ### Running the round
 
@@ -674,10 +718,32 @@ primary checkout for review. Require scratch work under `/tmp/` and prohibit
 `git reset`, `git add`, and commits in review trees. Before acting on a blocking
 finding, reproduce it on a clean exact-head review worktree.
 
-After addressing findings, re-review the fixed exact head. Reconcile the reviews
-publicly on the PR: attribute findings, state what was verified or dismissed, and
-link resolution commits or explain explicit non-actions. Do not mark the PR ready
-until every required fixed-head review is clean.
+Reconcile the reviews publicly on the PR: attribute findings, state what was
+verified or dismissed, and link resolution commits or explain explicit
+non-actions. Address actionable findings only after the locked-head reviews
+finish. If fixes move the head, push the replacement candidate, wait for its
+zero-conflict and green-CI gate unless it is a conflict-recovery round, and
+re-review it as the next numbered round. Do not mark the PR ready until every
+required fixed-head review is clean.
+
+After every round, post this report on the PR, filling every field and choosing
+exactly one feedback classification:
+
+```text
+Round <n> is complete for PR <number>.
+- Review models <model-a> and <model-b> were used for adversarial review.
+- Review feedback is: [converging, diverging, neutral].
+- Round start: <datetime>.
+- Round end: <datetime>.
+- Round duration: <hours:minutes>
+
+Fix description: <prose description of changes made for the round>.
+```
+
+Use `Fix description` to state the concrete review-driven changes. For a clean
+round, say that no fixes were required and that the locked head remained
+unchanged. Do not integrate the base after that clean result except through the
+approved carry-forward path.
 
 ### Keep review proportional to the contract
 
@@ -703,13 +769,17 @@ contract or threat model requires it.
 
 ### Stop after six rounds
 
-Do not begin a seventh review round without explicit user approval, and get
-fresh approval for every additional round. Before requesting approval, present
-an analysis of why six rounds did not converge. In particular, determine
-whether the repeated findings expose an architectural problem, missing test
-coverage, or reviewers expanding the contract beyond the intended threat
-model. State the proposed architectural or test remedy, or explain why the
-remaining concern should be dismissed, before spending another round.
+Do not begin a seventh review round without explicit user approval. Each
+approval authorizes one new block of up to six rounds: rounds 7-12, then 13-18,
+and so on. Stop as soon as review converges; approval is a ceiling, not a
+requirement to spend the full block.
+
+Before requesting each six-round block, present an analysis of why the prior
+six rounds did not converge. In particular, determine whether the repeated
+findings expose an architectural problem, missing test coverage, or reviewers
+expanding the contract beyond the intended threat model. State the proposed
+architectural or test remedy, or explain why the remaining concern should be
+dismissed, before spending another block.
 
 ## PR and CI discipline
 
@@ -738,6 +808,10 @@ remaining concern should be dismissed, before spending another round.
 - Keep PR summaries conclusion-first. Include the behavioral claim, evidence,
   compatibility or non-action boundary, and exact validation appropriate to
   the change.
+- Agents are not authorized to merge pull requests unless the user explicitly
+  directs them to merge that specific PR. A clean review, green CI, mergeable
+  state, `Ready to merge` comment, or general request to prepare or finish a PR
+  is not merge authorization.
 - When all merge-blocking validation, CI, and required review are complete, post
   a PR comment that says `Ready to merge`. Label later work as non-blocking
   follow-up so readiness remains unambiguous.


### PR DESCRIPTION
Tightens adversarial review into a locked-head review/fix loop and makes no-value base-only reruns explicitly invalid outside the approved carry-forward path.

The policy now starts conflict-resolution rounds immediately after push, gates ordinary follow-up rounds on zero conflicts and green CI with a five-minute first check, treats docs-only CI as a five-minute path, grants six additional rounds per approval, requires a per-round report, and forbids agents from merging without explicit PR-specific authorization.

**Validation:** `npx markdownlint-cli --fix AGENTS.md`; `npx markdownlint-cli AGENTS.md`

**Compatibility:** Documentation-only workflow change; no product behavior changes.