### PR TITLE
Use Gallery source for Browser packages

### DIFF
--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -631,8 +631,18 @@ no listing concept. Gallery search reports `listed`, because unlisted
 coordinates do not appear in that search surface. `PackageVersionResult`
 exposes whether all listing states are authoritative, so raw Gallery and v3
 results cannot be admitted into a listing-aware cache. Registration joining
-remains follow-up work. No existing package-resolution consumer has moved to
-this client yet.
+remains follow-up work.
+
+The Browser workspace now uses this client as its built-in NuGet.org
+transport. Exact coordinates bypass discovery and request the Gallery package
+CDN directly. Omitted root versions use an exact-ID Gallery search and select
+its listed stable result. Raw flat-container enumeration remains available to
+the Browser version picker, while wildcard and range dependency selection
+fails closed when listing authority is absent. The typed payload's advertised
+length flows through the shared `PackagePayloadAcquisition` admission and
+store pipeline, so Browser cache reservation, archive limits, producer
+authorization, and publication are not reimplemented in the host. Desktop
+package-resolution consumers remain on the compatibility path.
 
 The v3 compatibility adapter initially exposes version and package-payload
 operations only, and validates package coordinates before any service-index or

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -34,12 +34,17 @@ shortening the selected assembly set.
 
 ## How a workspace is opened
 
-1. **Resolve an exact identity.** `PackageCoordinateResolver` validates the
-   package id and resolves an omitted version through the authorized nuget.org
-   source without a filesystem cache. The Browser adapter then selects one
-   target framework — never "whatever the package happens to ship".
+1. **Resolve an exact identity.** `PackageSourceCoordinateResolver` validates
+   the package id. An exact pin bypasses discovery; an omitted version uses the
+   NuGet Gallery search endpoint and accepts only the exact package ID's listed
+   stable result. Neither path requests the NuGet.org v3 service index. The
+   Browser adapter then selects one target framework — never "whatever the
+   package happens to ship".
 2. **Mint typed participants.** `PackagePayloadAcquisition` downloads and
-   admits the package through the shared source, transport, and archive policy.
+   admits the package from the Gallery package CDN through the shared typed
+   source, transport, and archive policy. The Gallery payload carries its
+   advertised length into the Browser reservation policy before body
+   materialization.
    `PackageCompileAssetSelector` adds reference-group semantics around the
    implementation universe selected by `PackageAssetSelector`, decodes each
    healthy entry's real metadata identity, and creates one
@@ -52,6 +57,11 @@ shortening the selected assembly set.
    shared resolver, retry, response-body, archive-validation, and store paths;
    expiry is surfaced as a visible timeout instead of leaving the page behind
    an unbounded loading indicator.
+   Gallery version enumeration currently exposes raw flat-container versions
+   with unknown listing state. The version picker may display that partial
+   enumeration, but dependency wildcard and range selection fails closed until
+   registration-backed listing state is implemented; exact dependency pins
+   remain available.
 3. **Hand the group to a query.** The participants open one `InspectionWorkspace`
    and one binding-consistent `AssemblyContextGroup`. `BrowserInspectionScope`
    exposes exactly two hand-offs — `Use(group => query(group))` and

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -12,6 +12,7 @@ using DotnetInspector.Queries;
 using ILInspector.Analysis;
 using ILInspector.CallGraph;
 using ILInspector.Metadata;
+using NuGetFetch;
 
 namespace InspectWeb.Engine.Tests;
 
