### PR TITLE
Expose bounded cross-library call neighborhoods

### DIFF
--- a/docs/design/call-graph-projection.md
+++ b/docs/design/call-graph-projection.md
@@ -321,6 +321,21 @@ a target-only catalog rather than mixing a detached tree with an evidence-free
 local tree; `CallGraph_KeepsVersionSkewedCallersWhenCalleesAreUnscoped` gates
 that projection never falls back to structural identity and collapses versions.
 
+`CrossLibraryCalleeNeighborhood` exposes the existing cross-library callee
+traversal as a call-only L1 inspection-graph neighborhood. Its request carries
+non-negative maximum edge depth and a positive call-node budget. The returned
+document retains one member seed, outgoing caller-to-callee direction, the
+generic neighborhood depth bound, the call-specific node bound, every retained
+physical call-site receipt, and any incomplete catalog correspondence. Depth
+zero retains only the seed. A missing in-scope definition remains an external
+boundary; an acquired definition may continue transitively across an assembly
+boundary. This surface does not add another resolver or traversal: it invokes
+`CatalogCallGraphScope.BuildCallTree`, projects the callee tree once, and applies
+the shared dense neighborhood projection. The
+`CrossLibraryCalleeNeighborhood_*` tests gate cross-boundary continuation,
+depth-zero and finite-depth behavior, node bounds, external placeholders,
+physical receipts, and correspondence disclosure.
+
 **No duplicated work.** At most two target-assembly indexes are ever built — the
 scoped single-body build and the full build — plus one build per cross-library
 package, and each is built once and reused for callees, callers, and any
@@ -479,5 +494,7 @@ Coverage lives in `src/ILInspector.Analysis.Tests/CallGraphProjectionTests.cs`
 deterministic ids and ordering, loop annotations across collapse and inversion,
 cross-assembly / generic-recursion-collapse / return-type identity behavior, the
 bodiless-target combined view, and the two-different-unsupported-roots rejection)
-and in `src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs` for the CLI
-section, its lowerings, and its `--fields` projection.
+and in `src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs` for
+progressive acquisition and bounded cross-library callee neighborhoods.
+`src/dotnet-inspect.Tests/MemberCallGraphSectionTests.cs` covers the CLI section,
+its lowerings, and its `--fields` projection.

--- a/docs/design/inspection-graph-document.md
+++ b/docs/design/inspection-graph-document.md
@@ -734,6 +734,17 @@ The resulting document retains both its `ModeRequest` and
 `NeighborhoodRequest`; a consumer never has to infer selection or bounds from
 the surviving topology.
 
+Relationship producers may retain a stricter typed breadth budget alongside
+that shared request. The bounded call neighborhood records
+`call.traversal-node-bound` in addition to
+`queries.neighborhood-depth-bound`, because Analysis enforces its node budget
+while building the cross-library callee tree. Hitting either bound remains
+visible through call traversal incompleteness; it does not erase the member
+seed or its physical evidence. Nonzero catalog correspondence counts likewise
+remain a typed `call.correspondence-incomplete` limit rather than a
+success-shaped empty graph. `CrossLibraryCalleeNeighborhood_*` gates these
+call-specific compositions.
+
 The Integration implementation validates catalog membership before producer
 execution. Its relationship set drives the deterministic query-registry plan,
 including opportunity's Integration and extension prerequisites for

--- a/docs/design/inspection-graph-modes.md
+++ b/docs/design/inspection-graph-modes.md
@@ -23,7 +23,9 @@ relationship set, semantic traversal direction, and finite edge-depth bound.
 The Integration query validates that relationship set before execution,
 requests only its required producers and prerequisites, and projects the
 bounded neighborhood without reversing stored edges or changing occurrence
-identity. Peer connecting neighborhoods, induced explicit-subject sets, and
+identity. The call session exposes the same request envelope for an outgoing,
+call-only member neighborhood while retaining its Analysis-owned node budget.
+Peer connecting neighborhoods, induced explicit-subject sets, and
 command/presentation surfaces remain design targets.
 
 `CallAdapter_PreservesTypedTopologyAndDisclosesEvidenceGap`,
