### PR TITLE
Declare inspection graph seed admission

### DIFF
--- a/docs/design/inspection-graph-document.md
+++ b/docs/design/inspection-graph-document.md
@@ -499,21 +499,22 @@ Seed admission is also descriptor-owned and separate from endpoint projection.
 A seed may enter a relationship as an exact logical `EdgeEndpoint`, as an
 original `OccurrenceEndpoint` retained behind a rolled-up edge, or through
 typed `OwnedSubjects`. Every admission names semantic source or target;
-incoming traversal never changes that role. Direct edge and occurrence
-admissions must use a subject kind declared by the corresponding descriptor
-endpoint domain. Owned-subject admission authorizes later expansion through
-typed ownership but does not change the logical edge's subject kind or
-direction.
+incoming traversal never changes that role. Callers can query all matching
+admissions without collapsing their entry kind or role. Direct edge and
+occurrence admissions must use a subject kind declared by the corresponding
+descriptor endpoint domain. An owned-subject admission must name a strict
+typed owner of a kind in that semantic endpoint domain; it authorizes later
+expansion but does not change the logical edge's subject kind or direction.
 
-A seeded request must have at least one selected relationship, and every seed
-kind must be admitted by at least one of them. Validation occurs before producer
-execution and fails with the selected relationship ids and typed guidance.
-Induced-set requests carry no seeds and bypass this gate.
+Once relationship selection is request-driven, a seeded request must have at
+least one selected relationship and every seed kind must be admitted by at
+least one of them. That future validation must occur before producer execution
+and fail with the selected relationship ids and typed guidance. Induced-set
+requests carry no seeds and bypass that gate.
 `RelationshipDescriptor_ValidatesAndSnapshotsSeedAdmissions`,
-`DirectAdmissionsMatchDeclaredEndpointDomains`,
-`RelationshipCatalogsDeclareCurrentSeedAdmissions`,
-`SeedAdmissionValidator_RejectsUnsupportedRelationshipSet`, and
-`SeedAdmissionValidator_DoesNotConstrainInducedSets` gate these contracts.
+`AdmissionsMatchDeclaredEndpointDomains`, and
+`RelationshipCatalogsDeclareCurrentSeedAdmissions` gate the implemented
+descriptor contracts.
 
 Each relationship descriptor owns an occurrence-identity projection within one
 document. Projection deduplicates repeated observations by that key before
@@ -1034,8 +1035,8 @@ subject lenses it advances.
    retain equal roles; and request-free workspace projection declares its
    workspace-participant induced-set rule. Relationship descriptors now own
    direct edge, original occurrence, and owned-subject seed admission, and
-   seeded Integration requests validate the relationship catalog before
-   producer execution. Admission-driven producer selection,
+   preserve each admission's semantic role for later request planning.
+   Admission-driven request validation, producer selection,
    connecting-neighborhood construction, explicit-subject induced sets, and
    presentation lowering remain.
 

--- a/docs/design/inspection-graph-document.md
+++ b/docs/design/inspection-graph-document.md
@@ -398,6 +398,7 @@ A relationship descriptor defines:
 - semantic direction and endpoint roles;
 - admitted edge source and target subject kinds;
 - admitted original-occurrence source and target subject kinds;
+- admitted seed subject kinds, entry mechanisms, and semantic endpoint roles;
 - the producer that owns the relation;
 - whether the relation is observed, derived, or synthetic;
 - the occurrence evidence contract;
@@ -493,6 +494,26 @@ while admitting only member-to-member original occurrences. The projection
 rule receives the typed occurrence, including its producer evidence, and the
 semantically directed selected endpoint. It does not recover package ownership
 from labels or capture an unvalidated per-document side map.
+
+Seed admission is also descriptor-owned and separate from endpoint projection.
+A seed may enter a relationship as an exact logical `EdgeEndpoint`, as an
+original `OccurrenceEndpoint` retained behind a rolled-up edge, or through
+typed `OwnedSubjects`. Every admission names semantic source or target;
+incoming traversal never changes that role. Direct edge and occurrence
+admissions must use a subject kind declared by the corresponding descriptor
+endpoint domain. Owned-subject admission authorizes later expansion through
+typed ownership but does not change the logical edge's subject kind or
+direction.
+
+A seeded request must have at least one selected relationship, and every seed
+kind must be admitted by at least one of them. Validation occurs before producer
+execution and fails with the selected relationship ids and typed guidance.
+Induced-set requests carry no seeds and bypass this gate.
+`RelationshipDescriptor_ValidatesAndSnapshotsSeedAdmissions`,
+`DirectAdmissionsMatchDeclaredEndpointDomains`,
+`RelationshipCatalogsDeclareCurrentSeedAdmissions`,
+`SeedAdmissionValidator_RejectsUnsupportedRelationshipSet`, and
+`SeedAdmissionValidator_DoesNotConstrainInducedSets` gate these contracts.
 
 Each relationship descriptor owns an occurrence-identity projection within one
 document. Projection deduplicates repeated observations by that key before
@@ -1011,7 +1032,10 @@ subject lenses it advances.
    `InspectionGraphPackageBoundary` and `InspectionGraphIntegrationsQuery`
    bind type, assembly, and package subjects to exact nodes or groups; peers
    retain equal roles; and request-free workspace projection declares its
-   workspace-participant induced-set rule. Producer admission,
+   workspace-participant induced-set rule. Relationship descriptors now own
+   direct edge, original occurrence, and owned-subject seed admission, and
+   seeded Integration requests validate the relationship catalog before
+   producer execution. Admission-driven producer selection,
    connecting-neighborhood construction, explicit-subject induced sets, and
    presentation lowering remain.
 

--- a/docs/design/inspection-graph-modes.md
+++ b/docs/design/inspection-graph-modes.md
@@ -16,10 +16,11 @@ also binds mixed peer seeds without selecting a primary and declares its
 request-free workspace projection as an induced set over workspace
 participants.
 
-This first executable mode slice binds request intent to graph subjects without
-changing producer demand or topology. Request-driven neighborhood construction,
-relationship-specific admission, traversal bounds, induced explicit-subject
-sets, and command/presentation surfaces remain design targets.
+The current executable mode slices bind request intent to graph subjects and
+make seed admission a descriptor-owned relationship contract without changing
+producer demand or topology. Request-driven relationship selection and
+neighborhood construction, traversal bounds, induced explicit-subject sets, and
+command/presentation surfaces remain design targets.
 
 `CallAdapter_PreservesTypedTopologyAndDisclosesEvidenceGap`,
 `PackageSeed_BindsToNodeOrGroupSelectedByLens`,
