### PR TITLE
Bound Browser package operations

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -47,6 +47,11 @@ shortening the selected assembly set.
    differ, per matching implementation asset. Malformed selected entries remain
    participants so queries report their rejection. Acquisition never inspects
    one.
+   The Browser adapter places one 30-second operation deadline around coordinate
+   resolution and payload acquisition. The deadline token flows through the
+   shared resolver, retry, response-body, archive-validation, and store paths;
+   expiry is surfaced as a visible timeout instead of leaving the page behind
+   an unbounded loading indicator.
 3. **Hand the group to a query.** The participants open one `InspectionWorkspace`
    and one binding-consistent `AssemblyContextGroup`. `BrowserInspectionScope`
    exposes exactly two hand-offs — `Use(group => query(group))` and
@@ -142,7 +147,10 @@ flat-container resource without losing a signed base query or allowing a
 coordinate to rewrite the resource path.
 `PackageCoordinateResolverTests.Coordinate_RejectsAPackageIdOutsideTheGrammar`,
 `ListVersions_UsesAuthorizedSourcesWithoutPersistentCaching`, and
-`BrowserEngineBoundaryTests.PackageCoordinates_AreRejectedBeforeAnyCacheOrNetworkAccess`
+`BrowserEngineBoundaryTests.PackageCoordinates_AreRejectedBeforeAnyCacheOrNetworkAccess`,
+`BrowserEngineBoundaryTests.PackageResolution_StallBecomesVisibleOperationTimeout`,
+and
+`BrowserEngineBoundaryTests.PackageAcquisition_StallBecomesVisibleOperationTimeout`
 gate these boundaries.
 
 Acquisition is bounded before content enters either cache or workspace. A

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -149,8 +149,10 @@ coordinate to rewrite the resource path.
 `ListVersions_UsesAuthorizedSourcesWithoutPersistentCaching`, and
 `BrowserEngineBoundaryTests.PackageCoordinates_AreRejectedBeforeAnyCacheOrNetworkAccess`,
 `BrowserEngineBoundaryTests.PackageResolution_StallBecomesVisibleOperationTimeout`,
+`BrowserEngineBoundaryTests.PackageAcquisition_StallBecomesVisibleOperationTimeout`,
+`BrowserEngineBoundaryTests.PackageAcquisition_SharedStallIsAVisibleTimeoutForEveryCaller`,
 and
-`BrowserEngineBoundaryTests.PackageAcquisition_StallBecomesVisibleOperationTimeout`
+`BrowserEngineBoundaryTests.PackageAcquisition_ExpiredDeadlineCannotPublishReservedContent`
 gate these boundaries.
 
 Acquisition is bounded before content enters either cache or workspace. A

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -151,8 +151,9 @@ coordinate to rewrite the resource path.
 `BrowserEngineBoundaryTests.PackageResolution_StallBecomesVisibleOperationTimeout`,
 `BrowserEngineBoundaryTests.PackageAcquisition_StallBecomesVisibleOperationTimeout`,
 `BrowserEngineBoundaryTests.PackageAcquisition_SharedStallIsAVisibleTimeoutForEveryCaller`,
+`BrowserEngineBoundaryTests.PackageAcquisition_ExpiredDeadlineCannotPublishReservedContent`,
 and
-`BrowserEngineBoundaryTests.PackageAcquisition_ExpiredDeadlineCannotPublishReservedContent`
+`BrowserEngineBoundaryTests.PackageOperation_LateFailureBecomesVisibleTimeout`
 gate these boundaries.
 
 Acquisition is bounded before content enters either cache or workspace. A

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1059,7 +1059,7 @@ public sealed class BrowserEngineBoundaryTests
             packageId,
             "1.0.0",
             client,
-            TimeSpan.FromMilliseconds(100));
+            TimeSpan.FromMilliseconds(500));
         await handler.RequestStarted.Task.WaitAsync(
             TimeSpan.FromSeconds(1),
             TestContext.Current.CancellationToken);
@@ -1067,11 +1067,37 @@ public sealed class BrowserEngineBoundaryTests
             packageId,
             "1.0.0",
             client,