@@ -112,6 +114,16 @@ the request and a typed depth-bound limit.
 The current `member -S "Call Graph"` path is the worked example. The member is
 the focus, while caller scopes widen evidence coverage without becoming seeds.
 The `call` relationship remains directed caller to callee.
+
+`CrossLibraryCalleeNeighborhood` is the bounded L1 form: one member seed,
+`call` as its only selected relationship, outgoing traversal, and finite depth
+and node bounds. Depth zero and a node budget exhausted at the seed both retain
+the seed without fabricating an edge. Depth truncation, node truncation,
+external targets, and incomplete catalog correspondence remain typed limits or
+node roles rather than changing the seed role. The
+`CrossLibraryCalleeNeighborhood_*` tests gate these contracts and prove that an
+acquired callee can continue into another assembly while every retained edge
+keeps its physical call-site receipt.
 
 ### Type seed
 
@@ -247,9 +259,12 @@ metadata-reference, and opportunity adapters; no mode turns those into calls.
    construct finite single-seed Integration neighborhoods from explicit
    relationship, direction, and depth axes. Selected relationships drive
    deterministic producer demand.
-4. **Partially implemented:** bind peer-seed requests without choosing a hero
+4. **Implemented:** expose the existing Analysis-owned cross-library callee
+   traversal as a finite outgoing member-seeded `call` neighborhood with
+   explicit depth and node bounds.
+5. **Partially implemented:** bind peer-seed requests without choosing a hero
    node. Connecting-neighborhood construction remains.
-5. **Partially implemented:** declare workspace-participant and
+6. **Partially implemented:** declare workspace-participant and
    document-subject induced-set rules. Explicit-subject admission and bounds
    remain.
 

--- a/src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs
@@ -61,6 +61,14 @@ public sealed class MemberCallGraphSessionTests
                 "Void"),
             Analysis.MemberKind.Method);
 
