### PR TITLE
Isolate vocabulary console capture tests

### DIFF
--- a/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
+++ b/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
@@ -9,6 +9,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace DotnetInspector.Tests;
 
+[Collection("Console")]
 public sealed class VocabularyCommandTests
 {
     [Fact]


### PR DESCRIPTION
## Summary

`VocabularyCommandTests` uses the process-global `ConsoleCapture` harness but was the only such command test class left outside an assembly-exclusive collection. The runtime guard therefore rejected all eight captured vocabulary tests whenever CI's path filters ran the Linux suite.

Place the class in the existing `Console` collection, matching every other `ConsoleCapture` caller and the contract introduced by #4324.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -trait- "Speed=Slow"` (2,952 total, 0 failed; 12 local unavailable-oracle skips)

**Review:** Trivial one-line test scheduling correction using the repository's existing collection; adversarial review is not warranted.