-            TimeSpan.FromSeconds(5));
+            TimeSpan.FromMilliseconds(100));
 
+        TimeoutException secondFailure =
+            await Assert.ThrowsAsync<TimeoutException>(() => second);
+        Assert.Contains(
+            "0.1-second deadline",
+            secondFailure.Message,
+            StringComparison.Ordinal);
+        Assert.False(first.IsCompleted);
         await Assert.ThrowsAsync<TimeoutException>(() => first);
-        await Assert.ThrowsAsync<TimeoutException>(() => second);
         Assert.Equal(1, handler.Requests);
+    }
+
+    [Fact]
+    public void PackageAcquisition_ExpiredDeadlineCannotPublishReservedContent()
+    {
+        using var deadline =
+            new BrowserPackageWorkspace.BrowserPackageOperationDeadline(
+                TimeSpan.FromMilliseconds(10));
+        var inner = new RecordingTransferPolicy();
+        var policy =
+            new BrowserPackageWorkspace.BrowserPackageOperationTransferPolicy(
+                inner,
+                deadline);
+        using IPackagePayloadReservation reservation =
+            policy.ApplyDeadline(inner.Reservation);
+        while (!deadline.HasExpired)
+            Thread.SpinWait(100);
+
+        Assert.Throws<TimeoutException>(() => reservation.Complete());
+        Assert.False(inner.Reservation.Completed);
     }
 
     [Fact]
@@ -1476,6 +1502,26 @@ public sealed class BrowserEngineBoundaryTests
                 cancellationToken);
             throw new InvalidOperationException(
                 "The stalling handler completed without cancellation.");
+        }
+    }
+
+    sealed class RecordingTransferPolicy : IPackagePayloadTransferPolicy
+    {
+        internal RecordingReservation Reservation { get; } = new();
+
+        public IPackagePayloadReservation Reserve(
+            PackagePayloadTransfer transfer) =>
+            Reservation;
+    }
+
+    sealed class RecordingReservation : IPackagePayloadReservation
+    {
+        internal bool Completed { get; private set; }
+
+        public void Complete() => Completed = true;
+
+        public void Dispose()
+        {
         }
     }
 

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1029,9 +1029,9 @@ public sealed class BrowserEngineBoundaryTests
             packageId,
             version: null,
             client,
-            TimeSpan.FromMilliseconds(200));
+            TimeSpan.FromSeconds(5));
         await handler.RequestStarted.Task.WaitAsync(
-            TimeSpan.FromSeconds(1),
+            TimeSpan.FromSeconds(10),
             TestContext.Current.CancellationToken);
 
         TimeoutException failure =

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -985,6 +985,96 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public async Task PackageAcquisition_StallBecomesVisibleOperationTimeout()
+    {
+        var handler = new StallingPackageHandler();
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        string packageId =
+            $"timeout.package.{Guid.NewGuid():N}";
+
+        Task<BrowserPackage> acquisition = BrowserPackageWorkspace.AcquireAsync(
+            packageId,
+            "1.0.0",
+            client,
+            TimeSpan.FromMilliseconds(200));
+        await handler.RequestStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
+
+        TimeoutException failure =
+            await Assert.ThrowsAsync<TimeoutException>(() => acquisition);
+
+        Assert.Contains(
+            "Browser package operation",
+            failure.Message,
+            StringComparison.Ordinal);
+        Assert.Equal(1, handler.Requests);
+    }
+
+    [Fact]
+    public async Task PackageResolution_StallBecomesVisibleOperationTimeout()
+    {
+        var handler = new StallingPackageHandler();
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        string packageId =
+            $"resolution.timeout.package.{Guid.NewGuid():N}";
+
+        Task<BrowserPackage> acquisition = BrowserPackageWorkspace.AcquireAsync(
+            packageId,
+            version: null,
+            client,
+            TimeSpan.FromMilliseconds(200));
+        await handler.RequestStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
+
+        TimeoutException failure =
+            await Assert.ThrowsAsync<TimeoutException>(() => acquisition);
+
+        Assert.Contains(
+            "Browser package operation",
+            failure.Message,
+            StringComparison.Ordinal);
+        Assert.Equal(1, handler.Requests);
+    }
+
+    [Fact]
+    public async Task PackageAcquisition_SharedStallIsAVisibleTimeoutForEveryCaller()
+    {
+        var handler = new StallingPackageHandler();
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        string packageId =
+            $"shared.timeout.package.{Guid.NewGuid():N}";
+
+        Task<BrowserPackage> first = BrowserPackageWorkspace.AcquireAsync(
+            packageId,
+            "1.0.0",
+            client,
+            TimeSpan.FromMilliseconds(100));
+        await handler.RequestStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
+        Task<BrowserPackage> second = BrowserPackageWorkspace.AcquireAsync(
+            packageId,
+            "1.0.0",
+            client,
+            TimeSpan.FromSeconds(5));
+
+        await Assert.ThrowsAsync<TimeoutException>(() => first);
+        await Assert.ThrowsAsync<TimeoutException>(() => second);
+        Assert.Equal(1, handler.Requests);
+    }
+
+    [Fact]
     public async Task PackageVersionIndex_ValidatesTheIdBeforeRequestingIt()
     {
         InvalidOperationException failure =
@@ -1367,6 +1457,26 @@ public sealed class BrowserEngineBoundaryTests
         }
 
         return content.ToArray();
