### PR TITLE
Prevent stale inspect-web boot graphs

### DIFF
--- a/.github/workflows/deploy-inspect-web.yml
+++ b/.github/workflows/deploy-inspect-web.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Verify staged site artifact
         shell: bash
-        run: test -f artifacts/inspect-web-publish/wwwroot/index.html
+        run: test -f artifacts/inspect-web-publish/wwwroot/index.html && test -f artifacts/inspect-web-publish/wwwroot/staticwebapp.config.json
 
       - name: Deploy to staging
         uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1

--- a/.github/workflows/promote-inspect-web.yml
+++ b/.github/workflows/promote-inspect-web.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Verify staged site artifact
         shell: bash
-        run: test -f artifacts/inspect-web-publish/wwwroot/index.html
+        run: test -f artifacts/inspect-web-publish/wwwroot/index.html && test -f artifacts/inspect-web-publish/wwwroot/staticwebapp.config.json
 
       - name: Deploy to production
         uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -15,8 +15,9 @@ internal static class PromotionWorkflowContract
         "actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1";
     private const string UploadArtifactAction =
         "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
-    private const string IndexCheck =
-        "test -f artifacts/inspect-web-publish/wwwroot/index.html";
+    private const string DeploymentFilesCheck =
+        "test -f artifacts/inspect-web-publish/wwwroot/index.html && " +
+        "test -f artifacts/inspect-web-publish/wwwroot/staticwebapp.config.json";
 
     internal static void AssertMutations(string repository)
     {
@@ -97,8 +98,8 @@ internal static class PromotionWorkflowContract
             "Promotion workflow contract accepted download before revalidation.");
         AssertMutationRejected(
             stagingWorkflow,
-            $"        run: {IndexCheck}\n",
-            $"        run: {IndexCheck} || true\n",
+            $"        run: {DeploymentFilesCheck}\n",
+            $"        run: {DeploymentFilesCheck} || true\n",
             ValidateStaging,
             "Staging workflow contract accepted disabled artifact verification.");
         AssertMutationRejected(
@@ -373,7 +374,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             verify,
             "run",
-            IndexCheck,
+            DeploymentFilesCheck,
             "artifact verification step");
 
         YamlMappingNode deployStep =
@@ -624,7 +625,7 @@ internal static class PromotionWorkflowContract
         RequireScalarValue(
             verify,
             "run",
-            IndexCheck,
+            DeploymentFilesCheck,
             "staging artifact verification step");
 
         YamlMappingNode deployStep =

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -508,10 +508,16 @@ and pin their checkout, SDK setup, and artifact actions to exact commits. The
 workflow contract gate enforces those references. Azure's pinned action still
 pulls Microsoft's `staticappsclient:stable` image; that vendor-controlled
 deployment dependency is not immutable and remains inside the Azure trust
-boundary. Both workflows disable Azure's own app build. The staging publish
-step embeds the CLI's authoritative `VersionPrefix`, exact source SHA, and UTC
-build timestamp. The home and workspace status bars show that version, link
-the short commit to GitHub, and disclose the binary build time.
+boundary. Both workflows disable Azure's own app build and require the
+published artifact to contain `staticwebapp.config.json`. That configuration
+serves `/` and `/index.html` with `Cache-Control: no-cache, no-store,
+must-revalidate`, so an Azure edge cannot retain an old browser boot graph
+after its fingerprinted Wasm assets rotate.
+`BrowserStaticWebAppConfigTests.RootDocumentsAreNotCachedAndConfigIsPublished`
+gates the header contract and publish wiring. The staging publish step embeds
+the CLI's authoritative `VersionPrefix`, exact source SHA, and UTC build
+timestamp. The home and workspace status bars show that version, link the
+short commit to GitHub, and disclose the binary build time.
 `BuildIdentity_UsesVersionedRepositoryProvenance` and
 `ready status shows versioned linked build provenance` gate the engine and UI
 halves.

