### PR TITLE
Give Windows CI measured timeout headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,7 +411,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name == 'pull_request'
     runs-on: windows-latest
-    timeout-minutes: 40
+    # Raised from 40 after #4350 measured a 29-minute CLI run followed by the
+    # expected six remaining suites. The lane needed about 42 minutes to report
+    # every result; 55 preserves that evidence with measured runner variance.
+    timeout-minutes: 55
     env:
       DOTNET_INSPECT_TIPS: q
     steps:

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -743,7 +743,7 @@ public class IlToolsActivationTests
             "\n    steps:\n",
             StringComparison.Ordinal);
         Assert.True(stepsStart >= 0);
-        Assert.Contains("timeout-minutes: 40", job[..stepsStart]);
+        Assert.Contains("timeout-minutes: 55", job[..stepsStart]);
 
         int install = job.IndexOf(
             "- name: Install ilasm/ildasm",


### PR DESCRIPTION
Raises the Windows PR lane timeout from 40 to 55 minutes without dropping or filtering any coverage. The filed run measured a 29-minute full CLI suite followed by the expected remaining suites; the lane needed about 42 minutes to report every result, so the former job budget cancelled metadata teardown and skipped services/query reporting. The new budget preserves the existing fail-visible suite sequence with measured runner variance.

Evidence at `89ca45a8e40c60cc483d2dbe8d7625f0ef73d9db`:
- Current base: `948a1562073e9c06e10fc884b575554ea9504f19`.
- Focused `IlToolsActivationTests` and `CiWorkflowTests`: 38/38 passed.
- Workflow YAML and diff checks passed.
- Historical successful Windows lane: ~24 minutes; filed outlier needed ~42 minutes to complete all configured steps.

Closes #4350