### PR TITLE
Match explicit-interface accessors by MethodDef name

### DIFF
--- a/src/ILInspector.Analysis.Tests/CallGraphMemberResolverTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphMemberResolverTests.cs
@@ -343,6 +343,87 @@ public sealed class CallGraphMemberResolverTests
     }
 
     [Fact]
+    public void Resolve_MatchesExplicitInterfaceAccessorNameAcrossProducers()
+    {
+        var member = new ApiMember
+        {
+            Name = "INamed.Value",
+            Kind = "property",
+            ReturnType = "int",
+            GetterToken = 0x06000002,
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "int",
+                Accessors =
+                [
+                    new ApiAccessor
+                    {
+                        Kind = "get",
+                        Name = "INamed.get_Value",
+                    },
+                ],
+            },
+        };
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Owner",
+            Members = [member],
+        };
+        var graph = CallGraphMemberResolver.CreateSelector(new MemberRef(
+            TypeRef.Definition("Samples", "Samples", "Owner"),
+            "INamed.get_Value",
+            ImmutableArray<TypeRef>.Empty,
+            TypeRef.CoreLib("System", "Int32"),
+            MemberKind.Method)
+        {
+            HasThis = true,
+        });
+
+        var getter = Assert.Single(CallGraphMemberResolver.CreateBodySelectors(type, member));
+        Assert.Equal("INamed.get_Value", getter.MemberName);
+        Assert.NotEqual("get_INamed.Value", getter.MemberName);
+        Assert.Equal(graph.Key, getter.SelectorKey);
+        Assert.Equal(
+            0x06000002,
+            CallGraphMemberResolver.Resolve(type, graph.Name, graph.Key)!.BodyToken);
+    }
+
+    [Fact]
+    public void Resolve_MatchesCompiledExplicitInterfaceAccessorAcrossProducers()
+    {
+        using var stream = File.OpenRead(typeof(ExplicitAccessorFixtures).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        ApiType type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(ExplicitAccessorFixtures));
+        ApiMember member = Assert.Single(
+            type.Members,
+            candidate => candidate.Kind == "property"
+                && candidate.Name.EndsWith(
+                    $".{nameof(IExplicitAccessor.Value)}",
+                    StringComparison.Ordinal));
+        CallGraphMemberBodySelector getter = Assert.Single(
+            CallGraphMemberResolver.CreateBodySelectors(type, member),
+            selector => selector.BodyToken == member.GetterToken);
+
+        MemberRef reference = MemberResolver.ResolveMethod(
+            peReader.GetMetadataReader(),
+            MetadataTokens.EntityHandle(getter.BodyToken),
+            GenericScope.Empty);
+        CallGraphMemberSelector graph = CallGraphMemberResolver.CreateSelector(reference);
+
+        Assert.Equal(reference.Name, getter.MemberName);
+        Assert.False(getter.MemberName.StartsWith("get_", StringComparison.Ordinal));
+        Assert.Contains(".get_", getter.MemberName, StringComparison.Ordinal);
+        Assert.Equal(graph.Key, getter.SelectorKey);
+        Assert.Equal(
+            getter.BodyToken,
+            CallGraphMemberResolver.Resolve(type, graph.Name, graph.Key)!.BodyToken);
+    }
+
+    [Fact]
     public void Selector_KeepsDisplaySpellingWhenModifiersArePresent()
     {
         var modified = TypeRef.UnsupportedModified(
@@ -1094,4 +1175,14 @@ public sealed class CallGraphMemberResolverTests
 public sealed class InitAccessorFixtures
 {
     public int Value { get; init; }
+}
+
+public interface IExplicitAccessor
+{
+    int Value { get; }
+}
+
+public sealed class ExplicitAccessorFixtures : IExplicitAccessor
+{
+    int IExplicitAccessor.Value => 1;
 }

--- a/src/ILInspector.Analysis/CallGraphMemberResolver.cs
+++ b/src/ILInspector.Analysis/CallGraphMemberResolver.cs
@@ -18,6 +18,8 @@ namespace ILInspector.Analysis;
 /// gates modifier, pinned, and function-pointer header identity across both producers.
 /// <c>CallGraphMemberResolverTests.Resolve_MatchesCompiledInitSetterAcrossProducers</c>
 /// gates <c>init</c> setter <c>modreq(IsExternalInit)</c> identity from extract through MemberRef.
+/// <c>CallGraphMemberResolverTests.Resolve_MatchesCompiledExplicitInterfaceAccessorAcrossProducers</c>
+/// gates explicit-interface accessor MethodDef names (<c>I.get_P</c>, not <c>get_I.P</c>).
 /// </remarks>
 public static class CallGraphMemberResolver
 {
@@ -175,7 +177,9 @@ public static class CallGraphMemberResolver
 
     /// <summary>
     /// Resolves an exact method or accessor. A MethodDef token wins within the already
-    /// selected type; structural fallback succeeds only for one unique candidate.
+    /// selected type; structural fallback succeeds only for one unique body. An
+    /// explicit-interface accessor may appear as both a method row and a property
+    /// accessor; those are one body, not a conflict.
     /// </summary>
     public static CallGraphMemberResolution? Resolve(
         ApiType type,
@@ -196,8 +200,8 @@ public static class CallGraphMemberResolver
                     && string.Equals(candidate.MemberName, memberName, StringComparison.Ordinal)
                     && string.Equals(candidate.SelectorKey, selectorKey, StringComparison.Ordinal))
                 .ToArray();
-            if (tokenMatches.Length == 1)
-                return tokenMatches[0].Resolution;
+            if (UniqueBody(tokenMatches) is { } tokenResolution)
+                return tokenResolution;
         }
 
         var matches = type.Members
@@ -206,7 +210,22 @@ public static class CallGraphMemberResolver
                 string.Equals(candidate.MemberName, memberName, StringComparison.Ordinal)
                 && string.Equals(candidate.SelectorKey, selectorKey, StringComparison.Ordinal))
             .ToArray();
-        return matches.Length == 1 ? matches[0].Resolution : null;
+        return UniqueBody(matches);
+    }
+
+    static CallGraphMemberResolution? UniqueBody(AccessorCandidate[] matches)
+    {
+        if (matches.Length == 0)
+            return null;
+
+        int token = matches[0].Resolution.BodyToken;
+        if (matches.Any(match => match.Resolution.BodyToken != token))
+            return null;
+
+        return matches
+            .FirstOrDefault(match => match.Resolution.Member.MetadataToken == token)
+            ?.Resolution
+            ?? matches[0].Resolution;
     }
 
     static IEnumerable<AccessorCandidate> CandidateBodies(ApiType type, ApiMember member)