@@ -988,17 +989,14 @@ public sealed class BrowserEngineBoundaryTests
     public async Task PackageAcquisition_StallBecomesVisibleOperationTimeout()
     {
         var handler = new StallingPackageHandler();
-        using var client = new HttpClient(handler)
-        {
-            Timeout = Timeout.InfiniteTimeSpan,
-        };
+        using IPackageSourceClient source = Gallery(handler);
         string packageId =
             $"timeout.package.{Guid.NewGuid():N}";
 
         Task<BrowserPackage> acquisition = BrowserPackageWorkspace.AcquireAsync(
             packageId,
             "1.0.0",
-            client,
+            source,
             TimeSpan.FromMilliseconds(200));
         await handler.RequestStarted.Task.WaitAsync(
             TimeSpan.FromSeconds(1),
@@ -1015,20 +1013,118 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public async Task PackageAcquisition_ExactPinUsesGalleryCdnWithoutServiceIndex()
+    {
+        string packageId = $"gallery.exact.{Guid.NewGuid():N}";
+        const string version = "1.2.3";
+        byte[] archive = PackageDocuments(1);
+        var handler = new GalleryPackageHandler(
+            packageId,
+            version,
+            archive);
+        using IPackageSourceClient source = Gallery(handler);
+
+        BrowserPackage package = await BrowserPackageWorkspace.AcquireAsync(
+            packageId,
+            version,
+            source,
+            TimeSpan.FromSeconds(5));
+
+        Assert.Equal(version, package.Version);
+        Assert.Equal(archive, package.RetainedBytes);
+        Assert.False(package.Content.FromCache);
+        Assert.Equal(
+            NuGetCache.GetSourceKey(PackageSourceIdentity.NuGetOrg.Value),
+            package.Content.ProducerKey);
+        Assert.Equal(
+            [$"https://globalcdn.nuget.org/packages/{packageId}.{version}.nupkg"],
+            handler.Requested);
+        Assert.DoesNotContain(
+            handler.Requested,
+            request => request.Contains(
+                "api.nuget.org",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task PackageAcquisition_GalleryFailureRemainsVisible()
+    {
+        string packageId = $"gallery.failure.{Guid.NewGuid():N}";
+        var handler = new GalleryPackageHandler(
+            packageId,
+            "1.0.0",
+            PackageDocuments(1),
+            packageStatus: System.Net.HttpStatusCode.BadGateway);
+        using IPackageSourceClient source = Gallery(handler);
+
+        InvalidOperationException failure =
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => BrowserPackageWorkspace.AcquireAsync(
+                    packageId,
+                    "1.0.0",
+                    source,
+                    TimeSpan.FromSeconds(5)));
+
+        Assert.Contains(
+            "transport failed",
+            failure.Message,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            "globalcdn.nuget.org",
+            failure.Message,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PackageAcquisition_FloatingRootUsesGallerySearchAndCdn()
+    {
+        string packageId = $"gallery.floating.{Guid.NewGuid():N}";
+        const string version = "4.5.6";
+        var handler = new GalleryPackageHandler(
+            packageId,
+            version,
+            PackageDocuments(1),
+            provideSearchResult: true);
+        using IPackageSourceClient source = Gallery(handler);
+
+        BrowserPackage package = await BrowserPackageWorkspace.AcquireAsync(
+            packageId,
+            version: null,
+            source,
+            TimeSpan.FromSeconds(5));
+
+        Assert.Equal(version, package.Version);
+        Assert.Equal(2, handler.Requested.Count);
+        Assert.StartsWith(
+            "https://azuresearch-usnc.nuget.org/query?",
+            handler.Requested[0],
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"q=packageid%3A{packageId}",
+            handler.Requested[0],
+            StringComparison.Ordinal);
+        Assert.Equal(
+            $"https://globalcdn.nuget.org/packages/{packageId}.{version}.nupkg",
+            handler.Requested[1]);
+        Assert.DoesNotContain(
+            handler.Requested,
+            request => request.Contains(
+                "api.nuget.org",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task PackageResolution_StallBecomesVisibleOperationTimeout()
     {
         var handler = new StallingPackageHandler();
-        using var client = new HttpClient(handler)
-        {
-            Timeout = Timeout.InfiniteTimeSpan,
-        };
+        using IPackageSourceClient source = Gallery(handler);
         string packageId =
             $"resolution.timeout.package.{Guid.NewGuid():N}";
 
         Task<BrowserPackage> acquisition = BrowserPackageWorkspace.AcquireAsync(
             packageId,
             version: null,
-            client,
+            source,
             TimeSpan.FromSeconds(5));
         await handler.RequestStarted.Task.WaitAsync(
             TimeSpan.FromSeconds(10),
@@ -1048,17 +1144,14 @@ public sealed class BrowserEngineBoundaryTests
     public async Task PackageAcquisition_SharedStallIsAVisibleTimeoutForEveryCaller()
     {
         var handler = new StallingPackageHandler();
-        using var client = new HttpClient(handler)
-        {
-            Timeout = Timeout.InfiniteTimeSpan,
-        };
+        using IPackageSourceClient source = Gallery(handler);
         string packageId =
             $"shared.timeout.package.{Guid.NewGuid():N}";
 
         Task<BrowserPackage> first = BrowserPackageWorkspace.AcquireAsync(
             packageId,
             "1.0.0",
-            client,
+            source,
             TimeSpan.FromMilliseconds(500));
         await handler.RequestStarted.Task.WaitAsync(
             TimeSpan.FromSeconds(1),
@@ -1066,7 +1159,7 @@ public sealed class BrowserEngineBoundaryTests
         Task<BrowserPackage> second = BrowserPackageWorkspace.AcquireAsync(
             packageId,
             "1.0.0",
-            client,
+            source,
             TimeSpan.FromMilliseconds(100));
 
         TimeoutException secondFailure =
@@ -1504,6 +1597,15 @@ public sealed class BrowserEngineBoundaryTests
         return content.ToArray();
     }
 
+    static IPackageSourceClient Gallery(HttpMessageHandler handler) =>
+        PackageSourceClientFactory.CreateGallery(
+            handler,
+            new NuGetFetchOptions
+            {
+                RequestTimeout = TimeSpan.FromMinutes(1),
+                OperationTimeout = TimeSpan.FromMinutes(1),
+            });
+
     sealed class StallingPackageHandler : HttpMessageHandler
     {
         public int Requests { get; private set; }
@@ -1521,6 +1623,53 @@ public sealed class BrowserEngineBoundaryTests
                 cancellationToken);
             throw new InvalidOperationException(
                 "The stalling handler completed without cancellation.");
+        }
+    }
+
+    sealed class GalleryPackageHandler(
+        string packageId,
+        string version,
+        byte[] archive,
+        bool provideSearchResult = false,
+        System.Net.HttpStatusCode packageStatus =
+            System.Net.HttpStatusCode.OK)
+        : HttpMessageHandler
+    {
+        readonly string _packageUrl =
+            $"https://globalcdn.nuget.org/packages/{packageId.ToLowerInvariant()}.{version}.nupkg";
+
+        public List<string> Requested { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            string url = request.RequestUri!.AbsoluteUri;
+            Requested.Add(url);
+            if (provideSearchResult
+                && url.StartsWith(
+                    "https://azuresearch-usnc.nuget.org/query?",
+                    StringComparison.Ordinal))
+            {
+                return Task.FromResult(
+                    new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(
+                            $$"""{"data":[{"id":"{{packageId}}","version":"{{version}}"}]}"""),
+                    });
+            }
+
+            return Task.FromResult(
+                url.Equals(_packageUrl, StringComparison.Ordinal)
+                    ? new HttpResponseMessage(packageStatus)
+                    {
+                        Content = packageStatus == System.Net.HttpStatusCode.OK
+                            ? new ByteArrayContent(archive)
+                            : null,
+                    }
+                    : new HttpResponseMessage(
+                        System.Net.HttpStatusCode.NotFound));
         }
     }
 

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1076,6 +1076,32 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public async Task PackageAcquisition_RejectedReservationDisposesGalleryPayload()
+    {
+        string packageId = $"gallery.no-length.{Guid.NewGuid():N}";
+        var handler = new GalleryPackageHandler(
+            packageId,
+            "1.0.0",
+            PackageDocuments(1),
+            omitContentLength: true);
+        using IPackageSourceClient source = Gallery(handler);
+
+        InvalidOperationException failure =
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => BrowserPackageWorkspace.AcquireAsync(
+                    packageId,
+                    "1.0.0",
+                    source,
+                    TimeSpan.FromSeconds(5)));
+
+        Assert.Contains(
+            "did not declare its byte length",
+            failure.Message,
+            StringComparison.Ordinal);
+        Assert.True(handler.PayloadDisposed);
+    }
+
+    [Fact]
     public async Task PackageAcquisition_FloatingRootUsesGallerySearchAndCdn()
     {
         string packageId = $"gallery.floating.{Guid.NewGuid():N}";
@@ -1632,13 +1658,15 @@ public sealed class BrowserEngineBoundaryTests
         byte[] archive,
         bool provideSearchResult = false,
         System.Net.HttpStatusCode packageStatus =
-            System.Net.HttpStatusCode.OK)
+            System.Net.HttpStatusCode.OK,
+        bool omitContentLength = false)
         : HttpMessageHandler
     {
         readonly string _packageUrl =
             $"https://globalcdn.nuget.org/packages/{packageId.ToLowerInvariant()}.{version}.nupkg";
 
         public List<string> Requested { get; } = [];
+        public bool PayloadDisposed { get; private set; }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
@@ -1660,16 +1688,44 @@ public sealed class BrowserEngineBoundaryTests
                     });
             }
 
-            return Task.FromResult(
-                url.Equals(_packageUrl, StringComparison.Ordinal)
-                    ? new HttpResponseMessage(packageStatus)
-                    {
-                        Content = packageStatus == System.Net.HttpStatusCode.OK
-                            ? new ByteArrayContent(archive)
-                            : null,
-                    }
-                    : new HttpResponseMessage(
+            if (!url.Equals(_packageUrl, StringComparison.Ordinal))
+            {
+                return Task.FromResult(
+                    new HttpResponseMessage(
                         System.Net.HttpStatusCode.NotFound));
+            }
+
+            var response = new HttpResponseMessage(packageStatus);
+            if (packageStatus == System.Net.HttpStatusCode.OK)
+            {
+                response.Content = omitContentLength
+                    ? new StreamContent(
+                        new TrackingPayloadStream(
+                            archive,
+                            () => PayloadDisposed = true))
+                    : new ByteArrayContent(archive);
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+
+    sealed class TrackingPayloadStream(byte[] bytes, Action onDispose)
+        : MemoryStream(bytes, writable: false)
+    {
+        public override bool CanSeek => false;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                onDispose();
+            base.Dispose(disposing);
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            onDispose();
+            return base.DisposeAsync();
         }
     }
 

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -47,6 +47,12 @@ namespace InspectWeb.Engine;
 /// gates the final monotonic check before cache publication, and
 /// <c>BrowserEngineBoundaryTests.PackageOperation_LateFailureBecomesVisibleTimeout</c>
 /// gates timeout classification after synchronous work overruns the deadline.
+/// <c>BrowserEngineBoundaryTests.PackageAcquisition_ExactPinUsesGalleryCdnWithoutServiceIndex</c>
+/// and
+/// <c>BrowserEngineBoundaryTests.PackageAcquisition_FloatingRootUsesGallerySearchAndCdn</c>
+/// gate the service-index-free Gallery routes, while
+/// <c>BrowserEngineBoundaryTests.PackageAcquisition_RejectedReservationDisposesGalleryPayload</c>
+/// gates response ownership when Browser capacity policy rejects a transfer.
 /// </para>
 /// </remarks>
 [SupportedOSPlatform("browser")]

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -58,12 +58,13 @@ internal static class BrowserPackageWorkspace
     internal static TimeSpan PackageOperationTimeout { get; } =
         TimeSpan.FromSeconds(30);
 
-    static readonly HttpClient Http = new()
-    {
-        Timeout = Timeout.InfiniteTimeSpan,
-    };
-    static readonly UniformPackageSourceAuthorization SourceAuthorization =
-        new([PackageSource.NuGetOrg]);
+    static readonly IPackageSourceClient Gallery =
+        PackageSourceClientFactory.CreateGallery(
+            new NuGetFetchOptions
+            {
+                RequestTimeout = TimeSpan.FromMinutes(2),
+                OperationTimeout = TimeSpan.FromMinutes(2),
+            });
     static readonly BrowserSessionPackageStore Store = new();
     static readonly PackagePayloadLimits PayloadLimits = new()
     {
@@ -77,7 +78,7 @@ internal static class BrowserPackageWorkspace
     static readonly Dictionary<string, PackageDownloadReservation> Reservations =
         new(StringComparer.Ordinal);
     static readonly Dictionary<string, int> Leases = new(StringComparer.Ordinal);
-    static readonly Dictionary<string, Task<AcquiredPackagePayload>> PendingAcquisitions =
+    static readonly Dictionary<string, Task<AcquiredPackageSourcePayload>> PendingAcquisitions =
         new(StringComparer.Ordinal);
     static readonly HashSet<string> Downloaded = new(StringComparer.Ordinal);
     static long _clock;
@@ -108,27 +109,27 @@ internal static class BrowserPackageWorkspace
             deadline => AcquireCoreAsync(
                 packageId,
                 version,
-                Http,
+                Gallery,
                 deadline),
             PackageOperationTimeout);
 
     internal static Task<BrowserPackage> AcquireAsync(
         string packageId,
         string? version,
-        HttpClient client,
+        IPackageSourceClient source,
         TimeSpan operationTimeout) =>
         RunPackageOperationAsync(
             deadline => AcquireCoreAsync(
                 packageId,
                 version,
-                client,
+                source,
                 deadline),
             operationTimeout);
 
     static async Task<BrowserPackage> AcquireCoreAsync(
         string packageId,
         string? version,
-        HttpClient client,
+        IPackageSourceClient source,
         BrowserPackageOperationDeadline deadline)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
@@ -138,26 +139,28 @@ internal static class BrowserPackageWorkspace
             || version.Equals("latest", StringComparison.OrdinalIgnoreCase)
                 ? null
                 : version;
-        ResolvedPackageCoordinate coordinate = await ResolveCoordinateAsync(
+        PackageSourceCoordinate coordinate = await ResolveCoordinateAsync(
             new PackageCoordinate(packageId, requestedVersion),
-            client,
+            source,
             deadline.Token);
 
         string key = PackageKey(coordinate.PackageId, coordinate.Version);
+        string pendingKey =
+            $"{key}@{NuGetCache.GetSourceKey(source.Identity.Value)}";
         bool ownsPendingAcquisition = false;
         if (!PendingAcquisitions.TryGetValue(
-                key,
-                out Task<AcquiredPackagePayload>? pending))
+                pendingKey,
+                out Task<AcquiredPackageSourcePayload>? pending))
         {
             pending = AcquirePayloadWithinOperationAsync(
                 coordinate,
-                client,
+                source,
                 deadline);
-            PendingAcquisitions.Add(key, pending);
+            PendingAcquisitions.Add(pendingKey, pending);
             ownsPendingAcquisition = true;
         }
 
-        AcquiredPackagePayload payload;
+        AcquiredPackageSourcePayload payload;
         try
         {
             payload = ownsPendingAcquisition
@@ -170,11 +173,11 @@ internal static class BrowserPackageWorkspace
         {
             if (ownsPendingAcquisition
                 && PendingAcquisitions.TryGetValue(
-                    key,
-                    out Task<AcquiredPackagePayload>? active)
+                    pendingKey,
+                    out Task<AcquiredPackageSourcePayload>? active)
                 && ReferenceEquals(active, pending))
             {
-                PendingAcquisitions.Remove(key);
+                PendingAcquisitions.Remove(pendingKey);
             }
         }
 
@@ -196,36 +199,29 @@ internal static class BrowserPackageWorkspace
             cached.ProducerKey);
     }
 
-    static async Task<ResolvedPackageCoordinate> ResolveCoordinateAsync(
+    static async Task<PackageSourceCoordinate> ResolveCoordinateAsync(
         PackageCoordinate request,
-        HttpClient client,
+        IPackageSourceClient source,
         CancellationToken cancellationToken)
     {
-        if (PackageCoordinateResolver.Validate(request) is { } invalid)
-            throw new InvalidOperationException(invalid.Message);
-
-        string canonicalId = request.PackageId.ToLowerInvariant();
-        PackageSourceAuthorization authorization =
-            SourceAuthorization.AuthorizeSourcesFor(canonicalId);
-        PackageCoordinateResolution resolution =
-            await PackageCoordinateResolver.ResolveAsync(
-                client,
+        PackageSourceCoordinateResolution resolution =
+            await PackageSourceCoordinateResolver.ResolveAsync(
+                source,
                 request,
-                authorization.Sources,
-                useVersionCache: false,
-                requireStableFloating: true,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-        ResolvedPackageCoordinate coordinate = resolution switch
+                cancellationToken).ConfigureAwait(false);
+        return resolution switch
         {
-            PackageCoordinateResolution.Resolved resolved => resolved.Coordinate,
-            PackageCoordinateResolution.Invalid rejected =>
+            PackageSourceCoordinateResolution.Resolved resolved =>
+                resolved.Coordinate,
+            PackageSourceCoordinateResolution.Invalid rejected =>
                 throw new InvalidOperationException(rejected.Message),
-            PackageCoordinateResolution.Unavailable unavailable =>
+            PackageSourceCoordinateResolution.Unavailable unavailable =>
                 throw new InvalidOperationException(unavailable.Message),
+            PackageSourceCoordinateResolution.Failed failed =>
+                throw new InvalidOperationException(failed.Failure.Message),
             _ => throw new InvalidOperationException(
                 "Package coordinate resolution returned an unknown outcome."),
         };
-        return coordinate;
     }
 
     /// <summary>
@@ -365,14 +361,15 @@ internal static class BrowserPackageWorkspace
         }
     }
 
-    static async Task<AcquiredPackagePayload> AcquirePayloadAsync(
-        ResolvedPackageCoordinate coordinate,
-        HttpClient client,
+    static async Task<AcquiredPackageSourcePayload> AcquirePayloadAsync(
+        PackageSourceCoordinate coordinate,
+        IPackageSourceClient source,
         CancellationToken cancellationToken,
         IPackagePayloadTransferPolicy transferPolicy)
     {
-        PackagePayloadResult result = await PackagePayloadAcquisition.AcquireAsync(
-            client,
+        PackageSourcePayloadResult result =
+            await PackagePayloadAcquisition.AcquireAsync(
+            source,
             coordinate,
             Store,
             limits: PayloadLimits,
@@ -380,24 +377,26 @@ internal static class BrowserPackageWorkspace
             transferPolicy: transferPolicy).ConfigureAwait(false);
         return result switch
         {
-            PackagePayloadResult.Acquired acquired => acquired.Payload,
-            PackagePayloadResult.Unavailable unavailable =>
+            PackageSourcePayloadResult.Acquired acquired => acquired.Payload,
+            PackageSourcePayloadResult.Unavailable unavailable =>
                 throw new InvalidOperationException(unavailable.Message),
+            PackageSourcePayloadResult.Failed failed =>
+                throw new InvalidOperationException(failed.Failure.Message),
             _ => throw new InvalidOperationException(
                 "Package payload acquisition returned an unknown outcome."),
         };
     }
 
-    static async Task<AcquiredPackagePayload> AcquirePayloadWithinOperationAsync(
-        ResolvedPackageCoordinate coordinate,
-        HttpClient client,
+    static async Task<AcquiredPackageSourcePayload> AcquirePayloadWithinOperationAsync(
+        PackageSourceCoordinate coordinate,
+        IPackageSourceClient source,
         BrowserPackageOperationDeadline deadline)
     {
         try
         {
             return await AcquirePayloadAsync(
                 coordinate,
-                client,
+                source,
                 deadline.Token,
                 new BrowserPackageOperationTransferPolicy(
                     Store,
@@ -428,24 +427,32 @@ internal static class BrowserPackageWorkspace
             throw new InvalidOperationException(invalid.Message);
         }
 
-        PackageSourceAuthorization authorization =
-            SourceAuthorization.AuthorizeSourcesFor(packageId.ToLowerInvariant());
-        PackageVersionListingResult result =
-            await PackageCoordinateResolver.ListVersionsAsync(
-                Http,
+        PackageVersionResult result = await GetVersionResultAsync(
+            Gallery,
+            packageId,
+            cancellationToken).ConfigureAwait(false);
+        return
+        [
+            .. result.Candidates.Select(candidate =>
+                candidate.Coordinate.Version),
+        ];
+    }
+
+    static async Task<PackageVersionResult> GetVersionResultAsync(
+        IPackageSourceClient source,
+        string packageId,
+        CancellationToken cancellationToken)
+    {
+        PackageSourceOperationResult<PackageVersionResult> operation =
+            await source.GetVersionsAsync(
                 packageId,
-                authorization.Sources,
-                includePrerelease: true,
-                useVersionCache: false,
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-        return result switch
+                cancellationToken).ConfigureAwait(false);
+        return operation switch
         {
-            PackageVersionListingResult.Available available =>
-                [.. available.Versions],
-            PackageVersionListingResult.Invalid rejected =>
-                throw new InvalidOperationException(rejected.Message),
-            PackageVersionListingResult.Unavailable unavailable =>
-                throw new InvalidOperationException(unavailable.Message),
+            PackageSourceOperationResult<PackageVersionResult>.Succeeded succeeded =>
+                succeeded.Value,
+            PackageSourceOperationResult<PackageVersionResult>.Failed failed =>
+                throw new InvalidOperationException(failed.Failure.Message),
             _ => throw new InvalidOperationException(
                 "Package version listing returned an unknown outcome."),
         };
@@ -469,18 +476,33 @@ internal static class BrowserPackageWorkspace
         if (PackageDependencyVersionRange.GetExactVersion(declaredRange)
             is { } exactVersion)
         {
-            ResolvedPackageCoordinate coordinate =
+            PackageSourceCoordinate coordinate =
                 await ResolveCoordinateAsync(
                     new PackageCoordinate(packageId, exactVersion),
-                    Http,
+                    Gallery,
                     cancellationToken).ConfigureAwait(false);
             return coordinate.Version;
         }
 
-        string[] versions = await GetVersionsCoreAsync(
+        PackageVersionResult result = await GetVersionResultAsync(
+            Gallery,
             packageId,
             cancellationToken).ConfigureAwait(false);
-        return SelectDependencyVersion(versions, declaredRange)
+        if (!result.HasAuthoritativeListingState)
+        {
+            throw new InvalidOperationException(
+                $"Package '{packageId}' cannot safely resolve the declared range "
+                + $"'{declaredRange}' because authoritative Gallery listing state is unavailable.");
+        }
+
+        return SelectDependencyVersion(
+                [
+                    .. result.Candidates
+                        .Where(candidate =>
+                            candidate.ListingState == PackageListingState.Listed)
+                        .Select(candidate => candidate.Coordinate.Version),
+                ],
+                declaredRange)
             ?? throw new InvalidOperationException(
                 $"Package '{packageId}' has no published version satisfying "
                 + $"the declared range '{declaredRange}'.");

--- a/src/DotnetInspector.Packages/PackagePayloadAcquisition.cs
+++ b/src/DotnetInspector.Packages/PackagePayloadAcquisition.cs
@@ -55,6 +55,32 @@ public abstract record PackagePayloadResult
 }
 
 /// <summary>
+/// One payload acquired through a typed source client.
+/// </summary>
+public sealed record AcquiredPackageSourcePayload(
+    PackageSourceCoordinate Coordinate,
+    IPackageContent Content,
+    string ProducerKey,
+    PackagePayloadOrigin Origin);
+
+/// <summary>The result of acquiring one exact typed-source package payload.</summary>
+public abstract record PackageSourcePayloadResult
+{
+    private protected PackageSourcePayloadResult()
+    {
+    }
+
+    public sealed record Acquired(AcquiredPackageSourcePayload Payload)
+        : PackageSourcePayloadResult;
+
+    public sealed record Unavailable(string Message)
+        : PackageSourcePayloadResult;
+
+    public sealed record Failed(PackageSourceFailure Failure)
+        : PackageSourcePayloadResult;
+}
+
+/// <summary>
 /// Acquires the payload for one already-resolved package coordinate through the
 /// caller's <see cref="IPackageStore"/>, without requiring a filesystem.
 /// </summary>
@@ -122,6 +148,109 @@ public abstract record PackagePayloadResult
 public static class PackagePayloadAcquisition
 {
     /// <summary>
+    /// Returns an exact payload through a typed source client while preserving
+    /// the same cache authorization, archive admission, and publication policy
+    /// as the legacy source path.
+    /// </summary>
+    public static async Task<PackageSourcePayloadResult> AcquireAsync(
+        IPackageSourceClient source,
+        PackageSourceCoordinate coordinate,
+        IPackageStore store,
+        Action<string>? log = null,
+        PackagePayloadLimits? limits = null,
+        CancellationToken cancellationToken = default,
+        IPackagePayloadTransferPolicy? transferPolicy = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(coordinate);
+        ArgumentNullException.ThrowIfNull(store);
+        limits = ValidateLimits(limits);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        string producerKey = NuGetCache.GetSourceKey(source.Identity.Value);
+        foreach (IPackageContent cached in store.EnumerateCached(
+                     coordinate.PackageId,
+                     coordinate.Version,
+                     [producerKey],
+                     log))
+        {
+            PackageContentAdmission.Outcome admission =
+                await PackageContentAdmission.EvaluateAsync(
+                    cached,
+                    limits,
+                    cancellationToken).ConfigureAwait(false);
+            if (admission != PackageContentAdmission.Outcome.Admissible)
+            {
+                log?.Invoke(
+                    $"Cached content for package '{coordinate.PackageId}' version "
+                    + $"'{coordinate.Version}' from the selected producer does "
+                    + "not satisfy the current payload limits.");
+                continue;
+            }
+
+            return Result(cached, PackagePayloadOrigin.Cache);
+        }
+
+        PackageSourceOperationResult<PackageSourcePayload> operation =
+            await source.GetPackageAsync(
+                coordinate.PackageId,
+                coordinate.Version,
+                cancellationToken).ConfigureAwait(false);
+        if (operation
+            is PackageSourceOperationResult<PackageSourcePayload>.Failed failed)
+        {
+            return failed.Failure.Kind == PackageSourceFailureKind.NotFound
+                ? new PackageSourcePayloadResult.Unavailable(
+                    $"Package '{coordinate.PackageId}' version "
+                    + $"'{coordinate.Version}' was not supplied by the selected source.")
+                : new PackageSourcePayloadResult.Failed(failed.Failure);
+        }
+
+        PackageSourcePayload payload =
+            ((PackageSourceOperationResult<PackageSourcePayload>.Succeeded)operation)
+            .Value;
+        if (payload.Kind != PackageSourcePayloadKind.Package
+            || payload.Coordinate != coordinate
+            || payload.Producer != source.Identity)
+        {
+            await payload.Content.DisposeAsync().ConfigureAwait(false);
+            return new PackageSourcePayloadResult.Unavailable(
+                "The package source returned a payload that did not match the requested coordinate.");
+        }
+
+        IPackageContent? content = await TryAdmitAsync(
+            payload.Content,
+            payload.AdvertisedLength,
+            coordinate,
+            producerKey,
+            $"source '{source.Kind}'",
+            store,
+            log,
+            limits,
+            transferPolicy,
+            cancellationToken).ConfigureAwait(false);
+        return content is null
+            ? new PackageSourcePayloadResult.Unavailable(
+                $"Package '{coordinate.PackageId}' version "
+                + $"'{coordinate.Version}' did not satisfy the payload policy.")
+            : Result(content, PackagePayloadOrigin.Download);
+
+        PackageSourcePayloadResult Result(
+            IPackageContent content,
+            PackagePayloadOrigin origin) =>
+            content.ProducerKey.Equals(producerKey, StringComparison.Ordinal)
+                ? new PackageSourcePayloadResult.Acquired(
+                    new AcquiredPackageSourcePayload(
+                        coordinate,
+                        content,
+                        producerKey,
+                        origin))
+                : new PackageSourcePayloadResult.Unavailable(
+                    $"Content for package '{coordinate.PackageId}' version "
+                    + $"'{coordinate.Version}' belongs to an unauthorized producer.");
+    }
+
+    /// <summary>
     /// Returns the payload for <paramref name="coordinate"/>, preferring a
     /// cached entry committed by one of its authorized producers and otherwise
     /// downloading from those sources in order.
@@ -138,13 +267,7 @@ public static class PackagePayloadAcquisition
         ArgumentNullException.ThrowIfNull(client);
         ArgumentNullException.ThrowIfNull(coordinate);
         ArgumentNullException.ThrowIfNull(store);
-        limits ??= PackagePayloadLimits.Default;
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
-            limits.MaxArchiveBytes);
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
-            limits.MaxExpandedBytes);
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
-            limits.MaxEntryCount);
+        limits = ValidateLimits(limits);
         cancellationToken.ThrowIfCancellationRequested();
 
         if (coordinate.Sources.Count == 0)
@@ -286,14 +409,6 @@ public static class PackagePayloadAcquisition
             return null;
         }
 
-        string producerKey = NuGetCache.GetSourceKey(source.Url);
-        using IPackagePayloadReservation? reservation = transferPolicy?.Reserve(
-            new PackagePayloadTransfer(
-                coordinate,
-                producerKey,
-                advertisedLength));
-
-        byte[] archive;
         try
         {
             // ResponseHeadersRead leaves the body outside HttpClient.Timeout.
@@ -311,78 +426,19 @@ public static class PackagePayloadAcquisition
             Stream payload = await response.Content
                 .ReadAsStreamAsync(bodyTimeout.Token)
                 .ConfigureAwait(false);
-            await using (payload.ConfigureAwait(false))
-            {
-                // A declared length is read into exactly that many bytes, once:
-                // the advertised number is what the host reserved against above,
-                // and the generic bounded reader — which must serve sources that
-                // advertise nothing or under-report — would grow into it while
-                // still holding the previous array. A body that falls short of
-                // its own declaration is a truncated transfer, and one that
-                // overruns it contradicts its header; both fail this source
-                // rather than being accepted at the declared prefix.
-                byte[]? received = advertisedLength is { } declared
-                    && declared >= 0
-                    && declared <= int.MaxValue
-                    ? await PackageContentAdmission.ReadExactAsync(
-                            payload,
-                            (int)declared,
-                            bodyTimeout.Token)
-                        .ConfigureAwait(false)
-                    : await PackageContentAdmission.ReadBoundedAsync(
-                            payload,
-                            limits.MaxArchiveBytes,
-                            bodyTimeout.Token)
-                        .ConfigureAwait(false);
-                if (received is null)
-                {
-                    log?.Invoke(
-                        advertisedLength is null
-                            ? $"Source {PackageSourceDisplay.ForDiagnostics(source)} sent a package payload above the configured archive limit."
-                            : $"Source {PackageSourceDisplay.ForDiagnostics(source)} did not send the package payload length it advertised.");
-                    return null;
-                }
-
-                archive = received;
-            }
-
-            if (PackageArchiveValidator.Validate(
-                    archive,
-                    limits,
-                    cancellationToken)
-                is PackageArchiveValidation.Rejected rejection)
-            {
-                // The bytes are not a package this host will publish, so this
-                // source failed to serve the coordinate and nothing is
-                // committed. The next authorized source is tried.
-                log?.Invoke(
-                    $"Source {PackageSourceDisplay.ForDiagnostics(source)} did not deliver a usable package payload: {rejection.Reason}");
-                return null;
-            }
-
-            IPackageContent committed = await store.CommitAsync(
-                coordinate.PackageId,
-                coordinate.Version,
-                producerKey,
-                new MemoryStream(
-                    archive,
-                    index: 0,
-                    count: archive.Length,
-                    writable: false,
-                    publiclyVisible: true),
-                cancellationToken).ConfigureAwait(false);
-            if (!await PackageContentAdmission.IsAdmissibleAsync(
-                    committed,
-                    limits,
-                    cancellationToken).ConfigureAwait(false))
-            {
-                log?.Invoke(
-                    $"Source {PackageSourceDisplay.ForDiagnostics(source)} did not publish content satisfying the current payload limits.");
-                return null;
-            }
-
-            reservation?.Complete();
-            return committed;
+            return await TryAdmitAsync(
+                payload,
+                advertisedLength,
+                PackageSourceCoordinate.Create(
+                    coordinate.PackageId,
+                    coordinate.Version),
+                NuGetCache.GetSourceKey(source.Url),
+                $"source {PackageSourceDisplay.ForDiagnostics(source)}",
+                store,
+                log,
+                limits,
+                transferPolicy,
+                bodyTimeout.Token).ConfigureAwait(false);
         }
         catch (HttpRequestException ex)
         {
@@ -413,6 +469,121 @@ public static class PackagePayloadAcquisition
             // an archive-derived name can reach it.
             log?.Invoke(
                 $"Source {PackageSourceDisplay.ForDiagnostics(source)} did not deliver a usable package payload.");
+            return null;
+        }
+    }
+
+    static PackagePayloadLimits ValidateLimits(PackagePayloadLimits? limits)
+    {
+        limits ??= PackagePayloadLimits.Default;
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            limits.MaxArchiveBytes);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            limits.MaxExpandedBytes);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            limits.MaxEntryCount);
+        return limits;
+    }
+
+    static async Task<IPackageContent?> TryAdmitAsync(
+        Stream payload,
+        long? advertisedLength,
+        PackageSourceCoordinate coordinate,
+        string producerKey,
+        string sourceDescription,
+        IPackageStore store,
+        Action<string>? log,
+        PackagePayloadLimits limits,
+        IPackagePayloadTransferPolicy? transferPolicy,
+        CancellationToken cancellationToken)
+    {
+        if (advertisedLength > limits.MaxArchiveBytes)
+        {
+            await payload.DisposeAsync().ConfigureAwait(false);
+            log?.Invoke(
+                $"{sourceDescription} advertised a package payload above the configured archive limit.");
+            return null;
+        }
+
+        using IPackagePayloadReservation? reservation = transferPolicy?.Reserve(
+            new PackagePayloadTransfer(
+                coordinate,
+                producerKey,
+                advertisedLength));
+        try
+        {
+            byte[]? archive;
+            await using (payload.ConfigureAwait(false))
+            {
+                archive = advertisedLength is { } declared
+                    && declared >= 0
+                    && declared <= int.MaxValue
+                    ? await PackageContentAdmission.ReadExactAsync(
+                            payload,
+                            (int)declared,
+                            cancellationToken)
+                        .ConfigureAwait(false)
+                    : await PackageContentAdmission.ReadBoundedAsync(
+                            payload,
+                            limits.MaxArchiveBytes,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+            }
+
+            if (archive is null)
+            {
+                log?.Invoke(
+                    advertisedLength is null
+                        ? $"{sourceDescription} sent a package payload above the configured archive limit."
+                        : $"{sourceDescription} did not send the package payload length it advertised.");
+                return null;
+            }
+
+            if (PackageArchiveValidator.Validate(
+                    archive,
+                    limits,
+                    cancellationToken)
+                is PackageArchiveValidation.Rejected rejection)
+            {
+                log?.Invoke(
+                    $"{sourceDescription} did not deliver a usable package payload: {rejection.Reason}");
+                return null;
+            }
+
+            IPackageContent committed = await store.CommitAsync(
+                coordinate.PackageId,
+                coordinate.Version,
+                producerKey,
+                new MemoryStream(
+                    archive,
+                    index: 0,
+                    count: archive.Length,
+                    writable: false,
+                    publiclyVisible: true),
+                cancellationToken).ConfigureAwait(false);
+            if (!await PackageContentAdmission.IsAdmissibleAsync(
+                    committed,
+                    limits,
+                    cancellationToken).ConfigureAwait(false))
+            {
+                log?.Invoke(
+                    $"{sourceDescription} did not publish content satisfying the current payload limits.");
+                return null;
+            }
+
+            reservation?.Complete();
+            return committed;
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or InvalidDataException
+                or NotSupportedException
+                || (ex is OperationCanceledException
+                    && !cancellationToken.IsCancellationRequested))
+        {
+            log?.Invoke(
+                $"{sourceDescription} did not deliver a usable package payload.");
             return null;
         }
     }

--- a/src/DotnetInspector.Packages/PackagePayloadAcquisition.cs
+++ b/src/DotnetInspector.Packages/PackagePayloadAcquisition.cs
@@ -140,6 +140,8 @@ public abstract record PackageSourcePayloadResult
 /// <c>TransferPolicy_RejectedPayloadDisposesWithoutCompleting</c>, and
 /// <c>TransferPolicy_CanRequireContentLengthBeforeBodyRead</c> for the optional
 /// host-capacity seam,
+/// <c>BodyTransferDeadline_DoesNotBoundCacheCommit</c> for separation between
+/// transport consumption and post-transfer admission work,
 /// <c>InvalidArchiveFromOneSource_LetsTheNextSourceServe</c> for source
 /// failover without cache poisoning, and
 /// <c>Acquisition_ObservesCancellationDuringDownload</c> for cancellation.
@@ -228,6 +230,7 @@ public static class PackagePayloadAcquisition
             log,
             limits,
             transferPolicy,
+            cancellationToken,
             cancellationToken).ConfigureAwait(false);
         return content is null
             ? new PackageSourcePayloadResult.Unavailable(
@@ -438,7 +441,8 @@ public static class PackagePayloadAcquisition
                 log,
                 limits,
                 transferPolicy,
-                bodyTimeout.Token).ConfigureAwait(false);
+                bodyTimeout.Token,
+                cancellationToken).ConfigureAwait(false);
         }
         catch (HttpRequestException ex)
         {
@@ -495,96 +499,96 @@ public static class PackagePayloadAcquisition
         Action<string>? log,
         PackagePayloadLimits limits,
         IPackagePayloadTransferPolicy? transferPolicy,
-        CancellationToken cancellationToken)
+        CancellationToken bodyCancellationToken,
+        CancellationToken operationCancellationToken)
     {
-        if (advertisedLength > limits.MaxArchiveBytes)
+        await using (payload.ConfigureAwait(false))
         {
-            await payload.DisposeAsync().ConfigureAwait(false);
-            log?.Invoke(
-                $"{sourceDescription} advertised a package payload above the configured archive limit.");
-            return null;
-        }
-
-        using IPackagePayloadReservation? reservation = transferPolicy?.Reserve(
-            new PackagePayloadTransfer(
-                coordinate,
-                producerKey,
-                advertisedLength));
-        try
-        {
-            byte[]? archive;
-            await using (payload.ConfigureAwait(false))
+            if (advertisedLength > limits.MaxArchiveBytes)
             {
-                archive = advertisedLength is { } declared
+                log?.Invoke(
+                    $"{sourceDescription} advertised a package payload above the configured archive limit.");
+                return null;
+            }
+
+            using IPackagePayloadReservation? reservation =
+                transferPolicy?.Reserve(
+                    new PackagePayloadTransfer(
+                        coordinate,
+                        producerKey,
+                        advertisedLength));
+            try
+            {
+                byte[]? archive = advertisedLength is { } declared
                     && declared >= 0
                     && declared <= int.MaxValue
                     ? await PackageContentAdmission.ReadExactAsync(
                             payload,
                             (int)declared,
-                            cancellationToken)
+                            bodyCancellationToken)
                         .ConfigureAwait(false)
                     : await PackageContentAdmission.ReadBoundedAsync(
                             payload,
                             limits.MaxArchiveBytes,
-                            cancellationToken)
+                            bodyCancellationToken)
                         .ConfigureAwait(false);
-            }
 
-            if (archive is null)
+                if (archive is null)
+                {
+                    log?.Invoke(
+                        advertisedLength is null
+                            ? $"{sourceDescription} sent a package payload above the configured archive limit."
+                            : $"{sourceDescription} did not send the package payload length it advertised.");
+                    return null;
+                }
+
+                if (PackageArchiveValidator.Validate(
+                        archive,
+                        limits,
+                        operationCancellationToken)
+                    is PackageArchiveValidation.Rejected rejection)
+                {
+                    log?.Invoke(
+                        $"{sourceDescription} did not deliver a usable package payload: {rejection.Reason}");
+                    return null;
+                }
+
+                IPackageContent committed = await store.CommitAsync(
+                    coordinate.PackageId,
+                    coordinate.Version,
+                    producerKey,
+                    new MemoryStream(
+                        archive,
+                        index: 0,
+                        count: archive.Length,
+                        writable: false,
+                        publiclyVisible: true),
+                    operationCancellationToken).ConfigureAwait(false);
+                if (!await PackageContentAdmission.IsAdmissibleAsync(
+                        committed,
+                        limits,
+                        operationCancellationToken).ConfigureAwait(false))
+                {
+                    log?.Invoke(
+                        $"{sourceDescription} did not publish content satisfying the current payload limits.");
+                    return null;
+                }
+
+                reservation?.Complete();
+                return committed;
+            }
+            catch (Exception ex) when (
+                ex is IOException
+                    or UnauthorizedAccessException
+                    or InvalidDataException
+                    or NotSupportedException
+                    || (ex is OperationCanceledException
+                        && !operationCancellationToken.IsCancellationRequested))
             {
                 log?.Invoke(
-                    advertisedLength is null
-                        ? $"{sourceDescription} sent a package payload above the configured archive limit."
-                        : $"{sourceDescription} did not send the package payload length it advertised.");
+                    $"{sourceDescription} did not deliver a usable package payload.");
                 return null;
             }
