### PR TITLE
Deploy automatic CoreCLR website staging

### DIFF
--- a/.github/workflows/deploy-inspect-web-coreclr.yml
+++ b/.github/workflows/deploy-inspect-web-coreclr.yml
@@ -1,0 +1,103 @@
+name: Deploy inspect-web CoreCLR staging
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-inspect-web-coreclr-staging
+  cancel-in-progress: true
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+  DOTNET_SDK_VERSION: '11.0.100-preview.7.26381.103'
+
+jobs:
+  build:
+    name: Build CoreCLR staging artifact
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+
+      - name: Install browser Wasm workload
+        run: dotnet workload install wasm-tools
+
+      - name: Publish CoreCLR browser app
+        shell: bash
+        run: |
+          version=$(dotnet msbuild src/dotnet-inspect/dotnet-inspect.csproj -getProperty:VersionPrefix -nologo)
+          built_at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          dotnet publish \
+            prototypes/inspect-web/engine/InspectWeb.Engine.csproj \
+            -c Release \
+            --output artifacts/inspect-web-coreclr-publish \
+            -p:VersionPrefix="$version" \
+            -p:SourceRevisionId="$GITHUB_SHA" \
+            -p:BuildTimestampUtc="$built_at" \
+            -p:UseMonoRuntime=false \
+            -p:WasmBuildNative=false \
+            -p:WasmNestedPublishAppDependsOn= \
+            -p:WasmEnableExceptionHandling=true
+
+      - name: Verify CoreCLR site artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f artifacts/inspect-web-coreclr-publish/wwwroot/index.html
+          test -f artifacts/inspect-web-coreclr-publish/wwwroot/staticwebapp.config.json
+          test "$(find artifacts/inspect-web-coreclr-publish/wwwroot/_framework -maxdepth 1 -type f -name 'dotnet.native.*.js' | wc -l)" -eq 1
+          grep -q GetDotNetRuntimeHeap artifacts/inspect-web-coreclr-publish/wwwroot/_framework/dotnet.native.*.js
+
+      - name: Upload CoreCLR staged site artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: inspect-web-coreclr-site
+          path: artifacts/inspect-web-coreclr-publish/wwwroot
+          if-no-files-found: error
+          retention-days: 30
+
+  deploy:
+    name: Publish CoreCLR staging
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: inspect-web-coreclr-staging
+      url: https://coreclr.dotnet-inspect.ca
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Download CoreCLR staged site artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: inspect-web-coreclr-site
+          path: artifacts/inspect-web-coreclr-publish/wwwroot
+          digest-mismatch: error
+
+      - name: Verify CoreCLR staged site artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f artifacts/inspect-web-coreclr-publish/wwwroot/index.html
+          test -f artifacts/inspect-web-coreclr-publish/wwwroot/staticwebapp.config.json
+          test "$(find artifacts/inspect-web-coreclr-publish/wwwroot/_framework -maxdepth 1 -type f -name 'dotnet.native.*.js' | wc -l)" -eq 1
+          grep -q GetDotNetRuntimeHeap artifacts/inspect-web-coreclr-publish/wwwroot/_framework/dotnet.native.*.js
+
+      - name: Deploy to CoreCLR staging
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_CORECLR }}
+          action: upload
+          app_location: artifacts/inspect-web-coreclr-publish/wwwroot
+          output_location: ''
+          skip_app_build: true

