### PR TITLE
Project bounded Integration neighborhoods

### DIFF
--- a/docs/design/inspection-graph-document.md
+++ b/docs/design/inspection-graph-document.md
@@ -736,20 +736,26 @@ the surviving topology.
 
 The Integration implementation validates catalog membership before producer
 execution. Its relationship set drives the deterministic query-registry plan,
-including opportunity's Integration prerequisite. Projection begins through
-the selected descriptor's exact edge, original-occurrence, or typed
-owned-subject seed admission, then walks logical endpoints for the remaining
-hops. Incoming traversal changes which endpoint is followed, never the stored
-edge or occurrence direction.
+including opportunity's Integration and extension prerequisites for
+fulfillment reconciliation. Projection begins through the selected
+descriptor's exact edge, original-occurrence, or typed owned-subject seed
+admission, then walks logical endpoints for the remaining hops. Incoming
+traversal changes which endpoint is followed, never the stored edge or
+occurrence direction.
 
 Projection assigns new dense document-local ids while retaining semantic
 subjects, relationship descriptors, occurrence evidence and occurrence
-identity. Selected-producer failures remain visible even when their target is
-outside healthy reached topology. A typed `queries.neighborhood-depth-bound`
-limit records the requested bound, including depth zero.
+identity. Failures from requested relationship producers and their required
+composition prerequisites remain visible even when their target is outside
+healthy reached topology. A typed `queries.neighborhood-depth-bound` limit
+records the requested bound, including depth zero. An admissible owner-issued
+seed remains bound even when selected producers emit no relationship evidence.
 `Execute_BoundsMixedRelationshipNeighborhoodByDepth`,
 `Execute_ZeroDepthRetainsSeedWithoutEdges`,
-`Execute_NeighborhoodRetainsSelectedProducerFailures`, and
+`Execute_ZeroDepthRetainsAdmissibleSeedWithoutSelectedEvidence`,
+`Execute_OpportunityNeighborhoodPreservesFulfillmentSuppression`,
+`Execute_NeighborhoodRetainsSelectedProducerFailures`,
+`Execute_OpportunityNeighborhoodRetainsPrerequisiteFailures`, and
 `Execute_RejectsForeignRelationshipBeforeProducerExecution` gate these
 contracts.
 

--- a/docs/design/inspection-graph-document.md
+++ b/docs/design/inspection-graph-document.md
@@ -506,11 +506,11 @@ descriptor endpoint domain. An owned-subject admission must name a strict
 typed owner of a kind in that semantic endpoint domain; it authorizes later
 expansion but does not change the logical edge's subject kind or direction.
 
-Once relationship selection is request-driven, a seeded request must have at
-least one selected relationship and every seed kind must be admitted by at
-least one of them. That future validation must occur before producer execution
-and fail with the selected relationship ids and typed guidance. Induced-set
-requests carry no seeds and bypass that gate.
+The single-seed neighborhood requires at least one selected relationship and
+the seed kind and semantic direction must be admitted by at least one of them.
+Integration catalog validation occurs before producer execution and fails with
+the selected relationship id and typed guidance. Induced-set requests carry no
+seeds and bypass that gate.
 `RelationshipDescriptor_ValidatesAndSnapshotsSeedAdmissions`,
 `AdmissionsMatchDeclaredEndpointDomains`, and
 `RelationshipCatalogsDeclareCurrentSeedAdmissions` gate the implemented
@@ -726,6 +726,32 @@ typed package-owned members and retains member-to-member call semantics.
 No mode chooses a subject lens, relationship set, or characteristic selection
 automatically. The same relationship, identity, direction, limit, and failure
 contracts apply in every mode.
+
+`InspectionGraphNeighborhoodRequest` is the first composed request over these
+orthogonal axes. It currently requires one seed, one or more typed relationship
+descriptors, semantic traversal direction, and a finite maximum edge depth.
+The resulting document retains both its `ModeRequest` and
+`NeighborhoodRequest`; a consumer never has to infer selection or bounds from
+the surviving topology.
+
+The Integration implementation validates catalog membership before producer
+execution. Its relationship set drives the deterministic query-registry plan,
+including opportunity's Integration prerequisite. Projection begins through
+the selected descriptor's exact edge, original-occurrence, or typed
+owned-subject seed admission, then walks logical endpoints for the remaining
+hops. Incoming traversal changes which endpoint is followed, never the stored
+edge or occurrence direction.
+
+Projection assigns new dense document-local ids while retaining semantic
+subjects, relationship descriptors, occurrence evidence and occurrence
+identity. Selected-producer failures remain visible even when their target is
+outside healthy reached topology. A typed `queries.neighborhood-depth-bound`
+limit records the requested bound, including depth zero.
+`Execute_BoundsMixedRelationshipNeighborhoodByDepth`,
+`Execute_ZeroDepthRetainsSeedWithoutEdges`,
+`Execute_NeighborhoodRetainsSelectedProducerFailures`, and
+`Execute_RejectsForeignRelationshipBeforeProducerExecution` gate these
+contracts.
 
 ### Type outward
 
@@ -1035,10 +1061,11 @@ subject lenses it advances.
    retain equal roles; and request-free workspace projection declares its
    workspace-participant induced-set rule. Relationship descriptors now own
    direct edge, original occurrence, and owned-subject seed admission, and
-   preserve each admission's semantic role for later request planning.
-   Admission-driven request validation, producer selection,
-   connecting-neighborhood construction, explicit-subject induced sets, and
-   presentation lowering remain.
+   preserve each admission's semantic role for request planning.
+   `InspectionGraphNeighborhoodRequest` now drives finite single-seed
+   Integration traversal and producer selection. Peer connecting
+   neighborhoods, explicit-subject induced sets, and presentation lowering
+   remain.
 
 ## Required implementation gates
 

--- a/docs/design/inspection-graph-modes.md
+++ b/docs/design/inspection-graph-modes.md
@@ -17,10 +17,14 @@ request-free workspace projection as an induced set over workspace
 participants.
 
 The current executable mode slices bind request intent to graph subjects and
-make seed admission a descriptor-owned relationship contract without changing
-producer demand or topology. Request-driven relationship selection, admission
-validation and neighborhood construction, traversal bounds, induced
-explicit-subject sets, and command/presentation surfaces remain design targets.
+make seed admission a descriptor-owned relationship contract. An
+`InspectionGraphNeighborhoodRequest` now composes one seed with an explicit
+relationship set, semantic traversal direction, and finite edge-depth bound.
+The Integration query validates that relationship set before execution,
+requests only its required producers and prerequisites, and projects the
+bounded neighborhood without reversing stored edges or changing occurrence
+identity. Peer connecting neighborhoods, induced explicit-subject sets, and
+command/presentation surfaces remain design targets.
 
 `CallAdapter_PreservesTypedTopologyAndDisclosesEvidenceGap`,
 `PackageSeed_BindsToNodeOrGroupSelectedByLens`,
@@ -32,6 +36,11 @@ explicit-subject sets, and command/presentation surfaces remain design targets.
 `RelationshipDescriptor_ValidatesAndSnapshotsSeedAdmissions`,
 `AdmissionsMatchDeclaredEndpointDomains`, and
 `RelationshipCatalogsDeclareCurrentSeedAdmissions` gate descriptor admission.
+`Execute_BoundsMixedRelationshipNeighborhoodByDepth`,
+`Execute_PackageSeedExpandsThroughOwnedSourceSubjects`,
+`Execute_OpportunitySourceTypeUsesOccurrenceAdmission`, and
+`Execute_SelectedRelationshipsControlProducerDemand` gate the first
+load-bearing neighborhood.
 
 | Mode | Focus | Input | Primary question |
 | --- | --- | --- | --- |
@@ -90,6 +99,12 @@ lens, characteristic selection, and bounds.
 **Output:** one focus subject plus the bounded, evidence-backed neighborhood
 admitted by the request. Walking an incoming edge never reverses its semantic
 direction.
+
+The current Integration implementation accepts an explicit relationship set,
+`Outgoing`, `Incoming`, or `Both`, and a non-negative maximum edge depth.
+Depth zero retains the bound seed and selected-producer failures without
+traversing an edge. Every result carries the request and a typed depth-bound
+limit.
 
 ### Member seed
 
@@ -184,12 +199,12 @@ the descriptor's corresponding semantic source or target domain.
 that semantic endpoint domain; it does not fabricate an edge at the owner's
 subject kind.
 
-The current slice declares and validates these descriptor capabilities. Once
-request-driven relationship selection lands, unsupported combinations must
-fail before producer execution with guidance rather than dropping or relabeling
-the seed. Induced-set requests have no seeds and therefore need no seed
-admission. This slice does not yet use admission to select producers or
-construct a bounded neighborhood.
+The Integration neighborhood consumes these capabilities. Unsupported
+seed/direction/relationship combinations fail while constructing the request;
+relationships outside the Integration catalog fail before any producer runs.
+Selected relationships determine registry demand, including declared
+prerequisites. Induced-set requests have no seeds and therefore need no seed
+admission.
 
 ## Shared contract
 
@@ -226,9 +241,10 @@ metadata-reference, and opportunity adapters; no mode turns those into calls.
    request and document.
 3. **Implemented:** bind type, assembly, and realized-package seeds to existing
    Integration/package graph subjects, declare direct endpoint and
-   strict typed owned-subject admission on each relationship descriptor.
-   Admission-driven request validation, producer selection, and neighborhood
-   construction remain.
+   strict typed owned-subject admission on each relationship descriptor, and
+   construct finite single-seed Integration neighborhoods from explicit
+   relationship, direction, and depth axes. Selected relationships drive
+   deterministic producer demand.
 4. **Partially implemented:** bind peer-seed requests without choosing a hero
    node. Connecting-neighborhood construction remains.
 5. **Partially implemented:** declare workspace-participant and

--- a/docs/design/inspection-graph-modes.md
+++ b/docs/design/inspection-graph-modes.md
@@ -102,9 +102,10 @@ direction.
 
 The current Integration implementation accepts an explicit relationship set,
 `Outgoing`, `Incoming`, or `Both`, and a non-negative maximum edge depth.
-Depth zero retains the bound seed and selected-producer failures without
-traversing an edge. Every result carries the request and a typed depth-bound
-limit.
+Depth zero retains the bound seed and failures from requested producers and
+their required composition prerequisites without traversing an edge, including
+when those producers emit no relationship for the seed. Every result carries
+the request and a typed depth-bound limit.
 
 ### Member seed
 
@@ -203,8 +204,9 @@ The Integration neighborhood consumes these capabilities. Unsupported
 seed/direction/relationship combinations fail while constructing the request;
 relationships outside the Integration catalog fail before any producer runs.
 Selected relationships determine registry demand, including declared