-
-            if (PackageArchiveValidator.Validate(
-                    archive,
-                    limits,
-                    cancellationToken)
-                is PackageArchiveValidation.Rejected rejection)
-            {
-                log?.Invoke(
-                    $"{sourceDescription} did not deliver a usable package payload: {rejection.Reason}");
-                return null;
-            }
-
-            IPackageContent committed = await store.CommitAsync(
-                coordinate.PackageId,
-                coordinate.Version,
-                producerKey,
-                new MemoryStream(
-                    archive,
-                    index: 0,
-                    count: archive.Length,
-                    writable: false,
-                    publiclyVisible: true),
-                cancellationToken).ConfigureAwait(false);
-            if (!await PackageContentAdmission.IsAdmissibleAsync(
-                    committed,
-                    limits,
-                    cancellationToken).ConfigureAwait(false))
-            {
-                log?.Invoke(
-                    $"{sourceDescription} did not publish content satisfying the current payload limits.");
-                return null;
-            }
-
-            reservation?.Complete();
-            return committed;
-        }
-        catch (Exception ex) when (
-            ex is IOException
-                or UnauthorizedAccessException
-                or InvalidDataException
-                or NotSupportedException
-                || (ex is OperationCanceledException
-                    && !cancellationToken.IsCancellationRequested))
-        {
-            log?.Invoke(
-                $"{sourceDescription} did not deliver a usable package payload.");
-            return null;
         }
     }
 

