### PR TITLE
Exclude network SourceLink audits from alone/together gate

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -16562,6 +16562,18 @@ public partial class CommandExecutionTests
             SectionNames.BodyShapes,
         ];
 
+        // Network SourceLink audits issue one HEAD/GET per source file. Their counts move with
+        // host load and rate limits between the together process and each alone process, so a
+        // mismatch proves transport nondeterminism, not a missing prerequisite. Offline
+        // SourceLink: Diagnostics (cache-only PDB facts) stays in the set. SourceLink: Files is
+        // registered without a scanner or query key, so it is not in this coverage set.
+        string[] networkSourceLink =
+        [
+            SectionNames.SourceLinkAvailability,
+            SectionNames.SourceLinkMissingFiles,
+            SectionNames.SourceLinkIntegrity,
+        ];
+
         var registry = LibrarySections.CreateScannerRegistry();
         var pipeline = LibrarySections.CreatePipeline();
 
@@ -16572,7 +16584,7 @@ public partial class CommandExecutionTests
 
         // Excluding a name that no longer exists would silently shrink to a no-op, so the
         // exclusion must still name a real data-bound section.
-        foreach (var name in parameterScoped)
+        foreach (var name in parameterScoped.Concat(networkSourceLink))
             Assert.Contains(name, bound);
 
         var scannerNames = pipeline.ScannerBoundSections
@@ -16584,6 +16596,7 @@ public partial class CommandExecutionTests
         var names = scannerNames
             .Concat(queryNames)
             .Where(n => !parameterScoped.Contains(n, StringComparer.Ordinal))
+            .Where(n => !networkSourceLink.Contains(n, StringComparer.Ordinal))
             .Distinct(StringComparer.Ordinal)
             .OrderBy(n => n, StringComparer.Ordinal)
             .ToArray();


### PR DESCRIPTION
## Summary

`LibrarySections_RenderIdenticallyAloneAndTogether` failed on Windows CI for #4332 after the negative-ZIP64 tip landed: alone vs together runs of **SourceLink: Availability / Missing Files / Integrity** disagreed on Missing / CR-LF / Source Files counts.

Those sections issue one HEAD/GET per source file. Count drift between processes under host load is **transport nondeterminism**, not a missing section prerequisite — which is what this gate is for.

## Change

- Exclude the three network SourceLink audits from the alone/together name set.
- Keep offline **SourceLink: Diagnostics** in coverage.
- Assert the excluded names remain pipeline-bound so the exclusion cannot silently rot.

## Evidence

- CI failure on `9ef05696a` (`test-windows`): three theory cases with Missing/CRLF count deltas only on SourceLink audit bodies.
- Linux same SHA green (timing/load differ).
- Product path unchanged; test scope only.

## Non-action

Does not change SourceLink acquisition, budgets, or Browser source behavior from #4332.

## Validation

- Diff-reviewed compile-level change (constants already used by pipeline).
- Full alone/together theory is multi-process and network-heavy; CI is the intended host for Windows confirmation.

Trivial tier: test exclusion only; no product behavior change.