### PR TITLE
Make structural reviews reviewer-sized

### DIFF
--- a/docs/decompiler-raise-discipline.md
+++ b/docs/decompiler-raise-discipline.md
@@ -68,11 +68,14 @@ gaps verbatim. Add `--json` when the revision-bound diff document itself must be
 retained or replayed; never replace it with caller-authored correspondence.
 
 Never hand-place carets or recover correspondence from equal ids, coordinates,
-text, labels, or display order. When the documents predate provenance support,
-describe different method bodies, or leave the changed nodes unsupported or
-ambiguous, record
+text, labels, or display order. A generated `Partial` status is a decline
+boundary, not qualified proof: state whether the PR's claimed changed structure
+has a unique matched row. When it appears only among unsupported or ambiguous
+gaps, treat any matched rows as incidental and record
 `Not generated — unsupported or ambiguous product correspondence: {detail}`
-and retain the standalone Before and After bodies.
+for the claimed structural review. The same decline applies when the documents
+predate provenance support or describe different method bodies. Retain the
+standalone Before and After bodies.
 
 The structural review explains *what changed*; it is not a correctness oracle.
 Keep the independent validity, correctness, compile-back fidelity, and exact

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -144,10 +144,13 @@ This model exists only for node/span structure that the line-oriented
 diff-row hierarchy. Ordinary indented spans reuse the annotation comment gutter
 and its stacking rules. When a covered extent includes indentation and a
 non-whitespace token, the display caret starts at that token; whitespace-only
-extents preserve their exact geometry. A resulting span too close to the left
-edge for the gutter uses an exact gutter-free caret row instead. Typed UTF-16
-spans are unchanged. `CSharpStructuralComparisonTests.
-RenderAnnotatedBody_IndentedExtentAlignsCaretToFirstCoveredToken` gates this
+extents preserve their exact geometry. Tab-indented extents retain the source
+tab prefix in an exact fallback row so the renderer's tab stops remain aligned.
+A resulting span too close to the left edge for the gutter uses an exact
+gutter-free caret row instead. Typed UTF-16 spans are unchanged.
+`CSharpStructuralComparisonTests.
+RenderAnnotatedBody_IndentedExtentAlignsCaretToFirstCoveredToken` and
+`RenderAnnotatedBody_TabIndentedExtentPreservesTabAlignment` gate this
 display-only alignment.
 
 ## Research comparison model

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -145,13 +145,16 @@ diff-row hierarchy. Ordinary indented spans reuse the annotation comment gutter
 and its stacking rules. When a covered extent includes indentation and a
 non-whitespace token, the display caret starts at that token; whitespace-only
 extents preserve their exact geometry. Tab-indented extents retain the source
-tab prefix in an exact fallback row so the renderer's tab stops remain aligned.
-A resulting span too close to the left edge for the gutter uses an exact
-gutter-free caret row instead. Typed UTF-16 spans are unchanged.
+tab prefix in an exact fallback row so the renderer's tab stops remain aligned;
+a tabbed member indent also selects exact fallback because it cannot establish
+a stable comment-gutter column for differently indented lines. A resulting span
+too close to the left edge for the gutter uses an exact gutter-free caret row
+instead. Typed UTF-16 spans are unchanged.
 `CSharpStructuralComparisonTests.
 RenderAnnotatedBody_IndentedExtentAlignsCaretToFirstCoveredToken` and
-`RenderAnnotatedBody_TabIndentedExtentPreservesTabAlignment` gate this
-display-only alignment.
+`RenderAnnotatedBody_TabIndentedExtentPreservesTabAlignment` and
+`RenderAnnotatedBody_TabbedMemberIndentUsesExactFallback` gate this display-only
+alignment.
 
 ## Research comparison model
 

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -128,14 +128,27 @@ artifact, reissues its correspondence, and renders it later. Both forms read
 untrusted input through Decompiler-owned `AnnotatedSourceJson`, so the CLI
 document writer and harness reader share one model-owned contract while
 retaining separate writer and strict-reader policies. Unsupported and ambiguous