@@ -27,8 +28,11 @@ sets, and command/presentation surfaces remain design targets.
 `Execute_BindsAssemblySeedToExactNode`,
 `Execute_BindsPackageSeedToDetailedLensGroup`,
 `Execute_BindsPeerSeedsWithoutChoosingPrimary`, and
-`Execute_DefaultsToWorkspaceInducedSetWithoutSeeds` gate the implemented
-contract.
+`Execute_DefaultsToWorkspaceInducedSetWithoutSeeds` gate mode binding.
+`RelationshipDescriptor_ValidatesAndSnapshotsSeedAdmissions`,
+`RelationshipCatalogsDeclareCurrentSeedAdmissions`, and
+`SeedAdmissionValidator_RejectsUnsupportedRelationshipSet` gate descriptor
+admission and request validation.
 
 | Mode | Focus | Input | Primary question |
 | --- | --- | --- | --- |
@@ -168,16 +172,23 @@ single-seed default.
 
 Mode does not impose one expansion algorithm on every producer:
 
-| Relationship | Example seed admission |
+| Current relationship | Declared seed admission |
 | --- | --- |
-| Call | Member directly; type/assembly/package through typed owned-member admission |
-| Metadata reference | Member/type/assembly directly, with descriptor-approved roll-up |
-| Extension or implementation | Type/member directly; package through owned API evidence |
-| Integration or opportunity | API/type/package according to producer-issued subjects |
-| Dependency or ownership | Assembly/package directly |
+| `call` | Member at either logical edge endpoint |
+| `api.extension`, `integration.observed` | Member at the logical source, type at the logical target, assembly/package through source-owned subjects |
+| `metadata.reference` | Assembly at either logical endpoint, package through source- or target-owned subjects |
+| `integration.opportunity` | Assembly at the logical source, type at the original occurrence source or logical target, package through source-owned subjects |
 
-Unsupported combinations fail discovery or execution with guidance. They do
-not drop the seed, relabel it, or substitute a different relationship.
+`EdgeEndpoint` and `OccurrenceEndpoint` admissions must name a subject kind in
+the descriptor's corresponding semantic source or target domain.
+`OwnedSubjects` declares that the seed may expand through subjects it owns; it
+does not fabricate an edge at the owner's subject kind. Unsupported selected
+relationship sets fail before producer execution with guidance. They do not
+drop the seed, relabel it, or substitute a different relationship. Induced-set
+requests have no seeds and therefore do not require seed admission.
+
+The current slice declares and validates these capabilities. It does not yet
+use them to select producers or construct a bounded neighborhood.
 
 ## Shared contract
 
@@ -212,9 +223,11 @@ metadata-reference, and opportunity adapters; no mode turns those into calls.
 1. **Implemented:** preserve and name the current member-seeded call behavior.
 2. **Implemented:** add generic typed seed roles to the inspection-graph mode
    request and document.
-3. **Partially implemented:** bind type, assembly, and realized-package seeds
-   to existing Integration/package graph subjects. Descriptor-owned producer
-   admission remains.
+3. **Implemented:** bind type, assembly, and realized-package seeds to existing
+   Integration/package graph subjects, declare direct endpoint and
+   owned-subject admission on each relationship descriptor, and reject a
+   selected relationship set that admits none of a request's seeds.
+   Admission-driven producer selection and neighborhood construction remain.
 4. **Partially implemented:** bind peer-seed requests without choosing a hero
    node. Connecting-neighborhood construction remains.
 5. **Partially implemented:** declare workspace-participant and

--- a/docs/design/inspection-graph-modes.md
+++ b/docs/design/inspection-graph-modes.md
@@ -18,9 +18,9 @@ participants.
 
 The current executable mode slices bind request intent to graph subjects and
 make seed admission a descriptor-owned relationship contract without changing
-producer demand or topology. Request-driven relationship selection and
-neighborhood construction, traversal bounds, induced explicit-subject sets, and
-command/presentation surfaces remain design targets.
+producer demand or topology. Request-driven relationship selection, admission
+validation and neighborhood construction, traversal bounds, induced
+explicit-subject sets, and command/presentation surfaces remain design targets.
 
 `CallAdapter_PreservesTypedTopologyAndDisclosesEvidenceGap`,
 `PackageSeed_BindsToNodeOrGroupSelectedByLens`,
@@ -30,9 +30,8 @@ command/presentation surfaces remain design targets.
 `Execute_BindsPeerSeedsWithoutChoosingPrimary`, and
 `Execute_DefaultsToWorkspaceInducedSetWithoutSeeds` gate mode binding.
 `RelationshipDescriptor_ValidatesAndSnapshotsSeedAdmissions`,
-`RelationshipCatalogsDeclareCurrentSeedAdmissions`, and
-`SeedAdmissionValidator_RejectsUnsupportedRelationshipSet` gate descriptor
-admission and request validation.
+`AdmissionsMatchDeclaredEndpointDomains`, and
+`RelationshipCatalogsDeclareCurrentSeedAdmissions` gate descriptor admission.
 
 | Mode | Focus | Input | Primary question |
 | --- | --- | --- | --- |
@@ -181,14 +180,16 @@ Mode does not impose one expansion algorithm on every producer:
 
 `EdgeEndpoint` and `OccurrenceEndpoint` admissions must name a subject kind in
 the descriptor's corresponding semantic source or target domain.
-`OwnedSubjects` declares that the seed may expand through subjects it owns; it
-does not fabricate an edge at the owner's subject kind. Unsupported selected
-relationship sets fail before producer execution with guidance. They do not
-drop the seed, relabel it, or substitute a different relationship. Induced-set
-requests have no seeds and therefore do not require seed admission.
+`OwnedSubjects` must name a strict typed owner of at least one subject kind in
+that semantic endpoint domain; it does not fabricate an edge at the owner's
+subject kind.
 
-The current slice declares and validates these capabilities. It does not yet
-use them to select producers or construct a bounded neighborhood.
+The current slice declares and validates these descriptor capabilities. Once
+request-driven relationship selection lands, unsupported combinations must
+fail before producer execution with guidance rather than dropping or relabeling
+the seed. Induced-set requests have no seeds and therefore need no seed
+admission. This slice does not yet use admission to select producers or
+construct a bounded neighborhood.
 
 ## Shared contract
 
@@ -225,9 +226,9 @@ metadata-reference, and opportunity adapters; no mode turns those into calls.
    request and document.
 3. **Implemented:** bind type, assembly, and realized-package seeds to existing
    Integration/package graph subjects, declare direct endpoint and
