### PR TITLE
Fix final vocabulary review findings

### DIFF
--- a/docs/design/vocabulary.md
+++ b/docs/design/vocabulary.md
@@ -20,7 +20,7 @@ dotnet-inspect vocabulary -S @Decompiler --count
 - `-D` discovers sections, categories, and fields.
 - `-S` selects the values to materialize.
 - `--columns`, `--fields`, `--rows`, and `--count` narrow those values.
-- Markdown, table, TSV, JSONL, and JSON use the same section and row identities.
+- Markdown, plain text, table, TSV, JSONL, and JSON use the same section and row identities.
 
 The structured document carries a schema version. Every section declares its
 stable ID, categories, accepted query inputs, field schema, legal operators, and

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -121,6 +121,15 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void VocabularyCommand_AcceptsPlainText()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(
+            ["vocabulary", "-S", "Accessibility", "--plaintext"]);
+
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
     public void BodyShapeCommand_RejectsUnknownOrCaseVariantKind()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(

--- a/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
+++ b/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
@@ -332,6 +332,35 @@ public sealed class VocabularyCommandTests
         Assert.DoesNotContain("| Section |", result.Output);
     }
 
+    [Fact]
+    public async Task Command_CountUsesRowCardinalityBeforeColumnProjection()
+    {
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select =
+                [
+                    VocabularyCatalog.AccessibilitySection,
+                    VocabularyCatalog.StyleTiersSection,
+                ],
+                Count = true,
+                Columns = ["byte_divergent"],
+            })));
+        VocabularySection accessibility =
+            VocabularyCatalog.GetById("api.accessibility");
+        VocabularySection tiers =
+            VocabularyCatalog.GetById("csharp.style-tiers");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Contains(
+            $"| Accessibility | {accessibility.Values.Length} |",
+            result.Output);
+        Assert.Contains(
+            $"| C# Style Tiers | {tiers.Values.Length} |",
+            result.Output);
+    }
+
     private static string ValueId(VocabularyRow row) =>
         row.GetRequired("id").Text!;
 }

--- a/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
+++ b/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
@@ -230,9 +230,9 @@ public sealed class VocabularyCommandTests
     }
 
     [Fact]
-    public async Task Command_PartialProjectedJsonOmitsUnmatchedSections()
+    public async Task Command_PartialMachineKeyProjectionKeepsSectionIdentityAcrossFormats()
     {
-        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+        var json = await ConsoleCapture.RunAsync(() => Task.FromResult(
             VocabularyCommand.Execute(new VocabularyOptions
             {
                 Select =
@@ -241,15 +241,32 @@ public sealed class VocabularyCommandTests
                     VocabularyCatalog.StyleTiersSection,
                 ],
                 JsonOutput = true,
-                Columns = ["Title"],
+                Columns = ["byte_divergent"],
+            })));
+        var markdown = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select =
+                [
+                    VocabularyCatalog.AccessibilitySection,
+                    VocabularyCatalog.StyleTiersSection,
+                ],
+                Columns = ["byte_divergent"],
             })));
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Empty(result.Error);
-        using JsonDocument document = JsonDocument.Parse(result.Output);
+        Assert.Equal(0, json.ExitCode);
+        Assert.Empty(json.Error);
+        using JsonDocument document = JsonDocument.Parse(json.Output);
         Assert.False(document.RootElement.TryGetProperty("accessibility", out _));
         Assert.True(document.RootElement.TryGetProperty("c#style_tiers", out JsonElement rows));
         Assert.Equal(JsonValueKind.Array, rows.ValueKind);
+        Assert.Equal(4, rows.GetArrayLength());
+
+        Assert.Equal(0, markdown.ExitCode);
+        Assert.Empty(markdown.Error);
+        Assert.DoesNotContain("## Accessibility", markdown.Output);
+        Assert.Contains("## C# Style Tiers", markdown.Output);
+        Assert.Contains("| Byte Divergent |", markdown.Output);
     }
 
     [Fact]
@@ -294,6 +311,25 @@ public sealed class VocabularyCommandTests
         Assert.Contains("Accessibility", result.Output);
         Assert.DoesNotContain("# Vocabulary", result.Output);
         Assert.DoesNotContain("| ID |", result.Output);
