### PR TITLE
Preflight aggregate type-name budgets in legacy readers

### DIFF
--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -404,8 +404,8 @@ and report `NameBudget` rather than malformed or success-shaped output.
 Display string APIs (`GetFullName`, `GetTypeNameFrom*`) keep only the encoded
 cap so a 5,030-character classifier fixture can still be spelled;
 `Resolve*`/`Read` remain on the 4,096-character policy.
-`SeedMaterialized` charges the declaring name's actual UTF-8 byte count, not
-its UTF-16 length. Shared #Strings entries, many individually
+`AppendLeaf` continues the declaring walk's live encoded and character
+ledgers rather than reseeding them from rendered text. Shared #Strings entries, many individually
 small segments, projected WinRT virtual strings, TypeSpec `NameBudget` kind
 preservation, and the display/structured split are gated by
 `SharedOversizeHeapString_IsRejectedBeforeAggregateMaterialization`,

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -414,8 +414,11 @@ preservation, and the display/structured split are gated by
 `StructuredRead_ReportsNameBudgetNotMalformed`,
 `ProjectedVirtualStringLength_IsRecheckedAfterBlobReader`,
 `TypeSpecNameBudget_IsPreservedAsTypedEvidence`,
-`AppendLeaf_PreflightsActualUtf8OfMaterializedDeclaringName`, and
-`DisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`. Tuple-name, nullability, and dynamic
+`TypeSpecNameBudget_SurvivesLaterMalformedArgument`,
+`AppendLeaf_PreflightsActualUtf8OfMaterializedDeclaringName`,
+`DisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`,
+`NestedDisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`, and
+`EmptyLeadingNameSegment_DoesNotCollideWithTopLevelName`. Tuple-name, nullability, and dynamic
 transform arrays charge their encoded blob before allocating arrays, and one
 type generic context is reused across all of that type's members.
 Visibility probes use bounded blob readers rather than copying skipped

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -398,9 +398,9 @@ estimates, and bounded decoding charges each constructed node's complete
 estimated output so repeated wrapping cannot reallocate an uncharged subtree.
 Structured nested type names are read once and enforce their cumulative limit
 before the remaining chain is materialized. Legacy `FormatChain`, `ReadChain`,
-and leaf-append readers preflight UTF-8 storage against that same 4,096-character
-budget, then recheck decoded length, and report `NameBudget` rather than
-malformed or success-shaped output. Shared #Strings entries, many individually
+and leaf-append readers preflight UTF-8 storage against three times that
+4,096-character budget (the UTF-8 worst case), then recheck decoded length,
+and report `NameBudget` rather than malformed or success-shaped output. Shared #Strings entries, many individually
 small segments, and projected virtual strings whose blob length is obtained
 only after SRM materializes them are gated by
 `SharedOversizeHeapString_IsRejectedBeforeAggregateMaterialization`,

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -419,8 +419,10 @@ preservation, and the display/structured split are gated by
 `DisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`,
 `NestedDisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`,
 `TypeSpecDisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`,
-`EmptyLeadingNameSegment_DoesNotCollideWithTopLevelName`, and
-`EmptyNamespaceExactCharacterBudget_AgreesWithCreate`. Tuple-name, nullability, and dynamic
+`EmptyLeadingNameSegment_DoesNotCollideWithTopLevelName`,
+`EmptyNamespaceExactCharacterBudget_AgreesWithCreate`,
+`EmptyNamespaceNestedResolveFullName_AgreesWithCreate`, and
+`NilNameAfterEncodedCap_IsRejectedOnDisplayPath`. Tuple-name, nullability, and dynamic
 transform arrays charge their encoded blob before allocating arrays, and one
 type generic context is reused across all of that type's members.
 Visibility probes use bounded blob readers rather than copying skipped

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -400,14 +400,22 @@ Structured nested type names are read once and enforce their cumulative limit
 before the remaining chain is materialized. Legacy `FormatChain`, `ReadChain`,
 and leaf-append readers preflight UTF-8 storage against three times that
 4,096-character budget (the UTF-8 worst case), then recheck decoded length,
-and report `NameBudget` rather than malformed or success-shaped output. Shared #Strings entries, many individually
-small segments, and projected virtual strings whose blob length is obtained
-only after SRM materializes them are gated by
+and report `NameBudget` rather than malformed or success-shaped output.
+Display string APIs (`GetFullName`, `GetTypeNameFrom*`) keep only the encoded
+cap so a 5,030-character classifier fixture can still be spelled;
+`Resolve*`/`Read` remain on the 4,096-character policy.
+`SeedMaterialized` charges the declaring name's actual UTF-8 byte count, not
+its UTF-16 length. Shared #Strings entries, many individually
+small segments, projected WinRT virtual strings, TypeSpec `NameBudget` kind
+preservation, and the display/structured split are gated by
 `SharedOversizeHeapString_IsRejectedBeforeAggregateMaterialization`,
 `ManySmallSegments_AreRejectedOnAggregateEncodedLength`,
 `LeafAppendOverBudget_IsRejectedBeforeLeafMaterialization`,
-`StructuredRead_ReportsNameBudgetNotMalformed`, and
-`ProjectedVirtualStringLength_IsRecheckedAfterBlobReader`. Tuple-name, nullability, and dynamic
+`StructuredRead_ReportsNameBudgetNotMalformed`,
+`ProjectedVirtualStringLength_IsRecheckedAfterBlobReader`,
+`TypeSpecNameBudget_IsPreservedAsTypedEvidence`,
+`AppendLeaf_PreflightsActualUtf8OfMaterializedDeclaringName`, and
+`DisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`. Tuple-name, nullability, and dynamic
 transform arrays charge their encoded blob before allocating arrays, and one
 type generic context is reused across all of that type's members.
 Visibility probes use bounded blob readers rather than copying skipped

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -417,8 +417,10 @@ preservation, and the display/structured split are gated by
 `TypeSpecNameBudget_SurvivesLaterMalformedArgument`,
 `AppendLeaf_PreflightsActualUtf8OfMaterializedDeclaringName`,
 `DisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`,
-`NestedDisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`, and
-`EmptyLeadingNameSegment_DoesNotCollideWithTopLevelName`. Tuple-name, nullability, and dynamic
+`NestedDisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`,
+`TypeSpecDisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap`,
+`EmptyLeadingNameSegment_DoesNotCollideWithTopLevelName`, and
+`EmptyNamespaceExactCharacterBudget_AgreesWithCreate`. Tuple-name, nullability, and dynamic
 transform arrays charge their encoded blob before allocating arrays, and one
 type generic context is reused across all of that type's members.
 Visibility probes use bounded blob readers rather than copying skipped

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -397,7 +397,17 @@ before the check. Composite type nodes carry non-materializing rendered-length
 estimates, and bounded decoding charges each constructed node's complete
 estimated output so repeated wrapping cannot reallocate an uncharged subtree.
 Structured nested type names are read once and enforce their cumulative limit
-before the remaining chain is materialized. Tuple-name, nullability, and dynamic
+before the remaining chain is materialized. Legacy `FormatChain`, `ReadChain`,
+and leaf-append readers preflight UTF-8 storage against that same 4,096-character
+budget, then recheck decoded length, and report `NameBudget` rather than
+malformed or success-shaped output. Shared #Strings entries, many individually
+small segments, and projected virtual strings whose blob length is obtained
+only after SRM materializes them are gated by
+`SharedOversizeHeapString_IsRejectedBeforeAggregateMaterialization`,
+`ManySmallSegments_AreRejectedOnAggregateEncodedLength`,
+`LeafAppendOverBudget_IsRejectedBeforeLeafMaterialization`,
+`StructuredRead_ReportsNameBudgetNotMalformed`, and
+`ProjectedVirtualStringLength_IsRecheckedAfterBlobReader`. Tuple-name, nullability, and dynamic
 transform arrays charge their encoded blob before allocating arrays, and one
 type generic context is reused across all of that type's members.
 Visibility probes use bounded blob readers rather than copying skipped

--- a/src/ILInspector.Metadata/MetadataTypeDefinitionName.cs
+++ b/src/ILInspector.Metadata/MetadataTypeDefinitionName.cs
@@ -547,8 +547,7 @@ internal static class MetadataTypeDefinitionNameReader
     {
         var segments = ImmutableArray.CreateBuilder<string>(rootToLeaf.Length);
         string? @namespace = null;
-        long encodedBytes = 0;
-        long characters = 0;
+        var budget = new MetadataTypeNameBudget();
 
         for (int i = 0; i < rootToLeaf.Length; i++)
         {
@@ -558,32 +557,27 @@ internal static class MetadataTypeDefinitionNameReader
                 var (namespaceHandle, nameHandle) = TRow.GetName(reader, handle);
                 if (i == 0)
                 {
-                    int encodedNamespaceLength =
-                        reader.GetBlobReader(namespaceHandle).Length;
-                    beforeMaterialize?.Invoke(encodedNamespaceLength);
-                    encodedBytes += encodedNamespaceLength;
-                    if (encodedBytes
-                        > MetadataSafetyPolicy.MaxTypeNameCharacters * 4L)
+                    if (!budget.TryRead(
+                            reader,
+                            namespaceHandle,
+                            delimiterChars: 0,
+                            beforeMaterialize,
+                            out @namespace))
                     {
-                        return NameTooLong(TRow.ToEntity(handle));
+                        return NameTooLong(TRow.ToEntity(handle), i + 1);
                     }
-                    @namespace = reader.GetString(namespaceHandle);
-                    characters = @namespace.Length;
                 }
 
-                int encodedNameLength = reader.GetBlobReader(nameHandle).Length;
-                beforeMaterialize?.Invoke(encodedNameLength);
-                encodedBytes += encodedNameLength + 1L;
-                if (encodedBytes
-                    > MetadataSafetyPolicy.MaxTypeNameCharacters * 4L)
+                if (!budget.TryRead(
+                        reader,
+                        nameHandle,
+                        delimiterChars: 1,
+                        beforeMaterialize,
+                        out string segment))
                 {
-                    return NameTooLong(TRow.ToEntity(handle));
+                    return NameTooLong(TRow.ToEntity(handle), i + 1);
                 }
 
-                string segment = reader.GetString(nameHandle);
-                characters += segment.Length + 1L;
-                if (characters > MetadataSafetyPolicy.MaxTypeNameCharacters)
-                    return NameTooLong(TRow.ToEntity(handle));
                 segments.Add(segment);
             }
             catch (BadImageFormatException ex)
@@ -611,12 +605,17 @@ internal static class MetadataTypeDefinitionNameReader
                 $"Invalid structured metadata type name: {invalid.Kind}."));
     }
 
-    static MetadataTypeDefinitionNameReadResult NameTooLong(EntityHandle subject) =>
+    static MetadataTypeDefinitionNameReadResult NameTooLong(
+        EntityHandle subject,
+        int consumedNodes) =>
         new MetadataTypeDefinitionNameReadResult.Rejected(
-            MetadataTypeNameFailure.Malformed(
-                subject,
-                $"Invalid structured metadata type name: "
-                    + $"{MetadataTypeNameRejectionKind.SegmentsTooLong}."));
+            MetadataTypeNameFailure.From(
+                new RelationshipTraversalRejection(
+                    RelationshipTraversalRejectionKind.NameBudget,
+                    $"The structured type name exceeds "
+                    + $"{MetadataSafetyPolicy.MaxTypeNameCharacters} characters.",
+                    subject,
+                    consumedNodes)));
 
     static MetadataTypeDefinitionNameReadResult RejectedTraversal(
         RelationshipTraversalRejection rejection) =>

--- a/src/ILInspector.Metadata/TypeNodeProvider.cs
+++ b/src/ILInspector.Metadata/TypeNodeProvider.cs
@@ -34,25 +34,49 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
     }
 
     public TypeNode GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
-    {
-        string name = TypeResolver.GetTypeNameFromDefinition(
-            reader,
-            handle,
-            _beforeMaterialize);
-        _beforeRetain?.Invoke(name);
-        bool isRef = rawTypeKind != 0x11; // 0x11 = ELEMENT_TYPE_VALUETYPE
-        return new NamedTypeNode(name, isRef);
-    }
+        => ReadNamedType(
+            TypeResolver.TryGetTypeNameFromDefinition(
+                reader,
+                handle,
+                _beforeMaterialize,
+                out string? name,
+                out var rejection),
+            name,
+            rejection,
+            rawTypeKind);
 
     public TypeNode GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+        => ReadNamedType(
+            TypeResolver.TryGetTypeNameFromReference(
+                reader,
+                handle,
+                _beforeMaterialize,
+                out string? name,
+                out var rejection),
+            name,
+            rejection,
+            rawTypeKind);
+
+    TypeNode ReadNamedType(
+        bool resolved,
+        string? name,
+        RelationshipTraversalRejection? rejection,
+        byte rawTypeKind)
     {
-        string name = TypeResolver.GetTypeNameFromReference(
-            reader,
-            handle,
-            _beforeMaterialize);
-        _beforeRetain?.Invoke(name);
-        bool isRef = rawTypeKind != 0x11; // 0x11 = ELEMENT_TYPE_VALUETYPE
-        return new NamedTypeNode(name, isRef);
+        if (resolved)
+        {
+            _beforeRetain?.Invoke(name!);
+            bool isRef = rawTypeKind != 0x11; // 0x11 = ELEMENT_TYPE_VALUETYPE
+            return new NamedTypeNode(name!, isRef);
+        }
+
+        ArgumentNullException.ThrowIfNull(rejection);
+        if (rejection.Kind == RelationshipTraversalRejectionKind.NameBudget)
+            return new DegradedTypeNode();
+
+        throw new BadImageFormatException(
+            $"Metadata relationship traversal rejected ({rejection.Kind}): "
+            + rejection.Detail);
     }
 
     public TypeNode GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)