+    static Analysis.MemberRef InspectionMember(
+        InspectionGraphNode node) =>
+        Assert.IsType<InspectionGraphMemberIdentity.CallGraph>(
+            Assert.IsType<InspectionGraphSubject.MemberSubject>(
+                node.Subject)
+                .Identity)
+            .Member;
+
     [Fact]
     public void Callees_ScopedFirstPaint_BuildsScopedIndexOnly()
     {
@@ -103,6 +111,264 @@ public sealed class MemberCallGraphSessionTests
         Assert.Equal(
             Analysis.CallTreeStatus.DepthLimited,
             Child(view.CalleeRoot!, "Run").Status);
+    }
+
+    [Fact]
+    public void CrossLibraryCalleeNeighborhood_CrossesBoundaryAndContinues()
+    {
+        using GraphContext context =
+            GraphContext.Create(CallerPath, TargetPath);
+        int root = MemberToken(
+            CallerPath,
+            "Entry",
+            "RunAcrossBoundary");
+        using var graph = new MemberCallGraphSession(
+            context.Group,
+            context.Sources[0].Assembly,
+            root);
+
+        InspectionGraphDocument document =
+            graph.CrossLibraryCalleeNeighborhood(
+                new(
+                    maxDepth: 2,
+                    maxNodes: 10));
+
+        Assert.Equal(
+            InspectionGraphTraversalDirection.Outgoing,
+            document.NeighborhoodRequest!.Direction);
+        Assert.Equal(2, document.NeighborhoodRequest.MaxDepth);
+        Assert.Same(
+            CallGraphInspectionGraphCatalog.Call,
+            Assert.Single(
+                document.NeighborhoodRequest.Relationships));
+        Assert.Equal(
+            [
+                ("RunAcrossBoundary", "Forward"),
+                ("Forward", "Leaf"),
+            ],
+            document.Edges.Select(edge =>
+                (
+                    InspectionMember(
+                        document.Nodes[edge.FromNodeId]).Name,
+                    InspectionMember(
+                        document.Nodes[edge.ToNodeId]).Name)));
+        Assert.Equal(2, document.Occurrences.Length);
+        Assert.All(
+            document.Occurrences,
+            occurrence => Assert.IsType<
+                CallGraphCallSiteEvidence>(
+                    occurrence.Evidence));
+        var depth = Assert.IsType<
+            InspectionGraphNeighborhoodDepthBoundEvidence>(
+                Assert.Single(
+                    document.Limits,
+                    limit => ReferenceEquals(
+                        limit.Descriptor,
+                        InspectionGraphNeighborhoodCatalog
+                            .DepthBound))
+                    .Evidence);
+        Assert.Equal(2, depth.MaxDepth);
+        var nodes = Assert.IsType<
+            CallGraphTraversalNodeBoundEvidence>(
+                Assert.Single(
+                    document.Limits,
+                    limit => ReferenceEquals(
+                        limit.Descriptor,
+                        CallGraphInspectionGraphCatalog
+                            .TraversalNodeBound))
+                    .Evidence);
+        Assert.Equal(10, nodes.MaxNodes);
+        Assert.Equal(
+            new MemberCallGraphBuildCounts(0, 1, 1),
+            graph.BuildCounts);
+        Assert.All(
+            context.Sources,
+            source => Assert.Equal(1, source.OpenCount));
+    }
+
+    [Fact]
+    public void CrossLibraryCalleeNeighborhood_DepthBoundStopsAfterBoundary()
+    {
+        using GraphContext context =
+            GraphContext.Create(CallerPath, TargetPath);
+        int root = MemberToken(
+            CallerPath,
+            "Entry",
+            "RunAcrossBoundary");
+        using var graph = new MemberCallGraphSession(
+            context.Group,
+            context.Sources[0].Assembly,
+            root);
+
+        InspectionGraphDocument document =
+            graph.CrossLibraryCalleeNeighborhood(
+                new(
+                    maxDepth: 1,
+                    maxNodes: 10));
+
+        InspectionGraphEdge edge = Assert.Single(document.Edges);
+        Assert.Equal(
+            "Forward",
+            InspectionMember(
+                document.Nodes[edge.ToNodeId]).Name);
+        Assert.Equal(
+            InspectionGraphNodeRole.Truncated,
+            document.Nodes[edge.ToNodeId].Role);
+        Assert.Contains(
+            document.Limits,
+            limit => ReferenceEquals(
+                limit.Descriptor,
+                CallGraphInspectionGraphCatalog
+                    .TraversalIncomplete));
+    }
+
+    [Fact]
+    public void CrossLibraryCalleeNeighborhood_ZeroDepthRetainsOnlySeed()
+    {
+        using GraphContext context =
+            GraphContext.Create(CallerPath, TargetPath);
+        int root = MemberToken(
+            CallerPath,
+            "Entry",
+            "RunAcrossBoundary");
+        using var graph = new MemberCallGraphSession(
+            context.Group,
+            context.Sources[0].Assembly,
+            root);
+
+        InspectionGraphDocument document =
+            graph.CrossLibraryCalleeNeighborhood(
+                new(
+                    maxDepth: 0,
+                    maxNodes: 10));
+
+        Assert.Single(document.Nodes);
+        Assert.Empty(document.Edges);
+        Assert.Empty(document.Occurrences);
+        Assert.Equal(
+            "RunAcrossBoundary",
+            InspectionMember(document.Nodes[0]).Name);
+        Assert.Equal(
+            0,
+            Assert.IsType<
+                InspectionGraphNeighborhoodDepthBoundEvidence>(
+                    Assert.Single(
+                        document.Limits,
+                        limit => ReferenceEquals(
+                            limit.Descriptor,
+                            InspectionGraphNeighborhoodCatalog
+                                .DepthBound))
+                    .Evidence)
+                .MaxDepth);
+    }
+
+    [Fact]
+    public void CrossLibraryCalleeNeighborhood_NodeBoundRetainsOnlySeed()
+    {
+        using GraphContext context =
+            GraphContext.Create(CallerPath, TargetPath);
+        int root = MemberToken(
+            CallerPath,
+            "Entry",
+            "RunAcrossBoundary");
+        using var graph = new MemberCallGraphSession(
+            context.Group,
+            context.Sources[0].Assembly,
+            root);
+
+        InspectionGraphDocument document =
+            graph.CrossLibraryCalleeNeighborhood(
+                new(
+                    maxDepth: 3,
+                    maxNodes: 1));
+
+        Assert.Single(document.Nodes);
+        Assert.Empty(document.Edges);
+        Assert.Empty(document.Occurrences);
+        Assert.Equal(
+            "RunAcrossBoundary",
+            InspectionMember(document.Nodes[0]).Name);
+        Assert.Equal(
+            InspectionGraphNodeRole.Unclassified,
+            document.Nodes[0].Role);
+        Assert.Contains(
+            document.Limits,
+            limit => ReferenceEquals(
+                limit.Descriptor,
+                CallGraphInspectionGraphCatalog
+                    .TraversalIncomplete));
+    }
+
+    [Fact]
+    public void CrossLibraryCalleeNeighborhood_OutsideGroupStaysExternal()
+    {
+        using GraphContext context =
+            GraphContext.Create(CallerPath);
+        int root = MemberToken(CallerPath, "Entry", "Run");
+        using var graph = new MemberCallGraphSession(
+            context.Group,
+            context.Sources[0].Assembly,
+            root);
+
+        InspectionGraphDocument document =
+            graph.CrossLibraryCalleeNeighborhood(
+                new(
+                    maxDepth: 3,
+                    maxNodes: 10));
+
+        InspectionGraphEdge edge = Assert.Single(document.Edges);
+        InspectionGraphNode target =
+            document.Nodes[edge.ToNodeId];
+        Assert.Equal("Ping", InspectionMember(target).Name);
+        Assert.Equal(
+            InspectionGraphNodeRole.External,
+            target.Role);
+        Assert.Single(document.Occurrences);
+    }
+
+    [Fact]
+    public void CrossLibraryCalleeNeighborhood_DisclosesCorrespondenceLimits()
+    {
+        using GraphContext context =
+            GraphContext.Create(TargetV2Path, CallerPath);
+        int root = MemberToken(
+            TargetV2Path,
+            "Api",
+            "Ping");
+        using var graph = new MemberCallGraphSession(
+            context.Group,
+            context.Sources[0].Assembly,
+            root);
+
+        InspectionGraphDocument document =
+            graph.CrossLibraryCalleeNeighborhood(
+                new(
+                    maxDepth: 1,
+                    maxNodes: 10));
+
+        var evidence = Assert.IsType<
+            CallGraphCorrespondenceIncompleteEvidence>(
+                Assert.Single(
+                    document.Limits,
+                    limit => ReferenceEquals(
+                        limit.Descriptor,
+                        CallGraphInspectionGraphCatalog
+                            .CorrespondenceIncomplete))
+                    .Evidence);
+        Assert.True(evidence.IncompleteEdgeCount > 0);
+    }
+
+    [Fact]
+    public void CalleeNeighborhoodRequest_RequiresFiniteValidBounds()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new MemberCallGraphCalleeNeighborhoodRequest(
+                maxDepth: -1,
+                maxNodes: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new MemberCallGraphCalleeNeighborhoodRequest(
+                maxDepth: 1,
+                maxNodes: 0));
     }
 
     [Fact]