--- a/src/DotnetInspector.Packages/PackagePayloadTransferPolicy.cs
+++ b/src/DotnetInspector.Packages/PackagePayloadTransferPolicy.cs
@@ -1,10 +1,12 @@
+using NuGetFetch;
+
 namespace DotnetInspector.Packages;
 
 /// <summary>
 /// One package response a host may reserve before its body is materialized.
 /// </summary>
 public sealed record PackagePayloadTransfer(
-    ResolvedPackageCoordinate Coordinate,
+    PackageSourceCoordinate Coordinate,
     string ProducerKey,
     long? AdvertisedLength);
 

--- a/src/DotnetInspector.Packages/PackageSourceCoordinateResolver.cs
+++ b/src/DotnetInspector.Packages/PackageSourceCoordinateResolver.cs
@@ -1,0 +1,96 @@
+using NuGet.Versioning;
+using NuGetFetch;
+
+namespace DotnetInspector.Packages;
+
+/// <summary>The result of resolving one coordinate through a typed source client.</summary>
+public abstract record PackageSourceCoordinateResolution
+{
+    private protected PackageSourceCoordinateResolution()
+    {
+    }
+
+    public sealed record Resolved(
+        PackageSourceCoordinate Coordinate,
+        bool WasFloating)
+        : PackageSourceCoordinateResolution;
+
+    public sealed record Invalid(string Message)
+        : PackageSourceCoordinateResolution;
+
+    public sealed record Unavailable(string Message)
+        : PackageSourceCoordinateResolution;
+
+    public sealed record Failed(PackageSourceFailure Failure)
+        : PackageSourceCoordinateResolution;
+}
+
+/// <summary>
+/// Resolves exact pins directly and floating coordinates through a typed
+/// source's listed search results.
+/// </summary>
+public static class PackageSourceCoordinateResolver
+{
+    public static async Task<PackageSourceCoordinateResolution> ResolveAsync(
+        IPackageSourceClient source,
+        PackageCoordinate coordinate,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(coordinate);
+        if (PackageCoordinateResolver.Validate(coordinate) is { } invalid)
+            return new PackageSourceCoordinateResolution.Invalid(invalid.Message);
+
+        if (coordinate.Version is { } exactVersion)
+        {
+            return new PackageSourceCoordinateResolution.Resolved(
+                PackageSourceCoordinate.Create(
+                    coordinate.PackageId,
+                    exactVersion),
+                WasFloating: false);
+        }
+
+        PackageSourceOperationResult<PackageSearchResult> search =
+            await source.SearchAsync(
+                $"packageid:{coordinate.PackageId}",
+                take: 20,
+                prerelease: false,
+                cancellationToken).ConfigureAwait(false);
+        if (search is PackageSourceOperationResult<PackageSearchResult>.Failed failed)
+            return new PackageSourceCoordinateResolution.Failed(failed.Failure);
+
+        PackageSearchResult result =
+            ((PackageSourceOperationResult<PackageSearchResult>.Succeeded)search)
+            .Value;
+        PackageCandidateObservation? selected = null;
+        NuGetVersion? selectedVersion = null;
+        foreach (PackageCandidateObservation candidate in
+                 result.Matches.Select(match => match.Candidate))
+        {
+            if (candidate.Producer != source.Identity
+                || !candidate.Coordinate.PackageId.Equals(
+                    coordinate.PackageId,
+                    StringComparison.OrdinalIgnoreCase)
+                || candidate.ListingState != PackageListingState.Listed
+                || !NuGetVersion.TryParse(
+                    candidate.Coordinate.Version,
+                    out NuGetVersion? parsed)
+                || parsed.IsPrerelease
+                || selectedVersion is not null
+                    && parsed <= selectedVersion)
+            {
+                continue;
+            }
+
+            selected = candidate;
+            selectedVersion = parsed;
+        }
+
+        return selected is null
+            ? new PackageSourceCoordinateResolution.Unavailable(
+                $"Package '{coordinate.PackageId}' has no listed stable version in the selected source.")
+            : new PackageSourceCoordinateResolution.Resolved(
+                selected.Coordinate,
+                WasFloating: true);
+    }
+}