-prerequisites. Induced-set requests have no seeds and therefore need no seed
-admission.
+prerequisites. Opportunity demand includes extension and Integration evidence
+because fulfillment suppression composes both before projection. Induced-set
+requests have no seeds and therefore need no seed admission.
 
 ## Shared contract
 

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -461,12 +461,10 @@ that workspace scope. Its request-free overload explicitly produces a
 workspace-participant induced set; type and assembly seeds bind exact nodes,
 package seeds bind exact package groups in the detailed Integration lens, and
 mixed peers remain equal. Mode binding happens after the same deterministic
-producer plan, so it does not change occurrence identity or semantic edge
-direction. Integration relationship descriptors now declare whether a seed may
-enter as a logical edge endpoint, an original occurrence endpoint, or through
-strict typed ownership. Request-driven relationship selection and admission
-validation remain deferred, so these declarations do not change the
-deterministic sequential plan.
+full producer plan, so the existing mode-only overloads do not change
+occurrence identity or semantic edge direction. Integration relationship
+descriptors declare whether a seed may enter as a logical edge endpoint, an
+original occurrence endpoint, or through strict typed ownership.
 `Execute_DefaultsToWorkspaceInducedSetWithoutSeeds`,
 `Execute_BindsTypeSeedToExactNode`,
 `Execute_BindsAssemblySeedToExactNode`,
@@ -477,6 +475,26 @@ deterministic sequential plan.
 `RelationshipDescriptor_ValidatesAndSnapshotsSeedAdmissions`, and
 `AdmissionsMatchDeclaredEndpointDomains` gate the catalog declarations and
 their endpoint constraints.
+
+`InspectionGraphNeighborhoodRequest` now makes those declarations load-bearing
+for single-seed Integration graphs. The request keeps mode, selected
+relationships, semantic direction, and finite edge depth separate. Catalog and
+seed admission validation occur before the registry runs. The selected
+relationships request only extension, reference, Integration, or opportunity
+queries they require; the registry still expands typed prerequisites and runs
+them once in registration order. Opportunity therefore activates Integrations
+without activating unrelated extension or reference scans.
+
+The completed evidence is projected sequentially into a dense bounded document.
+Incoming traversal does not reverse stored semantic direction, original
+occurrence receipts and identity survive id remapping, and failures from
+selected producers remain visible beside reached topology.
+`Execute_SelectedRelationshipsControlProducerDemand`,
+`Execute_BoundsMixedRelationshipNeighborhoodByDepth`,
+`Execute_PackageSeedExpandsThroughOwnedSourceSubjects`,
+`Execute_OpportunitySourceTypeUsesOccurrenceAdmission`, and
+`Execute_NeighborhoodRetainsSelectedProducerFailures` gate the planner,
+ownership, receipt, and failure contracts.
 `GroupedIntegrationsFailure_IsVisibleAndDeduplicated` gates diagnostic
 composition and the shared nonzero completion status used after Markdown,
 count, tabular, or JSON output.

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -482,14 +482,19 @@ relationships, semantic direction, and finite edge depth separate. Catalog and
 seed admission validation occur before the registry runs. The selected
 relationships request only extension, reference, Integration, or opportunity
 queries they require; the registry still expands typed prerequisites and runs
-them once in registration order. Opportunity therefore activates Integrations
-without activating unrelated extension or reference scans.
+them once in registration order. Opportunity activates both extension and
+Integration evidence because fulfillment suppression composes those results
+before projecting opportunity edges; it does not activate unrelated reference
+scans.
 
 The completed evidence is projected sequentially into a dense bounded document.
 Incoming traversal does not reverse stored semantic direction, original
-occurrence receipts and identity survive id remapping, and failures from
-selected producers remain visible beside reached topology.
+occurrence receipts and identity survive id remapping, and failures from the
+requested relationship producers and their required composition prerequisites
+remain visible beside reached topology.
 `Execute_SelectedRelationshipsControlProducerDemand`,
+`Execute_OpportunityNeighborhoodPreservesFulfillmentSuppression`,
+`Execute_OpportunityNeighborhoodRetainsPrerequisiteFailures`,
 `Execute_BoundsMixedRelationshipNeighborhoodByDepth`,
 `Execute_PackageSeedExpandsThroughOwnedSourceSubjects`,
 `Execute_OpportunitySourceTypeUsesOccurrenceAdmission`, and

--- a/src/DotnetInspector.Queries.Tests/InspectionGraphDocumentTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionGraphDocumentTests.cs
@@ -554,6 +554,115 @@ public sealed class InspectionGraphDocumentTests
     }
 
     [Fact]