-nodes remain a separate correspondence-gap section; an incomplete result is
+nodes remain a separate correspondence-gap section. The default Markdown table
+keeps change, structure, and region, adds fidelity only when populated, and
+omits absolute spans. Gaps are grouped by side and reason with counts and at
+most five node examples. Any gap marks the review partial because matched rows
+cannot establish changes represented only by unsupported or ambiguous nodes.
+That status appears before either body so a long artifact cannot bury the
+evidence limit. The portable JSON remains exhaustive for spans, unmatched
+nodes, and IL provenance. `AuthoredCorpusHarnessProcessTests.
+Harness_BoundsStructuralReviewGapsWithoutDiscardingJsonEvidence` gates that
+bounded-presentation/exhaustive-evidence boundary. An incomplete result is
 never reported as "no structural changes."
 This model exists only for node/span structure that the line-oriented
 `CSharpDiffRow` cannot represent; it does not introduce another generic
 diff-row hierarchy. Ordinary indented spans reuse the annotation comment gutter
-and its stacking rules. A span too close to the left edge for that gutter uses
-an exact gutter-free caret row instead; it is never shifted, widened, clipped,
-or silently dropped.
+and its stacking rules. When a covered extent includes indentation and a
+non-whitespace token, the display caret starts at that token; whitespace-only
+extents preserve their exact geometry. A resulting span too close to the left
+edge for the gutter uses an exact gutter-free caret row instead. Typed UTF-16
+spans are unchanged. `CSharpStructuralComparisonTests.
+RenderAnnotatedBody_IndentedExtentAlignsCaretToFirstCoveredToken` gates this
+display-only alignment.
 
 ## Research comparison model
 

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -129,8 +129,11 @@ selected text, labels, and display order never establish correspondence.
 Fidelity and retained IL notes are independent evidence, not claims inferred
 from the C# transition.
 
-When either document lacks product provenance, the physical method identities
-differ, or the changed nodes are unsupported or ambiguous, write:
+If the generated review reports `Partial`, explicitly determine whether the
+claimed changed structure has a unique matched row. Incidental matched rows do
+not prove a change represented only by unsupported or ambiguous gaps. In that
+case, or when either document lacks product provenance or the physical method
+identities differ, write:
 
 Not generated — unsupported or ambiguous product correspondence: {detail}
 

--- a/src/ILInspector.Decompiler.Tests/AuthoredCorpusHarnessProcessTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredCorpusHarnessProcessTests.cs
@@ -74,6 +74,9 @@ public class AuthoredCorpusHarnessProcessTests
                 "raise: Break case body; changed from return;",
                 run.Output,
                 StringComparison.Ordinal);
+            Assert.Contains("| Change | Structure | Region | Fidelity |", run.Output, StringComparison.Ordinal);
+            Assert.DoesNotContain("Before spans", run.Output, StringComparison.Ordinal);
+            Assert.DoesNotContain("After spans", run.Output, StringComparison.Ordinal);
             Assert.Contains("Return -&gt; Break", run.Output, StringComparison.Ordinal);
             Assert.Contains("OpcodeDiff -&gt; Exact", run.Output, StringComparison.Ordinal);
         }
@@ -149,12 +152,70 @@ public class AuthoredCorpusHarnessProcessTests
             Assert.Contains("@event(value)", run.Output, StringComparison.Ordinal);
             Assert.Contains("this.@event(value)", run.Output, StringComparison.Ordinal);
             Assert.Contains("Changed", run.Output, StringComparison.Ordinal);