+    }
+
+    sealed class StallingPackageHandler : HttpMessageHandler
+    {
+        public int Requests { get; private set; }
+        public TaskCompletionSource RequestStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Requests++;
+            RequestStarted.TrySetResult();
+            await Task.Delay(
+                Timeout.InfiniteTimeSpan,
+                cancellationToken);
+            throw new InvalidOperationException(
+                "The stalling handler completed without cancellation.");
+        }
     }
 
 }

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1101,6 +1101,25 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public async Task PackageOperation_LateFailureBecomesVisibleTimeout()
+    {
+        TimeoutException failure =
+            await Assert.ThrowsAsync<TimeoutException>(
+                () => BrowserPackageWorkspace.RunPackageOperationAsync<int>(
+                    deadline =>
+                    {
+                        while (!deadline.HasExpired)
+                            Thread.SpinWait(100);
+                        return Task.FromException<int>(
+                            new InvalidOperationException(
+                                "Synchronous work failed after the deadline."));
+                    },
+                    TimeSpan.FromMilliseconds(10)));
+
+        Assert.IsType<InvalidOperationException>(failure.InnerException);
+    }
+
+    [Fact]
     public async Task PackageVersionIndex_ValidatesTheIdBeforeRequestingIt()
     {
         InvalidOperationException failure =

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Runtime.Versioning;
 using System.Text;
 using DotnetInspector.Packages;
@@ -40,6 +41,10 @@ namespace InspectWeb.Engine;
 /// <c>BrowserEngineBoundaryTests.PackageAcquisition_StallBecomesVisibleOperationTimeout</c>
 /// gate the Browser operation deadline through shared coordinate resolution
 /// and payload acquisition.
+/// <c>BrowserEngineBoundaryTests.PackageAcquisition_SharedStallIsAVisibleTimeoutForEveryCaller</c>
+/// gates per-caller deadlines over a shared transfer, and
+/// <c>BrowserEngineBoundaryTests.PackageAcquisition_ExpiredDeadlineCannotPublishReservedContent</c>
+/// gates the final monotonic check before cache publication.
 /// </para>
 /// </remarks>
 [SupportedOSPlatform("browser")]
@@ -98,12 +103,11 @@ internal static class BrowserPackageWorkspace
         string packageId,
         string? version) =>
         RunPackageOperationAsync(
-            cancellationToken => AcquireCoreAsync(
+            deadline => AcquireCoreAsync(
                 packageId,
                 version,
                 Http,
-                cancellationToken,
-                PackageOperationTimeout),
+                deadline),
             PackageOperationTimeout);
 
     internal static Task<BrowserPackage> AcquireAsync(
@@ -112,20 +116,18 @@ internal static class BrowserPackageWorkspace
         HttpClient client,
         TimeSpan operationTimeout) =>
         RunPackageOperationAsync(
-            cancellationToken => AcquireCoreAsync(
+            deadline => AcquireCoreAsync(
                 packageId,
                 version,
                 client,
-                cancellationToken,
-                operationTimeout),
+                deadline),
             operationTimeout);
 
     static async Task<BrowserPackage> AcquireCoreAsync(
         string packageId,
         string? version,
         HttpClient client,
-        CancellationToken cancellationToken,
-        TimeSpan operationTimeout)
+        BrowserPackageOperationDeadline deadline)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
 