--- a/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataRelationshipTraversal.cs
@@ -107,7 +107,12 @@ public static class MetadataSafetyPolicy
     /// arbitrary length, so a malformed image can encode a name of hundreds of megabytes within
     /// the depth budget. Real names are far smaller — the deepest generated names in the .NET
     /// libraries are a few hundred characters — so this ceiling only trips on input that was
-    /// never a name.
+    /// never a name. Legacy readers preflight UTF-8 storage then recheck decoded length;
+    /// gated by
+    /// <c>SharedOversizeHeapString_IsRejectedBeforeAggregateMaterialization</c>,
+    /// <c>ManySmallSegments_AreRejectedOnAggregateEncodedLength</c>,
+    /// <c>LeafAppendOverBudget_IsRejectedBeforeLeafMaterialization</c>, and
+    /// <c>StructuredRead_ReportsNameBudgetNotMalformed</c>.
     /// </remarks>
     public const int MaxTypeNameCharacters = 4096;
 

--- a/src/ILInspector.MetadataPrimitives/MetadataTypeNameBudget.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataTypeNameBudget.cs
@@ -1,5 +1,4 @@
 using System.Reflection.Metadata;
-using System.Text;
 
 namespace ILInspector.Metadata;
 
@@ -32,10 +31,10 @@ internal struct MetadataTypeNameBudget
     long encoded;
     long characters;
 
-    public void SeedMaterialized(string value)
+    public void CopyFrom(in MetadataTypeNameBudget other)
     {
-        encoded += Encoding.UTF8.GetByteCount(value);
-        characters += value.Length;
+        encoded = other.encoded;
+        characters = other.characters;
     }
 
     public bool TryRead(
@@ -51,8 +50,9 @@ internal struct MetadataTypeNameBudget
             value = string.Empty;
             encoded += delimiterChars;
             characters += delimiterChars;
-            return !enforceCharacterBudget
-                || characters <= MetadataSafetyPolicy.MaxTypeNameCharacters;
+            return encoded <= MaxEncodedBytes
+                && (!enforceCharacterBudget
+                    || characters <= MetadataSafetyPolicy.MaxTypeNameCharacters);
         }
 
         int utf8Length = reader.GetBlobReader(handle).Length;

--- a/src/ILInspector.MetadataPrimitives/MetadataTypeNameBudget.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataTypeNameBudget.cs
@@ -1,4 +1,5 @@
 using System.Reflection.Metadata;
+using System.Text;
 
 namespace ILInspector.Metadata;
 
@@ -33,7 +34,7 @@ internal struct MetadataTypeNameBudget
 
     public void SeedMaterialized(string value)
     {
-        encoded += value.Length;
+        encoded += Encoding.UTF8.GetByteCount(value);
         characters += value.Length;
     }
 
@@ -42,8 +43,18 @@ internal struct MetadataTypeNameBudget
         StringHandle handle,
         int delimiterChars,
         Action<int>? beforeMaterialize,
-        out string value)
+        out string value,
+        bool enforceCharacterBudget = true)
     {
+        if (handle.IsNil)
+        {
+            value = string.Empty;
+            encoded += delimiterChars;
+            characters += delimiterChars;
+            return !enforceCharacterBudget
+                || characters <= MetadataSafetyPolicy.MaxTypeNameCharacters;
+        }
+
         int utf8Length = reader.GetBlobReader(handle).Length;
         beforeMaterialize?.Invoke(utf8Length);
         encoded += utf8Length + delimiterChars;
@@ -55,6 +66,7 @@ internal struct MetadataTypeNameBudget
 
         value = reader.GetString(handle);
         characters += value.Length + delimiterChars;
-        return characters <= MetadataSafetyPolicy.MaxTypeNameCharacters;
+        return !enforceCharacterBudget
+            || characters <= MetadataSafetyPolicy.MaxTypeNameCharacters;
     }
 }

--- a/src/ILInspector.MetadataPrimitives/MetadataTypeNameBudget.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataTypeNameBudget.cs
@@ -9,15 +9,25 @@ namespace ILInspector.Metadata;
 /// materializes an over-budget heap entry or concatenates many shared ones.
 /// </summary>
 /// <remarks>
-/// UTF-8 storage length is an upper bound on UTF-16 length, so the encoded
-/// preflight is sufficient to refuse a huge #Strings entry. Projected virtual
-/// strings may already be materialized by <see cref="MetadataReader.GetBlobReader(StringHandle)"/>;
+/// UTF-8 storage is at most three bytes per UTF-16 code unit, so the encoded
+/// preflight uses <c>3 * MaxTypeNameCharacters</c> and refuses a huge #Strings
+/// entry before <see cref="MetadataReader.GetString(StringHandle)"/>. The
+/// decoded recheck is the 4,096-character policy; a legal CJK name must not
+/// fail the encoded check. Projected virtual strings may already be
+/// materialized by <see cref="MetadataReader.GetBlobReader(StringHandle)"/>;
 /// the decoded recheck still prevents later segments from being appended.
 /// Accounting matches <c>MetadataTypeDefinitionName.Create</c>: namespace
 /// characters plus one delimiter per name segment.
 /// </remarks>
 internal struct MetadataTypeNameBudget
 {
+    /// <summary>
+    /// Worst-case UTF-8 bytes for a name that is still within
+    /// <see cref="MetadataSafetyPolicy.MaxTypeNameCharacters"/> UTF-16 units.
+    /// </summary>
+    public const int MaxEncodedBytes =
+        MetadataSafetyPolicy.MaxTypeNameCharacters * 3;
+
     long encoded;
     long characters;
 
@@ -37,7 +47,7 @@ internal struct MetadataTypeNameBudget
         int utf8Length = reader.GetBlobReader(handle).Length;
         beforeMaterialize?.Invoke(utf8Length);
         encoded += utf8Length + delimiterChars;
-        if (encoded > MetadataSafetyPolicy.MaxTypeNameCharacters)
+        if (encoded > MaxEncodedBytes)
         {
             value = string.Empty;
             return false;

--- a/src/ILInspector.MetadataPrimitives/MetadataTypeNameBudget.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataTypeNameBudget.cs
@@ -1,0 +1,50 @@
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Accumulates encoded then decoded type-name lengths against
+/// <see cref="MetadataSafetyPolicy.MaxTypeNameCharacters"/> so a relationship
+/// reader can refuse a name before <see cref="MetadataReader.GetString(StringHandle)"/>
+/// materializes an over-budget heap entry or concatenates many shared ones.
+/// </summary>
+/// <remarks>
+/// UTF-8 storage length is an upper bound on UTF-16 length, so the encoded
+/// preflight is sufficient to refuse a huge #Strings entry. Projected virtual
+/// strings may already be materialized by <see cref="MetadataReader.GetBlobReader(StringHandle)"/>;
+/// the decoded recheck still prevents later segments from being appended.
+/// Accounting matches <c>MetadataTypeDefinitionName.Create</c>: namespace
+/// characters plus one delimiter per name segment.
+/// </remarks>
+internal struct MetadataTypeNameBudget
+{
+    long encoded;
+    long characters;
+
+    public void SeedMaterialized(string value)
+    {
+        encoded += value.Length;
+        characters += value.Length;
+    }
+
+    public bool TryRead(
+        MetadataReader reader,
+        StringHandle handle,
+        int delimiterChars,
+        Action<int>? beforeMaterialize,
+        out string value)
+    {
+        int utf8Length = reader.GetBlobReader(handle).Length;
+        beforeMaterialize?.Invoke(utf8Length);
+        encoded += utf8Length + delimiterChars;
+        if (encoded > MetadataSafetyPolicy.MaxTypeNameCharacters)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        value = reader.GetString(handle);
+        characters += value.Length + delimiterChars;
+        return characters <= MetadataSafetyPolicy.MaxTypeNameCharacters;
+    }
+}

--- a/src/ILInspector.MetadataPrimitives/RelationshipTraversalResult.cs
+++ b/src/ILInspector.MetadataPrimitives/RelationshipTraversalResult.cs
@@ -13,14 +13,14 @@ public enum RelationshipTraversalRejectionKind
     /// <summary>The relationship chain exceeded the fixed node ceiling.</summary>
     NodeBudget,
 
+    /// <summary>SRM rejected a row or relationship handle.</summary>
+    MalformedMetadata,
+
     /// <summary>
     /// The namespace and root-to-leaf segments exceed
     /// <see cref="MetadataSafetyPolicy.MaxTypeNameCharacters"/>.
     /// </summary>
     NameBudget,
-
-    /// <summary>SRM rejected a row or relationship handle.</summary>
-    MalformedMetadata,
 }
 
 /// <summary>Inspectable evidence for a rejected metadata relationship walk.</summary>

--- a/src/ILInspector.MetadataPrimitives/RelationshipTraversalResult.cs
+++ b/src/ILInspector.MetadataPrimitives/RelationshipTraversalResult.cs
@@ -13,6 +13,12 @@ public enum RelationshipTraversalRejectionKind
     /// <summary>The relationship chain exceeded the fixed node ceiling.</summary>
     NodeBudget,
 
+    /// <summary>
+    /// The namespace and root-to-leaf segments exceed
+    /// <see cref="MetadataSafetyPolicy.MaxTypeNameCharacters"/>.
+    /// </summary>
+    NameBudget,
+
     /// <summary>SRM rejected a row or relationship handle.</summary>
     MalformedMetadata,
 }

--- a/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
@@ -131,8 +131,20 @@ public static class GuardedSignatureDecoder
         MetadataReader reader,
         TypeSpecificationHandle handle,
         GenericContext? context = null,
-        Action<int>? beforeMaterialize = null,
-        bool enforceCharacterBudget = true)
+        Action<int>? beforeMaterialize = null)
+        => DecodeTypeSpecification(
+            reader,
+            handle,
+            context,
+            beforeMaterialize,
+            enforceCharacterBudget: true);
+
+    public static SignatureDecodeResult<string> DecodeTypeSpecification(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        GenericContext? context,
+        Action<int>? beforeMaterialize,
+        bool enforceCharacterBudget)
         => SignatureDecoder.Decode(() =>
         {
             beforeMaterialize?.Invoke(

--- a/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
@@ -131,7 +131,8 @@ public static class GuardedSignatureDecoder
         MetadataReader reader,
         TypeSpecificationHandle handle,
         GenericContext? context = null,
-        Action<int>? beforeMaterialize = null)
+        Action<int>? beforeMaterialize = null,
+        bool enforceCharacterBudget = true)
         => SignatureDecoder.Decode(() =>
         {
             beforeMaterialize?.Invoke(
@@ -154,10 +155,11 @@ public static class GuardedSignatureDecoder
 
             using (scope)
             {
+                SignatureDecoder decoder = beforeMaterialize is null && enforceCharacterBudget
+                    ? SignatureDecoder.Instance
+                    : new SignatureDecoder(beforeMaterialize, enforceCharacterBudget);
                 return reader.GetTypeSpecification(handle).DecodeSignature(
-                    beforeMaterialize is null
-                        ? SignatureDecoder.Instance
-                        : new SignatureDecoder(beforeMaterialize),
+                    decoder,
                     context);
             }
         });

--- a/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecodeResult.cs
@@ -14,6 +14,12 @@ public enum SignatureDecodeRejectionKind
 
     /// <summary>SRM rejected malformed metadata during the bounded decode.</summary>
     MalformedMetadata,
+
+    /// <summary>
+    /// A TypeDef/TypeRef/ExportedType name in the signature exceeds
+    /// <see cref="MetadataSafetyPolicy.MaxTypeNameCharacters"/>.
+    /// </summary>
+    NameBudget,
 }
 
 /// <summary>Inspectable detail for a rejected guarded signature decode.</summary>

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -151,7 +151,7 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
         {
             Reject(
                 new SignatureDecodeRejection(
-                    SignatureDecodeRejectionKind.MalformedMetadata,
+                    SignatureDecodeRejectionKind.NameBudget,
                     rejection.Detail));
             return Unresolved;
         }

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -120,11 +120,11 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
         }
         catch (BadImageFormatException ex)
         {
-            return Malformed<T>(ex);
+            return RecordedOrMalformed<T>(ex);
         }
         catch (ArgumentOutOfRangeException ex)
         {
-            return Malformed<T>(ex);
+            return RecordedOrMalformed<T>(ex);
         }
         finally
         {
@@ -160,6 +160,12 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
             $"Metadata relationship traversal rejected ({rejection.Kind}): "
             + rejection.Detail);
     }
+
+    static SignatureDecodeResult<T> RecordedOrMalformed<T>(Exception exception)
+        where T : notnull
+        => s_rejection is { } recorded
+            ? new SignatureDecodeResult<T>.Rejected(recorded)
+            : Malformed<T>(exception);
 
     static SignatureDecodeResult<T> Malformed<T>(Exception exception)
         where T : notnull

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -54,10 +54,26 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
     };
 
     public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
