### PR TITLE
Stabilize overlay allocation gate

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -4716,23 +4716,30 @@ public class LibraryBodyIndexTests
                 stream.SetLength(
                     stream.Length + OverlaySize);
             }
-            long before =
-                GC.GetAllocatedBytesForCurrentThread();
-            _ = LibraryBodyIndex.Open(
-                paddedPath,
-                LibraryBodyAnalysisFeatures.MethodEvidence,
-                resolver);
-            long allocated =
-                GC.GetAllocatedBytesForCurrentThread()
-                - before;
+            long baseline = AllocatedFor(targetPath);
+            long padded = AllocatedFor(paddedPath);
+            long overlayAllocation = padded - baseline;
 
             Assert.True(
-                allocated < OverlaySize / 2,
-                $"Method-evidence acquisition allocated {allocated:N0} bytes for an unused resolver.");
+                overlayAllocation < OverlaySize / 2,
+                $"Method-evidence acquisition allocated {overlayAllocation:N0} additional bytes for the file overlay.");
+            Assert.Equal(0, resolver.ResolveCalls);
         }
         finally
         {
             File.Delete(paddedPath);
+        }
+
+        long AllocatedFor(string path)
+        {
+            long before =
+                GC.GetAllocatedBytesForCurrentThread();
+            _ = LibraryBodyIndex.Open(
+                path,
+                LibraryBodyAnalysisFeatures.MethodEvidence,
+                resolver);
+            return GC.GetAllocatedBytesForCurrentThread()
+                - before;
         }
     }
 


### PR DESCRIPTION
## Summary

Measure the padded PE overlay allocation relative to the same index build over the unpadded assembly instead of treating all current-thread index-build allocations as overlay cost. This preserves the original guard while excluding scheduler-dependent parallel analysis allocations.

PR #4354 hit the old absolute threshold twice in Linux CI (33,027,776 and 21,053,784 bytes) even though the exact gate passed locally and `origin/main` passed earlier. The adjacent retained-image test already uses the differential pattern.

## Validation

- Exact test: 5 consecutive passes
- `ILInspector.Analysis.Tests`: 947 passed
- `git diff --check`

## Scope

Test-only; no product behavior changes.