--- a/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace InspectWeb.Engine.Tests;
+
+public class BrowserStaticWebAppConfigTests
+{
+    [Fact]
+    public void RootDocumentsAreNotCachedAndConfigIsPublished()
+    {
+        string repository = RepositoryRoot();
+        string configPath = Path.Combine(
+            repository,
+            "prototypes",
+            "inspect-web",
+            "staticwebapp.config.json");
+
+        using JsonDocument config = JsonDocument.Parse(File.ReadAllText(configPath));
+        JsonElement[] routes =
+        [
+            .. config.RootElement.GetProperty("routes").EnumerateArray(),
+        ];
+
+        Assert.Equal(2, routes.Length);
+        AssertRoute(routes[0], "/");
+        AssertRoute(routes[1], "/index.html");
+
+        XDocument project = XDocument.Load(Path.Combine(
+            repository,
+            "prototypes",
+            "inspect-web",
+            "engine",
+            "InspectWeb.Engine.csproj"));
+        XElement content = Assert.Single(
+            project.Descendants("Content"),
+            element =>
+                (string?)element.Attribute("Include") ==
+                @"..\staticwebapp.config.json");
+
+        Assert.Equal(
+            @"wwwroot\staticwebapp.config.json",
+            (string?)content.Attribute("Link"));
+        Assert.Equal(
+            "PreserveNewest",
+            (string?)content.Attribute("CopyToPublishDirectory"));
+    }
+
+    private static void AssertRoute(JsonElement route, string expectedPath)
+    {
+        Assert.Equal(expectedPath, route.GetProperty("route").GetString());
+        Assert.Equal(
+            "no-cache, no-store, must-revalidate",
+            route
+                .GetProperty("headers")
+                .GetProperty("Cache-Control")
+                .GetString());
+    }
+
+    private static string RepositoryRoot()
+    {
+        for (DirectoryInfo? directory = new(AppContext.BaseDirectory);
+            directory is not null;
+            directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+                return directory.FullName;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not find repository root containing dotnet-inspect.slnx.");
+    }
+}

--- a/prototypes/inspect-web/engine/InspectWeb.Engine.csproj
+++ b/prototypes/inspect-web/engine/InspectWeb.Engine.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\..\..\src\ILInspector.Research\ILInspector.Research.csproj" />
     <ProjectReference Include="..\..\..\src\ILInspector.SourceLink\ILInspector.SourceLink.csproj" />
     <Content Include="..\index.html" Link="wwwroot\index.html" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\staticwebapp.config.json" Link="wwwroot\staticwebapp.config.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
     <Content Include="..\src\app.js" Link="wwwroot\src\app.js" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\src\graph-mermaid.js" Link="wwwroot\src\graph-mermaid.js" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="..\src\annotated-source-view.js" Link="wwwroot\src\annotated-source-view.js" CopyToOutputDirectory="PreserveNewest" />

--- a/prototypes/inspect-web/staticwebapp.config.json
+++ b/prototypes/inspect-web/staticwebapp.config.json
@@ -1,0 +1,16 @@
+{
+  "routes": [
+    {
+      "route": "/",
+      "headers": {
+        "Cache-Control": "no-cache, no-store, must-revalidate"
+      }
+    },
+    {
+      "route": "/index.html",
+      "headers": {
+        "Cache-Control": "no-cache, no-store, must-revalidate"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Outcome

Azure Static Web Apps will no longer cache the inspect-web root documents across deployments, preventing an old index from referencing fingerprinted runtime/Wasm files removed by a newer staging build.

## Change

- Publish `staticwebapp.config.json` with `no-cache, no-store, must-revalidate` for `/` and `/index.html`.
- Gate the exact header contract and publish wiring in `BrowserStaticWebAppConfigTests`.
- Require both staging and production artifact verification to find the configuration file.
- Keep the privileged workflow contract closed over the stronger verification command.

## Evidence

- `InspectWeb.Engine.Tests`: 55 passed.
- Real Release Wasm publish contains `wwwroot/staticwebapp.config.json` with the two routes.
- CI change-detection and deployment workflow mutation gate passed.
- JSON, YAML, Markdown, and diff checks passed.

## Boundary

The staging workflow is temporarily disabled while this fix is reviewed because frequent main deployments keep Azure custom-domain edges on incompatible boot graphs. After merge, re-enable it, deploy once, verify response headers and every referenced Wasm asset across edges, then restore normal automatic staging. Production is unchanged.