-        => TypeResolver.GetTypeNameFromDefinition(reader, handle, _beforeMaterialize);
+        => ReadNameOrContinue(
+            TypeResolver.TryGetTypeNameFromDefinition(
+                reader,
+                handle,
+                _beforeMaterialize,
+                out string? name,
+                out var rejection),
+            name,
+            rejection);
 
     public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
-        => TypeResolver.GetTypeNameFromReference(reader, handle, _beforeMaterialize);
+        => ReadNameOrContinue(
+            TypeResolver.TryGetTypeNameFromReference(
+                reader,
+                handle,
+                _beforeMaterialize,
+                out string? name,
+                out var rejection),
+            name,
+            rejection);
 
     public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
     {
@@ -120,6 +136,29 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
     {
         ArgumentNullException.ThrowIfNull(rejection);
         s_rejection ??= rejection;
+    }
+
+    static string ReadNameOrContinue(
+        bool resolved,
+        string? name,
+        RelationshipTraversalRejection? rejection)
+    {
+        if (resolved)
+            return name!;
+
+        ArgumentNullException.ThrowIfNull(rejection);
+        if (rejection.Kind == RelationshipTraversalRejectionKind.NameBudget)
+        {
+            Reject(
+                new SignatureDecodeRejection(
+                    SignatureDecodeRejectionKind.MalformedMetadata,
+                    rejection.Detail));
+            return Unresolved;
+        }
+
+        throw new BadImageFormatException(
+            $"Metadata relationship traversal rejected ({rejection.Kind}): "
+            + rejection.Detail);
     }
 
     static SignatureDecodeResult<T> Malformed<T>(Exception exception)

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -11,6 +11,7 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
 {
     const string Unresolved = "object";
     readonly Action<int>? _beforeMaterialize;
+    readonly bool _enforceCharacterBudget;
 
     [ThreadStatic]
     static SignatureDecodeRejection? s_rejection;
@@ -21,13 +22,20 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
     public static SignatureDecoder Instance { get; } = new();
 
     public SignatureDecoder()
+        : this(beforeMaterialize: null, enforceCharacterBudget: true)
     {
     }
 
     internal SignatureDecoder(Action<int> beforeMaterialize)
+        : this(beforeMaterialize, enforceCharacterBudget: true)
     {
-        _beforeMaterialize = beforeMaterialize
-            ?? throw new ArgumentNullException(nameof(beforeMaterialize));
+        ArgumentNullException.ThrowIfNull(beforeMaterialize);
+    }
+
+    internal SignatureDecoder(Action<int>? beforeMaterialize, bool enforceCharacterBudget)
+    {
+        _beforeMaterialize = beforeMaterialize;
+        _enforceCharacterBudget = enforceCharacterBudget;
     }
 
     public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode switch
@@ -60,7 +68,8 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
                 handle,
                 _beforeMaterialize,
                 out string? name,
-                out var rejection),
+                out var rejection,
+                _enforceCharacterBudget),
             name,
             rejection);
 
@@ -71,7 +80,8 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
                 handle,
                 _beforeMaterialize,
                 out string? name,
-                out var rejection),
+                out var rejection,
+                _enforceCharacterBudget),
             name,
             rejection);
 

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -63,7 +63,8 @@ public static class TypeResolver
                 reader,
                 (TypeSpecificationHandle)handle,
                 context,
-                beforeMaterialize).TryGetValue(out var name)
+                beforeMaterialize,
+                enforceCharacterBudget: false).TryGetValue(out var name)
                     ? name
                     : null,
             _ => null
@@ -408,7 +409,12 @@ public static class TypeResolver
         MetadataReader reader,
         TypeSpecificationHandle handle,
         GenericContext? context = null)
-        => DecodeTypeNameFromSpecification(reader, handle, context).GetValueOrThrow();
+        => DecodeTypeNameFromSpecification(
+            reader,
+            handle,
+            context,
+            beforeMaterialize: null,
+            enforceCharacterBudget: false).GetValueOrThrow();
 
     /// <summary>
     /// Gets the guarded decode outcome for a TypeSpecification handle (generic instantiations).
@@ -417,12 +423,14 @@ public static class TypeResolver
         MetadataReader reader,
         TypeSpecificationHandle handle,
         GenericContext? context = null,
-        Action<int>? beforeMaterialize = null)
+        Action<int>? beforeMaterialize = null,
+        bool enforceCharacterBudget = true)
         => GuardedSignatureDecoder.DecodeTypeSpecification(
             reader,
             handle,
             context,
-            beforeMaterialize);
+            beforeMaterialize,
+            enforceCharacterBudget);
 
     /// <summary>
     /// Gets the full name of a type definition (Namespace.Name), qualifying a
@@ -780,7 +788,8 @@ public static class TypeResolver
                         reader,
                         ref budget,
                         namespaceHandle,
-                        delimiterChars: 0,
+                        chargeDelimiterChars: 0,
+                        renderDelimiterChars: 0,
                         builder,
                         getSubject(handle),
                         i + 1,
@@ -790,12 +799,12 @@ public static class TypeResolver
                     return namespaceRejection;
                 }
 
-                int nameDelimiter = i > 0 || builder.Length > 0 ? 1 : 0;
                 if (!TryAppendNamePart(
                         reader,
                         ref budget,
                         nameHandle,
-                        nameDelimiter,
+                        chargeDelimiterChars: 1,
+                        renderDelimiterChars: i > 0 || builder.Length > 0 ? 1 : 0,
                         builder,
                         getSubject(handle),
                         i + 1,
@@ -851,7 +860,8 @@ public static class TypeResolver
                     reader,
                     ref budget,
                     leafName,
-                    delimiterChars: 1,
+                    chargeDelimiterChars: 1,
+                    renderDelimiterChars: 1,
                     builder,
                     subject,
                     completed.ConsumedNodes + 1,
@@ -891,7 +901,8 @@ public static class TypeResolver
                     reader,
                     ref budget,
                     namespaceHandle,
-                    delimiterChars: 0,
+                    chargeDelimiterChars: 0,
+                    renderDelimiterChars: 0,
                     builder,
                     subject,
                     consumedNodes,
@@ -905,7 +916,8 @@ public static class TypeResolver
                     reader,
                     ref budget,
                     nameHandle,
-                    delimiterChars: builder.Length > 0 ? 1 : 0,
+                    chargeDelimiterChars: 1,
+                    renderDelimiterChars: builder.Length > 0 ? 1 : 0,
                     builder,
                     subject,
                     consumedNodes,
@@ -933,7 +945,8 @@ public static class TypeResolver
         MetadataReader reader,
         ref MetadataTypeNameBudget budget,
         StringHandle handle,
-        int delimiterChars,
+        int chargeDelimiterChars,
+        int renderDelimiterChars,
         StringBuilder builder,
         EntityHandle subject,
         int consumedNodes,
@@ -943,7 +956,7 @@ public static class TypeResolver
         if (!budget.TryRead(
                 reader,
                 handle,
-                delimiterChars,
+                chargeDelimiterChars,
                 beforeMaterialize: null,
                 out string value,
                 enforceCharacterBudget))
@@ -952,7 +965,7 @@ public static class TypeResolver
             return false;
         }
 
-        if (delimiterChars > 0)
+        if (renderDelimiterChars > 0)
             builder.Append('.');
         builder.Append(value);
         rejection = null!;

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
 using System.Text;
 
@@ -84,20 +85,45 @@ public static class TypeResolver
         MetadataReader reader,
         TypeReferenceHandle handle,
         Action<int>? beforeMaterialize)
+        => TryGetTypeNameFromReference(
+            reader,
+            handle,
+            beforeMaterialize,
+            out string? name,
+            out var rejection)
+            ? name
+            : throw RejectedName(rejection!);
+
+    internal static bool TryGetTypeNameFromReference(
+        MetadataReader reader,
+        TypeReferenceHandle handle,
+        Action<int>? beforeMaterialize,
+        [NotNullWhen(true)] out string? name,
+        out RelationshipTraversalRejection? rejection)
     {
         ObserveTypeReferenceName(reader, handle, beforeMaterialize);
         try
         {
             var typeRef = reader.GetTypeReference(handle);
             if (typeRef.ResolutionScope.Kind != HandleKind.TypeReference)
-                return GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
+            {
+                return CompleteLeafName(
+                    reader,
+                    typeRef.Namespace,
+                    typeRef.Name,
+                    handle,
+                    consumedNodes: 1).TryComplete(out name, out rejection);
+            }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
         {
-            return ThrowMalformed(ex, handle);
+            name = null;
+            rejection = MalformedRejection(ex, handle, consumedNodes: 1);
+            return false;
         }
 
-        return ResolveTypeNameFromReference(reader, handle).GetValueOrThrow();
+        return ResolveTypeNameFromReference(reader, handle)
+            .TryComplete(out name, out rejection);
     }
 
     /// <summary>
@@ -151,20 +177,45 @@ public static class TypeResolver
         MetadataReader reader,
         TypeDefinitionHandle handle,
         Action<int>? beforeMaterialize)