+    public void NeighborhoodRequest_ValidatesAndSnapshotsSelection()
+    {
+        InspectionGraphSubject member = Subject("Member");
+        var relationships =
+            new List<InspectionGraphRelationshipDescriptor>
+            {
+                CallGraphInspectionGraphCatalog.Call,
+            };
+        InspectionGraphNeighborhoodRequest request =
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                member,
+                relationships,
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 2);
+
+        relationships.Clear();
+
+        Assert.Equal(
+            [CallGraphInspectionGraphCatalog.Call],
+            request.Relationships);
+        Assert.Equal(member, request.Seed);
+        Assert.Equal(2, request.MaxDepth);
+        Assert.Equal(
+            InspectionGraphTraversalDirection.Outgoing,
+            request.Direction);
+        Assert.Throws<ArgumentException>(
+            () => InspectionGraphNeighborhoodRequest.SingleSeed(
+                member,
+                [],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 1));
+        Assert.Throws<ArgumentException>(
+            () => InspectionGraphNeighborhoodRequest.SingleSeed(
+                member,
+                default(ImmutableArray<
+                    InspectionGraphRelationshipDescriptor>),
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 1));
+        Assert.Throws<ArgumentException>(
+            () => InspectionGraphNeighborhoodRequest.SingleSeed(
+                member,
+                [
+                    CallGraphInspectionGraphCatalog.Call,
+                    CallGraphInspectionGraphCatalog.Call,
+                ],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => InspectionGraphNeighborhoodRequest.SingleSeed(
+                member,
+                [CallGraphInspectionGraphCatalog.Call],
+                (InspectionGraphTraversalDirection)42,
+                maxDepth: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => InspectionGraphNeighborhoodRequest.SingleSeed(
+                member,
+                [CallGraphInspectionGraphCatalog.Call],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: -1));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new InspectionGraphNeighborhoodDepthBoundEvidence(-1));
+    }
+
+    [Fact]
+    public void NeighborhoodRequest_RequiresDirectionalSeedAdmission()
+    {
+        InspectionGraphSubject package =
+            InspectionGraphSubject.ForRealizedPackage(
+                new RealizedMemberCoordinate.Package(
+                    "sample.package",
+                    "1.0.0",
+                    "feed",
+                    "net11.0",
+                    null));
+
+        InspectionQueryException unsupported = Assert.Throws<
+            InspectionQueryException>(
+                () => InspectionGraphNeighborhoodRequest.SingleSeed(
+                    package,
+                    [CallGraphInspectionGraphCatalog.Call],
+                    InspectionGraphTraversalDirection.Outgoing,
+                    maxDepth: 1));
+        InspectionQueryException wrongDirection = Assert.Throws<
+            InspectionQueryException>(
+                () => InspectionGraphNeighborhoodRequest.SingleSeed(
+                    package,
+                    [
+                        InspectionGraphIntegrationsCatalog
+                            .IntegrationObserved,
+                    ],
+                    InspectionGraphTraversalDirection.Incoming,
+                    maxDepth: 1));
+        InspectionGraphNeighborhoodRequest outgoing =
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                package,
+                [
+                    InspectionGraphIntegrationsCatalog
+                        .IntegrationObserved,
+                ],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 1);
+
+        Assert.Contains("package seed", unsupported.Message);
+        Assert.Contains("call", unsupported.Message);
+        Assert.Contains("incoming", wrongDirection.Message);
+        Assert.Equal(package, outgoing.Seed);
+    }
+
+    [Fact]
     public void RelationshipDescriptor_ValidatesAndSnapshotsSeedAdmissions()
     {
         static InspectionGraphRelationshipDescriptor Descriptor(

--- a/src/DotnetInspector.Queries.Tests/InspectionGraphIntegrationsQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionGraphIntegrationsQueryTests.cs
@@ -186,6 +186,414 @@ public sealed class InspectionGraphIntegrationsQueryTests
     }
 
     [Fact]
+    public void Execute_BoundsMixedRelationshipNeighborhoodByDepth()
+    {
+        using var fixture = IntegrationFixture.Create();
+        InspectionGraphDocument induced =
+            InspectionGraphIntegrationsQuery.Execute(fixture.Context);
+        InspectionGraphSubject.TypeSubject hub = FindType(
+            induced,
+            "Microsoft.Extensions.AI.Abstractions",
+            "Microsoft.Extensions.AI",
+            "IChatClient");
+        InspectionGraphRelationshipDescriptor[] relationships =
+        [
+            InspectionGraphIntegrationsCatalog.IntegrationObserved,
+            InspectionGraphIntegrationsCatalog.Extension,
+        ];
+        InspectionGraphNeighborhoodRequest depthOne =
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                hub,
+                relationships,
+                InspectionGraphTraversalDirection.Both,
+                maxDepth: 1);
+        InspectionGraphNeighborhoodRequest depthTwo =
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                hub,
+                relationships,
+                InspectionGraphTraversalDirection.Both,
+                maxDepth: 2);
+
+        InspectionGraphDocument one =
+            InspectionGraphIntegrationsQuery.Execute(
+                fixture.Context,
+                depthOne);
+        InspectionGraphDocument two =
+            InspectionGraphIntegrationsQuery.Execute(
+                fixture.Context,
+                depthTwo);
+
+        Assert.Same(depthOne, one.NeighborhoodRequest);
+        Assert.Same(depthOne.ModeRequest, one.ModeRequest);
+        Assert.Equal(2, one.Edges.Length);
+        Assert.All(
+            one.Edges,
+            edge => Assert.Same(
+                InspectionGraphIntegrationsCatalog.IntegrationObserved,
+                edge.Relationship));
+        Assert.Equal(4, two.Edges.Length);
+        Assert.Equal(
+            2,
+            two.Edges.Count(edge =>
+                edge.Relationship
+                    == InspectionGraphIntegrationsCatalog.Extension));
+        Assert.Equal(
+            2,
+            two.Edges.Count(edge =>
+                edge.Relationship
+                    == InspectionGraphIntegrationsCatalog
+                        .IntegrationObserved));
+        Assert.All(
+            one.Edges,
+            edge => Assert.Equal(
+                hub,
+                one.Nodes[edge.ToNodeId].Subject));
+        Assert.Equal(one.Edges.Length, one.Occurrences.Length);
+        Assert.Equal(
+            induced.Occurrences
+                .Where(occurrence =>
+                    occurrence.Relationship
+                        == InspectionGraphIntegrationsCatalog
+                            .IntegrationObserved)
+                .Select(occurrence =>
+                    occurrence.Relationship.OccurrenceIdentity.Project(
+                        occurrence)),
+            one.Occurrences.Select(occurrence =>
+                occurrence.Relationship.OccurrenceIdentity.Project(
+                    occurrence)));
+        Assert.Equal(
+            induced.Occurrences
+                .Where(occurrence =>
+                    occurrence.Relationship
+                        == InspectionGraphIntegrationsCatalog
+                            .IntegrationObserved)
+                .Select(occurrence =>
+                    (
+                        occurrence.SourceSubject,
+                        occurrence.TargetSubject)),
+            one.Occurrences.Select(occurrence =>
+                (
+                    occurrence.SourceSubject,
+                    occurrence.TargetSubject)));
+        var bound = Assert.IsType<
+            InspectionGraphNeighborhoodDepthBoundEvidence>(
+                Assert.Single(
+                    one.Limits,
+                    limit =>
+                        limit.Descriptor
+                            == InspectionGraphNeighborhoodCatalog
+                                .DepthBound)
+                    .Evidence);
+        Assert.Equal(1, bound.MaxDepth);
+    }
+
+    [Fact]
+    public void Execute_PackageSeedExpandsThroughOwnedSourceSubjects()
+    {
+        using var fixture = IntegrationFixture.Create();
+        InspectionGraphDocument induced =
+            InspectionGraphIntegrationsQuery.Execute(fixture.Context);
+        InspectionGraphSubject.PackageSubject openAi =
+            PackageSubject(
+                induced,
+                "microsoft.extensions.ai.openai");
+        InspectionGraphNeighborhoodRequest request =
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                openAi,
+                [
+                    InspectionGraphIntegrationsCatalog
+                        .IntegrationObserved,
+                ],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 1);
+
+        InspectionGraphDocument document =
+            InspectionGraphIntegrationsQuery.Execute(
+                fixture.Context,
+                request);
+
+        InspectionGraphEdge edge = Assert.Single(document.Edges);
+        Assert.Equal(
+            "microsoft.extensions.ai.openai",
+            PackageId(
+                document,
+                document.Nodes[edge.FromNodeId]));
+        Assert.Equal(
+            "Microsoft.Extensions.AI.IChatClient",
+            TypeName(document.Nodes[edge.ToNodeId].Subject));
+        InspectionGraphSeed seed = Assert.Single(document.Seeds);
+        Assert.Equal(InspectionGraphTargetKind.Group, seed.Target.Kind);
+        Assert.Equal(
+            openAi,
+            document.Groups[seed.Target.Id].Subject);
+    }
+
+    [Fact]
+    public void Execute_OpportunitySourceTypeUsesOccurrenceAdmission()
+    {
+        using var fixture = IntegrationFixture.Create();
+        InspectionGraphDocument induced =
+            InspectionGraphIntegrationsQuery.Execute(fixture.Context);
+        InspectionGraphOccurrence inducedOpportunity = Assert.Single(
+            induced.Occurrences,
+            occurrence =>
+                occurrence.Relationship
+                    == InspectionGraphIntegrationsCatalog
+                        .IntegrationOpportunity);
+        InspectionGraphSubject.TypeSubject source =
+            Assert.IsType<InspectionGraphSubject.TypeSubject>(
+                inducedOpportunity.SourceSubject);
+        InspectionGraphNeighborhoodRequest request =
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                source,
+                [
+                    InspectionGraphIntegrationsCatalog
+                        .IntegrationOpportunity,
+                ],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 1);
+
+        InspectionGraphDocument document =
+            InspectionGraphIntegrationsQuery.Execute(
+                fixture.Context,
+                request);
+
+        InspectionGraphEdge edge = Assert.Single(document.Edges);
+        Assert.Equal(
+            "Azure.AI.OpenAI",
+            AssemblyName(document.Nodes[edge.FromNodeId].Subject));
+        Assert.NotEqual(
+            source,
+            document.Nodes[edge.FromNodeId].Subject);
+        InspectionGraphOccurrence occurrence =
+            document.Occurrences[
+                Assert.Single(edge.OccurrenceIds)];
+        Assert.Equal(source, occurrence.SourceSubject);
+        Assert.Equal(
+            source,
+            document.Nodes[
+                Assert.Single(document.Seeds).Target.Id]
+                .Subject);
+    }
+
+    [Fact]
+    public void Execute_ZeroDepthRetainsSeedWithoutEdges()
+    {
+        using var fixture = IntegrationFixture.Create();
+        InspectionGraphDocument induced =
+            InspectionGraphIntegrationsQuery.Execute(fixture.Context);
+        InspectionGraphSubject.TypeSubject hub = FindType(
+            induced,
+            "Microsoft.Extensions.AI.Abstractions",
+            "Microsoft.Extensions.AI",
+            "IChatClient");
+
+        InspectionGraphDocument document =
+            InspectionGraphIntegrationsQuery.Execute(
+                fixture.Context,
+                InspectionGraphNeighborhoodRequest.SingleSeed(
+                    hub,
+                    [
+                        InspectionGraphIntegrationsCatalog
+                            .IntegrationObserved,
+                    ],
+                    InspectionGraphTraversalDirection.Incoming,
+                    maxDepth: 0));
+
+        Assert.Empty(document.Edges);
+        Assert.Empty(document.Occurrences);
+        Assert.Single(document.Seeds);
+        Assert.Contains(
+            document.Nodes,
+            node => node.Subject == hub);
+        var evidence = Assert.IsType<
+            InspectionGraphNeighborhoodDepthBoundEvidence>(
+                Assert.Single(document.Limits).Evidence);
+        Assert.Equal(0, evidence.MaxDepth);
+    }
+
+    [Fact]
+    public void Execute_SelectedRelationshipsControlProducerDemand()
+    {
+        using var fixture = IntegrationFixture.Create();
+        InspectionGraphDocument induced =
+            InspectionGraphIntegrationsQuery.Execute(fixture.Context);
+        InspectionGraphSubject.TypeSubject hub = FindType(
+            induced,
+            "Microsoft.Extensions.AI.Abstractions",
+            "Microsoft.Extensions.AI",
+            "IChatClient");
+        InspectionGraphSubject.TypeSubject opportunitySource =
+            Assert.IsType<InspectionGraphSubject.TypeSubject>(
+                Assert.Single(
+                    induced.Occurrences,
+                    occurrence =>
+                        occurrence.Relationship
+                            == InspectionGraphIntegrationsCatalog
+                                .IntegrationOpportunity)
+                    .SourceSubject);
+        InspectionGraphSubject.MemberSubject extensionSource =
+            Assert.IsType<InspectionGraphSubject.MemberSubject>(
+                induced.Occurrences.First(occurrence =>
+                    occurrence.Relationship
+                        == InspectionGraphIntegrationsCatalog.Extension)
+                    .SourceSubject);
+        InspectionGraphSubject.AssemblySubject referenceSource =
+            Assert.IsType<InspectionGraphSubject.AssemblySubject>(
+                induced.Nodes[
+                    Assert.Single(
+                        induced.Edges,
+                        edge =>
+                            edge.Relationship
+                                == InspectionGraphIntegrationsCatalog
+                                    .MetadataReference
+                            && AssemblyName(
+                                induced.Nodes[edge.FromNodeId].Subject)
+                                == "Azure.AI.OpenAI")
+                    .FromNodeId]
+                .Subject);
+        var extensionExecutions =
+            new List<InspectionQueryDefinition>();
+        var referenceExecutions =
+            new List<InspectionQueryDefinition>();
+        var observedExecutions =
+            new List<InspectionQueryDefinition>();
+        var opportunityExecutions =
+            new List<InspectionQueryDefinition>();
+
+        InspectionGraphIntegrationsQuery.Execute(
+            fixture.Context,
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                extensionSource,
+                [InspectionGraphIntegrationsCatalog.Extension],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 1),
+            (query, _) => extensionExecutions.Add(query));
+        InspectionGraphIntegrationsQuery.Execute(
+            fixture.Context,
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                referenceSource,
+                [
+                    InspectionGraphIntegrationsCatalog
+                        .MetadataReference,
+                ],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 1),
+            (query, _) => referenceExecutions.Add(query));
+        InspectionGraphIntegrationsQuery.Execute(
+            fixture.Context,
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                hub,
+                [
+                    InspectionGraphIntegrationsCatalog
+                        .IntegrationObserved,
+                ],
+                InspectionGraphTraversalDirection.Incoming,
+                maxDepth: 1),
+            (query, _) => observedExecutions.Add(query));
+        InspectionGraphIntegrationsQuery.Execute(
+            fixture.Context,
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                opportunitySource,
+                [
+                    InspectionGraphIntegrationsCatalog
+                        .IntegrationOpportunity,
+                ],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 1),
+            (query, _) => opportunityExecutions.Add(query));
+
+        Assert.Equal(
+            [AssemblyContextExtensionMethodsQuery.Definition],
+            extensionExecutions);
+        Assert.Equal(
+            [AssemblyContextReferencesQuery.Definition],
+            referenceExecutions);
+        Assert.Equal(
+            [AssemblyContextIntegrationsQuery.Definition],
+            observedExecutions);
+        Assert.Equal(
+            [
+                AssemblyContextIntegrationsQuery.Definition,
+                AssemblyContextIntegrationOpportunitiesQuery.Definition,
+            ],
+            opportunityExecutions);
+    }
+
+    [Fact]
+    public void Execute_RejectsForeignRelationshipBeforeProducerExecution()
+    {
+        using var fixture = IntegrationFixture.Create();
+        InspectionGraphDocument induced =
+            InspectionGraphIntegrationsQuery.Execute(fixture.Context);
+        InspectionGraphOccurrence integration =
+            induced.Occurrences.First(occurrence =>
+                occurrence.Relationship
+                    == InspectionGraphIntegrationsCatalog
+                        .IntegrationObserved);
+        InspectionGraphSubject.MemberSubject member =
+            Assert.IsType<InspectionGraphSubject.MemberSubject>(
+                integration.SourceSubject);
+        InspectionGraphNeighborhoodRequest request =
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                member,
+                [CallGraphInspectionGraphCatalog.Call],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth: 1);
+        bool producerRan = false;
+
+        InspectionQueryException exception = Assert.Throws<
+            InspectionQueryException>(
+                () => InspectionGraphIntegrationsQuery.Execute(
+                    fixture.Context,
+                    request,
+                    (_, _) => producerRan = true));
+
+        Assert.Contains("not supported", exception.Message);
+        Assert.False(producerRan);
+    }
+
+    [Fact]
+    public void Execute_NeighborhoodRetainsSelectedProducerFailures()
+    {
+        using var fixture = IntegrationFixture.Create(
+            includeRejectedParticipant: true);
+        InspectionGraphDocument induced =
+            InspectionGraphIntegrationsQuery.Execute(fixture.Context);
+        InspectionGraphSubject.TypeSubject hub = FindType(
+            induced,
+            "Microsoft.Extensions.AI.Abstractions",
+            "Microsoft.Extensions.AI",
+            "IChatClient");
+
+        InspectionGraphDocument document =
+            InspectionGraphIntegrationsQuery.Execute(
+                fixture.Context,
+                InspectionGraphNeighborhoodRequest.SingleSeed(
+                    hub,
+                    [
+                        InspectionGraphIntegrationsCatalog
+                            .IntegrationObserved,
+                    ],
+                    InspectionGraphTraversalDirection.Incoming,
+                    maxDepth: 1));
+
+        InspectionGraphFailure failure = Assert.Single(document.Failures);
+        Assert.Equal(
+            InspectionGraphTargetKind.Node,
+            failure.Target!.Value.Kind);
+        Assert.Equal(
+            "Rejected.Integration",
+            AssemblyName(
+                document.Nodes[failure.Target.Value.Id].Subject));
+        Assert.All(
+            document.Edges,
+            edge => Assert.Same(
+                InspectionGraphIntegrationsCatalog.IntegrationObserved,
+                edge.Relationship));
+    }
+
+    [Fact]
     public void Execute_ProjectsLockedIChatClientEvidenceAcrossPackageGroups()
     {
         using var fixture = IntegrationFixture.Create();

--- a/src/DotnetInspector.Queries.Tests/InspectionGraphIntegrationsQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionGraphIntegrationsQueryTests.cs
@@ -377,6 +377,46 @@ public sealed class InspectionGraphIntegrationsQueryTests
     }
 
     [Fact]