@@ -137,9 +139,10 @@ internal static class BrowserPackageWorkspace
         ResolvedPackageCoordinate coordinate = await ResolveCoordinateAsync(
             new PackageCoordinate(packageId, requestedVersion),
             client,
-            cancellationToken);
+            deadline.Token);
 
         string key = PackageKey(coordinate.PackageId, coordinate.Version);
+        bool ownsPendingAcquisition = false;
         if (!PendingAcquisitions.TryGetValue(
                 key,
                 out Task<AcquiredPackagePayload>? pending))
@@ -147,19 +150,30 @@ internal static class BrowserPackageWorkspace
             pending = AcquirePayloadWithinOperationAsync(
                 coordinate,
                 client,
-                cancellationToken,
-                operationTimeout);
+                deadline);
             PendingAcquisitions.Add(key, pending);
+            ownsPendingAcquisition = true;
         }
 
         AcquiredPackagePayload payload;
         try
         {
-            payload = await pending.ConfigureAwait(false);
+            payload = ownsPendingAcquisition
+                ? await pending.ConfigureAwait(false)
+                : await pending
+                    .WaitAsync(deadline.Token)
+                    .ConfigureAwait(false);
         }
         finally
         {
-            PendingAcquisitions.Remove(key);
+            if (ownsPendingAcquisition
+                && PendingAcquisitions.TryGetValue(
+                    key,
+                    out Task<AcquiredPackagePayload>? active)
+                && ReferenceEquals(active, pending))
+            {
+                PendingAcquisitions.Remove(key);
+            }
         }
 
         if (!Cache.TryGetValue(key, out CacheEntry? cached)
@@ -352,7 +366,8 @@ internal static class BrowserPackageWorkspace
     static async Task<AcquiredPackagePayload> AcquirePayloadAsync(
         ResolvedPackageCoordinate coordinate,
         HttpClient client,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IPackagePayloadTransferPolicy transferPolicy)
     {
         PackagePayloadResult result = await PackagePayloadAcquisition.AcquireAsync(
             client,
@@ -360,7 +375,7 @@ internal static class BrowserPackageWorkspace
             Store,
             limits: PayloadLimits,
             cancellationToken: cancellationToken,
-            transferPolicy: Store).ConfigureAwait(false);
+            transferPolicy: transferPolicy).ConfigureAwait(false);
         return result switch
         {
             PackagePayloadResult.Acquired acquired => acquired.Payload,
@@ -374,28 +389,30 @@ internal static class BrowserPackageWorkspace
     static async Task<AcquiredPackagePayload> AcquirePayloadWithinOperationAsync(
         ResolvedPackageCoordinate coordinate,
         HttpClient client,
-        CancellationToken cancellationToken,
-        TimeSpan operationTimeout)
+        BrowserPackageOperationDeadline deadline)
     {
         try
         {
             return await AcquirePayloadAsync(
                 coordinate,
                 client,
-                cancellationToken).ConfigureAwait(false);
+                deadline.Token,
+                new BrowserPackageOperationTransferPolicy(
+                    Store,
+                    deadline)).ConfigureAwait(false);
         }
         catch (OperationCanceledException exception)
-            when (cancellationToken.IsCancellationRequested)
+            when (deadline.HasExpired)
         {
-            throw PackageOperationTimedOut(operationTimeout, exception);
+            throw deadline.Timeout(exception);
         }
     }
 
     internal static Task<string[]> GetVersionsAsync(string packageId) =>
         RunPackageOperationAsync(
-            cancellationToken => GetVersionsCoreAsync(
+            deadline => GetVersionsCoreAsync(
                 packageId,
-                cancellationToken),
+                deadline.Token),
             PackageOperationTimeout);
 
     static async Task<string[]> GetVersionsCoreAsync(
@@ -436,10 +453,10 @@ internal static class BrowserPackageWorkspace
         string packageId,
         string? declaredRange) =>
         RunPackageOperationAsync(
-            cancellationToken => ResolveDependencyVersionCoreAsync(
+            deadline => ResolveDependencyVersionCoreAsync(
                 packageId,
                 declaredRange,
-                cancellationToken),
+                deadline.Token),
             PackageOperationTimeout);
 
     static async Task<string> ResolveDependencyVersionCoreAsync(
@@ -468,7 +485,7 @@ internal static class BrowserPackageWorkspace
     }
 
     static async Task<T> RunPackageOperationAsync<T>(
-        Func<CancellationToken, Task<T>> operation,
+        Func<BrowserPackageOperationDeadline, Task<T>> operation,
         TimeSpan timeout)
     {
         ArgumentNullException.ThrowIfNull(operation);
@@ -480,24 +497,86 @@ internal static class BrowserPackageWorkspace
                 "The Browser package-operation timeout must be positive.");
         }
 