+            Assert.Contains("| Change | Structure | Region |", run.Output, StringComparison.Ordinal);
+            Assert.DoesNotContain("| Change | Structure | Region | Fidelity |", run.Output, StringComparison.Ordinal);
             Assert.DoesNotContain("IL_", run.Output, StringComparison.Ordinal);
         }
         finally
         {
             File.Delete(beforePath);
             File.Delete(afterPath);
+        }
+    }
+
+    [Fact]
+    public void Harness_BoundsStructuralReviewGapsWithoutDiscardingJsonEvidence()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"structural-review-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, LargeGapStructuralReviewJson(20));
+
+        try
+        {
+            var markdown = RunHarness("--structural-review", path);
+
+            Assert.Equal(0, markdown.ExitCode);
+            Assert.Contains(
+                "Structural review status: **Partial** - 40 unsupported or ambiguous nodes were excluded.",
+                markdown.Output,
+                StringComparison.Ordinal);
+            Assert.True(
+                markdown.Output.IndexOf("Structural review status:", StringComparison.Ordinal) <
+                markdown.Output.IndexOf("## Before", StringComparison.Ordinal));
+            Assert.Contains("| Change | Structure | Region |", markdown.Output, StringComparison.Ordinal);
+            Assert.DoesNotContain("| Change | Structure | Region | Fidelity |", markdown.Output, StringComparison.Ordinal);
+            Assert.DoesNotContain("Before spans", markdown.Output, StringComparison.Ordinal);
+            Assert.Contains(
+                "| Before | Ambiguous | 20 | 1, 2, 3, 4, 5 (+15 more) |",
+                markdown.Output,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "| After | Ambiguous | 20 | 1, 2, 3, 4, 5 (+15 more) |",
+                markdown.Output,
+                StringComparison.Ordinal);
+            Assert.DoesNotContain("IL_0020", markdown.Output, StringComparison.Ordinal);
+
+            var json = RunHarness("--structural-review", path, "--json");
+
+            Assert.Equal(0, json.ExitCode);
+            var replayed = AnnotatedSourceJson.DeserializeStructuralDiff(json.Output);
+            Assert.Equal(
+                20,
+                replayed.Correspondence.UnmatchedBefore.Count(
+                    static node => node.Reason == CSharpUnmatchedNodeReason.Ambiguous));
+            Assert.Equal(
+                20,
+                replayed.Correspondence.UnmatchedAfter.Count(
+                    static node => node.Reason == CSharpUnmatchedNodeReason.Ambiguous));
+            Assert.All(
+                replayed.Correspondence.UnmatchedBefore,
+                static node => Assert.Equal([0x20, 0x21, 0x22], node.Evidence!.IlOffsets));
+            Assert.All(
+                replayed.Correspondence.UnmatchedAfter,
+                static node => Assert.Equal([0x20, 0x21, 0x22], node.Evidence!.IlOffsets));
+        }
+        finally
+        {
+            File.Delete(path);
         }
     }
 
@@ -1011,6 +1072,66 @@ public class AuthoredCorpusHarnessProcessTests
                 IlBodyDiffOutcome.Exact,
                 note));
         return AnnotatedSourceJson.SerializeStructuralDiff(document);
+    }
+
+    static string LargeGapStructuralReviewJson(int gapCount)
+    {
+        string beforeText = "return;\n" +
+            string.Join('\n', Enumerable.Range(1, gapCount).Select(static index => $"Before{index}();"));
+        string afterText = "break;\n" +
+            string.Join('\n', Enumerable.Range(1, gapCount).Select(static index => $"After{index}();"));
+        var source = new AnnotatedSourceDocumentSource(
+            "Fixture",
+            new Guid("11111111-2222-3333-4444-555555555555"),
+            0x06000001,
+            new string('A', 64),
+            "M");
+
+        AnnotatedSourceDocument Document(
+            string text,
+            string matchedKind,
+            int matchedLength)
+        {
+            var nodes = new List<AnnotatedSourceNode>
+            {
+                new(
+                    0,
+                    matchedKind,
+                    SourceLineKind.CSharp,
+                    [new(0, matchedLength)],
+                    Provenance: new AnnotatedSourceNodeProvenance([0x10]))
+            };
+
+            int lineStart = matchedLength + 1;
+            for (int index = 1; index <= gapCount; index++)
+            {
+                int lineEnd = text.IndexOf('\n', lineStart);
+                if (lineEnd < 0)
+                    lineEnd = text.Length;
+
+                nodes.Add(
+                    new AnnotatedSourceNode(
+                        index,
+                        "ExpressionStatement",
+                        SourceLineKind.CSharp,
+                        [new(lineStart, lineEnd - lineStart)],
+                        Provenance: new AnnotatedSourceNodeProvenance([0x20, 0x21, 0x22])));
+                lineStart = lineEnd + 1;
+            }
+
+            return new AnnotatedSourceDocument(
+                text,
+                nodes,
+                [new AnnotatedSourceRegion(PrintedRegionRole.Case, [new(0, text.Length)])],
+                [],
+                [],
+                source);
+        }
+
+        return AnnotatedSourceJson.SerializeStructuralDiff(
+            CSharpStructuralDiffDocument.Create(
+                Document(beforeText, "ReturnStatement", "return;".Length),
+                Document(afterText, "BreakStatement", "break;".Length)));
     }
 
     static AnnotatedSourceDocument StructuralDocument(

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -588,6 +588,47 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void RenderAnnotatedBody_TabIndentedExtentPreservesTabAlignment()
+    {
+        const string beforeText = "\treturn;";
+        const string afterText = "\tbreak;";
+        var before = new AnnotatedSourceDocument(
+            beforeText,
+            [new AnnotatedSourceNode(
+                0,
+                "ReturnStatement",
+                SourceLineKind.CSharp,
+                [new(0, beforeText.Length)])],
+            [],
+            [],
+            []);
+        var after = new AnnotatedSourceDocument(
+            afterText,
+            [new AnnotatedSourceNode(
+                0,
+                "BreakStatement",
+                SourceLineKind.CSharp,
+                [new(0, afterText.Length)])],
+            [],
+            [],
+            []);
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        string[] rendered = CSharpStructuralDiffPrinter
+            .RenderAnnotatedBody(comparison, CSharpStructuralSide.Before)
+            .Split('\n');
+
+        Assert.Equal(beforeText, rendered[0]);
+        Assert.StartsWith("\t^^^^^^^ raise: Return", rendered[1], StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderAnnotatedBody_EarlyColumnSpansUseExactGutterFreeCarets()
     {
         const string beforeText = "a(b);";

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -590,15 +590,17 @@ public class CSharpStructuralComparisonTests
     [Fact]
     public void RenderAnnotatedBody_TabIndentedExtentPreservesTabAlignment()
     {
-        const string beforeText = "\treturn;";
-        const string afterText = "\tbreak;";
+        const string beforeText = "int value = 0;\n\t\t\treturn value;";
+        const string afterText = "int value = 0;\n\t\t\tbreak;";
+        int beforeStart = beforeText.IndexOf("\t\t\treturn value;", StringComparison.Ordinal);
+        int afterStart = afterText.IndexOf("\t\t\tbreak;", StringComparison.Ordinal);
         var before = new AnnotatedSourceDocument(
             beforeText,
             [new AnnotatedSourceNode(
                 0,
                 "ReturnStatement",
                 SourceLineKind.CSharp,
-                [new(0, beforeText.Length)])],
+                [new(beforeStart, "\t\t\treturn value;".Length)])],
             [],
             [],
             []);
@@ -608,7 +610,7 @@ public class CSharpStructuralComparisonTests
                 0,
                 "BreakStatement",
                 SourceLineKind.CSharp,
-                [new(0, afterText.Length)])],
+                [new(afterStart, "\t\t\tbreak;".Length)])],
             [],
             [],
             []);