+    public void Execute_OpportunityNeighborhoodPreservesFulfillmentSuppression()
+    {
+        using var fixture = IntegrationFixture.Create();
+        InspectionGraphDocument induced =
+            InspectionGraphIntegrationsQuery.Execute(fixture.Context);
+        InspectionGraphSubject.TypeSubject fulfilled = FindType(
+            induced,
+            "OpenAI",
+            "OpenAI.Chat",
+            "ChatClient");
+        Assert.DoesNotContain(
+            induced.Occurrences,
+            occurrence =>
+                occurrence.Relationship
+                    == InspectionGraphIntegrationsCatalog
+                        .IntegrationOpportunity
+                && occurrence.SourceSubject == fulfilled);
+
+        InspectionGraphDocument document =
+            InspectionGraphIntegrationsQuery.Execute(
+                fixture.Context,
+                InspectionGraphNeighborhoodRequest.SingleSeed(
+                    fulfilled,
+                    [
+                        InspectionGraphIntegrationsCatalog
+                            .IntegrationOpportunity,
+                    ],
+                    InspectionGraphTraversalDirection.Outgoing,
+                    maxDepth: 1));
+
+        Assert.Empty(document.Edges);
+        Assert.Empty(document.Occurrences);
+        Assert.Equal(
+            fulfilled,
+            document.Nodes[
+                Assert.Single(document.Seeds).Target.Id]
+                .Subject);
+    }
+
+    [Fact]
     public void Execute_ZeroDepthRetainsSeedWithoutEdges()
     {
         using var fixture = IntegrationFixture.Create();
@@ -410,6 +450,46 @@ public sealed class InspectionGraphIntegrationsQueryTests
             InspectionGraphNeighborhoodDepthBoundEvidence>(
                 Assert.Single(document.Limits).Evidence);
         Assert.Equal(0, evidence.MaxDepth);
+    }
+
+    [Fact]
+    public void Execute_ZeroDepthRetainsAdmissibleSeedWithoutSelectedEvidence()
+    {
+        using var fixture = IntegrationFixture.Create();
+        InspectionGraphDocument induced =
+            InspectionGraphIntegrationsQuery.Execute(fixture.Context);
+        InspectionGraphSubject.TypeSubject isolated = FindType(
+            induced,
+            "OpenAI",
+            "OpenAI.Chat",
+            "ChatClient");
+        Assert.DoesNotContain(
+            induced.Occurrences,
+            occurrence =>
+                occurrence.Relationship
+                    == InspectionGraphIntegrationsCatalog
+                        .IntegrationObserved
+                && (occurrence.SourceSubject == isolated
+                    || occurrence.TargetSubject == isolated));
+
+        InspectionGraphDocument document =
+            InspectionGraphIntegrationsQuery.Execute(
+                fixture.Context,
+                InspectionGraphNeighborhoodRequest.SingleSeed(
+                    isolated,
+                    [
+                        InspectionGraphIntegrationsCatalog
+                            .IntegrationObserved,
+                    ],
+                    InspectionGraphTraversalDirection.Incoming,
+                    maxDepth: 0));
+
+        Assert.Empty(document.Edges);
+        Assert.Empty(document.Occurrences);
+        InspectionGraphSeed seed = Assert.Single(document.Seeds);
+        Assert.Equal(
+            isolated,
+            document.Nodes[seed.Target.Id].Subject);
     }
 
     [Fact]
@@ -514,6 +594,7 @@ public sealed class InspectionGraphIntegrationsQueryTests
             observedExecutions);
         Assert.Equal(
             [
+                AssemblyContextExtensionMethodsQuery.Definition,
                 AssemblyContextIntegrationsQuery.Definition,
                 AssemblyContextIntegrationOpportunitiesQuery.Definition,
             ],
@@ -590,6 +671,58 @@ public sealed class InspectionGraphIntegrationsQueryTests
             document.Edges,
             edge => Assert.Same(
                 InspectionGraphIntegrationsCatalog.IntegrationObserved,
+                edge.Relationship));
+    }
+
+    [Fact]
+    public void Execute_OpportunityNeighborhoodRetainsPrerequisiteFailures()
+    {
+        using var fixture = IntegrationFixture.Create(
+            includeRejectedParticipant: true);
+        InspectionGraphDocument induced =
+            InspectionGraphIntegrationsQuery.Execute(fixture.Context);
+        InspectionGraphSubject.TypeSubject source =
+            Assert.IsType<InspectionGraphSubject.TypeSubject>(
+                Assert.Single(
+                    induced.Occurrences,
+                    occurrence =>
+                        occurrence.Relationship
+                            == InspectionGraphIntegrationsCatalog
+                                .IntegrationOpportunity)
+                    .SourceSubject);
+
+        InspectionGraphDocument document =
+            InspectionGraphIntegrationsQuery.Execute(
+                fixture.Context,
+                InspectionGraphNeighborhoodRequest.SingleSeed(
+                    source,
+                    [
+                        InspectionGraphIntegrationsCatalog
+                            .IntegrationOpportunity,
+                    ],
+                    InspectionGraphTraversalDirection.Outgoing,
+                    maxDepth: 1));
+
+        string[] failedProducers =
+        [
+            .. document.Failures
+                .SelectMany(failure =>
+                    Assert.IsType<
+                        InspectionGraphIntegrationFailureEvidence>(
+                            failure.Evidence)
+                        .Details)
+                .Select(static detail => detail.Producer)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal),
+        ];
+        Assert.Equal(
+            ["extensions", "integrations", "opportunities"],
+            failedProducers);
+        Assert.All(
+            document.Edges,
+            edge => Assert.Same(
+                InspectionGraphIntegrationsCatalog
+                    .IntegrationOpportunity,
                 edge.Relationship));
     }
 

--- a/src/DotnetInspector.Queries/InspectionGraphDocument.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphDocument.cs
@@ -1208,11 +1208,67 @@ public sealed class InspectionGraphDocument
         IEnumerable<InspectionGraphSeed> seeds,
         IEnumerable<InspectionGraphLimit> limits,
         IEnumerable<InspectionGraphFailure> failures)
+        : this(
+            scope,
+            modeRequest,
+            neighborhoodRequest: null,
+            nodes,
+            groups,
+            edges,
+            occurrences,
+            characteristics,
+            seeds,
+            limits,
+            failures)
+    {
+    }
+
+    public InspectionGraphDocument(
+        InspectionGraphDocumentScope scope,
+        InspectionGraphNeighborhoodRequest neighborhoodRequest,
+        IEnumerable<InspectionGraphNode> nodes,
+        IEnumerable<InspectionGraphGroup> groups,
+        IEnumerable<InspectionGraphEdge> edges,
+        IEnumerable<InspectionGraphOccurrence> occurrences,
+        IEnumerable<InspectionGraphCharacteristic> characteristics,
+        IEnumerable<InspectionGraphSeed> seeds,
+        IEnumerable<InspectionGraphLimit> limits,
+        IEnumerable<InspectionGraphFailure> failures)
+        : this(
+            scope,
+            neighborhoodRequest?.ModeRequest
+                ?? throw new ArgumentNullException(
+                    nameof(neighborhoodRequest)),
+            neighborhoodRequest,
+            nodes,
+            groups,
+            edges,
+            occurrences,
+            characteristics,
+            seeds,
+            limits,
+            failures)
+    {
+    }
+
+    InspectionGraphDocument(
+        InspectionGraphDocumentScope scope,
+        InspectionGraphModeRequest modeRequest,
+        InspectionGraphNeighborhoodRequest? neighborhoodRequest,
+        IEnumerable<InspectionGraphNode> nodes,
+        IEnumerable<InspectionGraphGroup> groups,
+        IEnumerable<InspectionGraphEdge> edges,
+        IEnumerable<InspectionGraphOccurrence> occurrences,
+        IEnumerable<InspectionGraphCharacteristic> characteristics,
+        IEnumerable<InspectionGraphSeed> seeds,
+        IEnumerable<InspectionGraphLimit> limits,
+        IEnumerable<InspectionGraphFailure> failures)
     {
         InspectionGraphCollections.RequireDefined(scope, nameof(scope));
         ArgumentNullException.ThrowIfNull(modeRequest);
         Scope = scope;
         ModeRequest = modeRequest;
+        NeighborhoodRequest = neighborhoodRequest;
         Nodes = InspectionGraphCollections.Snapshot(nodes, nameof(nodes));
         Groups = InspectionGraphCollections.Snapshot(groups, nameof(groups));
         Edges = InspectionGraphCollections.Snapshot(edges, nameof(edges));
@@ -1276,6 +1332,7 @@ public sealed class InspectionGraphDocument
 
     public InspectionGraphDocumentScope Scope { get; }
     public InspectionGraphModeRequest ModeRequest { get; }
+    public InspectionGraphNeighborhoodRequest? NeighborhoodRequest { get; }
     public ImmutableArray<InspectionGraphNode> Nodes { get; }
     public ImmutableArray<InspectionGraphGroup> Groups { get; }
     public ImmutableArray<InspectionGraphEdge> Edges { get; }

--- a/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
@@ -167,6 +167,15 @@ public static class InspectionGraphIntegrationsCatalog
             InspectionGraphOwner.Queries,
             [FailureEvidence]);
 