--- a/src/DotnetInspector.Services.Tests/PackagePayloadAcquisitionTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackagePayloadAcquisitionTests.cs
@@ -2580,6 +2580,32 @@ public sealed class PackagePayloadAcquisitionTests
         Assert.False(bodyRead);
     }
 
+    [Fact]
+    public async Task BodyTransferDeadline_DoesNotBoundCacheCommit()
+    {
+        byte[] nupkg = TestPackageArchive.Create(
+            "lib/net10.0/Sample.dll");
+        var store = new DelayedCommitStore(
+            TimeSpan.FromMilliseconds(150));
+        using var client = new HttpClient(
+            new NuGetOrgPayloadHandler(nupkg))
+        {
+            Timeout = TimeSpan.FromMilliseconds(50),
+        };
+
+        PackagePayloadResult result =
+            await PackagePayloadAcquisition.AcquireAsync(
+                client,
+                Coordinate(NuGetOrg),
+                store,
+                cancellationToken:
+                    TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            PackagePayloadOrigin.Download,
+            Acquired(result).Origin);
+    }
+
     static AcquiredPackagePayload Acquired(PackagePayloadResult result)
         => Assert.IsType<PackagePayloadResult.Acquired>(result).Payload;
 
@@ -2903,6 +2929,49 @@ public sealed class PackagePayloadAcquisitionTests
         {
             onRead();
             return base.ReadAsync(buffer, cancellationToken);
+        }
+    }
+
+    sealed class DelayedCommitStore(TimeSpan delay) : IPackageStore
+    {
+        readonly InMemoryPackageStore _inner = new();
+
+        public IPackageContent? TryGetCached(
+            string packageName,
+            string version,
+            IReadOnlyList<string>? allowedSourceKeys,
+            Action<string>? log = null) =>
+            _inner.TryGetCached(
+                packageName,
+                version,
+                allowedSourceKeys,
+                log);
+
+        public IEnumerable<IPackageContent> EnumerateCached(
+            string packageName,
+            string version,
+            IReadOnlyList<string>? allowedSourceKeys,
+            Action<string>? log = null) =>
+            _inner.EnumerateCached(
+                packageName,
+                version,
+                allowedSourceKeys,
+                log);
+
+        public async ValueTask<IPackageContent> CommitAsync(
+            string packageName,
+            string version,
+            string sourceKey,
+            Stream nupkg,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(delay, cancellationToken);
+            return await _inner.CommitAsync(
+                packageName,
+                version,
+                sourceKey,
+                nupkg,
+                cancellationToken);
         }
     }
 

