### PR TITLE
Add inspect-web staging promotion flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,9 @@ jobs:
         working-directory: prototypes/inspect-web
         run: npm test
 
+      - name: Test inspect-web promotion validation
+        run: dotnet run eng/validate-inspect-web-promotion.cs -- --self-test
+
       - name: Test annotated-source viewer
         working-directory: prototypes/annotated-source-viewer
         run: npm test

--- a/.github/workflows/deploy-inspect-web.yml
+++ b/.github/workflows/deploy-inspect-web.yml
@@ -1,4 +1,4 @@
-name: Deploy inspect-web
+name: Deploy inspect-web staging
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: deploy-inspect-web
+  group: deploy-inspect-web-staging
   cancel-in-progress: true
 
 env:
@@ -21,9 +21,11 @@ env:
 
 jobs:
   deploy:
-    name: Publish and deploy
+    name: Publish staging
     if: github.ref == 'refs/heads/main'
-    environment: inspect-web-production
+    environment:
+      name: inspect-web-staging
+      url: https://dotnet-inspect.ca
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
@@ -49,11 +51,19 @@ jobs:
             -p:SourceRevisionId="$GITHUB_SHA" \
             -p:BuildTimestampUtc="$built_at"
 
-      - name: Deploy to Azure Static Web Apps
+      - name: Upload staged site artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: inspect-web-site
+          path: artifacts/inspect-web-publish/wwwroot
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Deploy to staging
         id: deploy
         uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB }}
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_STAGING }}
           action: upload
           app_location: artifacts/inspect-web-publish/wwwroot
           output_location: ''

--- a/.github/workflows/deploy-inspect-web.yml
+++ b/.github/workflows/deploy-inspect-web.yml
@@ -24,8 +24,6 @@ jobs:
     name: Build staging artifact
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-26.04
-    outputs:
-      artifact_id: ${{ steps.site.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@v6
 
@@ -51,7 +49,6 @@ jobs:
             -p:BuildTimestampUtc="$built_at"
 
       - name: Upload staged site artifact
-        id: site
         uses: actions/upload-artifact@v7
         with:
           name: inspect-web-site
@@ -71,7 +68,7 @@ jobs:
       - name: Download staged site artifact
         uses: actions/download-artifact@v8
         with:
-          artifact-ids: ${{ needs.build.outputs.artifact_id }}
+          name: inspect-web-site
           path: artifacts/inspect-web-publish/wwwroot
           digest-mismatch: error
 

--- a/.github/workflows/deploy-inspect-web.yml
+++ b/.github/workflows/deploy-inspect-web.yml
@@ -20,13 +20,12 @@ env:
   DOTNET_SDK_VERSION: '11.0.100-preview.6.26359.118'
 
 jobs:
-  deploy:
-    name: Publish staging
+  build:
+    name: Build staging artifact
     if: github.ref == 'refs/heads/main'
-    environment:
-      name: inspect-web-staging
-      url: https://dotnet-inspect.ca
     runs-on: ubuntu-26.04
+    outputs:
+      artifact_id: ${{ steps.site.outputs.artifact-id }}
     steps:
       - uses: actions/checkout@v6
 
@@ -52,6 +51,7 @@ jobs:
             -p:BuildTimestampUtc="$built_at"
 
       - name: Upload staged site artifact
+        id: site
         uses: actions/upload-artifact@v7
         with:
           name: inspect-web-site
@@ -59,8 +59,27 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  deploy:
+    name: Publish staging
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: inspect-web-staging
+      url: https://dotnet-inspect.ca
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Download staged site artifact
+        uses: actions/download-artifact@v8
+        with:
+          artifact-ids: ${{ needs.build.outputs.artifact_id }}
+          path: artifacts/inspect-web-publish/wwwroot
+          digest-mismatch: error
+
+      - name: Verify staged site artifact
+        shell: bash
+        run: test -f artifacts/inspect-web-publish/wwwroot/index.html
+
       - name: Deploy to staging
-        id: deploy
         uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_STAGING }}

--- a/.github/workflows/deploy-inspect-web.yml
+++ b/.github/workflows/deploy-inspect-web.yml
@@ -25,10 +25,10 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
 
@@ -49,7 +49,7 @@ jobs:
             -p:BuildTimestampUtc="$built_at"
 
       - name: Upload staged site artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: inspect-web-site
           path: artifacts/inspect-web-publish/wwwroot
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
       - name: Download staged site artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: inspect-web-site
           path: artifacts/inspect-web-publish/wwwroot

--- a/.github/workflows/promote-inspect-web.yml
+++ b/.github/workflows/promote-inspect-web.yml
@@ -72,8 +72,6 @@ jobs:
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.resolve.outputs.sha }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/promote-inspect-web.yml
+++ b/.github/workflows/promote-inspect-web.yml
@@ -1,0 +1,124 @@
+name: Promote inspect-web
+
+on:
+  workflow_dispatch:
+    inputs:
+      staging_run_id:
+        description: 'Successful main staging run whose site artifact will be promoted'
+        required: true
+      confirm:
+        description: 'Type "promote" to confirm production deployment'
+        required: true
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: promote-inspect-web
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    name: Validate staging evidence
+    runs-on: ubuntu-26.04
+    outputs:
+      sha: ${{ steps.evidence.outputs.sha }}
+      run_attempt: ${{ steps.evidence.outputs.run_attempt }}
+      artifact_id: ${{ steps.evidence.outputs.artifact_id }}
+      artifact_digest: ${{ steps.evidence.outputs.artifact_digest }}
+    steps:
+      - name: Validate dispatch intent
+        shell: bash
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != refs/heads/main ]; then
+            echo "::error::Production promotion must be dispatched from main." >&2
+            exit 1
+          fi
+          if [ "$CONFIRM" != promote ]; then
+            echo "::error::Type promote to confirm production deployment." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: preview
+
+      - name: Validate staged site
+        id: evidence
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STAGING_RUN_ID: ${{ inputs.staging_run_id }}
+        run: |
+          bash eng/validate-inspect-web-promotion.sh \
+            "$STAGING_RUN_ID" \
+            720 \
+            "$GITHUB_OUTPUT"
+
+  deploy:
+    name: Promote to production
+    needs: resolve
+    environment:
+      name: inspect-web-production
+      url: https://dotnet-inspect.net
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: preview
+
+      - name: Revalidate staged site
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STAGING_RUN_ID: ${{ inputs.staging_run_id }}
+          EXPECTED_SHA: ${{ needs.resolve.outputs.sha }}
+          EXPECTED_ATTEMPT: ${{ needs.resolve.outputs.run_attempt }}
+          EXPECTED_ARTIFACT_ID: ${{ needs.resolve.outputs.artifact_id }}
+          EXPECTED_DIGEST: ${{ needs.resolve.outputs.artifact_digest }}
+        run: |
+          bash eng/validate-inspect-web-promotion.sh \
+            "$STAGING_RUN_ID" \
+            720 \
+            "$RUNNER_TEMP/revalidated-inspect-web" \
+            "$EXPECTED_SHA" \
+            "$EXPECTED_ATTEMPT" \
+            "$EXPECTED_ARTIFACT_ID" \
+            "$EXPECTED_DIGEST"
+
+      - name: Download staged site artifact
+        uses: actions/download-artifact@v8
+        with:
+          artifact-ids: ${{ needs.resolve.outputs.artifact_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.staging_run_id }}
+          path: artifacts/inspect-web-publish/wwwroot
+          digest-mismatch: error
+
+      - name: Verify staged site artifact
+        shell: bash
+        run: test -f artifacts/inspect-web-publish/wwwroot/index.html
+
+      - name: Deploy to production
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB }}
+          action: upload
+          app_location: artifacts/inspect-web-publish/wwwroot
+          output_location: ''
+          skip_app_build: true

--- a/.github/workflows/promote-inspect-web.yml
+++ b/.github/workflows/promote-inspect-web.yml
@@ -43,10 +43,10 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '11.0.x'
           dotnet-quality: preview
@@ -71,10 +71,10 @@ jobs:
       url: https://dotnet-inspect.net
     runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: '11.0.x'
           dotnet-quality: preview
@@ -99,7 +99,7 @@ jobs:
             "$EXPECTED_DIGEST"
 
       - name: Download staged site artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           artifact-ids: ${{ needs.resolve.outputs.artifact_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promote-inspect-web.yml
+++ b/.github/workflows/promote-inspect-web.yml
@@ -67,7 +67,7 @@ jobs:
     name: Promote to production
     needs: resolve
     environment:
-      name: inspect-web-production
+      name: inspect-web-production-promotion
       url: https://dotnet-inspect.net
     runs-on: ubuntu-26.04
     steps:
@@ -115,7 +115,7 @@ jobs:
       - name: Deploy to production
         uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB }}
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_PRODUCTION }}
           action: upload
           app_location: artifacts/inspect-web-publish/wwwroot
           output_location: ''

--- a/eng/CiChangeDetection/ChangeDetectionApp.cs
+++ b/eng/CiChangeDetection/ChangeDetectionApp.cs
@@ -50,6 +50,7 @@ public static class ChangeDetectionApp
             repository,
             workflowText,
             validateProvenancePin: true);
+        PromotionWorkflowContract.AssertMutations(repository);
         ProvenancePin.AssertMutations(
             workflowText,
             mutated => _ = LoadContract(

--- a/eng/CiChangeDetection/DetectionTestSuite.cs
+++ b/eng/CiChangeDetection/DetectionTestSuite.cs
@@ -340,6 +340,26 @@ internal static class DetectionTestSuite
             throw new InvalidOperationException(
                 $"Web canary did not select only web: {FormatValues(web)}");
         }
+        foreach (string promotionInput in new[]
+        {
+            ".github/workflows/promote-inspect-web.yml",
+            "eng/validate-inspect-web-promotion.cs",
+            "eng/validate-inspect-web-promotion.sh",
+        })
+        {
+            Dictionary<string, string> promotion = RunDetection(
+                repository,
+                body,
+                "pull_request",
+                promotionInput,
+                outputs);
+            if (promotion["code"] != "false" || promotion["web"] != "true")
+            {
+                throw new InvalidOperationException(
+                    $"Promotion input {promotionInput} did not select only web: " +
+                    FormatValues(promotion));
+            }
+        }
         AssertRouting(
             source,
             selected: "shipped",

--- a/eng/CiChangeDetection/DetectionTestSuite.cs
+++ b/eng/CiChangeDetection/DetectionTestSuite.cs
@@ -360,6 +360,19 @@ internal static class DetectionTestSuite
                     FormatValues(promotion));
             }
         }
+        Dictionary<string, string> promotionContract = RunDetection(
+            repository,
+            body,
+            "pull_request",
+            "eng/CiChangeDetection/PromotionWorkflowContract.cs",
+            outputs);
+        if (promotionContract["code"] != "true" ||
+            promotionContract["web"] != "true")
+        {
+            throw new InvalidOperationException(
+                "Promotion workflow contract did not select code and web: " +
+                FormatValues(promotionContract));
+        }
         AssertRouting(
             source,
             selected: "shipped",

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -103,7 +103,7 @@ internal static class PromotionWorkflowContract
         const string productionJob =
             """
                 environment:
-                  name: inspect-web-production
+                  name: inspect-web-production-promotion
                   url: https://dotnet-inspect.net
                 runs-on: ubuntu-26.04
                 steps:
@@ -111,7 +111,7 @@ internal static class PromotionWorkflowContract
         const string productionBashEnv =
             """
                 environment:
-                  name: inspect-web-production
+                  name: inspect-web-production-promotion
                   url: https://dotnet-inspect.net
                 runs-on: ubuntu-26.04
                 env:
@@ -131,7 +131,7 @@ internal static class PromotionWorkflowContract
 
               bypass:
                 name: Bypass production
-                environment: inspect-web-production
+                environment: inspect-web-production-promotion
                 runs-on: ubuntu-26.04
                 steps:
                   - run: echo bypass
@@ -246,7 +246,7 @@ internal static class PromotionWorkflowContract
             environment,
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["name"] = "inspect-web-production",
+                ["name"] = "inspect-web-production-promotion",
                 ["url"] = "https://dotnet-inspect.net",
             },
             "jobs.deploy.environment");
@@ -384,7 +384,7 @@ internal static class PromotionWorkflowContract
             new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 ["azure_static_web_apps_api_token"] =