--- a/src/DotnetInspector.Queries/CallGraphInspectionGraphAdapter.cs
+++ b/src/DotnetInspector.Queries/CallGraphInspectionGraphAdapter.cs
@@ -141,6 +141,29 @@ public static class CallGraphInspectionGraphCatalog
     public static InspectionGraphLimitDescriptor TraversalIncomplete { get; } =
         new("call.traversal-incomplete", InspectionGraphOwner.CallGraph);
 
+    public static InspectionGraphEvidenceDescriptor
+        TraversalNodeBoundEvidence { get; } =
+        new("call.traversal-node-bound", InspectionGraphOwner.CallGraph);
+
+    public static InspectionGraphLimitDescriptor TraversalNodeBound { get; } =
+        new(
+            "call.traversal-node-bound",
+            InspectionGraphOwner.CallGraph,
+            [TraversalNodeBoundEvidence]);
+
+    public static InspectionGraphEvidenceDescriptor
+        CorrespondenceIncompleteEvidence { get; } =
+        new(
+            "call.correspondence-incomplete",
+            InspectionGraphOwner.CallGraph);
+
+    public static InspectionGraphLimitDescriptor
+        CorrespondenceIncomplete { get; } =
+        new(
+            "call.correspondence-incomplete",
+            InspectionGraphOwner.CallGraph,
+            [CorrespondenceIncompleteEvidence]);
+
     public static InspectionGraphLimitDescriptor
         PhysicalOccurrencesUnavailable { get; } =
         new(
@@ -198,6 +221,56 @@ public sealed record CallGraphCallSiteEvidence(
         CallGraphInspectionGraphCatalog.CallSiteEvidence;
 }
 
+/// <summary>The maximum topology nodes admitted by one call traversal.</summary>
+public sealed record CallGraphTraversalNodeBoundEvidence
+    : IInspectionGraphDiagnosticEvidence
+{
+    public CallGraphTraversalNodeBoundEvidence(int maxNodes)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxNodes, 1);
+        MaxNodes = maxNodes;
+    }
+
+    public int MaxNodes { get; }
+
+    public InspectionGraphEvidenceDescriptor Descriptor =>
+        CallGraphInspectionGraphCatalog.TraversalNodeBoundEvidence;
+}
+
+/// <summary>Counts of call correspondence that could not be completed.</summary>
+public sealed record CallGraphCorrespondenceIncompleteEvidence
+    : IInspectionGraphDiagnosticEvidence
+{
+    public CallGraphCorrespondenceIncompleteEvidence(
+        int incompleteNodeCount,
+        int incompleteEdgeCount,
+        int bindingIdentityConflictCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(incompleteNodeCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(incompleteEdgeCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(
+            bindingIdentityConflictCount);
+        if (incompleteNodeCount == 0
+            && incompleteEdgeCount == 0
+            && bindingIdentityConflictCount == 0)
+        {
+            throw new ArgumentException(
+                "Incomplete correspondence evidence requires a nonzero count.");
+        }
+
+        IncompleteNodeCount = incompleteNodeCount;
+        IncompleteEdgeCount = incompleteEdgeCount;
+        BindingIdentityConflictCount = bindingIdentityConflictCount;
+    }
+
+    public int IncompleteNodeCount { get; }
+    public int IncompleteEdgeCount { get; }
+    public int BindingIdentityConflictCount { get; }
+
+    public InspectionGraphEvidenceDescriptor Descriptor =>
+        CallGraphInspectionGraphCatalog.CorrespondenceIncompleteEvidence;
+}
+
 /// <summary>
 /// Adapts the current member call projection without changing its acquisition
 /// or presentation behavior.
@@ -208,7 +281,72 @@ public static class CallGraphInspectionGraphAdapter
         CallGraphProjection projection)
     {
         ArgumentNullException.ThrowIfNull(projection);
+        InspectionGraphSubject seed = FocusSubject(projection);
+        return Create(
+            projection,
+            InspectionGraphModeRequest.SingleSeed(seed),
+            []);
+    }
 
+    internal static InspectionGraphDocument CreateOutgoingNeighborhood(
+        CallGraphProjection projection,
+        int maxDepth,
+        int maxNodes,
+        CatalogCallGraphDiagnostics diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(projection);
+        ArgumentNullException.ThrowIfNull(diagnostics);
+        ArgumentOutOfRangeException.ThrowIfNegative(maxDepth);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxNodes, 1);
+
+        InspectionGraphSubject seed = FocusSubject(projection);
+        InspectionGraphNeighborhoodRequest request =
+            InspectionGraphNeighborhoodRequest.SingleSeed(
+                seed,
+                [CallGraphInspectionGraphCatalog.Call],
+                InspectionGraphTraversalDirection.Outgoing,
+                maxDepth);
+        var limits = new List<InspectionGraphLimit>
+        {
+            new(
+                CallGraphInspectionGraphCatalog.TraversalNodeBound,
+                InspectionGraphTarget.Node(projection.Focus.Id),
+                new CallGraphTraversalNodeBoundEvidence(maxNodes)),
+        };
+        if (diagnostics.IsIncomplete)
+        {
+            limits.Add(
+                new InspectionGraphLimit(
+                    CallGraphInspectionGraphCatalog
+                        .CorrespondenceIncomplete,
+                    InspectionGraphTarget.Node(
+                        projection.Focus.Id),
+                    new CallGraphCorrespondenceIncompleteEvidence(
+                        diagnostics.IncompleteNodeCount,
+                        diagnostics.IncompleteEdgeCount,
+                        diagnostics.BindingIdentityConflictCount)));
+        }
+
+        InspectionGraphDocument source = Create(
+            projection,
+            request.ModeRequest,
+            limits);
+        return InspectionGraphNeighborhoodProjection.Project(
+            source,
+            request);
+    }
+
+    static InspectionGraphSubject FocusSubject(
+        CallGraphProjection projection) =>
+        InspectionGraphSubject.ForMember(
+            projection.Focus.Identity,
+            projection.Focus.Member);
+
+    static InspectionGraphDocument Create(
+        CallGraphProjection projection,
+        InspectionGraphModeRequest modeRequest,
+        IEnumerable<InspectionGraphLimit> additionalLimits)
+    {
         InspectionGraphNode[] nodes =
         [
             .. projection.Nodes.Select(node =>
@@ -330,6 +468,7 @@ public static class CallGraphInspectionGraphAdapter
                             .AnalysisIncomplete),
                 ]
                 : [];
+        limits.AddRange(additionalLimits);
 
         return new InspectionGraphDocument(
             projection.Nodes.All(static node =>
@@ -338,8 +477,7 @@ public static class CallGraphInspectionGraphAdapter
                 callSite.Identity.IsPortable)
                 ? InspectionGraphDocumentScope.Portable
                 : InspectionGraphDocumentScope.SessionBound,
-            InspectionGraphModeRequest.SingleSeed(
-                nodes[projection.Focus.Id].Subject),
+            modeRequest,
             nodes,
             [],
             edges,

--- a/src/DotnetInspector.Queries/MemberCallGraphSession.cs
+++ b/src/DotnetInspector.Queries/MemberCallGraphSession.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 
 using Analysis = ILInspector.Analysis;
+using ILInspector.CallGraph;
 using ILInspector.Metadata;
 using DotnetInspector.Services;
 
@@ -128,6 +129,25 @@ public sealed record MemberCallGraphOptions
 }
 
 /// <summary>
+/// Bounds one outgoing call neighborhood over the session's workspace group.
+/// </summary>
+public sealed record MemberCallGraphCalleeNeighborhoodRequest
+{
+    public MemberCallGraphCalleeNeighborhoodRequest(
+        int maxDepth,
+        int maxNodes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(maxDepth);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxNodes, 1);
+        MaxDepth = maxDepth;
+        MaxNodes = maxNodes;
+    }
+
+    public int MaxDepth { get; }
+    public int MaxNodes { get; }
+}
+
+/// <summary>
 /// Acquires and retains the minimum cumulative Analysis state required for
 /// progressively richer member call graphs.
 /// </summary>