+    public static ImmutableArray<InspectionGraphRelationshipDescriptor>
+        Relationships { get; } =
+        [
+            Extension,
+            IntegrationObserved,
+            MetadataReference,
+            IntegrationOpportunity,
+        ];
+
     sealed class IntegrationOccurrenceIdentityProjection :
         InspectionGraphOccurrenceIdentityProjection
     {
@@ -482,23 +491,7 @@ public static class InspectionGraphIntegrationsQuery
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(modeRequest);
 
-        var registry =
-            new InspectionQueryRegistry<AssemblyContextGroup>()
-                .Add(
-                    AssemblyContextExtensionMethodsQuery.Definition,
-                    static group =>
-                        AssemblyContextExtensionMethodsQuery.Execute(group))
-                .Add(
-                    AssemblyContextReferencesQuery.Definition,
-                    AssemblyContextReferencesQuery.Execute)
-                .Add(
-                    AssemblyContextIntegrationsQuery.Definition,
-                    AssemblyContextIntegrationsQuery.Execute)
-                .Add(
-                    AssemblyContextIntegrationOpportunitiesQuery.Definition,
-                    AssemblyContextIntegrationOpportunitiesQuery.Execute,
-                    AssemblyContextIntegrationsQuery.Definition);
-        InspectionQueryResults results = registry.Run(
+        InspectionQueryResults results = CreateRegistry().Run(
             [
                 AssemblyContextExtensionMethodsQuery.Definition,
                 AssemblyContextReferencesQuery.Definition,
@@ -515,6 +508,94 @@ public static class InspectionGraphIntegrationsQuery
             results.Get(
                 AssemblyContextIntegrationOpportunitiesQuery.Definition),
             results.Get(AssemblyContextReferencesQuery.Definition));
+    }
+
+    public static InspectionGraphDocument Execute(
+        WorkspaceContextLoadOutcome.Loaded context,
+        InspectionGraphNeighborhoodRequest request) =>
+        Execute(
+            context,
+            request,
+            recordExecution: null);
+
+    internal static InspectionGraphDocument Execute(
+        WorkspaceContextLoadOutcome.Loaded context,
+        InspectionGraphNeighborhoodRequest request,
+        Action<InspectionQueryDefinition, TimeSpan>? recordExecution)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(request);
+        ValidateRelationships(request);
+        InspectionQueryResults results = CreateRegistry().Run(
+            Plan(request),
+            context.Group,
+            recordExecution);
+        return Create(context, request, results);
+    }
+
+    internal static ImmutableArray<InspectionQueryDefinition> Plan(
+        InspectionGraphNeighborhoodRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ValidateRelationships(request);
+        var queries =
+            ImmutableArray.CreateBuilder<InspectionQueryDefinition>();
+        if (request.Relationships.Contains(
+            InspectionGraphIntegrationsCatalog.Extension))
+        {
+            queries.Add(
+                AssemblyContextExtensionMethodsQuery.Definition);
+        }
+        if (request.Relationships.Contains(
+            InspectionGraphIntegrationsCatalog.MetadataReference))
+        {
+            queries.Add(AssemblyContextReferencesQuery.Definition);
+        }
+        if (request.Relationships.Contains(
+            InspectionGraphIntegrationsCatalog.IntegrationObserved))
+        {
+            queries.Add(AssemblyContextIntegrationsQuery.Definition);
+        }
+        if (request.Relationships.Contains(
+            InspectionGraphIntegrationsCatalog.IntegrationOpportunity))
+        {
+            queries.Add(
+                AssemblyContextIntegrationOpportunitiesQuery.Definition);
+        }
+        return queries.ToImmutable();
+    }
+
+    static InspectionQueryRegistry<AssemblyContextGroup> CreateRegistry() =>
+        new InspectionQueryRegistry<AssemblyContextGroup>()
+            .Add(
+                AssemblyContextExtensionMethodsQuery.Definition,
+                static group =>
+                    AssemblyContextExtensionMethodsQuery.Execute(group))
+            .Add(
+                AssemblyContextReferencesQuery.Definition,
+                AssemblyContextReferencesQuery.Execute)
+            .Add(
+                AssemblyContextIntegrationsQuery.Definition,
+                AssemblyContextIntegrationsQuery.Execute)
+            .Add(
+                AssemblyContextIntegrationOpportunitiesQuery.Definition,
+                AssemblyContextIntegrationOpportunitiesQuery.Execute,
+                AssemblyContextIntegrationsQuery.Definition);
+
+    static void ValidateRelationships(
+        InspectionGraphNeighborhoodRequest request)
+    {
+        foreach (InspectionGraphRelationshipDescriptor relationship
+            in request.Relationships)
+        {
+            if (!InspectionGraphIntegrationsCatalog.Relationships.Contains(
+                relationship))
+            {
+                throw new InspectionQueryException(
+                    $"Relationship '{relationship.Id}' is not supported by "
+                    + "the Integration graph.");
+            }
+        }
     }
 
     internal static InspectionGraphDocument Create(
@@ -555,6 +636,91 @@ public static class InspectionGraphIntegrationsQuery
         builder.AddReferences(references);
         builder.AddOpportunities(opportunities);
         return builder.Build(modeRequest);
+    }
+
+    internal static InspectionGraphDocument Create(
+        WorkspaceContextLoadOutcome.Loaded context,
+        InspectionGraphNeighborhoodRequest request,
+        InspectionQueryResults results)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(results);
+        ValidateRelationships(request);
+
+        InspectionGraphPackageBoundary boundary =
+            InspectionGraphPackageBoundary.Create(context);
+        var builder = new Builder(context, boundary);
+        bool extensionsSelected = request.Relationships.Contains(
+            InspectionGraphIntegrationsCatalog.Extension);
+        bool integrationsSelected = request.Relationships.Contains(
+            InspectionGraphIntegrationsCatalog.IntegrationObserved);
+        bool referencesSelected = request.Relationships.Contains(
+            InspectionGraphIntegrationsCatalog.MetadataReference);
+        bool opportunitiesSelected = request.Relationships.Contains(
+            InspectionGraphIntegrationsCatalog.IntegrationOpportunity);
+
+        AssemblyContextResult<ImmutableArray<ExtensionMethodInfo>>?
+            extensions = extensionsSelected
+                ? results.Get(
+                    AssemblyContextExtensionMethodsQuery.Definition)
+                : null;
+        AssemblyContextIntegrationsResult? integrations =
+            integrationsSelected || opportunitiesSelected
+                ? results.Get(
+                    AssemblyContextIntegrationsQuery.Definition)
+                : null;
+        AssemblyContextResult<ImmutableArray<AssemblyReferenceIdentity>>?
+            references = referencesSelected
+                ? results.Get(AssemblyContextReferencesQuery.Definition)
+                : null;
+        AssemblyContextIntegrationOpportunitiesResult? opportunities =
+            opportunitiesSelected
+                ? results.Get(
+                    AssemblyContextIntegrationOpportunitiesQuery.Definition)
+                : null;
+
+        if (extensions is not null)
+        {
+            builder.ValidateResults(
+                extensions.Assemblies,
+                static entry => entry.Subject);
+        }
+        if (integrations is not null)
+        {
+            builder.ValidateResults(
+                integrations.Assemblies,
+                static entry => entry.Subject);
+        }
+        if (references is not null)
+        {
+            builder.ValidateResults(
+                references.Assemblies,
+                static entry => entry.Subject);
+        }
+        if (opportunities is not null)
+        {
+            builder.ValidateResults(
+                opportunities.Assemblies,
+                static entry => entry.Subject);
+        }
+
+        if (integrations is not null)
+            builder.AddTypeCurrency(integrations);
+        if (extensions is not null)
+            builder.AddExtensions(extensions);
+        if (integrationsSelected)
+            builder.AddIntegrations(integrations!);
+        if (references is not null)
+            builder.AddReferences(references);
+        if (opportunities is not null)
+            builder.AddOpportunities(opportunities);
+
+        InspectionGraphDocument source =
+            builder.Build(request.ModeRequest);
+        return InspectionGraphNeighborhoodProjection.Project(
+            source,
+            request);
     }
 
     sealed class Builder

--- a/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
@@ -540,8 +540,11 @@ public static class InspectionGraphIntegrationsQuery
         ValidateRelationships(request);
         var queries =
             ImmutableArray.CreateBuilder<InspectionQueryDefinition>();