--- a/src/NuGetFetch.Tests/NuGetDeadlineTests.cs
+++ b/src/NuGetFetch.Tests/NuGetDeadlineTests.cs
@@ -48,6 +48,32 @@ public sealed class NuGetDeadlineTests
     }
 
     [Fact]
+    public async Task RequestDeadline_DoesNotTranslateLateMetadataRejection()
+    {
+        using var operation = new NuGetOperationDeadline(
+            Options(
+                request: TimeSpan.FromMilliseconds(40),
+                operation: TimeSpan.FromSeconds(1)),
+            Timeout.InfiniteTimeSpan,
+            TestContext.Current.CancellationToken);
+
+        NuGetMetadataResponseTooLargeException error =
+            await Assert.ThrowsAsync<NuGetMetadataResponseTooLargeException>(
+                () => operation.RunRequestAsync<bool>(
+                    async cancellationToken =>
+                    {
+                        while (!cancellationToken.IsCancellationRequested)
+                        {
+                            await Task.Yield();
+                        }
+
+                        throw new NuGetMetadataResponseTooLargeException(8);
+                    }));
+
+        Assert.Equal(8, error.MaximumBytes);
+    }
+
+    [Fact]
     public void RequestTimeout_DoesNotCreateASecondResponseBodyTimer()
     {
         var options = new NuGetFetchOptions

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -1492,6 +1492,23 @@ public sealed class PackageSourceClientTests
     }
 
     [Fact]
+    public async Task GalleryRetriesBrowserStatuslessTransportFailure()
+    {
+        var handler = new TransientGalleryHandler(statuslessFailure: true);
+        using IPackageSourceClient runtime =
+            PackageSourceClientFactory.CreateGallery(handler);
+
+        Assert.Single(
+            Succeeded(
+                await runtime.GetVersionsAsync(
+                    "contoso",
+                    TestContext.Current.CancellationToken))
+            .Candidates);
+
+        Assert.Equal(2, handler.Requests);
+    }
+
+    [Fact]
     public async Task GalleryRetryBackoffUsesOperationNotRequestTimeout()
     {
         var handler = new TransientGalleryHandler();
@@ -1783,7 +1800,8 @@ public sealed class PackageSourceClientTests
         }
     }
 
-    private sealed class TransientGalleryHandler : HttpMessageHandler
+    private sealed class TransientGalleryHandler(
+        bool statuslessFailure = false) : HttpMessageHandler
     {
         public int Requests { get; private set; }
 
@@ -1794,6 +1812,14 @@ public sealed class PackageSourceClientTests
             cancellationToken.ThrowIfCancellationRequested();
             if (Requests++ == 0)
             {
+                if (statuslessFailure)
+                {
+                    throw new HttpRequestException(
+                        "Browser fetch failed.",
+                        new InvalidOperationException(
+                            "JavaScript transport failure."));
+                }
+
                 return Task.FromResult(
                     new HttpResponseMessage(HttpStatusCode.BadGateway));
             }

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -1409,6 +1409,52 @@ public sealed class PackageSourceClientTests
             failure.Capability);
     }
 
+    [Theory]
+    [InlineData("search")]
+    [InlineData("versions")]
+    [InlineData("package")]
+    public async Task GalleryRetriesTransientFailuresWithinOneOperation(
+        string operation)
+    {
+        var handler = new TransientGalleryHandler();
+        using IPackageSourceClient runtime =
+            PackageSourceClientFactory.CreateGallery(handler);
+
+        switch (operation)
+        {
+            case "search":
+                Assert.Single(
+                    Succeeded(
+                        await runtime.SearchAsync(
+                            "contoso",
+                            cancellationToken:
+                                TestContext.Current.CancellationToken))
+                    .Matches);
+                break;
+            case "versions":
+                Assert.Single(
+                    Succeeded(
+                        await runtime.GetVersionsAsync(
+                            "contoso",
+                            TestContext.Current.CancellationToken))
+                    .Candidates);
+                break;
+            case "package":
+                PackageSourcePayload payload = Succeeded(
+                    await runtime.GetPackageAsync(
+                        "contoso",
+                        "1.0.0",
+                        TestContext.Current.CancellationToken));
+                await payload.Content.DisposeAsync();
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(operation));
+        }
+
+        Assert.Equal(2, handler.Requests);
+    }
+
     [Fact]
     public async Task GalleryCallerCancellationRemainsCancellation()
     {
@@ -1676,6 +1722,39 @@ public sealed class PackageSourceClientTests
         {
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
             throw new InvalidOperationException("Unreachable.");
+        }
+    }
+
+    private sealed class TransientGalleryHandler : HttpMessageHandler
+    {
+        public int Requests { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (Requests++ == 0)
+            {
+                return Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.BadGateway));
+            }
+
+            string url = request.RequestUri!.AbsoluteUri;
+            HttpContent content = url.StartsWith(
+                    GallerySearch,
+                    StringComparison.Ordinal)
+                ? new StringContent(
+                    """{"data":[{"id":"Contoso","version":"1.0.0"}]}""")
+                : url.Equals(GalleryVersions, StringComparison.Ordinal)
+                    ? new StringContent(
+                        """{"versions":["1.0.0"]}""")
+                    : new ByteArrayContent("package bytes"u8.ToArray());
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = content,
+                });
         }
     }
 

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -847,6 +847,8 @@ public sealed class PackageSourceClientTests
         Assert.Equal(
             PackageSourceKind.NuGetGallery,
             symbolPayload.TransportKind);
+        Assert.Equal("package bytes".Length, packagePayload.AdvertisedLength);
+        Assert.Equal("symbol bytes".Length, symbolPayload.AdvertisedLength);
         Assert.Equal(packagePayload.Coordinate, symbolPayload.Coordinate);
         Assert.Equal(runtime.Identity, packagePayload.Producer);
         Assert.Equal(runtime.Identity, symbolPayload.Producer);

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -1000,6 +1000,7 @@ public sealed class PackageSourceClientTests
         Assert.Equal(
             PackageSourceFailureKind.ResponseRejected,
             failure.Kind);
+        Assert.Equal([GalleryVersions], handler.Requested);
     }
 
     [Fact]
@@ -1452,6 +1453,28 @@ public sealed class PackageSourceClientTests
                     nameof(operation));
         }
 
+        Assert.Equal(2, handler.Requests);
+    }
+
+    [Fact]
+    public async Task GalleryRetryBackoffUsesOperationNotRequestTimeout()
+    {
+        var handler = new TransientGalleryHandler();
+        using IPackageSourceClient runtime =
+            PackageSourceClientFactory.CreateGallery(
+                handler,
+                new NuGetFetchOptions
+                {
+                    RequestTimeout = TimeSpan.FromMilliseconds(50),
+                    OperationTimeout = TimeSpan.FromSeconds(1),
+                });
+
+        Assert.Single(
+            Succeeded(
+                await runtime.GetVersionsAsync(
+                    "contoso",
+                    TestContext.Current.CancellationToken))
+            .Candidates);
         Assert.Equal(2, handler.Requests);
     }
 

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -1004,6 +1004,41 @@ public sealed class PackageSourceClientTests
     }
 
     [Fact]