@@ -624,8 +626,11 @@ public class CSharpStructuralComparisonTests
             .RenderAnnotatedBody(comparison, CSharpStructuralSide.Before)
             .Split('\n');
 
-        Assert.Equal(beforeText, rendered[0]);
-        Assert.StartsWith("\t^^^^^^^ raise: Return", rendered[1], StringComparison.Ordinal);
+        Assert.Equal("\t\t\treturn value;", rendered[1]);
+        Assert.StartsWith(
+            "\t\t\t^^^^^^^^^^^^^ raise: Return",
+            rendered[2],
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -629,6 +629,49 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void RenderAnnotatedBody_TabbedMemberIndentUsesExactFallback()
+    {
+        const string beforeText = "\tvoid M()\n    return;";
+        const string afterText = "\tvoid M()\n    break;";
+        int beforeStart = beforeText.IndexOf("    return;", StringComparison.Ordinal);
+        int afterStart = afterText.IndexOf("    break;", StringComparison.Ordinal);
+        var before = new AnnotatedSourceDocument(
+            beforeText,
+            [new AnnotatedSourceNode(
+                0,
+                "ReturnStatement",
+                SourceLineKind.CSharp,
+                [new(beforeStart, "    return;".Length)])],
+            [],
+            [],
+            []);
+        var after = new AnnotatedSourceDocument(
+            afterText,
+            [new AnnotatedSourceNode(
+                0,
+                "BreakStatement",
+                SourceLineKind.CSharp,
+                [new(afterStart, "    break;".Length)])],
+            [],
+            [],
+            []);
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        string[] rendered = CSharpStructuralDiffPrinter
+            .RenderAnnotatedBody(comparison, CSharpStructuralSide.Before)
+            .Split('\n');
+
+        Assert.Equal("    return;", rendered[1]);
+        Assert.StartsWith("    ^^^^^^^ raise: Return", rendered[2], StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RenderAnnotatedBody_EarlyColumnSpansUseExactGutterFreeCarets()
     {
         const string beforeText = "a(b);";

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -527,6 +527,67 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void RenderAnnotatedBody_IndentedExtentAlignsCaretToFirstCoveredToken()
+    {
+        const string beforeText =
+            "int value = 0;\n" +
+            "    if (value == 0)\n" +
+            "    {\n" +
+            "        return value;\n" +
+            "    }";
+        const string afterText =
+            "int value = 0;\n" +
+            "    if (value == 0)\n" +
+            "    {\n" +
+            "        break;\n" +
+            "    }";
+        int beforeStart = beforeText.IndexOf("        return value;", StringComparison.Ordinal);
+        int afterStart = afterText.IndexOf("        break;", StringComparison.Ordinal);
+        var before = new AnnotatedSourceDocument(
+            beforeText,
+            [new AnnotatedSourceNode(
+                0,
+                "ReturnStatement",
+                SourceLineKind.CSharp,
+                [new(beforeStart, "        return value;".Length)])],
+            [],
+            [],
+            []);
+        var after = new AnnotatedSourceDocument(
+            afterText,
+            [new AnnotatedSourceNode(
+                0,
+                "BreakStatement",
+                SourceLineKind.CSharp,
+                [new(afterStart, "        break;".Length)])],
+            [],
+            [],
+            []);
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+        Assert.Equal(
+            new AnnotatedSourceSpan(beforeStart, "        return value;".Length),
+            Assert.Single(Assert.Single(comparison.Rows).BeforeSpans));
+
+        string[] rendered = CSharpStructuralDiffPrinter
+            .RenderAnnotatedBody(comparison, CSharpStructuralSide.Before)
+            .Split('\n');
+        int sourceLineIndex = Array.FindIndex(
+            rendered,
+            static line => line.Contains("return value;", StringComparison.Ordinal));
+
+        Assert.True(sourceLineIndex >= 0);
+        Assert.Equal(
+            rendered[sourceLineIndex].IndexOf("return", StringComparison.Ordinal),
+            rendered[sourceLineIndex + 1].IndexOf('^'));
+    }
+
+    [Fact]
     public void RenderAnnotatedBody_EarlyColumnSpansUseExactGutterFreeCarets()
     {
         const string beforeText = "a(b);";

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -131,7 +131,8 @@ public static class CSharpStructuralDiffPrinter
                 int result = left.Extent.Column.CompareTo(right.Extent.Column);
                 return result != 0 ? result : right.Extent.Length.CompareTo(left.Extent.Length);
             });
-            if (HasTabBeforeExtent(line.Text, entries)
+            if (memberIndent.Contains('\t')
+                || HasTabBeforeExtent(line.Text, entries)
                 || !CanRenderInCommentGutter(entries, memberIndent.Length))
             {
                 output.AddRange(RenderExactFallback(line.Text, entries));

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -131,16 +131,17 @@ public static class CSharpStructuralDiffPrinter
                 int result = left.Extent.Column.CompareTo(right.Extent.Column);
                 return result != 0 ? result : right.Extent.Length.CompareTo(left.Extent.Length);
             });
-            if (!CanRenderInCommentGutter(entries, memberIndent.Length))
+            if (HasTabBeforeExtent(line.Text, entries)
+                || !CanRenderInCommentGutter(entries, memberIndent.Length))
             {
-                output.AddRange(RenderExactFallback(entries));
+                output.AddRange(RenderExactFallback(line.Text, entries));
                 continue;
             }
 
             var facts = entries.Select(static entry => entry.Fact).ToArray();
             var extents = entries.ToDictionary(static entry => entry.Fact, static entry => entry.Extent);
             var rendered = AnnotationCaret.Render(line.Text, memberIndent, facts, extents: extents);
-            output.AddRange(rendered.Count > 0 ? rendered : RenderExactFallback(entries));
+            output.AddRange(rendered.Count > 0 ? rendered : RenderExactFallback(line.Text, entries));
         }
 
         return string.Join('\n', output);
@@ -282,7 +283,13 @@ public static class CSharpStructuralDiffPrinter
         return true;
     }
 
+    static bool HasTabBeforeExtent(
+        string sourceLine,
+        IReadOnlyList<(IAnnotation Fact, AnnotationAnchor.CaretExtent Extent)> entries)
+        => entries.Any(entry => sourceLine.AsSpan(0, entry.Extent.Column).Contains('\t'));
+
     static IReadOnlyList<string> RenderExactFallback(
+        string sourceLine,
         IReadOnlyList<(IAnnotation Fact, AnnotationAnchor.CaretExtent Extent)> entries)
     {
         var lines = new List<string>();
@@ -292,7 +299,7 @@ public static class CSharpStructuralDiffPrinter
             foreach (var entry in group)
             {
                 lines.Add(
-                    new string(' ', entry.Extent.Column)
+                    RenderFallbackPadding(sourceLine, entry.Extent.Column)
                     + (first ? new string('^', entry.Extent.Length) : new string(' ', entry.Extent.Length))
                     + " "
                     + AnnotationText.Format(entry.Fact));
@@ -300,6 +307,14 @@ public static class CSharpStructuralDiffPrinter
             }
         }
         return lines;
+    }
+
+    static string RenderFallbackPadding(string sourceLine, int length)
+    {
+        var padding = new char[length];
+        for (int index = 0; index < padding.Length; index++)
+            padding[index] = sourceLine[index] == '\t' ? '\t' : ' ';
+        return new string(padding);
     }
 
     static void EnsureDisplaySafe(

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -92,12 +92,27 @@ public static class CSharpStructuralDiffPrinter
                     if (end <= start)
                         continue;
 
+                    int column = start - line.Start;
+                    int length = end - start;
+                    ReadOnlySpan<char> coveredText = line.Text.AsSpan(column, length);
+                    int visibleOffset = 0;
+                    while (visibleOffset < coveredText.Length
+                           && char.IsWhiteSpace(coveredText[visibleOffset]))
+                    {
+                        visibleOffset++;
+                    }
+                    if (visibleOffset < coveredText.Length)
+                    {
+                        column += visibleOffset;
+                        length -= visibleOffset;
+                    }
+
                     var fact = new StructuralAnnotation(annotationText);
                     if (!annotationsByLine.TryGetValue(lineIndex, out var lineAnnotations))
                         annotationsByLine[lineIndex] = lineAnnotations = [];
                     lineAnnotations.Add((
                         fact,
-                        new AnnotationAnchor.CaretExtent(start - line.Start, end - start)));
+                        new AnnotationAnchor.CaretExtent(column, length)));
                 }
             }
         }

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -45,6 +45,13 @@ renders complete Before and After C# documents with generated structural caret
 comments plus a compact rich-diff table from the resulting
 `CSharpStructuralComparison`.
 