-        if (request.Relationships.Contains(
-            InspectionGraphIntegrationsCatalog.Extension))
+        bool opportunitiesSelected = request.Relationships.Contains(
+            InspectionGraphIntegrationsCatalog.IntegrationOpportunity);
+        if (opportunitiesSelected
+            || request.Relationships.Contains(
+                InspectionGraphIntegrationsCatalog.Extension))
         {
             queries.Add(
                 AssemblyContextExtensionMethodsQuery.Definition);
@@ -551,13 +554,13 @@ public static class InspectionGraphIntegrationsQuery
         {
             queries.Add(AssemblyContextReferencesQuery.Definition);
         }
-        if (request.Relationships.Contains(
-            InspectionGraphIntegrationsCatalog.IntegrationObserved))
+        if (opportunitiesSelected
+            || request.Relationships.Contains(
+                InspectionGraphIntegrationsCatalog.IntegrationObserved))
         {
             queries.Add(AssemblyContextIntegrationsQuery.Definition);
         }
-        if (request.Relationships.Contains(
-            InspectionGraphIntegrationsCatalog.IntegrationOpportunity))
+        if (opportunitiesSelected)
         {
             queries.Add(
                 AssemblyContextIntegrationOpportunitiesQuery.Definition);
@@ -659,14 +662,18 @@ public static class InspectionGraphIntegrationsQuery
             InspectionGraphIntegrationsCatalog.MetadataReference);
         bool opportunitiesSelected = request.Relationships.Contains(
             InspectionGraphIntegrationsCatalog.IntegrationOpportunity);
+        bool extensionsNeeded =
+            extensionsSelected || opportunitiesSelected;
+        bool integrationsNeeded =
+            integrationsSelected || opportunitiesSelected;
 
         AssemblyContextResult<ImmutableArray<ExtensionMethodInfo>>?
-            extensions = extensionsSelected
+            extensions = extensionsNeeded
                 ? results.Get(
                     AssemblyContextExtensionMethodsQuery.Definition)
                 : null;
         AssemblyContextIntegrationsResult? integrations =
-            integrationsSelected || opportunitiesSelected
+            integrationsNeeded
                 ? results.Get(
                     AssemblyContextIntegrationsQuery.Definition)
                 : null;
@@ -709,12 +716,13 @@ public static class InspectionGraphIntegrationsQuery
             builder.AddTypeCurrency(integrations);
         if (extensions is not null)
             builder.AddExtensions(extensions);
-        if (integrationsSelected)
-            builder.AddIntegrations(integrations!);
+        if (integrations is not null)
+            builder.AddIntegrations(integrations);
         if (references is not null)
             builder.AddReferences(references);
         if (opportunities is not null)
             builder.AddOpportunities(opportunities);
+        builder.EnsureSeed(request.Seed);
 
         InspectionGraphDocument source =
             builder.Build(request.ModeRequest);
@@ -803,6 +811,17 @@ public static class InspectionGraphIntegrationsQuery
                         "An Integration graph prerequisite result does not match workspace participant order.");
                 }
             }