+    }
+
+    [Fact]
+    public async Task Command_PlainTextMultiSectionCountUsesPlainTextTable()
+    {
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select = ["@Decompiler"],
+                Count = true,
+                PlainText = true,
+            })));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Contains("Section", result.Output);
+        Assert.Contains("C# Style Tiers", result.Output);
+        Assert.Contains("C# Style Choices", result.Output);
+        Assert.DoesNotContain("| Section |", result.Output);
     }
 
     private static string ValueId(VocabularyRow row) =>

--- a/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
+++ b/src/dotnet-inspect.Tests/VocabularyCommandTests.cs
@@ -9,6 +9,7 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace DotnetInspector.Tests;
 
+[Collection("Console")]
 public sealed class VocabularyCommandTests
 {
     [Fact]
@@ -226,6 +227,73 @@ public sealed class VocabularyCommandTests
         Assert.Empty(result.Error);
         foreach (VocabularySection section in VocabularyCatalog.Document.Sections)
             Assert.Contains($"| {section.Name} | {section.Values.Length} |", result.Output);
+    }
+
+    [Fact]
+    public async Task Command_PartialProjectedJsonOmitsUnmatchedSections()
+    {
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select =
+                [
+                    VocabularyCatalog.AccessibilitySection,
+                    VocabularyCatalog.StyleTiersSection,
+                ],
+                JsonOutput = true,
+                Columns = ["Title"],
+            })));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        using JsonDocument document = JsonDocument.Parse(result.Output);
+        Assert.False(document.RootElement.TryGetProperty("accessibility", out _));
+        Assert.True(document.RootElement.TryGetProperty("c#style_tiers", out JsonElement rows));
+        Assert.Equal(JsonValueKind.Array, rows.ValueKind);
+    }
+
+    [Fact]
+    public async Task Command_PlainTextUsesThePlainTextFormatter()
+    {
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            VocabularyCommand.Execute(new VocabularyOptions
+            {
+                Select = [VocabularyCatalog.AccessibilitySection],
+                PlainText = true,
+            })));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Contains("Vocabulary", result.Output);
+        Assert.Contains("Accessibility", result.Output);
+        Assert.DoesNotContain("# Vocabulary", result.Output);
+        Assert.DoesNotContain("| ID |", result.Output);
+    }
+
+    [Fact]
+    public async Task CommandLine_PlainTextEnvironmentOverrideUsesThePlainTextFormatter()
+    {
+        string? original = Environment.GetEnvironmentVariable("DOTNET_INSPECT_FORMAT");
+        var result = await ConsoleCapture.RunAsync(async () =>
+        {
+            Environment.SetEnvironmentVariable("DOTNET_INSPECT_FORMAT", "plaintext");
+            try
+            {
+                return await CommandLineBuilder.CreateRootCommand()
+                    .Parse(["vocabulary", "-S", "Accessibility"])
+                    .InvokeAsync();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("DOTNET_INSPECT_FORMAT", original);
+            }
+        });
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.Contains("Accessibility", result.Output);
+        Assert.DoesNotContain("# Vocabulary", result.Output);
+        Assert.DoesNotContain("| ID |", result.Output);
     }
 
     private static string ValueId(VocabularyRow row) =>

--- a/src/dotnet-inspect/CommandLine/Commands/VocabularyCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/VocabularyCommandDefinitions.cs
@@ -18,9 +18,12 @@ public static class VocabularyCommandDefinitions
         opts.AddOutputOptionsTo(command);
         opts.AddSectionOptionsTo(command);
         opts.AddCountOptionTo(command);
+        command.Options.Add(opts.PlainText);
 