+        => TryGetTypeNameFromDefinition(
+            reader,
+            handle,
+            beforeMaterialize,
+            out string? name,
+            out var rejection)
+            ? name
+            : throw RejectedName(rejection!);
+
+    internal static bool TryGetTypeNameFromDefinition(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        Action<int>? beforeMaterialize,
+        [NotNullWhen(true)] out string? name,
+        out RelationshipTraversalRejection? rejection)
     {
         ObserveTypeDefinitionName(reader, handle, beforeMaterialize);
         try
         {
             var typeDef = reader.GetTypeDefinition(handle);
             if (typeDef.GetDeclaringType().IsNil)
-                return GetFullName(reader.GetString(typeDef.Namespace), reader.GetString(typeDef.Name));
+            {
+                return CompleteLeafName(
+                    reader,
+                    typeDef.Namespace,
+                    typeDef.Name,
+                    handle,
+                    consumedNodes: 1).TryComplete(out name, out rejection);
+            }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
         {
-            return ThrowMalformed(ex, handle);
+            name = null;
+            rejection = MalformedRejection(ex, handle, consumedNodes: 1);
+            return false;
         }
 
-        return ResolveTypeNameFromDefinition(reader, handle).GetValueOrThrow();
+        return ResolveTypeNameFromDefinition(reader, handle)
+            .TryComplete(out name, out rejection);
     }
 
     static void ObserveTypeReferenceName(
@@ -314,7 +365,14 @@ public static class TypeResolver
         {
             var exportedType = reader.GetExportedType(handle);
             if (exportedType.Implementation.Kind != HandleKind.ExportedType)
-                return GetFullName(reader.GetString(exportedType.Namespace), reader.GetString(exportedType.Name));
+            {
+                return CompleteLeafName(
+                    reader,
+                    exportedType.Namespace,
+                    exportedType.Name,
+                    handle,
+                    consumedNodes: 1).GetValueOrThrow();
+            }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
         {
@@ -358,7 +416,14 @@ public static class TypeResolver
         {
             declaringType = typeDef.GetDeclaringType();
             if (declaringType.IsNil)
-                return GetFullName(reader.GetString(typeDef.Namespace), reader.GetString(typeDef.Name));
+            {
+                return CompleteLeafName(
+                    reader,
+                    typeDef.Namespace,
+                    typeDef.Name,
+                    default,
+                    consumedNodes: 1).GetValueOrThrow();
+            }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
         {
@@ -428,7 +493,14 @@ public static class TypeResolver
         {
             resolutionScope = typeRef.ResolutionScope;
             if (resolutionScope.Kind != HandleKind.TypeReference)
-                return GetFullName(reader.GetString(typeRef.Namespace), reader.GetString(typeRef.Name));
+            {
+                return CompleteLeafName(
+                    reader,
+                    typeRef.Namespace,
+                    typeRef.Name,
+                    default,
+                    consumedNodes: 1).GetValueOrThrow();
+            }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
         {
@@ -527,7 +599,14 @@ public static class TypeResolver
         {
             implementation = exportedType.Implementation;
             if (implementation.Kind != HandleKind.ExportedType)
-                return GetFullName(reader.GetString(exportedType.Namespace), reader.GetString(exportedType.Name));
+            {
+                return CompleteLeafName(
+                    reader,
+                    exportedType.Namespace,
+                    exportedType.Name,
+                    default,
+                    consumedNodes: 1).GetValueOrThrow();
+            }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
         {
@@ -653,6 +732,7 @@ public static class TypeResolver
             return Reject<string>(rejected.Rejection);
 
         var chain = ((RelationshipTraversalResult<RelationshipChain<THandle>>.Completed)traversal).Value;
+        var budget = new MetadataTypeNameBudget();
         var builder = new StringBuilder();
         for (int i = 0; i < chain.Handles.Length; i++)
         {
@@ -660,21 +740,32 @@ public static class TypeResolver
             try
             {
                 var (namespaceHandle, nameHandle) = getName(handle);
-                if (i == 0)
+                if (i == 0
+                    && !TryAppendNamePart(
+                        reader,
+                        ref budget,
+                        namespaceHandle,
+                        delimiterChars: 0,
+                        builder,
+                        getSubject(handle),
+                        i + 1,
+                        out var namespaceRejection))
                 {
-                    string ns = reader.GetString(namespaceHandle);
-                    if (ns.Length > 0)
-                    {
-                        builder.Append(ns);
-                        builder.Append('.');
-                    }
-                }
-                else
-                {
-                    builder.Append('.');
+                    return namespaceRejection;
                 }
 
-                builder.Append(reader.GetString(nameHandle));
+                if (!TryAppendNamePart(
+                        reader,
+                        ref budget,
+                        nameHandle,
+                        delimiterChars: 1,
+                        builder,
+                        getSubject(handle),
+                        i + 1,
+                        out var nameRejection))
+                {
+                    return nameRejection;
+                }
             }
             catch (BadImageFormatException ex)
             {
@@ -714,8 +805,24 @@ public static class TypeResolver
 
         try
         {
+            var budget = new MetadataTypeNameBudget();
+            budget.SeedMaterialized(completed.Value);
+            var builder = new StringBuilder(completed.Value);
+            if (!TryAppendNamePart(
+                    reader,
+                    ref budget,
+                    leafName,
+                    delimiterChars: 1,
+                    builder,
+                    subject,
+                    completed.ConsumedNodes + 1,
+                    out var rejection))
+            {
+                return rejection;
+            }
+
             return new RelationshipTraversalResult<string>.Completed(
-                $"{completed.Value}.{reader.GetString(leafName)}",
+                builder.ToString(),
                 completed.ConsumedNodes + 1);
         }
         catch (BadImageFormatException ex)
@@ -737,8 +844,36 @@ public static class TypeResolver
     {
         try
         {
+            var budget = new MetadataTypeNameBudget();
+            var builder = new StringBuilder();
+            if (!TryAppendNamePart(
+                    reader,
+                    ref budget,
+                    namespaceHandle,
+                    delimiterChars: 0,
+                    builder,
+                    subject,
+                    consumedNodes,
+                    out var namespaceRejection))
+            {
+                return namespaceRejection;
+            }
+
+            if (!TryAppendNamePart(
+                    reader,
+                    ref budget,
+                    nameHandle,
+                    delimiterChars: 1,
+                    builder,
+                    subject,
+                    consumedNodes,
+                    out var nameRejection))
+            {
+                return nameRejection;
+            }
+
             return new RelationshipTraversalResult<string>.Completed(
-                GetFullName(reader.GetString(namespaceHandle), reader.GetString(nameHandle)),
+                builder.ToString(),
                 consumedNodes);
         }
         catch (BadImageFormatException ex)
@@ -750,6 +885,52 @@ public static class TypeResolver
             return Malformed<string>(ex, subject, consumedNodes);
         }
     }
+
+    static bool TryAppendNamePart(
+        MetadataReader reader,
+        ref MetadataTypeNameBudget budget,
+        StringHandle handle,
+        int delimiterChars,
+        StringBuilder builder,
+        EntityHandle subject,
+        int consumedNodes,
+        out RelationshipTraversalResult<string> rejection)
+    {
+        if (!budget.TryRead(
+                reader,
+                handle,
+                delimiterChars,
+                beforeMaterialize: null,
+                out string value))
+        {
+            rejection = NameBudget<string>(subject, consumedNodes);
+            return false;
+        }
+
+        if (value.Length == 0)
+        {
+            rejection = null!;
+            return true;
+        }
+
+        if (builder.Length > 0)
+            builder.Append('.');
+        builder.Append(value);
+        rejection = null!;
+        return true;
+    }
+
+    static RelationshipTraversalResult<T> NameBudget<T>(
+        EntityHandle subject,
+        int consumedNodes)
+        where T : notnull
+        => new RelationshipTraversalResult<T>.Rejected(
+            new RelationshipTraversalRejection(
+                RelationshipTraversalRejectionKind.NameBudget,
+                $"The structured type name exceeds "
+                + $"{MetadataSafetyPolicy.MaxTypeNameCharacters} characters.",
+                subject,
+                consumedNodes));
 
     static RelationshipTraversalResult<T> Malformed<T>(
         Exception exception,
@@ -794,6 +975,38 @@ public static class TypeResolver
             _ => throw new InvalidOperationException(
                 "Unknown metadata signature decode result."),
         };
+
+    static bool TryComplete(
+        this RelationshipTraversalResult<string> result,
+        [NotNullWhen(true)] out string? name,
+        out RelationshipTraversalRejection? rejection)
+    {
+        if (result is RelationshipTraversalResult<string>.Completed completed)
+        {
+            name = completed.Value;
+            rejection = null;
+            return true;
+        }
+
+        name = null;
+        rejection = ((RelationshipTraversalResult<string>.Rejected)result).Rejection;
+        return false;
+    }
+
+    static BadImageFormatException RejectedName(RelationshipTraversalRejection rejection)
+        => new(
+            $"Metadata relationship traversal rejected ({rejection.Kind}): "
+            + rejection.Detail);
+
+    static RelationshipTraversalRejection MalformedRejection(
+        Exception exception,
+        EntityHandle subject,
+        int consumedNodes)
+        => new(
+            RelationshipTraversalRejectionKind.MalformedMetadata,
+            exception.Message,
+            subject,
+            consumedNodes);
 
     static string ThrowMalformed(
         Exception exception,

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -116,7 +116,8 @@ public static class TypeResolver
                     typeRef.Name,
                     handle,
                     consumedNodes: 1,
-                    enforceCharacterBudget).TryComplete(out name, out rejection);
+                    enforceCharacterBudget,
+                    out _).TryComplete(out name, out rejection);
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -138,6 +139,17 @@ public static class TypeResolver
         MetadataReader reader,
         TypeReferenceHandle handle,
         bool enforceCharacterBudget = true)
+        => ResolveTypeNameFromReference(
+            reader,
+            handle,
+            enforceCharacterBudget,
+            out _);
+
+    static RelationshipTraversalResult<string> ResolveTypeNameFromReference(
+        MetadataReader reader,
+        TypeReferenceHandle handle,
+        bool enforceCharacterBudget,
+        out MetadataTypeNameBudget budget)
     {
         try
         {
@@ -150,15 +162,18 @@ public static class TypeResolver
                     typeRef.Name,
                     handle,
                     consumedNodes: 1,
-                    enforceCharacterBudget);
+                    enforceCharacterBudget,
+                    out budget);
             }
         }
         catch (BadImageFormatException ex)
         {
+            budget = default;
             return Malformed<string>(ex, handle, consumedNodes: 1);
         }
         catch (ArgumentOutOfRangeException ex)
         {
+            budget = default;
             return Malformed<string>(ex, handle, consumedNodes: 1);
         }
 
@@ -171,7 +186,8 @@ public static class TypeResolver
                 return (typeRef.Namespace, typeRef.Name);
             },
             static current => current,
-            enforceCharacterBudget);
+            enforceCharacterBudget,
+            out budget);
     }
 
     /// <summary>
@@ -214,7 +230,8 @@ public static class TypeResolver
                     typeDef.Name,
                     handle,
                     consumedNodes: 1,
-                    enforceCharacterBudget).TryComplete(out name, out rejection);
+                    enforceCharacterBudget,
+                    out _).TryComplete(out name, out rejection);
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -290,6 +307,17 @@ public static class TypeResolver
         MetadataReader reader,
         TypeDefinitionHandle handle,
         bool enforceCharacterBudget = true)
+        => ResolveTypeNameFromDefinition(
+            reader,
+            handle,
+            enforceCharacterBudget,
+            out _);
+
+    static RelationshipTraversalResult<string> ResolveTypeNameFromDefinition(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        bool enforceCharacterBudget,
+        out MetadataTypeNameBudget budget)
     {
         try
         {
@@ -302,15 +330,18 @@ public static class TypeResolver
                     typeDef.Name,
                     handle,
                     consumedNodes: 1,
-                    enforceCharacterBudget);
+                    enforceCharacterBudget,
+                    out budget);
             }
         }
         catch (BadImageFormatException ex)
         {
+            budget = default;
             return Malformed<string>(ex, handle, consumedNodes: 1);
         }
         catch (ArgumentOutOfRangeException ex)
         {
+            budget = default;
             return Malformed<string>(ex, handle, consumedNodes: 1);
         }
 
@@ -323,7 +354,8 @@ public static class TypeResolver
                 return (typeDef.Namespace, typeDef.Name);
             },
             static current => current,
-            enforceCharacterBudget);
+            enforceCharacterBudget,
+            out budget);
     }
 
     /// <summary>
@@ -334,6 +366,17 @@ public static class TypeResolver
         MetadataReader reader,
         ExportedTypeHandle handle,
         bool enforceCharacterBudget = true)
+        => ResolveTypeNameFromExportedType(
+            reader,
+            handle,
+            enforceCharacterBudget,
+            out _);
+
+    static RelationshipTraversalResult<string> ResolveTypeNameFromExportedType(
+        MetadataReader reader,
+        ExportedTypeHandle handle,
+        bool enforceCharacterBudget,
+        out MetadataTypeNameBudget budget)
     {
         try
         {
@@ -346,15 +389,18 @@ public static class TypeResolver
                     exportedType.Name,
                     handle,
                     consumedNodes: 1,
-                    enforceCharacterBudget);
+                    enforceCharacterBudget,
+                    out budget);
             }
         }
         catch (BadImageFormatException ex)
         {
+            budget = default;
             return Malformed<string>(ex, handle, consumedNodes: 1);
         }
         catch (ArgumentOutOfRangeException ex)
         {
+            budget = default;
             return Malformed<string>(ex, handle, consumedNodes: 1);
         }
 
@@ -367,7 +413,8 @@ public static class TypeResolver
                 return (exportedType.Namespace, exportedType.Name);
             },
             static current => current,
-            enforceCharacterBudget);
+            enforceCharacterBudget,
+            out budget);
     }
 
     /// <summary>
@@ -388,7 +435,8 @@ public static class TypeResolver
                     exportedType.Name,
                     handle,
                     consumedNodes: 1,
-                    enforceCharacterBudget: false).GetValueOrThrow();
+                    enforceCharacterBudget: false,
+                    out _).GetValueOrThrow();
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -450,7 +498,8 @@ public static class TypeResolver
                     typeDef.Name,
                     default,
                     consumedNodes: 1,
-                    enforceCharacterBudget: false).GetValueOrThrow();
+                    enforceCharacterBudget: false,
+                    out _).GetValueOrThrow();
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -458,14 +507,17 @@ public static class TypeResolver
             return ThrowMalformed(ex, default, consumedNodes: 0);
         }
 
+        var declaringName = ResolveTypeNameFromDefinition(
+            reader,
+            declaringType,
+            enforceCharacterBudget: false,
+            out var declaringBudget);
         return AppendLeaf(
             reader,
-            ResolveTypeNameFromDefinition(
-                reader,
-                declaringType,
-                enforceCharacterBudget: false),
+            declaringName,
             typeDef.Name,
             declaringType,
+            declaringBudget,
             enforceCharacterBudget: false).GetValueOrThrow();
     }
 
@@ -487,14 +539,22 @@ public static class TypeResolver
                     typeDef.Namespace,
                     typeDef.Name,
                     default,
-                    consumedNodes: 1);
+                    consumedNodes: 1,
+                    enforceCharacterBudget: true,
+                    out _);
             }
 
+            var declaringName = ResolveTypeNameFromDefinition(
+                reader,
+                declaringType,
+                enforceCharacterBudget: true,
+                out var declaringBudget);
             return AppendLeaf(
                 reader,
-                ResolveTypeNameFromDefinition(reader, declaringType),
+                declaringName,
                 typeDef.Name,
-                declaringType);
+                declaringType,
+                declaringBudget);
         }
         catch (BadImageFormatException ex)
         {
@@ -532,7 +592,8 @@ public static class TypeResolver
                     typeRef.Name,
                     default,
                     consumedNodes: 1,
-                    enforceCharacterBudget: false).GetValueOrThrow();
+                    enforceCharacterBudget: false,
+                    out _).GetValueOrThrow();
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -540,14 +601,17 @@ public static class TypeResolver
             return ThrowMalformed(ex, default, consumedNodes: 0);
         }
 
+        var declaringName = ResolveTypeNameFromReference(
+            reader,
+            (TypeReferenceHandle)resolutionScope,
+            enforceCharacterBudget: false,
+            out var declaringBudget);
         return AppendLeaf(
             reader,
-            ResolveTypeNameFromReference(
-                reader,
-                (TypeReferenceHandle)resolutionScope,
-                enforceCharacterBudget: false),
+            declaringName,
             typeRef.Name,
             resolutionScope,
+            declaringBudget,
             enforceCharacterBudget: false).GetValueOrThrow();
     }
 
@@ -569,14 +633,22 @@ public static class TypeResolver
                     typeRef.Namespace,
                     typeRef.Name,
                     resolutionScope,
-                    consumedNodes: 1);
+                    consumedNodes: 1,
+                    enforceCharacterBudget: true,
+                    out _);
             }
 