-   owned-subject admission on each relationship descriptor, and reject a
-   selected relationship set that admits none of a request's seeds.
-   Admission-driven producer selection and neighborhood construction remain.
+   strict typed owned-subject admission on each relationship descriptor.
+   Admission-driven request validation, producer selection, and neighborhood
+   construction remain.
 4. **Partially implemented:** bind peer-seed requests without choosing a hero
    node. Connecting-neighborhood construction remains.
 5. **Partially implemented:** declare workspace-participant and

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -453,13 +453,11 @@ workspace-participant induced set; type and assembly seeds bind exact nodes,
 package seeds bind exact package groups in the detailed Integration lens, and
 mixed peers remain equal. Mode binding happens after the same deterministic
 producer plan, so it does not change occurrence identity or semantic edge
-direction. Before that plan runs, each seeded request validates that the
-Integration relationship catalog admits every seed kind as a logical edge
-endpoint, an original occurrence endpoint, or through owned subjects.
-Unsupported combinations fail with typed guidance rather than running
-producers and returning a success-shaped empty graph. Induced-set requests have
-no seed-admission requirement. Admission-driven producer selection remains
-deferred, so this validation preserves the deterministic sequential plan.
+direction. Integration relationship descriptors now declare whether a seed may
+enter as a logical edge endpoint, an original occurrence endpoint, or through
+strict typed ownership. Request-driven relationship selection and admission
+validation remain deferred, so these declarations do not change the
+deterministic sequential plan.
 `Execute_DefaultsToWorkspaceInducedSetWithoutSeeds`,
 `Execute_BindsTypeSeedToExactNode`,
 `Execute_BindsAssemblySeedToExactNode`,
@@ -467,9 +465,9 @@ deferred, so this validation preserves the deterministic sequential plan.
 `Execute_BindsPeerSeedsWithoutChoosingPrimary`, and
 `PackageAndTypeModesShareSemanticIntegrationOccurrences` gate those claims.
 `RelationshipCatalogsDeclareCurrentSeedAdmissions`,
-`SeedAdmissionValidator_RejectsUnsupportedRelationshipSet`, and
-`SeedAdmissionValidator_DoesNotConstrainInducedSets` gate catalog admission and
-its seeded/induced boundary.
+`RelationshipDescriptor_ValidatesAndSnapshotsSeedAdmissions`, and
+`AdmissionsMatchDeclaredEndpointDomains` gate the catalog declarations and
+their endpoint constraints.
 `GroupedIntegrationsFailure_IsVisibleAndDeduplicated` gates diagnostic
 composition and the shared nonzero completion status used after Markdown,
 count, tabular, or JSON output.

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -453,13 +453,23 @@ workspace-participant induced set; type and assembly seeds bind exact nodes,
 package seeds bind exact package groups in the detailed Integration lens, and
 mixed peers remain equal. Mode binding happens after the same deterministic
 producer plan, so it does not change occurrence identity or semantic edge
-direction.
+direction. Before that plan runs, each seeded request validates that the
+Integration relationship catalog admits every seed kind as a logical edge
+endpoint, an original occurrence endpoint, or through owned subjects.
+Unsupported combinations fail with typed guidance rather than running
+producers and returning a success-shaped empty graph. Induced-set requests have
+no seed-admission requirement. Admission-driven producer selection remains
+deferred, so this validation preserves the deterministic sequential plan.
 `Execute_DefaultsToWorkspaceInducedSetWithoutSeeds`,
 `Execute_BindsTypeSeedToExactNode`,
 `Execute_BindsAssemblySeedToExactNode`,
 `Execute_BindsPackageSeedToDetailedLensGroup`,
 `Execute_BindsPeerSeedsWithoutChoosingPrimary`, and
 `PackageAndTypeModesShareSemanticIntegrationOccurrences` gate those claims.
+`RelationshipCatalogsDeclareCurrentSeedAdmissions`,
+`SeedAdmissionValidator_RejectsUnsupportedRelationshipSet`, and
+`SeedAdmissionValidator_DoesNotConstrainInducedSets` gate catalog admission and
+its seeded/induced boundary.
 `GroupedIntegrationsFailure_IsVisibleAndDeduplicated` gates diagnostic
 composition and the shared nonzero completion status used after Markdown,
 count, tabular, or JSON output.

--- a/src/DotnetInspector.Queries.Tests/InspectionGraphDocumentTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionGraphDocumentTests.cs
@@ -582,9 +582,11 @@ public sealed class InspectionGraphDocumentTests
         admissions.Clear();
 
         Assert.Equal(2, descriptor.SeedAdmissions.Length);
-        Assert.True(descriptor.AdmitsSeed(
-            InspectionGraphSubjectKind.Member));
-        Assert.False(descriptor.AdmitsSeed(
+        Assert.Equal(
+            descriptor.SeedAdmissions,
+            descriptor.GetSeedAdmissions(
+                InspectionGraphSubjectKind.Member));
+        Assert.Empty(descriptor.GetSeedAdmissions(
             InspectionGraphSubjectKind.Package));
         Assert.Throws<ArgumentException>(
             () => Descriptor([]));
@@ -613,29 +615,6 @@ public sealed class InspectionGraphDocumentTests
                     MemberAdmission(InspectionGraphEndpointRole.Source),
                     MemberAdmission(InspectionGraphEndpointRole.Source),
                 ]));
-    }
-
-    [Fact]
-    public void SeedAdmissionValidator_RejectsUnsupportedRelationshipSet()
-    {
-        InspectionGraphSubject package =
-            InspectionGraphSubject.ForRealizedPackage(
-                new RealizedMemberCoordinate.Package(
-                    "sample.package",
-                    "1.0.0",
-                    "feed",
-                    "net11.0",
-                    null));
-
-        InspectionQueryException exception = Assert.Throws<
-            InspectionQueryException>(
-                () => InspectionGraphSeedAdmissionValidator.Validate(
-                    InspectionGraphModeRequest.SingleSeed(package),
-                    [CallGraphInspectionGraphCatalog.Call]));
-
-        Assert.Contains("package seed", exception.Message);
-        Assert.Contains("call", exception.Message);
-        Assert.Contains("owned subjects", exception.Message);
     }
 
     [Fact]
@@ -719,16 +698,7 @@ public sealed class InspectionGraphDocumentTests
     }
 
     [Fact]