@@ -220,7 +239,7 @@ public static class CallGraphMemberResolver
         if (member.GetterToken is int getter)
         {
             var selector = CreateSelector(
-                $"get_{member.Name}",
+                AccessorMethodName(member, "get", $"get_{member.Name}"),
                 0,
                 !member.IsStatic,
                 owner.ParameterTypes,
@@ -233,7 +252,7 @@ public static class CallGraphMemberResolver
         if (member.SetterToken is int setter)
         {
             var selector = CreateSelector(
-                $"set_{member.Name}",
+                AccessorMethodName(member, "set", $"set_{member.Name}"),
                 0,
                 !member.IsStatic,
                 owner.ParameterTypes.Append(owner.ReturnType),
@@ -246,7 +265,7 @@ public static class CallGraphMemberResolver
         if (member.AdderToken is int adder)
         {
             var selector = CreateSelector(
-                $"add_{member.Name}",
+                AccessorMethodName(member, "add", $"add_{member.Name}"),
                 0,
                 !member.IsStatic,
                 [owner.ReturnType],
@@ -259,7 +278,7 @@ public static class CallGraphMemberResolver
         if (member.RemoverToken is int remover)
         {
             var selector = CreateSelector(
-                $"remove_{member.Name}",
+                AccessorMethodName(member, "remove", $"remove_{member.Name}"),
                 0,
                 !member.IsStatic,
                 [owner.ReturnType],
@@ -268,6 +287,15 @@ public static class CallGraphMemberResolver
                 AccessorStructuralReturn(member, "remove", "System.Void"));
             yield return new(selector.Name, selector.Key, new(type, member, remover));
         }
+    }
+
+    static string AccessorMethodName(ApiMember member, string kind, string fallback)
+    {
+        string? name = member.SignatureModel?.Accessors
+            .FirstOrDefault(accessor =>
+                string.Equals(accessor.Kind, kind, StringComparison.Ordinal))
+            ?.Name;
+        return string.IsNullOrEmpty(name) ? fallback : name;
     }
 
     static string AccessorStructuralReturn(ApiMember member, string kind, string fallback)

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -629,6 +629,14 @@ public class ApiAccessor
     public List<string> ReturnAttributes { get; set; } = [];
 
     /// <summary>
+    /// The accessor MethodDef name. Ordinary properties use <c>get_Value</c>;
+    /// explicit-interface properties use <c>I.get_Value</c>, which is not
+    /// <c>get_</c> prefixed onto the property display name. Null on older
+    /// serialized surfaces.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
     /// Opaque structural return-type identity for the accessor method itself.
     /// Null when the display spelling is already injective, including ordinary
     /// <c>void</c> setters. <c>init</c> setters carry

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1217,7 +1217,8 @@ public static class ApiSurfaceExtractor
                     },
                     eventTypeNodeProvider,
                     typeContext,
-                    observeText);
+                    observeText,
+                    observeDecodeWork);
 
                 string eventName = DecodeString(
                     reader,
@@ -3842,7 +3843,8 @@ public static class ApiSurfaceExtractor
             },
             typeNodeProvider,
             context,
-            beforeRetainText);
+            beforeRetainText,
+            beforeDecodeWork);
 
         var requiredPrefix = AttributeReader.HasRequiredMemberAttribute(
                 reader,
@@ -3994,17 +3996,36 @@ public static class ApiSurfaceExtractor
         Func<string, MethodDefinitionHandle> handleForKind,
         TypeNodeProvider provider,
         GenericContext context,
-        Action<string>? beforeRetainText)
+        Action<string>? beforeRetainText,
+        Action<int>? beforeDecodeWork)
     {
         foreach (ApiAccessor accessor in accessors)
         {
+            MethodDefinitionHandle handle = handleForKind(accessor.Kind);
+            accessor.Name = MethodDefinitionName(reader, handle, beforeDecodeWork);
+            if (accessor.Name is not null)
+                beforeRetainText?.Invoke(accessor.Name);
             accessor.StructuralReturnType = MethodStructuralReturnType(
                 reader,
-                handleForKind(accessor.Kind),
+                handle,
                 provider,
                 context,
                 beforeRetainText);
         }
+    }
+
+    static string? MethodDefinitionName(
+        MetadataReader reader,
+        MethodDefinitionHandle handle,
+        Action<int>? beforeDecodeWork)
+    {
+        if (handle.IsNil)
+            return null;
+
+        return DecodeString(
+            reader,
+            reader.GetMethodDefinition(handle).Name,
+            beforeDecodeWork);
     }
 
     static string? MethodStructuralReturnType(
@@ -4186,6 +4207,7 @@ public static class ApiSurfaceExtractor
             AddText(ref count, accessor.Kind);
             AddText(ref count, accessor.Accessibility);
             AddText(ref count, accessor.ReturnAttributes);
+            AddText(ref count, accessor.Name);
             AddText(ref count, accessor.StructuralReturnType);
         }
     }

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -135,6 +135,28 @@ public sealed class ApiSignatureModelTests
     }
 
     [Fact]