-        using var deadline = new CancellationTokenSource(timeout);
+        using var deadline = new BrowserPackageOperationDeadline(timeout);
         try
         {
-            return await operation(deadline.Token).ConfigureAwait(false);
+            T result = await operation(deadline).ConfigureAwait(false);
+            deadline.ThrowIfExpired();
+            return result;
         }
         catch (OperationCanceledException exception)
-            when (deadline.IsCancellationRequested)
+            when (deadline.HasExpired)
         {
-            throw PackageOperationTimedOut(timeout, exception);
+            throw deadline.Timeout(exception);
         }
     }
 
-    static TimeoutException PackageOperationTimedOut(
-        TimeSpan timeout,
-        OperationCanceledException exception) =>
-        new(
-            $"The Browser package operation exceeded its {timeout.TotalSeconds:g}-second deadline.",
-            exception);
+    internal sealed class BrowserPackageOperationDeadline : IDisposable
+    {
+        readonly CancellationTokenSource _cancellation;
+        readonly long _started = Stopwatch.GetTimestamp();
+        readonly TimeSpan _timeout;
+
+        internal BrowserPackageOperationDeadline(TimeSpan timeout)
+        {
+            _timeout = timeout;
+            _cancellation = new CancellationTokenSource(timeout);
+        }
+
+        internal CancellationToken Token => _cancellation.Token;
+
+        internal bool HasExpired =>
+            _cancellation.IsCancellationRequested
+            || Stopwatch.GetElapsedTime(_started) >= _timeout;
+
+        internal void ThrowIfExpired()
+        {
+            if (HasExpired)
+            {
+                throw Timeout(
+                    new OperationCanceledException(
+                        "Browser package operation deadline expired.",
+                        Token));
+            }
+        }
+
+        internal TimeoutException Timeout(Exception exception) =>
+            new(
+                $"The Browser package operation exceeded its {_timeout.TotalSeconds:g}-second deadline.",
+                exception);
+
+        public void Dispose() => _cancellation.Dispose();
+    }
+
+    internal sealed class BrowserPackageOperationTransferPolicy(
+        IPackagePayloadTransferPolicy inner,
+        BrowserPackageOperationDeadline deadline)
+        : IPackagePayloadTransferPolicy
+    {
+        public IPackagePayloadReservation Reserve(
+            PackagePayloadTransfer transfer) =>
+            ApplyDeadline(inner.Reserve(transfer));
+
+        internal IPackagePayloadReservation ApplyDeadline(
+            IPackagePayloadReservation reservation) =>
+            new DeadlineReservation(
+                reservation,
+                deadline);
+
+        sealed class DeadlineReservation(
+            IPackagePayloadReservation inner,
+            BrowserPackageOperationDeadline deadline)
+            : IPackagePayloadReservation
+        {
+            public void Complete()
+            {
+                deadline.ThrowIfExpired();
+                inner.Complete();
+            }
+
+            public void Dispose() => inner.Dispose();
+        }
+    }
 
     internal static string? SelectDependencyVersion(
         string[] versions,

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -44,7 +44,9 @@ namespace InspectWeb.Engine;
 /// <c>BrowserEngineBoundaryTests.PackageAcquisition_SharedStallIsAVisibleTimeoutForEveryCaller</c>
 /// gates per-caller deadlines over a shared transfer, and
 /// <c>BrowserEngineBoundaryTests.PackageAcquisition_ExpiredDeadlineCannotPublishReservedContent</c>
-/// gates the final monotonic check before cache publication.
+/// gates the final monotonic check before cache publication, and
+/// <c>BrowserEngineBoundaryTests.PackageOperation_LateFailureBecomesVisibleTimeout</c>
+/// gates timeout classification after synchronous work overruns the deadline.
 /// </para>
 /// </remarks>
 [SupportedOSPlatform("browser")]
@@ -484,7 +486,7 @@ internal static class BrowserPackageWorkspace
                 + $"the declared range '{declaredRange}'.");
     }
 