-                    "${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB }}",
+                    "${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_PRODUCTION }}",
                 ["action"] = "upload",
                 ["app_location"] = "artifacts/inspect-web-publish/wwwroot",
                 ["output_location"] = "",

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -138,6 +138,30 @@ internal static class PromotionWorkflowContract
             """,
             ValidatePromotion,
             "Promotion workflow contract accepted an extra environment-scoped job.");
+
+        AssertMutationRejected(
+            stagingWorkflow,
+            "  workflow_dispatch:\n",
+            "  workflow_dispatch:\n  pull_request_target:\n",
+            ValidateStaging,
+            "Staging workflow contract accepted pull_request_target.");
+        AssertMutationRejected(
+            stagingWorkflow,
+            "permissions:\n  contents: read\n",
+            "permissions:\n  contents: write\n",
+            ValidateStaging,
+            "Staging workflow contract accepted write permission.");
+        AssertMutationRejected(
+            stagingWorkflow,
+            "    steps:\n      - uses: actions/checkout@v6\n",
+            """
+                steps:
+                  - uses: actions/checkout@v6
+                    with:
+                      ref: ${{ github.event.pull_request.head.sha }}
+            """,
+            ValidateStaging,
+            "Staging workflow contract accepted PR-head checkout.");
     }
 
     private static void ValidatePromotion(string workflow)
@@ -158,6 +182,25 @@ internal static class PromotionWorkflowContract
             root,
             ["name", "on", "permissions", "concurrency", "jobs"],
             "promotion workflow");
+        RequireScalarValue(root, "name", "Promote inspect-web", "promotion workflow");
+        ValidatePromotionTrigger(
+            GetRequiredMapping(root, "on", "promotion workflow"));
+        RequireExactScalarValues(
+            GetRequiredMapping(root, "permissions", "promotion workflow"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["actions"] = "read",
+                ["contents"] = "read",
+            },
+            "promotion workflow.permissions");
+        RequireExactScalarValues(
+            GetRequiredMapping(root, "concurrency", "promotion workflow"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["group"] = "promote-inspect-web",
+                ["cancel-in-progress"] = "false",
+            },
+            "promotion workflow.concurrency");
         YamlMappingNode jobs = GetRequiredMapping(root, "jobs", "promotion workflow");
         RequireExactKeys(jobs, ["resolve", "deploy"], "promotion jobs");
         YamlMappingNode resolve = GetRequiredMapping(jobs, "resolve", "promotion jobs");
@@ -165,10 +208,34 @@ internal static class PromotionWorkflowContract
             resolve,
             ["name", "runs-on", "outputs", "steps"],
             "jobs.resolve");
+        RequireScalarValue(
+            resolve,
+            "name",
+            "Validate staging evidence",
+            "jobs.resolve");
+        RequireScalarValue(resolve, "runs-on", "ubuntu-26.04", "jobs.resolve");
+        RequireExactScalarValues(
+            GetRequiredMapping(resolve, "outputs", "jobs.resolve"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["sha"] = "${{ steps.evidence.outputs.sha }}",
+                ["run_attempt"] = "${{ steps.evidence.outputs.run_attempt }}",
+                ["artifact_id"] = "${{ steps.evidence.outputs.artifact_id }}",
+                ["artifact_digest"] =
+                    "${{ steps.evidence.outputs.artifact_digest }}",
+            },
+            "jobs.resolve.outputs");
+        ValidateResolveSteps(
+            GetRequiredSequence(resolve, "steps", "jobs.resolve"));
         YamlMappingNode deploy = GetRequiredMapping(jobs, "deploy", "promotion jobs");
         RequireExactKeys(
             deploy,
             ["name", "needs", "environment", "runs-on", "steps"],
+            "jobs.deploy");
+        RequireScalarValue(
+            deploy,
+            "name",
+            "Promote to production",
             "jobs.deploy");
         RequireScalarValue(deploy, "needs", "resolve", "jobs.deploy");
         RequireScalarValue(deploy, "runs-on", "ubuntu-26.04", "jobs.deploy");
@@ -344,6 +411,27 @@ internal static class PromotionWorkflowContract
             root,
             ["name", "on", "permissions", "concurrency", "env", "jobs"],
             "staging workflow");
+        RequireScalarValue(
+            root,
+            "name",
+            "Deploy inspect-web staging",
+            "staging workflow");
+        ValidateStagingTrigger(GetRequiredMapping(root, "on", "staging workflow"));
+        RequireExactScalarValues(
+            GetRequiredMapping(root, "permissions", "staging workflow"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["contents"] = "read",
+            },
+            "staging workflow.permissions");
+        RequireExactScalarValues(
+            GetRequiredMapping(root, "concurrency", "staging workflow"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["group"] = "deploy-inspect-web-staging",
+                ["cancel-in-progress"] = "true",
+            },
+            "staging workflow.concurrency");
         RequireExactScalarValues(
             GetRequiredMapping(root, "env", "staging workflow"),
             new Dictionary<string, string>(StringComparer.Ordinal)
@@ -360,11 +448,85 @@ internal static class PromotionWorkflowContract
             build,
             ["name", "if", "runs-on", "steps"],
             "jobs.build");
-        YamlSequenceNode buildSteps = GetRequiredSequence(build, "steps", "jobs.build");
-        YamlMappingNode upload = RequireNamedStep(
-            buildSteps,
-            "Upload staged site artifact",
+        RequireScalarValue(
+            build,
+            "name",
+            "Build staging artifact",
             "jobs.build");
+        RequireScalarValue(
+            build,
+            "if",
+            "github.ref == 'refs/heads/main'",
+            "jobs.build");
+        RequireScalarValue(build, "runs-on", "ubuntu-26.04", "jobs.build");
+        YamlSequenceNode buildSteps = GetRequiredSequence(build, "steps", "jobs.build");
+        if (buildSteps.Children.Count != 5)
+        {
+            throw new InvalidOperationException(
+                "Staging build must contain checkout, setup, workload install, " +
+                "publish, and artifact upload steps.");
+        }
+        YamlMappingNode checkout =
+            RequireStep(buildSteps, 0, null, "jobs.build");
+        RequireExactKeys(checkout, ["uses"], "staging build checkout");
+        RequireScalarValue(
+            checkout,
+            "uses",
+            "actions/checkout@v6",
+            "staging build checkout");
+
+        YamlMappingNode setup =
+            RequireStep(buildSteps, 1, "Setup .NET", "jobs.build");
+        RequireExactKeys(setup, ["name", "uses", "with"], "staging setup step");
+        RequireScalarValue(
+            setup,
+            "uses",
+            "actions/setup-dotnet@v5",
+            "staging setup step");
+        RequireExactScalarValues(
+            GetRequiredMapping(setup, "with", "staging setup step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["dotnet-version"] = "${{ env.DOTNET_SDK_VERSION }}",
+            },
+            "staging setup step.with");
+
+        YamlMappingNode install =
+            RequireStep(buildSteps, 2, "Install browser Wasm workload", "jobs.build");
+        RequireExactScalarValues(
+            install,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["name"] = "Install browser Wasm workload",
+                ["run"] = "dotnet workload install wasm-experimental",
+            },
+            "staging workload step");
+
+        YamlMappingNode publish =
+            RequireStep(buildSteps, 3, "Publish browser app", "jobs.build");
+        RequireExactKeys(publish, ["name", "shell", "run"], "staging publish step");
+        RequireScalarValue(publish, "shell", "bash", "staging publish step");
+        const string ExpectedPublish =
+            """
+            version=$(dotnet msbuild src/dotnet-inspect/dotnet-inspect.csproj -getProperty:VersionPrefix -nologo)
+            built_at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            dotnet publish \
+              prototypes/inspect-web/engine/InspectWeb.Engine.csproj \
+              -c Release \
+              --output artifacts/inspect-web-publish \
+              -p:VersionPrefix="$version" \
+              -p:SourceRevisionId="$GITHUB_SHA" \
+              -p:BuildTimestampUtc="$built_at"
+            """;
+        if (GetRequiredScalar(publish, "run", "staging publish step").TrimEnd() !=
+            ExpectedPublish)
+        {
+            throw new InvalidOperationException(
+                "Staging publish command does not match the trusted contract.");
+        }
+
+        YamlMappingNode upload =
+            RequireStep(buildSteps, 4, "Upload staged site artifact", "jobs.build");
         RequireExactKeys(
             upload,
             ["name", "uses", "with"],
@@ -391,6 +553,13 @@ internal static class PromotionWorkflowContract
             ["name", "needs", "if", "environment", "runs-on", "steps"],
             "jobs.deploy");
         RequireScalarValue(deploy, "needs", "build", "jobs.deploy");
+        RequireScalarValue(deploy, "name", "Publish staging", "jobs.deploy");
+        RequireScalarValue(
+            deploy,
+            "if",
+            "github.ref == 'refs/heads/main'",
+            "jobs.deploy");
+        RequireScalarValue(deploy, "runs-on", "ubuntu-26.04", "jobs.deploy");
         YamlMappingNode environment =
             GetRequiredMapping(deploy, "environment", "jobs.deploy");
         RequireExactScalarValues(
@@ -475,21 +644,164 @@ internal static class PromotionWorkflowContract
             "staging deploy step.with");
     }
 
-    private static YamlMappingNode RequireNamedStep(
-        YamlSequenceNode steps,
-        string name,
-        string context)
+    private static void ValidatePromotionTrigger(YamlMappingNode on)
     {
-        YamlMappingNode[] matches = steps.Children
-            .Select((node, index) => RequireMapping(node, $"{context} step {index}"))
-            .Where(step => GetOptionalScalar(step, "name") == name)
-            .ToArray();
-        if (matches.Length != 1)
+        RequireExactKeys(on, ["workflow_dispatch"], "promotion workflow.on");
+        YamlMappingNode dispatch =
+            GetRequiredMapping(on, "workflow_dispatch", "promotion workflow.on");
+        RequireExactKeys(dispatch, ["inputs"], "promotion workflow_dispatch");
+        YamlMappingNode inputs =
+            GetRequiredMapping(dispatch, "inputs", "promotion workflow_dispatch");
+        RequireExactKeys(
+            inputs,
+            ["staging_run_id", "confirm"],
+            "promotion workflow_dispatch.inputs");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                inputs,
+                "staging_run_id",
+                "promotion workflow_dispatch.inputs"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["description"] =
+                    "Successful main staging run whose site artifact will be promoted",
+                ["required"] = "true",
+            },
+            "promotion staging_run_id input");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                inputs,
+                "confirm",
+                "promotion workflow_dispatch.inputs"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["description"] = "Type \"promote\" to confirm production deployment",
+                ["required"] = "true",
+            },
+            "promotion confirm input");
+    }
+
+    private static void ValidateStagingTrigger(YamlMappingNode on)
+    {
+        RequireExactKeys(
+            on,
+            ["push", "workflow_dispatch"],
+            "staging workflow.on");
+        YamlMappingNode push = GetRequiredMapping(on, "push", "staging workflow.on");
+        RequireExactKeys(push, ["branches"], "staging workflow.on.push");
+        YamlSequenceNode branches =
+            GetRequiredSequence(push, "branches", "staging workflow.on.push");
+        if (branches.Children.Count != 1 ||
+            RequireScalar(branches.Children[0], "staging push branch") != "main")
         {
             throw new InvalidOperationException(
-                $"{context} contains {matches.Length} '{name}' steps; expected one.");
+                "Staging push trigger must name only main.");
         }
-        return matches[0];
+        if (!TryGetNode(on, "workflow_dispatch", out YamlNode dispatch) ||
+            dispatch is not YamlScalarNode { Value: null or "" })
+        {
+            throw new InvalidOperationException(
+                "Staging workflow_dispatch must not declare inputs.");
+        }
+    }
+
+    private static void ValidateResolveSteps(YamlSequenceNode steps)
+    {
+        if (steps.Children.Count != 4)
+        {
+            throw new InvalidOperationException(
+                "Promotion resolution must contain intent, checkout, setup, " +
+                "and staging validation steps.");
+        }
+
+        YamlMappingNode intent =
+            RequireStep(steps, 0, "Validate dispatch intent", "jobs.resolve");
+        RequireExactKeys(
+            intent,
+            ["name", "shell", "env", "run"],
+            "dispatch intent step");
+        RequireScalarValue(intent, "shell", "bash", "dispatch intent step");
+        RequireExactScalarValues(
+            GetRequiredMapping(intent, "env", "dispatch intent step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["CONFIRM"] = "${{ inputs.confirm }}",
+            },
+            "dispatch intent step.env");
+        const string ExpectedIntent =
+            """
+            set -euo pipefail
+            if [ "$GITHUB_REF" != refs/heads/main ]; then
+              echo "::error::Production promotion must be dispatched from main." >&2
+              exit 1
+            fi
+            if [ "$CONFIRM" != promote ]; then
+              echo "::error::Type promote to confirm production deployment." >&2
+              exit 1
+            fi
+            """;
+        if (GetRequiredScalar(intent, "run", "dispatch intent step").TrimEnd() !=
+            ExpectedIntent)
+        {
+            throw new InvalidOperationException(
+                "Dispatch intent command does not match the trusted contract.");
+        }
+
+        YamlMappingNode checkout =
+            RequireStep(steps, 1, null, "jobs.resolve");
+        RequireExactKeys(checkout, ["uses"], "resolution checkout");
+        RequireScalarValue(
+            checkout,
+            "uses",
+            "actions/checkout@v6",
+            "resolution checkout");
+
+        YamlMappingNode setup =
+            RequireStep(steps, 2, "Setup .NET", "jobs.resolve");
+        RequireExactKeys(setup, ["name", "uses", "with"], "resolution setup step");
+        RequireScalarValue(
+            setup,
+            "uses",
+            "actions/setup-dotnet@v5",
+            "resolution setup step");
+        RequireExactScalarValues(
+            GetRequiredMapping(setup, "with", "resolution setup step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["dotnet-version"] = "11.0.x",
+                ["dotnet-quality"] = "preview",
+            },
+            "resolution setup step.with");
+
+        YamlMappingNode validate =
+            RequireStep(steps, 3, "Validate staged site", "jobs.resolve");
+        RequireExactKeys(
+            validate,
+            ["name", "id", "shell", "env", "run"],
+            "staging evidence step");
+        RequireScalarValue(validate, "id", "evidence", "staging evidence step");
+        RequireScalarValue(validate, "shell", "bash", "staging evidence step");
+        RequireExactScalarValues(
+            GetRequiredMapping(validate, "env", "staging evidence step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["GH_TOKEN"] = "${{ secrets.GITHUB_TOKEN }}",
+                ["STAGING_RUN_ID"] = "${{ inputs.staging_run_id }}",
+            },
+            "staging evidence step.env");
+        const string ExpectedValidation =
+            """
+            bash eng/validate-inspect-web-promotion.sh \
+              "$STAGING_RUN_ID" \
+              720 \
+              "$GITHUB_OUTPUT"
+            """;
+        if (GetRequiredScalar(validate, "run", "staging evidence step").TrimEnd() !=
+            ExpectedValidation)
+        {
+            throw new InvalidOperationException(
+                "Staging evidence command does not match the trusted contract.");
+        }
     }
 
     private static void ExpectFailure(Action action, string message)
@@ -531,13 +843,14 @@ internal static class PromotionWorkflowContract
     private static YamlMappingNode RequireStep(
         YamlSequenceNode steps,
         int index,
-        string? name)
+        string? name,
+        string context = "jobs.deploy")
     {
         YamlMappingNode step = RequireMapping(
             steps.Children[index],
-            $"jobs.deploy step {index}");
+            $"{context} step {index}");
         if (name is not null)
-            RequireScalarValue(step, "name", name, $"jobs.deploy step {index}");
+            RequireScalarValue(step, "name", name, $"{context} step {index}");
         return step;
     }
 }

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -7,6 +7,14 @@ internal static class PromotionWorkflowContract
 {
     private const string AzureAction =
         "Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1";
+    private const string CheckoutAction =
+        "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803";
+    private const string DownloadArtifactAction =
+        "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c";
+    private const string SetupDotnetAction =
+        "actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1";
+    private const string UploadArtifactAction =
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
     private const string IndexCheck =
         "test -f artifacts/inspect-web-publish/wwwroot/index.html";
 
@@ -30,14 +38,14 @@ internal static class PromotionWorkflowContract
         const string trustedCheckout =
             """
                 steps:
