### PR TITLE
Isolate EvilPool file-app NuGet restores

### DIFF
--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -67,7 +67,8 @@ jobs:
           # evidence, so it wants what ships today, not the pinned pool the EVIL
           # corpus measures. The pin exists to make the corpus reproducible
           # (#3353); honoring it here would quietly turn discovery into a replay.
-          dotnet run eng/prepare-decompiler-package-sweep.cs -- \
+          dotnet run -p:NoWarn=NU1507 -p:NuGetAudit=false \
+            eng/prepare-decompiler-package-sweep.cs -- \
             artifacts/package-sweep 1 10 --resolve-latest \
             | tee artifacts/package-sweep/acquisition.txt
 

--- a/eng/prepare-decompiler-package-sweep.cs
+++ b/eng/prepare-decompiler-package-sweep.cs
@@ -24,10 +24,13 @@ string[] positional = args
 // which is the shape this file exists to remove: a caller reading the exit code sees
 // a crash where the contract promises a stated refusal.
 const string UsageText =
-    "Usage: dotnet run eng/prepare-decompiler-package-sweep.cs -- "
+    "Usage: dotnet run -p:NoWarn=NU1507 -p:NuGetAudit=false "
+    + "eng/prepare-decompiler-package-sweep.cs -- "
     + "<output-directory> [start-rank] [package-count] [--resolve-latest] [--refresh-pin]"
-    + "\n   or: dotnet run eng/prepare-decompiler-package-sweep.cs -- --validate-pin <pin-file>..."
-    + "\n   or: dotnet run eng/prepare-decompiler-package-sweep.cs -- --list-pin-rules";
+    + "\n   or: dotnet run -p:NoWarn=NU1507 -p:NuGetAudit=false "
+    + "eng/prepare-decompiler-package-sweep.cs -- --validate-pin <pin-file>..."
+    + "\n   or: dotnet run -p:NoWarn=NU1507 -p:NuGetAudit=false "
+    + "eng/prepare-decompiler-package-sweep.cs -- --list-pin-rules";
 
 // The names of the shape rules above, one per line, so that the suite holding them can
 // ask which rules exist instead of keeping its own list of them. Round fourteen added a

--- a/eng/prepare-evil-corpus.sh
+++ b/eng/prepare-evil-corpus.sh
@@ -50,7 +50,9 @@ trap 'rm -rf "$work"' EXIT
 # 1. Broad-source NuGet sweep. The sweep extracts assemblies into
 #    <outdir>/sweep/packages/... and lists those durable paths, so it must write
 #    into the persisted output directory, never the temp dir.
-dotnet run "$root/eng/prepare-decompiler-package-sweep.cs" -- "$outdir/sweep" 1 "$PACKAGE_COUNT" >&2
+dotnet run -p:NoWarn=NU1507 -p:NuGetAudit=false \
+    "$root/eng/prepare-decompiler-package-sweep.cs" -- \
+    "$outdir/sweep" 1 "$PACKAGE_COUNT" >&2
 
 # 2. Fixed real-world corpus assemblies -> $work/real-world.txt (durable repo/nuget
 #    cache paths, so the intermediate list itself may be ephemeral).