+            var declaringName = ResolveTypeNameFromReference(
+                reader,
+                (TypeReferenceHandle)resolutionScope,
+                enforceCharacterBudget: true,
+                out var declaringBudget);
             return AppendLeaf(
                 reader,
-                ResolveTypeNameFromReference(reader, (TypeReferenceHandle)resolutionScope),
+                declaringName,
                 typeRef.Name,
-                resolutionScope);
+                resolutionScope,
+                declaringBudget);
         }
         catch (BadImageFormatException ex)
         {
@@ -606,14 +678,22 @@ public static class TypeResolver
                     exportedType.Namespace,
                     exportedType.Name,
                     implementation,
-                    consumedNodes: 1);
+                    consumedNodes: 1,
+                    enforceCharacterBudget: true,
+                    out _);
             }
 
+            var declaringName = ResolveTypeNameFromExportedType(
+                reader,
+                (ExportedTypeHandle)implementation,
+                enforceCharacterBudget: true,
+                out var declaringBudget);
             return AppendLeaf(
                 reader,
-                ResolveTypeNameFromExportedType(reader, (ExportedTypeHandle)implementation),
+                declaringName,
                 exportedType.Name,
-                implementation);
+                implementation,
+                declaringBudget);
         }
         catch (BadImageFormatException ex)
         {
@@ -643,7 +723,8 @@ public static class TypeResolver
                     exportedType.Name,
                     default,
                     consumedNodes: 1,
-                    enforceCharacterBudget: false).GetValueOrThrow();
+                    enforceCharacterBudget: false,
+                    out _).GetValueOrThrow();
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -651,14 +732,17 @@ public static class TypeResolver
             return ThrowMalformed(ex, default, consumedNodes: 0);
         }
 
+        var declaringName = ResolveTypeNameFromExportedType(
+            reader,
+            (ExportedTypeHandle)implementation,
+            enforceCharacterBudget: false,
+            out var declaringBudget);
         return AppendLeaf(
             reader,
-            ResolveTypeNameFromExportedType(
-                reader,
-                (ExportedTypeHandle)implementation,
-                enforceCharacterBudget: false),
+            declaringName,
             exportedType.Name,
             implementation,
+            declaringBudget,
             enforceCharacterBudget: false).GetValueOrThrow();
     }
 
@@ -768,14 +852,16 @@ public static class TypeResolver
         RelationshipTraversalResult<RelationshipChain<THandle>> traversal,
         Func<THandle, (StringHandle Namespace, StringHandle Name)> getName,
         Func<THandle, EntityHandle> getSubject,
-        bool enforceCharacterBudget)
+        bool enforceCharacterBudget,
+        out MetadataTypeNameBudget budget)
         where THandle : struct
     {
+        budget = default;
         if (traversal is RelationshipTraversalResult<RelationshipChain<THandle>>.Rejected rejected)
             return Reject<string>(rejected.Rejection);
 
         var chain = ((RelationshipTraversalResult<RelationshipChain<THandle>>.Completed)traversal).Value;
-        var budget = new MetadataTypeNameBudget();
+        var accumulated = new MetadataTypeNameBudget();
         var builder = new StringBuilder();
         for (int i = 0; i < chain.Handles.Length; i++)
         {
@@ -786,7 +872,7 @@ public static class TypeResolver
                 if (i == 0
                     && !TryAppendNamePart(
                         reader,
-                        ref budget,
+                        ref accumulated,
                         namespaceHandle,
                         chargeDelimiterChars: 0,
                         renderDelimiterChars: 0,
@@ -801,7 +887,7 @@ public static class TypeResolver
 
                 if (!TryAppendNamePart(
                         reader,
-                        ref budget,
+                        ref accumulated,
                         nameHandle,
                         chargeDelimiterChars: 1,
                         renderDelimiterChars: i > 0 || builder.Length > 0 ? 1 : 0,
@@ -824,6 +910,7 @@ public static class TypeResolver
             }
         }
 
+        budget = accumulated;
         return new RelationshipTraversalResult<string>.Completed(
             builder.ToString(),
             chain.Handles.Length);
@@ -834,6 +921,7 @@ public static class TypeResolver
         RelationshipTraversalResult<string> declaringName,
         StringHandle leafName,
         EntityHandle subject,
+        in MetadataTypeNameBudget declaringBudget,
         bool enforceCharacterBudget = true)
     {
         if (declaringName is RelationshipTraversalResult<string>.Rejected rejected)
@@ -854,7 +942,7 @@ public static class TypeResolver
         try
         {
             var budget = new MetadataTypeNameBudget();
-            budget.SeedMaterialized(completed.Value);
+            budget.CopyFrom(declaringBudget);
             var builder = new StringBuilder(completed.Value);
             if (!TryAppendNamePart(
                     reader,
@@ -891,15 +979,17 @@ public static class TypeResolver
         StringHandle nameHandle,
         EntityHandle subject,
         int consumedNodes,
-        bool enforceCharacterBudget = true)
+        bool enforceCharacterBudget,
+        out MetadataTypeNameBudget budget)
     {
+        budget = default;
         try
         {
-            var budget = new MetadataTypeNameBudget();
+            var accumulated = new MetadataTypeNameBudget();
             var builder = new StringBuilder();
             if (!TryAppendNamePart(
                     reader,
-                    ref budget,
+                    ref accumulated,
                     namespaceHandle,
                     chargeDelimiterChars: 0,
                     renderDelimiterChars: 0,
@@ -914,7 +1004,7 @@ public static class TypeResolver
 
             if (!TryAppendNamePart(
                     reader,
-                    ref budget,
+                    ref accumulated,
                     nameHandle,
                     chargeDelimiterChars: 1,
                     renderDelimiterChars: builder.Length > 0 ? 1 : 0,
@@ -927,6 +1017,7 @@ public static class TypeResolver
                 return nameRejection;
             }
 
+            budget = accumulated;
             return new RelationshipTraversalResult<string>.Completed(
                 builder.ToString(),
                 consumedNodes);

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -90,7 +90,8 @@ public static class TypeResolver
             handle,
             beforeMaterialize,
             out string? name,
-            out var rejection)
+            out var rejection,
+            enforceCharacterBudget: false)
             ? name
             : throw RejectedName(rejection!);
 
@@ -99,7 +100,8 @@ public static class TypeResolver
         TypeReferenceHandle handle,
         Action<int>? beforeMaterialize,
         [NotNullWhen(true)] out string? name,
-        out RelationshipTraversalRejection? rejection)
+        out RelationshipTraversalRejection? rejection,
+        bool enforceCharacterBudget = true)
     {
         ObserveTypeReferenceName(reader, handle, beforeMaterialize);
         try
@@ -112,7 +114,8 @@ public static class TypeResolver
                     typeRef.Namespace,
                     typeRef.Name,
                     handle,
-                    consumedNodes: 1).TryComplete(out name, out rejection);
+                    consumedNodes: 1,
+                    enforceCharacterBudget).TryComplete(out name, out rejection);
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -182,7 +185,8 @@ public static class TypeResolver
             handle,
             beforeMaterialize,
             out string? name,
-            out var rejection)
+            out var rejection,
+            enforceCharacterBudget: false)
             ? name
             : throw RejectedName(rejection!);
 
@@ -191,7 +195,8 @@ public static class TypeResolver
         TypeDefinitionHandle handle,
         Action<int>? beforeMaterialize,
         [NotNullWhen(true)] out string? name,
-        out RelationshipTraversalRejection? rejection)
+        out RelationshipTraversalRejection? rejection,
+        bool enforceCharacterBudget = true)
     {
         ObserveTypeDefinitionName(reader, handle, beforeMaterialize);
         try
@@ -204,7 +209,8 @@ public static class TypeResolver
                     typeDef.Namespace,
                     typeDef.Name,
                     handle,
-                    consumedNodes: 1).TryComplete(out name, out rejection);
+                    consumedNodes: 1,
+                    enforceCharacterBudget).TryComplete(out name, out rejection);
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -371,7 +377,8 @@ public static class TypeResolver
                     exportedType.Namespace,
                     exportedType.Name,
                     handle,
-                    consumedNodes: 1).GetValueOrThrow();
+                    consumedNodes: 1,
+                    enforceCharacterBudget: false).GetValueOrThrow();
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -422,7 +429,8 @@ public static class TypeResolver
                     typeDef.Namespace,
                     typeDef.Name,
                     default,
-                    consumedNodes: 1).GetValueOrThrow();
+                    consumedNodes: 1,
+                    enforceCharacterBudget: false).GetValueOrThrow();
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -499,7 +507,8 @@ public static class TypeResolver
                     typeRef.Namespace,
                     typeRef.Name,
                     default,
-                    consumedNodes: 1).GetValueOrThrow();
+                    consumedNodes: 1,
+                    enforceCharacterBudget: false).GetValueOrThrow();
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -605,7 +614,8 @@ public static class TypeResolver
                     exportedType.Namespace,
                     exportedType.Name,
                     default,
-                    consumedNodes: 1).GetValueOrThrow();
+                    consumedNodes: 1,
+                    enforceCharacterBudget: false).GetValueOrThrow();
             }
         }
         catch (Exception ex) when (ex is BadImageFormatException or ArgumentOutOfRangeException)
@@ -749,6 +759,7 @@ public static class TypeResolver
                         builder,
                         getSubject(handle),
                         i + 1,
+                        enforceCharacterBudget: true,
                         out var namespaceRejection))
                 {
                     return namespaceRejection;
@@ -762,6 +773,7 @@ public static class TypeResolver
                         builder,
                         getSubject(handle),
                         i + 1,
+                        enforceCharacterBudget: true,
                         out var nameRejection))
                 {
                     return nameRejection;
@@ -816,6 +828,7 @@ public static class TypeResolver
                     builder,
                     subject,
                     completed.ConsumedNodes + 1,
+                    enforceCharacterBudget: true,
                     out var rejection))
             {
                 return rejection;
@@ -840,7 +853,8 @@ public static class TypeResolver
         StringHandle namespaceHandle,
         StringHandle nameHandle,
         EntityHandle subject,
-        int consumedNodes)
+        int consumedNodes,
+        bool enforceCharacterBudget = true)
     {
         try
         {
@@ -854,6 +868,7 @@ public static class TypeResolver
                     builder,
                     subject,
                     consumedNodes,
+                    enforceCharacterBudget,
                     out var namespaceRejection))
             {
                 return namespaceRejection;
@@ -867,6 +882,7 @@ public static class TypeResolver
                     builder,
                     subject,
                     consumedNodes,
+                    enforceCharacterBudget,
                     out var nameRejection))
             {
                 return nameRejection;
@@ -894,6 +910,7 @@ public static class TypeResolver
         StringBuilder builder,
         EntityHandle subject,
         int consumedNodes,
+        bool enforceCharacterBudget,
         out RelationshipTraversalResult<string> rejection)
     {
         if (!budget.TryRead(
@@ -901,16 +918,11 @@ public static class TypeResolver
                 handle,
                 delimiterChars,
                 beforeMaterialize: null,
-                out string value))
+                out string value,
+                enforceCharacterBudget))
         {
             rejection = NameBudget<string>(subject, consumedNodes);
             return false;
-        }
-
-        if (value.Length == 0)
-        {
-            rejection = null!;
-            return true;
         }
 
         if (builder.Length > 0)

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -125,7 +125,7 @@ public static class TypeResolver
             return false;
         }
 
-        return ResolveTypeNameFromReference(reader, handle)
+        return ResolveTypeNameFromReference(reader, handle, enforceCharacterBudget)
             .TryComplete(out name, out rejection);
     }
 
@@ -135,7 +135,8 @@ public static class TypeResolver
     /// </summary>
     public static RelationshipTraversalResult<string> ResolveTypeNameFromReference(
         MetadataReader reader,
-        TypeReferenceHandle handle)
+        TypeReferenceHandle handle,
+        bool enforceCharacterBudget = true)
     {
         try
         {
@@ -147,7 +148,8 @@ public static class TypeResolver
                     typeRef.Namespace,
                     typeRef.Name,
                     handle,
-                    consumedNodes: 1);
+                    consumedNodes: 1,
+                    enforceCharacterBudget);
             }
         }
         catch (BadImageFormatException ex)
@@ -167,7 +169,8 @@ public static class TypeResolver
                 var typeRef = reader.GetTypeReference(current);
                 return (typeRef.Namespace, typeRef.Name);
             },
-            static current => current);
+            static current => current,
+            enforceCharacterBudget);
     }
 
     /// <summary>
@@ -220,7 +223,7 @@ public static class TypeResolver
             return false;
         }
 
-        return ResolveTypeNameFromDefinition(reader, handle)
+        return ResolveTypeNameFromDefinition(reader, handle, enforceCharacterBudget)
             .TryComplete(out name, out rejection);
     }
 
@@ -284,7 +287,8 @@ public static class TypeResolver
     /// </summary>
     public static RelationshipTraversalResult<string> ResolveTypeNameFromDefinition(
         MetadataReader reader,
-        TypeDefinitionHandle handle)
+        TypeDefinitionHandle handle,
+        bool enforceCharacterBudget = true)
     {
         try
         {
@@ -296,7 +300,8 @@ public static class TypeResolver
                     typeDef.Namespace,
                     typeDef.Name,
                     handle,
-                    consumedNodes: 1);
+                    consumedNodes: 1,
+                    enforceCharacterBudget);
             }
         }
         catch (BadImageFormatException ex)
@@ -316,7 +321,8 @@ public static class TypeResolver
                 var typeDef = reader.GetTypeDefinition(current);
                 return (typeDef.Namespace, typeDef.Name);
             },