-                  - uses: actions/checkout@v6
+                  - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
                   - name: Setup .NET
             """;
         const string candidateCheckout =
             """
                 steps:
-                  - uses: actions/checkout@v6
+                  - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
                     with:
                       ref: ${{ needs.resolve.outputs.sha }}
 
@@ -58,7 +66,7 @@ internal static class PromotionWorkflowContract
         const string stagingCheckout =
             """
                 steps:
-                  - uses: actions/checkout@v6
+                  - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
                   - name: Download staged site artifact
             """;
@@ -71,8 +79,8 @@ internal static class PromotionWorkflowContract
 
         AssertMutationRejected(
             promotionWorkflow,
-            "      - name: Setup .NET\n        uses: actions/setup-dotnet@v5",
-            "      - name: Setup .NET\n        uses: actions/download-artifact@v8",
+            "      - name: Setup .NET\n        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5",
+            "      - name: Setup .NET\n        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8",
             ValidatePromotion,
             "Promotion workflow contract accepted an alternate setup action.");
         AssertMutationRejected(
@@ -153,10 +161,10 @@ internal static class PromotionWorkflowContract
             "Staging workflow contract accepted write permission.");
         AssertMutationRejected(
             stagingWorkflow,
-            "    steps:\n      - uses: actions/checkout@v6\n",
+            "    steps:\n      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6\n",
             """
                 steps:
-                  - uses: actions/checkout@v6
+                  - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
                     with:
                       ref: ${{ github.event.pull_request.head.sha }}
             """,
@@ -264,7 +272,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             checkout,
             "uses",
-            "actions/checkout@v6",
+            CheckoutAction,
             "jobs.deploy checkout");
 
         YamlMappingNode setup = RequireStep(steps, 1, "Setup .NET");
@@ -272,7 +280,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             setup,
             "uses",
-            "actions/setup-dotnet@v5",
+            SetupDotnetAction,
             "production setup step");
         RequireExactScalarValues(
             GetRequiredMapping(setup, "with", "production setup step"),
@@ -334,7 +342,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             download,
             "uses",
-            "actions/download-artifact@v8",
+            DownloadArtifactAction,
             "artifact download step");
         YamlMappingNode downloadWith =
             GetRequiredMapping(download, "with", "artifact download step");
@@ -472,7 +480,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             checkout,
             "uses",
-            "actions/checkout@v6",
+            CheckoutAction,
             "staging build checkout");
 
         YamlMappingNode setup =
@@ -481,7 +489,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             setup,
             "uses",
-            "actions/setup-dotnet@v5",
+            SetupDotnetAction,
             "staging setup step");
         RequireExactScalarValues(
             GetRequiredMapping(setup, "with", "staging setup step"),
@@ -534,7 +542,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             upload,
             "uses",
-            "actions/upload-artifact@v7",
+            UploadArtifactAction,
             "staging artifact upload step");
         RequireExactScalarValues(
             GetRequiredMapping(upload, "with", "staging artifact upload step"),
@@ -588,7 +596,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             download,
             "uses",
-            "actions/download-artifact@v8",
+            DownloadArtifactAction,
             "staging artifact download step");
         YamlMappingNode downloadWith =
             GetRequiredMapping(download, "with", "staging artifact download step");
@@ -753,7 +761,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             checkout,
             "uses",
-            "actions/checkout@v6",
+            CheckoutAction,
             "resolution checkout");
 
         YamlMappingNode setup =
@@ -762,7 +770,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             setup,
             "uses",
