### PR TITLE
Link Browser loading brand to home

### DIFF
--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -5919,7 +5919,7 @@ function openPackageFromError(packageId, version) {
 function renderLoading() {
   app.innerHTML = `
     <div class="loading-screen">
-      <div class="loading-brand"><span>◇</span> dotnet-inspect</div>
+      <a class="loading-brand" href="/" aria-label="dotnet inspect home"><span>◇</span> dotnet-inspect</a>
       ${state.error
         ? `<div class="load-error">
              <strong>${escapeHtml(state.errorTitle || "Inspection query failed")}</strong>

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1143,7 +1143,7 @@ kbd {
     radial-gradient(circle at 50% 35%, rgba(229,102,63,.08), transparent 26rem),
     var(--bg);
 }
-.loading-brand { position: fixed; top: 20px; left: 22px; color: var(--muted); font: 13px var(--mono); }
+.loading-brand { position: fixed; top: 20px; left: 22px; color: var(--muted); text-decoration: none; font: 13px var(--mono); }
 .loading-brand span { color: var(--accent); font-size: 19px; }
 .load-progress { display: flex; flex-direction: column; align-items: center; gap: 10px; }
 .loading-bot {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -214,6 +214,15 @@ test("bare home paints before wasm engine download", () => {
     /#error-package-query[\s\S]*loadPackage\(packageId, version/);
 });
 
+test("loading brand links back to the site root", () => {
+  assert.match(
+    appSource,
+    /<a class="loading-brand" href="\/" aria-label="dotnet inspect home"><span>◇<\/span> dotnet-inspect<\/a>/);
+  assert.match(
+    stylesSource,
+    /\.loading-brand\s*\{[^}]*text-decoration: none;/s);
+});
+
 test("settings keep a viewport-bounded scroll region", () => {
   const settingsPageRule =
     stylesSource.match(/\.settings-page\s*\{([^}]*)\}/s)?.[1] ?? "";


### PR DESCRIPTION
The dotnet-inspect brand on the package loading and error screen now links to the site root, matching the existing workbench, home, and settings headers. The link keeps the current visual treatment and supports normal browser link behavior.

Validation: `npm test` (55 passed); `git diff --check`.

This is a trivial semantic-markup change with a focused static regression, so no adversarial review round is required.