### PR TITLE
Carry NuGet mirror in the inspect-web share envelope

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -70,7 +70,8 @@ service-index URL (`n`). Opening that link validates the same way Settings does,
 persists the mirror on success, and loads packages from it. Shares from nuget.org
 omit `n` so they do not wipe a recipient's stored corporate mirror. A shared
 mirror that fails validation falls back to the recipient's stored source (if
-any) and surfaces a notice.
+any) and surfaces a notice. Settings rewrite the address-bar packet before
+reload so "Use nuget.org" or switching mirrors is not undone by a stale `n`.
 
 ## Run the .NET 11 browser-WASM prototype
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -66,12 +66,15 @@ NuGet.org capability because `PackageBaseAddress` does not serve `.snupkg`
 payloads; when that endpoint is blocked, Source falls back to decompilation.
 
 When a non-default mirror is active, the opaque share packet (`w`) includes its
-service-index URL (`n`). Opening that link validates the same way Settings does,
-persists the mirror on success, and loads packages from it. Shares from nuget.org
-omit `n` so they do not wipe a recipient's stored corporate mirror. A shared
-mirror that fails validation falls back to the recipient's stored source (if
-any) and surfaces a notice. Settings rewrite the address-bar packet before
-reload so "Use nuget.org" or switching mirrors is not undone by a stale `n`.
+service-index URL (`n`). Opening that link validates the same way Settings does
+and applies the mirror for **this session only**, with a banner to **Keep** it in
+local storage or dismiss the offer. History back/forward may re-apply a packet
+mirror in-session but does not rewrite local storage, so Settings → Use nuget.org
+stays durable across Back. Shares from nuget.org omit `n` so they do not wipe a
+recipient's stored corporate mirror. A shared mirror that fails validation falls
+back to the recipient's stored source (if any) and surfaces a notice. Settings
+rewrite the address-bar packet before reload so a stale `n` is not the active
+entry after a source change.
 
 ## Run the .NET 11 browser-WASM prototype
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -65,6 +65,13 @@ replaced or cleared under Settings. Package search uses the mirror's
 NuGet.org capability because `PackageBaseAddress` does not serve `.snupkg`
 payloads; when that endpoint is blocked, Source falls back to decompilation.
 
+When a non-default mirror is active, the opaque share packet (`w`) includes its
+service-index URL (`n`). Opening that link validates the same way Settings does,
+persists the mirror on success, and loads packages from it. Shares from nuget.org
+omit `n` so they do not wipe a recipient's stored corporate mirror. A shared
+mirror that fails validation falls back to the recipient's stored source (if
+any) and surfaces a notice.
+
 ## Run the .NET 11 browser-WASM prototype
 
 Install the experimental browser workload selected by the repository SDK:

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -68,13 +68,15 @@ payloads; when that endpoint is blocked, Source falls back to decompilation.
 When a non-default mirror is active, the opaque share packet (`w`) includes its
 service-index URL (`n`). Opening that link validates the same way Settings does
 and applies the mirror for **this session only**, with a banner to **Keep** it in
-local storage or dismiss the offer. History back/forward may re-apply a packet
-mirror in-session but does not rewrite local storage, so Settings → Use nuget.org
-stays durable across Back. Shares from nuget.org omit `n` so they do not wipe a
-recipient's stored corporate mirror. A shared mirror that fails validation falls
-back to the recipient's stored source (if any) and surfaces a notice. Settings
-rewrite the address-bar packet before reload so a stale `n` is not the active
-entry after a source change.
+local storage or dismiss (revert to the stored source or nuget.org and reload).
+History back/forward re-applies a packet mirror in-session without writing local
+storage; entries without `n` restore the stored preference or nuget.org so a
+session mirror cannot stick. Settings → Use nuget.org remains durable across
+Back. Shares from nuget.org omit `n` so they do not wipe a recipient's stored
+corporate mirror. Failed shared mirrors fall back to the stored source (if any)
+and keep their notice through package load. Settings rewrite the address-bar
+packet before reload so a stale `n` is not the active entry after a source
+change.
 
 ## Run the .NET 11 browser-WASM prototype
 

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -5399,46 +5399,31 @@ async function restorePackageSource(previousSource) {
   }
 }
 
-// Validate a service index without mutating workspace state. Callers that race with a newer
-// navigation can discard the result instead of wiping packages mid-flight.
-async function validateNuGetMirror(serviceIndexUrl) {
-  return inspectConfigurePackageSource(serviceIndexUrl);
-}
-
-// Commit an already-validated configuration. Persistence is opt-in: Settings and Keep write
-// localStorage; history and cold shared-link open only switch the engine.
-function commitNuGetMirror(configuration, { persist = false, resetWorkspace = true, previousSource = null } = {}) {
+// Point the engine at a service index. ConfigurePackageSource commits the engine source
+// before it returns, so JS state must lockstep immediately — a "validate then maybe commit"
+// split desyncs engine fetches from Settings/share encoding after a discarded popstate.
+async function switchPackageSource(serviceIndexUrl, { persist = false, resetWorkspace = true } = {}) {
+  const previousSource = state.packageSource;
+  const configuration = await inspectConfigurePackageSource(serviceIndexUrl);
+  // Engine is already on `configuration`; keep UI/source-generation in agreement now.
+  state.packageSource = configuration;
+  bumpPackageSourceGeneration();
   if (persist) {
     try {
       localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, configuration.serviceIndexUrl);
     } catch (error) {
-      if (previousSource) {
-        // Best-effort restore; caller may also await restorePackageSource.
-        state.packageSource = previousSource.isDefault
-          ? inspectUseDefaultPackageSource()
-          : previousSource;
-        bumpPackageSourceGeneration();
-      }
+      await restorePackageSource(previousSource);
       throw new Error(
         `Mirror validated but could not be stored in this browser: ${String(error?.message || error)}`);
     }
   }
-  state.packageSource = configuration;
-  bumpPackageSourceGeneration();
   if (resetWorkspace) resetSourceScopedWorkspace();
   return configuration;
 }
 
-// Apply a validated NuGet service index for this session.
+// Apply a NuGet service index for this session (persist only when requested).
 async function applyNuGetMirror(serviceIndexUrl, { persist = false, resetWorkspace = true } = {}) {
-  const previousSource = state.packageSource;
-  const configuration = await validateNuGetMirror(serviceIndexUrl);
-  try {
-    return commitNuGetMirror(configuration, { persist, resetWorkspace, previousSource });
-  } catch (error) {
-    if (persist) await restorePackageSource(previousSource);
-    throw error;
-  }
+  return switchPackageSource(serviceIndexUrl, { persist, resetWorkspace });
 }
 
 async function configureNuGetMirror(serviceIndexUrl) {
@@ -5506,35 +5491,55 @@ function dismissSharedNuGetMirrorOffer() {
   location.reload();
 }
 
-// Align the active engine source with a history/share location without persisting.
+// Align engine + JS source with a history/share location without persisting.
 // Entries with `n` apply that mirror session-only; entries without `n` restore the stored
 // preference or nuget.org so a prior session mirror cannot stick across Forward/Back.
+// On success the switch is fully committed (engine+JS); a superseded popstate leaves both
+// on the new source and the newer turn re-aligns from there.
 async function alignPackageSourceToLocation(loc) {
   if (loc.nugetMirror) {
     if (!state.packageSource.isDefault
       && packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, loc.nugetMirror)) {
-      return { switched: false, notice: "" };
+      return { switched: false, offerUrl: "" };
     }
-    const configuration = await validateNuGetMirror(loc.nugetMirror);
-    return { switched: true, configuration, notice: "", offerUrl: loc.nugetMirror };
+    await switchPackageSource(loc.nugetMirror, { persist: false, resetWorkspace: true });
+    return { switched: true, offerUrl: loc.nugetMirror };
   }
   const stored = loadStoredNuGetMirror();
   if (stored) {
     if (!state.packageSource.isDefault
       && packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, stored)) {
-      return { switched: false, notice: "" };
+      return { switched: false, offerUrl: "" };
     }
-    if (state.packageSource.isDefault
-      || !packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, stored)) {
-      const configuration = await validateNuGetMirror(stored);
-      return { switched: true, configuration, notice: "", offerUrl: "" };
-    }
-    return { switched: false, notice: "" };
+    await switchPackageSource(stored, { persist: false, resetWorkspace: true });
+    return { switched: true, offerUrl: "" };
   }
   if (!state.packageSource.isDefault) {
-    return { switched: true, useDefault: true, notice: "", offerUrl: "" };
+    useDefaultNuGetSource({ clearStorage: false, resetWorkspace: true });
+    return { switched: true, offerUrl: "" };
   }