-        command.SetAction((parseResult) => VocabularyCommand.Execute(
-            new VocabularyOptions
+        command.SetAction((parseResult) =>
+        {
+            OutputFormat format = opts.ResolveFormat(parseResult);
+            return VocabularyCommand.Execute(new VocabularyOptions
             {
                 Discover = opts.ParseDiscover(parseResult),
                 Select = opts.ParseSelect(parseResult),
@@ -31,12 +34,14 @@ public static class VocabularyCommandDefinitions
                 Tree = opts.ParseTree(parseResult),
                 Count = parseResult.GetValue(opts.Count),
                 Rows = opts.ParseRows(parseResult),
-                JsonOutput = opts.ResolveFormat(parseResult) == OutputFormat.Json,
+                JsonOutput = format == OutputFormat.Json,
+                PlainText = format == OutputFormat.PlainText,
                 Tabular = opts.ResolveTabular(parseResult),
                 Tsv = opts.ResolveTsv(parseResult),
                 Jsonl = opts.ResolveJsonl(parseResult),
                 NoHeader = parseResult.GetValue(opts.NoHeaders),
-            }));
+            });
+        });
 
         return command;
     }

--- a/src/dotnet-inspect/Commands/VocabularyCommand.cs
+++ b/src/dotnet-inspect/Commands/VocabularyCommand.cs
@@ -2,6 +2,7 @@ using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Vocabulary;
 using Markout;
+using System.Globalization;
 
 namespace DotnetInspector.Commands;
 
@@ -67,6 +68,14 @@ public static class VocabularyCommand
         {
             return 1;
         }
+        VocabularySection[] renderedSections = projectedColumns is { Length: > 0 }
+            ?
+            [
+                .. sections.Where(section =>
+                    schema.ValidateProjection(section.Name, projectedColumns)
+                        .Resolved.Length > 0),
+            ]
+            : sections;
 
         if (options.Count)
         {
@@ -80,9 +89,11 @@ public static class VocabularyCommand
                     section => section.Name,
                     section => RowWindow.Apply(options.Rows, section.Values).Count,
                     StringComparer.Ordinal);
-                CountOutput.WriteCountMap(
-                    counts,
-                    [.. sections.Select(section => section.Name)]);
+                string[] orderedSections = [.. sections.Select(section => section.Name)];
+                if (options.PlainText)
+                    WritePlainTextCountMap(counts, orderedSections);
+                else
+                    CountOutput.WriteCountMap(counts, orderedSections);
             }
             return 0;
         }
@@ -99,13 +110,6 @@ public static class VocabularyCommand
         {
             if (projectedColumns is { Length: > 0 })
             {
-                VocabularySection[] projectedSections =
-                [
-                    .. sections.Where(section => section.Fields.Any(field =>
-                        projectedColumns.Contains(
-                            field.Label,
-                            StringComparer.OrdinalIgnoreCase))),
-                ];
                 OutputFormatter.WriteProjectedJson(
                     Console.Out,
                     projectedColumns,
@@ -113,7 +117,7 @@ public static class VocabularyCommand
                     (writer, formatter, writerOptions) =>
                         WriteSections(
                             new MarkoutWriter(writer, formatter, writerOptions),
-                            projectedSections,
+                            renderedSections,
                             includeDocumentHeading: true),
                     maxRows: options.Rows);
             }
@@ -161,7 +165,7 @@ public static class VocabularyCommand
                 ? new PlainTextFormatter()
                 : new MarkdownFormatter(),
             markdownOptions);
-        WriteSections(markdown, sections, includeDocumentHeading: true);
+        WriteSections(markdown, renderedSections, includeDocumentHeading: true);
         markdown.Flush();
         return 0;
     }
@@ -196,6 +200,28 @@ public static class VocabularyCommand
                         : "").ToArray()),
         ];
         writer.WriteTable(labels, ids, rows);
+    }
+
+    private static void WritePlainTextCountMap(
+        IReadOnlyDictionary<string, int> counts,
+        IReadOnlyList<string> orderedSections)
+    {
+        using var output = new StringWriter(CultureInfo.InvariantCulture);
+        var writer = new MarkoutWriter(output, new PlainTextFormatter());
+        writer.WriteTable(
+            ["Section", "Count"],
+            ["section", "count"],
+            [
+                .. orderedSections.Select(section =>
+                    new[]
+                    {
+                        section,
+                        counts.GetValueOrDefault(section)
+                            .ToString(CultureInfo.InvariantCulture),
+                    }),
+            ]);
+        writer.Flush();
+        CountOutput.WriteCountResult(output.ToString(), outputPath: null);
     }
 
     private static DocumentSchema CreateSchema(VocabularyDocument document)