+The Markdown projection keeps `Change`, `Structure`, and `Region`, adding
+`Fidelity` only when a fidelity label is present. Absolute UTF-16 spans and
+complete IL provenance remain in JSON. Unsupported or ambiguous correspondence
+makes the review explicitly partial before either body is shown; gaps are
+grouped by side and reason with counts and at most five example node IDs. The
+portable JSON document retains every unmatched node and its complete evidence.
+
 The documents must carry equal physical method provenance. The issuer binds its
 result to SHA-256 identities of the exact document values and matches only
 unique product-owned IL-origin sets. Repeated sets remain ambiguous even when
@@ -53,9 +60,9 @@ substitution can shift those depths without preserving identity. A unique
 one-sided set becomes `NoCounterpart` only when the opposite node population
 has complete provenance. Document-local ids, rendered coordinates, text, kind
 labels, and display order never establish identity. Other nodes remain explicit
-`Unsupported`, `Ambiguous`, or `NoCounterpart` rows;
-unsupported and ambiguous rows appear under **Correspondence gaps** rather than
-being guessed as additions or removals.
+`Unsupported`, `Ambiguous`, or `NoCounterpart` rows; unsupported and ambiguous
+nodes appear in a bounded **Correspondence gaps** summary rather than being
+guessed as additions or removals.
 
 Add `--json` to emit a `CSharpStructuralDiffDocument`. That product-issued
 artifact carries schema and methodology versions, both exact documents and

