### PR TITLE
Avoid package archive downloads for dependency-only inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ context for copied DLLs. A future `--deps` source can represent runtime
 | `cache` | Inspect or clear dotnet-inspect caches. |
 | `skill` | Print the base LLM skill; routes to focused skills (`skill list`, `skill source`, `skill performance`). |
 
+Remote dependency trees requested with `depends --package` or the legacy
+`package --dependencies` option resolve from nuspec manifests without
+downloading package archives. Local `.nupkg` inputs, wildcard selectors, and
+.NET tool redirects retain archive acquisition.
+
 Single-type `type X` output is tree-shaped by default. Use `-v:n` or `-v:d`
 to grow that tree to overload leaves; use `--markdown -v:q` when you want the
 compact Markdown section view instead.

--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -2705,14 +2705,20 @@ public static class PackageExtractor
     public static async Task<List<PackageVersionInfo>?> GetVersionListingsAsync(
         HttpClient client, string packageName, bool includePrerelease, bool includeUnlisted,
         int? limit, Action<string>? log,
-        NuGetSourceOptions? sourceOptions = null)
+        NuGetSourceOptions? sourceOptions = null,
+        bool useVersionCache = true)
     {
         string normalizedName = packageName.ToLowerInvariant();
         var sources = NuGetSourceResolver.ResolveSourcesForPackage(
             sourceOptions,
             packageName);
 
-        var allListings = await GetAllVersionListingsWithCacheAsync(client, normalizedName, sources, log).ConfigureAwait(false);
+        var allListings = await GetAllVersionListingsWithCacheAsync(
+            client,
+            normalizedName,
+            sources,
+            log,
+            useVersionCache).ConfigureAwait(false);
         if (allListings == null)
             return null;
 
@@ -3010,9 +3016,15 @@ public static class PackageExtractor
         HttpClient client,
         string normalizedName,
         List<NuGetSource> sources,
-        Action<string>? log)
+        Action<string>? log,
+        bool useVersionCache)
     {
-        var perSource = await FetchListingsPerSourceAsync(client, normalizedName, sources, log).ConfigureAwait(false);
+        var perSource = await FetchListingsPerSourceAsync(
+            client,
+            normalizedName,
+            sources,
+            log,
+            useVersionCache).ConfigureAwait(false);
         if (perSource == null)
             return null;
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14414,11 +14414,11 @@ public partial class CommandExecutionTests
         var (token, callOffset) = FindIlCoordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.AllSignals),
-            0x6F);
+            ILOpCode.Callvirt);
         var (returnToken, returnCallOffset) = FindIlCoordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.UnsafeAs),
-            0x28);
+            ILOpCode.Call);
         var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
         await File.WriteAllTextAsync(path,
             $$"""
@@ -14456,15 +14456,15 @@ public partial class CommandExecutionTests
         var (allSignalsToken, virtualCallOffset) = FindIlCoordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.AllSignals),
-            0x6F);
+            ILOpCode.Callvirt);
         var (_, allocationOffset) = FindIlCoordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.AllSignals),
-            0x8D);
+            ILOpCode.Newarr);
         var (unsafeToken, unsafeCallOffset) = FindIlCoordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.UnsafeAs),
-            0x28);
+            ILOpCode.Call);
 
         var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
         await File.WriteAllLinesAsync(
@@ -14507,7 +14507,7 @@ public partial class CommandExecutionTests
         var (token, callOffset) = FindIlCoordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.AllSignals),
-            0x6F);
+            ILOpCode.Callvirt);
         var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
         await File.WriteAllTextAsync(path,
             $$"""
@@ -14536,7 +14536,7 @@ public partial class CommandExecutionTests
     private static (int Token, int Offset) FindIlCoordinate(
         Type type,
         string methodName,
-        byte opcode)
+        ILOpCode opcode)
     {
         // This suite inspects its own assembly, whose MethodDef ordering changes
         // whenever tests are added.
@@ -14547,10 +14547,13 @@ public partial class CommandExecutionTests
                 | BindingFlags.Static
                 | BindingFlags.DeclaredOnly)!;
         byte[] il = method.GetMethodBody()!.GetILAsByteArray()!;
-        int offset = Array.IndexOf(il, opcode);
+        int offset = InstructionDecoder.Decode(il)
+            .FirstOrDefault(instruction => instruction.OpCode == opcode)
+            ?.Offset
+            ?? -1;
         Assert.True(
             offset >= 0,
-            $"opcode 0x{opcode:X2} not found in {methodName}");
+            $"opcode {opcode} not found in {methodName}");
         return (method.MetadataToken, offset);
     }
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14411,12 +14411,20 @@ public partial class CommandExecutionTests
     [Fact]
     public async Task LibraryCommand_IlOffsetsFile_RendersCoordinateSummary()
     {
+        var (token, callOffset) = FindIlCoordinate(
+            typeof(SemanticFactsFixture),
+            nameof(SemanticFactsFixture.AllSignals),
+            0x6F);
+        var (returnToken, returnCallOffset) = FindIlCoordinate(
+            typeof(SemanticFactsFixture),
+            nameof(SemanticFactsFixture.UnsafeAs),
+            0x28);
         var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
         await File.WriteAllTextAsync(path,
-            """
+            $$"""
             # label coordinate
-            profiler-sample 0x06000001+0x1
-            return-address 0x06000001+0x6
+            profiler-sample 0x{{token:X8}}+0x{{callOffset:X}}
+            return-address 0x{{returnToken:X8}}+0x{{returnCallOffset + 5:X}}
             """,
             TestContext.Current.CancellationToken);
         try
@@ -14445,26 +14453,15 @@ public partial class CommandExecutionTests
     [Fact]
     public async Task LibraryCommand_IlOffsetsFile_PrefersExactOperationIdentity()
     {
-        static (int Token, int Offset) Coordinate(Type type, string methodName, byte opcode)
-        {
-            var method = type.GetMethod(
-                methodName,
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)!;
-            var il = method.GetMethodBody()!.GetILAsByteArray()!;
-            var offset = Array.IndexOf(il, opcode);
-            Assert.True(offset >= 0, $"opcode 0x{opcode:X2} not found in {methodName}");
-            return (method.MetadataToken, offset);
-        }
-
-        var (allSignalsToken, virtualCallOffset) = Coordinate(
+        var (allSignalsToken, virtualCallOffset) = FindIlCoordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.AllSignals),
             0x6F);
-        var (_, allocationOffset) = Coordinate(
+        var (_, allocationOffset) = FindIlCoordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.AllSignals),
             0x8D);
-        var (unsafeToken, unsafeCallOffset) = Coordinate(
+        var (unsafeToken, unsafeCallOffset) = FindIlCoordinate(
             typeof(SemanticFactsFixture),
             nameof(SemanticFactsFixture.UnsafeAs),
             0x28);
@@ -14507,11 +14504,15 @@ public partial class CommandExecutionTests
     [Fact]
     public async Task LibraryCommand_IlOffsetsFile_RejectsBadCoordinateLine()
     {
+        var (token, callOffset) = FindIlCoordinate(
+            typeof(SemanticFactsFixture),
+            nameof(SemanticFactsFixture.AllSignals),
+            0x6F);
         var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
         await File.WriteAllTextAsync(path,
-            """
+            $$"""
             bad debugger frame
-            good 0x06000001+0x1
+            good 0x{{token:X8}}+0x{{callOffset:X}}
             """,
             TestContext.Current.CancellationToken);
         try
@@ -14530,6 +14531,27 @@ public partial class CommandExecutionTests
         {
             File.Delete(path);
         }
+    }
+
+    private static (int Token, int Offset) FindIlCoordinate(
+        Type type,
+        string methodName,
+        byte opcode)
+    {
+        // This suite inspects its own assembly, whose MethodDef ordering changes
+        // whenever tests are added.
+        MethodInfo method = type.GetMethod(
+            methodName,
+            BindingFlags.Public
+                | BindingFlags.NonPublic
+                | BindingFlags.Static
+                | BindingFlags.DeclaredOnly)!;
+        byte[] il = method.GetMethodBody()!.GetILAsByteArray()!;
+        int offset = Array.IndexOf(il, opcode);
+        Assert.True(
+            offset >= 0,
+            $"opcode 0x{opcode:X2} not found in {methodName}");
+        return (method.MetadataToken, offset);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
+++ b/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
@@ -132,7 +132,7 @@ public class DependencyGraphServiceTests : IDisposable
                     <?xml version="1.0"?>
                     <package>
                       <metadata>
-                        <id>Depends.Local</id>
+                        <id>Depends.Manifest</id>
                         <version>1.0.0</version>
                       </metadata>
                     </package>
@@ -150,7 +150,12 @@ public class DependencyGraphServiceTests : IDisposable
                     sourceOptions: null,
                     logger);
 