-    public void SeedAdmissionValidator_DoesNotConstrainInducedSets()
-    {
-        InspectionGraphSeedAdmissionValidator.Validate(
-            InspectionGraphModeRequest.InducedSet(
-                InspectionGraphInducedSetRule.WorkspaceParticipants),
-            []);
-    }
-
-    [Fact]
-    public void DirectAdmissionsMatchDeclaredEndpointDomains()
+    public void AdmissionsMatchDeclaredEndpointDomains()
     {
         Assert.Throws<ArgumentException>(
             () => new InspectionGraphRelationshipDescriptor(
@@ -762,6 +732,42 @@ public sealed class InspectionGraphDocumentTests
                         InspectionGraphSubjectKind.Member,
                         InspectionGraphSeedAdmissionKind.EdgeEndpoint,
                         InspectionGraphEndpointRole.Target),
+                ],
+                InspectionGraphEndpointProjection.Exact,
+                new TestOccurrenceIdentityProjection(),
+                [TestEvidence]));
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphRelationshipDescriptor(
+                "test.invalid-owned-endpoint",
+                InspectionGraphOwner.Queries,
+                InspectionGraphRelationshipSemantics.Observed,
+                [InspectionGraphSubjectKind.Assembly],
+                [InspectionGraphSubjectKind.Assembly],
+                [InspectionGraphSubjectKind.Assembly],
+                [InspectionGraphSubjectKind.Assembly],
+                [
+                    Admission(
+                        InspectionGraphSubjectKind.Member,
+                        InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                        InspectionGraphEndpointRole.Source),
+                ],
+                InspectionGraphEndpointProjection.Exact,
+                new TestOccurrenceIdentityProjection(),
+                [TestEvidence]));
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphRelationshipDescriptor(
+                "test.self-owned-endpoint",
+                InspectionGraphOwner.Queries,
+                InspectionGraphRelationshipSemantics.Observed,
+                [InspectionGraphSubjectKind.Assembly],
+                [InspectionGraphSubjectKind.Assembly],
+                [InspectionGraphSubjectKind.Assembly],
+                [InspectionGraphSubjectKind.Assembly],
+                [
+                    Admission(
+                        InspectionGraphSubjectKind.Assembly,
+                        InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                        InspectionGraphEndpointRole.Source),
                 ],
                 InspectionGraphEndpointProjection.Exact,
                 new TestOccurrenceIdentityProjection(),

--- a/src/DotnetInspector.Queries.Tests/InspectionGraphDocumentTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionGraphDocumentTests.cs
@@ -22,6 +22,10 @@ public sealed class InspectionGraphDocumentTests
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Member],
+            [
+                MemberAdmission(InspectionGraphEndpointRole.Source),
+                MemberAdmission(InspectionGraphEndpointRole.Target),
+            ],
             InspectionGraphEndpointProjection.Exact,
             new TestOccurrenceIdentityProjection(),
             [TestEvidence]);
@@ -550,6 +554,221 @@ public sealed class InspectionGraphDocumentTests
     }
 
     [Fact]
+    public void RelationshipDescriptor_ValidatesAndSnapshotsSeedAdmissions()
+    {
+        static InspectionGraphRelationshipDescriptor Descriptor(
+            IEnumerable<InspectionGraphSeedAdmission> admissions) =>
+            new(
+                "test.seed-admission",
+                InspectionGraphOwner.Queries,
+                InspectionGraphRelationshipSemantics.Observed,
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Member],
+                admissions,
+                InspectionGraphEndpointProjection.Exact,
+                new TestOccurrenceIdentityProjection(),
+                [TestEvidence]);
+
+        var admissions = new List<InspectionGraphSeedAdmission>
+        {
+            MemberAdmission(InspectionGraphEndpointRole.Source),
+            MemberAdmission(InspectionGraphEndpointRole.Target),
+        };
+        InspectionGraphRelationshipDescriptor descriptor =
+            Descriptor(admissions);
+
+        admissions.Clear();
+
+        Assert.Equal(2, descriptor.SeedAdmissions.Length);
+        Assert.True(descriptor.AdmitsSeed(
+            InspectionGraphSubjectKind.Member));
+        Assert.False(descriptor.AdmitsSeed(
+            InspectionGraphSubjectKind.Package));
+        Assert.Throws<ArgumentException>(
+            () => Descriptor([]));
+        Assert.Throws<ArgumentException>(
+            () => Descriptor(
+                default(ImmutableArray<InspectionGraphSeedAdmission>)));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Descriptor(
+                [
+                    Admission(
+                        InspectionGraphSubjectKind.Member,
+                        (InspectionGraphSeedAdmissionKind)42,
+                        InspectionGraphEndpointRole.Source),
+                ]));
+        Assert.Throws<ArgumentException>(
+            () => Descriptor(
+                [
+                    Admission(
+                        InspectionGraphSubjectKind.Package,
+                        InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                        InspectionGraphEndpointRole.Source),
+                ]));
+        Assert.Throws<ArgumentException>(
+            () => Descriptor(
+                [
+                    MemberAdmission(InspectionGraphEndpointRole.Source),
+                    MemberAdmission(InspectionGraphEndpointRole.Source),
+                ]));
+    }
+
+    [Fact]
+    public void SeedAdmissionValidator_RejectsUnsupportedRelationshipSet()
+    {
+        InspectionGraphSubject package =
+            InspectionGraphSubject.ForRealizedPackage(
+                new RealizedMemberCoordinate.Package(
+                    "sample.package",
+                    "1.0.0",
+                    "feed",
+                    "net11.0",
+                    null));
+
+        InspectionQueryException exception = Assert.Throws<
+            InspectionQueryException>(
+                () => InspectionGraphSeedAdmissionValidator.Validate(
+                    InspectionGraphModeRequest.SingleSeed(package),
+                    [CallGraphInspectionGraphCatalog.Call]));
+
+        Assert.Contains("package seed", exception.Message);
+        Assert.Contains("call", exception.Message);
+        Assert.Contains("owned subjects", exception.Message);
+    }
+
+    [Fact]
+    public void RelationshipCatalogsDeclareCurrentSeedAdmissions()
+    {
+        InspectionGraphSeedAdmission[] outwardIntegrationAdmissions =
+        [
+            Admission(
+                InspectionGraphSubjectKind.Member,
+                InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                InspectionGraphEndpointRole.Source),
+            Admission(
+                InspectionGraphSubjectKind.Type,
+                InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                InspectionGraphEndpointRole.Target),
+            Admission(
+                InspectionGraphSubjectKind.Assembly,
+                InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                InspectionGraphEndpointRole.Source),
+            Admission(
+                InspectionGraphSubjectKind.Package,
+                InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                InspectionGraphEndpointRole.Source),
+        ];
+
+        Assert.Equal(
+            [
+                MemberAdmission(InspectionGraphEndpointRole.Source),
+                MemberAdmission(InspectionGraphEndpointRole.Target),
+            ],
+            CallGraphInspectionGraphCatalog.Call.SeedAdmissions);
+        Assert.Equal(
+            outwardIntegrationAdmissions,
+            InspectionGraphIntegrationsCatalog.Extension.SeedAdmissions);
+        Assert.Equal(
+            outwardIntegrationAdmissions,
+            InspectionGraphIntegrationsCatalog
+                .IntegrationObserved.SeedAdmissions);
+        Assert.Equal(
+            [
+                Admission(
+                    InspectionGraphSubjectKind.Assembly,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                Admission(
+                    InspectionGraphSubjectKind.Assembly,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Target),
+                Admission(
+                    InspectionGraphSubjectKind.Package,
+                    InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                    InspectionGraphEndpointRole.Source),
+                Admission(
+                    InspectionGraphSubjectKind.Package,
+                    InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                    InspectionGraphEndpointRole.Target),
+            ],
+            InspectionGraphIntegrationsCatalog
+                .MetadataReference.SeedAdmissions);
+        Assert.Equal(
+            [
+                Admission(
+                    InspectionGraphSubjectKind.Assembly,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                Admission(
+                    InspectionGraphSubjectKind.Type,
+                    InspectionGraphSeedAdmissionKind.OccurrenceEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                Admission(
+                    InspectionGraphSubjectKind.Type,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Target),
+                Admission(
+                    InspectionGraphSubjectKind.Package,
+                    InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                    InspectionGraphEndpointRole.Source),
+            ],
+            InspectionGraphIntegrationsCatalog
+                .IntegrationOpportunity.SeedAdmissions);
+    }
+
+    [Fact]
+    public void SeedAdmissionValidator_DoesNotConstrainInducedSets()
+    {
+        InspectionGraphSeedAdmissionValidator.Validate(
+            InspectionGraphModeRequest.InducedSet(
+                InspectionGraphInducedSetRule.WorkspaceParticipants),
+            []);
+    }
+
+    [Fact]
+    public void DirectAdmissionsMatchDeclaredEndpointDomains()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphRelationshipDescriptor(
+                "test.wrong-occurrence-endpoint",
+                InspectionGraphOwner.Queries,
+                InspectionGraphRelationshipSemantics.Observed,
+                [InspectionGraphSubjectKind.Assembly],
+                [InspectionGraphSubjectKind.Type],
+                [InspectionGraphSubjectKind.Type],
+                [InspectionGraphSubjectKind.Type],
+                [
+                    Admission(
+                        InspectionGraphSubjectKind.Assembly,
+                        InspectionGraphSeedAdmissionKind.OccurrenceEndpoint,
+                        InspectionGraphEndpointRole.Source),
+                ],
+                InspectionGraphEndpointProjection.Exact,
+                new TestOccurrenceIdentityProjection(),
+                [TestEvidence]));
+        Assert.Throws<ArgumentException>(
+            () => new InspectionGraphRelationshipDescriptor(
+                "test.wrong-edge-role",
+                InspectionGraphOwner.Queries,
+                InspectionGraphRelationshipSemantics.Observed,
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Type],
+                [InspectionGraphSubjectKind.Member],
+                [InspectionGraphSubjectKind.Type],
+                [
+                    Admission(
+                        InspectionGraphSubjectKind.Member,
+                        InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                        InspectionGraphEndpointRole.Target),
+                ],
+                InspectionGraphEndpointProjection.Exact,
+                new TestOccurrenceIdentityProjection(),
+                [TestEvidence]));
+    }
+
+    [Fact]
     public void Document_RequiresModeRequestAndSeedBindingsToAgree()
     {
         InspectionGraphSubject first = Subject("First");
@@ -721,6 +940,10 @@ public sealed class InspectionGraphDocumentTests
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Member],
+            [
+                MemberAdmission(InspectionGraphEndpointRole.Source),
+                MemberAdmission(InspectionGraphEndpointRole.Target),
+            ],
             InspectionGraphEndpointProjection.Exact,
             InspectionGraphOccurrenceIdentityProjection
                 .SyntheticNoOccurrence,