-            static current => current);
+            static current => current,
+            enforceCharacterBudget);
     }
 
     /// <summary>
@@ -325,7 +331,8 @@ public static class TypeResolver
     /// </summary>
     public static RelationshipTraversalResult<string> ResolveTypeNameFromExportedType(
         MetadataReader reader,
-        ExportedTypeHandle handle)
+        ExportedTypeHandle handle,
+        bool enforceCharacterBudget = true)
     {
         try
         {
@@ -337,7 +344,8 @@ public static class TypeResolver
                     exportedType.Namespace,
                     exportedType.Name,
                     handle,
-                    consumedNodes: 1);
+                    consumedNodes: 1,
+                    enforceCharacterBudget);
             }
         }
         catch (BadImageFormatException ex)
@@ -357,7 +365,8 @@ public static class TypeResolver
                 var exportedType = reader.GetExportedType(current);
                 return (exportedType.Namespace, exportedType.Name);
             },
-            static current => current);
+            static current => current,
+            enforceCharacterBudget);
     }
 
     /// <summary>
@@ -386,7 +395,10 @@ public static class TypeResolver
             return ThrowMalformed(ex, handle);
         }
 
-        return ResolveTypeNameFromExportedType(reader, handle).GetValueOrThrow();
+        return ResolveTypeNameFromExportedType(
+            reader,
+            handle,
+            enforceCharacterBudget: false).GetValueOrThrow();
     }
 
     /// <summary>
@@ -440,9 +452,13 @@ public static class TypeResolver
 
         return AppendLeaf(
             reader,
-            ResolveTypeNameFromDefinition(reader, declaringType),
+            ResolveTypeNameFromDefinition(
+                reader,
+                declaringType,
+                enforceCharacterBudget: false),
             typeDef.Name,
-            declaringType).GetValueOrThrow();
+            declaringType,
+            enforceCharacterBudget: false).GetValueOrThrow();
     }
 
     /// <summary>
@@ -518,9 +534,13 @@ public static class TypeResolver
 
         return AppendLeaf(
             reader,
-            ResolveTypeNameFromReference(reader, (TypeReferenceHandle)resolutionScope),
+            ResolveTypeNameFromReference(
+                reader,
+                (TypeReferenceHandle)resolutionScope,
+                enforceCharacterBudget: false),
             typeRef.Name,
-            resolutionScope).GetValueOrThrow();
+            resolutionScope,
+            enforceCharacterBudget: false).GetValueOrThrow();
     }
 
     /// <summary>
@@ -625,9 +645,13 @@ public static class TypeResolver
 
         return AppendLeaf(
             reader,
-            ResolveTypeNameFromExportedType(reader, (ExportedTypeHandle)implementation),
+            ResolveTypeNameFromExportedType(
+                reader,
+                (ExportedTypeHandle)implementation,
+                enforceCharacterBudget: false),
             exportedType.Name,
-            implementation).GetValueOrThrow();
+            implementation,
+            enforceCharacterBudget: false).GetValueOrThrow();
     }
 
     /// <summary>
@@ -735,7 +759,8 @@ public static class TypeResolver
         MetadataReader reader,
         RelationshipTraversalResult<RelationshipChain<THandle>> traversal,
         Func<THandle, (StringHandle Namespace, StringHandle Name)> getName,
-        Func<THandle, EntityHandle> getSubject)
+        Func<THandle, EntityHandle> getSubject,
+        bool enforceCharacterBudget)
         where THandle : struct
     {
         if (traversal is RelationshipTraversalResult<RelationshipChain<THandle>>.Rejected rejected)
@@ -759,21 +784,22 @@ public static class TypeResolver
                         builder,
                         getSubject(handle),
                         i + 1,
-                        enforceCharacterBudget: true,
+                        enforceCharacterBudget,
                         out var namespaceRejection))
                 {
                     return namespaceRejection;
                 }
 
+                int nameDelimiter = i > 0 || builder.Length > 0 ? 1 : 0;
                 if (!TryAppendNamePart(
                         reader,
                         ref budget,
                         nameHandle,
-                        delimiterChars: 1,
+                        nameDelimiter,
                         builder,
                         getSubject(handle),
                         i + 1,
-                        enforceCharacterBudget: true,
+                        enforceCharacterBudget,
                         out var nameRejection))
                 {
                     return nameRejection;
@@ -798,7 +824,8 @@ public static class TypeResolver
         MetadataReader reader,
         RelationshipTraversalResult<string> declaringName,
         StringHandle leafName,
-        EntityHandle subject)
+        EntityHandle subject,
+        bool enforceCharacterBudget = true)
     {
         if (declaringName is RelationshipTraversalResult<string>.Rejected rejected)
             return Reject<string>(rejected.Rejection);
@@ -828,7 +855,7 @@ public static class TypeResolver
                     builder,
                     subject,
                     completed.ConsumedNodes + 1,
-                    enforceCharacterBudget: true,
+                    enforceCharacterBudget,
                     out var rejection))
             {
                 return rejection;
@@ -878,7 +905,7 @@ public static class TypeResolver
                     reader,
                     ref budget,
                     nameHandle,
-                    delimiterChars: 1,
+                    delimiterChars: builder.Length > 0 ? 1 : 0,
                     builder,
                     subject,
                     consumedNodes,
@@ -925,7 +952,7 @@ public static class TypeResolver
             return false;
         }
 
-        if (builder.Length > 0)
+        if (delimiterChars > 0)
             builder.Append('.');
         builder.Append(value);
         rejection = null!;

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -137,8 +137,16 @@ public static class TypeResolver
     /// </summary>
     public static RelationshipTraversalResult<string> ResolveTypeNameFromReference(
         MetadataReader reader,
+        TypeReferenceHandle handle)
+        => ResolveTypeNameFromReference(
+            reader,
+            handle,
+            enforceCharacterBudget: true);
+
+    public static RelationshipTraversalResult<string> ResolveTypeNameFromReference(
+        MetadataReader reader,
         TypeReferenceHandle handle,
-        bool enforceCharacterBudget = true)
+        bool enforceCharacterBudget)
         => ResolveTypeNameFromReference(
             reader,
             handle,
@@ -305,8 +313,16 @@ public static class TypeResolver
     /// </summary>
     public static RelationshipTraversalResult<string> ResolveTypeNameFromDefinition(
         MetadataReader reader,
+        TypeDefinitionHandle handle)
+        => ResolveTypeNameFromDefinition(
+            reader,
+            handle,
+            enforceCharacterBudget: true);
+
+    public static RelationshipTraversalResult<string> ResolveTypeNameFromDefinition(
+        MetadataReader reader,
         TypeDefinitionHandle handle,
-        bool enforceCharacterBudget = true)
+        bool enforceCharacterBudget)
         => ResolveTypeNameFromDefinition(
             reader,
             handle,
@@ -364,8 +380,16 @@ public static class TypeResolver
     /// </summary>
     public static RelationshipTraversalResult<string> ResolveTypeNameFromExportedType(
         MetadataReader reader,
+        ExportedTypeHandle handle)
+        => ResolveTypeNameFromExportedType(
+            reader,
+            handle,
+            enforceCharacterBudget: true);
+
+    public static RelationshipTraversalResult<string> ResolveTypeNameFromExportedType(
+        MetadataReader reader,
         ExportedTypeHandle handle,
-        bool enforceCharacterBudget = true)
+        bool enforceCharacterBudget)
         => ResolveTypeNameFromExportedType(
             reader,
             handle,
@@ -471,8 +495,20 @@ public static class TypeResolver
         MetadataReader reader,
         TypeSpecificationHandle handle,
         GenericContext? context = null,
-        Action<int>? beforeMaterialize = null,
-        bool enforceCharacterBudget = true)
+        Action<int>? beforeMaterialize = null)
+        => DecodeTypeNameFromSpecification(
+            reader,
+            handle,
+            context,
+            beforeMaterialize,
+            enforceCharacterBudget: true);
+
+    public static SignatureDecodeResult<string> DecodeTypeNameFromSpecification(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        GenericContext? context,
+        Action<int>? beforeMaterialize,
+        bool enforceCharacterBudget)
         => GuardedSignatureDecoder.DecodeTypeSpecification(
             reader,
             handle,

--- a/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
@@ -1,4 +1,7 @@
 using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using ILInspector.Metadata;
 
 namespace ILInspector.Metadata.Tests;
@@ -99,5 +102,278 @@ public class MetadataTypeNameBudgetTests
         Assert.Equal(nested.ToNestedMetadataName(), literalPlus.ToNestedMetadataName());
         Assert.NotEqual(nested.ToEscapedFullName(), literalPlus.ToEscapedFullName());
         Assert.Equal(@"N.Outer\+Inner", literalPlus.ToEscapedFullName());
+    }
+
+    [Fact]
+    public void SharedOversizeHeapString_IsRejectedBeforeAggregateMaterialization()
+    {
+        string oversize = new string('A', 64 * 1024);
+        TypeDefinitionHandle leaf = default;
+        using var image = BuildNestedDefinitions(
+            MetadataSafetyPolicy.MaxRelationshipNodes,
+            oversize,
+            sharedName: true,
+            out leaf);
+
+        _ = MetadataRelationshipTraversal.WalkTypeDefinitionDeclaringChain(
+            image.Reader,
+            leaf);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        var result = TypeResolver.ResolveTypeNameFromDefinition(image.Reader, leaf);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        var rejected = Assert.IsType<RelationshipTraversalResult<string>.Rejected>(result);
+        Assert.Equal(RelationshipTraversalRejectionKind.NameBudget, rejected.Rejection.Kind);
+        Assert.True(
+            allocated < 256 * 1024,
+            $"Allocated {allocated} bytes concatenating a shared {oversize.Length}-character name.");
+    }
+
+    [Fact]
+    public void ManySmallSegments_AreRejectedOnAggregateEncodedLength()
+    {
+        const string small = "SmallSegmentName20!";
+        TypeDefinitionHandle leaf = default;
+        using var image = BuildNestedDefinitions(
+            MetadataSafetyPolicy.MaxRelationshipNodes,
+            small,
+            sharedName: true,
+            out leaf);
+
+        var result = TypeResolver.ResolveTypeNameFromDefinition(image.Reader, leaf);
+
+        var rejected = Assert.IsType<RelationshipTraversalResult<string>.Rejected>(result);
+        Assert.Equal(RelationshipTraversalRejectionKind.NameBudget, rejected.Rejection.Kind);
+        Assert.True(rejected.Rejection.ConsumedNodes < MetadataSafetyPolicy.MaxRelationshipNodes);
+    }
+
+    [Fact]
+    public void LeafAppendOverBudget_IsRejectedBeforeLeafMaterialization()
+    {
+        string declaring = new string('D', MetadataSafetyPolicy.MaxTypeNameCharacters - 8);
+        string leafName = new string('L', 64 * 1024);
+        TypeDefinitionHandle declaringHandle = default;
+        TypeDefinitionHandle leaf = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            declaringHandle = AddTypeDefinition(
+                metadata,
+                TypeAttributes.Public,
+                "",
+                declaring);
+            leaf = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "",
+                leafName);
+            metadata.AddNestedType(leaf, declaringHandle);
+        });
+
+        TypeDefinition leafDef = image.Reader.GetTypeDefinition(leaf);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        var result = TypeResolver.ResolveFullName(image.Reader, leafDef);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        var rejected = Assert.IsType<RelationshipTraversalResult<string>.Rejected>(result);
+        Assert.Equal(RelationshipTraversalRejectionKind.NameBudget, rejected.Rejection.Kind);
+        Assert.True(
+            allocated < 256 * 1024,
+            $"Allocated {allocated} bytes appending a {leafName.Length}-character leaf.");
+    }
+
+    [Fact]
+    public void StructuredRead_ReportsNameBudgetNotMalformed()
+    {
+        string oversize = new string('S', 64 * 1024);
+        TypeDefinitionHandle leaf = default;
+        using var image = BuildNestedDefinitions(2, oversize, sharedName: true, out leaf);
+
+        var result = MetadataTypeDefinitionNameReader.Read(image.Reader, leaf);
+
+        var rejected = Assert.IsType<MetadataTypeDefinitionNameReadResult.Rejected>(result);
+        Assert.Equal(MetadataTypeNameFailureMechanism.Relationship, rejected.Failure.Mechanism);
+        Assert.Equal(
+            RelationshipTraversalRejectionKind.NameBudget,
+            rejected.Failure.RelationshipKind);
+        Assert.NotEqual("MalformedMetadata", rejected.Failure.Kind);
+    }
+
+    [Fact]
+    public void TypeRefAndExportedType_ShareTheSameBudget()
+    {
+        string oversize = new string('R', 64 * 1024);
+        TypeReferenceHandle typeRef = default;
+        ExportedTypeHandle exported = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            AssemblyReferenceHandle assembly = AddAssemblyReference(metadata);
+            typeRef = metadata.AddTypeReference(
+                assembly,
+                default,
+                metadata.GetOrAddString(oversize));
+            exported = metadata.AddExportedType(
+                TypeAttributes.Public,
+                default,
+                metadata.GetOrAddString(oversize),
+                assembly,
+                typeDefinitionId: 0);
+        });
+
+        var typeRefResult = TypeResolver.ResolveTypeNameFromReference(image.Reader, typeRef);
+        var exportedResult = TypeResolver.ResolveTypeNameFromExportedType(image.Reader, exported);
+        var typeRefRead = MetadataTypeDefinitionNameReader.Read(image.Reader, typeRef);
+        var exportedRead = MetadataTypeDefinitionNameReader.Read(image.Reader, exported);
+
+        AssertNameBudget(typeRefResult);
+        AssertNameBudget(exportedResult);
+        Assert.Equal(
+            RelationshipTraversalRejectionKind.NameBudget,
+            Assert.IsType<MetadataTypeDefinitionNameReadResult.Rejected>(typeRefRead)
+                .Failure.RelationshipKind);
+        Assert.Equal(
+            RelationshipTraversalRejectionKind.NameBudget,
+            Assert.IsType<MetadataTypeDefinitionNameReadResult.Rejected>(exportedRead)
+                .Failure.RelationshipKind);
+    }
+
+    [Fact]
+    public void ProjectedVirtualStringLength_IsRecheckedAfterBlobReader()
+    {
+        // SRM may materialize a projected virtual string while answering
+        // GetBlobReader.Length. The same Length-then-decode admission must
+        // still refuse the part and must not treat the materialized value as
+        // success-shaped output.
+        string oversize = new string('V', 64 * 1024);
+        TypeDefinitionHandle handle = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            handle = AddTypeDefinition(metadata, TypeAttributes.Public, "", oversize);
+        });
+
+        TypeDefinition definition = image.Reader.GetTypeDefinition(handle);
+        int blobLength = image.Reader.GetBlobReader(definition.Name).Length;
+        Assert.True(blobLength > MetadataSafetyPolicy.MaxTypeNameCharacters);
+
+        var result = TypeResolver.ResolveTypeNameFromDefinition(image.Reader, handle);
+        AssertNameBudget(result);
+        Assert.Throws<BadImageFormatException>(
+            () => TypeResolver.GetTypeNameFromDefinition(image.Reader, handle));
+    }
+
+    [Fact]
+    public void ExactBudgetNameFromMetadata_IsAccepted()
+    {
+        string name = new string(
+            'E',
+            MetadataSafetyPolicy.MaxTypeNameCharacters - 1);
+        TypeDefinitionHandle handle = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            handle = AddTypeDefinition(metadata, TypeAttributes.Public, "", name);
+        });
+
+        Assert.Equal(
+            name,
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, handle)
+                .GetValueOrThrow());
+        var read = Assert.IsType<MetadataTypeDefinitionNameReadResult.Read>(
+            MetadataTypeDefinitionNameReader.Read(image.Reader, handle));
+        Assert.Equal(name, read.Name.Segments[0]);
+    }
+
+    static void AssertNameBudget(RelationshipTraversalResult<string> result)
+    {
+        var rejected = Assert.IsType<RelationshipTraversalResult<string>.Rejected>(result);
+        Assert.Equal(RelationshipTraversalRejectionKind.NameBudget, rejected.Rejection.Kind);
+    }
+
+    static MetadataImage BuildNestedDefinitions(
+        int depth,
+        string name,
+        bool sharedName,
+        out TypeDefinitionHandle leaf)
+    {
+        TypeDefinitionHandle localLeaf = default;
+        var image = BuildMetadata(metadata =>
+        {
+            StringHandle shared = metadata.GetOrAddString(name);
+            TypeDefinitionHandle parent = default;
+            for (int i = 0; i < depth; i++)
+            {
+                StringHandle nameHandle = sharedName
+                    ? shared
+                    : metadata.GetOrAddString(name);
+                TypeDefinitionHandle current = metadata.AddTypeDefinition(
+                    i == 0 ? TypeAttributes.Public : TypeAttributes.NestedPublic,
+                    default,
+                    nameHandle,
+                    baseType: default,
+                    fieldList: MetadataTokens.FieldDefinitionHandle(1),
+                    methodList: MetadataTokens.MethodDefinitionHandle(1));
+                if (i > 0)
+                    metadata.AddNestedType(current, parent);
+                parent = current;
+                localLeaf = current;
+            }
+        });
+        leaf = localLeaf;
+        return image;
+    }
+
+    static TypeDefinitionHandle AddTypeDefinition(
+        MetadataBuilder metadata,
+        TypeAttributes attributes,
+        string ns,
+        string name)
+        => metadata.AddTypeDefinition(
+            attributes,
+            ns.Length == 0 ? default : metadata.GetOrAddString(ns),
+            metadata.GetOrAddString(name),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+    static AssemblyReferenceHandle AddAssemblyReference(MetadataBuilder metadata)
+        => metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Reference"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+
+    static MetadataImage BuildMetadata(Action<MetadataBuilder> addRows)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        AddTypeDefinition(metadata, default, "", "<Module>");
+        addRows(metadata);
+
+        var rootBuilder = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var image = new BlobBuilder();
+        rootBuilder.Serialize(image, methodBodyStreamRva: 0, mappedFieldDataStreamRva: 0);
+        return new MetadataImage(image.ToImmutableArray());
+    }
+
+    sealed class MetadataImage(ImmutableArray<byte> image) : IDisposable
+    {
+        readonly MetadataReaderProvider provider =
+            MetadataReaderProvider.FromMetadataImage(image);
+
+        public MetadataReader Reader => provider.GetMetadataReader();
+
+        public void Dispose() => provider.Dispose();
     }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
