### PR TITLE
Exercise runtime async in CoreCLR website staging

### DIFF
--- a/.github/workflows/deploy-inspect-web-coreclr.yml
+++ b/.github/workflows/deploy-inspect-web-coreclr.yml
@@ -46,6 +46,7 @@ jobs:
             -p:VersionPrefix="$version" \
             -p:SourceRevisionId="$GITHUB_SHA" \
             -p:BuildTimestampUtc="$built_at" \
+            -p:Features=runtime-async=on \
             -p:UseMonoRuntime=false \
             -p:WasmBuildNative=false \
             -p:WasmNestedPublishAppDependsOn= \

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,8 +15,10 @@
     <PublishReferencesDocumentationFiles>false</PublishReferencesDocumentationFiles>
   </PropertyGroup>
 
-  <!-- Runtime async is a NativeAOT optimization. Other runtimes use the compiler
-       default, which emits classic async state machines. -->
+  <!-- Runtime async is enabled by default only for NativeAOT. Ordinary non-AOT
+       builds use the compiler default, which emits classic async state machines.
+       The CoreCLR Browser comparison workflow opts in explicitly for that one
+       published application graph. -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net11.0' and '$(PublishAot)' == 'true'">
     <Features>$(Features);runtime-async=on</Features>
   </PropertyGroup>

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -144,6 +144,12 @@ internal static class PromotionWorkflowContract
             "Staging workflow contract accepted Azure app build.");
         AssertMutationRejected(
             coreClrStagingWorkflow,
+            "            -p:Features=runtime-async=on \\\n",
+            "",
+            ValidateCoreClrStaging,
+            "CoreCLR staging contract accepted classic async lowering.");
+        AssertMutationRejected(
+            coreClrStagingWorkflow,
             "            -p:UseMonoRuntime=false \\\n",
             "",
             ValidateCoreClrStaging,
@@ -891,6 +897,7 @@ internal static class PromotionWorkflowContract
               -p:VersionPrefix="$version" \
               -p:SourceRevisionId="$GITHUB_SHA" \
               -p:BuildTimestampUtc="$built_at" \
+              -p:Features=runtime-async=on \
               -p:UseMonoRuntime=false \
               -p:WasmBuildNative=false \
               -p:WasmNestedPublishAppDependsOn= \

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -481,10 +481,13 @@ main-only `inspect-web-coreclr-staging` environment, a distinct deployment
 token, and the non-promotable `inspect-web-coreclr-site` artifact. The site is
 interpreter-only while the .NET 11 Preview 7 SDK lacks the packaged headers and
 Emscripten cache wiring needed for CoreCLR native relinking. The workflow pins
-the proven preview SDK and the `UseMonoRuntime=false`,
-`WasmBuildNative=false`, `WasmNestedPublishAppDependsOn=`, and
-`WasmEnableExceptionHandling=true` overrides. It verifies the CoreCLR-specific
-`GetDotNetRuntimeHeap` hook before and after artifact transfer.
+the proven preview SDK, enables `runtime-async=on` across this application
+graph, and applies the `UseMonoRuntime=false`, `WasmBuildNative=false`,
+`WasmNestedPublishAppDependsOn=`, and `WasmEnableExceptionHandling=true`
+overrides. This exercises runtime async only in the CoreCLR comparison
+deployment; Mono staging and ordinary non-AOT builds retain classic async
+lowering. The workflow verifies the CoreCLR-specific `GetDotNetRuntimeHeap`
+hook before and after artifact transfer.
 
 `.github/workflows/promote-inspect-web.yml` intentionally promotes one
 successful staging run to production at `https://dotnet-inspect.net`. The

--- a/prototypes/inspect-web/architecture-spike.md
+++ b/prototypes/inspect-web/architecture-spike.md
@@ -74,7 +74,9 @@ packaged CoreCLR interpreter from .NET 11 Preview 7 without changing the
 prototype's Mono default or production promotion path. It remains an
 experimental deployment rather than a product dependency until the browser
 runtime and native toolchain are complete enough to replace those explicit
-preview workarounds.
+preview workarounds. Its publish explicitly enables runtime async across the
+application graph so the comparison continuously exercises that CoreCLR
+capability while Mono staging retains classic async lowering.
 
 Create a focused engine spike before wiring the full app:
 


### PR DESCRIPTION
Enable compiler runtime async across only the CoreCLR comparison publish graph, so every `main` deployment at https://coreclr.dotnet-inspect.ca continuously exercises the CoreCLR implementation while Mono staging and ordinary non-AOT builds retain classic async lowering.

This follows #4384: NativeAOT remains the only repository-default opt-in. The CoreCLR workflow is the narrow non-AOT exception and passes `Features=runtime-async=on` as a global publish property, which applies to every project compiled for that one application. The exact workflow mutation contract rejects removal of the flag.

Behavioral evidence on .NET 11 Preview 7:
- the current CoreCLR publish emitted 0 runtime-async methods across `InspectWeb.Engine` and `NuGetFetch`
- the same clean publish with `Features=runtime-async=on` emitted 95 across those assemblies
- the runtime-async CoreCLR artifact started in headless Edge, queried the NuGet Gallery, loaded `System.Text.Json` 10.0.0/net10.0, and displayed 81 public types
- workflow contract, 55 Browser JavaScript tests, Markdown lint, C# formatting, and diff checks passed

Non-action: Mono staging and production promotion remain unchanged; CoreCLR remains interpreter-only and non-promotable.

Base: `8e228992f66f5ca704bc7c0bb32a5938b5741ea1`
Head: `85bac45cf055e3d6d5920fd492662ce676993c8e`