--- a/tools/DecompilerHarness/StructuralReview.cs
+++ b/tools/DecompilerHarness/StructuralReview.cs
@@ -6,6 +6,8 @@ namespace ILInspector.DecompilerHarness;
 
 internal static class StructuralReview
 {
+    const int MaximumCorrespondenceGapExamples = 5;
+
     public static int Run(string path, string? afterPath, bool json)
     {
         try
@@ -48,6 +50,7 @@ internal static class StructuralReview
             comparison,
             CSharpStructuralSide.After);
         var rows = CSharpStructuralDiffPrinter.ToDisplayRows(comparison);
+        var correspondenceGaps = GetCorrespondenceGaps(comparison.Correspondence);
 
         using var output = new StringWriter { NewLine = "\n" };
         output.WriteLine("# Structural review");
@@ -55,6 +58,13 @@ internal static class StructuralReview
         output.Write("Target: ");
         output.WriteLine(InlineCode(comparison.Subject));
         output.WriteLine();
+        if (correspondenceGaps.Length > 0)
+        {
+            output.WriteLine(
+                $"Structural review status: **Partial** - {correspondenceGaps.Length} unsupported or ambiguous " +
+                "nodes were excluded. Matched rows do not establish changes represented only by the gaps below.");
+            output.WriteLine();
+        }
         output.WriteLine("## Before");
         output.WriteLine();
         output.WriteLine(FencedCSharp(beforeBody));
@@ -80,8 +90,13 @@ internal static class StructuralReview
         }
         else
         {
-            output.WriteLine("| Change | Structure | Region | Before spans | After spans | Fidelity |");
-            output.WriteLine("| --- | --- | --- | --- | --- | --- |");
+            bool includeFidelity = rows.Any(static row => row.Fidelity.Length > 0);
+            output.WriteLine(includeFidelity
+                ? "| Change | Structure | Region | Fidelity |"
+                : "| Change | Structure | Region |");
+            output.WriteLine(includeFidelity
+                ? "| --- | --- | --- | --- |"
+                : "| --- | --- | --- |");
             foreach (var row in rows)
             {
                 output.Write("| ");
@@ -90,60 +105,69 @@ internal static class StructuralReview
                 output.Write(TableCell(row.Structure));
                 output.Write(" | ");
                 output.Write(TableCell(row.Region));
-                output.Write(" | ");
-                output.Write(TableCell(row.BeforeSpans));
-                output.Write(" | ");
-                output.Write(TableCell(row.AfterSpans));
-                output.Write(" | ");
-                output.Write(TableCell(row.Fidelity));
+                if (includeFidelity)
+                {
+                    output.Write(" | ");
+                    output.Write(TableCell(row.Fidelity));
+                }
                 output.WriteLine(" |");
             }
         }
 