-            "actions/setup-dotnet@v5",
+            SetupDotnetAction,
             "resolution setup step");
         RequireExactScalarValues(
             GetRequiredMapping(setup, "with", "resolution setup step"),

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -5,6 +5,11 @@ namespace CiChangeDetection;
 
 internal static class PromotionWorkflowContract
 {
+    private const string AzureAction =
+        "Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1";
+    private const string IndexCheck =
+        "test -f artifacts/inspect-web-publish/wwwroot/index.html";
+
     internal static void AssertMutations(string repository)
     {
         string promotionPath = Path.Combine(
@@ -38,14 +43,11 @@ internal static class PromotionWorkflowContract
 
                   - name: Setup .NET
             """;
-        string mutatedPromotion = promotionWorkflow.Replace(
+        AssertMutationRejected(
+            promotionWorkflow,
             trustedCheckout,
             candidateCheckout,
-            StringComparison.Ordinal);
-        if (mutatedPromotion == promotionWorkflow)
-            throw new InvalidOperationException("Promotion checkout mutation did not apply.");
-        ExpectFailure(
-            () => ValidatePromotion(mutatedPromotion),
+            ValidatePromotion,
             "Promotion workflow contract accepted candidate-controlled production checkout.");
 
         const string stagingDownload =
@@ -60,15 +62,43 @@ internal static class PromotionWorkflowContract
 
                   - name: Download staged site artifact
             """;
-        string mutatedStaging = stagingWorkflow.Replace(
+        AssertMutationRejected(
+            stagingWorkflow,
             stagingDownload,
             stagingCheckout,
-            StringComparison.Ordinal);
-        if (mutatedStaging == stagingWorkflow)
-            throw new InvalidOperationException("Staging checkout mutation did not apply.");
-        ExpectFailure(
-            () => ValidateStaging(mutatedStaging),
+            ValidateStaging,
             "Staging workflow contract accepted candidate code in the deployment job.");
+
+        AssertMutationRejected(
+            promotionWorkflow,
+            "      - name: Setup .NET\n        uses: actions/setup-dotnet@v5",
+            "      - name: Setup .NET\n        uses: actions/download-artifact@v8",
+            ValidatePromotion,
+            "Promotion workflow contract accepted an alternate setup action.");
+        AssertMutationRejected(
+            promotionWorkflow,
+            "            \"$EXPECTED_DIGEST\"\n",
+            "            \"$EXPECTED_DIGEST\" || true\n",
+            ValidatePromotion,
+            "Promotion workflow contract accepted disabled revalidation.");
+        AssertMutationRejected(
+            promotionWorkflow,
+            "      - name: Revalidate staged site\n",
+            "      - name: Download staged site artifact\n",
+            ValidatePromotion,
+            "Promotion workflow contract accepted download before revalidation.");
+        AssertMutationRejected(
+            stagingWorkflow,
+            $"        run: {IndexCheck}\n",
+            $"        run: {IndexCheck} || true\n",
+            ValidateStaging,
+            "Staging workflow contract accepted disabled artifact verification.");
+        AssertMutationRejected(
+            stagingWorkflow,
+            "          skip_app_build: true\n",
+            "",
+            ValidateStaging,
+            "Staging workflow contract accepted Azure app build.");
     }
 
     private static void ValidatePromotion(string workflow)
@@ -92,10 +122,13 @@ internal static class PromotionWorkflowContract
 
         YamlMappingNode environment =
             GetRequiredMapping(deploy, "environment", "jobs.deploy");
-        RequireScalarValue(
+        RequireExactScalarValues(
             environment,
-            "name",
-            "inspect-web-production",
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["name"] = "inspect-web-production",
+                ["url"] = "https://dotnet-inspect.net",
+            },
             "jobs.deploy.environment");
 
         YamlSequenceNode steps = GetRequiredSequence(deploy, "steps", "jobs.deploy");
@@ -114,24 +147,70 @@ internal static class PromotionWorkflowContract
             "actions/checkout@v6",
             "jobs.deploy checkout");
 
-        RequireStep(steps, 1, "Setup .NET");
+        YamlMappingNode setup = RequireStep(steps, 1, "Setup .NET");
+        RequireExactKeys(setup, ["name", "uses", "with"], "production setup step");
+        RequireScalarValue(
+            setup,
+            "uses",
+            "actions/setup-dotnet@v5",
+            "production setup step");
+        RequireExactScalarValues(
+            GetRequiredMapping(setup, "with", "production setup step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["dotnet-version"] = "11.0.x",
+                ["dotnet-quality"] = "preview",
+            },
+            "production setup step.with");
+
         YamlMappingNode revalidate =
             RequireStep(steps, 2, "Revalidate staged site");
+        RequireExactKeys(
+            revalidate,
+            ["name", "shell", "env", "run"],
+            "revalidation step");
         RequireScalarValue(revalidate, "shell", "bash", "revalidation step");
+        RequireExactScalarValues(
+            GetRequiredMapping(revalidate, "env", "revalidation step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["GH_TOKEN"] = "${{ secrets.GITHUB_TOKEN }}",
+                ["STAGING_RUN_ID"] = "${{ inputs.staging_run_id }}",
+                ["EXPECTED_SHA"] = "${{ needs.resolve.outputs.sha }}",
+                ["EXPECTED_ATTEMPT"] = "${{ needs.resolve.outputs.run_attempt }}",
+                ["EXPECTED_ARTIFACT_ID"] =
+                    "${{ needs.resolve.outputs.artifact_id }}",
+                ["EXPECTED_DIGEST"] =
+                    "${{ needs.resolve.outputs.artifact_digest }}",
+            },
+            "revalidation step.env");
         string revalidationCommand = GetRequiredScalar(
             revalidate,
             "run",
             "revalidation step");
-        if (!revalidationCommand.Contains(
-                "bash eng/validate-inspect-web-promotion.sh",
-                StringComparison.Ordinal))
+        const string ExpectedRevalidation =
+            """
+            bash eng/validate-inspect-web-promotion.sh \
+              "$STAGING_RUN_ID" \
+              720 \
+              "$RUNNER_TEMP/revalidated-inspect-web" \
+              "$EXPECTED_SHA" \
+              "$EXPECTED_ATTEMPT" \
+              "$EXPECTED_ARTIFACT_ID" \
+              "$EXPECTED_DIGEST"
+            """;
+        if (revalidationCommand.TrimEnd() != ExpectedRevalidation)
         {
             throw new InvalidOperationException(
-                "Production revalidation must execute the trusted promotion validator.");
+                "Production revalidation command does not match the trusted contract.");
         }
 
         YamlMappingNode download =
             RequireStep(steps, 3, "Download staged site artifact");
+        RequireExactKeys(
+            download,
+            ["name", "uses", "with"],
+            "artifact download step");
         RequireScalarValue(
             download,
             "uses",
@@ -139,32 +218,59 @@ internal static class PromotionWorkflowContract
             "artifact download step");
         YamlMappingNode downloadWith =
             GetRequiredMapping(download, "with", "artifact download step");
-        RequireScalarValue(
+        RequireExactScalarValues(
             downloadWith,
-            "artifact-ids",
-            "${{ needs.resolve.outputs.artifact_id }}",
-            "artifact download step.with");
-        RequireScalarValue(
-            downloadWith,
-            "digest-mismatch",
-            "error",
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["artifact-ids"] = "${{ needs.resolve.outputs.artifact_id }}",
+                ["github-token"] = "${{ secrets.GITHUB_TOKEN }}",
+                ["repository"] = "${{ github.repository }}",
+                ["run-id"] = "${{ inputs.staging_run_id }}",
+                ["path"] = "artifacts/inspect-web-publish/wwwroot",
+                ["digest-mismatch"] = "error",
+            },
             "artifact download step.with");
 
         YamlMappingNode verify =
             RequireStep(steps, 4, "Verify staged site artifact");
+        RequireExactKeys(
+            verify,
+            ["name", "shell", "run"],
+            "artifact verification step");
+        RequireScalarValue(
+            verify,
+            "shell",
+            "bash",
+            "artifact verification step");
         RequireScalarValue(
             verify,
             "run",
-            "test -f artifacts/inspect-web-publish/wwwroot/index.html",
+            IndexCheck,
             "artifact verification step");
 
         YamlMappingNode deployStep =
             RequireStep(steps, 5, "Deploy to production");
+        RequireExactKeys(
+            deployStep,
+            ["name", "uses", "with"],
+            "production deploy step");
         RequireScalarValue(
             deployStep,
             "uses",
-            "Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1",
+            AzureAction,
             "production deploy step");
+        RequireExactScalarValues(
+            GetRequiredMapping(deployStep, "with", "production deploy step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["azure_static_web_apps_api_token"] =
+                    "${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB }}",
+                ["action"] = "upload",
+                ["app_location"] = "artifacts/inspect-web-publish/wwwroot",
+                ["output_location"] = "",
+                ["skip_app_build"] = "true",
+            },
+            "production deploy step.with");
     }
 
     private static void ValidateStaging(string workflow)
@@ -184,33 +290,43 @@ internal static class PromotionWorkflowContract
         YamlMappingNode jobs = GetRequiredMapping(root, "jobs", "staging workflow");
         YamlMappingNode build = GetRequiredMapping(jobs, "build", "staging jobs");
         RequireAbsent(build, "environment", "jobs.build");
-        YamlMappingNode buildOutputs =
-            GetRequiredMapping(build, "outputs", "jobs.build");
-        RequireScalarValue(
-            buildOutputs,
-            "artifact_id",
-            "${{ steps.site.outputs.artifact-id }}",
-            "jobs.build.outputs");
+        RequireAbsent(build, "outputs", "jobs.build");
         YamlSequenceNode buildSteps = GetRequiredSequence(build, "steps", "jobs.build");
         YamlMappingNode upload = RequireNamedStep(
             buildSteps,
             "Upload staged site artifact",
             "jobs.build");
-        RequireScalarValue(upload, "id", "site", "staging artifact upload step");
+        RequireExactKeys(
+            upload,
+            ["name", "uses", "with"],
+            "staging artifact upload step");
         RequireScalarValue(
             upload,
             "uses",
             "actions/upload-artifact@v7",
             "staging artifact upload step");
+        RequireExactScalarValues(
+            GetRequiredMapping(upload, "with", "staging artifact upload step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["name"] = "inspect-web-site",
+                ["path"] = "artifacts/inspect-web-publish/wwwroot",
+                ["if-no-files-found"] = "error",
+                ["retention-days"] = "30",
+            },
+            "staging artifact upload step.with");
 
         YamlMappingNode deploy = GetRequiredMapping(jobs, "deploy", "staging jobs");
         RequireScalarValue(deploy, "needs", "build", "jobs.deploy");
         YamlMappingNode environment =
             GetRequiredMapping(deploy, "environment", "jobs.deploy");
-        RequireScalarValue(
+        RequireExactScalarValues(
             environment,
-            "name",
-            "inspect-web-staging",
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["name"] = "inspect-web-staging",
+                ["url"] = "https://dotnet-inspect.ca",
+            },
             "jobs.deploy.environment");
         YamlSequenceNode deploySteps =
             GetRequiredSequence(deploy, "steps", "jobs.deploy");
@@ -223,6 +339,10 @@ internal static class PromotionWorkflowContract
 
         YamlMappingNode download =
             RequireStep(deploySteps, 0, "Download staged site artifact");
+        RequireExactKeys(
+            download,
+            ["name", "uses", "with"],
+            "staging artifact download step");
         RequireScalarValue(
             download,
             "uses",
@@ -230,32 +350,56 @@ internal static class PromotionWorkflowContract
             "staging artifact download step");
         YamlMappingNode downloadWith =
             GetRequiredMapping(download, "with", "staging artifact download step");
-        RequireScalarValue(
+        RequireExactScalarValues(
             downloadWith,
-            "artifact-ids",
-            "${{ needs.build.outputs.artifact_id }}",
-            "staging artifact download step.with");
-        RequireScalarValue(
-            downloadWith,
-            "digest-mismatch",
-            "error",
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["name"] = "inspect-web-site",
+                ["path"] = "artifacts/inspect-web-publish/wwwroot",
+                ["digest-mismatch"] = "error",
+            },
             "staging artifact download step.with");
 
         YamlMappingNode verify =
             RequireStep(deploySteps, 1, "Verify staged site artifact");
+        RequireExactKeys(
+            verify,
+            ["name", "shell", "run"],
+            "staging artifact verification step");
+        RequireScalarValue(
+            verify,
+            "shell",
+            "bash",
+            "staging artifact verification step");
         RequireScalarValue(
             verify,
             "run",
-            "test -f artifacts/inspect-web-publish/wwwroot/index.html",
+            IndexCheck,
             "staging artifact verification step");
 
         YamlMappingNode deployStep =
             RequireStep(deploySteps, 2, "Deploy to staging");
+        RequireExactKeys(
+            deployStep,
+            ["name", "uses", "with"],
+            "staging deploy step");
         RequireScalarValue(
             deployStep,
             "uses",
-            "Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1",
+            AzureAction,
             "staging deploy step");
+        RequireExactScalarValues(
+            GetRequiredMapping(deployStep, "with", "staging deploy step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["azure_static_web_apps_api_token"] =
+                    "${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_STAGING }}",
+                ["action"] = "upload",
+                ["app_location"] = "artifacts/inspect-web-publish/wwwroot",
+                ["output_location"] = "",
+                ["skip_app_build"] = "true",
+            },
+            "staging deploy step.with");
     }
 
     private static YamlMappingNode RequireNamedStep(
@@ -287,6 +431,22 @@ internal static class PromotionWorkflowContract
         }
 
         throw new InvalidOperationException(message);
+    }
+
+    private static void AssertMutationRejected(
+        string workflow,
+        string oldValue,
+        string newValue,
+        Action<string> validate,
+        string message)
+    {
+        string mutated = workflow.Replace(
+            oldValue,
+            newValue,
+            StringComparison.Ordinal);
+        if (mutated == workflow)
+            throw new InvalidOperationException($"Mutation did not apply: {message}");
+        ExpectFailure(() => validate(mutated), message);
     }
 
     private static YamlMappingNode RequireStep(

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -99,6 +99,45 @@ internal static class PromotionWorkflowContract
             "",
             ValidateStaging,
             "Staging workflow contract accepted Azure app build.");
+
+        const string productionJob =
+            """
+                environment:
+                  name: inspect-web-production
+                  url: https://dotnet-inspect.net
+                runs-on: ubuntu-26.04
+                steps:
+            """;
+        const string productionBashEnv =
+            """
+                environment:
+                  name: inspect-web-production
+                  url: https://dotnet-inspect.net
+                runs-on: ubuntu-26.04
+                env:
+                  BASH_ENV: artifacts/inspect-web-publish/wwwroot/payload.sh
+                steps:
+            """;
+        AssertMutationRejected(
+            promotionWorkflow,
+            productionJob,
+            productionBashEnv,
+            ValidatePromotion,
+            "Promotion workflow contract accepted inherited BASH_ENV.");
+
+        AssertRejected(
+            promotionWorkflow +
+            """
+
+              bypass:
+                name: Bypass production
+                environment: inspect-web-production
+                runs-on: ubuntu-26.04
+                steps:
+                  - run: echo bypass
+            """,
+            ValidatePromotion,
+            "Promotion workflow contract accepted an extra environment-scoped job.");
     }
 
     private static void ValidatePromotion(string workflow)
@@ -115,8 +154,22 @@ internal static class PromotionWorkflowContract
         YamlMappingNode root = RequireMapping(
             yaml.Documents[0].RootNode,
             "promotion workflow root");
+        RequireExactKeys(
+            root,
+            ["name", "on", "permissions", "concurrency", "jobs"],
+            "promotion workflow");
         YamlMappingNode jobs = GetRequiredMapping(root, "jobs", "promotion workflow");
+        RequireExactKeys(jobs, ["resolve", "deploy"], "promotion jobs");
+        YamlMappingNode resolve = GetRequiredMapping(jobs, "resolve", "promotion jobs");
+        RequireExactKeys(
+            resolve,
+            ["name", "runs-on", "outputs", "steps"],
+            "jobs.resolve");
         YamlMappingNode deploy = GetRequiredMapping(jobs, "deploy", "promotion jobs");
+        RequireExactKeys(
+            deploy,
+            ["name", "needs", "environment", "runs-on", "steps"],
+            "jobs.deploy");
         RequireScalarValue(deploy, "needs", "resolve", "jobs.deploy");
         RequireScalarValue(deploy, "runs-on", "ubuntu-26.04", "jobs.deploy");
 
@@ -287,10 +340,26 @@ internal static class PromotionWorkflowContract
         YamlMappingNode root = RequireMapping(
             yaml.Documents[0].RootNode,
             "staging workflow root");