+    public async Task GalleryLateMetadataRejectionIsNotRetriedAsTimeout()
+    {
+        var handler = new RecordingHandler();
+        handler.SetResponse(
+            GalleryVersions,
+            request => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StreamContent(
+                    new LateOversizeStream(
+                        """{"versions":["1.0.0"]}"""u8.ToArray())),
+                RequestMessage = request,
+            });
+        using IPackageSourceClient runtime =
+            PackageSourceClientFactory.CreateGallery(
+                handler,
+                new NuGetFetchOptions
+                {
+                    MaxMetadataResponseBytes = 8,
+                    RequestTimeout = TimeSpan.FromSeconds(1),
+                    OperationTimeout = TimeSpan.FromSeconds(2),
+                    MetadataBodyTimeout = TimeSpan.FromMilliseconds(40),
+                });
+
+        PackageSourceFailure failure = Failed(
+            await runtime.GetVersionsAsync(
+                "contoso",
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            PackageSourceFailureKind.ResponseRejected,
+            failure.Kind);
+        Assert.Equal([GalleryVersions], handler.Requested);
+    }
+
+    [Fact]
     public async Task GalleryMissingPackageHasNoVersions()
     {
         var handler = new RecordingHandler();
@@ -1804,6 +1839,62 @@ public sealed class PackageSourceClientTests
             CancellationToken cancellationToken = default) =>
             ValueTask.FromException<int>(
                 new IOException("The response body ended."));
+
+        public override void Flush() =>
+            throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class LateOversizeStream(byte[] content) : Stream
+    {
+        private int _position;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (_position == content.Length)
+                return 0;
+            if (_position == 0)
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                    await Task.Yield();
+            }
+
+            int count = Math.Min(
+                content.Length - _position,
+                buffer.Length);
+            content.AsSpan(_position, count).CopyTo(buffer.Span);
+            _position += count;
+            return count;
+        }
+
+        public override int Read(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            throw new NotSupportedException();
 
         public override void Flush() =>
             throw new NotSupportedException();

--- a/src/NuGetFetch/NuGetFetch.csproj
+++ b/src/NuGetFetch/NuGetFetch.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="DotnetInspector.Packages" />
     <InternalsVisibleTo Include="DotnetInspector.Services" />
+    <InternalsVisibleTo Include="InspectWeb.Engine.Tests" />
     <InternalsVisibleTo Include="NuGetFetch.Tests" />
   </ItemGroup>
 

--- a/src/NuGetFetch/NuGetGalleryPackageSourceClient.cs
+++ b/src/NuGetFetch/NuGetGalleryPackageSourceClient.cs
@@ -24,7 +24,8 @@ internal sealed class NuGetGalleryPackageSourceClient : IPackageSourceClient
         _search = new SearchService(
             client,
             SearchEndpoint,
-            _options);
+            _options,
+            retryTransientRequests: true);
     }
 
     public PackageSourceIdentity Identity => PackageSourceIdentity.NuGetOrg;

--- a/src/NuGetFetch/NuGetGalleryPackageSourceClient.cs
+++ b/src/NuGetFetch/NuGetGalleryPackageSourceClient.cs
@@ -153,14 +153,20 @@ internal sealed class NuGetGalleryPackageSourceClient : IPackageSourceClient
             Identity,
             Kind,
             PackageSourceCapabilities.PackagePayload,
-            async () => new PackageSourcePayload(
-                coordinate,
-                Identity,
-                Kind,
-                PackageSourcePayloadKind.Package,
-                await GetPayloadAsync(
-                    $"{PackageEndpoint}{fileName}",
-                    cancellationToken).ConfigureAwait(false)),
+            async () =>
+            {
+                (Stream content, long? advertisedLength) =
+                    await GetPayloadAsync(
+                        $"{PackageEndpoint}{fileName}",
+                        cancellationToken).ConfigureAwait(false);
+                return new PackageSourcePayload(
+                    coordinate,
+                    Identity,
+                    Kind,
+                    PackageSourcePayloadKind.Package,
+                    content,
+                    advertisedLength);
+            },
             cancellationToken,
             coordinate).ConfigureAwait(false);
     }
@@ -179,19 +185,25 @@ internal sealed class NuGetGalleryPackageSourceClient : IPackageSourceClient
             Identity,
             Kind,
             PackageSourceCapabilities.SymbolPayload,
-            async () => new PackageSourcePayload(
-                coordinate,
-                Identity,
-                Kind,
-                PackageSourcePayloadKind.Symbols,
-                await GetPayloadAsync(
-                    $"{SymbolEndpoint}{fileName}",
-                    cancellationToken).ConfigureAwait(false)),
+            async () =>
+            {
+                (Stream content, long? advertisedLength) =
+                    await GetPayloadAsync(
+                        $"{SymbolEndpoint}{fileName}",
+                        cancellationToken).ConfigureAwait(false);
+                return new PackageSourcePayload(
+                    coordinate,
+                    Identity,
+                    Kind,
+                    PackageSourcePayloadKind.Symbols,
+                    content,
+                    advertisedLength);
+            },
             cancellationToken,
             coordinate).ConfigureAwait(false);
     }
 