--- a/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolPinTests.cs
@@ -355,17 +355,7 @@ public class EvilPoolPinTests
     /// </summary>
     static HashSet<string> PinRuleNamesFromSweep(string root)
     {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") is { Length: > 0 } host
-                ? host
-                : "dotnet",
-            WorkingDirectory = root,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
-        startInfo.ArgumentList.Add("run");
-        startInfo.ArgumentList.Add(Path.Combine(root, "eng", "prepare-decompiler-package-sweep.cs"));
+        var startInfo = EvilPoolSweepProcess.Create(root, root);
         startInfo.ArgumentList.Add("--");
         startInfo.ArgumentList.Add("--list-pin-rules");
 
@@ -466,17 +456,7 @@ public class EvilPoolPinTests
     static (int ExitCode, string Output, string Errors) RunSweep(
         string root, string workingDirectory, string outputDirectory)
     {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") is { Length: > 0 } host
-                ? host
-                : "dotnet",
-            WorkingDirectory = workingDirectory,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
-        startInfo.ArgumentList.Add("run");
-        startInfo.ArgumentList.Add(Path.Combine(root, "eng", "prepare-decompiler-package-sweep.cs"));
+        var startInfo = EvilPoolSweepProcess.Create(root, workingDirectory);
         startInfo.ArgumentList.Add("--");
         startInfo.ArgumentList.Add(outputDirectory);
         startInfo.ArgumentList.Add("1");
@@ -519,17 +499,7 @@ public class EvilPoolPinTests
     /// </summary>
     static PinVerdict[] ValidateWithSweep(string root, string[] paths)
     {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") is { Length: > 0 } host
-                ? host
-                : "dotnet",
-            WorkingDirectory = root,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
-        startInfo.ArgumentList.Add("run");
-        startInfo.ArgumentList.Add(Path.Combine(root, "eng", "prepare-decompiler-package-sweep.cs"));
+        var startInfo = EvilPoolSweepProcess.Create(root, root);
         startInfo.ArgumentList.Add("--");
         startInfo.ArgumentList.Add("--validate-pin");
         foreach (string path in paths)

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -150,14 +150,14 @@ public class EvilPoolSweepGateTests
     }
 
     [Fact]
-    public void SweepLauncherOverridesAmbientNuGetSourcesAndAudit()
+    public void SweepLauncherSuppressesAmbientSourceAndAuditDiagnostics()
     {
         var startInfo = EvilPoolSweepProcess.Create("/repository", "/working");
 
         Assert.Equal(
             [
                 "run",
-                "-p:RestoreSources=https://api.nuget.org/v3/index.json",
+                "-p:NoWarn=NU1507",
                 "-p:NuGetAudit=false",
                 Path.Combine(
                     "/repository",

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepGateTests.cs
@@ -149,6 +149,24 @@ public class EvilPoolSweepGateTests
         Assert.False(File.Exists(world.ManifestPath));
     }
 
+    [Fact]
+    public void SweepLauncherOverridesAmbientNuGetSourcesAndAudit()
+    {
+        var startInfo = EvilPoolSweepProcess.Create("/repository", "/working");
+
+        Assert.Equal(
+            [
+                "run",
+                "-p:RestoreSources=https://api.nuget.org/v3/index.json",
+                "-p:NuGetAudit=false",
+                Path.Combine(
+                    "/repository",
+                    "eng",
+                    "prepare-decompiler-package-sweep.cs"),
+            ],
+            startInfo.ArgumentList);
+    }
+
     /// <summary>
     /// A sweep that cannot write its assembly record refuses the output directory.
     ///
@@ -1873,20 +1891,9 @@ public class EvilPoolSweepGateTests
         /// </summary>
         public (int ExitCode, string Output, string Errors) Run()
         {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH") is { Length: > 0 } host
-                    ? host
-                    : "dotnet",
-                WorkingDirectory = FakeRoot,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-            };
-            startInfo.ArgumentList.Add("run");
-            startInfo.ArgumentList.Add(Path.Combine(
+            var startInfo = EvilPoolSweepProcess.Create(
                 AuthoredCorpusRatchetTests.FindRepositoryRoot(),
-                "eng",
-                "prepare-decompiler-package-sweep.cs"));
+                FakeRoot);
             startInfo.ArgumentList.Add("--");
             startInfo.ArgumentList.Add(OutputDirectory);
 

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepProcess.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepProcess.cs
@@ -9,7 +9,7 @@ namespace ILInspector.Decompiler.Tests;
 /// This controls only the implicit restore that happens before the script runs.
 /// The sweep's runtime package-source boundary remains
 /// <c>DOTNET_INSPECT_SWEEP_NUGET_CONFIG</c>. The exact build arguments are gated
-/// by <c>EvilPoolSweepGateTests.SweepLauncherOverridesAmbientNuGetSourcesAndAudit</c>.
+/// by <c>EvilPoolSweepGateTests.SweepLauncherSuppressesAmbientSourceAndAuditDiagnostics</c>.
 /// </remarks>
 internal static class EvilPoolSweepProcess
 {
@@ -28,8 +28,9 @@ internal static class EvilPoolSweepProcess
             RedirectStandardError = true,
         };
         startInfo.ArgumentList.Add("run");
-        startInfo.ArgumentList.Add(
-            "-p:RestoreSources=https://api.nuget.org/v3/index.json");
+        // Keep the machine's usable sources, including corporate proxies. The
+        // sweep's own package acquisition is isolated separately at runtime.
+        startInfo.ArgumentList.Add("-p:NoWarn=NU1507");
         startInfo.ArgumentList.Add("-p:NuGetAudit=false");
         startInfo.ArgumentList.Add(Path.Combine(
             repositoryRoot,

--- a/src/ILInspector.Decompiler.Tests/EvilPoolSweepProcess.cs
+++ b/src/ILInspector.Decompiler.Tests/EvilPoolSweepProcess.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Starts the file-based sweep with a deterministic build-time restore policy.
+/// </summary>
+/// <remarks>
+/// This controls only the implicit restore that happens before the script runs.
+/// The sweep's runtime package-source boundary remains
+/// <c>DOTNET_INSPECT_SWEEP_NUGET_CONFIG</c>. The exact build arguments are gated
+/// by <c>EvilPoolSweepGateTests.SweepLauncherOverridesAmbientNuGetSourcesAndAudit</c>.
+/// </remarks>
+internal static class EvilPoolSweepProcess
+{
+    public static ProcessStartInfo Create(
+        string repositoryRoot,
+        string workingDirectory)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = Environment.GetEnvironmentVariable("DOTNET_HOST_PATH")
+                is { Length: > 0 } host
+                    ? host
+                    : "dotnet",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        startInfo.ArgumentList.Add("run");
+        startInfo.ArgumentList.Add(
+            "-p:RestoreSources=https://api.nuget.org/v3/index.json");
+        startInfo.ArgumentList.Add("-p:NuGetAudit=false");
+        startInfo.ArgumentList.Add(Path.Combine(
+            repositoryRoot,
+            "eng",
+            "prepare-decompiler-package-sweep.cs"));
+        return startInfo;
+    }
+}

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -520,7 +520,8 @@ difficulty profile is selection/analysis metadata the oracle ignores.
 The sweep also answers questions about a pin file without acquiring anything:
 
 ```bash
-dotnet run eng/prepare-decompiler-package-sweep.cs -- \
+dotnet run -p:NoWarn=NU1507 -p:NuGetAudit=false \
+  eng/prepare-decompiler-package-sweep.cs -- \
   --validate-pin docs/data/nuget-top-packages.lock.json
 ```
 
@@ -537,7 +538,8 @@ short at exit 1.
 It also names the rules it applies, one per line:
 
 ```bash
-dotnet run eng/prepare-decompiler-package-sweep.cs -- --list-pin-rules
+dotnet run -p:NoWarn=NU1507 -p:NuGetAudit=false \
+  eng/prepare-decompiler-package-sweep.cs -- --list-pin-rules
 ```
 
 `EvilPoolPinTests` holds each of those rules with a tampered pin file and asserts the


### PR DESCRIPTION
Fixes nested EvilPool file-app restores without replacing machine-configured package sources. All four test launch paths now use one helper that suppresses the central-package-management multi-source diagnostic and disables NuGet auditing for the launcher build. The local EVIL-corpus launcher, Deep Inspect workflow, command help, and harness documentation use the same policy. The sweep app’s separate runtime source contract remains unchanged.

Focused evidence at `01691aee1f2205e232566a7c3de17cc9f5533016`:
- Complete EvilPool pin and sweep-gate classes: 39 executions, 0 failures, 2 expected platform/cache skips.
- Proxy-safe file-app launch successfully listed all 10 pin rules while retaining configured sources.
- Shell syntax, workflow YAML, Markdown lint, and diff checks passed.

Closes #4316