@@ -815,6 +1038,24 @@ public sealed class InspectionGraphDocumentTests
             [InspectionGraphSubjectKind.Package],
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Member],
+            [
+                new(
+                    InspectionGraphSubjectKind.Type,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Package,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Target),
+                new(
+                    InspectionGraphSubjectKind.Member,
+                    InspectionGraphSeedAdmissionKind.OccurrenceEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Member,
+                    InspectionGraphSeedAdmissionKind.OccurrenceEndpoint,
+                    InspectionGraphEndpointRole.Target),
+            ],
             new TestRollupEndpointProjection(),
             new TestOccurrenceIdentityProjection(),
             [TestEvidence]);
@@ -926,6 +1167,10 @@ public sealed class InspectionGraphDocumentTests
                 [InspectionGraphSubjectKind.Member],
                 [InspectionGraphSubjectKind.Member],
                 [InspectionGraphSubjectKind.Member],
+                [
+                    MemberAdmission(InspectionGraphEndpointRole.Source),
+                    MemberAdmission(InspectionGraphEndpointRole.Target),
+                ],
                 InspectionGraphEndpointProjection.Exact,
                 new TestOccurrenceIdentityProjection(),
                 [TestEvidence]);
@@ -968,6 +1213,10 @@ public sealed class InspectionGraphDocumentTests
                 [InspectionGraphSubjectKind.Member],
                 [InspectionGraphSubjectKind.Member],
                 [InspectionGraphSubjectKind.Member],
+                [
+                    MemberAdmission(InspectionGraphEndpointRole.Source),
+                    MemberAdmission(InspectionGraphEndpointRole.Target),
+                ],
                 InspectionGraphEndpointProjection.Exact,
                 new TestOccurrenceIdentityProjection(),
                 [TestEvidence]);
@@ -1241,6 +1490,10 @@ public sealed class InspectionGraphDocumentTests
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Member],
+            [
+                MemberAdmission(InspectionGraphEndpointRole.Source),
+                MemberAdmission(InspectionGraphEndpointRole.Target),
+            ],
             InspectionGraphEndpointProjection.Exact,
             InspectionGraphOccurrenceIdentityProjection
                 .SyntheticNoOccurrence,
@@ -1285,6 +1538,19 @@ public sealed class InspectionGraphDocumentTests
             [],
             [],
             []);
+
+    static InspectionGraphSeedAdmission Admission(
+        InspectionGraphSubjectKind subjectKind,
+        InspectionGraphSeedAdmissionKind kind,
+        InspectionGraphEndpointRole role) =>
+        new(subjectKind, kind, role);
+
+    static InspectionGraphSeedAdmission MemberAdmission(
+        InspectionGraphEndpointRole role) =>
+        Admission(
+            InspectionGraphSubjectKind.Member,
+            InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+            role);
 
     sealed record TestOccurrenceEvidence(int Identity)
         : IInspectionGraphOccurrenceEvidence