+        }
+
+        internal void EnsureSeed(InspectionGraphSubject seed)
+        {
+            if (seed is InspectionGraphSubject.PackageSubject)
+                return;
+
+            AssemblyAcquisitionRegistration registration =
+                Registration(seed);
+            if (_participants.ContainsKey(registration))
+                AddNode(seed, registration);
         }
 
         internal void AddTypeCurrency(

--- a/src/DotnetInspector.Queries/InspectionGraphNeighborhoodRequest.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphNeighborhoodRequest.cs
@@ -1,0 +1,698 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>Which semantic endpoint roles a neighborhood may traverse.</summary>
+public enum InspectionGraphTraversalDirection
+{
+    Outgoing,
+    Incoming,
+    Both,
+}
+
+/// <summary>
+/// A finite relationship neighborhood around one typed seed.
+/// </summary>
+public sealed class InspectionGraphNeighborhoodRequest
+{
+    InspectionGraphNeighborhoodRequest(
+        InspectionGraphSubject seed,
+        IEnumerable<InspectionGraphRelationshipDescriptor> relationships,
+        InspectionGraphTraversalDirection direction,
+        int maxDepth)
+    {
+        ArgumentNullException.ThrowIfNull(seed);
+        InspectionGraphCollections.RequireDefined(direction, nameof(direction));
+        ArgumentOutOfRangeException.ThrowIfNegative(maxDepth);
+        Relationships = InspectionGraphCollections.Snapshot(
+            relationships,
+            nameof(relationships));
+        if (Relationships.IsEmpty)
+        {
+            throw new ArgumentException(
+                "A neighborhood requires at least one relationship.",
+                nameof(relationships));
+        }
+        if (Relationships.Distinct().Count() != Relationships.Length
+            || Relationships.Select(static relationship => relationship.Id)
+                .Distinct(StringComparer.Ordinal).Count()
+                != Relationships.Length)
+        {
+            throw new ArgumentException(
+                "Selected relationships must have distinct identities and ids.",
+                nameof(relationships));
+        }
+
+        ModeRequest = InspectionGraphModeRequest.SingleSeed(seed);
+        Direction = direction;
+        MaxDepth = maxDepth;
+        if (!Relationships
+            .SelectMany(relationship =>
+                relationship.GetSeedAdmissions(seed.Kind))
+            .Any(admission => Includes(admission.Role)))
+        {
+            string ids = string.Join(
+                ", ",
+                Relationships.Select(static relationship =>
+                    relationship.Id));
+            throw new InspectionQueryException(
+                $"No selected relationship admits the "
+                + $"{seed.Kind.ToString().ToLowerInvariant()} seed in the "
+                + $"{direction.ToString().ToLowerInvariant()} direction. "
+                + $"Selected relationships: {ids}.");
+        }
+    }
+
+    public InspectionGraphModeRequest ModeRequest { get; }
+    public InspectionGraphSubject Seed => ModeRequest.Seeds[0];
+    public ImmutableArray<InspectionGraphRelationshipDescriptor>
+        Relationships { get; }
+    public InspectionGraphTraversalDirection Direction { get; }
+    public int MaxDepth { get; }
+
+    public static InspectionGraphNeighborhoodRequest SingleSeed(
+        InspectionGraphSubject seed,
+        IEnumerable<InspectionGraphRelationshipDescriptor> relationships,
+        InspectionGraphTraversalDirection direction,
+        int maxDepth) =>
+        new(seed, relationships, direction, maxDepth);
+
+    internal bool Includes(InspectionGraphEndpointRole role) =>
+        Direction switch
+        {
+            InspectionGraphTraversalDirection.Outgoing =>
+                role == InspectionGraphEndpointRole.Source,
+            InspectionGraphTraversalDirection.Incoming =>
+                role == InspectionGraphEndpointRole.Target,
+            InspectionGraphTraversalDirection.Both =>
+                true,
+            _ => throw new ArgumentOutOfRangeException(nameof(Direction)),
+        };
+}
+
+/// <summary>Neighborhood-owned graph contracts.</summary>
+public static class InspectionGraphNeighborhoodCatalog
+{
+    public static InspectionGraphEvidenceDescriptor DepthBoundEvidence
+        { get; } =
+        new("queries.neighborhood-depth-bound", InspectionGraphOwner.Queries);
+
+    public static InspectionGraphLimitDescriptor DepthBound { get; } =
+        new(
+            "queries.neighborhood-depth-bound",
+            InspectionGraphOwner.Queries,
+            [DepthBoundEvidence]);
+}
+
+/// <summary>The requested maximum number of traversed relationship edges.</summary>
+public sealed record InspectionGraphNeighborhoodDepthBoundEvidence
+    : IInspectionGraphDiagnosticEvidence
+{
+    public InspectionGraphNeighborhoodDepthBoundEvidence(int maxDepth)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(maxDepth);
+        MaxDepth = maxDepth;
+    }
+
+    public int MaxDepth { get; }
+
+    public InspectionGraphEvidenceDescriptor Descriptor =>
+        InspectionGraphNeighborhoodCatalog.DepthBoundEvidence;
+}
+
+internal static class InspectionGraphNeighborhoodProjection
+{
+    internal static InspectionGraphDocument Project(
+        InspectionGraphDocument source,
+        InspectionGraphNeighborhoodRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(request);
+        if (!ReferenceEquals(source.ModeRequest, request.ModeRequest))
+        {
+            throw new ArgumentException(
+                "The source document must use the neighborhood's mode request.",
+                nameof(source));
+        }
+
+        var selectedRelationships =
+            request.Relationships.ToHashSet();
+        InspectionGraphEdge[] selectedEdges =
+        [
+            .. source.Edges.Where(edge =>
+                selectedRelationships.Contains(edge.Relationship)),
+        ];
+        IReadOnlyDictionary<int, ImmutableArray<InspectionGraphEdge>>
+            outgoingEdges = IndexEdges(
+                selectedEdges,
+                static edge => edge.FromNodeId);
+        IReadOnlyDictionary<int, ImmutableArray<InspectionGraphEdge>>
+            incomingEdges = IndexEdges(
+                selectedEdges,
+                static edge => edge.ToNodeId);
+        var retainedEdgeIds = new HashSet<int>();
+        var retainedNodeIds = new HashSet<int>();
+        var queue = new Queue<(int NodeId, int Depth)>();
+        var nodeDepths = new Dictionary<int, int>();
+        InspectionGraphSeed sourceSeed = AssertSingleSeed(source, request);
+        RetainTarget(
+            sourceSeed.Target,
+            retainedNodeIds,
+            retainedGroupIds: null);
+        if (sourceSeed.Target.Kind == InspectionGraphTargetKind.Node)
+            nodeDepths[sourceSeed.Target.Id] = 0;
+
+        if (request.MaxDepth > 0)
+        {
+            foreach (InspectionGraphEdge edge in selectedEdges)
+            {
+                foreach (InspectionGraphSeedAdmission admission
+                    in edge.Relationship.GetSeedAdmissions(
+                        request.Seed.Kind))
+                {
+                    if (!request.Includes(admission.Role)
+                        || !AdmissionMatches(
+                            source,
+                            edge,
+                            request.Seed,
+                            admission))
+                    {
+                        continue;
+                    }
+
+                    RetainEdge(edge, retainedEdgeIds, retainedNodeIds);
+                    int nextNodeId =
+                        admission.Role == InspectionGraphEndpointRole.Source
+                            ? edge.ToNodeId
+                            : edge.FromNodeId;
+                    Enqueue(nextNodeId, 1, nodeDepths, queue);
+                }
+            }
+        }
+
+        while (queue.TryDequeue(out (int NodeId, int Depth) item))
+        {
+            if (item.Depth >= request.MaxDepth)
+                continue;
+
+            if (request.Includes(InspectionGraphEndpointRole.Source)
+                && outgoingEdges.TryGetValue(
+                    item.NodeId,
+                    out ImmutableArray<InspectionGraphEdge> outgoing))
+            {
+                foreach (InspectionGraphEdge edge in outgoing)
+                {
+                    RetainEdge(edge, retainedEdgeIds, retainedNodeIds);
+                    Enqueue(
+                        edge.ToNodeId,
+                        item.Depth + 1,
+                        nodeDepths,
+                        queue);
+                }
+            }
+            if (request.Includes(InspectionGraphEndpointRole.Target)
+                && incomingEdges.TryGetValue(
+                    item.NodeId,
+                    out ImmutableArray<InspectionGraphEdge> incoming))
+            {
+                foreach (InspectionGraphEdge edge in incoming)
+                {
+                    RetainEdge(edge, retainedEdgeIds, retainedNodeIds);
+                    Enqueue(
+                        edge.FromNodeId,
+                        item.Depth + 1,
+                        nodeDepths,
+                        queue);
+                }
+            }
+        }
+
+        foreach (InspectionGraphFailure failure in source.Failures)
+        {
+            if (failure.Target is
+                {
+                    Kind: InspectionGraphTargetKind.Node,
+                } target)
+            {
+                retainedNodeIds.Add(target.Id);
+            }
+        }
+
+        var retainedOccurrenceIds = retainedEdgeIds
+            .SelectMany(id => source.Edges[id].OccurrenceIds)
+            .ToHashSet();
+        if (retainedOccurrenceIds.Any(id =>
+            !source.Occurrences[id].DerivedFromOccurrenceIds.IsEmpty))
+        {
+            throw new InspectionQueryException(
+                "Neighborhood projection does not yet support derived occurrence receipts.");
+        }
+
+        var retainedGroupIds = new HashSet<int>();
+        RetainTarget(
+            sourceSeed.Target,
+            retainedNodeIds: null,
+            retainedGroupIds: retainedGroupIds);
+        foreach (int nodeId in retainedNodeIds)
+        {
+            retainedGroupIds.UnionWith(
+                source.Nodes[nodeId].GroupIds);
+        }
+        RetainGroupParents(source, retainedGroupIds);
+
+        Dictionary<int, int> groupIds = DenseMap(retainedGroupIds);
+        Dictionary<int, int> nodeIds = DenseMap(retainedNodeIds);
+        Dictionary<int, int> occurrenceIds =
+            DenseMap(retainedOccurrenceIds);
+        Dictionary<int, int> edgeIds = DenseMap(retainedEdgeIds);
+
+        InspectionGraphGroup[] groups =
+        [
+            .. retainedGroupIds.Order().Select(id =>
+                new InspectionGraphGroup(
+                    groupIds[id],
+                    source.Groups[id].Subject,
+                    source.Groups[id].ParentId is int parentId
+                        ? groupIds[parentId]
+                        : null)),
+        ];
+        InspectionGraphNode[] nodes =
+        [
+            .. retainedNodeIds.Order().Select(id =>
+                new InspectionGraphNode(
+                    nodeIds[id],
+                    source.Nodes[id].Subject,
+                    source.Nodes[id].Role,
+                    source.Nodes[id].GroupIds
+                        .Where(groupIds.ContainsKey)
+                        .Select(groupId => groupIds[groupId]))),
+        ];
+        InspectionGraphOccurrence[] occurrences =
+        [
+            .. retainedOccurrenceIds.Order().Select(id =>
+            {
+                InspectionGraphOccurrence occurrence =
+                    source.Occurrences[id];
+                return new InspectionGraphOccurrence(
+                    occurrenceIds[id],
+                    occurrence.Relationship,
+                    occurrence.SourceSubject,
+                    occurrence.TargetSubject,
+                    occurrence.Evidence,
+                    []);
+            }),
+        ];
+        InspectionGraphEdge[] edges =
+        [
+            .. retainedEdgeIds.Order().Select(id =>
+            {
+                InspectionGraphEdge edge = source.Edges[id];
+                return new InspectionGraphEdge(
+                    edgeIds[id],
+                    nodeIds[edge.FromNodeId],
+                    nodeIds[edge.ToNodeId],
+                    edge.Relationship,
+                    edge.OccurrenceIds.Select(
+                        occurrenceId =>
+                            occurrenceIds[occurrenceId]));
+            }),
+        ];
+        InspectionGraphCharacteristic[] characteristics =
+        [
+            .. source.Characteristics.Select(characteristic =>
+                RemapCharacteristic(
+                    characteristic,
+                    nodeIds,
+                    groupIds,
+                    edgeIds,
+                    occurrenceIds))
+                .Where(static characteristic =>
+                    characteristic is not null)
+                .Select(static characteristic => characteristic!),
+        ];
+        InspectionGraphSeed seed = new(
+            sourceSeed.Subject,
+            RemapTarget(
+                sourceSeed.Target,
+                nodeIds,
+                groupIds,
+                edgeIds,
+                occurrenceIds)
+                ?? throw new InspectionQueryException(
+                    "The neighborhood seed target was not retained."),
+            sourceSeed.Role);
+        InspectionGraphLimit[] limits =
+        [
+            .. source.Limits.Select(limit =>
+                RemapLimit(
+                    limit,
+                    nodeIds,
+                    groupIds,
+                    edgeIds,
+                    occurrenceIds))
+                .Where(static limit => limit is not null)
+                .Select(static limit => limit!),
+            new(
+                InspectionGraphNeighborhoodCatalog.DepthBound,
+                seed.Target,
+                new InspectionGraphNeighborhoodDepthBoundEvidence(
+                    request.MaxDepth)),
+        ];
+        InspectionGraphFailure[] failures =
+        [
+            .. source.Failures.Select(failure =>
+                RemapFailure(
+                    failure,
+                    nodeIds,
+                    groupIds,
+                    edgeIds,
+                    occurrenceIds))
+                .Where(static failure => failure is not null)
+                .Select(static failure => failure!),
+        ];
+
+        return new InspectionGraphDocument(
+            source.Scope,
+            request,
+            nodes,
+            groups,
+            edges,
+            occurrences,
+            characteristics,
+            [seed],
+            limits,
+            failures);
+    }
+
+    static IReadOnlyDictionary<int, ImmutableArray<InspectionGraphEdge>>
+        IndexEdges(
+            IEnumerable<InspectionGraphEdge> edges,
+            Func<InspectionGraphEdge, int> getNodeId) =>
+        edges.GroupBy(getNodeId)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.ToImmutableArray());
+
+    static InspectionGraphSeed AssertSingleSeed(
+        InspectionGraphDocument source,
+        InspectionGraphNeighborhoodRequest request)
+    {
+        InspectionGraphSeed seed = source.Seeds.SingleOrDefault()
+            ?? throw new InspectionQueryException(
+                "A single-seed neighborhood requires one bound seed.");
+        if (seed.Subject != request.Seed
+            || seed.Role != InspectionGraphSeedRole.Primary)
+        {
+            throw new InspectionQueryException(
+                "The source document seed does not match the neighborhood request.");
+        }
+        return seed;
+    }
+
+    static bool AdmissionMatches(
+        InspectionGraphDocument source,
+        InspectionGraphEdge edge,
+        InspectionGraphSubject seed,
+        InspectionGraphSeedAdmission admission)
+    {
+        InspectionGraphSubject edgeEndpoint =
+            admission.Role == InspectionGraphEndpointRole.Source
+                ? source.Nodes[edge.FromNodeId].Subject
+                : source.Nodes[edge.ToNodeId].Subject;
+        return admission.Kind switch
+        {
+            InspectionGraphSeedAdmissionKind.EdgeEndpoint =>
+                edgeEndpoint == seed,
+            InspectionGraphSeedAdmissionKind.OccurrenceEndpoint =>
+                edge.OccurrenceIds.Any(id =>
+                    OccurrenceEndpoint(
+                        source.Occurrences[id],
+                        admission.Role)
+                    == seed),
+            InspectionGraphSeedAdmissionKind.OwnedSubjects =>
+                StrictlyOwns(source, seed, edgeEndpoint)
+                || edge.OccurrenceIds.Any(id =>
+                    StrictlyOwns(
+                        source,
+                        seed,
+                        OccurrenceEndpoint(
+                            source.Occurrences[id],
+                            admission.Role))),
+            _ => throw new ArgumentOutOfRangeException(nameof(admission)),
+        };
+    }
+
+    static InspectionGraphSubject OccurrenceEndpoint(
+        InspectionGraphOccurrence occurrence,
+        InspectionGraphEndpointRole role) =>
+        role == InspectionGraphEndpointRole.Source
+            ? occurrence.SourceSubject
+            : occurrence.TargetSubject;
+
+    static bool StrictlyOwns(
+        InspectionGraphDocument source,
+        InspectionGraphSubject owner,
+        InspectionGraphSubject subject)
+    {
+        if (owner.Kind == subject.Kind)
+            return false;
+        if (owner is InspectionGraphSubject.PackageSubject package)
+        {
+            InspectionGraphNode? node = source.Nodes.SingleOrDefault(
+                candidate => candidate.Subject == subject);
+            return node is not null
+                && node.GroupIds.Any(groupId =>
+                    source.Groups[groupId].Subject == package);
+        }
+        if (!TryGetRegistration(owner, out var ownerRegistration)
+            || !TryGetRegistration(subject, out var subjectRegistration)
+            || !ReferenceEquals(
+                ownerRegistration,
+                subjectRegistration))
+        {
+            return false;
+        }
+
+        return owner switch
+        {
+            InspectionGraphSubject.AssemblySubject =>
+                subject.Kind is InspectionGraphSubjectKind.Type
+                    or InspectionGraphSubjectKind.Member,
+            InspectionGraphSubject.TypeSubject
+                {
+                    Identity:
+                        InspectionGraphTypeIdentity.AcquiredDefinition
+                        ownerType,
+                } when subject is InspectionGraphSubject.MemberSubject
+                {
+                    Identity:
+                        InspectionGraphMemberIdentity.AcquiredApi member,
+                } =>
+                string.Equals(
+                    ownerType.Type.ToMetadataFullName(),
+                    member.Member.TypeFullName,
+                    StringComparison.Ordinal),
+            _ => false,
+        };
+    }
+
+    static bool TryGetRegistration(
+        InspectionGraphSubject subject,
+        out AssemblyAcquisitionRegistration? registration)
+    {
+        registration = subject switch
+        {
+            InspectionGraphSubject.MemberSubject
+            {
+                Identity:
+                    InspectionGraphMemberIdentity.AcquiredApi acquired,
+            } => acquired.Registration,
+            InspectionGraphSubject.TypeSubject
+            {
+                Identity:
+                    InspectionGraphTypeIdentity.AcquiredDefinition acquired,
+            } => acquired.Registration,
+            InspectionGraphSubject.AssemblySubject
+            {
+                Identity:
+                    InspectionGraphAssemblyIdentity.Acquired acquired,
+            } => acquired.Registration,
+            _ => null,
+        };
+        return registration is not null;
+    }
+
+    static void RetainEdge(
+        InspectionGraphEdge edge,
+        HashSet<int> retainedEdgeIds,
+        HashSet<int> retainedNodeIds)
+    {
+        retainedEdgeIds.Add(edge.Id);
+        retainedNodeIds.Add(edge.FromNodeId);
+        retainedNodeIds.Add(edge.ToNodeId);
+    }
+
+    static void Enqueue(
+        int nodeId,
+        int depth,
+        Dictionary<int, int> nodeDepths,
+        Queue<(int NodeId, int Depth)> queue)
+    {
+        if (nodeDepths.TryGetValue(nodeId, out int priorDepth)
+            && priorDepth <= depth)
+        {
+            return;
+        }
+        nodeDepths[nodeId] = depth;
+        queue.Enqueue((nodeId, depth));
+    }
+
+    static void RetainTarget(
+        InspectionGraphTarget target,
+        HashSet<int>? retainedNodeIds,
+        HashSet<int>? retainedGroupIds)
+    {
+        if (target.Kind == InspectionGraphTargetKind.Node)
+            retainedNodeIds?.Add(target.Id);
+        else if (target.Kind == InspectionGraphTargetKind.Group)
+            retainedGroupIds?.Add(target.Id);
+    }
+
+    static void RetainGroupParents(
+        InspectionGraphDocument source,
+        HashSet<int> retainedGroupIds)
+    {
+        int[] initial = [.. retainedGroupIds];
+        foreach (int id in initial)
+        {
+            int? parentId = source.Groups[id].ParentId;
+            while (parentId is int parent)
+            {
+                retainedGroupIds.Add(parent);
+                parentId = source.Groups[parent].ParentId;
+            }
+        }
+    }
+
+    static Dictionary<int, int> DenseMap(
+        HashSet<int> retainedIds) =>
+        retainedIds.Order().Select((id, index) => (id, index))
+            .ToDictionary(static item => item.id, static item => item.index);
+
+    static InspectionGraphCharacteristic? RemapCharacteristic(
+        InspectionGraphCharacteristic characteristic,
+        IReadOnlyDictionary<int, int> nodeIds,
+        IReadOnlyDictionary<int, int> groupIds,
+        IReadOnlyDictionary<int, int> edgeIds,
+        IReadOnlyDictionary<int, int> occurrenceIds)
+    {
+        InspectionGraphTarget? target = RemapTarget(
+            characteristic.Target,
+            nodeIds,
+            groupIds,
+            edgeIds,
+            occurrenceIds);
+        if (target is null)
+            return null;
+
+        InspectionGraphTarget?[] sources =
+        [
+            .. characteristic.Derivation.Sources.Select(source =>
+                RemapTarget(
+                    source,
+                    nodeIds,
+                    groupIds,
+                    edgeIds,
+                    occurrenceIds)),
+        ];
+        if (sources.Any(static source => source is null))
+            return null;
+
+        return new InspectionGraphCharacteristic(
+            characteristic.Descriptor,
+            target.Value,
+            characteristic.Value,
+            new InspectionGraphCharacteristicDerivation(
+                characteristic.Derivation.Kind,
+                sources.Select(static source => source!.Value)));
+    }
+
+    static InspectionGraphLimit? RemapLimit(
+        InspectionGraphLimit limit,
+        IReadOnlyDictionary<int, int> nodeIds,
+        IReadOnlyDictionary<int, int> groupIds,
+        IReadOnlyDictionary<int, int> edgeIds,
+        IReadOnlyDictionary<int, int> occurrenceIds)
+    {
+        if (limit.Target is not { } sourceTarget)
+            return limit;
+        InspectionGraphTarget? target = RemapTarget(
+            sourceTarget,
+            nodeIds,
+            groupIds,
+            edgeIds,
+            occurrenceIds);
+        return target is null
+            ? null
+            : new InspectionGraphLimit(
+                limit.Descriptor,
+                target,
+                limit.Evidence);
+    }
+
+    static InspectionGraphFailure? RemapFailure(
+        InspectionGraphFailure failure,
+        IReadOnlyDictionary<int, int> nodeIds,
+        IReadOnlyDictionary<int, int> groupIds,
+        IReadOnlyDictionary<int, int> edgeIds,
+        IReadOnlyDictionary<int, int> occurrenceIds)
+    {
+        if (failure.Target is not { } sourceTarget)
+            return failure;
+        InspectionGraphTarget? target = RemapTarget(
+            sourceTarget,
+            nodeIds,
+            groupIds,
+            edgeIds,
+            occurrenceIds);
+        return target is null
+            ? null
+            : new InspectionGraphFailure(
+                failure.Descriptor,
+                target,
+                failure.Evidence);
+    }
+
+    static InspectionGraphTarget? RemapTarget(
+        InspectionGraphTarget target,
+        IReadOnlyDictionary<int, int> nodeIds,
+        IReadOnlyDictionary<int, int> groupIds,
+        IReadOnlyDictionary<int, int> edgeIds,
+        IReadOnlyDictionary<int, int> occurrenceIds)
+    {
+        IReadOnlyDictionary<int, int> ids = target.Kind switch
+        {
+            InspectionGraphTargetKind.Node => nodeIds,
+            InspectionGraphTargetKind.Group => groupIds,
+            InspectionGraphTargetKind.Edge => edgeIds,
+            InspectionGraphTargetKind.Occurrence => occurrenceIds,
+            _ => throw new ArgumentOutOfRangeException(nameof(target)),
+        };
+        if (!ids.TryGetValue(target.Id, out int id))
+            return null;
+        return target.Kind switch
+        {
+            InspectionGraphTargetKind.Node =>
+                InspectionGraphTarget.Node(id),
+            InspectionGraphTargetKind.Group =>
+                InspectionGraphTarget.Group(id),
+            InspectionGraphTargetKind.Edge =>
+                InspectionGraphTarget.Edge(id),
+            InspectionGraphTargetKind.Occurrence =>
+                InspectionGraphTarget.Occurrence(id),
+            _ => throw new ArgumentOutOfRangeException(nameof(target)),
+        };
+    }
+}