+        RequireExactKeys(
+            root,
+            ["name", "on", "permissions", "concurrency", "env", "jobs"],
+            "staging workflow");
+        RequireExactScalarValues(
+            GetRequiredMapping(root, "env", "staging workflow"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "true",
+                ["DOTNET_NOLOGO"] = "true",
+                ["DOTNET_SDK_VERSION"] = "11.0.100-preview.6.26359.118",
+            },
+            "staging workflow.env");
         YamlMappingNode jobs = GetRequiredMapping(root, "jobs", "staging workflow");
+        RequireExactKeys(jobs, ["build", "deploy"], "staging jobs");
         YamlMappingNode build = GetRequiredMapping(jobs, "build", "staging jobs");
-        RequireAbsent(build, "environment", "jobs.build");
-        RequireAbsent(build, "outputs", "jobs.build");
+        RequireExactKeys(
+            build,
+            ["name", "if", "runs-on", "steps"],
+            "jobs.build");
         YamlSequenceNode buildSteps = GetRequiredSequence(build, "steps", "jobs.build");
         YamlMappingNode upload = RequireNamedStep(
             buildSteps,
@@ -317,6 +386,10 @@ internal static class PromotionWorkflowContract
             "staging artifact upload step.with");
 
         YamlMappingNode deploy = GetRequiredMapping(jobs, "deploy", "staging jobs");
+        RequireExactKeys(
+            deploy,
+            ["name", "needs", "if", "environment", "runs-on", "steps"],
+            "jobs.deploy");
         RequireScalarValue(deploy, "needs", "build", "jobs.deploy");
         YamlMappingNode environment =
             GetRequiredMapping(deploy, "environment", "jobs.deploy");
@@ -448,6 +521,12 @@ internal static class PromotionWorkflowContract
             throw new InvalidOperationException($"Mutation did not apply: {message}");
         ExpectFailure(() => validate(mutated), message);
     }