@@ -212,6 +232,18 @@ public sealed class MemberCallGraphSession : IDisposable
     /// </summary>
     public MemberCallGraphView CrossLibrary() =>
         Execute(CrossLibraryCore);
+
+    /// <summary>
+    /// Projects one bounded outgoing call neighborhood through every acquired
+    /// participant in this session's assembly context group.
+    /// </summary>
+    public InspectionGraphDocument CrossLibraryCalleeNeighborhood(
+        MemberCallGraphCalleeNeighborhoodRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        return Execute(() =>
+            CrossLibraryCalleeNeighborhoodCore(request));
+    }
 
     /// <summary>Lazily yields each cumulative graph tier in order.</summary>
     public IEnumerable<MemberCallGraphView> Tiers()
@@ -332,6 +364,26 @@ public sealed class MemberCallGraphSession : IDisposable
                 _options.Depth,
                 _options.MaxNodes),
             _catalogScope!.Diagnostics);
+    }
+
+    InspectionGraphDocument CrossLibraryCalleeNeighborhoodCore(
+        MemberCallGraphCalleeNeighborhoodRequest request)
+    {
+        IndexBuildResult.Available root = Require(GetFullRoot());
+        EnsureCrossLibraryScope();
+        ThrowIfCrossLibraryFailed();
+        Analysis.CallTreeNode calleeRoot =
+            root.Index.BuildCallTree(
+                _memberToken,
+                _catalogScope!,
+                request.MaxDepth,
+                request.MaxNodes);
+        return CallGraphInspectionGraphAdapter
+            .CreateOutgoingNeighborhood(
+                CallGraphProjection.FromCallees(calleeRoot),
+                request.MaxDepth,
+                request.MaxNodes,
+                _catalogScope!.Diagnostics);
     }
 
     MemberCallGraphView View(


### PR DESCRIPTION
# Summary

Exposes the existing transitive cross-library callee traversal as a bounded,
call-only L1 inspection-graph neighborhood.

- adds explicit maximum depth and node budgets;
- retains outgoing caller-to-callee semantics and physical call-site receipts;
- keeps targets outside the assembly context group as external placeholders;
- discloses traversal and catalog-correspondence incompleteness as typed limits;
- reuses `CatalogCallGraphScope`, `CallGraphProjection`, and the shared
  neighborhood projector rather than adding another resolver or traversal.

The issue's original Analysis gap has since been filled by the catalog call
graph. This PR supplies the missing host-neutral bounded query surface over
that capability.

## Demo

Given:

```text
Caller.Entry.RunAcrossBoundary()
    -> Target.Api.Forward()
        -> Target.Api.Leaf()
```

where `Caller` and `Target` are separate assemblies in one
`AssemblyContextGroup`:

```csharp
using var session = new MemberCallGraphSession(
    group,
    callerAssembly,
    runAcrossBoundaryToken);

InspectionGraphDocument graph =
    session.CrossLibraryCalleeNeighborhood(
        new(maxDepth: 2, maxNodes: 10));
```

The document contains both cross-assembly hops:

```mermaid
flowchart LR
    RunAcrossBoundary --> Forward
    Forward --> Leaf
```

Each edge retains its `CallGraphCallSiteEvidence`. Reducing `maxDepth` to `1`
retains only the first hop and reports traversal incompleteness; setting it to
`0` retains only the seed. A one-node budget also retains only the seed while
recording the call-specific node bound.

## Architecture

Analysis continues to own resolution, traversal, cycle handling, and budgets.
CallGraph owns deterministic logical projection. Queries owns workspace
lifetime and lowers the request into a generic
`InspectionGraphNeighborhoodRequest`, which performs dense evidence-preserving
projection.

This PR does not add a CLI command or browser presentation. Those hosts can
consume the host-neutral `InspectionGraphDocument` without implementing
traversal.

## Validation

- `DotnetInspector.Queries.Tests`: 68 focused tests passed
- changed design documents pass `markdownlint`

Closes #3632