-    private async Task<Stream> GetPayloadAsync(
+    private async Task<(Stream Content, long? AdvertisedLength)> GetPayloadAsync(
         string url,
         CancellationToken cancellationToken)
     {
@@ -213,7 +225,10 @@ internal sealed class NuGetGalleryPackageSourceClient : IPackageSourceClient
                         Stream stream = await response.Content
                             .ReadAsStreamAsync(requestToken)
                             .ConfigureAwait(false);
-                        return (stream, response);
+                        return (
+                            stream,
+                            response,
+                            response.Content.Headers.ContentLength);
                     }
                     catch
                     {

--- a/src/NuGetFetch/NuGetGalleryPackageSourceClient.cs
+++ b/src/NuGetFetch/NuGetGalleryPackageSourceClient.cs
@@ -90,7 +90,8 @@ internal sealed class NuGetGalleryPackageSourceClient : IPackageSourceClient
                     $"{FlatContainer}{EscapeSegment(normalizedId)}/index.json";
                 using var operation = CreateOperation(cancellationToken);
                 (bool found, VersionIndex? index) =
-                    await operation.RunRequestAsync(
+                    await NuGetHttpRetry.RunRequestAsync(
+                        operation,
                         async requestToken =>
                         {
                             using HttpRequestMessage request =
@@ -210,7 +211,8 @@ internal sealed class NuGetGalleryPackageSourceClient : IPackageSourceClient
         var operation = CreateOperation(cancellationToken);
         try
         {
-            return await operation.RunStreamingRequestAsync(
+            return await NuGetHttpRetry.RunStreamingRequestAsync(
+                operation,
                 async requestToken =>
                 {
                     using HttpRequestMessage request =

--- a/src/NuGetFetch/NuGetHttpRetry.cs
+++ b/src/NuGetFetch/NuGetHttpRetry.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Net.Sockets;
 
 namespace NuGetFetch;
 
@@ -64,31 +63,11 @@ internal static class NuGetHttpRetry
             and not NuGetMetadataResponseTooLargeException
             and not NuGetRedirectLimitExceededException
         || exception is HttpRequestException request
-            && (request.StatusCode is
+            && (request.StatusCode is null
+                || request.StatusCode is
                     HttpStatusCode.RequestTimeout
                     or HttpStatusCode.InternalServerError
                     or HttpStatusCode.BadGateway
                     or HttpStatusCode.ServiceUnavailable
-                    or HttpStatusCode.GatewayTimeout
-                || HasTransientSocketError(request));
-
-    private static bool HasTransientSocketError(Exception exception)
-    {
-        for (Exception? current = exception.InnerException;
-             current is not null;
-             current = current.InnerException)
-        {
-            if (current is SocketException socket)
-            {
-                return socket.SocketErrorCode is
-                    SocketError.ConnectionReset
-                    or SocketError.ConnectionAborted
-                    or SocketError.Shutdown
-                    or SocketError.TimedOut
-                    or SocketError.TryAgain;
-            }
-        }
-
-        return false;
-    }
+                    or HttpStatusCode.GatewayTimeout);
 }

--- a/src/NuGetFetch/NuGetHttpRetry.cs
+++ b/src/NuGetFetch/NuGetHttpRetry.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace NuGetFetch;
+
+internal static class NuGetHttpRetry
+{
+    private const int MaximumRetries = 3;
+
+    public static async Task<T> RunRequestAsync<T>(
+        NuGetOperationDeadline operation,
+        Func<CancellationToken, Task<T>> request)
+    {
+        for (int retry = 0; ; retry++)
+        {
+            try
+            {
+                return await operation.RunRequestAsync(request)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+                when (retry < MaximumRetries
+                    && IsTransient(exception))
+            {
+                await DelayAsync(operation, retry).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public static async Task<(Stream Stream, T Metadata)>
+        RunStreamingRequestAsync<T>(
+            NuGetOperationDeadline operation,
+            Func<CancellationToken, Task<(
+                Stream Stream,
+                IDisposable Owner,
+                T Metadata)>> request)
+    {
+        for (int retry = 0; ; retry++)
+        {
+            try
+            {
+                return await operation.RunStreamingRequestAsync(request)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+                when (retry < MaximumRetries
+                    && IsTransient(exception))
+            {
+                await DelayAsync(operation, retry).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static Task<bool> DelayAsync(
+        NuGetOperationDeadline operation,
+        int retry) =>
+        operation.RunRequestAsync(
+            async cancellationToken =>
+            {
+                await Task.Delay(
+                    TimeSpan.FromMilliseconds(100 * (1 << retry)),
+                    cancellationToken).ConfigureAwait(false);
+                return true;
+            });
+
+    private static bool IsTransient(Exception exception) =>
+        exception is NuGetRequestTimeoutException
+        || exception is IOException
+        || exception is HttpRequestException request
+            && (request.StatusCode is
+                    HttpStatusCode.RequestTimeout
+                    or HttpStatusCode.InternalServerError
+                    or HttpStatusCode.BadGateway
+                    or HttpStatusCode.ServiceUnavailable
+                    or HttpStatusCode.GatewayTimeout
+                || HasTransientSocketError(request));
+
+    private static bool HasTransientSocketError(Exception exception)
+    {
+        for (Exception? current = exception.InnerException;
+             current is not null;
+             current = current.InnerException)
+        {
+            if (current is SocketException socket)
+            {
+                return socket.SocketErrorCode is
+                    SocketError.ConnectionReset
+                    or SocketError.ConnectionAborted
+                    or SocketError.Shutdown
+                    or SocketError.TimedOut
+                    or SocketError.TryAgain;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/NuGetFetch/NuGetHttpRetry.cs
+++ b/src/NuGetFetch/NuGetHttpRetry.cs
@@ -51,21 +51,18 @@ internal static class NuGetHttpRetry
         }
     }
 
-    private static Task<bool> DelayAsync(
+    private static Task DelayAsync(
         NuGetOperationDeadline operation,
         int retry) =>
-        operation.RunRequestAsync(
-            async cancellationToken =>
-            {
-                await Task.Delay(
-                    TimeSpan.FromMilliseconds(100 * (1 << retry)),
-                    cancellationToken).ConfigureAwait(false);
-                return true;
-            });
+        operation.DelayAsync(
+            TimeSpan.FromMilliseconds(100 * (1 << retry)));
 
     private static bool IsTransient(Exception exception) =>
         exception is NuGetRequestTimeoutException
+            or NuGetMetadataBodyTimeoutException
         || exception is IOException
+            and not NuGetMetadataResponseTooLargeException
+            and not NuGetRedirectLimitExceededException
         || exception is HttpRequestException request
             && (request.StatusCode is
                     HttpStatusCode.RequestTimeout

--- a/src/NuGetFetch/NuGetMetadataReader.cs
+++ b/src/NuGetFetch/NuGetMetadataReader.cs
@@ -113,6 +113,8 @@ internal static class NuGetMetadataReader
 
     private static bool IsDeadlineAbort(Exception exception) =>
         exception is IOException
+            and not NuGetMetadataResponseTooLargeException
+            and not NuGetRedirectLimitExceededException
             or HttpRequestException
             or ObjectDisposedException;
 

--- a/src/NuGetFetch/NuGetOperationDeadline.cs
+++ b/src/NuGetFetch/NuGetOperationDeadline.cs
@@ -247,6 +247,8 @@ internal sealed class NuGetOperationDeadline : IDisposable
 
     private static bool IsDeadlineAbort(Exception exception) =>
         exception is IOException
+            and not NuGetMetadataResponseTooLargeException
+            and not NuGetRedirectLimitExceededException
             or HttpRequestException
             or ObjectDisposedException;
 

--- a/src/NuGetFetch/NuGetOperationDeadline.cs
+++ b/src/NuGetFetch/NuGetOperationDeadline.cs
@@ -80,11 +80,27 @@ internal sealed class NuGetOperationDeadline : IDisposable
     public async Task<Stream> RunStreamingRequestAsync(
         Func<CancellationToken, Task<(Stream Stream, IDisposable Owner)>> request)
     {
+        (Stream stream, _) = await RunStreamingRequestAsync(
+            async cancellationToken =>
+            {
+                (Stream responseStream, IDisposable owner) =
+                    await request(cancellationToken).ConfigureAwait(false);
+                return (responseStream, owner, Metadata: false);
+            }).ConfigureAwait(false);
+        return stream;
+    }
+
+    public async Task<(Stream Stream, T Metadata)> RunStreamingRequestAsync<T>(
+        Func<CancellationToken, Task<(
+            Stream Stream,
+            IDisposable Owner,
+            T Metadata)>> request)
+    {
         CancellationTokenSource requestCancellation =
             CreateRequestCancellation();
         try
         {
-            (Stream stream, IDisposable owner) =
+            (Stream stream, IDisposable owner, T metadata) =
                 await request(requestCancellation.Token).ConfigureAwait(false);
             if (requestCancellation.IsCancellationRequested)
             {
@@ -105,11 +121,13 @@ internal sealed class NuGetOperationDeadline : IDisposable
             }
 
             _ownershipTransferred = true;
-            return new DeadlineStream(
-                stream,
-                owner,
-                requestCancellation,
-                this);
+            return (
+                new DeadlineStream(
+                    stream,
+                    owner,
+                    requestCancellation,
+                    this),
+                metadata);
         }
         catch (OperationCanceledException ex)
         {

--- a/src/NuGetFetch/NuGetOperationDeadline.cs
+++ b/src/NuGetFetch/NuGetOperationDeadline.cs
@@ -77,6 +77,33 @@ internal sealed class NuGetOperationDeadline : IDisposable
         }
     }
 
+    public async Task DelayAsync(TimeSpan delay)
+    {
+        ThrowIfExpired();
+        try
+        {
+            await Task.Delay(
+                delay,
+                _operationCancellation.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException exception)
+        {
+            if (_callerToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(
+                    "NuGet operation was canceled by the caller.",
+                    exception,
+                    _callerToken);
+            }
+
+            throw new NuGetOperationTimeoutException(
+                _operationTimeout,
+                exception);
+        }
+
+        ThrowIfExpired();
+    }
+
     public async Task<Stream> RunStreamingRequestAsync(
         Func<CancellationToken, Task<(Stream Stream, IDisposable Owner)>> request)
     {

--- a/src/NuGetFetch/PackageSourceResults.cs
+++ b/src/NuGetFetch/PackageSourceResults.cs
@@ -199,7 +199,8 @@ public sealed record PackageSourcePayload(
     PackageSourceIdentity Producer,
     PackageSourceKind TransportKind,
     PackageSourcePayloadKind Kind,
-    Stream Content);
+    Stream Content,
+    long? AdvertisedLength = null);
 
 /// <summary>The expected failure classes produced by source operations.</summary>
 public enum PackageSourceFailureKind

--- a/src/NuGetFetch/SearchService.cs
+++ b/src/NuGetFetch/SearchService.cs
@@ -104,7 +104,8 @@ public class SearchService
                 "The search endpoint is not a usable absolute HTTP or HTTPS URL.");
         }
 
-        SearchResponse? parsed = await operation.RunRequestAsync(
+        SearchResponse? parsed = await NuGetHttpRetry.RunRequestAsync(
+            operation,
             async requestToken =>
             {
                 using HttpRequestMessage request =

--- a/src/NuGetFetch/SearchService.cs
+++ b/src/NuGetFetch/SearchService.cs
@@ -12,6 +12,7 @@ public class SearchService
     private const int MaxPrefixSearchPages = 32;
     private readonly HttpClient _client;
     private readonly NuGetFetchOptions _options;
+    private readonly bool _retryTransientRequests;
     private readonly string _searchUrl;
 
     /// <summary>
@@ -29,11 +30,25 @@ public class SearchService
         HttpClient client,
         string? searchUrl,
         NuGetFetchOptions options)
+        : this(
+            client,
+            searchUrl,
+            options,
+            retryTransientRequests: false)
+    {
+    }
+
+    internal SearchService(
+        HttpClient client,
+        string? searchUrl,
+        NuGetFetchOptions options,
+        bool retryTransientRequests)
     {
         ArgumentNullException.ThrowIfNull(client);
         _client = client;
         _searchUrl = searchUrl ?? NuGetClient.NuGetOrgSearchUrl;
         _options = NuGetFetchOptions.Validate(options);
+        _retryTransientRequests = retryTransientRequests;
     }
 
     /// <summary>
@@ -104,30 +119,36 @@ public class SearchService
                 "The search endpoint is not a usable absolute HTTP or HTTPS URL.");
         }
 
-        SearchResponse? parsed = await NuGetHttpRetry.RunRequestAsync(
-            operation,
-            async requestToken =>
+        async Task<SearchResponse?> SendAsync(
+            CancellationToken requestToken)
+        {
+            using HttpRequestMessage request =
+                NuGetHttpRequest.CreateGetPreservingPathAndQuery(url);
+            if (auth is not null)
             {
-                using HttpRequestMessage request =
-                    NuGetHttpRequest.CreateGetPreservingPathAndQuery(url);
-                if (auth is not null)
-                {
-                    request.Headers.Authorization = auth;
-                }
+                request.Headers.Authorization = auth;
+            }
 
-                using HttpResponseMessage response = await _client.SendAsync(
-                    request,
-                    HttpCompletionOption.ResponseHeadersRead,
-                    requestToken).ConfigureAwait(false);
-                response.EnsureSuccessStatusCode();
+            using HttpResponseMessage response = await _client.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                requestToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
 
-                return await NuGetMetadataReader.ReadResponseAsync(
-                    response,
-                    NuGetApi.DeserializeSearchResponseAsync,
-                    _options,
-                    _client.Timeout,
-                    requestToken).ConfigureAwait(false);
-            }).ConfigureAwait(false);
+            return await NuGetMetadataReader.ReadResponseAsync(
+                response,
+                NuGetApi.DeserializeSearchResponseAsync,
+                _options,
+                _client.Timeout,
+                requestToken).ConfigureAwait(false);
+        }
+
+        SearchResponse? parsed = _retryTransientRequests
+            ? await NuGetHttpRetry.RunRequestAsync(
+                operation,
+                SendAsync).ConfigureAwait(false)
+            : await operation.RunRequestAsync(
+                SendAsync).ConfigureAwait(false);
 
         // A null document is not an empty result set. Reporting it as one would
         // hide the failure behind a successful-looking zero-result search. The


### PR DESCRIPTION
The Browser workspace now resolves and acquires NuGet.org packages without requesting the blocked v3 service index. Exact pins go directly to the Gallery package CDN; omitted root versions use exact-ID Gallery search, and all payloads still pass through the shared bounded admission, reservation, provenance, and store pipeline.

Gallery payloads now retain advertised content length for Browser capacity reservation. Raw flat-container versions remain available to the version picker, but dependency wildcard/range selection fails closed until registration-backed listing state is implemented; exact dependency pins remain supported. Desktop package consumers are unchanged.

Focused validation at `78c920e22cad44fd00d18bca7d14348fd99a9cd6`:
- `InspectWeb.Engine.Tests`: 51 passed
- `PackageSourceClientTests`: 80 passed
- Browser/Wasm `dotnet publish -c Release`: passed
- Markdown lint and `git diff --check`: passed

The combined shared package test classes passed 209/210 locally; the sole failure is the pre-existing `CaseOnlyNupkgSibling_CountsTowardExpandedBytesOnCaseSensitiveFs`, which assumes every non-Windows filesystem is case-sensitive and fails on the default case-insensitive macOS volume.