--- a/eng/CiChangeDetection/DetectionTestSuite.cs
+++ b/eng/CiChangeDetection/DetectionTestSuite.cs
@@ -342,6 +342,8 @@ internal static class DetectionTestSuite
         }
         foreach (string promotionInput in new[]
         {
+            ".github/workflows/deploy-inspect-web.yml",
+            ".github/workflows/deploy-inspect-web-coreclr.yml",
             ".github/workflows/promote-inspect-web.yml",
             "eng/validate-inspect-web-promotion.cs",
             "eng/validate-inspect-web-promotion.sh",

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -18,6 +18,14 @@ internal static class PromotionWorkflowContract
     private const string DeploymentFilesCheck =
         "test -f artifacts/inspect-web-publish/wwwroot/index.html && " +
         "test -f artifacts/inspect-web-publish/wwwroot/staticwebapp.config.json";
+    private const string CoreClrDeploymentFilesCheck =
+        """
+        set -euo pipefail
+        test -f artifacts/inspect-web-coreclr-publish/wwwroot/index.html
+        test -f artifacts/inspect-web-coreclr-publish/wwwroot/staticwebapp.config.json
+        test "$(find artifacts/inspect-web-coreclr-publish/wwwroot/_framework -maxdepth 1 -type f -name 'dotnet.native.*.js' | wc -l)" -eq 1
+        grep -q GetDotNetRuntimeHeap artifacts/inspect-web-coreclr-publish/wwwroot/_framework/dotnet.native.*.js
+        """;
 
     internal static void AssertMutations(string repository)
     {
@@ -31,10 +39,17 @@ internal static class PromotionWorkflowContract
             ".github",
             "workflows",
             "deploy-inspect-web.yml");
+        string coreClrStagingPath = Path.Combine(
+            repository,
+            ".github",
+            "workflows",
+            "deploy-inspect-web-coreclr.yml");
         string promotionWorkflow = File.ReadAllText(promotionPath);
         string stagingWorkflow = File.ReadAllText(stagingPath);
+        string coreClrStagingWorkflow = File.ReadAllText(coreClrStagingPath);
         ValidatePromotion(promotionWorkflow);
         ValidateStaging(stagingWorkflow);
+        ValidateCoreClrStaging(coreClrStagingWorkflow);
 
         const string trustedCheckout =
             """
@@ -78,6 +93,25 @@ internal static class PromotionWorkflowContract
             ValidateStaging,
             "Staging workflow contract accepted candidate code in the deployment job.");
 
+        const string coreClrStagingDownload =
+            """
+                steps:
+                  - name: Download CoreCLR staged site artifact
+            """;
+        const string coreClrStagingCheckout =
+            """
+                steps:
+                  - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+                  - name: Download CoreCLR staged site artifact
+            """;
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
+            coreClrStagingDownload,
+            coreClrStagingCheckout,
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted candidate code in the deployment job.");
+
         AssertMutationRejected(
             promotionWorkflow,
             "      - name: Setup .NET\n        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5",
@@ -108,6 +142,36 @@ internal static class PromotionWorkflowContract
             "",
             ValidateStaging,
             "Staging workflow contract accepted Azure app build.");
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
+            "            -p:UseMonoRuntime=false \\\n",
+            "",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted the Mono runtime.");
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
+            "            -p:WasmBuildNative=false \\\n",
+            "",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted native relinking.");
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
+            "          grep -q GetDotNetRuntimeHeap artifacts/inspect-web-coreclr-publish/wwwroot/_framework/dotnet.native.*.js\n",
+            "          grep -q GetDotNetRuntimeHeap artifacts/inspect-web-coreclr-publish/wwwroot/_framework/dotnet.native.*.js || true\n",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted disabled runtime verification.");
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
+            "secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_CORECLR",
+            "secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_STAGING",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted the Mono staging credential.");
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
+            "          skip_app_build: true\n",
+            "",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted Azure app build.");
 
         const string productionJob =
             """
@@ -171,6 +235,26 @@ internal static class PromotionWorkflowContract
             """,
             ValidateStaging,
             "Staging workflow contract accepted PR-head checkout.");
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
+            "  workflow_dispatch:\n",
+            "  workflow_dispatch:\n  pull_request_target:\n",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted pull_request_target.");
+
+        AssertRejected(
+            coreClrStagingWorkflow +
+            """
+
+              bypass:
+                name: Bypass CoreCLR staging
+                environment: inspect-web-coreclr-staging
+                runs-on: ubuntu-26.04
+                steps:
+                  - run: echo bypass
+            """,
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted an extra environment-scoped job.");
     }
 
     private static void ValidatePromotion(string workflow)
@@ -651,6 +735,335 @@ internal static class PromotionWorkflowContract
                 ["skip_app_build"] = "true",
             },
             "staging deploy step.with");
+    }
+
+    private static void ValidateCoreClrStaging(string workflow)
+    {
+        using TextReader reader = new StringReader(workflow);
+        YamlStream yaml = [];
+        yaml.Load(reader);
+        if (yaml.Documents.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected one CoreCLR staging workflow document, found {yaml.Documents.Count}.");
+        }
+
+        YamlMappingNode root = RequireMapping(
+            yaml.Documents[0].RootNode,
+            "CoreCLR staging workflow root");
+        RequireExactKeys(
+            root,
+            ["name", "on", "permissions", "concurrency", "env", "jobs"],
+            "CoreCLR staging workflow");
+        RequireScalarValue(
+            root,
+            "name",
+            "Deploy inspect-web CoreCLR staging",
+            "CoreCLR staging workflow");
+        ValidateStagingTrigger(
+            GetRequiredMapping(root, "on", "CoreCLR staging workflow"));
+        RequireExactScalarValues(
+            GetRequiredMapping(root, "permissions", "CoreCLR staging workflow"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["contents"] = "read",
+            },
+            "CoreCLR staging workflow.permissions");
+        RequireExactScalarValues(
+            GetRequiredMapping(root, "concurrency", "CoreCLR staging workflow"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["group"] = "deploy-inspect-web-coreclr-staging",
+                ["cancel-in-progress"] = "true",
+            },
+            "CoreCLR staging workflow.concurrency");
+        RequireExactScalarValues(
+            GetRequiredMapping(root, "env", "CoreCLR staging workflow"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["DOTNET_CLI_TELEMETRY_OPTOUT"] = "true",
+                ["DOTNET_NOLOGO"] = "true",
+                ["DOTNET_SDK_VERSION"] = "11.0.100-preview.7.26381.103",
+            },
+            "CoreCLR staging workflow.env");
+
+        YamlMappingNode jobs =
+            GetRequiredMapping(root, "jobs", "CoreCLR staging workflow");
+        RequireExactKeys(jobs, ["build", "deploy"], "CoreCLR staging jobs");
+
+        YamlMappingNode build =
+            GetRequiredMapping(jobs, "build", "CoreCLR staging jobs");
+        RequireExactKeys(
+            build,
+            ["name", "if", "runs-on", "steps"],
+            "CoreCLR jobs.build");
+        RequireScalarValue(
+            build,
+            "name",
+            "Build CoreCLR staging artifact",
+            "CoreCLR jobs.build");
+        RequireScalarValue(
+            build,
+            "if",
+            "github.ref == 'refs/heads/main'",
+            "CoreCLR jobs.build");
+        RequireScalarValue(
+            build,
+            "runs-on",
+            "ubuntu-26.04",
+            "CoreCLR jobs.build");
+
+        YamlSequenceNode buildSteps =
+            GetRequiredSequence(build, "steps", "CoreCLR jobs.build");
+        if (buildSteps.Children.Count != 6)
+        {
+            throw new InvalidOperationException(
+                "CoreCLR staging build must contain checkout, setup, workload " +
+                "install, publish, verification, and artifact upload steps.");
+        }
+
+        YamlMappingNode checkout =
+            RequireStep(buildSteps, 0, null, "CoreCLR jobs.build");
+        RequireExactKeys(checkout, ["uses"], "CoreCLR staging build checkout");
+        RequireScalarValue(
+            checkout,
+            "uses",
+            CheckoutAction,
+            "CoreCLR staging build checkout");
+
+        YamlMappingNode setup =
+            RequireStep(buildSteps, 1, "Setup .NET", "CoreCLR jobs.build");
+        RequireExactKeys(
+            setup,
+            ["name", "uses", "with"],
+            "CoreCLR staging setup step");
+        RequireScalarValue(
+            setup,
+            "uses",
+            SetupDotnetAction,
+            "CoreCLR staging setup step");
+        RequireExactScalarValues(
+            GetRequiredMapping(setup, "with", "CoreCLR staging setup step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["dotnet-version"] = "${{ env.DOTNET_SDK_VERSION }}",
+            },
+            "CoreCLR staging setup step.with");
+
+        YamlMappingNode install =
+            RequireStep(
+                buildSteps,
+                2,
+                "Install browser Wasm workload",
+                "CoreCLR jobs.build");
+        RequireExactScalarValues(
+            install,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["name"] = "Install browser Wasm workload",
+                ["run"] = "dotnet workload install wasm-tools",
+            },
+            "CoreCLR staging workload step");
+
+        YamlMappingNode publish =
+            RequireStep(
+                buildSteps,
+                3,
+                "Publish CoreCLR browser app",
+                "CoreCLR jobs.build");
+        RequireExactKeys(
+            publish,
+            ["name", "shell", "run"],
+            "CoreCLR staging publish step");
+        RequireScalarValue(
+            publish,
+            "shell",
+            "bash",
+            "CoreCLR staging publish step");
+        const string ExpectedPublish =
+            """
+            version=$(dotnet msbuild src/dotnet-inspect/dotnet-inspect.csproj -getProperty:VersionPrefix -nologo)
+            built_at=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            dotnet publish \
+              prototypes/inspect-web/engine/InspectWeb.Engine.csproj \
+              -c Release \
+              --output artifacts/inspect-web-coreclr-publish \
+              -p:VersionPrefix="$version" \
+              -p:SourceRevisionId="$GITHUB_SHA" \
+              -p:BuildTimestampUtc="$built_at" \
+              -p:UseMonoRuntime=false \
+              -p:WasmBuildNative=false \
+              -p:WasmNestedPublishAppDependsOn= \
+              -p:WasmEnableExceptionHandling=true
+            """;
+        if (GetRequiredScalar(
+                publish,
+                "run",
+                "CoreCLR staging publish step").TrimEnd() != ExpectedPublish)
+        {
+            throw new InvalidOperationException(
+                "CoreCLR staging publish command does not match the trusted contract.");
+        }
+
+        YamlMappingNode buildVerify =
+            RequireStep(
+                buildSteps,
+                4,
+                "Verify CoreCLR site artifact",
+                "CoreCLR jobs.build");
+        ValidateCoreClrArtifactVerification(
+            buildVerify,
+            "CoreCLR build artifact verification step");
+
+        YamlMappingNode upload =
+            RequireStep(
+                buildSteps,
+                5,
+                "Upload CoreCLR staged site artifact",
+                "CoreCLR jobs.build");
+        RequireExactKeys(
+            upload,
+            ["name", "uses", "with"],
+            "CoreCLR staging artifact upload step");
+        RequireScalarValue(
+            upload,
+            "uses",
+            UploadArtifactAction,
+            "CoreCLR staging artifact upload step");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                upload,
+                "with",
+                "CoreCLR staging artifact upload step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["name"] = "inspect-web-coreclr-site",
+                ["path"] = "artifacts/inspect-web-coreclr-publish/wwwroot",
+                ["if-no-files-found"] = "error",
+                ["retention-days"] = "30",
+            },
+            "CoreCLR staging artifact upload step.with");
+
+        YamlMappingNode deploy =
+            GetRequiredMapping(jobs, "deploy", "CoreCLR staging jobs");
+        RequireExactKeys(
+            deploy,
+            ["name", "needs", "if", "environment", "runs-on", "steps"],
+            "CoreCLR jobs.deploy");
+        RequireScalarValue(deploy, "needs", "build", "CoreCLR jobs.deploy");
+        RequireScalarValue(
+            deploy,
+            "name",
+            "Publish CoreCLR staging",
+            "CoreCLR jobs.deploy");
+        RequireScalarValue(
+            deploy,
+            "if",
+            "github.ref == 'refs/heads/main'",
+            "CoreCLR jobs.deploy");
+        RequireScalarValue(
+            deploy,
+            "runs-on",
+            "ubuntu-26.04",
+            "CoreCLR jobs.deploy");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                deploy,
+                "environment",
+                "CoreCLR jobs.deploy"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["name"] = "inspect-web-coreclr-staging",
+                ["url"] = "https://coreclr.dotnet-inspect.ca",
+            },
+            "CoreCLR jobs.deploy.environment");
+
+        YamlSequenceNode deploySteps =
+            GetRequiredSequence(deploy, "steps", "CoreCLR jobs.deploy");
+        if (deploySteps.Children.Count != 3)
+        {
+            throw new InvalidOperationException(
+                "CoreCLR staging deployment must contain only artifact download, " +
+                "artifact verification, and deploy steps.");
+        }
+
+        YamlMappingNode download =
+            RequireStep(
+                deploySteps,
+                0,
+                "Download CoreCLR staged site artifact");
+        RequireExactKeys(
+            download,
+            ["name", "uses", "with"],
+            "CoreCLR staging artifact download step");
+        RequireScalarValue(
+            download,
+            "uses",
+            DownloadArtifactAction,
+            "CoreCLR staging artifact download step");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                download,
+                "with",
+                "CoreCLR staging artifact download step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["name"] = "inspect-web-coreclr-site",
+                ["path"] = "artifacts/inspect-web-coreclr-publish/wwwroot",
+                ["digest-mismatch"] = "error",
+            },
+            "CoreCLR staging artifact download step.with");
+
+        YamlMappingNode deployVerify =
+            RequireStep(
+                deploySteps,
+                1,
+                "Verify CoreCLR staged site artifact");
+        ValidateCoreClrArtifactVerification(
+            deployVerify,
+            "CoreCLR staging artifact verification step");
+
+        YamlMappingNode deployStep =
+            RequireStep(deploySteps, 2, "Deploy to CoreCLR staging");
+        RequireExactKeys(
+            deployStep,
+            ["name", "uses", "with"],
+            "CoreCLR staging deploy step");
+        RequireScalarValue(
+            deployStep,
+            "uses",
+            AzureAction,
+            "CoreCLR staging deploy step");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                deployStep,
+                "with",
+                "CoreCLR staging deploy step"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["azure_static_web_apps_api_token"] =
+                    "${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_CORECLR }}",
+                ["action"] = "upload",
+                ["app_location"] =
+                    "artifacts/inspect-web-coreclr-publish/wwwroot",
+                ["output_location"] = "",
+                ["skip_app_build"] = "true",
+            },
+            "CoreCLR staging deploy step.with");
+    }
+
+    private static void ValidateCoreClrArtifactVerification(
+        YamlMappingNode step,
+        string context)
+    {
+        RequireExactKeys(step, ["name", "shell", "run"], context);
+        RequireScalarValue(step, "shell", "bash", context);
+        if (GetRequiredScalar(step, "run", context).TrimEnd() !=
+            CoreClrDeploymentFilesCheck)
+        {
+            throw new InvalidOperationException(
+                $"{context} does not match the trusted contract.");
+        }
     }
 
     private static void ValidatePromotionTrigger(YamlMappingNode on)

--- a/eng/ci-detect-changes.sh
+++ b/eng/ci-detect-changes.sh
@@ -327,6 +327,7 @@ while IFS= read -r -d '' file; do
     *.props|*.targets|*.sln|*.slnx) CODE=true; WEB=true ;;
     .github/workflows/ci.yml) CODE=true; WEB=true ;;
     .github/workflows/deploy-inspect-web.yml) WEB=true ;;
+    .github/workflows/deploy-inspect-web-coreclr.yml) WEB=true ;;
     .github/workflows/promote-inspect-web.yml) WEB=true ;;
     .github/workflows/*) CODE=true ;;
   esac

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -474,6 +474,18 @@ the staging deployment job. The separate `inspect-web-staging` GitHub
 environment accepts only `main` and holds a deployment token scoped to the
 staging Azure Static Web App.
 
+`.github/workflows/deploy-inspect-web-coreclr.yml` publishes the same `main`
+commit to the isolated comparison site at
+`https://coreclr.dotnet-inspect.ca`. It uses a third Azure Static Web App, the
+main-only `inspect-web-coreclr-staging` environment, a distinct deployment
+token, and the non-promotable `inspect-web-coreclr-site` artifact. The site is
+interpreter-only while the .NET 11 Preview 7 SDK lacks the packaged headers and
+Emscripten cache wiring needed for CoreCLR native relinking. The workflow pins
+the proven preview SDK and the `UseMonoRuntime=false`,
+`WasmBuildNative=false`, `WasmNestedPublishAppDependsOn=`, and
+`WasmEnableExceptionHandling=true` overrides. It verifies the CoreCLR-specific
+`GetDotNetRuntimeHeap` hook before and after artifact transfer.
+
 `.github/workflows/promote-inspect-web.yml` intentionally promotes one
 successful staging run to production at `https://dotnet-inspect.net`. The
 operator supplies the staging run ID and types `promote`; the workflow verifies
@@ -484,11 +496,11 @@ the run attempt, commit, artifact identity, and digest, downloads the exact
 artifact ID with digest mismatch configured as an error, and deploys the
 archived staging files. `validate-inspect-web-promotion.cs --self-test`, run
 by inspect-web CI, gates the evidence discriminator and close negative cases;
-the CI change-detection workflow contract gate keeps both deployment jobs free
-of candidate code, keeps production revalidation on the trusted dispatch
-revision, and orders each artifact download before only verification and
-deployment. Manual staging runs remain useful for recovery but are deliberately
-not promotable.
+the CI change-detection workflow contract gate keeps all deployment jobs free
+of candidate code, closes the CoreCLR runtime and credential contract, keeps
+production revalidation on the trusted dispatch revision, and orders each
+artifact download before only verification and deployment. Manual staging runs
+remain useful for recovery but are deliberately not promotable.
 
 Production promotion uses the distinct `inspect-web-production-promotion`
 environment and `AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_PRODUCTION`
@@ -500,16 +512,16 @@ repository-scoped token. Token rotation invalidates credentials already copied
 into queued parent-era jobs; deleting both old secret locations makes later
 reruns fail closed.
 
-Both deployment workflows pin the Azure deployment action to an exact commit
-and pin their checkout, SDK setup, and artifact actions to exact commits. The
-workflow contract gate enforces those references. Azure's pinned action still
-pulls Microsoft's `staticappsclient:stable` image; that vendor-controlled
-deployment dependency is not immutable and remains inside the Azure trust
-boundary. Both workflows disable Azure's own app build and require the
-published artifact to contain `staticwebapp.config.json`. That configuration
-serves `/` and `/index.html` with `Cache-Control: no-cache, no-store,
-must-revalidate`, so an Azure edge cannot retain an old browser boot graph
-after its fingerprinted Wasm assets rotate.
+All three deployment workflows pin the Azure deployment action to an exact
+commit and pin their checkout, SDK setup, and artifact actions to exact
+commits. The workflow contract gate enforces those references. Azure's pinned
+action still pulls Microsoft's `staticappsclient:stable` image; that
+vendor-controlled deployment dependency is not immutable and remains inside
+the Azure trust boundary. All three workflows disable Azure's own app build
+and require the published artifact to contain `staticwebapp.config.json`. That
+configuration serves `/` and `/index.html` with `Cache-Control: no-cache,
+no-store, must-revalidate`, so an Azure edge cannot retain an old browser boot
+graph after its fingerprinted Wasm assets rotate.
 `BrowserStaticWebAppConfigTests.RootDocumentsAreNotCachedAndConfigIsPublished`
 gates the header contract and publish wiring. The staging publish step embeds
 the CLI's authoritative `VersionPrefix`, exact source SHA, and UTC build
@@ -523,9 +535,8 @@ The Azure resources, custom-domain assignments, GitHub environments, branch
 restrictions, required production reviewer, and environment-scoped deployment
 tokens live outside this repository and are **not** verified by anything in it.
 Treat successful staging and promotion runs, not this file, as evidence that
-the corresponding deployed site is current. The staging domain is intentionally
-not publicized, but it is public infrastructure and is not a confidentiality
-boundary.
+the corresponding deployed site is current. Both staging domains are public
+infrastructure and are not confidentiality boundaries.
 
 See [architecture-spike.md](architecture-spike.md) for the proposed .NET 11
 browser engine and the NativeAOT decision.

--- a/prototypes/inspect-web/architecture-spike.md
+++ b/prototypes/inspect-web/architecture-spike.md
@@ -59,7 +59,7 @@ There are three different ideas often called ".NET AOT to Wasm":
 | Path | Browser DOM host | Status for this prototype |
 | --- | --- | --- |
 | Mono browser AOT | Yes | Supported baseline for .NET 11 |
-| CoreCLR/RyuJIT browser Wasm | Early .NET 11 preview | Track, but do not make it a prototype dependency |
+| CoreCLR/RyuJIT browser Wasm | Early .NET 11 preview | Deploy as an isolated comparison; retain Mono as the baseline |
 | NativeAOT-LLVM browser Wasm | Experimental branch | Rejected: no maintained browser product path |
 | NativeAOT for `wasi-wasm` | No direct DOM/browser host | Useful for WASI components, not the frontend engine |
 
@@ -68,6 +68,13 @@ not an appropriate product dependency. Current activity is centered on WASI,
 while the browser `dotnet.js` work remains an experimental runtimelab path.
 The app will retain dotnet-inspect's trimming and NativeAOT-friendly product
 constraints without depending on that runtime.
+
+The comparison deployment at <https://coreclr.dotnet-inspect.ca> exercises the
+packaged CoreCLR interpreter from .NET 11 Preview 7 without changing the
+prototype's Mono default or production promotion path. It remains an
+experimental deployment rather than a product dependency until the browser
+runtime and native toolchain are complete enough to replace those explicit
+preview workarounds.
 
 Create a focused engine spike before wiring the full app:
 


### PR DESCRIPTION
Deploy every merged `main` commit to an isolated CoreCLR browser comparison site at https://coreclr.dotnet-inspect.ca while retaining Mono staging as the production-promotion source.

- builds with .NET 11 Preview 7 and the proven interpreter-only CoreCLR overrides
- transfers a distinct immutable artifact into a fresh environment-gated deployment job
- uses the main-only `inspect-web-coreclr-staging` environment and its dedicated Azure token
- verifies the CoreCLR-specific `GetDotNetRuntimeHeap` marker before and after artifact transfer
- closes triggers, permissions, action pins, artifact identity, runtime flags, credential identity, and change-detection routing in the workflow mutation contract

The CoreCLR workflow is intentionally non-promotable; production promotion remains bound to the Mono staging workflow and `inspect-web-site` artifact. Azure resource, DNS, custom-domain, environment-policy, and secret configuration are external and not proven by repository tests. The custom domain is currently Ready in Azure.

Base: `a13b5666987872936698f33a6da4ecb58516418e`
Head: `5a828c6b253eda43c660cd78bbe40cc4860eaf23`

Validation:
- `dotnet run eng/test-ci-change-detection.cs`
- `dotnet run --project prototypes/inspect-web/engine.Tests/InspectWeb.Engine.Tests.csproj -c Release` (55 passed)
- clean CoreCLR Release publish with the workflow four runtime overrides and `GetDotNetRuntimeHeap` artifact check
- `npx markdownlint-cli prototypes/inspect-web/README.md prototypes/inspect-web/architecture-spike.md`
- `bash -n eng/ci-detect-changes.sh`