--- a/src/DotnetInspector.Queries/InspectionGraphNeighborhoodRequest.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphNeighborhoodRequest.cs
@@ -152,6 +152,9 @@ internal static class InspectionGraphNeighborhoodProjection
             incomingEdges = IndexEdges(
                 selectedEdges,
                 static edge => edge.ToNodeId);
+        IReadOnlyDictionary<InspectionGraphSubject, InspectionGraphNode>
+            nodesBySubject = source.Nodes.ToDictionary(
+                static node => node.Subject);
         var retainedEdgeIds = new HashSet<int>();
         var retainedNodeIds = new HashSet<int>();
         var queue = new Queue<(int NodeId, int Depth)>();
@@ -175,6 +178,7 @@ internal static class InspectionGraphNeighborhoodProjection
                     if (!request.Includes(admission.Role)
                         || !AdmissionMatches(
                             source,
+                            nodesBySubject,
                             edge,
                             request.Seed,
                             admission))
@@ -413,6 +417,9 @@ internal static class InspectionGraphNeighborhoodProjection
 
     static bool AdmissionMatches(
         InspectionGraphDocument source,
+        IReadOnlyDictionary<
+            InspectionGraphSubject,
+            InspectionGraphNode> nodesBySubject,
         InspectionGraphEdge edge,
         InspectionGraphSubject seed,
         InspectionGraphSeedAdmission admission)
@@ -432,10 +439,15 @@ internal static class InspectionGraphNeighborhoodProjection
                         admission.Role)
                     == seed),
             InspectionGraphSeedAdmissionKind.OwnedSubjects =>
-                StrictlyOwns(source, seed, edgeEndpoint)
+                StrictlyOwns(
+                    source,
+                    nodesBySubject,
+                    seed,
+                    edgeEndpoint)
                 || edge.OccurrenceIds.Any(id =>
                     StrictlyOwns(
                         source,
+                        nodesBySubject,
                         seed,
                         OccurrenceEndpoint(
                             source.Occurrences[id],
@@ -453,6 +465,9 @@ internal static class InspectionGraphNeighborhoodProjection
 
     static bool StrictlyOwns(
         InspectionGraphDocument source,
+        IReadOnlyDictionary<
+            InspectionGraphSubject,
+            InspectionGraphNode> nodesBySubject,
         InspectionGraphSubject owner,
         InspectionGraphSubject subject)
     {
@@ -460,9 +475,9 @@ internal static class InspectionGraphNeighborhoodProjection
             return false;
         if (owner is InspectionGraphSubject.PackageSubject package)
         {
-            InspectionGraphNode? node = source.Nodes.SingleOrDefault(
-                candidate => candidate.Subject == subject);
-            return node is not null
+            return nodesBySubject.TryGetValue(
+                    subject,
+                    out InspectionGraphNode? node)
                 && node.GroupIds.Any(groupId =>
                     source.Groups[groupId].Subject == package);
         }

--- a/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
+++ b/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
@@ -9,6 +9,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace DotnetInspector.Tests;
 
+[Collection("Console")]
 public sealed class VocabularyCommandTests
 {
     [Fact]


### PR DESCRIPTION
# Bounded Integration neighborhoods

## Summary

Implements the first load-bearing single-seed Integration neighborhood for
issue #4133: callers select an explicit relationship set, semantic
incoming/outgoing/both traversal, and a finite edge-depth bound.

- validates descriptor-owned seed admission and the Integration relationship
  catalog before producer execution
- plans only selected producers and required composition prerequisites,
  preserving deterministic sequential execution for Browser/Wasm
- densely remaps the bounded result while preserving semantic edge direction,
  typed subjects, evidence, physical occurrence identity, scoped failures,
  and a typed depth-bound disclosure

Existing mode-only Integration overloads retain their full-plan behavior. This
slice does not add a command or presentation surface; peer/induced
neighborhoods, derived occurrence receipts, and call-graph traversal remain
deferred.

## Demo

This slice is an L1 API, so the demo starts with a loaded workspace context and
its owner-issued `IChatClient` type subject:

```csharp
var request = InspectionGraphNeighborhoodRequest.SingleSeed(
    iChatClient,
    [
        InspectionGraphIntegrationsCatalog.IntegrationObserved,
        InspectionGraphIntegrationsCatalog.Extension,
    ],
    InspectionGraphTraversalDirection.Both,
    maxDepth: 2);

InspectionGraphDocument graph =
    InspectionGraphIntegrationsQuery.Execute(context, request);
```

Against the locked multi-assembly Integration fixture, depth one retains the
two observed adapter relationships into `IChatClient`. Depth two reaches the
same adapter members' extension relationships:

```mermaid
flowchart LR
    openai["OpenAI adapter member"] -->|integration.observed| hub["IChatClient"]
    bedrock["Bedrock adapter member"] -->|integration.observed| hub
    openai -->|api.extension| chat["OpenAI.Chat.ChatClient"]
    bedrock -->|api.extension| runtime["IAmazonBedrockRuntime"]
```

The result has four semantic edges: two `integration.observed` and two
`api.extension`. Their original physical occurrences and evidence remain
attached after dense id remapping. Traversing inward from `IChatClient` does
not reverse the stored adapter-to-interface edge direction.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- full Queries suite: 403/403
- Browser/Wasm publish
- browser-engine suite: 43/43
- focused graph/Integration suite: 57/57
- focused console-isolation suite: 10/10
- Markdown lint and diff checks
- exact-head GPT-5.6 Sol and Claude Opus 5 reviews: clean
- current-head `ci-required`: success