-            Assert.IsType<PackageDependencyGraphResult.Empty>(result);
+            var empty =
+                Assert.IsType<PackageDependencyGraphResult.Empty>(result);
+            Assert.Equal("Depends.Local", empty.PackageName);
+            Assert.Equal(
+                "Depends.Manifest",
+                empty.ManifestPackageName);
         }
         finally
         {
@@ -387,6 +392,119 @@ public class DependencyGraphServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task PackageDependencies_PreviewCacheRetainsTimeoutDiagnostic()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Package.Dependencies.Preview.{suffix}";
+        const string PreviewVersion = "2.0.0-preview.1";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        SeedCachedPackage(packageId, PreviewVersion, serviceIndex);
+        using var httpClient = new HttpClient(
+            new DelayedNotFoundHandler());
+        var logger = new VerboseLogger(enabled: false);
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                packageId,
+                requestedTfm: null,
+                new NuGetSourceOptions { Sources = [serviceIndex] },
+                logger,
+                includePrerelease: true);
+
+        var error =
+            Assert.IsType<PackageDependencyGraphResult.Error>(result);
+        Assert.Contains("lookup timed out", error.Message);
+        Assert.Contains(
+            $"Locally cached versions: {PreviewVersion}",
+            error.Message);
+    }
+
+    [Fact]
+    public async Task PackageDependencies_FeedFailureRetainsSourceDiagnostic()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Package.Dependencies.Auth.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        using var httpClient = new HttpClient(
+            new FixedStatusHandler(HttpStatusCode.Unauthorized));
+
+        var rendered = await ConsoleCapture.RunAsync(
+            () => PackageCommand.ExecuteAsync(
+                new InspectionOptions
+                {
+                    PackageArgs = [$"{packageId}@1.0.0"],
+                    ShowDependencies = true,
+                    SourceOptions = new NuGetSourceOptions
+                    {
+                        Sources = [serviceIndex],
+                    },
+                },
+                new CommandContext(
+                    verbose: false,
+                    httpClient)));
+
+        Assert.Equal(1, rendered.ExitCode);
+        Assert.Contains(
+            "could not be resolved because a source requires credentials",
+            rendered.Error);
+        Assert.Contains(serviceIndex, rendered.Error);
+        Assert.DoesNotContain(
+            "Nuspec for package",
+            rendered.Error);
+    }
+
+    [Fact]
+    public async Task PackageDependencies_MissingVersionRetainsVersionsHint()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Package.Dependencies.Missing.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        var handler = new ManifestOnlyHandler(
+            serviceIndex,
+            $"https://content.example.test/{suffix}/flat/",
+            $"https://other.example.test/{suffix}/v3/index.json",
+            $"https://other-content.example.test/{suffix}/flat/",
+            packageId);
+        using var httpClient = new HttpClient(handler);
+
+        var rendered = await ConsoleCapture.RunAsync(
+            () => PackageCommand.ExecuteAsync(
+                new InspectionOptions
+                {
+                    PackageArgs = [$"{packageId}@9.9.9"],
+                    ShowDependencies = true,
+                    SourceOptions = new NuGetSourceOptions
+                    {
+                        Sources = [serviceIndex],
+                    },
+                },
+                new CommandContext(
+                    verbose: false,
+                    httpClient)));
+
+        Assert.Equal(1, rendered.ExitCode);
+        Assert.Contains(
+            "Version '9.9.9' of package",
+            rendered.Error);
+        Assert.Contains(
+            packageId,
+            rendered.Error,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "Use --versions to see available versions.",
+            rendered.Error);
+        Assert.DoesNotContain(
+            handler.Requests,
+            uri => uri.AbsolutePath.EndsWith(
+                ".nupkg",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task BuildPackageDependencyTreeAsync_ReporterDoesNotReactivateDisabledAlias()
     {
         string suffix = Guid.NewGuid().ToString("N");
@@ -560,6 +678,35 @@ public class DependencyGraphServiceTests : IDisposable
                 cancellationToken);
             throw new InvalidOperationException("Unreachable.");
         }
+    }
+
+    private sealed class DelayedNotFoundHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(
+                TimeSpan.FromMilliseconds(1500),
+                cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = request,
+            };
+        }
+    }
+
+    private sealed class FixedStatusHandler(HttpStatusCode status)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(
+                new HttpResponseMessage(status)
+                {
+                    RequestMessage = request,
+                });
     }
 
     private sealed class ManifestOnlyHandler(

--- a/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
+++ b/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
@@ -556,6 +556,52 @@ public class DependencyGraphServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task PackageDependencies_ExactVersionDiagnosisBypassesStaleListing()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Package.Dependencies.Stale.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        string flatContainer =
+            $"https://content.example.test/{suffix}/flat/";
+        var handler = new ChangingVersionHandler(
+            serviceIndex,
+            flatContainer,
+            packageId,
+            firstVersion: "1.0.0",
+            subsequentVersion: "2.0.0");
+        using var httpClient = new HttpClient(handler);
+        var sourceOptions =
+            new NuGetSourceOptions { Sources = [serviceIndex] };
+
+        List<PackageVersionInfo>? seeded =
+            await PackageExtractor.GetVersionListingsAsync(
+                httpClient,
+                packageId,
+                includePrerelease: true,
+                includeUnlisted: true,
+                limit: null,
+                log: null,
+                sourceOptions: sourceOptions);
+        Assert.Equal("1.0.0", Assert.Single(seeded!).Version);
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                $"{packageId}@2.0.0",
+                requestedTfm: null,
+                sourceOptions,
+                new VerboseLogger(enabled: false));
+
+        var error =
+            Assert.IsType<PackageDependencyGraphResult.Error>(result);
+        Assert.Contains(
+            $"Nuspec for package '{packageId}' version '2.0.0' could not be resolved.",
+            error.Message);
+        Assert.Equal(2, handler.VersionIndexRequests);
+    }
+
+    [Fact]
     public async Task PackageDependencies_MissingVersionRetainsVersionsHint()
     {
         string suffix = Guid.NewGuid().ToString("N");
@@ -843,7 +889,9 @@ public class DependencyGraphServiceTests : IDisposable
     private sealed class ChangingVersionHandler(
         string serviceIndex,
         string flatContainer,
-        string packageId) : HttpMessageHandler
+        string packageId,
+        string firstVersion = "2.0.0",
+        string subsequentVersion = "1.0.0") : HttpMessageHandler
     {
         public int VersionIndexRequests { get; private set; }
 
@@ -874,8 +922,8 @@ public class DependencyGraphServiceTests : IDisposable
             {
                 VersionIndexRequests++;
                 string version = VersionIndexRequests == 1
-                    ? "2.0.0"
-                    : "1.0.0";
+                    ? firstVersion
+                    : subsequentVersion;
                 return Task.FromResult(Response(
                     $$"""{"versions":["{{version}}"]}"""));
             }

--- a/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
+++ b/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
@@ -1,6 +1,8 @@
 using System.IO.Compression;
 using System.Net;
+using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
+using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
@@ -281,6 +283,110 @@ public class DependencyGraphServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task PackageDependencies_AcquiresOnlyPrereleaseRootNuspec()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Package.Dependencies.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        string flatContainer =
+            $"https://content.example.test/{suffix}/flat/";
+        const string PreviewVersion = "2.0.0-preview.1";
+        var handler = new ManifestOnlyHandler(
+            serviceIndex,
+            flatContainer,
+            $"https://other.example.test/{suffix}/v3/index.json",
+            $"https://other-content.example.test/{suffix}/flat/",
+            packageId,
+            reportingVersions: ["1.0.0", PreviewVersion],
+            manifestVersion: PreviewVersion);
+        using var httpClient = new HttpClient(handler);
+
+        var rendered = await ConsoleCapture.RunAsync(
+            () => PackageCommand.ExecuteAsync(
+                new InspectionOptions
+                {
+                    PackageArgs = [packageId],
+                    ShowDependencies = true,
+                    IncludePrerelease = true,
+                    SourceOptions = new NuGetSourceOptions
+                    {
+                        Sources = [serviceIndex],
+                    },
+                },
+                new CommandContext(
+                    verbose: false,
+                    httpClient)));
+
+        Assert.Equal(0, rendered.ExitCode);
+        Assert.Contains(
+            "Tip: use 'depends --package' for dependency trees.",
+            rendered.Error);
+        Assert.Contains(
+            "No dependencies declared in package.",
+            rendered.Error);
+        Assert.Contains(
+            handler.Requests,
+            uri => uri.AbsolutePath.EndsWith(
+                $"/{PreviewVersion}/{packageId.ToLowerInvariant()}.nuspec",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            handler.Requests,
+            uri => uri.AbsolutePath.EndsWith(
+                ".nupkg",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task PackageDependencies_RequestedTfmRequiresExactRootGroup()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Package.Dependencies.Tfm.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        var handler = new ManifestOnlyHandler(
+            serviceIndex,
+            $"https://content.example.test/{suffix}/flat/",
+            $"https://other.example.test/{suffix}/v3/index.json",
+            $"https://other-content.example.test/{suffix}/flat/",
+            packageId,
+            dependenciesXml:
+                """
+                <dependencies>
+                  <group targetFramework="net8.0" />
+                </dependencies>
+                """);
+        using var httpClient = new HttpClient(handler);
+
+        var rendered = await ConsoleCapture.RunAsync(
+            () => PackageCommand.ExecuteAsync(
+                new InspectionOptions
+                {
+                    PackageArgs = [$"{packageId}@1.0.0"],
+                    ShowDependencies = true,
+                    Tfm = "net9.0",
+                    SourceOptions = new NuGetSourceOptions
+                    {
+                        Sources = [serviceIndex],
+                    },
+                },
+                new CommandContext(
+                    verbose: false,
+                    httpClient)));
+
+        Assert.Equal(1, rendered.ExitCode);
+        Assert.Contains(
+            "No dependencies found for TFM 'net9.0'.",
+            rendered.Error);
+        Assert.Contains("Available TFMs: net8.0", rendered.Error);
+        Assert.DoesNotContain(
+            handler.Requests,
+            uri => uri.AbsolutePath.EndsWith(
+                ".nupkg",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task BuildPackageDependencyTreeAsync_ReporterDoesNotReactivateDisabledAlias()
     {
         string suffix = Guid.NewGuid().ToString("N");
@@ -462,7 +568,10 @@ public class DependencyGraphServiceTests : IDisposable
         string otherServiceIndex,
         string otherFlatContainer,
         string packageId,
-        bool isToolPackage = false) : HttpMessageHandler
+        bool isToolPackage = false,
+        IReadOnlyList<string>? reportingVersions = null,
+        string manifestVersion = "1.0.0",
+        string dependenciesXml = "") : HttpMessageHandler
     {
         public List<Uri> Requests { get; } = [];
 
@@ -494,7 +603,12 @@ public class DependencyGraphServiceTests : IDisposable
                 StringComparison.Ordinal))
             {
                 return Task.FromResult(Response(
-                    """{"versions":["1.0.0"]}"""));
+                    System.Text.Json.JsonSerializer.Serialize(
+                        new
+                        {
+                            versions =
+                                reportingVersions ?? ["1.0.0"],
+                        })));
             }
             if (uri.AbsoluteUri.Equals(
                 $"{otherFlatContainer}{normalizedPackageId}/index.json",
@@ -505,7 +619,7 @@ public class DependencyGraphServiceTests : IDisposable
             }
 
             if (uri.AbsolutePath.EndsWith(
-                $"/1.0.0/{normalizedPackageId}.nuspec",
+                $"/{manifestVersion}/{normalizedPackageId}.nuspec",
                 StringComparison.Ordinal))
             {
                 return Task.FromResult(Response(
@@ -515,8 +629,9 @@ public class DependencyGraphServiceTests : IDisposable
                     <package>
                       <metadata>
                         <id>{{packageId}}</id>
-                        <version>1.0.0</version>
+                        <version>{{manifestVersion}}</version>
                         {{(isToolPackage ? "<packageTypes><packageType name=\"DotnetTool\" /></packageTypes>" : "")}}
+                        {{dependenciesXml}}
                       </metadata>
                     </package>
                     """));

--- a/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
+++ b/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
@@ -457,6 +457,105 @@ public class DependencyGraphServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task PackageDependencies_FloatingFeedFailureRetainsSourceDiagnostic()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Package.Dependencies.Floating.Auth.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        using var httpClient = new HttpClient(
+            new FixedStatusHandler(HttpStatusCode.Unauthorized));
+
+        var rendered = await ConsoleCapture.RunAsync(
+            () => PackageCommand.ExecuteAsync(
+                new InspectionOptions
+                {
+                    PackageArgs = [packageId],
+                    ShowDependencies = true,
+                    SourceOptions = new NuGetSourceOptions
+                    {
+                        Sources = [serviceIndex],
+                    },
+                },
+                new CommandContext(
+                    verbose: false,
+                    httpClient)));
+
+        Assert.Equal(1, rendered.ExitCode);
+        Assert.Contains(
+            "could not be resolved because a source requires credentials",
+            rendered.Error);
+        Assert.Contains(serviceIndex, rendered.Error);
+    }
+
+    [Fact]
+    public async Task PackageDependencies_FloatingResolutionProvesVersionExists()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Package.Dependencies.Floating.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        string flatContainer =
+            $"https://content.example.test/{suffix}/flat/";
+        var handler = new ChangingVersionHandler(
+            serviceIndex,
+            flatContainer,
+            packageId);
+        using var httpClient = new HttpClient(handler);
+        var logger = new VerboseLogger(enabled: false);
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                $"{packageId}@latest",
+                requestedTfm: null,
+                new NuGetSourceOptions { Sources = [serviceIndex] },
+                logger);
+
+        var error =
+            Assert.IsType<PackageDependencyGraphResult.Error>(result);
+        Assert.Contains(
+            $"Nuspec for package '{packageId}' version '2.0.0' could not be resolved.",
+            error.Message);
+        Assert.DoesNotContain("Version '2.0.0'", error.Message);
+        Assert.Equal(1, handler.VersionIndexRequests);
+    }
+
+    [Fact]
+    public async Task PackageDependencies_UnlistedExactVersionIsNotReportedMissing()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Package.Dependencies.Unlisted.{suffix}";
+        const string Version = "2.0.0";
+        using var httpClient = new HttpClient(
+            new UnlistedMissingManifestHandler(packageId));
+        var logger = new VerboseLogger(enabled: false);
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                $"{packageId}@{Version}",
+                requestedTfm: null,
+                new NuGetSourceOptions
+                {
+                    Sources =
+                    [
+                        "https://api.nuget.org/v3/index.json",
+                    ],
+                },
+                logger);
+
+        var error =
+            Assert.IsType<PackageDependencyGraphResult.Error>(result);
+        Assert.Contains(
+            $"Nuspec for package '{packageId}' version '{Version}' could not be resolved.",
+            error.Message);
+        Assert.DoesNotContain(
+            $"Version '{Version}' of package",
+            error.Message);
+    }
+
+    [Fact]
     public async Task PackageDependencies_MissingVersionRetainsVersionsHint()
     {
         string suffix = Guid.NewGuid().ToString("N");
@@ -633,6 +732,38 @@ public class DependencyGraphServiceTests : IDisposable
                 StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public async Task BuildPackageDependencyTreeAsync_ToolRedirectPreservesRequestedIdentity()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Depends.Tool.Wrapper.{suffix}";
+        string targetPackageId = $"Depends.Tool.Target.{suffix}";
+        string serviceIndex =
+            $"https://feed.example.test/{suffix}/v3/index.json";
+        string flatContainer =
+            $"https://content.example.test/{suffix}/flat/";
+        var handler = new ToolRedirectHandler(
+            serviceIndex,
+            flatContainer,
+            packageId,
+            targetPackageId);
+        using var httpClient = new HttpClient(handler);
+        var logger = new VerboseLogger(enabled: false);
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                $"{packageId}@1.0.0",
+                requestedTfm: null,
+                new NuGetSourceOptions { Sources = [serviceIndex] },
+                logger);
+
+        var empty =
+            Assert.IsType<PackageDependencyGraphResult.Empty>(result);
+        Assert.Equal(packageId, empty.PackageName);
+        Assert.Equal(targetPackageId, empty.ManifestPackageName);
+    }
+
     private void SeedCachedPackage(
         string packageId,
         string version,
@@ -707,6 +838,256 @@ public class DependencyGraphServiceTests : IDisposable
                 {
                     RequestMessage = request,
                 });
+    }
+
+    private sealed class ChangingVersionHandler(
+        string serviceIndex,
+        string flatContainer,
+        string packageId) : HttpMessageHandler
+    {
+        public int VersionIndexRequests { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string url = request.RequestUri!.AbsoluteUri;
+            if (url.Equals(serviceIndex, StringComparison.Ordinal))
+            {
+                return Task.FromResult(Response(
+                    $$"""
+                    {
+                      "resources": [
+                        {
+                          "@type": "PackageBaseAddress/3.0.0",
+                          "@id": "{{flatContainer}}"
+                        }
+                      ]
+                    }
+                    """));
+            }
+
+            string normalizedPackageId = packageId.ToLowerInvariant();
+            if (url.Equals(
+                $"{flatContainer}{normalizedPackageId}/index.json",
+                StringComparison.Ordinal))
+            {
+                VersionIndexRequests++;
+                string version = VersionIndexRequests == 1
+                    ? "2.0.0"
+                    : "1.0.0";
+                return Task.FromResult(Response(
+                    $$"""{"versions":["{{version}}"]}"""));
+            }
+
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    RequestMessage = request,
+                });
+        }
+    }
+
+    private sealed class ToolRedirectHandler(
+        string serviceIndex,
+        string flatContainer,
+        string packageId,
+        string targetPackageId) : HttpMessageHandler
+    {
+        private const string Version = "1.0.0";
+        private readonly byte[] _wrapper =
+            CreateToolWrapperArchive(
+                packageId,
+                targetPackageId);
+        private readonly byte[] _target =
+            CreatePackageArchive(targetPackageId);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string url = request.RequestUri!.AbsoluteUri;
+            if (url.Equals(serviceIndex, StringComparison.Ordinal))
+            {
+                return Task.FromResult(Response(
+                    $$"""
+                    {
+                      "resources": [
+                        {
+                          "@type": "PackageBaseAddress/3.0.0",
+                          "@id": "{{flatContainer}}"
+                        }
+                      ]
+                    }
+                    """));
+            }
+
+            string normalizedPackageId = packageId.ToLowerInvariant();
+            string normalizedTargetPackageId =
+                targetPackageId.ToLowerInvariant();
+            if (url.Equals(
+                $"{flatContainer}{normalizedPackageId}/{Version}/{normalizedPackageId}.nuspec",
+                StringComparison.Ordinal))
+            {
+                return Task.FromResult(Response(
+                    $$"""
+                    <package>
+                      <metadata>
+                        <id>{{packageId}}</id>
+                        <version>{{Version}}</version>
+                        <packageTypes>
+                          <packageType name="DotnetTool" />
+                        </packageTypes>
+                      </metadata>
+                    </package>
+                    """));
+            }
+            if (url.Equals(
+                $"{flatContainer}{normalizedPackageId}/{Version}/{normalizedPackageId}.{Version}.nupkg",
+                StringComparison.Ordinal))
+            {
+                return Task.FromResult(Response(_wrapper));
+            }
+            if (url.Equals(
+                $"{flatContainer}{normalizedTargetPackageId}/{Version}/{normalizedTargetPackageId}.{Version}.nupkg",
+                StringComparison.Ordinal))
+            {
+                return Task.FromResult(Response(_target));
+            }
+
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    RequestMessage = request,
+                });
+        }
+
+        private static byte[] CreateToolWrapperArchive(
+            string wrapperPackageId,
+            string targetPackageId)
+        {
+            using var buffer = new MemoryStream();
+            using (var archive = new ZipArchive(
+                buffer,
+                ZipArchiveMode.Create,
+                leaveOpen: true))
+            {
+                WriteEntry(
+                    archive,
+                    $"{wrapperPackageId}.nuspec",
+                    $$"""
+                    <package>
+                      <metadata>
+                        <id>{{wrapperPackageId}}</id>
+                        <version>{{Version}}</version>
+                      </metadata>
+                    </package>
+                    """);
+                WriteEntry(
+                    archive,
+                    "tools/net10.0/any/DotnetToolSettings.xml",
+                    $$"""
+                    <DotNetCliTool Version="2">
+                      <Commands>
+                        <Command Name="{{wrapperPackageId}}" />
+                      </Commands>
+                      <RuntimeIdentifierPackages>
+                        <RuntimeIdentifierPackage RuntimeIdentifier="any" Id="{{targetPackageId}}" />
+                      </RuntimeIdentifierPackages>
+                    </DotNetCliTool>
+                    """);
+            }
+
+            return buffer.ToArray();
+        }
+
+        private static byte[] CreatePackageArchive(
+            string targetPackageId)
+        {
+            using var buffer = new MemoryStream();
+            using (var archive = new ZipArchive(
+                buffer,
+                ZipArchiveMode.Create,
+                leaveOpen: true))
+            {
+                WriteEntry(
+                    archive,
+                    $"{targetPackageId}.nuspec",
+                    $$"""
+                    <package>
+                      <metadata>
+                        <id>{{targetPackageId}}</id>
+                        <version>{{Version}}</version>
+                      </metadata>
+                    </package>
+                    """);
+            }
+
+            return buffer.ToArray();
+        }
+
+        private static void WriteEntry(
+            ZipArchive archive,
+            string path,
+            string content)
+        {
+            using Stream stream = archive.CreateEntry(path).Open();
+            using var writer = new StreamWriter(stream);
+            writer.Write(content);
+        }
+    }
+
+    private sealed class UnlistedMissingManifestHandler(
+        string packageId) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string normalizedPackageId = packageId.ToLowerInvariant();
+            string url = request.RequestUri!.AbsoluteUri;
+            if (url.Equals(
+                $"https://api.nuget.org/v3-flatcontainer/{normalizedPackageId}/index.json",
+                StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(Response(
+                    """{"versions":["1.0.0","2.0.0"]}"""));
+            }
+            if (url.Equals(
+                $"https://api.nuget.org/v3/registration5-gz-semver2/{normalizedPackageId}/index.json",
+                StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(Response(
+                    """
+                    {
+                      "items": [
+                        {
+                          "items": [
+                            {
+                              "catalogEntry": {
+                                "version": "1.0.0",
+                                "listed": true
+                              }
+                            },
+                            {
+                              "catalogEntry": {
+                                "version": "2.0.0",
+                                "listed": false
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """));
+            }
+
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    RequestMessage = request,
+                });
+        }
     }
 
     private sealed class ManifestOnlyHandler(
@@ -809,4 +1190,16 @@ public class DependencyGraphServiceTests : IDisposable
                 Content = new StringContent(content),
             };
     }
+
+    private static HttpResponseMessage Response(string content) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content),
+        };
+
+    private static HttpResponseMessage Response(byte[] content) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent(content),
+        };
 }

--- a/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
+++ b/src/dotnet-inspect.Tests/DependencyGraphServiceTests.cs
@@ -194,6 +194,46 @@ public class DependencyGraphServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task BuildPackageDependencyTreeAsync_FloatingTimeoutRetainsFeedFailure()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Depends.Cached.Auth.{suffix}";
+        const string Version = "1.0.0";
+        string unauthorizedSource =
+            $"https://unauthorized.example.test/{suffix}/v3/index.json";
+        string blockingSource =
+            $"https://blocking.example.test/{suffix}/v3/index.json";
+        SeedCachedPackage(packageId, Version, unauthorizedSource);
+        var handler = new CredentialThenBlockingHandler(
+            unauthorizedSource,
+            blockingSource);
+        using var httpClient = new HttpClient(handler);
+        var logger = new VerboseLogger(enabled: false);
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                httpClient,
+                packageId,
+                requestedTfm: null,
+                new NuGetSourceOptions
+                {
+                    Sources =
+                    [
+                        unauthorizedSource,
+                        blockingSource,
+                    ],
+                },
+                logger);
+
+        var error =
+            Assert.IsType<PackageDependencyGraphResult.Error>(result);
+        Assert.Contains(
+            "could not be resolved because a source requires credentials",
+            error.Message);
+        Assert.Contains(unauthorizedSource, error.Message);
+    }
+
+    [Fact]
     public async Task BuildPackageDependencyTreeAsync_MissingLocalPackageReportsError()
     {
         string suffix = Guid.NewGuid().ToString("N");
@@ -854,6 +894,41 @@ public class DependencyGraphServiceTests : IDisposable
                 Timeout.InfiniteTimeSpan,
                 cancellationToken);
             throw new InvalidOperationException("Unreachable.");
+        }
+    }
+
+    private sealed class CredentialThenBlockingHandler(
+        string unauthorizedSource,
+        string blockingSource) : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string url = request.RequestUri!.AbsoluteUri;
+            if (url.Equals(
+                unauthorizedSource,
+                StringComparison.Ordinal))
+            {
+                return new HttpResponseMessage(
+                    HttpStatusCode.Unauthorized)
+                {
+                    RequestMessage = request,
+                };
+            }
+            if (url.Equals(
+                blockingSource,
+                StringComparison.Ordinal))
+            {
+                await Task.Delay(
+                    Timeout.InfiniteTimeSpan,
+                    cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                RequestMessage = request,
+            };
         }
     }
 

--- a/src/dotnet-inspect.Tests/PackageExtractorOfflineTests.cs
+++ b/src/dotnet-inspect.Tests/PackageExtractorOfflineTests.cs
@@ -1,4 +1,6 @@
 using System.IO.Compression;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Output;
 using DotnetInspector.Packages;
 
 namespace DotnetInspector.Tests;
@@ -59,6 +61,30 @@ public sealed class PackageExtractorOfflineTests : IDisposable
         Assert.Contains("not available offline", outcome.ErrorMessage);
         Assert.Contains("no cached package", outcome.ErrorMessage);
         Assert.DoesNotContain("not found", outcome.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PackageDependencyTree_OfflineUncachedVersion_ReportsCacheMiss()
+    {
+        string packageName =
+            $"Definitely.Uncached.Dependencies.{Guid.NewGuid():N}";
+
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                Core.HttpClientFactory.Shared,
+                $"{packageName}@1.0.0",
+                requestedTfm: null,
+                sourceOptions: null,
+                new VerboseLogger(enabled: false));
+
+        var error =
+            Assert.IsType<PackageDependencyGraphResult.Error>(result);
+        Assert.Contains("not available offline", error.Message);
+        Assert.Contains("no cached package", error.Message);
+        Assert.DoesNotContain(
+            "not found",
+            error.Message,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -4556,9 +4556,13 @@ public class PackageCommand
             }
 
             var packageName =
-                new InertString(TextPolicy.Field, empty.PackageName);
+                new InertString(
+                    TextPolicy.Field,
+                    empty.ManifestPackageName);
             var version =
-                new InertString(TextPolicy.Field, empty.Version);
+                new InertString(
+                    TextPolicy.Field,
+                    empty.ManifestVersion);
             var description =
                 new InertString(TextPolicy.Field, empty.Message);
             var emptyView = new EmptyDepsView
@@ -4577,9 +4581,13 @@ public class PackageCommand
 
         var graph = (PackageDependencyGraphResult.Graph)result;
         var packageText =
-            new InertString(TextPolicy.Field, graph.PackageName);
+            new InertString(
+                TextPolicy.Field,
+                graph.ManifestPackageName);
         var versionText =
-            new InertString(TextPolicy.Field, graph.Version);
+            new InertString(
+                TextPolicy.Field,
+                graph.ManifestVersion);
         var view = new PackageDependenciesView
         {
             Title = InertString.Format(

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -566,6 +566,21 @@ public class PackageCommand
             version.Length > 0 ? $"package {packageName}@{version}" : $"package {packageName}",
             "package inspect");
 
+        if (options.ShowDependencies)
+        {
+            CommandError.WriteLine("Tip: use 'depends --package' for dependency trees.");
+            string packageReference = target.IsLocalFile
+                ? target.OriginalArgument
+                : version.Length > 0
+                    ? $"{packageName}@{version}"
+                    : packageName;
+            return await ShowDependencyTreeAsync(
+                client,
+                packageReference,
+                options,
+                logger);
+        }
+
         string? extractPath = null;
         PackageExtractionResult? resolution = null;
 
@@ -600,7 +615,7 @@ public class PackageCommand
             if (options.ListTfms)
                 return ListPackageTfms(extractPath, options);
 
-            // Parse nuspec (needed for the --dependencies early exit and full inspection)
+            // Parse nuspec for full package inspection.
             var nuspec = Services.NuspecParser.FindAndParse(extractPath);
 
             // Handle file content modes and exit early.
@@ -612,15 +627,6 @@ public class PackageCommand
                 return PrintPackageFileContents(
                     [ReadPackageFileContents(extractPath, packageId, packageVersion, packageReadme, nuspec?.ReadmeFile, options)],
                     options);
-            }
-
-            // Handle --dependencies mode: resolve transitive deps and show tree
-            if (options.ShowDependencies)
-            {
-                CommandError.WriteLine("Tip: use 'depends --package' for dependency trees.");
-                var depResult = new InspectionResult { PackageName = packageName, Version = version };
-                if (nuspec != null) ApplyNuspec(nuspec, depResult);
-                return await ShowDependencyTreeAsync(client, depResult, options, logger);
             }
 
             if (options.AllLibraries)
@@ -4517,64 +4523,75 @@ public class PackageCommand
     }
 
     private static async Task<int> ShowDependencyTreeAsync(
-        HttpClient client, InspectionResult result, InspectionOptions options, VerboseLogger logger)
+        HttpClient client,
+        string packageReference,
+        InspectionOptions options,
+        VerboseLogger logger)
     {
-        var selection = DependencyResolutionService.SelectDependencyGroup(
-            result.DependencyGroups,
-            options.Tfm,
-            allowCompatibleFallbackForRequestedTfm: false);
-        if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoDependencyGroups)
-        {
-            CommandError.WriteLine("No dependencies declared in package.");
-            return 0;
-        }
+        PackageDependencyGraphResult result =
+            await DependencyGraphService.BuildPackageDependencyTreeAsync(
+                client,
+                packageReference,
+                options.Tfm,
+                options.SourceOptions,
+                logger,
+                includePrerelease: options.IncludePrerelease,
+                allowCompatibleFallbackForRequestedTfm: false);
 
-        if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoMatchingTargetFramework)
+        if (result is PackageDependencyGraphResult.Error error)
         {
-            CommandError.Write($"No dependencies found for TFM '{selection.TargetFramework}'.");
-            CommandError.WriteLine("Available TFMs: " + string.Join(", ", selection.AvailableTargetFrameworks));
+            CommandError.Write(
+                error.Message,
+                error.Detail is null ? [] : [error.Detail]);
             return 1;
         }
 
-        var group = selection.Group!;
-        var tfm = selection.TargetFramework ?? group.TargetFramework;
-        var packageText = new PackageInspectionText(result);
-        var tfmText = new InertString(TextPolicy.Field, tfm);
-
-        if (group.Dependencies.Count == 0)
+        if (result is PackageDependencyGraphResult.Empty empty)
         {
+            if (empty.Kind
+                == PackageDependencyGraphResult.EmptyKind.NoDependencyGroups)
+            {
+                CommandError.WriteLine(empty.Message);
+                return 0;
+            }
+
+            var packageName =
+                new InertString(TextPolicy.Field, empty.PackageName);
+            var version =
+                new InertString(TextPolicy.Field, empty.Version);
+            var description =
+                new InertString(TextPolicy.Field, empty.Message);
             var emptyView = new EmptyDepsView
             {
                 Title = InertString.Format(
                     TextPolicy.Field,
-                    $"{packageText.PackageName} ({packageText.Version})").ToString(),
-                Description = InertString.Format(
-                    TextPolicy.Field,
-                    $"No additional dependencies for {tfmText}.").ToString()
+                    $"{packageName} ({version})").ToString(),
+                Description = description.ToString()
             };
-            Console.WriteLine(MarkoutSerializer.Serialize(emptyView, InspectionContext.Default));
+            Console.WriteLine(
+                MarkoutSerializer.Serialize(
+                    emptyView,
+                    InspectionContext.Default));
             return 0;
         }
 
-        // Resolve transitive dependencies
-        var globalSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var depNodes = await DependencyResolutionService.ResolveDependencyTreeAsync(
-            client,
-            group.Dependencies,
-            tfm,
-            globalSeen,
-            logger.Log,
-            options.SourceOptions);
-
+        var graph = (PackageDependencyGraphResult.Graph)result;
+        var packageText =
+            new InertString(TextPolicy.Field, graph.PackageName);
+        var versionText =
+            new InertString(TextPolicy.Field, graph.Version);
         var view = new PackageDependenciesView
         {
             Title = InertString.Format(
                 TextPolicy.Field,
-                $"{packageText.PackageName} {packageText.Version}").ToString(),
-            Dependencies = ToTreeNodes(depNodes)
+                $"{packageText} {versionText}").ToString(),
+            Dependencies = ToTreeNodes(graph.Dependencies)
         };
 
-        MarkoutSerializer.Serialize(view, Console.Out, PackageDependenciesContext.Default);
+        MarkoutSerializer.Serialize(
+            view,
+            Console.Out,
+            PackageDependenciesContext.Default);
         return 0;
     }
 

--- a/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
+++ b/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
@@ -445,6 +445,14 @@ internal static class DependencyGraphService
         bool versionExistenceKnown,
         NuGetSourceOptions sourceOptions)
     {
+        if (Core.HttpClientFactory.IsOffline)
+        {
+            return InertString.Format(
+                TextPolicy.Field,
+                $"Package '{packageName}' version '{version}' is not available offline; no cached package was found.")
+                .ToString();
+        }
+
         if (FeedFailureTelemetry.Current
             is { HasFailures: true } acquisitionFailures)
         {
@@ -471,7 +479,8 @@ internal static class DependencyGraphService
                 includeUnlisted: true,
                 limit: null,
                 log: null,
-                sourceOptions: sourceOptions).ConfigureAwait(false);
+                sourceOptions: sourceOptions,
+                useVersionCache: false).ConfigureAwait(false);
 
         if (FeedFailureTelemetry.Current
             is { HasFailures: true } failures)

--- a/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
+++ b/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
@@ -311,6 +311,14 @@ internal static class DependencyGraphService
             {
                 PackageCoordinateResolution.Invalid invalid =>
                     invalid.Message,
+                PackageCoordinateResolution.Unavailable
+                    when FeedFailureTelemetry.Current
+                        is { HasFailures: true } failures =>
+                    (failures.DescribeFailure(packageName)
+                        ?? InertString.Format(
+                            TextPolicy.Field,
+                            $"Package '{packageName}' could not be fully resolved from every authorized source."))
+                        .ToString(),
                 PackageCoordinateResolution.Unavailable unavailable =>
                     unavailable.Message,
                 _ => $"Package '{packageRef}' could not be resolved.",
@@ -337,6 +345,7 @@ internal static class DependencyGraphService
                     httpClient,
                     packageName,
                     coordinate.Version,
+                    coordinate.WasFloating,
                     reportingSources).ConfigureAwait(false));
         }
 
@@ -394,7 +403,7 @@ internal static class DependencyGraphService
                 extracted.Version
                 ?? "";
             return new PackageNuspecResolution(
-                resolvedPackageName,
+                packageName,
                 resolvedVersion,
                 nuspec?.PackageName
                     ?? resolvedPackageName,
@@ -433,13 +442,33 @@ internal static class DependencyGraphService
         HttpClient httpClient,
         string packageName,
         string version,
+        bool versionExistenceKnown,
         NuGetSourceOptions sourceOptions)
     {
-        List<string>? knownVersions =
-            await PackageExtractor.GetVersionsAsync(
+        if (FeedFailureTelemetry.Current
+            is { HasFailures: true } acquisitionFailures)
+        {
+            return (acquisitionFailures.DescribeFailure(packageName)
+                ?? InertString.Format(
+                    TextPolicy.Field,
+                    $"Package '{packageName}' could not be fully resolved from every authorized source."))
+                .ToString();
+        }
+
+        if (versionExistenceKnown)
+        {
+            return InertString.Format(
+                TextPolicy.Field,
+                $"Nuspec for package '{packageName}' version '{version}' could not be resolved.")
+                .ToString();
+        }
+
+        List<PackageVersionInfo>? knownVersions =
+            await PackageExtractor.GetVersionListingsAsync(
                 httpClient,
                 packageName,
                 includePrerelease: true,
+                includeUnlisted: true,
                 limit: null,
                 log: null,
                 sourceOptions: sourceOptions).ConfigureAwait(false);
@@ -462,9 +491,11 @@ internal static class DependencyGraphService
                 .ToString();
         }
 
-        if (!knownVersions.Contains(
-                version,
-                StringComparer.OrdinalIgnoreCase))
+        if (!knownVersions.Any(candidate =>
+                string.Equals(
+                    candidate.Version,
+                    version,
+                    StringComparison.OrdinalIgnoreCase)))
         {
             return InertString.Format(
                 TextPolicy.Field,

--- a/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
+++ b/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
@@ -1,9 +1,11 @@
 using ILInspector.CSharp;
+using DotnetInspector.Core;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using ILInspector.Metadata;
+using InertText;
 using NuGetFetch;
 using PackageExtractor = DotnetInspector.Packages.PackageExtractor;
 
@@ -146,6 +148,8 @@ internal static class DependencyGraphService
             return new PackageDependencyGraphResult.Empty(
                 resolution.PackageName,
                 resolution.Version,
+                resolution.ManifestPackageName,
+                resolution.ManifestVersion,
                 "No dependencies declared in package.",
                 PackageDependencyGraphResult.EmptyKind.NoDependencyGroups);
         }
@@ -159,6 +163,8 @@ internal static class DependencyGraphService
             return new PackageDependencyGraphResult.Empty(
                 resolution.PackageName,
                 resolution.Version,
+                resolution.ManifestPackageName,
+                resolution.ManifestVersion,
                 "No dependencies declared in package.",
                 PackageDependencyGraphResult.EmptyKind.NoDependencyGroups);
         }
@@ -176,6 +182,8 @@ internal static class DependencyGraphService
             return new PackageDependencyGraphResult.Empty(
                 resolution.PackageName,
                 resolution.Version,
+                resolution.ManifestPackageName,
+                resolution.ManifestVersion,
                 $"No additional dependencies for {tfm}.",
                 PackageDependencyGraphResult.EmptyKind.SelectedGroup);
         }
@@ -192,6 +200,8 @@ internal static class DependencyGraphService
         return new PackageDependencyGraphResult.Graph(
             resolution.PackageName,
             resolution.Version,
+            resolution.ManifestPackageName,
+            resolution.ManifestVersion,
             depNodes);
     }
 
@@ -228,8 +238,12 @@ internal static class DependencyGraphService
                 logger).ConfigureAwait(false);
         }
 
+        using var feedFailureScope = FeedFailureTelemetry.Scope();
         IReadOnlyList<string> cachedVersions = floatingSelector
-            ? GetCachedPackageVersions(packageName, sourceOptions)
+            ? GetCachedPackageVersions(
+                packageName,
+                sourceOptions,
+                includePrerelease)
             : [];
         bool forceLatest = string.Equals(
             version,
@@ -319,8 +333,11 @@ internal static class DependencyGraphService
         {
             return PackageNuspecResolution.Error(
                 packageName,
-                $"Nuspec for package '{packageName}' version "
-                + $"'{coordinate.Version}' could not be resolved.");
+                await DescribeUnavailableNuspecAsync(
+                    httpClient,
+                    packageName,
+                    coordinate.Version,
+                    reportingSources).ConfigureAwait(false));
         }
 
         NuspecData nuspec = NuspecParser.ParseContent(nuspecXml);
@@ -335,6 +352,8 @@ internal static class DependencyGraphService
         }
 
         return new PackageNuspecResolution(
+            packageName,
+            coordinate.Version,
             nuspec.PackageName ?? packageName,
             nuspec.Version ?? coordinate.Version,
             nuspec,
@@ -368,13 +387,19 @@ internal static class DependencyGraphService
         {
             NuspecData? nuspec =
                 NuspecParser.FindAndParse(extracted.ExtractPath);
+            string resolvedPackageName =
+                extracted.PackageName
+                ?? packageName;
+            string resolvedVersion =
+                extracted.Version
+                ?? "";
             return new PackageNuspecResolution(
+                resolvedPackageName,
+                resolvedVersion,
                 nuspec?.PackageName
-                    ?? extracted.PackageName
-                    ?? packageName,
+                    ?? resolvedPackageName,
                 nuspec?.Version
-                    ?? extracted.Version
-                    ?? "",
+                    ?? resolvedVersion,
                 nuspec,
                 ErrorMessage: null);
         }
@@ -386,7 +411,8 @@ internal static class DependencyGraphService
 
     private static IReadOnlyList<string> GetCachedPackageVersions(
         string packageName,
-        NuGetSourceOptions? sourceOptions)
+        NuGetSourceOptions? sourceOptions,
+        bool includePrerelease)
     {
         try
         {
@@ -395,12 +421,61 @@ internal static class DependencyGraphService
                 NuGetSourceResolver.ResolveSourceKeysForPackage(
                     sourceOptions,
                     packageName),
-                includePrerelease: false);
+                includePrerelease);
         }
         catch (PackageSourceMappingException)
         {
             return [];
         }
+    }
+
+    private static async Task<string> DescribeUnavailableNuspecAsync(
+        HttpClient httpClient,
+        string packageName,
+        string version,
+        NuGetSourceOptions sourceOptions)
+    {
+        List<string>? knownVersions =
+            await PackageExtractor.GetVersionsAsync(
+                httpClient,
+                packageName,
+                includePrerelease: true,
+                limit: null,
+                log: null,
+                sourceOptions: sourceOptions).ConfigureAwait(false);
+
+        if (FeedFailureTelemetry.Current
+            is { HasFailures: true } failures)
+        {
+            return (failures.DescribeFailure(packageName)
+                ?? InertString.Format(
+                    TextPolicy.Field,
+                    $"Package '{packageName}' could not be fully resolved from every authorized source."))
+                .ToString();
+        }
+
+        if (knownVersions is not { Count: > 0 })
+        {
+            return InertString.Format(
+                TextPolicy.Field,
+                $"Package '{packageName}' not found.")
+                .ToString();
+        }
+
+        if (!knownVersions.Contains(
+                version,
+                StringComparer.OrdinalIgnoreCase))
+        {
+            return InertString.Format(
+                TextPolicy.Field,
+                $"Version '{version}' of package '{packageName}' not found. Use --versions to see available versions.")
+                .ToString();
+        }
+
+        return InertString.Format(
+            TextPolicy.Field,
+            $"Nuspec for package '{packageName}' version '{version}' could not be resolved.")
+            .ToString();
     }
 
     private static string DescribeCachedVersionFallback(
@@ -449,13 +524,21 @@ internal static class DependencyGraphService
     private sealed record PackageNuspecResolution(
         string PackageName,
         string Version,
+        string ManifestPackageName,
+        string ManifestVersion,
         NuspecData? Nuspec,
         string? ErrorMessage)
     {
         public static PackageNuspecResolution Error(
             string packageName,
             string message) =>
-            new(packageName, "", Nuspec: null, ErrorMessage: message);
+            new(
+                packageName,
+                "",
+                packageName,
+                "",
+                Nuspec: null,
+                ErrorMessage: message);
     }
 }
 
@@ -494,6 +577,8 @@ internal abstract record PackageDependencyGraphResult
     public sealed record Graph(
         string PackageName,
         string Version,
+        string ManifestPackageName,
+        string ManifestVersion,
         List<DependencyNode> Dependencies) : PackageDependencyGraphResult
     {
         public string Title => $"{PackageName} ({Version})";
@@ -502,6 +587,8 @@ internal abstract record PackageDependencyGraphResult
     public sealed record Empty(
         string PackageName,
         string Version,
+        string ManifestPackageName,
+        string ManifestVersion,
         string Message,
         EmptyKind Kind) : PackageDependencyGraphResult;
 

--- a/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
+++ b/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
@@ -278,6 +278,14 @@ internal static class DependencyGraphService
         catch (OperationCanceledException)
             when (latestTimeout?.IsCancellationRequested == true)
         {
+            if (DescribeFeedFailure(packageName)
+                is { } feedFailure)
+            {
+                return PackageNuspecResolution.Error(
+                    packageName,
+                    feedFailure);
+            }
+
             return PackageNuspecResolution.Error(
                 packageName,
                 DescribeCachedVersionFallback(
@@ -307,18 +315,15 @@ internal static class DependencyGraphService
                     offlineMessage);
             }
 
+            string? feedFailure =
+                DescribeFeedFailure(packageName);
             string message = coordinateResolution switch
             {
                 PackageCoordinateResolution.Invalid invalid =>
                     invalid.Message,
                 PackageCoordinateResolution.Unavailable
-                    when FeedFailureTelemetry.Current
-                        is { HasFailures: true } failures =>
-                    (failures.DescribeFailure(packageName)
-                        ?? InertString.Format(
-                            TextPolicy.Field,
-                            $"Package '{packageName}' could not be fully resolved from every authorized source."))
-                        .ToString(),
+                    when feedFailure is not null =>
+                    feedFailure,
                 PackageCoordinateResolution.Unavailable unavailable =>
                     unavailable.Message,
                 _ => $"Package '{packageRef}' could not be resolved.",
@@ -453,14 +458,10 @@ internal static class DependencyGraphService
                 .ToString();
         }
 
-        if (FeedFailureTelemetry.Current
-            is { HasFailures: true } acquisitionFailures)
+        if (DescribeFeedFailure(packageName)
+            is { } acquisitionFailure)
         {
-            return (acquisitionFailures.DescribeFailure(packageName)
-                ?? InertString.Format(
-                    TextPolicy.Field,
-                    $"Package '{packageName}' could not be fully resolved from every authorized source."))
-                .ToString();
+            return acquisitionFailure;
         }
 
         if (versionExistenceKnown)
@@ -482,14 +483,10 @@ internal static class DependencyGraphService
                 sourceOptions: sourceOptions,
                 useVersionCache: false).ConfigureAwait(false);
 
-        if (FeedFailureTelemetry.Current
-            is { HasFailures: true } failures)
+        if (DescribeFeedFailure(packageName)
+            is { } listingFailure)
         {
-            return (failures.DescribeFailure(packageName)
-                ?? InertString.Format(
-                    TextPolicy.Field,
-                    $"Package '{packageName}' could not be fully resolved from every authorized source."))
-                .ToString();
+            return listingFailure;
         }
 
         if (knownVersions is not { Count: > 0 })
@@ -515,6 +512,22 @@ internal static class DependencyGraphService
         return InertString.Format(
             TextPolicy.Field,
             $"Nuspec for package '{packageName}' version '{version}' could not be resolved.")
+            .ToString();
+    }
+
+    private static string? DescribeFeedFailure(
+        string packageName)
+    {
+        if (FeedFailureTelemetry.Current
+            is not { HasFailures: true } failures)
+        {
+            return null;
+        }
+
+        return (failures.DescribeFailure(packageName)
+            ?? InertString.Format(
+                TextPolicy.Field,
+                $"Package '{packageName}' could not be fully resolved from every authorized source."))
             .ToString();
     }
 

--- a/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
+++ b/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
@@ -126,24 +126,42 @@ internal static class DependencyGraphService
         string packageRef,
         string? requestedTfm,
         NuGetSourceOptions? sourceOptions,
-        VerboseLogger logger)
+        VerboseLogger logger,
+        bool includePrerelease = false,
+        bool allowCompatibleFallbackForRequestedTfm = true)
     {
         PackageNuspecResolution resolution =
             await ResolvePackageNuspecAsync(
                 httpClient,
                 packageRef,
                 sourceOptions,
-                logger).ConfigureAwait(false);
+                logger,
+                includePrerelease).ConfigureAwait(false);
         if (resolution.ErrorMessage is { } error)
             return new PackageDependencyGraphResult.Error(error);
 
         NuspecData? nuspec = resolution.Nuspec;
         if (nuspec == null)
-            return new PackageDependencyGraphResult.Empty("No dependencies declared in package.");
+        {
+            return new PackageDependencyGraphResult.Empty(
+                resolution.PackageName,
+                resolution.Version,
+                "No dependencies declared in package.",
+                PackageDependencyGraphResult.EmptyKind.NoDependencyGroups);
+        }
 
-        var selection = DependencyResolutionService.SelectDependencyGroup(nuspec.DependencyGroups, requestedTfm);
+        var selection = DependencyResolutionService.SelectDependencyGroup(
+            nuspec.DependencyGroups,
+            requestedTfm,
+            allowCompatibleFallbackForRequestedTfm);
         if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoDependencyGroups)
-            return new PackageDependencyGraphResult.Empty("No dependencies declared in package.");
+        {
+            return new PackageDependencyGraphResult.Empty(
+                resolution.PackageName,
+                resolution.Version,
+                "No dependencies declared in package.",
+                PackageDependencyGraphResult.EmptyKind.NoDependencyGroups);
+        }
         if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoMatchingTargetFramework)
         {
             return new PackageDependencyGraphResult.Error(
@@ -154,7 +172,13 @@ internal static class DependencyGraphService
         var group = selection.Group!;
         var tfm = selection.TargetFramework ?? group.TargetFramework;
         if (group.Dependencies.Count == 0)
-            return new PackageDependencyGraphResult.Empty($"No additional dependencies for {tfm}.");
+        {
+            return new PackageDependencyGraphResult.Empty(
+                resolution.PackageName,
+                resolution.Version,
+                $"No additional dependencies for {tfm}.",
+                PackageDependencyGraphResult.EmptyKind.SelectedGroup);
+        }
 
         var globalSeen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var depNodes = await DependencyResolutionService.ResolveDependencyTreeAsync(
@@ -166,7 +190,8 @@ internal static class DependencyGraphService
             sourceOptions);
 
         return new PackageDependencyGraphResult.Graph(
-            $"{resolution.PackageName} ({resolution.Version})",
+            resolution.PackageName,
+            resolution.Version,
             depNodes);
     }
 
@@ -174,7 +199,8 @@ internal static class DependencyGraphService
         HttpClient httpClient,
         string packageRef,
         NuGetSourceOptions? sourceOptions,
-        VerboseLogger logger)
+        VerboseLogger logger,
+        bool includePrerelease)
     {
         // Package dependency mode inspects nuspec dependency groups, not assembly sets.
         var (packageName, version) =
@@ -230,6 +256,7 @@ internal static class DependencyGraphService
                         floatingSelector ? null : version),
                     sourceOptions,
                     logger.Log,
+                    includePrerelease,
                     useVersionCache: !forceLatest,
                     cancellationToken: latestTimeout?.Token ?? default)
                     .ConfigureAwait(false);
@@ -308,8 +335,8 @@ internal static class DependencyGraphService
         }
 
         return new PackageNuspecResolution(
-            packageName,
-            coordinate.Version,
+            nuspec.PackageName ?? packageName,
+            nuspec.Version ?? coordinate.Version,
             nuspec,
             ErrorMessage: null);
     }
@@ -339,10 +366,16 @@ internal static class DependencyGraphService
         PackageExtractionResult extracted = outcome.Result!;
         try
         {
+            NuspecData? nuspec =
+                NuspecParser.FindAndParse(extracted.ExtractPath);
             return new PackageNuspecResolution(
-                packageName,
-                extracted.Version ?? "",
-                NuspecParser.FindAndParse(extracted.ExtractPath),
+                nuspec?.PackageName
+                    ?? extracted.PackageName
+                    ?? packageName,
+                nuspec?.Version
+                    ?? extracted.Version
+                    ?? "",
+                nuspec,
                 ErrorMessage: null);
         }
         finally
@@ -452,7 +485,25 @@ internal abstract record LibraryDependencyGraphResult
 
 internal abstract record PackageDependencyGraphResult
 {
-    public sealed record Graph(string Title, List<DependencyNode> Dependencies) : PackageDependencyGraphResult;
-    public sealed record Empty(string Message) : PackageDependencyGraphResult;
+    public enum EmptyKind
+    {
+        NoDependencyGroups,
+        SelectedGroup,
+    }
+
+    public sealed record Graph(
+        string PackageName,
+        string Version,
+        List<DependencyNode> Dependencies) : PackageDependencyGraphResult
+    {
+        public string Title => $"{PackageName} ({Version})";
+    }
+
+    public sealed record Empty(
+        string PackageName,
+        string Version,
+        string Message,
+        EmptyKind Kind) : PackageDependencyGraphResult;
+
     public sealed record Error(string Message, string? Detail = null) : PackageDependencyGraphResult;
 }


### PR DESCRIPTION
## Summary

- route legacy `package --dependencies` through `DependencyGraphService` before package extraction
- preserve prerelease floating resolution, exact-only requested-root TFM selection, manifest package identity, and existing empty/tree rendering
- retain archive acquisition for local `.nupkg` inputs, wildcard selectors, and .NET tool redirects

## Evidence

- `DependencyGraphServiceTests` + `PayloadLensContainmentTests`: 26 passed
- real `Newtonsoft.Json@13.0.3` trace: one root `.nuspec` GET and no `.nupkg` request
- `markdownlint README.md`
- `git diff --check`

The proxy measurements from #4318 ranged from 22.7x to 5,815.6x fewer transferred bytes for nuspecs versus archives; this brings the legacy dependency-only package surface onto that same path.

## Scope

Other `package` inspection modes still acquire package contents. This changes only the explicit `--dependencies` early-exit path and preserves its recommendation to use `depends --package`.

Follow-up to #4318.
Refs #2896