-        WriteCorrespondenceGaps(output, comparison.Correspondence);
+        WriteCorrespondenceGaps(output, correspondenceGaps);
         return output.ToString();
+    }
+
+    static (CSharpStructuralSide Side, CSharpUnmatchedNode Node)[] GetCorrespondenceGaps(
+        CSharpNodeCorrespondenceResult? correspondence)
+    {
+        if (correspondence is null)
+            return [];
+
+        return
+        [
+            .. correspondence.UnmatchedBefore
+            .Where(static node => node.Reason != CSharpUnmatchedNodeReason.NoCounterpart)
+            .Select(static node => (CSharpStructuralSide.Before, Node: node))
+            .Concat(correspondence.UnmatchedAfter
+                .Where(static node => node.Reason != CSharpUnmatchedNodeReason.NoCounterpart)
+                .Select(static node => (CSharpStructuralSide.After, Node: node)))
+        ];
     }
 
     static void WriteCorrespondenceGaps(
         StringWriter output,
-        CSharpNodeCorrespondenceResult? correspondence)
+        (CSharpStructuralSide Side, CSharpUnmatchedNode Node)[] gaps)
     {
-        if (correspondence is null)
-            return;
-
-        var gaps = correspondence.UnmatchedBefore
-            .Where(static node => node.Reason != CSharpUnmatchedNodeReason.NoCounterpart)
-            .Select(static node => (Side: "Before", Node: node))
-            .Concat(correspondence.UnmatchedAfter
-                .Where(static node => node.Reason != CSharpUnmatchedNodeReason.NoCounterpart)
-                .Select(static node => (Side: "After", Node: node)))
-            .ToArray();
         if (gaps.Length == 0)
             return;
 
         output.WriteLine();
         output.WriteLine("## Correspondence gaps");
         output.WriteLine();
-        output.WriteLine("| Side | Node | Reason | IL provenance |");
-        output.WriteLine("| --- | ---: | --- | --- |");
-        foreach (var gap in gaps)
+        output.WriteLine("| Side | Reason | Count | Example nodes |");
+        output.WriteLine("| --- | --- | ---: | --- |");
+        foreach (var group in gaps
+                     .GroupBy(static gap => (gap.Side, gap.Node.Reason))
+                     .OrderBy(static group => group.Key.Side)
+                     .ThenBy(static group => group.Key.Reason))
         {
+            int[] nodes = [.. group.Select(static gap => gap.Node.Node.NodeId).Order()];
+            string examples = string.Join(", ", nodes.Take(MaximumCorrespondenceGapExamples));
+            if (nodes.Length > MaximumCorrespondenceGapExamples)
+                examples += $" (+{nodes.Length - MaximumCorrespondenceGapExamples} more)";
+
             output.Write("| ");
-            output.Write(gap.Side);
+            output.Write(group.Key.Side);
             output.Write(" | ");
-            output.Write(gap.Node.Node.NodeId);
+            output.Write(group.Key.Reason);
             output.Write(" | ");
-            output.Write(gap.Node.Reason);
+            output.Write(nodes.Length);
             output.Write(" | ");
-            output.Write(TableCell(FormatEvidence(gap.Node.Evidence)));
+            output.Write(examples);
             output.WriteLine(" |");
         }
     }