+
+    private static void AssertRejected(
+        string workflow,
+        Action<string> validate,
+        string message) =>
+        ExpectFailure(() => validate(workflow), message);
 
     private static YamlMappingNode RequireStep(
         YamlSequenceNode steps,

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -7,13 +7,20 @@ internal static class PromotionWorkflowContract
 {
     internal static void AssertMutations(string repository)
     {
-        string path = Path.Combine(
+        string promotionPath = Path.Combine(
             repository,
             ".github",
             "workflows",
             "promote-inspect-web.yml");
-        string workflow = File.ReadAllText(path);
-        Validate(workflow);
+        string stagingPath = Path.Combine(
+            repository,
+            ".github",
+            "workflows",
+            "deploy-inspect-web.yml");
+        string promotionWorkflow = File.ReadAllText(promotionPath);
+        string stagingWorkflow = File.ReadAllText(stagingPath);
+        ValidatePromotion(promotionWorkflow);
+        ValidateStaging(stagingWorkflow);
 
         const string trustedCheckout =
             """
@@ -31,27 +38,40 @@ internal static class PromotionWorkflowContract
 
                   - name: Setup .NET
             """;
-        string mutated = workflow.Replace(
+        string mutatedPromotion = promotionWorkflow.Replace(
             trustedCheckout,
             candidateCheckout,
             StringComparison.Ordinal);
-        if (mutated == workflow)
+        if (mutatedPromotion == promotionWorkflow)
             throw new InvalidOperationException("Promotion checkout mutation did not apply.");
-
-        try
-        {
-            Validate(mutated);
-        }
-        catch (InvalidOperationException)
-        {
-            return;
-        }
-
-        throw new InvalidOperationException(
+        ExpectFailure(
+            () => ValidatePromotion(mutatedPromotion),
             "Promotion workflow contract accepted candidate-controlled production checkout.");
+
+        const string stagingDownload =
+            """
+                steps:
+                  - name: Download staged site artifact
+            """;
+        const string stagingCheckout =
+            """
+                steps:
+                  - uses: actions/checkout@v6
+
+                  - name: Download staged site artifact
+            """;
+        string mutatedStaging = stagingWorkflow.Replace(
+            stagingDownload,
+            stagingCheckout,
+            StringComparison.Ordinal);
+        if (mutatedStaging == stagingWorkflow)
+            throw new InvalidOperationException("Staging checkout mutation did not apply.");
+        ExpectFailure(
+            () => ValidateStaging(mutatedStaging),
+            "Staging workflow contract accepted candidate code in the deployment job.");
     }
 
-    private static void Validate(string workflow)
+    private static void ValidatePromotion(string workflow)
     {
         using TextReader reader = new StringReader(workflow);
         YamlStream yaml = [];
@@ -145,6 +165,128 @@ internal static class PromotionWorkflowContract
             "uses",
             "Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1",
             "production deploy step");
+    }
+
+    private static void ValidateStaging(string workflow)
+    {
+        using TextReader reader = new StringReader(workflow);
+        YamlStream yaml = [];
+        yaml.Load(reader);
+        if (yaml.Documents.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected one staging workflow document, found {yaml.Documents.Count}.");
+        }
+
+        YamlMappingNode root = RequireMapping(
+            yaml.Documents[0].RootNode,
+            "staging workflow root");
+        YamlMappingNode jobs = GetRequiredMapping(root, "jobs", "staging workflow");
+        YamlMappingNode build = GetRequiredMapping(jobs, "build", "staging jobs");
+        RequireAbsent(build, "environment", "jobs.build");
+        YamlMappingNode buildOutputs =
+            GetRequiredMapping(build, "outputs", "jobs.build");
+        RequireScalarValue(
+            buildOutputs,
+            "artifact_id",
+            "${{ steps.site.outputs.artifact-id }}",
+            "jobs.build.outputs");
+        YamlSequenceNode buildSteps = GetRequiredSequence(build, "steps", "jobs.build");
+        YamlMappingNode upload = RequireNamedStep(
+            buildSteps,
+            "Upload staged site artifact",
+            "jobs.build");
+        RequireScalarValue(upload, "id", "site", "staging artifact upload step");
+        RequireScalarValue(
+            upload,
+            "uses",
+            "actions/upload-artifact@v7",
+            "staging artifact upload step");
+
+        YamlMappingNode deploy = GetRequiredMapping(jobs, "deploy", "staging jobs");
+        RequireScalarValue(deploy, "needs", "build", "jobs.deploy");
+        YamlMappingNode environment =
+            GetRequiredMapping(deploy, "environment", "jobs.deploy");
+        RequireScalarValue(
+            environment,
+            "name",
+            "inspect-web-staging",
+            "jobs.deploy.environment");
+        YamlSequenceNode deploySteps =
+            GetRequiredSequence(deploy, "steps", "jobs.deploy");
+        if (deploySteps.Children.Count != 3)
+        {
+            throw new InvalidOperationException(
+                "Staging deployment must contain only artifact download, " +
+                "artifact verification, and deploy steps.");
+        }
+
+        YamlMappingNode download =
+            RequireStep(deploySteps, 0, "Download staged site artifact");
+        RequireScalarValue(
+            download,
+            "uses",
+            "actions/download-artifact@v8",
+            "staging artifact download step");
+        YamlMappingNode downloadWith =
+            GetRequiredMapping(download, "with", "staging artifact download step");
+        RequireScalarValue(
+            downloadWith,
+            "artifact-ids",
+            "${{ needs.build.outputs.artifact_id }}",
+            "staging artifact download step.with");
+        RequireScalarValue(
+            downloadWith,
+            "digest-mismatch",
+            "error",
+            "staging artifact download step.with");
+
+        YamlMappingNode verify =
+            RequireStep(deploySteps, 1, "Verify staged site artifact");
+        RequireScalarValue(
+            verify,
+            "run",
+            "test -f artifacts/inspect-web-publish/wwwroot/index.html",
+            "staging artifact verification step");
+
+        YamlMappingNode deployStep =
+            RequireStep(deploySteps, 2, "Deploy to staging");
+        RequireScalarValue(
+            deployStep,
+            "uses",
+            "Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1",
+            "staging deploy step");
+    }
+
+    private static YamlMappingNode RequireNamedStep(
+        YamlSequenceNode steps,
+        string name,
+        string context)
+    {
+        YamlMappingNode[] matches = steps.Children
+            .Select((node, index) => RequireMapping(node, $"{context} step {index}"))
+            .Where(step => GetOptionalScalar(step, "name") == name)
+            .ToArray();
+        if (matches.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"{context} contains {matches.Length} '{name}' steps; expected one.");
+        }
+        return matches[0];
+    }
+
+    private static void ExpectFailure(Action action, string message)
+    {
+        try
+        {
+            action();
+        }
+        catch (InvalidOperationException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(message);
     }
 
     private static YamlMappingNode RequireStep(

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -1,0 +1,162 @@
+using YamlDotNet.RepresentationModel;
+using static CiChangeDetection.YamlContractAssertions;
+
+namespace CiChangeDetection;
+
+internal static class PromotionWorkflowContract
+{
+    internal static void AssertMutations(string repository)
+    {
+        string path = Path.Combine(
+            repository,
+            ".github",
+            "workflows",
+            "promote-inspect-web.yml");
+        string workflow = File.ReadAllText(path);
+        Validate(workflow);
+
+        const string trustedCheckout =
+            """
+                steps:
+                  - uses: actions/checkout@v6
+
+                  - name: Setup .NET
+            """;
+        const string candidateCheckout =
+            """
+                steps:
+                  - uses: actions/checkout@v6
+                    with:
+                      ref: ${{ needs.resolve.outputs.sha }}
+
+                  - name: Setup .NET
+            """;
+        string mutated = workflow.Replace(
+            trustedCheckout,
+            candidateCheckout,
+            StringComparison.Ordinal);
+        if (mutated == workflow)
+            throw new InvalidOperationException("Promotion checkout mutation did not apply.");
+
+        try
+        {
+            Validate(mutated);
+        }
+        catch (InvalidOperationException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Promotion workflow contract accepted candidate-controlled production checkout.");
+    }
+
+    private static void Validate(string workflow)
+    {
+        using TextReader reader = new StringReader(workflow);
+        YamlStream yaml = [];
+        yaml.Load(reader);
+        if (yaml.Documents.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected one promotion workflow document, found {yaml.Documents.Count}.");
+        }
+
+        YamlMappingNode root = RequireMapping(
+            yaml.Documents[0].RootNode,
+            "promotion workflow root");
+        YamlMappingNode jobs = GetRequiredMapping(root, "jobs", "promotion workflow");
+        YamlMappingNode deploy = GetRequiredMapping(jobs, "deploy", "promotion jobs");
+        RequireScalarValue(deploy, "needs", "resolve", "jobs.deploy");
+        RequireScalarValue(deploy, "runs-on", "ubuntu-26.04", "jobs.deploy");
+
+        YamlMappingNode environment =
+            GetRequiredMapping(deploy, "environment", "jobs.deploy");
+        RequireScalarValue(
+            environment,
+            "name",
+            "inspect-web-production",
+            "jobs.deploy.environment");
+
+        YamlSequenceNode steps = GetRequiredSequence(deploy, "steps", "jobs.deploy");
+        if (steps.Children.Count != 6)
+        {
+            throw new InvalidOperationException(
+                "Production deployment must contain checkout, setup, revalidation, " +
+                "artifact download, artifact verification, and deploy steps.");
+        }
+
+        YamlMappingNode checkout = RequireStep(steps, 0, null);
+        RequireExactKeys(checkout, ["uses"], "jobs.deploy checkout");
+        RequireScalarValue(
+            checkout,
+            "uses",
+            "actions/checkout@v6",
+            "jobs.deploy checkout");
+
+        RequireStep(steps, 1, "Setup .NET");
+        YamlMappingNode revalidate =
+            RequireStep(steps, 2, "Revalidate staged site");
+        RequireScalarValue(revalidate, "shell", "bash", "revalidation step");
+        string revalidationCommand = GetRequiredScalar(
+            revalidate,
+            "run",
+            "revalidation step");
+        if (!revalidationCommand.Contains(
+                "bash eng/validate-inspect-web-promotion.sh",
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Production revalidation must execute the trusted promotion validator.");
+        }
+
+        YamlMappingNode download =
+            RequireStep(steps, 3, "Download staged site artifact");
+        RequireScalarValue(
+            download,
+            "uses",
+            "actions/download-artifact@v8",
+            "artifact download step");
+        YamlMappingNode downloadWith =
+            GetRequiredMapping(download, "with", "artifact download step");
+        RequireScalarValue(
+            downloadWith,
+            "artifact-ids",
+            "${{ needs.resolve.outputs.artifact_id }}",
+            "artifact download step.with");
+        RequireScalarValue(
+            downloadWith,
+            "digest-mismatch",
+            "error",
+            "artifact download step.with");
+
+        YamlMappingNode verify =
+            RequireStep(steps, 4, "Verify staged site artifact");
+        RequireScalarValue(
+            verify,
+            "run",
+            "test -f artifacts/inspect-web-publish/wwwroot/index.html",
+            "artifact verification step");
+
+        YamlMappingNode deployStep =
+            RequireStep(steps, 5, "Deploy to production");
+        RequireScalarValue(
+            deployStep,
+            "uses",
+            "Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1",
+            "production deploy step");
+    }
+
+    private static YamlMappingNode RequireStep(
+        YamlSequenceNode steps,
+        int index,
+        string? name)
+    {
+        YamlMappingNode step = RequireMapping(
+            steps.Children[index],
+            $"jobs.deploy step {index}");
+        if (name is not null)
+            RequireScalarValue(step, "name", name, $"jobs.deploy step {index}");
+        return step;
+    }
+}

--- a/eng/ci-detect-changes.sh
+++ b/eng/ci-detect-changes.sh
@@ -285,6 +285,7 @@ while IFS= read -r -d '' file; do
     # classifier gate and its pinned prerequisites. Editing either must run
     # the product test lane as well as executing the gate here in `changes`.
     eng/test-ci-change-detection.cs) CODE=true ;;
+    eng/CiChangeDetection/PromotionWorkflowContract.cs) CODE=true; WEB=true ;;
     eng/CiChangeDetection/*) CODE=true ;;
     eng/prepare-decompiler-assertion-corpus.sh) CODE=true ;;
     eng/prepare-decompiler-corpus.sh) CODE=true ;;

--- a/eng/ci-detect-changes.sh
+++ b/eng/ci-detect-changes.sh
@@ -310,6 +310,8 @@ while IFS= read -r -d '' file; do
     # `ci-required` passes on a `skipped`.
     eng/restore-iltools.sh) CODE=true ;;
     eng/activate-iltools.sh) CODE=true ;;
+    eng/validate-inspect-web-promotion.cs) WEB=true ;;
+    eng/validate-inspect-web-promotion.sh) WEB=true ;;
     # Global analyzer input consumed by every product and Browser build.
     eng/BannedSymbols.txt) CODE=true; WEB=true ;;
     # Controls checkout line endings on Windows, including the raw
@@ -324,6 +326,7 @@ while IFS= read -r -d '' file; do
     *.props|*.targets|*.sln|*.slnx) CODE=true; WEB=true ;;
     .github/workflows/ci.yml) CODE=true; WEB=true ;;
     .github/workflows/deploy-inspect-web.yml) WEB=true ;;
+    .github/workflows/promote-inspect-web.yml) WEB=true ;;
     .github/workflows/*) CODE=true ;;
   esac
   # C# Diff smoke coverage is separate from the full test lane for the

--- a/eng/validate-inspect-web-promotion.cs
+++ b/eng/validate-inspect-web-promotion.cs
@@ -1,0 +1,522 @@
+using System.Globalization;
+using System.Text.Json;
+
+const string StagingWorkflow = ".github/workflows/deploy-inspect-web.yml";
+const string StagingJob = "Publish staging";
+const string SiteArtifact = "inspect-web-site";
+
+try
+{
+    if (args is ["--self-test"])
+    {
+        RunSelfTest();
+        return;
+    }
+
+    Dictionary<string, string> options = ParseOptions(args);
+    RunInfo run = ReadRun(Required(options, "--run"));
+    JobInfo[] jobs = ReadJobs(Required(options, "--jobs"));
+    ArtifactInfo[] artifacts = ReadArtifacts(Required(options, "--artifacts"));
+    string repository = Required(options, "--repository");
+    double maxAgeHours = double.Parse(
+        Required(options, "--max-age-hours"),
+        CultureInfo.InvariantCulture);
+    string githubOutput = Required(options, "--github-output");
+
+    ValidationResult result = Validate(
+        run,
+        jobs,
+        artifacts,
+        repository,
+        TimeSpan.FromHours(maxAgeHours),
+        DateTimeOffset.UtcNow);
+
+    File.AppendAllText(
+        githubOutput,
+        $"sha={result.Sha}\n" +
+        $"run_attempt={result.RunAttempt}\n" +
+        $"artifact_id={result.ArtifactId}\n" +
+        $"artifact_digest={result.ArtifactDigest}\n");
+
+    Console.WriteLine(
+        $"Validated staging run {run.Id} attempt {result.RunAttempt} for {result.Sha}; " +
+        $"artifact {result.ArtifactId} has digest {result.ArtifactDigest}.");
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Inspect-web promotion validation failed: {ex.Message}");
+    Environment.ExitCode = 1;
+}
+
+static ValidationResult Validate(
+    RunInfo run,
+    IReadOnlyList<JobInfo> jobs,
+    IReadOnlyList<ArtifactInfo> artifacts,
+    string repository,
+    TimeSpan maxAge,
+    DateTimeOffset now)
+{
+    if (run.WorkflowPath != StagingWorkflow)
+    {
+        throw new InvalidOperationException(
+            $"Staging run uses {run.WorkflowPath}, not {StagingWorkflow}.");
+    }
+    if (run.Event != "push")
+        throw new InvalidOperationException($"Staging run event {run.Event} is not push.");
+    if (run.HeadBranch != "main")
+        throw new InvalidOperationException($"Staging run targets {run.HeadBranch}, not main.");
+    if (run.Repository != repository || run.HeadRepository != repository)
+    {
+        throw new InvalidOperationException(
+            $"Staging run repository identity is {run.Repository}/{run.HeadRepository}, " +
+            $"not {repository}.");
+    }
+    if (run.Status != "completed" || run.Conclusion != "success")
+    {
+        throw new InvalidOperationException(
+            $"Staging run is {run.Status}/{run.Conclusion}, not completed/success.");
+    }
+    if (run.HeadSha.Length != 40 || run.HeadSha.Any(c => !Uri.IsHexDigit(c)))
+        throw new InvalidOperationException($"Staging run has invalid head SHA {run.HeadSha}.");
+    if (run.RunAttempt < 1)
+        throw new InvalidOperationException($"Staging run has invalid attempt {run.RunAttempt}.");
+
+    JobInfo job = RequireSingle(
+        jobs,
+        job => job.Name == StagingJob,
+        $"'{StagingJob}' job");
+    if (job.Status != "completed" || job.Conclusion != "success")
+    {
+        throw new InvalidOperationException(
+            $"Job '{StagingJob}' is {job.Status}/{job.Conclusion}, not completed/success.");
+    }
+    RequireFresh(job.CompletedAt, maxAge, now, $"Job '{StagingJob}'");
+
+    ArtifactInfo artifact = RequireSingle(
+        artifacts,
+        artifact => artifact.Name == SiteArtifact,
+        $"'{SiteArtifact}' artifact");
+    if (artifact.WorkflowRunId != run.Id)
+    {
+        throw new InvalidOperationException(
+            $"Artifact {artifact.Id} belongs to run {artifact.WorkflowRunId}, not {run.Id}.");
+    }
+    if (artifact.Expired || artifact.ExpiresAt <= now)
+        throw new InvalidOperationException($"Artifact {artifact.Id} is expired.");
+    if (artifact.SizeInBytes < 1)
+        throw new InvalidOperationException($"Artifact {artifact.Id} is empty.");
+    if (!IsSha256Digest(artifact.Digest))
+    {
+        throw new InvalidOperationException(
+            $"Artifact {artifact.Id} has invalid digest {artifact.Digest}.");
+    }
+
+    return new(run.HeadSha, run.RunAttempt, artifact.Id, artifact.Digest);
+}
+
+static T RequireSingle<T>(
+    IReadOnlyList<T> values,
+    Func<T, bool> predicate,
+    string label)
+{
+    T[] matches = values.Where(predicate).ToArray();
+    if (matches.Length != 1)
+    {
+        throw new InvalidOperationException(
+            $"Staging run contains {matches.Length} {label}s; expected one.");
+    }
+
+    return matches[0];
+}
+
+static void RequireFresh(
+    DateTimeOffset completedAt,
+    TimeSpan maxAge,
+    DateTimeOffset now,
+    string label)
+{
+    TimeSpan age = now - completedAt;
+    if (age < TimeSpan.FromMinutes(-5))
+        throw new InvalidOperationException($"{label} completion time is in the future.");
+    if (age > maxAge)
+    {
+        throw new InvalidOperationException(
+            $"{label} is {age.TotalHours:F1} hours old; " +
+            $"maximum age is {maxAge.TotalHours:F1} hours.");
+    }
+}
+
+static bool IsSha256Digest(string digest) =>
+    digest.StartsWith("sha256:", StringComparison.Ordinal) &&
+    digest.Length == 71 &&
+    digest.AsSpan(7).ToString().All(Uri.IsHexDigit);
+
+static RunInfo ReadRun(string path)
+{
+    using JsonDocument document = JsonDocument.Parse(File.ReadAllText(path));
+    JsonElement root = document.RootElement;
+    return new(
+        RequiredInt64(root, "id"),
+        RequiredString(root, "path"),
+        RequiredString(root, "event"),
+        RequiredString(root, "head_branch"),
+        RequiredString(root, "head_sha"),
+        RequiredString(root, "status"),
+        RequiredString(root, "conclusion"),
+        RequiredInt32(root, "run_attempt"),
+        RequiredString(root.GetProperty("repository"), "full_name"),
+        RequiredString(root.GetProperty("head_repository"), "full_name"),
+        DateTimeOffset.Parse(
+            RequiredString(root, "updated_at"),
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal));
+}
+
+static JobInfo[] ReadJobs(string path)
+{
+    using JsonDocument document = JsonDocument.Parse(File.ReadAllText(path));
+    JsonElement root = document.RootElement;
+    int totalCount = root.GetProperty("total_count").GetInt32();
+    JobInfo[] jobs = root.GetProperty("jobs")
+        .EnumerateArray()
+        .Select(job => new JobInfo(
+            RequiredString(job, "name"),
+            RequiredString(job, "status"),
+            RequiredString(job, "conclusion"),
+            DateTimeOffset.Parse(
+                RequiredString(job, "completed_at"),
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal)))
+        .ToArray();
+
+    if (jobs.Length != totalCount)
+    {
+        throw new InvalidOperationException(
+            $"Staging jobs response is incomplete: received {jobs.Length} of {totalCount} jobs.");
+    }
+
+    return jobs;
+}
+
+static ArtifactInfo[] ReadArtifacts(string path)
+{
+    using JsonDocument document = JsonDocument.Parse(File.ReadAllText(path));
+    JsonElement root = document.RootElement;
+    int totalCount = root.GetProperty("total_count").GetInt32();
+    ArtifactInfo[] artifacts = root.GetProperty("artifacts")
+        .EnumerateArray()
+        .Select(artifact => new ArtifactInfo(
+            RequiredInt64(artifact, "id"),
+            RequiredString(artifact, "name"),
+            RequiredInt64(artifact, "size_in_bytes"),
+            artifact.GetProperty("expired").GetBoolean(),
+            DateTimeOffset.Parse(
+                RequiredString(artifact, "expires_at"),
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal),
+            RequiredString(artifact, "digest"),
+            RequiredInt64(artifact.GetProperty("workflow_run"), "id")))
+        .ToArray();
+
+    if (artifacts.Length != totalCount)
+    {
+        throw new InvalidOperationException(
+            $"Staging artifacts response is incomplete: " +
+            $"received {artifacts.Length} of {totalCount} artifacts.");
+    }
+
+    return artifacts;
+}
+
+static string RequiredString(JsonElement element, string property)
+{
+    if (!element.TryGetProperty(property, out JsonElement value) ||
+        value.ValueKind != JsonValueKind.String ||
+        string.IsNullOrWhiteSpace(value.GetString()))
+    {
+        throw new InvalidOperationException($"JSON property '{property}' is missing or invalid.");
+    }
+
+    return value.GetString()!;
+}
+
+static long RequiredInt64(JsonElement element, string property)
+{
+    if (!element.TryGetProperty(property, out JsonElement value) ||
+        !value.TryGetInt64(out long result))
+    {
+        throw new InvalidOperationException($"JSON property '{property}' is missing or invalid.");
+    }
+
+    return result;
+}
+
+static int RequiredInt32(JsonElement element, string property)
+{
+    if (!element.TryGetProperty(property, out JsonElement value) ||
+        !value.TryGetInt32(out int result))
+    {
+        throw new InvalidOperationException($"JSON property '{property}' is missing or invalid.");
+    }
+
+    return result;
+}
+
+static Dictionary<string, string> ParseOptions(string[] arguments)
+{
+    if (arguments.Length == 0 || arguments.Length % 2 != 0)
+        throw new ArgumentException("Options must be supplied as --name value pairs.");
+
+    var options = new Dictionary<string, string>(StringComparer.Ordinal);
+    for (int i = 0; i < arguments.Length; i += 2)
+    {
+        if (!arguments[i].StartsWith("--", StringComparison.Ordinal) ||
+            !options.TryAdd(arguments[i], arguments[i + 1]))
+        {
+            throw new ArgumentException($"Invalid or duplicate option '{arguments[i]}'.");
+        }
+    }
+
+    return options;
+}
+
+static string Required(IReadOnlyDictionary<string, string> options, string name) =>
+    options.TryGetValue(name, out string? value) && !string.IsNullOrWhiteSpace(value)
+        ? value
+        : throw new ArgumentException($"Missing required option {name}.");
+
+static void RunSelfTest()
+{
+    DateTimeOffset now = new(2026, 8, 17, 12, 0, 0, TimeSpan.Zero);
+    const string repository = "richlander/dotnet-inspect";
+    const string sha = "1111111111111111111111111111111111111111";
+    const string digest =
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+    RunInfo run = new(
+        101,
+        StagingWorkflow,
+        "push",
+        "main",
+        sha,
+        "completed",
+        "success",
+        1,
+        repository,
+        repository,
+        now.AddMinutes(-5));
+    JobInfo[] jobs =
+    [
+        new(StagingJob, "completed", "success", now.AddMinutes(-5)),
+    ];
+    ArtifactInfo[] artifacts =
+    [
+        new(202, SiteArtifact, 100, false, now.AddDays(30), digest, run.Id),
+    ];
+
+    ValidationResult result = Validate(
+        run,
+        jobs,
+        artifacts,
+        repository,
+        TimeSpan.FromDays(30),
+        now);
+    Assert(result.Sha == sha, "Validated SHA should be preserved.");
+    Assert(result.ArtifactId == 202, "Validated artifact ID should be preserved.");
+
+    ExpectFailure(
+        () => Validate(
+            run with { WorkflowPath = ".github/workflows/ci.yml" },
+            jobs,
+            artifacts,
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "not .github/workflows/deploy-inspect-web.yml");
+    ExpectFailure(
+        () => Validate(
+            run with { Event = "workflow_dispatch" },
+            jobs,
+            artifacts,
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "not push");
+    ExpectFailure(
+        () => Validate(
+            run with { HeadRepository = "other/repository" },
+            jobs,
+            artifacts,
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "repository identity");
+    ExpectFailure(
+        () => Validate(
+            run,
+            [new(StagingJob, "completed", "failure", now.AddMinutes(-5))],
+            artifacts,
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "not completed/success");
+    ExpectFailure(
+        () => Validate(
+            run,
+            jobs,
+            [],
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "contains 0");
+    ExpectFailure(
+        () => Validate(
+            run,
+            jobs,
+            [artifacts[0], artifacts[0] with { Id = 203 }],
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "contains 2");
+    ExpectFailure(
+        () => Validate(
+            run,
+            jobs,
+            [artifacts[0] with { Expired = true }],
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "expired");
+    ExpectFailure(
+        () => Validate(
+            run,
+            jobs,
+            [artifacts[0] with { WorkflowRunId = 999 }],
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "not 101");
+    ExpectFailure(
+        () => Validate(
+            run,
+            [jobs[0] with { CompletedAt = now.AddDays(-31) }],
+            artifacts,
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "maximum age");
+
+    string scratch = Path.Combine(
+        Path.GetTempPath(),
+        $"dotnet-inspect-web-promotion-{Guid.NewGuid():N}");
+    Directory.CreateDirectory(scratch);
+    try
+    {
+        string runPath = Path.Combine(scratch, "run.json");
+        string jobsPath = Path.Combine(scratch, "jobs.json");
+        string artifactsPath = Path.Combine(scratch, "artifacts.json");
+        File.WriteAllText(
+            runPath,
+            """
+            {"id":101,"path":"$WORKFLOW$","event":"push","head_branch":"main","head_sha":"$SHA$","status":"completed","conclusion":"success","run_attempt":1,"repository":{"full_name":"$REPOSITORY$"},"head_repository":{"full_name":"$REPOSITORY$"},"updated_at":"$UPDATED_AT$"}
+            """
+            .Replace("$WORKFLOW$", StagingWorkflow, StringComparison.Ordinal)
+            .Replace("$SHA$", sha, StringComparison.Ordinal)
+            .Replace("$REPOSITORY$", repository, StringComparison.Ordinal)
+            .Replace(
+                "$UPDATED_AT$",
+                now.ToString("O", CultureInfo.InvariantCulture),
+                StringComparison.Ordinal));
+        File.WriteAllText(
+            jobsPath,
+            """
+            {"total_count":1,"jobs":[{"name":"$JOB$","status":"completed","conclusion":"success","completed_at":"$COMPLETED_AT$"}]}
+            """
+            .Replace("$JOB$", StagingJob, StringComparison.Ordinal)
+            .Replace(
+                "$COMPLETED_AT$",
+                now.ToString("O", CultureInfo.InvariantCulture),
+                StringComparison.Ordinal));
+        File.WriteAllText(
+            artifactsPath,
+            """
+            {"total_count":1,"artifacts":[{"id":202,"name":"$ARTIFACT$","size_in_bytes":100,"expired":false,"expires_at":"$EXPIRES_AT$","digest":"$DIGEST$","workflow_run":{"id":101}}]}
+            """
+            .Replace("$ARTIFACT$", SiteArtifact, StringComparison.Ordinal)
+            .Replace(
+                "$EXPIRES_AT$",
+                now.AddDays(30).ToString("O", CultureInfo.InvariantCulture),
+                StringComparison.Ordinal)
+            .Replace("$DIGEST$", digest, StringComparison.Ordinal));
+
+        ValidationResult parsed = Validate(
+            ReadRun(runPath),
+            ReadJobs(jobsPath),
+            ReadArtifacts(artifactsPath),
+            repository,
+            TimeSpan.FromDays(30),
+            now);
+        Assert(parsed.ArtifactDigest == digest, "API parsing should preserve artifact digest.");
+    }
+    finally
+    {
+        Directory.Delete(scratch, recursive: true);
+    }
+
+    Console.WriteLine("Inspect-web promotion validator self-test passed.");
+}
+
+static void ExpectFailure(Action action, string messageFragment)
+{
+    try
+    {
+        action();
+    }
+    catch (Exception ex) when (
+        ex.Message.Contains(messageFragment, StringComparison.OrdinalIgnoreCase))
+    {
+        return;
+    }
+
+    throw new InvalidOperationException(
+        $"Expected failure containing '{messageFragment}'.");
+}
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+        throw new InvalidOperationException(message);
+}
+
+internal sealed record RunInfo(
+    long Id,
+    string WorkflowPath,
+    string Event,
+    string HeadBranch,
+    string HeadSha,
+    string Status,
+    string Conclusion,
+    int RunAttempt,
+    string Repository,
+    string HeadRepository,
+    DateTimeOffset UpdatedAt);
+
+internal sealed record JobInfo(
+    string Name,
+    string Status,
+    string Conclusion,
+    DateTimeOffset CompletedAt);
+
+internal sealed record ArtifactInfo(
+    long Id,
+    string Name,
+    long SizeInBytes,
+    bool Expired,
+    DateTimeOffset ExpiresAt,
+    string Digest,
+    long WorkflowRunId);
+
+internal sealed record ValidationResult(
+    string Sha,
+    int RunAttempt,
+    long ArtifactId,
+    string ArtifactDigest);

--- a/eng/validate-inspect-web-promotion.cs
+++ b/eng/validate-inspect-web-promotion.cs
@@ -92,10 +92,17 @@ static ValidationResult Validate(
     }
     RequireFresh(job.CompletedAt, maxAge, now, $"Job '{StagingJob}'");
 
-    ArtifactInfo artifact = RequireSingle(
-        artifacts,
-        artifact => artifact.Name == SiteArtifact,
-        $"'{SiteArtifact}' artifact");
+    if (artifacts.Count != 1)
+    {
+        throw new InvalidOperationException(
+            $"Staging run contains {artifacts.Count} artifacts; expected one.");
+    }
+    ArtifactInfo artifact = artifacts[0];
+    if (artifact.Name != SiteArtifact)
+    {
+        throw new InvalidOperationException(
+            $"Staging artifact is named {artifact.Name}, not {SiteArtifact}.");
+    }
     if (artifact.WorkflowRunId != run.Id)
     {
         throw new InvalidOperationException(
@@ -367,7 +374,7 @@ static void RunSelfTest()
             repository,
             TimeSpan.FromDays(30),
             now),
-        "contains 0");
+        "contains 0 artifacts");
     ExpectFailure(
         () => Validate(
             run,
@@ -376,7 +383,25 @@ static void RunSelfTest()
             repository,
             TimeSpan.FromDays(30),
             now),
-        "contains 2");
+        "contains 2 artifacts");
+    ExpectFailure(
+        () => Validate(
+            run,
+            jobs,
+            [artifacts[0], artifacts[0] with { Id = 203, Name = "other-artifact" }],
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "contains 2 artifacts");
+    ExpectFailure(
+        () => Validate(
+            run,
+            jobs,
+            [artifacts[0] with { Name = "other-artifact" }],
+            repository,
+            TimeSpan.FromDays(30),
+            now),
+        "not inspect-web-site");
     ExpectFailure(
         () => Validate(
             run,

--- a/eng/validate-inspect-web-promotion.sh
+++ b/eng/validate-inspect-web-promotion.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ] || [ "$#" -gt 7 ]; then
+  echo "usage: $0 <staging-run-id> <max-age-hours> <output> [expected-sha] [expected-attempt] [expected-artifact-id] [expected-digest]" >&2
+  exit 2
+fi
+
+staging_run_id=$1
+max_age_hours=$2
+output=$3
+expected_sha=${4:-}
+expected_attempt=${5:-}
+expected_artifact_id=${6:-}
+expected_digest=${7:-}
+
+if [[ ! "$staging_run_id" =~ ^[1-9][0-9]*$ ]]; then
+  echo "staging run ID must be a positive decimal run ID." >&2
+  exit 1
+fi
+if [[ ! "$max_age_hours" =~ ^[1-9][0-9]*$ ]]; then
+  echo "max-age-hours must be a positive integer." >&2
+  exit 1
+fi
+if [ -n "$expected_sha" ] && [[ ! "$expected_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "expected SHA must be 40 hexadecimal characters." >&2
+  exit 1
+fi
+if [ -n "$expected_attempt" ] && [[ ! "$expected_attempt" =~ ^[1-9][0-9]*$ ]]; then
+  echo "expected attempt must be a positive integer." >&2
+  exit 1
+fi
+if [ -n "$expected_artifact_id" ] && [[ ! "$expected_artifact_id" =~ ^[1-9][0-9]*$ ]]; then
+  echo "expected artifact ID must be a positive integer." >&2
+  exit 1
+fi
+if [ -n "$expected_digest" ] &&
+   [[ ! "$expected_digest" =~ ^sha256:[0-9a-fA-F]{64}$ ]]; then
+  echo "expected digest must be a SHA-256 digest." >&2
+  exit 1
+fi
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must identify the repository}"
+: "${RUNNER_TEMP:?RUNNER_TEMP must identify the runner temporary directory}"
+
+scratch=$(mktemp -d "$RUNNER_TEMP/inspect-web-promotion.XXXXXX")
+trap 'rm -rf "$scratch"' EXIT
+
+run_json="$scratch/run.json"
+jobs_json="$scratch/jobs.json"
+artifacts_json="$scratch/artifacts.json"
+validator_output="$scratch/validator-output"
+
+gh api "repos/$GITHUB_REPOSITORY/actions/runs/$staging_run_id" > "$run_json"
+gh api \
+  "repos/$GITHUB_REPOSITORY/actions/runs/$staging_run_id/jobs?filter=latest&per_page=100" \
+  > "$jobs_json"
+gh api \
+  "repos/$GITHUB_REPOSITORY/actions/runs/$staging_run_id/artifacts?per_page=100" \
+  > "$artifacts_json"
+
+dotnet run eng/validate-inspect-web-promotion.cs -- \
+  --run "$run_json" \
+  --jobs "$jobs_json" \
+  --artifacts "$artifacts_json" \
+  --repository "$GITHUB_REPOSITORY" \
+  --max-age-hours "$max_age_hours" \
+  --github-output "$validator_output"
+
+read_output() {
+  local name=$1
+  awk -F= -v key="$name" '
+    $1 == key {
+      count++
+      value = substr($0, length(key) + 2)
+    }
+    END {
+      if (count != 1) exit 1
+      print value
+    }
+  ' "$validator_output"
+}
+
+resolved_sha=$(read_output sha)
+resolved_attempt=$(read_output run_attempt)
+resolved_artifact_id=$(read_output artifact_id)
+resolved_digest=$(read_output artifact_digest)
+
+if [ -n "$expected_sha" ] && [ "$resolved_sha" != "$expected_sha" ]; then
+  echo "revalidated SHA $resolved_sha does not match resolved SHA $expected_sha." >&2
+  exit 1
+fi
+if [ -n "$expected_attempt" ] &&
+   [ "$resolved_attempt" != "$expected_attempt" ]; then
+  echo "revalidated attempt $resolved_attempt does not match resolved attempt $expected_attempt." >&2
+  exit 1
+fi
+if [ -n "$expected_artifact_id" ] &&
+   [ "$resolved_artifact_id" != "$expected_artifact_id" ]; then
+  echo "revalidated artifact $resolved_artifact_id does not match resolved artifact $expected_artifact_id." >&2
+  exit 1
+fi
+if [ -n "$expected_digest" ] && [ "$resolved_digest" != "$expected_digest" ]; then
+  echo "revalidated digest $resolved_digest does not match resolved digest $expected_digest." >&2
+  exit 1
+fi
+
+cat "$validator_output" >> "$output"

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -470,7 +470,9 @@ nonempty `inspect-web-site` artifact. After production approval it revalidates
 the run attempt, commit, artifact identity, and digest, downloads the exact
 artifact ID with digest mismatch configured as an error, and deploys the
 archived staging files. `validate-inspect-web-promotion.cs --self-test`, run
-by inspect-web CI, gates the evidence discriminator and close negative cases.
+by inspect-web CI, gates the evidence discriminator and close negative cases;
+the CI change-detection workflow contract gate keeps production revalidation
+on the trusted dispatch revision and ahead of candidate artifact download.
 Manual staging runs remain useful for recovery but are deliberately not
 promotable.
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -454,27 +454,42 @@ not answer report the engine's failure rather than fixture results.
 
 ## Deploy
 
-`.github/workflows/deploy-inspect-web.yml` publishes the browser-Wasm project and
-uploads the prebuilt `wwwroot` to an Azure Static Web App with Azure's own app
-build disabled. It runs on every push to `main`; `workflow_dispatch` remains
-available, but the deploy job itself requires `refs/heads/main`, so a manual run
-cannot publish another ref. The `inspect-web-production` GitHub environment
-restricts deployments to `main` and requires approval before the job can access
-its environment-scoped
-`AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB` deployment credential. The Azure
-deployment action is pinned to an exact commit.
-The publish step embeds the CLI's authoritative `VersionPrefix`, the exact
-`GITHUB_SHA`, and a UTC build timestamp in the engine. The home and workspace
-status bars show that version, link the short commit to GitHub, and disclose the
-binary build time. `BuildIdentity_UsesVersionedRepositoryProvenance` and
+`.github/workflows/deploy-inspect-web.yml` publishes every `main` commit,
+archives the resulting `wwwroot` as the run-scoped `inspect-web-site` GitHub
+artifact, and deploys it to the public staging site at
+`https://dotnet-inspect.ca`. The separate `inspect-web-staging` GitHub
+environment accepts only `main` and holds a deployment token scoped to the
+staging Azure Static Web App.
+
+`.github/workflows/promote-inspect-web.yml` intentionally promotes one
+successful staging run to production at `https://dotnet-inspect.net`. The
+operator supplies the staging run ID and types `promote`; the workflow verifies
+that the run was a successful `main` push through the staging workflow, that
+its `Publish staging` job succeeded, and that it produced one unexpired,
+nonempty `inspect-web-site` artifact. After production approval it revalidates
+the run attempt, commit, artifact identity, and digest, downloads the exact
+artifact ID with digest mismatch configured as an error, and deploys the
+archived staging files. `validate-inspect-web-promotion.cs --self-test`, run
+by inspect-web CI, gates the evidence discriminator and close negative cases.
+Manual staging runs remain useful for recovery but are deliberately not
+promotable.
+
+Both deployment workflows pin the Azure deployment action to an exact commit
+and disable Azure's own app build. The staging publish step embeds the CLI's
+authoritative `VersionPrefix`, exact source SHA, and UTC build timestamp. The
+home and workspace status bars show that version, link the short commit to
+GitHub, and disclose the binary build time.
+`BuildIdentity_UsesVersionedRepositoryProvenance` and
 `ready status shows versioned linked build provenance` gate the engine and UI
 halves.
 
-Three prerequisites live outside this repository and are **not** verified by
-anything in it: the environment must retain its `main` branch restriction and
-required reviewer, its secret must be present, and the Static Web App resource's
-production Branch setting must name the branch being deployed. Treat a green
-workflow run — not this file — as the evidence that a deployed site is current.
+The Azure resources, custom-domain assignments, GitHub environments, branch
+restrictions, required production reviewer, and environment-scoped deployment
+tokens live outside this repository and are **not** verified by anything in it.
+Treat successful staging and promotion runs, not this file, as evidence that
+the corresponding deployed site is current. The staging domain is intentionally
+not publicized, but it is public infrastructure and is not a confidentiality
+boundary.
 
 See [architecture-spike.md](architecture-spike.md) for the proposed .NET 11
 browser engine and the NativeAOT decision.

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -482,8 +482,12 @@ not promotable.
 Production promotion uses the distinct `inspect-web-production-promotion`
 environment and `AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_PRODUCTION`
 secret. Legacy deployment workflows reference neither name. During cutover,
-retire the old `inspect-web-production` environment secret before merging the
-parent workflow so queued or rerun parent-era jobs fail closed.
+cancel outstanding legacy deployment runs, reset the production Static Web App
+deployment token, put the replacement token only in the promotion environment,
+and delete both the old `inspect-web-production` environment secret and the
+repository-scoped token. Token rotation invalidates credentials already copied
+into queued parent-era jobs; deleting both old secret locations makes later
+reruns fail closed.
 
 Both deployment workflows pin the Azure deployment action to an exact commit
 and disable Azure's own app build. The staging publish step embeds the CLI's

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -490,10 +490,14 @@ into queued parent-era jobs; deleting both old secret locations makes later
 reruns fail closed.
 
 Both deployment workflows pin the Azure deployment action to an exact commit
-and disable Azure's own app build. The staging publish step embeds the CLI's
-authoritative `VersionPrefix`, exact source SHA, and UTC build timestamp. The
-home and workspace status bars show that version, link the short commit to
-GitHub, and disclose the binary build time.
+and pin their checkout, SDK setup, and artifact actions to exact commits. The
+workflow contract gate enforces those references. Azure's pinned action still
+pulls Microsoft's `staticappsclient:stable` image; that vendor-controlled
+deployment dependency is not immutable and remains inside the Azure trust
+boundary. Both workflows disable Azure's own app build. The staging publish
+step embeds the CLI's authoritative `VersionPrefix`, exact source SHA, and UTC
+build timestamp. The home and workspace status bars show that version, link
+the short commit to GitHub, and disclose the binary build time.
 `BuildIdentity_UsesVersionedRepositoryProvenance` and
 `ready status shows versioned linked build provenance` gate the engine and UI
 halves.

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -456,8 +456,10 @@ not answer report the engine's failure rather than fixture results.
 
 `.github/workflows/deploy-inspect-web.yml` publishes every `main` commit,
 archives the resulting `wwwroot` as the run-scoped `inspect-web-site` GitHub
-artifact, and deploys it to the public staging site at
-`https://dotnet-inspect.ca`. The separate `inspect-web-staging` GitHub
+artifact, then uses a fresh environment-gated job to download that artifact by
+ID with digest mismatch configured as an error and deploy it to the public
+staging site at `https://dotnet-inspect.ca`. Candidate build code never runs in
+the staging deployment job. The separate `inspect-web-staging` GitHub
 environment accepts only `main` and holds a deployment token scoped to the
 staging Azure Static Web App.
 
@@ -471,10 +473,11 @@ the run attempt, commit, artifact identity, and digest, downloads the exact
 artifact ID with digest mismatch configured as an error, and deploys the
 archived staging files. `validate-inspect-web-promotion.cs --self-test`, run
 by inspect-web CI, gates the evidence discriminator and close negative cases;
-the CI change-detection workflow contract gate keeps production revalidation
-on the trusted dispatch revision and ahead of candidate artifact download.
-Manual staging runs remain useful for recovery but are deliberately not
-promotable.
+the CI change-detection workflow contract gate keeps both deployment jobs free
+of candidate code, keeps production revalidation on the trusted dispatch
+revision, and orders each artifact download before only verification and
+deployment. Manual staging runs remain useful for recovery but are deliberately
+not promotable.
 
 Both deployment workflows pin the Azure deployment action to an exact commit
 and disable Azure's own app build. The staging publish step embeds the CLI's

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -479,6 +479,12 @@ revision, and orders each artifact download before only verification and
 deployment. Manual staging runs remain useful for recovery but are deliberately
 not promotable.
 
+Production promotion uses the distinct `inspect-web-production-promotion`
+environment and `AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_PRODUCTION`
+secret. Legacy deployment workflows reference neither name. During cutover,
+retire the old `inspect-web-production` environment secret before merging the
+parent workflow so queued or rerun parent-era jobs fail closed.
+
 Both deployment workflows pin the Azure deployment action to an exact commit
 and disable Azure's own app build. The staging publish step embeds the CLI's
 authoritative `VersionPrefix`, exact source SHA, and UTC build timestamp. The


### PR DESCRIPTION
## Summary

Deploy every `main` commit to a separate Free staging Static Web App and archive the resulting site as a run-scoped GitHub artifact. Production becomes an intentional promotion: a manually selected successful staging run is validated before approval, revalidated afterward, downloaded by artifact ID with digest mismatch treated as an error, and deployed to the existing production Static Web App.

## Stack

- Slice 2 of 2
- Parent: #4361
- This PR targets `harden/inspect-web-deploy` and contains only staging/promotion behavior.

## External configuration

- Created Free SWA `dotnet-inspect-staging` in West US 2.
- Created main-only GitHub environment `inspect-web-staging` with its own environment-scoped deployment token.
- Production remains isolated in `inspect-web-production` with approval and its own token.

## Residual

After both slices land and the first staging deployment succeeds, move `dotnet-inspect.ca` from the production SWA to `dotnet-inspect-staging` in Azure and Cloudflare. `dotnet-inspect.net` remains production. Delete the temporary repository-scoped production token after the parent workflow is on `main`.

## Evidence

- Candidate base: `ac82f52416adaf5837944f183341127435f03eda`
- Candidate head: `52fc8b760b29a3692715ec7850cd1d24fce2ee3c`
- `dotnet run eng/validate-inspect-web-promotion.cs -- --self-test`
- `dotnet run -p:NuGetAudit=false eng/test-ci-change-detection.cs`
- Bash syntax and ShellCheck for the promotion wrapper
- YAML parsing for all changed workflows
- `npx --yes markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

The local SDK is centrally managed and lacks `wasm-experimental`, so the real Wasm publish was not run locally; the path-selected `inspect-web` CI job is the required real publish/test evidence.