-    static async Task<T> RunPackageOperationAsync<T>(
+    internal static async Task<T> RunPackageOperationAsync<T>(
         Func<BrowserPackageOperationDeadline, Task<T>> operation,
         TimeSpan timeout)
     {
@@ -505,6 +507,15 @@ internal static class BrowserPackageWorkspace
             return result;
         }
         catch (OperationCanceledException exception)
+            when (deadline.HasExpired)
+        {
+            throw deadline.Timeout(exception);
+        }
+        catch (TimeoutException)
+        {
+            throw;
+        }
+        catch (Exception exception)
             when (deadline.HasExpired)
         {
             throw deadline.Timeout(exception);

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -34,6 +34,13 @@ namespace InspectWeb.Engine;
 /// <c>BrowserEngineBoundaryTests.WorkspaceOwnership_AccountsArchivesAndCarriesSelectedFailures</c>
 /// gates the aggregate package-cache and scope-retention budget.
 /// </para>
+/// <para>
+/// <c>BrowserEngineBoundaryTests.PackageResolution_StallBecomesVisibleOperationTimeout</c>
+/// and
+/// <c>BrowserEngineBoundaryTests.PackageAcquisition_StallBecomesVisibleOperationTimeout</c>
+/// gate the Browser operation deadline through shared coordinate resolution
+/// and payload acquisition.
+/// </para>
 /// </remarks>
 [SupportedOSPlatform("browser")]
 internal static class BrowserPackageWorkspace
@@ -41,8 +48,13 @@ internal static class BrowserPackageWorkspace
     const int MaxCachedPackages = 12;
     const long MaxCachedPackageBytes = 128L * 1024 * 1024;
     const int MaxOpenScopes = 4;
+    internal static TimeSpan PackageOperationTimeout { get; } =
+        TimeSpan.FromSeconds(30);
 
-    static readonly HttpClient Http = new();
+    static readonly HttpClient Http = new()
+    {
+        Timeout = Timeout.InfiniteTimeSpan,
+    };
     static readonly UniformPackageSourceAuthorization SourceAuthorization =
         new([PackageSource.NuGetOrg]);
     static readonly BrowserSessionPackageStore Store = new();
@@ -78,8 +90,42 @@ internal static class BrowserPackageWorkspace
             Cache.Values.Sum(entry => entry.Bytes.LongLength)
                 + Reservations.Values.Sum(reservation => reservation.ReservedBytes));
 
-    /// <summary>Resolves and acquires one package through the shared product owners.</summary>
-    public static async Task<BrowserPackage> AcquireAsync(string packageId, string? version)
+    /// <summary>
+    /// Resolves and acquires one package through the shared product owners
+    /// within the Browser operation deadline.
+    /// </summary>
+    public static Task<BrowserPackage> AcquireAsync(
+        string packageId,
+        string? version) =>
+        RunPackageOperationAsync(
+            cancellationToken => AcquireCoreAsync(
+                packageId,
+                version,
+                Http,
+                cancellationToken,
+                PackageOperationTimeout),
+            PackageOperationTimeout);
+
+    internal static Task<BrowserPackage> AcquireAsync(
+        string packageId,
+        string? version,
+        HttpClient client,
+        TimeSpan operationTimeout) =>
+        RunPackageOperationAsync(
+            cancellationToken => AcquireCoreAsync(
+                packageId,
+                version,
+                client,
+                cancellationToken,
+                operationTimeout),
+            operationTimeout);
+
+    static async Task<BrowserPackage> AcquireCoreAsync(
+        string packageId,
+        string? version,
+        HttpClient client,
+        CancellationToken cancellationToken,
+        TimeSpan operationTimeout)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
 
@@ -89,21 +135,27 @@ internal static class BrowserPackageWorkspace
                 ? null
                 : version;
         ResolvedPackageCoordinate coordinate = await ResolveCoordinateAsync(
-            new PackageCoordinate(packageId, requestedVersion));
+            new PackageCoordinate(packageId, requestedVersion),
+            client,
+            cancellationToken);
 
         string key = PackageKey(coordinate.PackageId, coordinate.Version);
         if (!PendingAcquisitions.TryGetValue(
                 key,
                 out Task<AcquiredPackagePayload>? pending))
         {
-            pending = AcquirePayloadAsync(coordinate);
+            pending = AcquirePayloadWithinOperationAsync(
+                coordinate,
+                client,
+                cancellationToken,
+                operationTimeout);
             PendingAcquisitions.Add(key, pending);
         }
 
         AcquiredPackagePayload payload;
         try
         {
-            payload = await pending;
+            payload = await pending.ConfigureAwait(false);
         }
         finally
         {
@@ -129,7 +181,9 @@ internal static class BrowserPackageWorkspace
     }
 
     static async Task<ResolvedPackageCoordinate> ResolveCoordinateAsync(
-        PackageCoordinate request)
+        PackageCoordinate request,
+        HttpClient client,
+        CancellationToken cancellationToken)
     {
         if (PackageCoordinateResolver.Validate(request) is { } invalid)
             throw new InvalidOperationException(invalid.Message);
@@ -139,11 +193,12 @@ internal static class BrowserPackageWorkspace
             SourceAuthorization.AuthorizeSourcesFor(canonicalId);
         PackageCoordinateResolution resolution =
             await PackageCoordinateResolver.ResolveAsync(
-                Http,
+                client,
                 request,
                 authorization.Sources,
                 useVersionCache: false,
-                requireStableFloating: true);
+                requireStableFloating: true,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
         ResolvedPackageCoordinate coordinate = resolution switch
         {
             PackageCoordinateResolution.Resolved resolved => resolved.Coordinate,
@@ -295,14 +350,17 @@ internal static class BrowserPackageWorkspace
     }
 
     static async Task<AcquiredPackagePayload> AcquirePayloadAsync(
-        ResolvedPackageCoordinate coordinate)
+        ResolvedPackageCoordinate coordinate,
+        HttpClient client,
+        CancellationToken cancellationToken)
     {
         PackagePayloadResult result = await PackagePayloadAcquisition.AcquireAsync(
-            Http,
+            client,
             coordinate,
             Store,
             limits: PayloadLimits,
-            transferPolicy: Store);
+            cancellationToken: cancellationToken,
+            transferPolicy: Store).ConfigureAwait(false);
         return result switch
         {
             PackagePayloadResult.Acquired acquired => acquired.Payload,
@@ -313,7 +371,36 @@ internal static class BrowserPackageWorkspace
         };
     }
 