+    public void PropertySignatureModel_ExposesExplicitInterfaceAccessorMethodName()
+    {
+        ApiMember member = Assert.Single(
+            GetType(nameof(ExplicitAccessorFixtures)).Members,
+            candidate => candidate.Kind == "property"
+                && candidate.Name.EndsWith(
+                    $".{nameof(IExplicitAccessor.Value)}",
+                    StringComparison.Ordinal));
+
+        Assert.NotNull(member.SignatureModel);
+        ApiAccessor getter = Assert.Single(
+            member.SignatureModel.Accessors,
+            accessor => accessor.Kind == "get");
+        Assert.False(string.IsNullOrEmpty(getter.Name));
+        Assert.False(getter.Name.StartsWith("get_", StringComparison.Ordinal));
+        Assert.EndsWith(
+            $".get_{nameof(IExplicitAccessor.Value)}",
+            getter.Name,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FieldAndEventSignatureModels_ExposeReturnType()
     {
         var field = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.Count));
@@ -531,6 +553,16 @@ public sealed class ApiSignatureFixtures
     }
 
     public int InitValue { get; init; }
+}
+
+public interface IExplicitAccessor
+{
+    int Value { get; }
+}
+
+public sealed class ExplicitAccessorFixtures : IExplicitAccessor
+{
+    int IExplicitAccessor.Value => 1;
 }
 
 public sealed class StructuralGenericPayloadFixtures


### PR DESCRIPTION
## Claim

Call-graph correspondence now uses each accessor's MethodDef name, so an explicit-interface property `I.P` resolves as `I.get_P` rather than `get_I.P`. A method row and a property accessor that name the same body are one hit.

## Why

#4396 r4 found this as the remaining well-behaved compiler miss after init-setter agreement: extract `CreateBodySelectors` prefixed `get_` onto the property display name, while `MemberRef` carries the compiler MethodDef name. Keys already matched; names did not. Aligning the names made the dual-listed EIM method + property collide, so Resolve now uniques by body token.

## Evidence

- Compiled extract-to-`MemberResolver` gate: `Resolve_MatchesCompiledExplicitInterfaceAccessorAcrossProducers`
- Synthetic name/key agreement: `Resolve_MatchesExplicitInterfaceAccessorNameAcrossProducers`
- Extract canary: `PropertySignatureModel_ExposesExplicitInterfaceAccessorMethodName`
- Focused Release: CallGraph 23, ApiSignatureModel 27

## Non-action

Does not change which members extract emits (#3975). Does not retarget generic-wrapped modifiers, brace encoding, #4217, or protobuf. Older serialized surfaces without `ApiAccessor.Name` still fall back to `get_{property}`.

## Validation

`dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -class ILInspector.Analysis.Tests.CallGraphMemberResolverTests`
`dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class ILInspector.Metadata.Tests.ApiSignatureModelTests`