-
-    static string FormatEvidence(AnnotatedSourceNodeProvenance? evidence)
-        => evidence is null
-            ? ""
-            : string.Join(", ", evidence.IlOffsets.Select(static offset => $"IL_{offset:X4}"));
 
     static string FencedCSharp(string body)
     {


### PR DESCRIPTION
Fixes #4309.

## Change

Structural-review Markdown is now reviewer-sized without weakening its portable
evidence:

- carets skip leading whitespace inside a covered extent and align beneath the
  first covered token, while typed UTF-16 spans remain exact;
- the default table keeps `Change`, `Structure`, and `Region`, adding
  `Fidelity` only when populated;
- unsupported and ambiguous correspondence is disclosed as `Partial` directly
  below the target, before either full body;
- correspondence gaps are grouped by side and reason with counts and at most
  five node examples; exhaustive unmatched nodes, spans, and IL provenance
  remain in JSON.

The raise discipline and PR template now require authors to treat matched rows
as incidental when the claimed changed structure exists only in correspondence
gaps.

## Real artifact

Replaying PR #4301's exact saved annotated-source documents reduced the
structural review from 65,153 to 20,433 bytes. Its 196 unsupported or ambiguous
nodes now render as four grouped gap rows, while its seven incidental assignment
rows remain visible beneath an explicit `Partial` warning. Deeply indented
assignment carets align with their source tokens rather than column zero.

## Demo

Excerpt from the generated #4301 replay; unchanged full-body context is omitted
here but remains in the artifact:

```text
Target: ILInspector.Decompiler.Pipeline.LambdaRaisingPass.RaiseLocalDisplayClasses (0x060009A9)

Structural review status: Partial - 196 unsupported or ambiguous nodes were
excluded. Matched rows do not establish changes represented only by the gaps
below.
```

```csharp
                            foreach (LoadLocal load in S_0.Where<LoadLocal>(S_1))
                            {
                                StoreField store = load.Parent as StoreField;
//                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//   raise: AssignmentStatement body; text changed
```

The default structural table drops absolute spans and an empty fidelity column:

| Change | Structure | Region |
| --- | --- | --- |
| Changed | AssignmentStatement | Body |
| Changed | AssignmentStatement | Body |
| Changed | AssignmentStatement | Body |
| Changed | AssignmentStatement | Body |
| Changed | AssignmentStatement | Body |
| Changed | AssignmentStatement | Body |
| Changed | AssignmentStatement | Body |

The 196 exhaustive gap rows become four bounded summaries:

| Side | Reason | Count | Example nodes |
| --- | --- | ---: | --- |
| Before | Unsupported | 12 | 8, 14, 20, 28, 34 (+7 more) |
| Before | Ambiguous | 79 | 0, 7, 13, 18, 21 (+74 more) |
| After | Unsupported | 14 | 8, 14, 20, 28, 34 (+9 more) |
| After | Ambiguous | 91 | 0, 7, 13, 18, 21 (+86 more) |

PR #4154 remains the second scale fixture tracked by #4328; this change keeps
full method bodies while removing coordinate columns and exhaustive gap
provenance from the default reviewer projection.

## Compatibility

`CSharpStructuralDiffDocument`, correspondence issuance, exact spans, rows,
provenance, strict JSON replay, and JSON output are unchanged. This is a
display-only caret adjustment and a bounded Markdown projection.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.CSharpStructuralComparisonTests -class ILInspector.Decompiler.Tests.AuthoredCorpusHarnessProcessTests`
- `npx markdownlint-cli tools/DecompilerHarness/README.md docs/design/implementation-diff.md docs/decompiler-raise-discipline.md docs/templates/decompiler-pr.md`
- `git diff --check`