-    internal static async Task<string[]> GetVersionsAsync(string packageId)
+    static async Task<AcquiredPackagePayload> AcquirePayloadWithinOperationAsync(
+        ResolvedPackageCoordinate coordinate,
+        HttpClient client,
+        CancellationToken cancellationToken,
+        TimeSpan operationTimeout)
+    {
+        try
+        {
+            return await AcquirePayloadAsync(
+                coordinate,
+                client,
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException exception)
+            when (cancellationToken.IsCancellationRequested)
+        {
+            throw PackageOperationTimedOut(operationTimeout, exception);
+        }
+    }
+
+    internal static Task<string[]> GetVersionsAsync(string packageId) =>
+        RunPackageOperationAsync(
+            cancellationToken => GetVersionsCoreAsync(
+                packageId,
+                cancellationToken),
+            PackageOperationTimeout);
+
+    static async Task<string[]> GetVersionsCoreAsync(
+        string packageId,
+        CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
         if (PackageCoordinateResolver.Validate(new PackageCoordinate(packageId))
@@ -330,7 +417,8 @@ internal static class BrowserPackageWorkspace
                 packageId,
                 authorization.Sources,
                 includePrerelease: true,
-                useVersionCache: false);
+                useVersionCache: false,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
         return result switch
         {
             PackageVersionListingResult.Available available =>
@@ -344,25 +432,72 @@ internal static class BrowserPackageWorkspace
         };
     }
 
-    internal static async Task<string> ResolveDependencyVersionAsync(
+    internal static Task<string> ResolveDependencyVersionAsync(
         string packageId,
-        string? declaredRange)
+        string? declaredRange) =>
+        RunPackageOperationAsync(
+            cancellationToken => ResolveDependencyVersionCoreAsync(
+                packageId,
+                declaredRange,
+                cancellationToken),
+            PackageOperationTimeout);
+
+    static async Task<string> ResolveDependencyVersionCoreAsync(
+        string packageId,
+        string? declaredRange,
+        CancellationToken cancellationToken)
     {
         if (PackageDependencyVersionRange.GetExactVersion(declaredRange)
             is { } exactVersion)
         {
             ResolvedPackageCoordinate coordinate =
                 await ResolveCoordinateAsync(
-                    new PackageCoordinate(packageId, exactVersion));
+                    new PackageCoordinate(packageId, exactVersion),
+                    Http,
+                    cancellationToken).ConfigureAwait(false);
             return coordinate.Version;
         }
 
-        string[] versions = await GetVersionsAsync(packageId);
+        string[] versions = await GetVersionsCoreAsync(
+            packageId,
+            cancellationToken).ConfigureAwait(false);
         return SelectDependencyVersion(versions, declaredRange)
             ?? throw new InvalidOperationException(
                 $"Package '{packageId}' has no published version satisfying "
                 + $"the declared range '{declaredRange}'.");
     }