@@ -528,6 +528,92 @@ public class MetadataTypeNameBudgetTests
     }
 
     [Fact]
+    public void TypeSpecDisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap()
+    {
+        string name = new string('A', 5_030);
+        TypeSpecificationHandle specification = default;
+        TypeReferenceHandle typeRef = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            AssemblyReferenceHandle assembly = AddAssemblyReference(metadata);
+            typeRef = metadata.AddTypeReference(
+                assembly,
+                default,
+                metadata.GetOrAddString(name));
+            var signature = new BlobBuilder();
+            signature.WriteByte(0x12);
+            signature.WriteCompressedInteger(
+                MetadataTokens.GetRowNumber(typeRef) << 2 | 1);
+            specification = metadata.AddTypeSpecification(
+                metadata.GetOrAddBlob(signature));
+        });
+
+        Assert.Equal(
+            SignatureDecodeRejectionKind.NameBudget,
+            Assert.IsType<SignatureDecodeResult<string>.Rejected>(
+                    TypeResolver.DecodeTypeNameFromSpecification(
+                        image.Reader,
+                        specification))
+                .Rejection.Kind);
+        Assert.Equal(
+            name,
+            TypeResolver.GetTypeNameFromSpecification(image.Reader, specification));
+        Assert.Equal(
+            name,
+            TypeResolver.GetTypeName(image.Reader, specification));
+        Assert.Equal(
+            name,
+            TypeResolver.GetTypeNameFromReference(image.Reader, typeRef));
+    }
+
+    [Fact]
+    public void EmptyNamespaceExactCharacterBudget_AgreesWithCreate()
+    {
+        int budget = MetadataSafetyPolicy.MaxTypeNameCharacters;
+        string accepted = new string('E', budget - 1);
+        string rejected = new string('E', budget);
+        TypeDefinitionHandle acceptedHandle = default;
+        TypeDefinitionHandle rejectedHandle = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            acceptedHandle = AddTypeDefinition(
+                metadata,
+                TypeAttributes.Public,
+                "",
+                accepted);
+            rejectedHandle = AddTypeDefinition(
+                metadata,
+                TypeAttributes.Public,
+                "",
+                rejected);
+        });
+
+        Assert.Equal(
+            accepted,
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, acceptedHandle)
+                .GetValueOrThrow());
+        Assert.IsType<MetadataTypeDefinitionNameReadResult.Read>(
+            MetadataTypeDefinitionNameReader.Read(image.Reader, acceptedHandle));
+        Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create("", [accepted]));
+
+        AssertNameBudget(
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, rejectedHandle));
+        Assert.Equal(
+            RelationshipTraversalRejectionKind.NameBudget,
+            Assert.IsType<MetadataTypeDefinitionNameReadResult.Rejected>(
+                    MetadataTypeDefinitionNameReader.Read(
+                        image.Reader,
+                        rejectedHandle))
+                .Failure.RelationshipKind);
+        Assert.Equal(
+            MetadataTypeNameRejectionKind.SegmentsTooLong,
+            Assert.IsType<MetadataTypeDefinitionNameResult.Rejected>(
+                    MetadataTypeDefinitionName.Create("", [rejected]))
+                .Rejection.Kind);
+    }
+
+    [Fact]
     public void ExactBudgetNameFromMetadata_IsAccepted()
     {
         string name = new string(

--- a/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
@@ -426,6 +426,108 @@ public class MetadataTypeNameBudgetTests
     }
 
     [Fact]
+    public void NestedDisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap()
+    {
+        string leafName = new string('A', 5_030);
+        TypeDefinitionHandle leaf = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            TypeDefinitionHandle outer = AddTypeDefinition(
+                metadata,
+                TypeAttributes.Public,
+                "Ns",
+                "Outer");
+            leaf = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "",
+                leafName);
+            metadata.AddNestedType(leaf, outer);
+        });
+
+        AssertNameBudget(
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, leaf));
+        Assert.Equal(
+            "Ns.Outer." + leafName,
+            TypeResolver.GetTypeNameFromDefinition(image.Reader, leaf));
+        Assert.Equal(
+            "Ns.Outer." + leafName,
+            TypeResolver.GetFullName(image.Reader, image.Reader.GetTypeDefinition(leaf)));
+    }
+
+    [Fact]
+    public void EmptyLeadingNameSegment_DoesNotCollideWithTopLevelName()
+    {
+        TypeDefinitionHandle nested = default;
+        TypeDefinitionHandle topLevel = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            TypeDefinitionHandle emptyOuter = AddTypeDefinition(
+                metadata,
+                TypeAttributes.Public,
+                "",
+                "");
+            nested = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "",
+                "Inner");
+            metadata.AddNestedType(nested, emptyOuter);
+            topLevel = AddTypeDefinition(
+                metadata,
+                TypeAttributes.Public,
+                "",
+                "Inner");
+        });
+
+        Assert.Equal(
+            ".Inner",
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, nested)
+                .GetValueOrThrow());
+        Assert.Equal(
+            "Inner",
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, topLevel)
+                .GetValueOrThrow());
+    }
+
+    [Fact]
+    public void TypeSpecNameBudget_SurvivesLaterMalformedArgument()
+    {
+        TypeSpecificationHandle specification = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            AssemblyReferenceHandle assembly = AddAssemblyReference(metadata);
+            TypeReferenceHandle oversize = metadata.AddTypeReference(
+                assembly,
+                default,
+                metadata.GetOrAddString(new string('A', 64 * 1024) + "`1"));
+            var signature = new BlobBuilder();
+            signature.WriteByte(0x15);
+            signature.WriteByte(0x12);
+            signature.WriteCompressedInteger(
+                MetadataTokens.GetRowNumber(oversize) << 2 | 1);
+            signature.WriteCompressedInteger(1);
+            signature.WriteByte(0x12);
+            signature.WriteCompressedInteger((0x7FFFF << 2) | 1);
+            specification = metadata.AddTypeSpecification(
+                metadata.GetOrAddBlob(signature));
+        });
+
+        Assert.Equal(
+            SignatureDecodeRejectionKind.NameBudget,
+            Assert.IsType<SignatureDecodeResult<string>.Rejected>(
+                    TypeResolver.DecodeTypeNameFromSpecification(
+                        image.Reader,
+                        specification))
+                .Rejection.Kind);
+        Assert.Equal(
+            nameof(SignatureDecodeRejectionKind.NameBudget),
+            Assert.IsType<MetadataTypeNameResult.Rejected>(
+                    TypeResolver.ResolveTypeName(image.Reader, specification))
+                .Failure.Kind);
+    }
+
+    [Fact]
     public void ExactBudgetNameFromMetadata_IsAccepted()
     {
         string name = new string(

--- a/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Text;
 using ILInspector.Metadata;
 
 namespace ILInspector.Metadata.Tests;
@@ -260,25 +261,168 @@ public class MetadataTypeNameBudgetTests
     [Fact]
     public void ProjectedVirtualStringLength_IsRecheckedAfterBlobReader()
     {
-        // SRM may materialize a projected virtual string while answering
-        // GetBlobReader.Length. The same Length-then-decode admission must
-        // still refuse the part and must not treat the materialized value as
-        // success-shaped output.
-        string oversize = new string('V', 64 * 1024);
+        // A heap #Strings handle is not a WinRT projection. The gate below
+        // uses a real Managed Windows Metadata projection so GetBlobReader
+        // can answer a virtual handle whose Length is larger than the raw
+        // heap entry.
+        const int rawLength = 64 * 1024;
+        TypeDefinitionHandle projectedType = default;
+        StringHandle rawName = default;
+        using var image = BuildMetadata(
+            metadata =>
+            {
+                metadata.AddAssemblyReference(
+                    metadata.GetOrAddString("mscorlib"),
+                    new Version(4, 0, 0, 0),
+                    culture: default,
+                    publicKeyOrToken: default,
+                    flags: default,
+                    hashValue: default);
+                AssemblyReferenceHandle assembly = AddAssemblyReference(metadata);
+                TypeReferenceHandle baseType = metadata.AddTypeReference(
+                    assembly,
+                    metadata.GetOrAddString("Contracts"),
+                    metadata.GetOrAddString("Base"));
+                rawName = metadata.GetOrAddString(new string('V', rawLength));
+                projectedType = metadata.AddTypeDefinition(
+                    TypeAttributes.Public | TypeAttributes.WindowsRuntime,
+                    metadata.GetOrAddString("Samples"),
+                    rawName,
+                    baseType,
+                    MetadataTokens.FieldDefinitionHandle(1),
+                    MetadataTokens.MethodDefinitionHandle(1));
+            },
+            countingDecoder: true,
+            metadataVersion: "WindowsRuntime 1.4;CLR v4.0.30319");
+
+        Assert.Equal(MetadataKind.ManagedWindowsMetadata, image.Reader.MetadataKind);
+        StringHandle projectedName = image.Reader.GetTypeDefinition(projectedType).Name;
+        Assert.NotEqual(rawName, projectedName);
+        int projectedLength = image.Reader.GetBlobReader(projectedName).Length;
+        Assert.True(projectedLength > rawLength);
+
+        AssertNameBudget(
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, projectedType));
+        Assert.DoesNotContain(projectedLength, image.Decoder!.DecodedByteCounts);
+        Assert.Throws<BadImageFormatException>(
+            () => TypeResolver.GetTypeNameFromDefinition(image.Reader, projectedType));
+    }
+
+    [Fact]
+    public void DisplayNameApis_AdmitCharacterOverBudgetNamesUnderTheEncodedCap()
+    {
+        // Queries classifiers need the display spelling of a 5,030-character
+        // logging/AI fixture name; structured Read/Resolve still refuse it.
+        string name = new string('A', 5_030);
         TypeDefinitionHandle handle = default;
         using var image = BuildMetadata(metadata =>
         {
-            handle = AddTypeDefinition(metadata, TypeAttributes.Public, "", oversize);
+            handle = AddTypeDefinition(metadata, TypeAttributes.Public, "", name);
         });
 
-        TypeDefinition definition = image.Reader.GetTypeDefinition(handle);
-        int blobLength = image.Reader.GetBlobReader(definition.Name).Length;
-        Assert.True(blobLength > MetadataSafetyPolicy.MaxTypeNameCharacters);
+        AssertNameBudget(
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, handle));
+        Assert.IsType<MetadataTypeDefinitionNameReadResult.Rejected>(
+            MetadataTypeDefinitionNameReader.Read(image.Reader, handle));
+        Assert.Equal(name, TypeResolver.GetTypeNameFromDefinition(image.Reader, handle));
+        Assert.Equal(
+            name,
+            TypeResolver.GetFullName(image.Reader, image.Reader.GetTypeDefinition(handle)));
+    }
 