--- a/src/DotnetInspector.Queries/CallGraphInspectionGraphAdapter.cs
+++ b/src/DotnetInspector.Queries/CallGraphInspectionGraphAdapter.cs
@@ -25,6 +25,16 @@ public static class CallGraphInspectionGraphCatalog
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Member],
+            [
+                new(
+                    InspectionGraphSubjectKind.Member,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Member,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Target),
+            ],
             InspectionGraphEndpointProjection.Exact,
             CallOccurrenceIdentity,
             [CallSiteEvidence, LogicalEdgeEvidence]);

--- a/src/DotnetInspector.Queries/InspectionGraphDocument.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphDocument.cs
@@ -434,6 +434,24 @@ public abstract class InspectionGraphOccurrenceIdentityProjection
 }
 
 /// <summary>
+/// The ways a typed seed may enter a directed relationship.
+/// </summary>
+public enum InspectionGraphSeedAdmissionKind
+{
+    EdgeEndpoint,
+    OccurrenceEndpoint,
+    OwnedSubjects,
+}
+
+/// <summary>
+/// How one seed subject kind enters a relationship in semantic direction.
+/// </summary>
+public sealed record InspectionGraphSeedAdmission(
+    InspectionGraphSubjectKind SubjectKind,
+    InspectionGraphSeedAdmissionKind Kind,
+    InspectionGraphEndpointRole Role);
+
+/// <summary>
 /// The L1 semantic contract for one directed relationship family.
 /// </summary>
 public sealed class InspectionGraphRelationshipDescriptor
@@ -446,6 +464,7 @@ public sealed class InspectionGraphRelationshipDescriptor
         IEnumerable<InspectionGraphSubjectKind> edgeTargetKinds,
         IEnumerable<InspectionGraphSubjectKind> occurrenceSourceKinds,
         IEnumerable<InspectionGraphSubjectKind> occurrenceTargetKinds,
+        IEnumerable<InspectionGraphSeedAdmission> seedAdmissions,
         InspectionGraphEndpointProjection endpointProjection,
         InspectionGraphOccurrenceIdentityProjection occurrenceIdentity,
         IEnumerable<InspectionGraphEvidenceDescriptor> evidence)
@@ -472,6 +491,9 @@ public sealed class InspectionGraphRelationshipDescriptor
         OccurrenceTargetKinds = InspectionGraphCollections.Snapshot(
             occurrenceTargetKinds,
             nameof(occurrenceTargetKinds));
+        SeedAdmissions = InspectionGraphCollections.Snapshot(
+            seedAdmissions,
+            nameof(seedAdmissions));
         Evidence = InspectionGraphCollections.Snapshot(
             evidence,
             nameof(evidence));
@@ -487,6 +509,56 @@ public sealed class InspectionGraphRelationshipDescriptor
         InspectionGraphCollections.RequireDefined(
             OccurrenceTargetKinds,
             nameof(occurrenceTargetKinds));
+        if (SeedAdmissions.IsEmpty)
+        {
+            throw new ArgumentException(
+                "At least one seed admission is required.",
+                nameof(seedAdmissions));
+        }
+        foreach (InspectionGraphSeedAdmission admission in SeedAdmissions)
+        {
+            ArgumentNullException.ThrowIfNull(admission);
+            InspectionGraphCollections.RequireDefined(
+                admission.SubjectKind,
+                nameof(seedAdmissions));
+            InspectionGraphCollections.RequireDefined(
+                admission.Kind,
+                nameof(seedAdmissions));
+            InspectionGraphCollections.RequireDefined(
+                admission.Role,
+                nameof(seedAdmissions));
+            ImmutableArray<InspectionGraphSubjectKind>? endpointKinds =
+                (admission.Kind, admission.Role) switch
+                {
+                    (
+                        InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                        InspectionGraphEndpointRole.Source) =>
+                        EdgeSourceKinds,
+                    (
+                        InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                        InspectionGraphEndpointRole.Target) =>
+                        EdgeTargetKinds,
+                    (
+                        InspectionGraphSeedAdmissionKind.OccurrenceEndpoint,
+                        InspectionGraphEndpointRole.Source) =>
+                        OccurrenceSourceKinds,
+                    (
+                        InspectionGraphSeedAdmissionKind.OccurrenceEndpoint,
+                        InspectionGraphEndpointRole.Target) =>
+                        OccurrenceTargetKinds,
+                    (InspectionGraphSeedAdmissionKind.OwnedSubjects, _) =>
+                        null,
+                    _ => throw new ArgumentOutOfRangeException(
+                        nameof(seedAdmissions)),
+                };
+            if (endpointKinds is { } kinds
+                && !kinds.Contains(admission.SubjectKind))
+            {
+                throw new ArgumentException(
+                    "A direct seed admission must use a subject kind admitted by that endpoint.",
+                    nameof(seedAdmissions));
+            }
+        }
         if (EdgeSourceKinds.IsEmpty)
             throw new ArgumentException("At least one edge source subject kind is required.", nameof(edgeSourceKinds));
         if (EdgeTargetKinds.IsEmpty)
@@ -505,6 +577,12 @@ public sealed class InspectionGraphRelationshipDescriptor
             throw new ArgumentException("Occurrence source subject kinds must be distinct.", nameof(occurrenceSourceKinds));
         if (OccurrenceTargetKinds.Distinct().Count() != OccurrenceTargetKinds.Length)
             throw new ArgumentException("Occurrence target subject kinds must be distinct.", nameof(occurrenceTargetKinds));
+        if (SeedAdmissions.Distinct().Count() != SeedAdmissions.Length)
+        {
+            throw new ArgumentException(
+                "Seed admissions must be distinct.",
+                nameof(seedAdmissions));
+        }
         if (Evidence.Distinct().Count() != Evidence.Length)
             throw new ArgumentException("Evidence descriptors must be distinct.", nameof(evidence));
         if (Evidence.Select(static item => item.Id)
@@ -528,6 +606,7 @@ public sealed class InspectionGraphRelationshipDescriptor
         { get; }
     public ImmutableArray<InspectionGraphSubjectKind> OccurrenceTargetKinds
         { get; }
+    public ImmutableArray<InspectionGraphSeedAdmission> SeedAdmissions { get; }
     public InspectionGraphEndpointProjection EndpointProjection { get; }
     public InspectionGraphOccurrenceIdentityProjection OccurrenceIdentity
         { get; }
@@ -546,6 +625,15 @@ public sealed class InspectionGraphRelationshipDescriptor
     internal bool AdmitsOccurrenceTarget(
         InspectionGraphSubject subject) =>
         OccurrenceTargetKinds.Contains(subject.Kind);
+
+    public bool AdmitsSeed(InspectionGraphSubjectKind subjectKind)
+    {
+        InspectionGraphCollections.RequireDefined(
+            subjectKind,
+            nameof(subjectKind));
+        return SeedAdmissions.Any(
+            admission => admission.SubjectKind == subjectKind);
+    }
 
     internal bool AdmitsEvidence(
         IInspectionGraphOccurrenceEvidence evidence) =>

--- a/src/DotnetInspector.Queries/InspectionGraphDocument.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphDocument.cs
@@ -558,6 +558,17 @@ public sealed class InspectionGraphRelationshipDescriptor
                     "A direct seed admission must use a subject kind admitted by that endpoint.",
                     nameof(seedAdmissions));
             }