+
+    static async Task<T> RunPackageOperationAsync<T>(
+        Func<CancellationToken, Task<T>> operation,
+        TimeSpan timeout)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(timeout),
+                timeout,
+                "The Browser package-operation timeout must be positive.");
+        }
+
+        using var deadline = new CancellationTokenSource(timeout);
+        try
+        {
+            return await operation(deadline.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException exception)
+            when (deadline.IsCancellationRequested)
+        {
+            throw PackageOperationTimedOut(timeout, exception);
+        }
+    }
+
+    static TimeoutException PackageOperationTimedOut(
+        TimeSpan timeout,
+        OperationCanceledException exception) =>
+        new(
+            $"The Browser package operation exceeded its {timeout.TotalSeconds:g}-second deadline.",
+            exception);
 
     internal static string? SelectDependencyVersion(
         string[] versions,


### PR DESCRIPTION
Browser package resolution and payload acquisition now share one 30-second monotonic operation deadline, replacing the framework 100-second transport timeout and preventing retry-amplified loading spinners. Deadline expiry surfaces as a visible `TimeoutException`, including for every caller sharing one pending download, and expired work cannot publish reserved cache content.

**Stack:** slice 2, targeting parent PR #4338 (`feature/typed-package-source-results`).

**Evidence:**
- 5 focused resolution, payload, shared-pending, publication, and late-failure timeout regressions pass
- all 48 `InspectWeb.Engine.Tests` pass in Release
- `InspectWeb.Engine` builds for `browser-wasm` with 0 warnings/errors
- `prototypes/inspect-web/README.md` passes markdownlint
- exact-head adversarial review is clean from GPT-5.6 Sol and Claude Opus 5 at `3decd9e179696bb09bd0a489e9def9ab621bf2fd`

**Compatibility boundary:** the deadline is owned by the Browser C# adapter and flows through existing shared resolver, retry, response-body, archive, and store cancellation paths; JavaScript behavior is unchanged except that the existing visible failure path now completes promptly. Monotonic checks cover synchronous single-threaded Wasm work that can delay timer callbacks.

**Residual:** Gallery registration, remaining source-client migration, aggregation, availability observations, and browser source registry work remain subsequent architecture slices.