-        var result = TypeResolver.ResolveTypeNameFromDefinition(image.Reader, handle);
-        AssertNameBudget(result);
-        Assert.Throws<BadImageFormatException>(
-            () => TypeResolver.GetTypeNameFromDefinition(image.Reader, handle));
+    [Fact]
+    public void TypeSpecNameBudget_IsPreservedAsTypedEvidence()
+    {
+        TypeSpecificationHandle specification = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            AssemblyReferenceHandle assembly = AddAssemblyReference(metadata);
+            TypeReferenceHandle argument = metadata.AddTypeReference(
+                assembly,
+                default,
+                metadata.GetOrAddString(new string('A', 64 * 1024)));
+            var signature = new BlobBuilder();
+            signature.WriteByte(0x12);
+            signature.WriteCompressedInteger(
+                MetadataTokens.GetRowNumber(argument) << 2 | 1);
+            specification = metadata.AddTypeSpecification(
+                metadata.GetOrAddBlob(signature));
+        });
+
+        var rejected = Assert.IsType<MetadataTypeNameResult.Rejected>(
+            TypeResolver.ResolveTypeName(image.Reader, specification));
+        Assert.Equal(
+            nameof(SignatureDecodeRejectionKind.NameBudget),
+            rejected.Failure.Kind);
+        Assert.Equal(
+            SignatureDecodeRejectionKind.NameBudget,
+            rejected.Failure.SignatureKind);
+        Assert.Equal(
+            SignatureDecodeRejectionKind.NameBudget,
+            Assert.IsType<SignatureDecodeResult<string>.Rejected>(
+                    TypeResolver.DecodeTypeNameFromSpecification(
+                        image.Reader,
+                        specification))
+                .Rejection.Kind);
+    }
+
+    [Fact]
+    public void AppendLeaf_PreflightsActualUtf8OfMaterializedDeclaringName()
+    {
+        TypeDefinitionHandle leaf = default;
+        using var image = BuildMetadata(
+            metadata =>
+            {
+                TypeDefinitionHandle declaring = AddTypeDefinition(
+                    metadata,
+                    TypeAttributes.Public,
+                    "",
+                    new string('\u4E00', 4_000));
+                leaf = AddTypeDefinition(
+                    metadata,
+                    TypeAttributes.NestedPublic,
+                    "",
+                    new string('L', 8_000));
+                metadata.AddNestedType(leaf, declaring);
+            },
+            countingDecoder: true);
+
+        AssertNameBudget(
+            TypeResolver.ResolveFullName(
+                image.Reader,
+                image.Reader.GetTypeDefinition(leaf)));
+        Assert.DoesNotContain(8_000, image.Decoder!.DecodedByteCounts);
+    }
+
+    [Fact]
+    public void EmptyNestedNameSegment_KeepsTheDelimiter()
+    {
+        TypeDefinitionHandle leaf = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            TypeDefinitionHandle outer = AddTypeDefinition(
+                metadata,
+                TypeAttributes.Public,
+                "",
+                "Outer");
+            TypeDefinitionHandle empty = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "",
+                "");
+            leaf = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "",
+                "Inner");
+            metadata.AddNestedType(empty, outer);
+            metadata.AddNestedType(leaf, empty);
+        });
+
+        Assert.Equal(
+            "Outer..Inner",
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, leaf)
+                .GetValueOrThrow());
     }
 
     [Fact]
@@ -363,7 +507,10 @@ public class MetadataTypeNameBudgetTests
             flags: default,
             hashValue: default);
 
-    static MetadataImage BuildMetadata(Action<MetadataBuilder> addRows)
+    static MetadataImage BuildMetadata(
+        Action<MetadataBuilder> addRows,
+        bool countingDecoder = false,
+        string? metadataVersion = null)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -382,19 +529,51 @@ public class MetadataTypeNameBudgetTests
         AddTypeDefinition(metadata, default, "", "<Module>");
         addRows(metadata);
 
-        var rootBuilder = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var rootBuilder = new MetadataRootBuilder(
+            metadata,
+            metadataVersion,
+            suppressValidation: true);
         var image = new BlobBuilder();
         rootBuilder.Serialize(image, methodBodyStreamRva: 0, mappedFieldDataStreamRva: 0);
-        return new MetadataImage(image.ToImmutableArray());
+        return new MetadataImage(
+            image.ToImmutableArray(),
+            countingDecoder ? new CountingDecoder() : null);
     }
 
-    sealed class MetadataImage(ImmutableArray<byte> image) : IDisposable
+    sealed class MetadataImage : IDisposable
     {
-        readonly MetadataReaderProvider provider =
-            MetadataReaderProvider.FromMetadataImage(image);
+        readonly MetadataReaderProvider provider;
 
-        public MetadataReader Reader => provider.GetMetadataReader();
+        public MetadataImage(ImmutableArray<byte> image, CountingDecoder? decoder)
+        {
+            provider = MetadataReaderProvider.FromMetadataImage(image);
+            Decoder = decoder;
+            Reader = provider.GetMetadataReader(
+                MetadataReaderOptions.Default,
+                decoder);
+        }
+
+        public MetadataReader Reader { get; }
+        public CountingDecoder? Decoder { get; }
 
         public void Dispose() => provider.Dispose();
+    }
+
+    unsafe sealed class CountingDecoder : MetadataStringDecoder
+    {
+        public CountingDecoder()
+            : base(new UTF8Encoding(
+                encoderShouldEmitUTF8Identifier: false,
+                throwOnInvalidBytes: true))
+        {
+        }
+
+        public List<int> DecodedByteCounts { get; } = [];
+
+        public override string GetString(byte* bytes, int byteCount)
+        {
+            DecodedByteCounts.Add(byteCount);
+            return base.GetString(bytes, byteCount);
+        }
     }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
@@ -614,6 +614,77 @@ public class MetadataTypeNameBudgetTests
     }
 
     [Fact]
+    public void EmptyNamespaceNestedResolveFullName_AgreesWithCreate()
+    {
+        string outer = new string('O', 2_047);
+        string acceptedLeaf = new string('I', 2_047);
+        string rejectedLeaf = new string('I', 2_048);
+        TypeDefinitionHandle accepted = default;
+        TypeDefinitionHandle rejected = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            TypeDefinitionHandle acceptedOuter = AddTypeDefinition(
+                metadata,
+                TypeAttributes.Public,
+                "",
+                outer);
+            accepted = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "",
+                acceptedLeaf);
+            metadata.AddNestedType(accepted, acceptedOuter);
+            TypeDefinitionHandle rejectedOuter = AddTypeDefinition(
+                metadata,
+                TypeAttributes.Public,
+                "",
+                outer);
+            rejected = AddTypeDefinition(
+                metadata,
+                TypeAttributes.NestedPublic,
+                "",
+                rejectedLeaf);
+            metadata.AddNestedType(rejected, rejectedOuter);
+        });
+
+        Assert.Equal(
+            outer + "." + acceptedLeaf,
+            TypeResolver.ResolveFullName(
+                    image.Reader,
+                    image.Reader.GetTypeDefinition(accepted))
+                .GetValueOrThrow());
+        AssertNameBudget(
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, rejected));
+        AssertNameBudget(
+            TypeResolver.ResolveFullName(
+                image.Reader,
+                image.Reader.GetTypeDefinition(rejected)));
+        Assert.Equal(
+            MetadataTypeNameRejectionKind.SegmentsTooLong,
+            Assert.IsType<MetadataTypeDefinitionNameResult.Rejected>(
+                    MetadataTypeDefinitionName.Create("", [outer, rejectedLeaf]))
+                .Rejection.Kind);
+    }
+
+    [Fact]
+    public void NilNameAfterEncodedCap_IsRejectedOnDisplayPath()
+    {
+        string ns = new string(
+            'N',
+            MetadataSafetyPolicy.MaxTypeNameCharacters * 3);
+        TypeDefinitionHandle handle = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            handle = AddTypeDefinition(metadata, TypeAttributes.Public, ns, "");
+        });
+
+        Assert.Throws<BadImageFormatException>(
+            () => TypeResolver.GetTypeNameFromDefinition(image.Reader, handle));
+        AssertNameBudget(
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, handle));
+    }
+
+    [Fact]
     public void ExactBudgetNameFromMetadata_IsAccepted()
     {
         string name = new string(

--- a/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTypeNameBudgetTests.cs
@@ -130,6 +130,27 @@ public class MetadataTypeNameBudgetTests
     }
 
     [Fact]
+    public void CjkNameUnderTheCharacterBudget_IsAccepted()
+    {
+        // 2,000 BMP ideographs are 6,000 UTF-8 bytes and 2,000 UTF-16 units.
+        // Encoded preflight at 4,096 bytes would have rejected a legal name.
+        string name = new string('\u4E00', 2_000);
+        TypeDefinitionHandle handle = default;
+        using var image = BuildMetadata(metadata =>
+        {
+            handle = AddTypeDefinition(metadata, TypeAttributes.Public, "", name);
+        });
+
+        Assert.Equal(
+            name,
+            TypeResolver.ResolveTypeNameFromDefinition(image.Reader, handle)
+                .GetValueOrThrow());
+        var read = Assert.IsType<MetadataTypeDefinitionNameReadResult.Read>(
+            MetadataTypeDefinitionNameReader.Read(image.Reader, handle));
+        Assert.Equal(name, read.Name.Segments[0]);
+    }
+
+    [Fact]
     public void ManySmallSegments_AreRejectedOnAggregateEncodedLength()
     {
         const string small = "SmallSegmentName20!";


### PR DESCRIPTION
Closes #4303.

## Stack

Slice 2 of 2. Parent: #4234 (`fix/wasm-retained-api-text-budget`). Residual: none from #4303.

## Claim

Legacy type-name readers now enforce `MaxTypeNameCharacters` before materializing artifact-authored strings. `FormatChain`, `ReadChain`, and leaf-append preflight UTF-8 storage, recheck decoded length, and return `NameBudget` rather than `Malformed` or a concatenated success-shaped name. Shared #Strings entries and many individually small segments reject before large allocation. Signature walks continue after an over-budget leaf so extraction still charges remaining encoded arguments.

The 4,096-character policy and normal name rendering are unchanged.

## Evidence

On `4ffcd4d80` over parent `18ef03f63`:

- markdownlint on the threat-model doc
- `MetadataTypeNameBudgetTests` 12
- `ApiSurfaceExtractorBoundsTests` 77
- Metadata 1676
- Analysis 866

## Non-action

Does not change the 4,096-character ceiling, Browser retained-text policy, or protobuf/gRPC identity currency (#4302).