+            if (admission.Kind
+                    == InspectionGraphSeedAdmissionKind.OwnedSubjects
+                && !OwnedEndpointKinds(admission.Role).Any(
+                    endpointKind => StrictlyOwns(
+                        admission.SubjectKind,
+                        endpointKind)))
+            {
+                throw new ArgumentException(
+                    "An owned-subject seed admission must strictly own a subject kind in that semantic endpoint domain.",
+                    nameof(seedAdmissions));
+            }
         }
         if (EdgeSourceKinds.IsEmpty)
             throw new ArgumentException("At least one edge source subject kind is required.", nameof(edgeSourceKinds));
@@ -626,18 +637,56 @@ public sealed class InspectionGraphRelationshipDescriptor
         InspectionGraphSubject subject) =>
         OccurrenceTargetKinds.Contains(subject.Kind);
 
-    public bool AdmitsSeed(InspectionGraphSubjectKind subjectKind)
+    public ImmutableArray<InspectionGraphSeedAdmission> GetSeedAdmissions(
+        InspectionGraphSubjectKind subjectKind)
     {
         InspectionGraphCollections.RequireDefined(
             subjectKind,
             nameof(subjectKind));
-        return SeedAdmissions.Any(
-            admission => admission.SubjectKind == subjectKind);
+        return
+        [
+            .. SeedAdmissions.Where(
+                admission => admission.SubjectKind == subjectKind),
+        ];
     }
 
     internal bool AdmitsEvidence(
         IInspectionGraphOccurrenceEvidence evidence) =>
         Evidence.Contains(evidence.Descriptor);
+
+    IEnumerable<InspectionGraphSubjectKind> OwnedEndpointKinds(
+        InspectionGraphEndpointRole role) =>
+        role switch
+        {
+            InspectionGraphEndpointRole.Source =>
+                EdgeSourceKinds.Concat(OccurrenceSourceKinds),
+            InspectionGraphEndpointRole.Target =>
+                EdgeTargetKinds.Concat(OccurrenceTargetKinds),
+            _ => throw new ArgumentOutOfRangeException(nameof(role)),
+        };
+
+    static bool StrictlyOwns(
+        InspectionGraphSubjectKind owner,
+        InspectionGraphSubjectKind subject) =>
+        (owner, subject) switch
+        {
+            (
+                InspectionGraphSubjectKind.Type,
+                InspectionGraphSubjectKind.Member) =>
+                true,
+            (
+                InspectionGraphSubjectKind.Assembly,
+                InspectionGraphSubjectKind.Type
+                    or InspectionGraphSubjectKind.Member) =>
+                true,
+            (
+                InspectionGraphSubjectKind.Package,
+                InspectionGraphSubjectKind.Assembly
+                    or InspectionGraphSubjectKind.Type
+                    or InspectionGraphSubjectKind.Member) =>
+                true,
+            _ => false,
+        };
 }
 
 /// <summary>Document-local node classification.</summary>

--- a/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
@@ -43,6 +43,24 @@ public static class InspectionGraphIntegrationsCatalog
             [InspectionGraphSubjectKind.Type],
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Type],
+            [
+                new(
+                    InspectionGraphSubjectKind.Member,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Type,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Target),
+                new(
+                    InspectionGraphSubjectKind.Assembly,
+                    InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Package,
+                    InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                    InspectionGraphEndpointRole.Source),
+            ],
             InspectionGraphEndpointProjection.Exact,
             OccurrenceIdentity,
             [ExtensionEvidence]);
@@ -57,6 +75,24 @@ public static class InspectionGraphIntegrationsCatalog
             [InspectionGraphSubjectKind.Type],
             [InspectionGraphSubjectKind.Member],
             [InspectionGraphSubjectKind.Type],
+            [
+                new(
+                    InspectionGraphSubjectKind.Member,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Type,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Target),
+                new(
+                    InspectionGraphSubjectKind.Assembly,
+                    InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Package,
+                    InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                    InspectionGraphEndpointRole.Source),
+            ],
             InspectionGraphEndpointProjection.Exact,
             OccurrenceIdentity,
             [IntegrationEvidence]);
@@ -71,6 +107,24 @@ public static class InspectionGraphIntegrationsCatalog
             [InspectionGraphSubjectKind.Assembly],
             [InspectionGraphSubjectKind.Assembly],
             [InspectionGraphSubjectKind.Assembly],
+            [
+                new(
+                    InspectionGraphSubjectKind.Assembly,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Assembly,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Target),
+                new(
+                    InspectionGraphSubjectKind.Package,
+                    InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Package,
+                    InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                    InspectionGraphEndpointRole.Target),
+            ],
             InspectionGraphEndpointProjection.Exact,
             OccurrenceIdentity,
             [ReferenceEvidence]);
@@ -85,6 +139,24 @@ public static class InspectionGraphIntegrationsCatalog
             [InspectionGraphSubjectKind.Type],
             [InspectionGraphSubjectKind.Type],
             [InspectionGraphSubjectKind.Type],
+            [
+                new(
+                    InspectionGraphSubjectKind.Assembly,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Type,
+                    InspectionGraphSeedAdmissionKind.OccurrenceEndpoint,
+                    InspectionGraphEndpointRole.Source),
+                new(
+                    InspectionGraphSubjectKind.Type,
+                    InspectionGraphSeedAdmissionKind.EdgeEndpoint,
+                    InspectionGraphEndpointRole.Target),
+                new(
+                    InspectionGraphSubjectKind.Package,
+                    InspectionGraphSeedAdmissionKind.OwnedSubjects,
+                    InspectionGraphEndpointRole.Source),
+            ],
             OpportunityEndpointProjection,
             OccurrenceIdentity,
             [OpportunityEvidence]);
@@ -94,6 +166,15 @@ public static class InspectionGraphIntegrationsCatalog
             "queries.integration-graph-incomplete",
             InspectionGraphOwner.Queries,
             [FailureEvidence]);