-  return { switched: false, notice: "" };
+  return { switched: false, offerUrl: "" };
+}
+
+// After a failed history/share mirror alignment, fall back to stored preference or nuget.org
+// so packages are not served from a leftover transient mirror.
+async function restorePreferredPackageSourceSessionOnly() {
+  const stored = loadStoredNuGetMirror();
+  if (stored) {
+    if (!state.packageSource.isDefault
+      && packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, stored)) {
+      return;
+    }
+    try {
+      await switchPackageSource(stored, { persist: false, resetWorkspace: true });
+      return;
+    } catch {
+      // Fall through to default.
+    }
+  }
+  if (!state.packageSource.isDefault) {
+    useDefaultNuGetSource({ clearStorage: false, resetWorkspace: true });
+  }
 }
 
 async function promptForNuGetMirror() {
@@ -7296,9 +7301,9 @@ function renderSettingsView() {
             <input id="settings-nuget-source-url" type="url" inputmode="url" autocomplete="off" spellcheck="false" placeholder="https://mirror.example/nuget/v3/index.json" value="${escapeHtml(storedMirror)}" />
             <div class="settings-source-actions">
               <button type="submit" class="settings-reset">Validate and use mirror</button>
-              ${!state.packageSource.isDefault ? '<button id="settings-nuget-source-reset" type="button" class="settings-reset">Use nuget.org</button>' : ""}
+              ${(!state.packageSource.isDefault || storedMirror) ? '<button id="settings-nuget-source-reset" type="button" class="settings-reset">Use nuget.org</button>' : ""}
             </div>
-            <small>Current source: ${escapeHtml(state.packageSource.serviceIndexUrl)}${!state.packageSource.isDefault && !storedMirror ? " · session only (not kept)" : ""}</small>
+            <small>Current source: ${escapeHtml(state.packageSource.serviceIndexUrl)}${!state.packageSource.isDefault && !storedMirror ? " · session only (not kept)" : ""}${state.packageSource.isDefault && storedMirror ? " · stored mirror unreachable this session" : ""}</small>
           </form>
         </section>
 
@@ -7817,6 +7822,11 @@ async function restoreWorkspaceFromLocation(loc, deep, options = {}) {
   state.loading = true;
   state.error = "";
   if (isCurrent()) render();
+  else {
+    // Superseded before work started; do not leave a phantom spinner for the next turn.
+    state.loading = false;
+    return;
+  }
   const target = {
     id: loc.package,
     version: loc.version || "latest",
@@ -7838,11 +7848,17 @@ async function restoreWorkspaceFromLocation(loc, deep, options = {}) {
   // once, below — so a non-target tab (e.g. an STJ tab on a platform-library link) never
   // flashes into view before the target resolves.
   for (const tab of tabs) {
-    if (!isCurrent()) return;
+    if (!isCurrent()) {
+      state.loading = false;
+      return;
+    }
     if (isRuntimePackId(tab.id)) await loadRuntimePack(tab.framework);
     else await loadPackage(tab.id, tab.version, tab.framework, { background: true, keepQueryNotice });
   }
-  if (!isCurrent()) return;
+  if (!isCurrent()) {
+    state.loading = false;
+    return;
+  }
 
   const targetModel = state.packages.find(matchesTarget);
   if (targetModel) {
@@ -7851,7 +7867,10 @@ async function restoreWorkspaceFromLocation(loc, deep, options = {}) {
     // deep link, so a refreshed/shared platform-library link lands on that library.
     if (isRuntimePackId(targetModel.id) && loc.library) {
       await applyPlatformLibraryScope(loc.library);
-      if (!isCurrent()) return;
+      if (!isCurrent()) {
+        state.loading = false;
+        return;
+      }
     }
     applyDeepLink(deep);
     state.loading = false;
@@ -7864,6 +7883,7 @@ async function restoreWorkspaceFromLocation(loc, deep, options = {}) {
     // the foreground so its error (e.g. a 404) surfaces properly instead of a blank workbench.
     pendingDeepLink = deep;
     await loadPackage(target.id, target.version, target.framework, { keepQueryNotice });
+    if (!isCurrent()) state.loading = false;
   } else {
     state.loading = false;
     if (isCurrent()) render();
@@ -8153,39 +8173,50 @@ async function handlePopState(generation, loc) {
   urlSyncOwnerGeneration = generation;
   // Allow restore even when a prior stale turn wiped packages (package null, not home).
   const bareHome = !loc.package && !(loc.tabs && loc.tabs.length);
-  if (bareHome) {
-    if (!isCurrent()) return;
-    state.home = true;
-    render();
-    return;
-  }
   if (!isCurrent()) return;
-  state.home = false;
-  state.lens = loc.lens || "api";
-  state.atPackageRoot = loc.atPackageRoot || false;
-  state.packageLens = loc.packageLens || "overview";
+
+  // Drop a phantom spinner left by a superseded restore before this turn decides its UI.
+  state.loading = false;
 
   let sourceSwitched = false;
   let mirrorNotice = "";
   try {
+    // Align before bare-home return so no-n home entries leave a session mirror.
     const alignment = await alignPackageSourceToLocation(loc);
     if (!isCurrent()) return;
     if (alignment.switched) {
-      if (alignment.useDefault) {
-        useDefaultNuGetSource({ clearStorage: false, resetWorkspace: true });
-      } else if (alignment.configuration) {
-        commitNuGetMirror(alignment.configuration, { persist: false, resetWorkspace: true });
-      }
       sourceSwitched = true;
       if (alignment.offerUrl) offerSharedMirrorKeep(alignment.offerUrl);
       else state.sharedMirrorOffer = null;
     }
   } catch (error) {
     if (!isCurrent()) return;
-    mirrorNotice = `Shared NuGet mirror could not be used: ${String(error?.message || error)}`;
+    mirrorNotice = loc.nugetMirror
+      ? `Shared NuGet mirror could not be used: ${String(error?.message || error)}`
+      : `Stored NuGet mirror could not be used: ${String(error?.message || error)}`;
     state.queryNotice = mirrorNotice;
+    try {
+      await restorePreferredPackageSourceSessionOnly();
+    } catch {
+      // Best-effort; packages may still fail visibly.
+    }
+    if (!isCurrent()) return;
+    sourceSwitched = true;
+    state.sharedMirrorOffer = null;
   }
   if (!isCurrent()) return;
+
+  if (bareHome) {
+    state.home = true;
+    state.loading = false;
+    render();
+    return;
+  }
+
+  state.home = false;
+  state.lens = loc.lens || "api";
+  state.atPackageRoot = loc.atPackageRoot || false;
+  state.packageLens = loc.packageLens || "overview";
 
   const deep = { type: loc.type, member: loc.member, overload: loc.overload, section: loc.section };
   if (sourceSwitched) {
@@ -8217,6 +8248,7 @@ async function handlePopState(generation, loc) {
     } else {
       applyDeepLink(loc);
       if (!isCurrent()) return;
+      state.loading = false;
       render();
       loadSelectionData();
     }
@@ -8229,7 +8261,10 @@ async function handlePopState(generation, loc) {
     await loadPackage(loc.package, loc.version || "latest", loc.framework || "", {
       keepQueryNotice: Boolean(mirrorNotice)
     });
-    if (!isCurrent()) return;
+    if (!isCurrent()) {
+      state.loading = false;
+      return;
+    }
     if (mirrorNotice && !state.queryNotice) {
       state.queryNotice = mirrorNotice;
       render();

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -176,6 +176,7 @@ const state = {
   // Non-null when a shared/history link applied a mirror for this session only.
   // Keep persists it; dismiss clears the offer without changing the active engine source.
   sharedMirrorOffer: null,
+  bootstrapKeepQueryNotice: false,
   runtimePackLoading: false,
   runtimePackError: "",
   graphSourceOpen: false,
@@ -1199,9 +1200,10 @@ function render() {
             <span class="query-notice-glyph">ℹ</span>
             <span class="query-notice-text">This link uses NuGet mirror <strong>${escapeHtml(state.sharedMirrorOffer.host)}</strong> for this session only. Package content comes from that source.</span>
             <button id="keep-shared-mirror" type="button">Keep</button>
-            <button id="dismiss-shared-mirror" type="button" aria-label="Dismiss">×</button>
+            <button id="dismiss-shared-mirror" type="button" aria-label="Dismiss offer and leave mirror">×</button>
           </div>`
-        : state.queryNotice
+        : ""}
+      ${state.queryNotice
         ? `<div class="query-notice" role="alert">
             <span class="query-notice-glyph">⚠</span>
             <span class="query-notice-text">${escapeHtml(state.queryNotice)}</span>
@@ -5220,8 +5222,14 @@ function buildStateUrl(base = location.href) {
 // Rewrite the address bar to reflect the current selection so a refresh restores it and
 // the URL is always shareable. replaceState (not pushState) keeps the app's own
 // back/forward buttons authoritative and avoids flooding browser history on every render.
+// Stale popstate turns set urlSyncOwnerGeneration; once a newer popstate arrives they must
+// not rewrite the bar (their nested render→syncUrl would otherwise clobber it).
+let popStateGeneration = 0;
+let urlSyncOwnerGeneration = null;
+
 function syncUrl() {
   if (!state.package || state.loading) return;
+  if (urlSyncOwnerGeneration !== null && urlSyncOwnerGeneration !== popStateGeneration) return;
   document.title = `dotnet-inspect -- ${packageDisplayName(state.package)}`;
   try {
     history.replaceState(null, "", buildStateUrl().toString());
@@ -5391,19 +5399,26 @@ async function restorePackageSource(previousSource) {
   }
 }
 
-// Apply a validated NuGet service index for this session. Persistence is opt-in:
-// Settings and an explicit "Keep" on a shared link write localStorage; history and
-// cold shared-link open only switch the engine so Back cannot re-persist a rejected mirror.
-async function applyNuGetMirror(serviceIndexUrl, { persist = false, resetWorkspace = true } = {}) {
-  const previousSource = state.packageSource;
-  const configuration = await inspectConfigurePackageSource(serviceIndexUrl);
+// Validate a service index without mutating workspace state. Callers that race with a newer
+// navigation can discard the result instead of wiping packages mid-flight.
+async function validateNuGetMirror(serviceIndexUrl) {
+  return inspectConfigurePackageSource(serviceIndexUrl);
+}
+
+// Commit an already-validated configuration. Persistence is opt-in: Settings and Keep write
+// localStorage; history and cold shared-link open only switch the engine.
+function commitNuGetMirror(configuration, { persist = false, resetWorkspace = true, previousSource = null } = {}) {
   if (persist) {
     try {
       localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, configuration.serviceIndexUrl);
     } catch (error) {
-      // Engine already switched; restore the prior source and keep the workbench.
-      // Do not clear packages — that strands the UI on a permanent loading screen.
-      await restorePackageSource(previousSource);
+      if (previousSource) {
+        // Best-effort restore; caller may also await restorePackageSource.
+        state.packageSource = previousSource.isDefault
+          ? inspectUseDefaultPackageSource()
+          : previousSource;
+        bumpPackageSourceGeneration();
+      }
       throw new Error(
         `Mirror validated but could not be stored in this browser: ${String(error?.message || error)}`);
     }
@@ -5414,18 +5429,30 @@ async function applyNuGetMirror(serviceIndexUrl, { persist = false, resetWorkspa
   return configuration;
 }
 
+// Apply a validated NuGet service index for this session.
+async function applyNuGetMirror(serviceIndexUrl, { persist = false, resetWorkspace = true } = {}) {
+  const previousSource = state.packageSource;
+  const configuration = await validateNuGetMirror(serviceIndexUrl);
+  try {
+    return commitNuGetMirror(configuration, { persist, resetWorkspace, previousSource });
+  } catch (error) {
+    if (persist) await restorePackageSource(previousSource);
+    throw error;
+  }
+}
+
 async function configureNuGetMirror(serviceIndexUrl) {
   state.sharedMirrorOffer = null;
   return applyNuGetMirror(serviceIndexUrl, { persist: true, resetWorkspace: true });
 }
 
-function useDefaultNuGetSource() {
+function useDefaultNuGetSource({ clearStorage = true, resetWorkspace = true } = {}) {
   state.sharedMirrorOffer = null;
   const configuration = inspectUseDefaultPackageSource();
-  clearPersistedNuGetMirror();
+  if (clearStorage) clearPersistedNuGetMirror();
   state.packageSource = configuration;
   bumpPackageSourceGeneration();
-  resetSourceScopedWorkspace();
+  if (resetWorkspace) resetSourceScopedWorkspace();
   return configuration;
 }
 
@@ -5450,7 +5477,12 @@ async function keepSharedNuGetMirror() {
   const offer = state.sharedMirrorOffer;
   if (!offer?.serviceIndexUrl) return;
   try {
-    localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, offer.serviceIndexUrl);
+    // Prefer the engine's canonical URL when this session already applied the offer.
+    const url = (!state.packageSource.isDefault
+      && packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, offer.serviceIndexUrl))
+      ? state.packageSource.serviceIndexUrl
+      : offer.serviceIndexUrl;
+    localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, url);
     state.sharedMirrorOffer = null;
     showToast(`Kept NuGet mirror ${offer.host}`, 4000);
     render();
@@ -5459,9 +5491,50 @@ async function keepSharedNuGetMirror() {
   }
 }
 
+// Dismiss leaves the transient mirror: revert engine to stored preference or nuget.org,
+// strip `n` from the bar, and reload so refresh cannot re-apply the shared source.
 function dismissSharedNuGetMirrorOffer() {
   state.sharedMirrorOffer = null;
-  render();
+  const stored = loadStoredNuGetMirror();
+  if (stored) {
+    // Keep stored preference; only drop the session-only shared override from the URL.
+    rewriteSharePacketNuGetMirror(stored);
+  } else {
+    useDefaultNuGetSource({ clearStorage: false, resetWorkspace: false });
+    rewriteSharePacketNuGetMirror("");
+  }
+  location.reload();
+}
+
+// Align the active engine source with a history/share location without persisting.
+// Entries with `n` apply that mirror session-only; entries without `n` restore the stored
+// preference or nuget.org so a prior session mirror cannot stick across Forward/Back.
+async function alignPackageSourceToLocation(loc) {
+  if (loc.nugetMirror) {
+    if (!state.packageSource.isDefault
+      && packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, loc.nugetMirror)) {
+      return { switched: false, notice: "" };
+    }
+    const configuration = await validateNuGetMirror(loc.nugetMirror);
+    return { switched: true, configuration, notice: "", offerUrl: loc.nugetMirror };
+  }
+  const stored = loadStoredNuGetMirror();
+  if (stored) {
+    if (!state.packageSource.isDefault
+      && packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, stored)) {
+      return { switched: false, notice: "" };
+    }
+    if (state.packageSource.isDefault
+      || !packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, stored)) {
+      const configuration = await validateNuGetMirror(stored);
+      return { switched: true, configuration, notice: "", offerUrl: "" };
+    }
+    return { switched: false, notice: "" };
+  }
+  if (!state.packageSource.isDefault) {
+    return { switched: true, useDefault: true, notice: "", offerUrl: "" };
+  }
+  return { switched: false, notice: "" };
 }
 
 async function promptForNuGetMirror() {
@@ -7223,9 +7296,9 @@ function renderSettingsView() {
             <input id="settings-nuget-source-url" type="url" inputmode="url" autocomplete="off" spellcheck="false" placeholder="https://mirror.example/nuget/v3/index.json" value="${escapeHtml(storedMirror)}" />
             <div class="settings-source-actions">
               <button type="submit" class="settings-reset">Validate and use mirror</button>
-              ${storedMirror ? '<button id="settings-nuget-source-reset" type="button" class="settings-reset">Use nuget.org</button>' : ""}
+              ${!state.packageSource.isDefault ? '<button id="settings-nuget-source-reset" type="button" class="settings-reset">Use nuget.org</button>' : ""}
             </div>
-            <small>Current source: ${escapeHtml(state.packageSource.serviceIndexUrl)}</small>
+            <small>Current source: ${escapeHtml(state.packageSource.serviceIndexUrl)}${!state.packageSource.isDefault && !storedMirror ? " · session only (not kept)" : ""}</small>
           </form>
         </section>
 
@@ -7737,11 +7810,13 @@ async function runCallGraphDemo() {
 // Loads the full open-tab set described by a parsed location (opaque workspace bucket, or a
 // lone target), then restores the active tab's platform library scope and deep-link
 // selection. Shared by boot restore, refreshed/shared links, and the in-app demo buttons.
-async function restoreWorkspaceFromLocation(loc, deep) {
+async function restoreWorkspaceFromLocation(loc, deep, options = {}) {
+  const isCurrent = typeof options.isCurrent === "function" ? options.isCurrent : () => true;
+  const keepQueryNotice = options.keepQueryNotice === true;
   state.home = false;
   state.loading = true;
   state.error = "";
-  render();
+  if (isCurrent()) render();
   const target = {
     id: loc.package,
     version: loc.version || "latest",
@@ -7763,9 +7838,11 @@ async function restoreWorkspaceFromLocation(loc, deep) {
   // once, below — so a non-target tab (e.g. an STJ tab on a platform-library link) never
   // flashes into view before the target resolves.
   for (const tab of tabs) {
+    if (!isCurrent()) return;
     if (isRuntimePackId(tab.id)) await loadRuntimePack(tab.framework);
-    else await loadPackage(tab.id, tab.version, tab.framework, { background: true });
+    else await loadPackage(tab.id, tab.version, tab.framework, { background: true, keepQueryNotice });
   }
+  if (!isCurrent()) return;
 
   const targetModel = state.packages.find(matchesTarget);
   if (targetModel) {
@@ -7774,33 +7851,36 @@ async function restoreWorkspaceFromLocation(loc, deep) {
     // deep link, so a refreshed/shared platform-library link lands on that library.
     if (isRuntimePackId(targetModel.id) && loc.library) {
       await applyPlatformLibraryScope(loc.library);
+      if (!isCurrent()) return;
     }
     applyDeepLink(deep);
     state.loading = false;
-    render();
-    loadSelectionData();
+    if (isCurrent()) {
+      render();
+      loadSelectionData();
+    }
   } else if (!isRuntimePackId(target.id)) {
     // The focused NuGet target failed to load during the silent background pass; re-run it in
     // the foreground so its error (e.g. a 404) surfaces properly instead of a blank workbench.
     pendingDeepLink = deep;
-    await loadPackage(target.id, target.version, target.framework);
+    await loadPackage(target.id, target.version, target.framework, { keepQueryNotice });
   } else {
     state.loading = false;
-    render();
+    if (isCurrent()) render();
   }
 }
 
 // Restores the full open-tab set from the opaque workspace bucket (or just the visible
 // target for a lone/legacy link), loading each tab in order so the tab bar and any
 // cross-package dependency edges come back. Only the focused target restores its deep-link.
-async function restoreInitialWorkspace() {
+async function restoreInitialWorkspace(options = {}) {
   const loc = {
     ...initialLocation,
     package: state.requestedPackage,
     version: state.requestedVersion,
     framework: state.requestedFramework
   };
-  await restoreWorkspaceFromLocation(loc, pendingDeepLink);
+  await restoreWorkspaceFromLocation(loc, pendingDeepLink, options);
 }
 
 async function bootstrap() {
@@ -7830,6 +7910,7 @@ async function bootstrap() {
         // Fall through to the stored mirror (if any) so a bad shared URL does not
         // permanently block a recipient who already has a working source.
         state.queryNotice = `Shared NuGet mirror could not be used: ${String(error?.message || error)}`;
+        state.bootstrapKeepQueryNotice = true;
         if (storedMirror && !packageSourceUrlsMatch(storedMirror, sharedMirror)) {
           state.loadingMessage = "Connecting to your NuGet mirror…";
           render();
@@ -7875,7 +7956,10 @@ async function bootstrap() {
       render();
       return;
     }
-    await restoreInitialWorkspace();
+    await restoreInitialWorkspace({
+      keepQueryNotice: state.bootstrapKeepQueryNotice === true
+    });
+    state.bootstrapKeepQueryNotice = false;
     const tReady = performance.now();
     state.diag = computeDiagnostics(tStart, tEngine, tReady);
     render();
@@ -8041,14 +8125,16 @@ document.addEventListener("mousedown", event => {
 // Re-apply state when the address bar changes underneath us (browser back/forward, or a
 // hand-edited URL). Within the loaded package we mutate selection directly; a different
 // package is (re)loaded with the URL selection queued as a deep link.
-// Serialize handlers and stamp a generation so a stale turn cannot render/syncUrl over a
-// newer address bar after an await (queue alone is not enough once syncUrl rewrites history).
+// Capture location synchronously on the event (before any queued predecessor can syncUrl),
+// serialize handlers, and own urlSyncOwnerGeneration so stale nested renders cannot rewrite
+// the bar. Validate mirrors before resetting the workspace so a superseded turn cannot wipe
+// packages and permanently trip the null-package guard.
 let popStateQueue = Promise.resolve();
-let popStateGeneration = 0;
 window.addEventListener("popstate", () => {
   const generation = ++popStateGeneration;
+  const loc = parseLocation();
   popStateQueue = popStateQueue
-    .then(() => handlePopState(generation))
+    .then(() => handlePopState(generation, loc))
     .catch(error => {
       console.error("popstate restore failed", error);
       if (generation === popStateGeneration) {
@@ -8056,17 +8142,18 @@ window.addEventListener("popstate", () => {
         state.error = state.error || "Couldn’t restore that history entry.";
         render();
       }
+    })
+    .finally(() => {
+      if (urlSyncOwnerGeneration === generation) urlSyncOwnerGeneration = null;
     });
 });
 
-async function handlePopState(generation) {
+async function handlePopState(generation, loc) {
   const isCurrent = () => generation === popStateGeneration;
-  if (!state.package && !state.home) return;
-  // Read location at the start of this serialized turn so we apply the latest bar state.
-  const loc = parseLocation();
+  urlSyncOwnerGeneration = generation;
+  // Allow restore even when a prior stale turn wiped packages (package null, not home).
   const bareHome = !loc.package && !(loc.tabs && loc.tabs.length);
   if (bareHome) {
-    // Navigated back to the bare root — show the intro/home page (engine stays warm).
     if (!isCurrent()) return;
     state.home = true;
     render();
@@ -8077,34 +8164,45 @@ async function handlePopState(generation) {
   state.lens = loc.lens || "api";
   state.atPackageRoot = loc.atPackageRoot || false;
   state.packageLens = loc.packageLens || "overview";
-  // History may land on a share packet that named a different mirror. Apply session-only
-  // (no localStorage write) so Back cannot re-persist a mirror the user cleared in Settings.
-  // Missing `n` leaves the current source alone. Switching mirrors clears the workspace,
-  // so force a full multi-tab restore afterward.
-  let mirrorSwitched = false;
+
+  let sourceSwitched = false;
   let mirrorNotice = "";
-  if (loc.nugetMirror
-      && (state.packageSource.isDefault
-        || !packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, loc.nugetMirror))) {
-    try {
-      await applyNuGetMirror(loc.nugetMirror, { persist: false, resetWorkspace: true });
-      if (!isCurrent()) return;
-      mirrorSwitched = true;
-      offerSharedMirrorKeep(loc.nugetMirror);
-    } catch (error) {
-      if (!isCurrent()) return;
-      mirrorNotice = `Shared NuGet mirror could not be used: ${String(error?.message || error)}`;
-      state.queryNotice = mirrorNotice;
+  try {
+    const alignment = await alignPackageSourceToLocation(loc);
+    if (!isCurrent()) return;
+    if (alignment.switched) {
+      if (alignment.useDefault) {
+        useDefaultNuGetSource({ clearStorage: false, resetWorkspace: true });
+      } else if (alignment.configuration) {
+        commitNuGetMirror(alignment.configuration, { persist: false, resetWorkspace: true });
+      }
+      sourceSwitched = true;
+      if (alignment.offerUrl) offerSharedMirrorKeep(alignment.offerUrl);
+      else state.sharedMirrorOffer = null;
     }
+  } catch (error) {
+    if (!isCurrent()) return;
+    mirrorNotice = `Shared NuGet mirror could not be used: ${String(error?.message || error)}`;
+    state.queryNotice = mirrorNotice;
   }
   if (!isCurrent()) return;
+
   const deep = { type: loc.type, member: loc.member, overload: loc.overload, section: loc.section };
-  if (mirrorSwitched) {
-    await restoreWorkspaceFromLocation(loc, deep);
+  if (sourceSwitched) {
+    await restoreWorkspaceFromLocation(loc, deep, {
+      isCurrent,
+      keepQueryNotice: Boolean(mirrorNotice)
+    });
     if (!isCurrent()) return;
+    if (mirrorNotice && state.queryNotice && state.queryNotice !== mirrorNotice) {
+      state.queryNotice = `${mirrorNotice} ${state.queryNotice}`;
+    } else if (mirrorNotice && !state.queryNotice) {
+      state.queryNotice = mirrorNotice;
+    }
     render();
     return;
   }
+
   const activePackage = state.package;
   const samePackage = activePackage
     && loc.package
@@ -8114,8 +8212,6 @@ async function handlePopState(generation) {
         && (!loc.version || loc.version.toLowerCase() === activePackage.version.toLowerCase())));
   if (samePackage || (!loc.package && activePackage)) {
     if (isRuntimePackId(activePackage.id)) {
-      // Back/forward within the platform: re-scope to the target library (or the
-      // aggregate) before restoring selection, since scope is part of the view.
       await restorePlatformScopeThenDeepLink(loc);
       if (!isCurrent()) return;
     } else {
@@ -8125,8 +8221,6 @@ async function handlePopState(generation) {
       loadSelectionData();
     }
   } else if (isRuntimePackId(loc.package)) {
-    // The runtime pack has no nupkg; rebuild it from its TFM instead of 404-ing
-    // on a NuGet fetch when back/forward lands on a platform state.
     pendingDeepLink = deep;
     await restoreRuntimePackFromHistory(loc);
     if (!isCurrent()) return;
@@ -8136,7 +8230,6 @@ async function handlePopState(generation) {
       keepQueryNotice: Boolean(mirrorNotice)
     });
     if (!isCurrent()) return;
-    // Prefer a package-load failure notice over the mirror preamble when both fire.
     if (mirrorNotice && !state.queryNotice) {
       state.queryNotice = mirrorNotice;
       render();

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -398,10 +398,46 @@ function normalizeSharedNuGetMirror(value) {
 }
 
 function packageSourceUrlsMatch(left, right) {
-  const a = normalizeSharedNuGetMirror(left) || String(left || "").trim();
-  const b = normalizeSharedNuGetMirror(right) || String(right || "").trim();
-  if (!a || !b) return false;
-  return a.replace(/\/+$/, "").toLowerCase() === b.replace(/\/+$/, "").toLowerCase();
+  // Compare after WHATWG canonicalization only. Host/scheme case is already normalized by
+  // the URL parser; path case and trailing slashes are significant and must not be folded,
+  // or bootstrap/popstate can skip a real source change (or skip a stored fallback).
+  try {
+    const a = new URL(String(left || "").trim());
+    const b = new URL(String(right || "").trim());
+    if (a.protocol !== "https:" || b.protocol !== "https:") return false;
+    return a.origin === b.origin && a.pathname === b.pathname;
+  } catch {
+    return false;
+  }
+}
+
+// Rewrite the current address-bar share packet's `n` before a Settings-driven reload so
+// bootstrap does not re-apply (and re-persist) a stale mirror over the user's new choice.
+// serviceIndexUrl null/empty removes `n` (nuget.org); otherwise sets the validated URL.
+function rewriteSharePacketNuGetMirror(serviceIndexUrl) {
+  try {
+    const url = new URL(location.href);
+    const params = new URLSearchParams(url.search);
+    const encoded = params.get("w");
+    if (!encoded) return;
+    const raw = JSON.parse(base64UrlDecode(encoded));
+    if (!raw || Array.isArray(raw) || typeof raw !== "object") return;
+    const next = (typeof serviceIndexUrl === "string" && serviceIndexUrl.trim())
+      ? serviceIndexUrl.trim()
+      : "";
+    if (next) raw.n = next;
+    else delete raw.n;
+    params.set("w", base64UrlEncode(JSON.stringify(raw)));
+    url.search = params.toString();
+    history.replaceState(null, "", url.toString());
+  } catch {
+    // Best-effort: reload may still see a stale packet; Settings remains available.
+  }
+}
+
+function reloadAfterPackageSourceChange(serviceIndexUrl) {
+  rewriteSharePacketNuGetMirror(serviceIndexUrl);
+  location.reload();
 }
 
 function decodeShareState(value) {
@@ -7165,8 +7201,9 @@ function bindSettingsEvents() {
     if (!value) return;
     submit.disabled = true;
     try {
-      await configureNuGetMirror(value);
-      location.reload();
+      const configuration = await configureNuGetMirror(value);
+      // Drop/replace the previous share-packet mirror before reload so bootstrap honors this choice.
+      reloadAfterPackageSourceChange(configuration.serviceIndexUrl);
     } catch (error) {
       submit.disabled = false;
       showToast(`Mirror not saved: ${String(error?.message || error)}`, 6000);
@@ -7174,7 +7211,8 @@ function bindSettingsEvents() {
   });
   document.querySelector("#settings-nuget-source-reset")?.addEventListener("click", () => {
     useDefaultNuGetSource();
-    location.reload();
+    // Strip `n` from the address bar; otherwise reload re-applies and re-persists the old mirror.
+    reloadAfterPackageSourceChange("");
   });
 }
 
@@ -7269,7 +7307,8 @@ async function loadPackage(packageId, version, framework, options = {}) {
     state.loading = true;
     state.error = "";
     state.home = false;
-    state.queryNotice = "";
+    // History restore may set a mirror-validation notice just before load; keep it visible.
+    if (!options.keepQueryNotice) state.queryNotice = "";
     state.requestedPackage = packageId;
     state.requestedVersion = version;
     state.requestedFramework = framework;
@@ -7940,12 +7979,16 @@ document.addEventListener("mousedown", event => {
 // Re-apply state when the address bar changes underneath us (browser back/forward, or a
 // hand-edited URL). Within the loaded package we mutate selection directly; a different
 // package is (re)loaded with the URL selection queued as a deep link.
+// Serialize handlers: configureNuGetMirror has side effects (engine source + localStorage),
+// so overlapping popstates must not complete out of order against a newer address bar.
+let popStateQueue = Promise.resolve();
 window.addEventListener("popstate", () => {
-  void handlePopState();
+  popStateQueue = popStateQueue.then(() => handlePopState()).catch(() => {});
 });
 
 async function handlePopState() {
   if (!state.package && !state.home) return;
+  // Read location at the start of this serialized turn so we apply the latest bar state.
   const loc = parseLocation();
   const bareHome = !loc.package && !(loc.tabs && loc.tabs.length);
   if (bareHome) {
@@ -7961,8 +8004,9 @@ async function handlePopState() {
   // History may land on a share packet that named a different mirror. Apply it before
   // package fetch so back/forward keeps the feed that produced that view. Missing `n`
   // leaves the current source alone (same rule as cold bootstrap). Switching mirrors
-  // clears the workspace, so force a full package restore afterward.
+  // clears the workspace, so force a full multi-tab restore afterward.
   let mirrorSwitched = false;
+  let mirrorNotice = "";
   if (loc.nugetMirror
       && (state.packageSource.isDefault
         || !packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, loc.nugetMirror))) {
@@ -7970,12 +8014,19 @@ async function handlePopState() {
       await configureNuGetMirror(loc.nugetMirror);
       mirrorSwitched = true;
     } catch (error) {
-      state.queryNotice = `Shared NuGet mirror could not be used: ${String(error?.message || error)}`;
+      mirrorNotice = `Shared NuGet mirror could not be used: ${String(error?.message || error)}`;
+      state.queryNotice = mirrorNotice;
     }
   }
+  const deep = { type: loc.type, member: loc.member, overload: loc.overload, section: loc.section };
+  if (mirrorSwitched) {
+    await restoreWorkspaceFromLocation(loc, deep);
+    if (mirrorNotice) state.queryNotice = mirrorNotice;
+    render();
+    return;
+  }
   const activePackage = state.package;
-  const samePackage = !mirrorSwitched
-    && activePackage
+  const samePackage = activePackage
     && loc.package
     && (isRuntimePackId(loc.package)
       ? isRuntimePackId(activePackage.id)
@@ -7985,7 +8036,7 @@ async function handlePopState() {
     if (isRuntimePackId(activePackage.id)) {
       // Back/forward within the platform: re-scope to the target library (or the
       // aggregate) before restoring selection, since scope is part of the view.
-      restorePlatformScopeThenDeepLink(loc);
+      await restorePlatformScopeThenDeepLink(loc);
     } else {
       applyDeepLink(loc);
       render();
@@ -7994,11 +8045,17 @@ async function handlePopState() {
   } else if (isRuntimePackId(loc.package)) {
     // The runtime pack has no nupkg; rebuild it from its TFM instead of 404-ing
     // on a NuGet fetch when back/forward lands on a platform state.
-    pendingDeepLink = { type: loc.type, member: loc.member, overload: loc.overload, section: loc.section };
-    restoreRuntimePackFromHistory(loc);
+    pendingDeepLink = deep;
+    await restoreRuntimePackFromHistory(loc);
   } else if (loc.package) {
-    pendingDeepLink = { type: loc.type, member: loc.member, overload: loc.overload, section: loc.section };
-    loadPackage(loc.package, loc.version || "latest", loc.framework || "");
+    pendingDeepLink = deep;
+    await loadPackage(loc.package, loc.version || "latest", loc.framework || "", {
+      keepQueryNotice: Boolean(mirrorNotice)
+    });
+    if (mirrorNotice) {
+      state.queryNotice = mirrorNotice;
+      render();
+    }
   }
 }
 

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -332,16 +332,25 @@ function base64UrlDecode(value) {
 }
 
 // Compact, opaque share packet. Carries everything needed to fully restore a session — the
-// open-tab set, which tab is active, the current view, and (only in type view) the selected
-// type/member — so the visible query stays down to a human-readable ?package=<id>. Keys are
-// terse to keep the encoded string short:
+// open-tab set, which tab is active, the current view, (only in type view) the selected
+// type/member, and a non-default NuGet service-index URL when one is active — so the visible
+// query stays down to a human-readable ?package=<id>. Keys are terse to keep the encoded
+// string short:
 //   t = tabs [[id, version, framework], …]   a = active tab index   v = view token
 //   y/m/o/c = selected type / member / overload / member section (type view only)
+//   n = NuGet v3 service-index URL when the active source is not nuget.org
 function encodeShareState() {
   const packet = {
     t: state.packages.map(item => [item.id, item.version, item.activeFramework || ""]),
     a: Math.max(0, state.packages.indexOf(state.package))
   };
+  // Carry a non-default package source so a shared link can open on the same anonymous
+  // mirror the sender used. Omitted for nuget.org so a default share does not wipe a
+  // recipient's stored corporate mirror. Applied only after the same HTTPS/CORS validation
+  // path Settings uses — never trusted raw from the URL.
+  if (state.packageSource && !state.packageSource.isDefault && state.packageSource.serviceIndexUrl) {
+    packet.n = state.packageSource.serviceIndexUrl;
+  }
   // Which platform library the runtime pack is scoped to is part of the view's provenance —
   // capture it so refresh/back/share land on that library instead of the aggregate platform.
   if (isRuntimePackId(state.package.id) && state.libraryScope && state.libraryScope.size === 1) {
@@ -372,13 +381,36 @@ function tabsFromTuples(list) {
     .filter(tab => tab.id);
 }
 
+function normalizeSharedNuGetMirror(value) {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  // Reject obviously non-URL payloads early so the share packet cannot force a prompt
+  // body or localStorage write with garbage; full policy still runs in the engine.
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:") return "";
+    if (url.username || url.password || url.search || url.hash) return "";
+    return url.toString();
+  } catch {
+    return "";
+  }
+}
+
+function packageSourceUrlsMatch(left, right) {
+  const a = normalizeSharedNuGetMirror(left) || String(left || "").trim();
+  const b = normalizeSharedNuGetMirror(right) || String(right || "").trim();
+  if (!a || !b) return false;
+  return a.replace(/\/+$/, "").toLowerCase() === b.replace(/\/+$/, "").toLowerCase();
+}
+
 function decodeShareState(value) {
   if (!value) return null;
   try {
     const raw = JSON.parse(base64UrlDecode(value));
     // Legacy form: a bare tuple array of tabs, carrying no view or selection.
     if (Array.isArray(raw)) {
-      return { tabs: tabsFromTuples(raw), active: 0, view: "", rich: false, type: null, member: null, overload: null, section: null, library: null };
+      return { tabs: tabsFromTuples(raw), active: 0, view: "", rich: false, type: null, member: null, overload: null, section: null, library: null, nugetMirror: "" };
     }
     if (raw && Array.isArray(raw.t)) {
       return {
@@ -390,7 +422,8 @@ function decodeShareState(value) {
         member: raw.m != null ? String(raw.m) : null,
         overload: raw.o != null ? String(raw.o) : null,
         section: raw.c != null ? String(raw.c) : null,
-        library: raw.l != null ? String(raw.l) : null
+        library: raw.l != null ? String(raw.l) : null,
+        nugetMirror: normalizeSharedNuGetMirror(raw.n)
       };
     }
     return null;
@@ -465,7 +498,10 @@ function parseLocation() {
     packageLens: view.packageLens,
     tabs,
     active,
-    library
+    library,
+    // Rich share packets may carry a non-default NuGet service index; legacy packets and
+    // bare query links leave this empty so localStorage / default source stay in control.
+    nugetMirror: share?.rich ? (share.nugetMirror || "") : ""
   };
 }
 
@@ -7679,8 +7715,36 @@ async function bootstrap() {
       render();
     });
     const tEngine = performance.now();
+    // Share-envelope mirror wins over localStorage so a received link can pre-set the feed.
+    // Absence of `n` does not clear a stored mirror — default shares must not wipe a
+    // recipient's corporate source. Validation is the same path Settings uses.
+    const sharedMirror = initialLocation.nugetMirror || "";
     const storedMirror = loadStoredNuGetMirror();
-    if (storedMirror) {
+    if (sharedMirror) {
+      state.loadingMessage = "Connecting to shared NuGet mirror…";
+      render();
+      try {
+        await configureNuGetMirror(sharedMirror);
+      } catch (error) {
+        // Fall through to the stored mirror (if any) so a bad shared URL does not
+        // permanently block a recipient who already has a working source.
+        state.queryNotice = `Shared NuGet mirror could not be used: ${String(error?.message || error)}`;
+        if (storedMirror && !packageSourceUrlsMatch(storedMirror, sharedMirror)) {
+          state.loadingMessage = "Connecting to your NuGet mirror…";
+          render();
+          try {
+            state.packageSource = await inspectConfigurePackageSource(storedMirror);
+            bumpPackageSourceGeneration();
+          } catch {
+            state.packageSource = inspectUseDefaultPackageSource();
+            bumpPackageSourceGeneration();
+          }
+        } else {
+          state.packageSource = inspectUseDefaultPackageSource();
+          bumpPackageSourceGeneration();
+        }
+      }
+    } else if (storedMirror) {
       state.loadingMessage = "Connecting to your NuGet mirror…";
       render();
       try {
@@ -7877,7 +7941,11 @@ document.addEventListener("mousedown", event => {
 // hand-edited URL). Within the loaded package we mutate selection directly; a different
 // package is (re)loaded with the URL selection queued as a deep link.
 window.addEventListener("popstate", () => {
-  if (!state.package) return;
+  void handlePopState();
+});
+
+async function handlePopState() {
+  if (!state.package && !state.home) return;
   const loc = parseLocation();
   const bareHome = !loc.package && !(loc.tabs && loc.tabs.length);
   if (bareHome) {
@@ -7890,13 +7958,31 @@ window.addEventListener("popstate", () => {
   state.lens = loc.lens || "api";
   state.atPackageRoot = loc.atPackageRoot || false;
   state.packageLens = loc.packageLens || "overview";
-  const samePackage = loc.package
+  // History may land on a share packet that named a different mirror. Apply it before
+  // package fetch so back/forward keeps the feed that produced that view. Missing `n`
+  // leaves the current source alone (same rule as cold bootstrap). Switching mirrors
+  // clears the workspace, so force a full package restore afterward.
+  let mirrorSwitched = false;
+  if (loc.nugetMirror
+      && (state.packageSource.isDefault
+        || !packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, loc.nugetMirror))) {
+    try {
+      await configureNuGetMirror(loc.nugetMirror);
+      mirrorSwitched = true;
+    } catch (error) {
+      state.queryNotice = `Shared NuGet mirror could not be used: ${String(error?.message || error)}`;
+    }
+  }
+  const activePackage = state.package;
+  const samePackage = !mirrorSwitched
+    && activePackage
+    && loc.package
     && (isRuntimePackId(loc.package)
-      ? isRuntimePackId(state.package.id)
-      : (loc.package.toLowerCase() === state.package.id.toLowerCase()
-        && (!loc.version || loc.version.toLowerCase() === state.package.version.toLowerCase())));
-  if (samePackage || !loc.package) {
-    if (isRuntimePackId(state.package.id)) {
+      ? isRuntimePackId(activePackage.id)
+      : (loc.package.toLowerCase() === activePackage.id.toLowerCase()
+        && (!loc.version || loc.version.toLowerCase() === activePackage.version.toLowerCase())));
+  if (samePackage || (!loc.package && activePackage)) {
+    if (isRuntimePackId(activePackage.id)) {
       // Back/forward within the platform: re-scope to the target library (or the
       // aggregate) before restoring selection, since scope is part of the view.
       restorePlatformScopeThenDeepLink(loc);
@@ -7910,11 +7996,11 @@ window.addEventListener("popstate", () => {
     // on a NuGet fetch when back/forward lands on a platform state.
     pendingDeepLink = { type: loc.type, member: loc.member, overload: loc.overload, section: loc.section };
     restoreRuntimePackFromHistory(loc);
-  } else {
+  } else if (loc.package) {
     pendingDeepLink = { type: loc.type, member: loc.member, overload: loc.overload, section: loc.section };
     loadPackage(loc.package, loc.version || "latest", loc.framework || "");
   }
-});
+}
 
 // Re-scope the active runtime pack to the platform library named in a share/history packet
 // (lazily loading that assembly if needed via the same drill-in path as clicking it), or

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -173,6 +173,9 @@ const state = {
   packageVersions: {},
   packageVersionsLoading: {},
   packageSource: DEFAULT_PACKAGE_SOURCE,
+  // Non-null when a shared/history link applied a mirror for this session only.
+  // Keep persists it; dismiss clears the offer without changing the active engine source.
+  sharedMirrorOffer: null,
   runtimePackLoading: false,
   runtimePackError: "",
   graphSourceOpen: false,
@@ -1191,7 +1194,14 @@ function render() {
         </div>
       </header>
 
-      ${state.queryNotice
+      ${state.sharedMirrorOffer
+        ? `<div class="query-notice query-notice-info" role="status">
+            <span class="query-notice-glyph">ℹ</span>
+            <span class="query-notice-text">This link uses NuGet mirror <strong>${escapeHtml(state.sharedMirrorOffer.host)}</strong> for this session only. Package content comes from that source.</span>
+            <button id="keep-shared-mirror" type="button">Keep</button>
+            <button id="dismiss-shared-mirror" type="button" aria-label="Dismiss">×</button>
+          </div>`
+        : state.queryNotice
         ? `<div class="query-notice" role="alert">
             <span class="query-notice-glyph">⚠</span>
             <span class="query-notice-text">${escapeHtml(state.queryNotice)}</span>
@@ -3894,6 +3904,10 @@ function bindEvents() {
     state.queryNotice = "";
     render();
   });
+  document.querySelector("#keep-shared-mirror")?.addEventListener("click", () => {
+    void keepSharedNuGetMirror();
+  });
+  document.querySelector("#dismiss-shared-mirror")?.addEventListener("click", dismissSharedNuGetMirrorOffer);
   document.querySelector("#nav-back")?.addEventListener("click", navBack);
   document.querySelector("#nav-forward")?.addEventListener("click", navForward);
   document.querySelector("#go-home").addEventListener("click", goHome);
@@ -5377,31 +5391,77 @@ async function restorePackageSource(previousSource) {
   }
 }
 
-async function configureNuGetMirror(serviceIndexUrl) {
+// Apply a validated NuGet service index for this session. Persistence is opt-in:
+// Settings and an explicit "Keep" on a shared link write localStorage; history and
+// cold shared-link open only switch the engine so Back cannot re-persist a rejected mirror.
+async function applyNuGetMirror(serviceIndexUrl, { persist = false, resetWorkspace = true } = {}) {
   const previousSource = state.packageSource;
   const configuration = await inspectConfigurePackageSource(serviceIndexUrl);
-  try {
-    localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, configuration.serviceIndexUrl);
-  } catch (error) {
-    // Engine already switched; restore the prior source and keep the workbench.
-    // Do not clear packages — that strands the UI on a permanent loading screen.
-    await restorePackageSource(previousSource);
-    throw new Error(
-      `Mirror validated but could not be stored in this browser: ${String(error?.message || error)}`);
+  if (persist) {
+    try {
+      localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, configuration.serviceIndexUrl);
+    } catch (error) {
+      // Engine already switched; restore the prior source and keep the workbench.
+      // Do not clear packages — that strands the UI on a permanent loading screen.
+      await restorePackageSource(previousSource);
+      throw new Error(
+        `Mirror validated but could not be stored in this browser: ${String(error?.message || error)}`);
+    }
   }
   state.packageSource = configuration;
   bumpPackageSourceGeneration();
-  resetSourceScopedWorkspace();
+  if (resetWorkspace) resetSourceScopedWorkspace();
   return configuration;
 }
 
+async function configureNuGetMirror(serviceIndexUrl) {
+  state.sharedMirrorOffer = null;
+  return applyNuGetMirror(serviceIndexUrl, { persist: true, resetWorkspace: true });
+}
+
 function useDefaultNuGetSource() {
+  state.sharedMirrorOffer = null;
   const configuration = inspectUseDefaultPackageSource();
   clearPersistedNuGetMirror();
   state.packageSource = configuration;
   bumpPackageSourceGeneration();
   resetSourceScopedWorkspace();
   return configuration;
+}
+
+function sharedMirrorHost(serviceIndexUrl) {
+  try { return new URL(serviceIndexUrl).host; } catch { return serviceIndexUrl; }
+}
+
+function offerSharedMirrorKeep(serviceIndexUrl) {
+  // Only offer Keep when the validated shared source is not already the stored preference.
+  const stored = loadStoredNuGetMirror();
+  if (stored && packageSourceUrlsMatch(stored, serviceIndexUrl)) {
+    state.sharedMirrorOffer = null;
+    return;
+  }
+  state.sharedMirrorOffer = {
+    serviceIndexUrl,
+    host: sharedMirrorHost(serviceIndexUrl)
+  };
+}
+
+async function keepSharedNuGetMirror() {
+  const offer = state.sharedMirrorOffer;
+  if (!offer?.serviceIndexUrl) return;
+  try {
+    localStorage.setItem(NUGET_MIRROR_STORAGE_KEY, offer.serviceIndexUrl);
+    state.sharedMirrorOffer = null;
+    showToast(`Kept NuGet mirror ${offer.host}`, 4000);
+    render();
+  } catch (error) {
+    showToast(`Could not store mirror: ${String(error?.message || error)}`, 6000);
+  }
+}
+
+function dismissSharedNuGetMirrorOffer() {
+  state.sharedMirrorOffer = null;
+  render();
 }
 
 async function promptForNuGetMirror() {
@@ -7754,7 +7814,8 @@ async function bootstrap() {
       render();
     });
     const tEngine = performance.now();
-    // Share-envelope mirror wins over localStorage so a received link can pre-set the feed.
+    // Share-envelope mirror wins over localStorage for this session so a received link can
+    // pre-set the feed, but does not persist until the user clicks Keep (or Settings).
     // Absence of `n` does not clear a stored mirror — default shares must not wipe a
     // recipient's corporate source. Validation is the same path Settings uses.
     const sharedMirror = initialLocation.nugetMirror || "";
@@ -7763,7 +7824,8 @@ async function bootstrap() {
       state.loadingMessage = "Connecting to shared NuGet mirror…";
       render();
       try {
-        await configureNuGetMirror(sharedMirror);
+        await applyNuGetMirror(sharedMirror, { persist: false, resetWorkspace: true });
+        offerSharedMirrorKeep(sharedMirror);
       } catch (error) {
         // Fall through to the stored mirror (if any) so a bad shared URL does not
         // permanently block a recipient who already has a working source.
@@ -7979,49 +8041,67 @@ document.addEventListener("mousedown", event => {
 // Re-apply state when the address bar changes underneath us (browser back/forward, or a
 // hand-edited URL). Within the loaded package we mutate selection directly; a different
 // package is (re)loaded with the URL selection queued as a deep link.
-// Serialize handlers: configureNuGetMirror has side effects (engine source + localStorage),
-// so overlapping popstates must not complete out of order against a newer address bar.
+// Serialize handlers and stamp a generation so a stale turn cannot render/syncUrl over a
+// newer address bar after an await (queue alone is not enough once syncUrl rewrites history).
 let popStateQueue = Promise.resolve();
+let popStateGeneration = 0;
 window.addEventListener("popstate", () => {
-  popStateQueue = popStateQueue.then(() => handlePopState()).catch(() => {});
+  const generation = ++popStateGeneration;
+  popStateQueue = popStateQueue
+    .then(() => handlePopState(generation))
+    .catch(error => {
+      console.error("popstate restore failed", error);
+      if (generation === popStateGeneration) {
+        state.loading = false;
+        state.error = state.error || "Couldn’t restore that history entry.";
+        render();
+      }
+    });
 });
 
-async function handlePopState() {
+async function handlePopState(generation) {
+  const isCurrent = () => generation === popStateGeneration;
   if (!state.package && !state.home) return;
   // Read location at the start of this serialized turn so we apply the latest bar state.
   const loc = parseLocation();
   const bareHome = !loc.package && !(loc.tabs && loc.tabs.length);
   if (bareHome) {
     // Navigated back to the bare root — show the intro/home page (engine stays warm).
+    if (!isCurrent()) return;
     state.home = true;
     render();
     return;
   }
+  if (!isCurrent()) return;
   state.home = false;
   state.lens = loc.lens || "api";
   state.atPackageRoot = loc.atPackageRoot || false;
   state.packageLens = loc.packageLens || "overview";
-  // History may land on a share packet that named a different mirror. Apply it before
-  // package fetch so back/forward keeps the feed that produced that view. Missing `n`
-  // leaves the current source alone (same rule as cold bootstrap). Switching mirrors
-  // clears the workspace, so force a full multi-tab restore afterward.
+  // History may land on a share packet that named a different mirror. Apply session-only
+  // (no localStorage write) so Back cannot re-persist a mirror the user cleared in Settings.
+  // Missing `n` leaves the current source alone. Switching mirrors clears the workspace,
+  // so force a full multi-tab restore afterward.
   let mirrorSwitched = false;
   let mirrorNotice = "";
   if (loc.nugetMirror
       && (state.packageSource.isDefault
         || !packageSourceUrlsMatch(state.packageSource.serviceIndexUrl, loc.nugetMirror))) {
     try {
-      await configureNuGetMirror(loc.nugetMirror);
+      await applyNuGetMirror(loc.nugetMirror, { persist: false, resetWorkspace: true });
+      if (!isCurrent()) return;
       mirrorSwitched = true;
+      offerSharedMirrorKeep(loc.nugetMirror);
     } catch (error) {
+      if (!isCurrent()) return;
       mirrorNotice = `Shared NuGet mirror could not be used: ${String(error?.message || error)}`;
       state.queryNotice = mirrorNotice;
     }
   }
+  if (!isCurrent()) return;
   const deep = { type: loc.type, member: loc.member, overload: loc.overload, section: loc.section };
   if (mirrorSwitched) {
     await restoreWorkspaceFromLocation(loc, deep);
-    if (mirrorNotice) state.queryNotice = mirrorNotice;
+    if (!isCurrent()) return;
     render();
     return;
   }
@@ -8037,8 +8117,10 @@ async function handlePopState() {
       // Back/forward within the platform: re-scope to the target library (or the
       // aggregate) before restoring selection, since scope is part of the view.
       await restorePlatformScopeThenDeepLink(loc);
+      if (!isCurrent()) return;
     } else {
       applyDeepLink(loc);
+      if (!isCurrent()) return;
       render();
       loadSelectionData();
     }
@@ -8047,13 +8129,19 @@ async function handlePopState() {
     // on a NuGet fetch when back/forward lands on a platform state.
     pendingDeepLink = deep;
     await restoreRuntimePackFromHistory(loc);
+    if (!isCurrent()) return;
   } else if (loc.package) {
     pendingDeepLink = deep;
     await loadPackage(loc.package, loc.version || "latest", loc.framework || "", {
       keepQueryNotice: Boolean(mirrorNotice)
     });
-    if (mirrorNotice) {
+    if (!isCurrent()) return;
+    // Prefer a package-load failure notice over the mirror preamble when both fire.
+    if (mirrorNotice && !state.queryNotice) {
       state.queryNotice = mirrorNotice;
+      render();
+    } else if (mirrorNotice && state.queryNotice && state.queryNotice !== mirrorNotice) {
+      state.queryNotice = `${mirrorNotice} ${state.queryNotice}`;
       render();
     }
   }


### PR DESCRIPTION
## Summary

Shared inspect-web links can now pre-set the NuGet package source.

- Rich share packets (`w`) include `n` when the active source is not nuget.org.
- Cold open and history navigation validate `n` through the same path as Settings, then persist on success.
- Shares from nuget.org omit `n` so they do not wipe a recipient's stored corporate mirror.
- Failed shared mirrors fall back to the recipient's stored source (if any) and surface a notice.

## Non-goals

- Multi-feed lists
- Credential-bearing or non-HTTPS service indexes
- Forcing nuget.org when a share omits `n`
- Symbol-package routing through the mirror

## Validation

- `node --check prototypes/inspect-web/src/app.js`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- Node smoke of base64 envelope round-trip + reject http/creds/query for `n`

Base: `prototype/wasm-command-ui` (post-#4212).