--- a/src/dotnet-inspect/Commands/VocabularyCommand.cs
+++ b/src/dotnet-inspect/Commands/VocabularyCommand.cs
@@ -36,8 +36,9 @@ public static class VocabularyCommand
                 json: options.JsonOutput,
                 tsv: options.Tsv,
                 jsonl: options.Jsonl,
-                markdown: !options.Tabular && !options.JsonOutput,
-                sectionCategories: categoryMap);
+                markdown: !options.Tabular && !options.JsonOutput && !options.PlainText,
+                sectionCategories: categoryMap,
+                plainText: options.PlainText);
         }
 
         SelectResult selection = SelectResolver.ResolveSelectAsSections(
@@ -98,6 +99,13 @@ public static class VocabularyCommand
         {
             if (projectedColumns is { Length: > 0 })
             {
+                VocabularySection[] projectedSections =
+                [
+                    .. sections.Where(section => section.Fields.Any(field =>
+                        projectedColumns.Contains(
+                            field.Label,
+                            StringComparer.OrdinalIgnoreCase))),
+                ];
                 OutputFormatter.WriteProjectedJson(
                     Console.Out,
                     projectedColumns,
@@ -105,7 +113,7 @@ public static class VocabularyCommand
                     (writer, formatter, writerOptions) =>
                         WriteSections(
                             new MarkoutWriter(writer, formatter, writerOptions),
-                            sections,
+                            projectedSections,
                             includeDocumentHeading: true),
                     maxRows: options.Rows);
             }
@@ -149,7 +157,9 @@ public static class VocabularyCommand
             options.Rows);
         var markdown = new MarkoutWriter(
             Console.Out,
-            new MarkdownFormatter(),
+            options.PlainText
+                ? new PlainTextFormatter()
+                : new MarkdownFormatter(),
             markdownOptions);
         WriteSections(markdown, sections, includeDocumentHeading: true);
         markdown.Flush();

--- a/src/dotnet-inspect/Options/VocabularyOptions.cs
+++ b/src/dotnet-inspect/Options/VocabularyOptions.cs
@@ -15,6 +15,7 @@ public sealed record VocabularyOptions : IProjectionOptions
     public bool Count { get; init; }
     public RowWindow? Rows { get; init; }
     public bool JsonOutput { get; init; }
+    public bool PlainText { get; init; }
     public bool Tabular { get; init; }
     public bool Tsv { get; init; }
     public bool Jsonl { get; init; }

--- a/src/dotnet-inspect/Output/DiscoverOutput.cs
+++ b/src/dotnet-inspect/Output/DiscoverOutput.cs
@@ -24,7 +24,8 @@ public static class DiscoverOutput
         IReadOnlyDictionary<string, string[]>? sectionCategories = null,
         IReadOnlySet<string>? catalogHiddenSections = null,
         IReadOnlySet<string>? listedCategoryDoors = null,
-        IProjectionOptions? projection = null)
+        IProjectionOptions? projection = null,
+        bool plainText = false)
     {
         sectionCategories = FilterCategories(sectionCategories, schema.SectionNames);
 
@@ -71,6 +72,10 @@ public static class DiscoverOutput
         else if (markdown)
         {
             context.Serialize(view, Console.Out, new MarkdownFormatter());
+        }
+        else if (plainText)
+        {
+            context.Serialize(view, Console.Out, new PlainTextFormatter());
         }
         else
         {


### PR DESCRIPTION
## Summary

- honor explicit and environment-selected plain-text output for vocabulary values and discovery
- omit unmatched table sections from partial multi-section projected JSON instead of emitting `{}`
- place vocabulary console-capture tests in the assembly-exclusive collection required by current `main`

## Validation

- `VocabularyCommandTests` (12 passed)
- `CommandLineTests` (196 passed)
- Release test-project build
- explicit and environment plain-text CLI probes
- partial multi-section projected JSON probe
- Markdown lint and `git diff --check`

Follow-up to #4312.