+
+    public static ImmutableArray<InspectionGraphRelationshipDescriptor>
+        Relationships { get; } =
+        [
+            Extension,
+            IntegrationObserved,
+            MetadataReference,
+            IntegrationOpportunity,
+        ];
 
     sealed class IntegrationOccurrenceIdentityProjection :
         InspectionGraphOccurrenceIdentityProjection
@@ -409,6 +490,9 @@ public static class InspectionGraphIntegrationsQuery
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(modeRequest);
+        InspectionGraphSeedAdmissionValidator.Validate(
+            modeRequest,
+            InspectionGraphIntegrationsCatalog.Relationships);
 
         var registry =
             new InspectionQueryRegistry<AssemblyContextGroup>()

--- a/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
@@ -167,15 +167,6 @@ public static class InspectionGraphIntegrationsCatalog
             InspectionGraphOwner.Queries,
             [FailureEvidence]);
 
-    public static ImmutableArray<InspectionGraphRelationshipDescriptor>
-        Relationships { get; } =
-        [
-            Extension,
-            IntegrationObserved,
-            MetadataReference,
-            IntegrationOpportunity,
-        ];
-
     sealed class IntegrationOccurrenceIdentityProjection :
         InspectionGraphOccurrenceIdentityProjection
     {
@@ -490,9 +481,6 @@ public static class InspectionGraphIntegrationsQuery
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(modeRequest);
-        InspectionGraphSeedAdmissionValidator.Validate(
-            modeRequest,
-            InspectionGraphIntegrationsCatalog.Relationships);
 
         var registry =
             new InspectionQueryRegistry<AssemblyContextGroup>()

--- a/src/DotnetInspector.Queries/InspectionGraphModeRequest.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphModeRequest.cs
@@ -100,54 +100,6 @@ public sealed class InspectionGraphModeRequest
             rule);
 }
 
-internal static class InspectionGraphSeedAdmissionValidator
-{
-    internal static void Validate(
-        InspectionGraphModeRequest request,
-        IEnumerable<InspectionGraphRelationshipDescriptor> relationships)
-    {
-        ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(relationships);
-        if (request.Mode == InspectionGraphMode.InducedSet)
-            return;
-
-        InspectionGraphRelationshipDescriptor[] selected =
-        [
-            .. relationships,
-        ];
-        if (selected.Any(static relationship => relationship is null))
-        {
-            throw new ArgumentException(
-                "Selected relationships cannot contain null.",
-                nameof(relationships));
-        }
-        if (selected.Length == 0)
-        {
-            throw new InspectionQueryException(
-                "A seeded graph requires at least one selected relationship.");
-        }
-
-        foreach (InspectionGraphSubject seed in request.Seeds)
-        {
-            if (selected.Any(relationship =>
-                relationship.AdmitsSeed(seed.Kind)))
-            {
-                continue;
-            }
-
-            string ids = string.Join(
-                ", ",
-                selected.Select(static relationship =>
-                    relationship.Id));
-            throw new InspectionQueryException(
-                $"No selected relationship admits a "
-                + $"{seed.Kind.ToString().ToLowerInvariant()} seed. "
-                + $"Selected relationships: {ids}. Select a relationship "
-                + "that admits the seed directly or through owned subjects.");
-        }
-    }
-}
-
 internal enum InspectionGraphSeedTargetPreference
 {
     Node,

--- a/src/DotnetInspector.Queries/InspectionGraphModeRequest.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphModeRequest.cs
@@ -100,6 +100,54 @@ public sealed class InspectionGraphModeRequest
             rule);
 }
 
+internal static class InspectionGraphSeedAdmissionValidator
+{
+    internal static void Validate(
+        InspectionGraphModeRequest request,
+        IEnumerable<InspectionGraphRelationshipDescriptor> relationships)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(relationships);
+        if (request.Mode == InspectionGraphMode.InducedSet)
+            return;
+
+        InspectionGraphRelationshipDescriptor[] selected =
+        [
+            .. relationships,
+        ];
+        if (selected.Any(static relationship => relationship is null))
+        {
+            throw new ArgumentException(
+                "Selected relationships cannot contain null.",
+                nameof(relationships));
+        }
+        if (selected.Length == 0)
+        {
+            throw new InspectionQueryException(
+                "A seeded graph requires at least one selected relationship.");
+        }
+
+        foreach (InspectionGraphSubject seed in request.Seeds)
+        {
+            if (selected.Any(relationship =>
+                relationship.AdmitsSeed(seed.Kind)))
+            {
+                continue;
+            }
+
+            string ids = string.Join(
+                ", ",
+                selected.Select(static relationship =>
+                    relationship.Id));
+            throw new InspectionQueryException(
+                $"No selected relationship admits a "
+                + $"{seed.Kind.ToString().ToLowerInvariant()} seed. "
+                + $"Selected relationships: {ids}. Select a relationship "
+                + "that admits the seed directly or through owned subjects.");
+        }
+    }
+}
+
 internal enum InspectionGraphSeedTargetPreference
 {
     Node,


### PR DESCRIPTION
Seed admission is now an explicit relationship-descriptor contract: a typed
seed enters through a logical edge endpoint, an original occurrence endpoint,
or strict typed ownership into the semantic endpoint domain.

## Stack

- Slice 2 of the #4133 inspection-graph mode work.
- Parent #4325 merged as `d38530f19778c8086a4d5137ac7fd30ce2b3b2bc`;
  this PR now targets `main`.
- Original exact parent head:
  `64491b1a6cbc599eb3254f2aeeddab8c52ea59bf`.
- This slice was stacked in parallel at the user's direction while GitHub's
  merge endpoint returned HTTP 503 for the ready parent.
- The public child was restacked onto the squash result with a range-diff that
  mapped both authored commits exactly.

## Behavior

- Relationship descriptors declare immutable, validated seed admissions with
  semantic source/target roles.
- Direct admissions must match the corresponding logical-edge or original-
  occurrence endpoint domain.
- Owned-subject admissions must have a strict kind-level ownership path into
  that semantic endpoint domain.
- Callers can query every admission for a subject kind without collapsing its
  entry mechanism or semantic role.
- The call catalog admits only member source/target endpoints.
- Integration descriptors declare the exact member/type/assembly/package
  admissions their current evidence can honor, including the opportunity
  source type retained only on the original occurrence.

This changes neither graph topology nor occurrence identity, relationship
direction, producer demand, or deterministic sequential execution. It adds no
threading and preserves the Browser/Wasm baseline.

## Evidence

- 55 focused graph and Integration tests passed.
- Changed Markdown passed `markdownlint`.
- `git diff --check` passed.

## Residual

Request-driven relationship selection and admission validation,
admission-driven producer selection, and bounded single-seed neighborhood
construction remain the next stacked work. Explicit-subject induced sets and
presentation lowering also remain deferred.
