### PR TITLE
Add member-scoped body kind queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,21 @@ Use `--jsonl` for one machine-readable match per row or `--count` for the
 matching row count. Bodies that cannot be reconstructed at full fidelity are
 reported on stderr rather than mixed into structured output.
 
+Use the same predicate with one exact member name or stable selector to inspect
+only that member's MethodDef body:
+
+```bash
+dnx dotnet-inspect -y -- member JsonDocument RootElement:1 \
+  --platform System.Text.Json \
+  --where "Kind=ObjectCreationExpression" --jsonl
+```
+
+An unambiguous method or single-accessor member is auto-selected. Overloaded
+names require `Name:N` or `Name~digest`. A property or event with multiple body
+accessors requires an accessor selector; use the durable
+`Name~digest:1`/`Name~digest:2` form when the owner is overloaded. `--all`
+permits a selected non-public member.
+
 ## Capability inventory
 
 | Capability | Commands | Highlights |
@@ -176,7 +191,7 @@ reported on stderr rather than mixed into structured output.
 | Relationships | `depends`, `extensions`, `implements` | Type hierarchies, package dependencies, library reference graphs, extension methods/properties, implementors and subclasses. Add `--project` to search project-referenced packages. |
 | Source mapping | `library`/`package -S "SourceLink: Files"`, `type -S "Source Files"`, `member -S "Source Locations"` / `"Original Source"` | SourceLink URLs, member file/line locations, checksum-verified source fetching with final-origin redirect validation, token+IL-offset to source-line resolution. |
 | Performance analysis *(experimental)* | `library -S @Performance` (kind sections: `"Performance: Boxing"`, `"Performance: Arrays"`, …), `type`/`member -S "Performance Triage"`, `"Top Leverage"`, `"Resource Triage"`, `"Call Graph"` | Whole-assembly call-graph leverage ranking — direct callers, root reach, fanout, depth, loop calls — with opt-in per-node cost signals (alloc, copy, unsafe, reflection, throw/exception, catch/finally), actionable rewrite-shape detection, and exception-path resource-lifecycle candidates. |
-| Decompiler *(experimental)* | `member -S @Source` (`Decompiled Source`, `Annotated Source`, `Original Source`, `Source Diff`, `IL`); `member -S "Fidelity Causes"`; `library X --where "Kind=ObjectCreationExpression"`; `body-shape Kind --library path/to.dll` | Raises method bodies to C#, interleaves IL and hidden-fact annotations, searches one assembly for exact stable rendered-syntax kinds and ranges, diffs SourceLink-backed source against decompiled source, and exposes typed `DEC####` fidelity causes rather than emitting plausible-but-wrong source. |
+| Decompiler *(experimental)* | `member -S @Source` (`Decompiled Source`, `Annotated Source`, `Original Source`, `Source Diff`, `IL`); `member M --where "Kind=ObjectCreationExpression"`; `library X --where "Kind=ObjectCreationExpression"`; `body-shape Kind --library path/to.dll` | Raises method bodies to C#, interleaves IL and hidden-fact annotations, searches one selected member or one assembly for exact stable rendered-syntax kinds and ranges, diffs SourceLink-backed source against decompiled source, and exposes typed `DEC####` fidelity causes rather than emitting plausible-but-wrong source. |
 | Raw metadata | `library -S @Metadata` (table sections: `"Metadata: TypeDef"`, `"Metadata: MethodDef"`, …, plus `"Metadata: Image"`, the heap sections, and `--heap "#Strings:0x1a4"`) | The ECMA-335 metadata tables of an assembly, with handles resolved to the rows they point at and heap offsets to their values. Opt-in only: the tables are unbounded, so no verbosity renders them. |
 | Agent-friendly output | global flags | Markdown by default, compact `--table`, normalized `--tsv`, `--jsonl`, `--plaintext`, `--json`, Mermaid diagrams, section/field projection, `--count`, table row limiting, built-in head/tail limiting. |
 
@@ -188,7 +203,7 @@ reported on stderr rather than mixed into structured output.
 | `project [path]` | Inspect restored direct package references for skill files and package docs. |
 | `library X` | Inspect assembly metadata, symbols, SourceLink, references (`-S References`, optionally `--tree --depth N`), resources, async methods, and rendered body shapes (`--where "Kind=<ID>"`). |
 | `type X` | Discover types or render a single type shape. |
-| `member X` | Inspect members, docs, overloads, decompiled/lowered C#, SourceLink-backed original source, and IL. |
+| `member X` | Inspect members, docs, overloads, decompiled/lowered C#, rendered body shapes (`--where "Kind=<ID>"`), SourceLink-backed original source, and IL. |
 | `find X` | Search for types across packages, frameworks, projects, and local assets. Add `--members` (or lead the query with `.`, e.g. `.Serialize`) to search member names instead. |
 | `vocabulary` | Discover product-owned query vocabularies; select sections such as `Accessibility`, `C# Style Choices`, or `C# Body Kinds` to enumerate their legal values. |
 | `body-shape X` | Search one library's full-fidelity bodies for an exact stable rendered-syntax kind, returning the containing member, MethodDef token, exact range, and selected text. |

--- a/skills/decompiler/SKILL.md
+++ b/skills/decompiler/SKILL.md
@@ -60,18 +60,25 @@ dnx dotnet-inspect -y -- library MyLib.dll \
   --where "Kind=ObjectCreationExpression" --jsonl
 dnx dotnet-inspect -y -- library System.Text.Json \
   --where "Kind=TryStatement" --columns "Member;Token;Match" --rows 10
+dnx dotnet-inspect -y -- member JsonDocument RootElement:1 \
+  --platform System.Text.Json \
+  --where "Kind=ObjectCreationExpression" --jsonl
 ```
 
 `Kind=...` auto-selects the explicit-only section when no `-S` selection is
-present. Results include the containing stable member selector, MethodDef
+present. Results include a round-tripping qualified member selector, MethodDef
 token, one-based start/end range, and exact selected text. Bodies below `Full`
 fidelity are skipped and reported; add `--verbose` for per-member detail.
 The search runs the decompiler for each candidate body, so it may be expensive
-on a large library.
+on a large library. Member scope requires one exact member name or selector and
+decompiles only that member's MethodDef body. Unambiguous methods and
+single-accessor members are auto-selected; overloaded names require `Name:N`
+or `Name~digest`. A property or event with multiple body accessors requires an
+accessor selector; use `Name~digest:1`/`Name~digest:2` when the owner is
+overloaded. Use `--all` to select a non-public member.
 
-The standalone `body-shape` command remains temporarily for non-public
-`--all` searches and command-specific limits while type/member scoped queries
-reach parity:
+The standalone `body-shape` command remains temporarily while type-scoped
+queries reach parity:
 
 ```bash
 dnx dotnet-inspect -y -- body-shape TryStatement --library MyLib.dll --all --json

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -23,7 +23,7 @@ dnx dotnet-inspect -y -- <command>
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
 | Discover legal query values | `vocabulary -D`; select values with `vocabulary -S Accessibility`, `-S "C# Style Choices" --json`, or `-S "C# Body Kinds"`. |
-| Find rendered body syntax | `body-shape ObjectCreationExpression --library path/to.dll`; load `skill decompiler` for stable kinds and coordinates. |
+| Find rendered body syntax | `library path/to.dll --where "Kind=ObjectCreationExpression"` or `member Type Method:1 --library path/to.dll --where "Kind=InvocationExpression"`; load `skill decompiler` for stable kinds and coordinates. |
 | Compare APIs | `diff --package Foo@old..new --breaking` (`--additive` new APIs); `--alloc-regressions` for perf regressions (allocations up, hot first). |
 | Trace API evolution | `timeline --package Foo@old..new --type Type --members --at all`; omit `--at` to inspect the vector without acquiring packages. |
 | Inspect packages | `package Foo`; use `-D` to discover sections. Load `skill private-feeds` for custom/authenticated sources. |

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -122,11 +122,18 @@ the explicit-only `Body Shapes` section when no `-S` selection is present:
 dnx dotnet-inspect -y -- vocabulary -S "C# Body Kinds"
 dnx dotnet-inspect -y -- library MyLib.dll \
   --where "Kind=ObjectCreationExpression" --jsonl
+dnx dotnet-inspect -y -- member Widget Render:1 --library MyLib.dll \
+  --where "Kind=InvocationExpression" --jsonl
 ```
 
-The first slice accepts exactly one case-sensitive equality predicate. It does
-not combine a Body Shapes predicate with Performance Triage filters or
-`--order-by` in the same query.
+Member scope requires one exact member name or stable selector and decompiles
+only the selected MethodDef body. An unambiguous method or single-accessor
+member is auto-selected; overloaded names require `Name:N` or `Name~digest`.
+A property or event with multiple body accessors requires an accessor selector;
+use `Name~digest:1`/`Name~digest:2` when the owner is overloaded. The current
+query accepts exactly one case-sensitive equality predicate. It does not
+combine a Body Shapes predicate with Performance Triage filters or
+`--order-by`.
 
 ## Filter and order performance rows
 

--- a/src/ILInspector.Decompiler/BodyShapeSearch.cs
+++ b/src/ILInspector.Decompiler/BodyShapeSearch.cs
@@ -11,7 +11,7 @@ namespace ILInspector.Decompiler;
 /// One exact rendered-syntax occurrence in a decompiled method body.
 /// </summary>
 /// <param name="AssemblyName">Simple name of the inspected assembly.</param>
-/// <param name="Member">Stable qualified selector for the source-facing member that owns the body.</param>
+/// <param name="Member">Round-tripping qualified selector for the source-facing member body.</param>
 /// <param name="TypeName">Full metadata name of the declaring type.</param>
 /// <param name="MethodName">Metadata name of the containing method.</param>
 /// <param name="MethodToken">MethodDef token of the containing method.</param>
@@ -99,6 +99,60 @@ public static class BodyShapeSearch
         int? limit = null,
         CancellationToken cancellationToken = default,
         PrinterOptions? printerOptions = null)
+        => SearchCore(
+            source,
+            kind,
+            includeAll,
+            limit,
+            cancellationToken,
+            printerOptions,
+            methodTokens: null);
+
+    /// <summary>
+    /// Searches the selected MethodDef bodies for exact rendered-syntax node kinds.
+    /// </summary>
+    /// <param name="source">The metadata and PE source to inspect.</param>
+    /// <param name="kind">An exact stable kind from <see cref="SupportedKinds"/>.</param>
+    /// <param name="methodTokens">
+    /// MethodDef tokens that define the search scope. An empty set searches no bodies.
+    /// </param>
+    /// <param name="includeAll">
+    /// Whether non-public API-surface members may participate in the token scope. An explicitly
+    /// token-selected accessor of a public property or event remains eligible.
+    /// </param>
+    /// <param name="limit">Optional maximum number of matches.</param>
+    /// <param name="cancellationToken">Cancellation token checked between bodies.</param>
+    /// <param name="printerOptions">
+    /// Optional explicit rendering options. The library default preserves stable slot names.
+    /// </param>
+    public static BodyShapeSearchResult Search(
+        MetadataSource source,
+        string kind,
+        IReadOnlySet<int> methodTokens,
+        bool includeAll = false,
+        int? limit = null,
+        CancellationToken cancellationToken = default,
+        PrinterOptions? printerOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(methodTokens);
+        return SearchCore(
+            source,
+            kind,
+            includeAll,
+            limit,
+            cancellationToken,
+            printerOptions,
+            methodTokens);
+    }
+
+    static BodyShapeSearchResult SearchCore(
+        MetadataSource source,
+        string kind,
+        bool includeAll,
+        int? limit,
+        CancellationToken cancellationToken,
+        PrinterOptions? printerOptions,
+        IReadOnlySet<int>? methodTokens)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentException.ThrowIfNullOrWhiteSpace(kind);
@@ -113,7 +167,12 @@ public static class BodyShapeSearch
                 $"{failure.Operation} at 0x{failure.SubjectToken:X8}",
                 failure.Detail))
             .ToList();
-        var methods = SurfaceMethods(source.Reader, surface, includeAll, failures);
+        var methods = SurfaceMethods(
+            source.Reader,
+            surface,
+            includeAll,
+            methodTokens,
+            failures);
         var matches = new List<BodyShapeMatch>();
         int methodsInspected = 0;
 
@@ -122,7 +181,9 @@ public static class BodyShapeSearch
             cancellationToken.ThrowIfCancellationRequested();
             int methodToken = candidate.MethodToken;
             var anchor = ApiMemberIdentity.GetMemberAnchor(candidate.Type, candidate.Member);
-            string member = anchor.Format(MemberAnchorFormat.Qualified);
+            string member = candidate.AccessorOrdinal is { } accessorOrdinal
+                ? $"{anchor.TypeFullName}.{anchor.StableSelector}:{accessorOrdinal}"
+                : anchor.Format(MemberAnchorFormat.Qualified);
             string subject = $"{member} (0x{methodToken:X8})";
             var handle = (MethodDefinitionHandle)MetadataTokens.EntityHandle(methodToken);
             var method = source.Reader.GetMethodDefinition(handle);
@@ -244,6 +305,7 @@ public static class BodyShapeSearch
         MetadataReader reader,
         ApiSurface surface,
         bool includeAll,
+        IReadOnlySet<int>? methodTokens,
         List<BodyShapeSearchFailure> failures)
     {
         var methods = new SortedDictionary<int, SurfaceMethod>();
@@ -261,18 +323,30 @@ public static class BodyShapeSearch
         {
             foreach (var member in type.Members)
             {
-                Add(type, member, member.MetadataToken, accessor: false);
-                Add(type, member, member.GetterToken, accessor: true);
-                Add(type, member, member.SetterToken, accessor: true);
-                Add(type, member, member.AdderToken, accessor: true);
-                Add(type, member, member.RemoverToken, accessor: true);
+                Add(type, member, member.MetadataToken, accessorOrdinal: null);
+                int accessorOrdinal = 0;
+                if (member.GetterToken.HasValue)
+                    Add(type, member, member.GetterToken, ++accessorOrdinal);
+                if (member.SetterToken.HasValue)
+                    Add(type, member, member.SetterToken, ++accessorOrdinal);
+                accessorOrdinal = 0;
+                if (member.AdderToken.HasValue)
+                    Add(type, member, member.AdderToken, ++accessorOrdinal);
+                if (member.RemoverToken.HasValue)
+                    Add(type, member, member.RemoverToken, ++accessorOrdinal);
             }
         }
         return [.. methods.Values];
 
-        void Add(ApiType type, ApiMember member, int? token, bool accessor)
+        void Add(
+            ApiType type,
+            ApiMember member,
+            int? token,
+            int? accessorOrdinal)
         {
             if (token is not { } value)
+                return;
+            if (methodTokens is not null && !methodTokens.Contains(value))
                 return;
             var entity = MetadataTokens.EntityHandle(value);
             if (entity.Kind != HandleKind.MethodDefinition)
@@ -284,13 +358,17 @@ public static class BodyShapeSearch
             {
                 return;
             }
-            if (accessor && !includeAll)
+            if (accessorOrdinal.HasValue && !includeAll && methodTokens is null)
             {
                 var method = reader.GetMethodDefinition(methodHandle);
                 if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
                     return;
             }
-            var candidate = new SurfaceMethod(value, type, member);
+            var candidate = new SurfaceMethod(
+                value,
+                type,
+                member,
+                accessorOrdinal);
             if (!methods.TryGetValue(value, out var existing)
                 || Prefer(candidate, existing))
             {
@@ -331,7 +409,11 @@ public static class BodyShapeSearch
                 or "extension-method";
     }
 
-    private sealed record SurfaceMethod(int MethodToken, ApiType Type, ApiMember Member);
+    private sealed record SurfaceMethod(
+        int MethodToken,
+        ApiType Type,
+        ApiMember Member,
+        int? AccessorOrdinal);
 
     static string SelectText(IReadOnlyList<string> lines, PrintedExtent extent)
     {

--- a/src/ILInspector.Metadata/MemberTargetResolver.cs
+++ b/src/ILInspector.Metadata/MemberTargetResolver.cs
@@ -49,6 +49,9 @@ public sealed record MemberTargetSelector(
             };
             var suffix = DigestPrefix is { Length: > 0 }
                 ? $"~{DigestPrefix}"
+                    + (OverloadIndex is { } accessorIndex
+                        ? $":{accessorIndex}"
+                        : "")
                 : OverloadIndex is { } index ? $":{index}" : "";
             return $"{kindPrefix}{Name}{suffix}";
         }
@@ -70,8 +73,9 @@ public sealed record MemberTargetSelector(
             break;
         }
 
-        var (digestHead, digest) = SplitDigest(work);
+        var (digestHead, digest, accessorIndex) = SplitDigest(work);
         var (overloadHead, overloadIndex) = FqnParser.TrySplitOverload(digestHead);
+        overloadIndex ??= accessorIndex;
         var genericArity = TryGetGenericArity(overloadHead);
         var name = FqnParser.NormalizeMemberName(overloadHead);
         return new MemberTargetSelector(
@@ -95,17 +99,22 @@ public sealed record MemberTargetSelector(
     static string NormalizeKind(string value)
         => NormalizeKindQualifier(value) ?? value.ToLowerInvariant();
 
-    static (string Head, string? Digest) SplitDigest(string value)
+    static (string Head, string? Digest, int? AccessorIndex) SplitDigest(
+        string value)
     {
         var tilde = value.LastIndexOf('~');
         if (tilde <= 0 || tilde == value.Length - 1)
-            return (value, null);
+            return (value, null, null);
 
-        var digest = value[(tilde + 1)..];
+        var (digest, accessorIndex) =
+            FqnParser.TrySplitOverload(value[(tilde + 1)..]);
         if (!digest.All(Uri.IsHexDigit))
-            return (value, null);
+            return (value, null, null);
 
-        return (value[..tilde], digest.ToLowerInvariant());
+        return (
+            value[..tilde],
+            digest.ToLowerInvariant(),
+            accessorIndex);
     }
 
     static int? TryGetGenericArity(string value)
@@ -254,13 +263,6 @@ public static class MemberTargetResolver
                 candidates);
         }
 
-        if (selector.OverloadIndex.HasValue && selector.DigestPrefix is { Length: > 0 })
-        {
-            return Failure(MemberTargetDiagnosticKind.ConflictingSelectors,
-                "digest selector cannot be combined with --index/Name:N.",
-                candidates);
-        }
-
         MemberTargetCandidate selected;
         int? accessorOrdinal = null;
         if (selector.DigestPrefix is { Length: > 0 } digest)
@@ -284,6 +286,28 @@ public static class MemberTargetResolver
             }
 
             selected = matches[0];
+            if (selector.OverloadIndex is { } accessorIndex)
+            {
+                int accessorCount = AccessorCount(selected.Member);
+                if (accessorCount == 0)
+                {
+                    return Failure(
+                        MemberTargetDiagnosticKind.ConflictingSelectors,
+                        "digest selector cannot be combined with --index/Name:N.",
+                        candidates);
+                }
+                if (accessorIndex < 1 || accessorIndex > accessorCount)
+                {
+                    return Failure(
+                        MemberTargetDiagnosticKind.OverloadOutOfRange,
+                        $"{selector.Name}~{digest}:{accessorIndex} is out of range. "
+                            + $"Use {selector.Name}~{digest}:1 through "
+                            + $"{selector.Name}~{digest}:{accessorCount}.",
+                        matches);
+                }
+
+                accessorOrdinal = accessorIndex;
+            }
         }
         else if (selector.OverloadIndex is { } index)
         {

--- a/src/dotnet-inspect.Tests/BodyShapeCommandTests.cs
+++ b/src/dotnet-inspect.Tests/BodyShapeCommandTests.cs
@@ -50,6 +50,28 @@ public sealed class BodyShapeCommandTests
     }
 
     [Fact]
+    public void Search_MethodTokenScope_InspectsOnlyRequestedBodies()
+    {
+        using var source = MetadataSource.Open(FixturePath);
+        var surface = source.ExtractApiSurface(includeAll: false);
+        var type = Assert.Single(surface.Types, candidate =>
+            candidate.FullName == typeof(BodyShapeFixture).FullName);
+        var member = Assert.Single(type.Members, candidate =>
+            candidate.Name == nameof(BodyShapeFixture.PublicCreation));
+        int methodToken = Assert.IsType<int>(member.MetadataToken);
+
+        var result = BodyShapeSearch.Search(
+            source,
+            "ObjectCreationExpression",
+            new HashSet<int> { methodToken },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var match = Assert.Single(result.Matches);
+        Assert.Equal(methodToken, match.MethodToken);
+        Assert.Equal(1, result.MethodsInspected);
+    }
+
+    [Fact]
     public void MetadataSource_PrefetchedImageDoesNotRequireOriginalPath()
     {
         using var service =

--- a/src/dotnet-inspect.Tests/BodyShapesSectionTests.cs
+++ b/src/dotnet-inspect.Tests/BodyShapesSectionTests.cs
@@ -44,11 +44,8 @@ public sealed class BodyShapesSectionTests
             StringComparison.Ordinal);
     }
 
-    [Theory]
-    [InlineData("@Decompiler,Signature")]
-    [InlineData("Body*,Signature")]
-    public async Task MemberBodyShapeSelectorExpansion_RequiresKindPredicate(
-        string selection)
+    [Fact]
+    public async Task MemberBodyShapeGlobExpansion_RequiresKindPredicate()
     {
         var root = CommandLineBuilder.CreateRootCommand();
 
@@ -61,7 +58,7 @@ public sealed class BodyShapesSectionTests
                     "--library",
                     FixturePath,
                     "-S",
-                    selection,
+                    "Body*,Signature",
                 ]))
                 .InvokeAsync());
 
@@ -355,7 +352,7 @@ public sealed class BodyShapesSectionTests
     }
 
     [Fact]
-    public async Task MemberEffectiveDiscovery_ListsBodyShapesWhenKindIsPresent()
+    public async Task MemberEffectiveDiscovery_DescribesBodyShapesWhenKindIsPresent()
     {
         var root = CommandLineBuilder.CreateRootCommand();
 
@@ -368,7 +365,7 @@ public sealed class BodyShapesSectionTests
                     "--library",
                     FixturePath,
                     "-D",
-                    "@Decompiler",
+                    "Body Shapes",
                     "--where",
                     "Kind=ObjectCreationExpression",
                 ]))
@@ -376,7 +373,7 @@ public sealed class BodyShapesSectionTests
 
         Assert.Equal(0, result.ExitCode);
         Assert.DoesNotContain("Error:", result.Error, StringComparison.Ordinal);
-        Assert.Contains("Body Shapes", result.Output, StringComparison.Ordinal);
+        Assert.Contains("| Kind | column |", result.Output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -441,31 +438,6 @@ public sealed class BodyShapesSectionTests
                     "-S",
                     "Body Shapes",
                 ])
-                .InvokeAsync());
-
-        Assert.Equal(1, result.ExitCode);
-        Assert.Contains(
-            "requires --where \"Kind=<C# Body Kinds ID>\"",
-            result.Error,
-            StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public async Task MemberDecompilerCategory_RequiresKindPredicate()
-    {
-        var root = CommandLineBuilder.CreateRootCommand();
-
-        var result = await ConsoleCapture.RunAsync(() =>
-            root.Parse(CommandLineBuilder.PreprocessArgs(
-                [
-                    "member",
-                    typeof(BodyShapeFixture).FullName!,
-                    $"{nameof(BodyShapeFixture.PublicCreation)}:1",
-                    "--library",
-                    FixturePath,
-                    "-S",
-                    "@Decompiler",
-                ]))
                 .InvokeAsync());
 
         Assert.Equal(1, result.ExitCode);

--- a/src/dotnet-inspect.Tests/BodyShapesSectionTests.cs
+++ b/src/dotnet-inspect.Tests/BodyShapesSectionTests.cs
@@ -1,10 +1,15 @@
 using DotnetInspector.CommandLine;
 using DotnetInspector.Fixtures;
 using DotnetInspector.Models;
+using DotnetInspector.Output;
 using DotnetInspector.Sections;
 using DotnetInspector.Views;
 using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 using Markout;
+using System.Reflection;
 using System.Text.Json;
 
 namespace DotnetInspector.Tests;
@@ -36,6 +41,34 @@ public sealed class BodyShapesSectionTests
         Assert.Contains(
             nameof(BodyShapeFixture.PublicCreation),
             result.Output,
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("@Decompiler,Signature")]
+    [InlineData("Body*,Signature")]
+    public async Task MemberBodyShapeSelectorExpansion_RequiresKindPredicate(
+        string selection)
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(CommandLineBuilder.PreprocessArgs(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    $"{nameof(BodyShapeFixture.PublicCreation)}:1",
+                    "--library",
+                    FixturePath,
+                    "-S",
+                    selection,
+                ]))
+                .InvokeAsync());
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "requires --where \"Kind=<C# Body Kinds ID>\"",
+            result.Error,
             StringComparison.Ordinal);
     }
 
@@ -128,6 +161,31 @@ public sealed class BodyShapesSectionTests
     }
 
     [Fact]
+    public async Task MemberEffectiveDiscovery_BodyShapeGlobRequiresKind()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    $"{nameof(BodyShapeFixture.PublicCreation)}:1",
+                    "--library",
+                    FixturePath,
+                    "-D",
+                    "Body*",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "requires --where \"Kind=<C# Body Kinds ID>\"",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void EmptyBodyShapesResult_RendersExplicitEmptyState()
     {
         var inspection = new LibraryInspection
@@ -212,5 +270,648 @@ public sealed class BodyShapesSectionTests
             "cannot be combined with Performance Triage",
             result.Error,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_AutoSelectsBodyShapesForOnlyTheSelectedMethod()
+    {
+        var result = await RunMemberAsync(
+            nameof(BodyShapeFixture.PublicCreation),
+            "ObjectCreationExpression");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("Error:", result.Error, StringComparison.Ordinal);
+        Assert.Contains("## Body Shapes", result.Output, StringComparison.Ordinal);
+        Assert.Contains(
+            nameof(BodyShapeFixture.PublicCreation),
+            result.Output,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("PrivateCreation", result.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_QualifiedTypeMemberComposesWithCount()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    $"{typeof(BodyShapeFixture).FullName}."
+                        + nameof(BodyShapeFixture.PublicCreation),
+                    "--library",
+                    FixturePath,
+                    "--where",
+                    "Kind=ObjectCreationExpression",
+                    "--count",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("1", result.Output.Trim());
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_AutoSelectsTheUniqueOverload()
+    {
+        var result = await RunMemberAsync(
+            nameof(BodyShapeFixture.Branch),
+            "IfStatement",
+            includeSelector: false);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Body Shapes", result.Output, StringComparison.Ordinal);
+        Assert.Contains("if (value)", result.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_AmbiguousNameRequiresAnOverloadSelector()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeof(MemberCallsFixture).FullName!,
+                    nameof(MemberCallsFixture.Overloaded),
+                    "--library",
+                    typeof(MemberCallsFixture).Assembly.Location,
+                    "--where",
+                    "Kind=InvocationExpression",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "requires a single selected overload",
+            result.Error,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"{nameof(MemberCallsFixture.Overloaded)}:1",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberEffectiveDiscovery_ListsBodyShapesWhenKindIsPresent()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(CommandLineBuilder.PreprocessArgs(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    nameof(BodyShapeFixture.PublicCreation),
+                    "--library",
+                    FixturePath,
+                    "-D",
+                    "@Decompiler",
+                    "--where",
+                    "Kind=ObjectCreationExpression",
+                ]))
+                .InvokeAsync());
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("Error:", result.Error, StringComparison.Ordinal);
+        Assert.Contains("Body Shapes", result.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberEffectiveDiscovery_RequiresKindBeforeRunningBodyShapes()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(CommandLineBuilder.PreprocessArgs(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    $"{nameof(BodyShapeFixture.PublicCreation)}:1",
+                    "--library",
+                    FixturePath,
+                    "-D",
+                    "Body Shapes",
+                ]))
+                .InvokeAsync());
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "requires --where \"Kind=<C# Body Kinds ID>\"",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberBareDiscovery_DoesNotAdvertiseBodyShapesWithoutKind()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    nameof(BodyShapeFixture.PublicCreation),
+                    "--library",
+                    FixturePath,
+                    "-D",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.DoesNotContain("Body Shapes", result.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberBodyShapesSelection_RequiresKindPredicate()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    $"{nameof(BodyShapeFixture.PublicCreation)}:1",
+                    "--library",
+                    FixturePath,
+                    "-S",
+                    "Body Shapes",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "requires --where \"Kind=<C# Body Kinds ID>\"",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberDecompilerCategory_RequiresKindPredicate()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(CommandLineBuilder.PreprocessArgs(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    $"{nameof(BodyShapeFixture.PublicCreation)}:1",
+                    "--library",
+                    FixturePath,
+                    "-S",
+                    "@Decompiler",
+                ]))
+                .InvokeAsync());
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "requires --where \"Kind=<C# Body Kinds ID>\"",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberBroadSelection_OmitsBodyShapesWithoutKind()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    $"{nameof(BodyShapeFixture.PublicCreation)}:1",
+                    "--library",
+                    FixturePath,
+                    "-S",
+                    "*",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Signature", result.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain("## Body Shapes", result.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_RejectsAnotherSelectedSection()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    $"{nameof(BodyShapeFixture.PublicCreation)}:1",
+                    "--library",
+                    FixturePath,
+                    "-S",
+                    "Decompiled Source",
+                    "--where",
+                    "Kind=ObjectCreationExpression",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "targets section 'Body Shapes'",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_RejectsPerformancePredicatesInSameQuery()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    $"{nameof(BodyShapeFixture.PublicCreation)}:1",
+                    "--library",
+                    FixturePath,
+                    "--where",
+                    "Kind=ObjectCreationExpression",
+                    "--where",
+                    "Confidence=high",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "cannot yet be combined with Performance Triage",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("Public*")]
+    public async Task MemberKindPredicate_RequiresOneExactMember(string? memberFilter)
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var args = new List<string>
+        {
+            "member",
+            typeof(BodyShapeFixture).FullName!,
+            "--library",
+            FixturePath,
+            "--where",
+            "Kind=ObjectCreationExpression",
+        };
+        if (memberFilter is not null)
+        {
+            args.Add("-m");
+            args.Add(memberFilter);
+        }
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(args).InvokeAsync());
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "requires one exact member name or selector",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_UsesOrdinaryJsonlProjection()
+    {
+        var result = await RunMemberAsync(
+            nameof(BodyShapeFixture.PublicCreation),
+            "ObjectCreationExpression",
+            "--columns",
+            "Kind;Token",
+            "--jsonl");
+
+        Assert.Equal(0, result.ExitCode);
+        using var row = JsonDocument.Parse(result.Output);
+        Assert.Equal(
+            "ObjectCreationExpression",
+            row.RootElement.GetProperty("kind").GetString());
+        Assert.StartsWith(
+            "0x06",
+            row.RootElement.GetProperty("token").GetString(),
+            StringComparison.Ordinal);
+        Assert.Equal(2, row.RootElement.EnumerateObject().Count());
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_CountUsesTheScopedMatches()
+    {
+        var result = await RunMemberAsync(
+            nameof(BodyShapeFixture.PublicCreation),
+            "ObjectCreationExpression",
+            "--count");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("1", result.Output.Trim());
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_DocumentJsonFailsClosed()
+    {
+        var result = await RunMemberAsync(
+            nameof(BodyShapeFixture.PublicCreation),
+            "ObjectCreationExpression",
+            "--json");
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains(
+            "Document --json cannot represent Body Shapes analysis.",
+            result.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_RendersExplicitEmptyState()
+    {
+        var result = await RunMemberAsync(
+            nameof(BodyShapeFixture.PublicCreation),
+            "FixedStatement");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(
+            "No matching body shapes found.",
+            result.Output,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_AllCanSelectANonPublicBody()
+    {
+        var result = await RunMemberAsync(
+            "PrivateCreation",
+            "ObjectCreationExpression",
+            "--all");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("new Version(1, 2)", result.Output, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            nameof(BodyShapeFixture.PublicCreation),
+            result.Output,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_UsesOnlyTheSelectedAccessorBody()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        string assemblyPath = typeof(MemberAccessorModifierFixture).Assembly.Location;
+        string typeName = typeof(MemberAccessorModifierFixture).FullName!;
+
+        var getter = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeName,
+                    "State:1",
+                    "--library",
+                    assemblyPath,
+                    "--where",
+                    "Kind=ReturnStatement",
+                    "--count",
+                ])
+                .InvokeAsync());
+        var setter = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeName,
+                    "State:2",
+                    "--library",
+                    assemblyPath,
+                    "--where",
+                    "Kind=ReturnStatement",
+                    "--count",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(0, getter.ExitCode);
+        Assert.Equal("1", getter.Output.Trim());
+        Assert.Equal(0, setter.ExitCode);
+        Assert.Equal("0", setter.Output.Trim());
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_MultipleAccessorsRequireASelector()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeof(MemberAccessorModifierFixture).FullName!,
+                    "State",
+                    "--library",
+                    typeof(MemberAccessorModifierFixture).Assembly.Location,
+                    "--where",
+                    "Kind=AssignmentStatement",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("has 2 body accessors", result.Error, StringComparison.Ordinal);
+        Assert.Contains(":1 through", result.Error, StringComparison.Ordinal);
+        Assert.Contains(":2", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_EmitsAnAccessorSelectorThatRoundTrips()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        string assemblyPath = typeof(MemberAccessorModifierFixture).Assembly.Location;
+        string typeName = typeof(MemberAccessorModifierFixture).FullName!;
+
+        var first = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeName,
+                    "State:2",
+                    "--library",
+                    assemblyPath,
+                    "--where",
+                    "Kind=AssignmentStatement",
+                    "--jsonl",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(0, first.ExitCode);
+        using var row = JsonDocument.Parse(first.Output);
+        string selector = row.RootElement.GetProperty("member").GetString()!;
+        string token = row.RootElement.GetProperty("token").GetString()!;
+        Assert.StartsWith($"{typeName}.State~", selector, StringComparison.Ordinal);
+        Assert.EndsWith(":2", selector, StringComparison.Ordinal);
+
+        var replay = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    selector,
+                    "--library",
+                    assemblyPath,
+                    "--where",
+                    "Kind=AssignmentStatement",
+                    "--jsonl",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(0, replay.ExitCode);
+        using var replayRow = JsonDocument.Parse(replay.Output);
+        Assert.Equal(
+            token,
+            replayRow.RootElement.GetProperty("token").GetString());
+        Assert.Equal(
+            selector,
+            replayRow.RootElement.GetProperty("member").GetString());
+    }
+
+    [Fact]
+    public async Task MemberKindPredicate_OverloadedAccessorSelectorRoundTrips()
+    {
+        using var source = MetadataSource.Open(FixturePath);
+        var surface = source.ExtractApiSurface(includeAll: false);
+        var type = Assert.Single(surface.Types, candidate =>
+            candidate.FullName
+                == typeof(OverloadedIndexerBodyShapeFixture).FullName);
+        var stringIndexer = Assert.Single(type.Members, member =>
+            member.Kind == "property"
+            && member.Signature?.Contains(
+                "string key",
+                StringComparison.Ordinal) == true);
+        string stable = ApiMemberIdentity
+            .GetMemberAnchor(type, stringIndexer)
+            .StableSelector;
+        string selector = $"{stable}:2";
+        var root = CommandLineBuilder.CreateRootCommand();
+
+        var result = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeof(OverloadedIndexerBodyShapeFixture).FullName!,
+                    selector,
+                    "--library",
+                    FixturePath,
+                    "--where",
+                    "Kind=InvocationExpression",
+                    "--jsonl",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(0, result.ExitCode);
+        using var row = JsonDocument.Parse(result.Output);
+        string emitted = row.RootElement.GetProperty("member").GetString()!;
+        string token = row.RootElement.GetProperty("token").GetString()!;
+        Assert.Equal(
+            $"{typeof(OverloadedIndexerBodyShapeFixture).FullName}.{selector}",
+            emitted);
+
+        var replay = await ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    emitted,
+                    "--library",
+                    FixturePath,
+                    "--where",
+                    "Kind=InvocationExpression",
+                    "--jsonl",
+                ])
+                .InvokeAsync());
+
+        Assert.Equal(0, replay.ExitCode);
+        using var replayRow = JsonDocument.Parse(replay.Output);
+        Assert.Equal(
+            token,
+            replayRow.RootElement.GetProperty("token").GetString());
+        Assert.Equal(
+            emitted,
+            replayRow.RootElement.GetProperty("member").GetString());
+    }
+
+    [Fact]
+    public void MemberBodyResolution_UsesPropertyAndEventAccessorTokens()
+    {
+        using var source = MetadataSource.Open(FixturePath);
+        var surface = source.ExtractApiSurface(includeAll: true);
+        var type = Assert.Single(surface.Types, candidate =>
+            candidate.FullName == typeof(BodyShapeFixture).FullName);
+        var property = Assert.Single(type.Members, member =>
+            member.Kind == "property"
+            && member.Name.EndsWith(".Value", StringComparison.Ordinal));
+        var @event = Assert.Single(type.Members, member =>
+            member.Kind == "event"
+            && member.Name.EndsWith(".Changed", StringComparison.Ordinal));
+
+        type.Members = [property];
+        var propertyMethods = ApiOutputFormatter.ResolveBodyMethods(
+            type,
+            new HashSet<string> { SectionNames.BodyShapes });
+        type.Members = [@event];
+        var eventMethods = ApiOutputFormatter.ResolveBodyMethods(
+            type,
+            new HashSet<string> { SectionNames.BodyShapes });
+
+        var reflectionProperty = typeof(BodyShapeFixture).GetProperty(
+            $"{typeof(IBodyShapeValue).FullName}.{nameof(IBodyShapeValue.Value)}",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var reflectionEvent = typeof(BodyShapeFixture).GetEvent(
+            $"{typeof(IBodyShapeValue).FullName}.{nameof(IBodyShapeValue.Changed)}",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Assert.Equal(
+            [reflectionProperty.GetMethod!.MetadataToken],
+            propertyMethods.Select(method => method.MetadataToken));
+        Assert.Equal(
+            [
+                reflectionEvent.AddMethod!.MetadataToken,
+                reflectionEvent.RemoveMethod!.MetadataToken,
+            ],
+            eventMethods.Select(method => method.MetadataToken));
+        Assert.Equal(
+            reflectionEvent.RemoveMethod.MetadataToken,
+            Assert.Single(
+                ApiOutputFormatter.ResolveBodyShapeMethods(
+                    eventMethods,
+                    overloadIndex: 2)).MetadataToken);
+    }
+
+    static Task<(int ExitCode, string Output, string Error)> RunMemberAsync(
+        string member,
+        string kind,
+        params string[] extraArguments)
+        => RunMemberAsync(member, kind, includeSelector: true, extraArguments);
+
+    static Task<(int ExitCode, string Output, string Error)> RunMemberAsync(
+        string member,
+        string kind,
+        bool includeSelector,
+        params string[] extraArguments)
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        return ConsoleCapture.RunAsync(() =>
+            root.Parse(
+                [
+                    "member",
+                    typeof(BodyShapeFixture).FullName!,
+                    includeSelector ? $"{member}:1" : member,
+                    "--library",
+                    FixturePath,
+                    "--where",
+                    $"Kind={kind}",
+                    .. extraArguments,
+                ])
+                .InvokeAsync());
     }
 }

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -267,9 +267,26 @@ public static class MemberOptionsParser
         var select = opts.ParseSelect(parseResult);
         var selectDefault = opts.ParseSelectDefault(parseResult);
         bool hasExplicitSelect = select is { Length: > 0 } || selectDefault;
-        var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
+        var whereExpressions = parseResult.GetValue(opts.RowWhere) ?? [];
+        if (!BodyKindQueryOptions.TryExtract(
+                whereExpressions,
+                out var bodyKindQuery,
+                out var performanceWhere,
+                out var bodyKindError))
+        {
+            return new VersionError(bodyKindError);
+        }
+        var performanceTriage = opts.ParsePerformanceTriageOptions(
+            parseResult,
+            performanceWhere);
         if (!PerformanceTriageOptions.TryValidate(performanceTriage, out var triageShapeError))
             return new VersionError(triageShapeError);
+        if (bodyKindQuery.HasFilter && performanceTriage.HasFilters)
+        {
+            return new VersionError(
+                "A Body Shapes predicate cannot yet be combined with Performance Triage "
+                + "filters or --order-by in one query.");
+        }
         // Only surface Performance Triage from row filters when the user did not select sections
         // with -S; an explicit selection must not silently gain a second section.
         if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult) && !hasExplicitSelect)
@@ -350,6 +367,7 @@ public static class MemberOptionsParser
             Count = parseResult.GetValue(opts.Count),
             Rows = opts.ParseRows(parseResult),
             PerformanceTriage = performanceTriage,
+            BodyKindQuery = bodyKindQuery,
             Schema = opts.ParseSchema(parseResult),
             Verbose = parseResult.GetValue(opts.Verbose),
             Verbosity = opts.ParseVerbosity(parseResult),

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -303,8 +303,30 @@ public class ApiCommand
         {
             if (SelectOutput.WriteUnresolved(selectResult))
                 return (null!, 1);
+            if (options is MemberOptions bodyMemberOptions
+                && ApplyBodyShapeSelectionRequirements(
+                    bodyMemberOptions,
+                    selectResult) is { } bodyShapeError)
+            {
+                CommandError.Write(bodyShapeError);
+                return (null!, 1);
+            }
             if (selectResult.Sections != null)
                 options = options with { IncludeSections = selectResult.Sections };
+        }
+        if (options is MemberOptions
+            {
+                BodyKindQuery.HasFilter: true,
+                Select: null,
+                SelectDefault: false,
+                Discover: null,
+                IncludeSections: null,
+            })
+        {
+            options = options with
+            {
+                IncludeSections = [SectionNames.BodyShapes],
+            };
         }
 
         // A deferred select has no IncludeSections yet, and the preamble cannot know whether a
@@ -439,6 +461,66 @@ public class ApiCommand
         };
 
         return (new PreambleResult(options, typePipeline, memberPipeline), null);
+    }
+
+    internal static string? ApplyBodyShapeSelectionRequirements(
+        MemberOptions options,
+        SelectResult selectResult)
+    {
+        if (selectResult.Sections is not { } sections)
+            return options.BodyKindQuery.HasFilter
+                && options.Select is { Length: > 0 }
+                ? $"--where Kind=... targets section '{SectionNames.BodyShapes}'."
+                : null;
+
+        bool selected = sections.Contains(SectionNames.BodyShapes);
+        if (options.BodyKindQuery.HasFilter)
+        {
+            return selected
+                ? null
+                : $"--where Kind=... targets section '{SectionNames.BodyShapes}'. "
+                    + $"Omit -S or include -S \"{SectionNames.BodyShapes}\".";
+        }
+
+        if (!selected)
+            return null;
+
+        const string required =
+            "Section 'Body Shapes' requires --where \"Kind=<C# Body Kinds ID>\".";
+        if (TargetsBodyShapes(options, options.Select)
+            || sections.Count == 1)
+        {
+            return required;
+        }
+
+        sections.Remove(SectionNames.BodyShapes);
+        return null;
+    }
+
+    internal static bool TargetsBodyShapes(
+        MemberOptions options,
+        string[]? selectors)
+    {
+        if (selectors is not { Length: > 0 })
+            return false;
+
+        var pipeline = ApiMemberSectionPipelines.Create(options);
+        foreach (var selector in selectors)
+        {
+            var resolved = SelectResolver.ResolveSelectAsSections(
+                [selector],
+                pipeline.SelectableSectionNames,
+                pipeline.InfoSectionNames,
+                pipeline.GetCategoryMap());
+            if (!resolved.HasError
+                && resolved.Sections is { Count: 1 } sections
+                && sections.Contains(SectionNames.BodyShapes))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool ValidateMemberGraphFormat(
@@ -955,6 +1037,11 @@ public class ApiCommand
                 discover, pipeline.SelectableSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
             if (!resolved.HasError && resolved.Sections is { Count: > 0 })
                 sections.UnionWith(resolved.Sections);
+        }
+        if (options is MemberOptions { BodyKindQuery.HasFilter: false }
+            && options.Discover is not null)
+        {
+            sections.Remove(SectionNames.BodyShapes);
         }
         return sections;
     }
@@ -1664,6 +1751,16 @@ public class ApiCommand
                     + "Use --jsonl, --tsv, --table, or --print.");
                 return 1;
             }
+            if (GetRequestedMemberSections(type, options)
+                    .Contains(SectionNames.BodyShapes)
+                && options.IncludeSections?.Contains(
+                    SectionNames.BodyShapes) == true)
+            {
+                CommandError.Write(
+                    "Document --json cannot represent Body Shapes analysis. "
+                    + "Use --jsonl, --tsv, or --table.");
+                return 1;
+            }
             // --fields/--columns select table columns; document JSON has no column-slicing
             // facility, so the combination is rejected rather than silently dropped. A scalar
             // payload projection (--value/--print) does compose, and is handled above.
@@ -1749,6 +1846,15 @@ public class ApiCommand
                 var methods = ApiOutputFormatter.ResolveBodyMethods(type, requestedSections);
                 if (methods.Count > 0)
                 {
+                    if (requestedSections.Contains(SectionNames.BodyShapes))
+                    {
+                        ApiOutputFormatter.PopulateBodyShapes(
+                            view,
+                            mo4.DllPath!,
+                            mo4.PdbPath,
+                            methods,
+                            mo4);
+                    }
                     var analysisInspection = new ApiMemberAnalysisInspection(
                         mo4.DllPath!, methods, requestedSections, mo4.CallerScopeAssemblies, mo4);
                     ApiOutputFormatter.PopulateIndexSections(view, type, methods, mo4.DllPath!,
@@ -2411,6 +2517,14 @@ public class ApiCommand
         var fullSchema = GetTypeDocumentSchema(options);
         var filteredType = BuildFilteredTypeForSections(apiType, options);
         var effective = memberPipeline.GetDiscoverableSections(filteredType, options.IncludeSections);
+        if (options is MemberOptions { BodyKindQuery.HasFilter: false })
+        {
+            effective = effective
+                .Where(section => !section.Equals(
+                    SectionNames.BodyShapes,
+                    StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
         effective = DiscoverOutput.RestrictToSchemaSections(effective, fullSchema);
         var unprobed = memberPipeline.GetUnprobedSections();
         var bareDiscover = options.Discover is null or { Length: 0 };
@@ -2603,6 +2717,15 @@ public class ApiCommand
                 var methods = ApiOutputFormatter.ResolveBodyMethods(type, requestedSections);
                 if (methods.Count > 0)
                 {
+                    if (requestedSections.Contains(SectionNames.BodyShapes))
+                    {
+                        ApiOutputFormatter.PopulateBodyShapes(
+                            view,
+                            memberOptions.DllPath!,
+                            memberOptions.PdbPath,
+                            methods,
+                            memberOptions);
+                    }
                     var analysisInspection = new ApiMemberAnalysisInspection(
                         memberOptions.DllPath!, methods, requestedSections,
                         memberOptions.CallerScopeAssemblies, memberOptions);

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -116,6 +116,25 @@ public static class MemberCommand
                     options = options with { IncludeSections = actualSelect.Sections };
             }
 
+            if (options.BodyKindQuery.HasFilter
+                && (options.MemberFilter.Count != 1
+                    || options.MemberFilter.Any(MemberFilterHasWildcard)))
+            {
+                CommandError.Write(
+                    "--where Kind=... requires one exact member name or selector "
+                    + "(for example, Name:1 or Name~digest).");
+                return 1;
+            }
+            if (options.BodyKindQuery.HasFilter
+                && options.IncludeSections is null
+                && options.Discover is null)
+            {
+                options = options with
+                {
+                    IncludeSections = [SectionNames.BodyShapes],
+                };
+            }
+
             // Check each member filter before producing output
             if (options.MemberFilter.Count > 0)
             {
@@ -164,7 +183,17 @@ public static class MemberCommand
                 var autoMemberName = effectiveOptions.MemberFilter.First();
                 var autoOverloads = GetCandidateMembers(apiType, effectiveOptions, autoMemberName);
                 if (autoOverloads.Count == 1)
+                {
+                    if (effectiveOptions.BodyKindQuery.HasFilter
+                        && BodyAccessorCount(autoOverloads[0]) > 1)
+                    {
+                        WriteAccessorSelectionRequired(
+                            apiType,
+                            autoOverloads[0]);
+                        return 1;
+                    }
                     effectiveOptions = effectiveOptions with { OverloadIndex = 1 };
+                }
             }
 
             if (effectiveOptions.OverloadIndex.HasValue
@@ -194,6 +223,18 @@ public static class MemberCommand
 
                 var target = memberResolution.Target!;
                 var selected = target.ApiMember.Member;
+                bool explicitAccessorSelector =
+                    target.Kind is MemberTargetKind.Property or MemberTargetKind.Event
+                    && target.OverloadIndex.HasValue
+                    && (target.DigestPrefix is not null
+                        || memberResolution.Candidates.Count == 1);
+                if (effectiveOptions.BodyKindQuery.HasFilter
+                    && BodyAccessorCount(selected) > 1
+                    && !explicitAccessorSelector)
+                {
+                    WriteAccessorSelectionRequired(apiType, selected);
+                    return 1;
+                }
                 apiType.Members = [selected];
                 var detailDllPath = apiType.SourceAssemblyPath ?? apiDllPath;
                 effectiveOptions = effectiveOptions with
@@ -328,6 +369,16 @@ public static class MemberCommand
 
             if (effectiveOptions.EffectiveDiscovery)
             {
+                if (!effectiveOptions.BodyKindQuery.HasFilter
+                    && ApiCommand.TargetsBodyShapes(
+                        effectiveOptions,
+                        effectiveOptions.Discover))
+                {
+                    CommandError.Write(
+                        "Section 'Body Shapes' requires --where "
+                        + "\"Kind=<C# Body Kinds ID>\".");
+                    return 1;
+                }
                 return ApiCommand.ExecuteEffectiveDiscovery(
                     apiType, ApiMemberSectionPipelines.Create(effectiveOptions), effectiveOptions,
                     new ApiCommand.TypeAcquisitionContext(
@@ -492,11 +543,43 @@ public static class MemberCommand
         return true;
     }
 
+    private static bool MemberFilterHasWildcard(string filter)
+        => filter.Contains('*', StringComparison.Ordinal)
+           || filter.Contains('?', StringComparison.Ordinal);
+
+    private static int BodyAccessorCount(ApiMember member)
+        => member.Kind switch
+        {
+            "property" => (member.GetterToken.HasValue ? 1 : 0)
+                + (member.SetterToken.HasValue ? 1 : 0),
+            "event" => (member.AdderToken.HasValue ? 1 : 0)
+                + (member.RemoverToken.HasValue ? 1 : 0),
+            _ => 0,
+        };
+
+    private static void WriteAccessorSelectionRequired(
+        ApiType type,
+        ApiMember member)
+    {
+        var stable = ApiMemberIdentity
+            .GetMemberAnchor(type, member)
+            .StableSelector;
+        int count = BodyAccessorCount(member);
+        CommandError.Write(
+            $"Member '{member.Name}' has {count} body accessors. "
+                + $"Select one with {stable}:1 through {stable}:{count}.");
+    }
+
     private static bool TryGetSelectedSingleOverloadSections(MemberOptions options, out List<string> sections)
     {
         sections = [];
         if (options.MemberFilter.Count != 1)
             return false;
+        if (options.BodyKindQuery.HasFilter)
+        {
+            sections = [SectionNames.BodyShapes];
+            return true;
+        }
         if (options.IncludeSections is not { Count: > 0 } includeSections)
             return false;
         // Bare -S carries no selector value, so it cannot be recognized by inspecting Select.
@@ -538,6 +621,7 @@ public static class MemberCommand
         SectionNames.Callers,
         SectionNames.CallGraph,
         SectionNames.UnsafeOperations,
+        SectionNames.BodyShapes,
         SectionNames.TopLeverage,
         SectionNames.PerformanceTriage,
         SectionNames.Facts,
@@ -586,6 +670,7 @@ public static class MemberCommand
                && (sections.Contains(SectionNames.DecompiledSource)
                    || sections.Contains(SectionNames.AnnotatedSource)
                    || sections.Contains(SectionNames.AnnotatedSourceDocument)
+                   || sections.Contains(SectionNames.BodyShapes)
                    || sections.Contains(SectionNames.Facts));
     }
 

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -200,6 +200,7 @@ public partial record ApiOptions : IProjectionOptions
     public bool Count { get; init; }
     public RowWindow? Rows { get; init; }
     public PerformanceTriageOptions PerformanceTriage { get; init; } = PerformanceTriageOptions.Default;
+    public BodyKindQueryOptions BodyKindQuery { get; init; } = BodyKindQueryOptions.Default;
     public TipLevel TipLevel { get; init; } = TipLevel.Minimal;
 
     /// <summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2409,6 +2409,82 @@ public static class ApiOutputFormatter
             view.OptimizationOpportunityRows = rows;
     }
 
+    internal static void PopulateBodyShapes(
+        TypeView view,
+        string assemblyPath,
+        string? pdbPath,
+        IReadOnlyList<ApiMember> methods,
+        MemberOptions options)
+    {
+        string kind = options.BodyKindQuery.Kind
+            ?? throw new InvalidOperationException(
+                "The Body Shapes section requires a validated body-kind predicate.");
+        IReadOnlyList<ApiMember> scopedMethods = ResolveBodyShapeMethods(
+            methods,
+            options.OverloadIndex);
+        HashSet<int> methodTokens =
+        [
+            .. scopedMethods
+                .Where(method => method.MetadataToken.HasValue)
+                .Select(method => method.MetadataToken!.Value),
+        ];
+
+        options.RenderConfigWarnings?.EmitOnce();
+        using var source = Decompiler.Pipeline.MetadataSource.Open(
+            assemblyPath,
+            pdbPath,
+            ApiAnalysisInspection.CreateReferenceResolver(
+                assemblyPath,
+                options));
+        Decompiler.BodyShapeSearchResult result =
+            Decompiler.BodyShapeSearch.Search(
+                source,
+                kind,
+                methodTokens,
+                includeAll: options.IncludeAll,
+                printerOptions: options.RenderOptions);
+        view.BodyShapeRows =
+        [
+            .. result.Matches.Select(ApiBodyShapeRow.FromMatch),
+        ];
+
+        if (result.Failures.Count == 0)
+            return;
+
+        if (options.Verbose)
+        {
+            foreach (Decompiler.BodyShapeSearchFailure failure in result.Failures)
+            {
+                CommandError.WriteWarning(
+                    $"Body Shapes skipped {failure.Subject}: {failure.Reason}");
+            }
+        }
+
+        else
+        {
+            CommandError.WriteWarning(
+                $"Body Shapes skipped {result.Failures.Count} candidates; "
+                + "rerun with --verbose for details.");
+        }
+    }
+
+    internal static IReadOnlyList<ApiMember> ResolveBodyShapeMethods(
+        IReadOnlyList<ApiMember> methods,
+        int? overloadIndex)
+    {
+        if (methods.Count <= 1)
+            return methods;
+
+        int index = overloadIndex.GetValueOrDefault() - 1;
+        if ((uint)index >= (uint)methods.Count)
+        {
+            throw new InvalidOperationException(
+                "The selected accessor does not have a matching MethodDef body.");
+        }
+
+        return [methods[index]];
+    }
+
     /// <summary>
     /// Maps each API-surface member of <paramref name="type"/> to its drill selectors,
     /// keyed by metadata token: a round-tripping <c>Stable</c> selector (<c>Name~digest</c>),

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -634,9 +634,7 @@ public static class ApiMemberOverloadSectionDescriptors
                 SectionNames.AnnotatedSource,
                 SectionNames.OriginalSource,
                 SectionNames.SourceDiff,
-                SectionNames.IL)
-            .AddCategory(SectionCategoryNames.Decompiler,
-                SectionNames.BodyShapes);
+                SectionNames.IL);
     }
 
     private static bool HasSingleBodyBackedMember(ApiType model)
@@ -692,9 +690,7 @@ public static class ApiMemberDetailSectionDescriptors
                 SectionNames.AnnotatedSource,
                 SectionNames.OriginalSource,
                 SectionNames.SourceDiff,
-                SectionNames.IL)
-            .AddCategory(SectionCategoryNames.Decompiler,
-                SectionNames.BodyShapes);
+                SectionNames.IL);
     }
 
     public sealed class Summary : ISectionDescriptor<ApiType>

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -622,6 +622,7 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberDetailSectionDescriptors.Callers>()
             .Add<ApiMemberDetailSectionDescriptors.CallGraph>()
             .Add<ApiMemberDetailSectionDescriptors.UnsafeOperations>()
+            .Add<ApiMemberDetailSectionDescriptors.BodyShapes>(HasSingleBodyBackedMember)
             .Add<ApiMemberSectionDescriptors.TopLeverage>(HasSingleBodyBackedMember)
             .Add<ApiMemberSectionDescriptors.OptimizationOpportunities>(HasSingleBodyBackedMember)
             .Add<ApiMemberSectionDescriptors.CostOverlay>(HasSingleBodyBackedMember)
@@ -633,7 +634,9 @@ public static class ApiMemberOverloadSectionDescriptors
                 SectionNames.AnnotatedSource,
                 SectionNames.OriginalSource,
                 SectionNames.SourceDiff,
-                SectionNames.IL);
+                SectionNames.IL)
+            .AddCategory(SectionCategoryNames.Decompiler,
+                SectionNames.BodyShapes);
     }
 
     private static bool HasSingleBodyBackedMember(ApiType model)
@@ -679,6 +682,7 @@ public static class ApiMemberDetailSectionDescriptors
             .Add<Callers>()
             .Add<CallGraph>()
             .Add<UnsafeOperations>()
+            .Add<BodyShapes>()
             .Add<ApiMemberSectionDescriptors.TopLeverage>()
             .Add<ApiMemberSectionDescriptors.OptimizationOpportunities>()
             .Add<Facts>()
@@ -688,7 +692,9 @@ public static class ApiMemberDetailSectionDescriptors
                 SectionNames.AnnotatedSource,
                 SectionNames.OriginalSource,
                 SectionNames.SourceDiff,
-                SectionNames.IL);
+                SectionNames.IL)
+            .AddCategory(SectionCategoryNames.Decompiler,
+                SectionNames.BodyShapes);
     }
 
     public sealed class Summary : ISectionDescriptor<ApiType>
@@ -903,6 +909,21 @@ public static class ApiMemberDetailSectionDescriptors
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static bool ProbeEffectiveness => false;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Count == 1
+               && model.Members.Any(ApiMemberSectionDescriptors.IsBodyBacked);
+    }
+
+    public sealed class BodyShapes : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.BodyShapes;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static bool ProbeEffectiveness => false;
+        public static SectionCost Cost => SectionCost.Unbounded;
+        public static SectionCapabilities Capabilities =>
+            SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Count == 1

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -1,5 +1,6 @@
 using ILInspector.CSharp;
 using System.Text.Json.Serialization;
+using DotnetInspector.Output;
 using DotnetInspector.Sections;
 using ILInspector.Metadata;
 using Markout;
@@ -268,6 +269,10 @@ public class TypeView
     [MarkoutSection(Name = SectionNames.PerformanceTriage, EmptyText = "No optimization opportunities were found for this type.")]
     [JsonIgnore]
     public List<OptimizationOpportunityRow>? OptimizationOpportunityRows { get; set; }
+
+    [MarkoutSection(Name = SectionNames.BodyShapes, EmptyText = "No matching body shapes found.")]
+    [JsonIgnore]
+    public List<ApiBodyShapeRow>? BodyShapeRows { get; set; }
 
     public static bool TopLeverageVisibilityEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Visibility));
     public static bool TopLeverageGeneratedEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Generated));
@@ -1020,6 +1025,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(CostFactRow))]
 [MarkoutContext(typeof(TopLeverageRow))]
 [MarkoutContext(typeof(OptimizationOpportunityRow))]
+[MarkoutContext(typeof(ApiBodyShapeRow))]
 [MarkoutContext(typeof(ConstructorOverloadView))]
 [MarkoutContext(typeof(ConstructorParameterRow))]
 [MarkoutContext(typeof(EnumValueRow))]
@@ -1035,6 +1041,43 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(ApiInfoSection))]
 public partial class ApiViewContext : MarkoutSerializerContext
 {
+}
+
+[MarkoutSerializable]
+public sealed record ApiBodyShapeRow(
+    string Kind,
+    string Member,
+    string Token,
+    int StartLine,
+    int StartColumn,
+    int EndLine,
+    int EndColumn,
+    string Match)
+{
+    public string Kind { get; init; } = CSharpIdentifier.ContainRenderedText(Kind);
+    public string Member { get; init; } = MarkoutInline.Code(Member);
+    public string Token { get; init; } = MarkoutInline.Code(Token);
+    [MarkoutPropertyName("Start Line")]
+    public int StartLine { get; init; } = StartLine;
+    [MarkoutPropertyName("Start Column")]
+    public int StartColumn { get; init; } = StartColumn;
+    [MarkoutPropertyName("End Line")]
+    public int EndLine { get; init; } = EndLine;
+    [MarkoutPropertyName("End Column")]
+    public int EndColumn { get; init; } = EndColumn;
+    public string Match { get; init; } = MarkoutInline.Code(Match);
+
+    internal static ApiBodyShapeRow FromMatch(
+        ILInspector.Decompiler.BodyShapeMatch match)
+        => new(
+            match.Kind,
+            match.Member,
+            $"0x{match.MethodToken:X8}",
+            match.Extent.StartLine + 1,
+            match.Extent.StartColumn + 1,
+            match.Extent.EndLine + 1,
+            match.Extent.EndColumn + 1,
+            match.Text);
 }
 
 [MarkoutSerializable]

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -36,6 +36,11 @@
 
 ### Experimental analysis and decompilation
 
+- Rendered body-kind queries can now target one exact `member` overload. The
+  query resolves properties and events to their accessor MethodDef tokens,
+  emits round-tripping owner-plus-accessor selectors, supports non-public
+  selections with `--all`, and decompiles only the selected body instead of
+  scanning the assembly.
 - Adds bounded exact structural clone comparison and same-assembly discovery.
   Exact normalized IL/control-flow witnesses remain distinct from unsupported,
   failed, limited, ambiguous, and different outcomes; incomplete candidate

--- a/tests/DotnetInspector.Fixtures/BodyShapeFixture.cs
+++ b/tests/DotnetInspector.Fixtures/BodyShapeFixture.cs
@@ -54,3 +54,18 @@ public sealed class GenericBodyShapeFixture<T>
 {
     public static object Create() => new object();
 }
+
+public sealed class OverloadedIndexerBodyShapeFixture
+{
+    public string this[int index]
+    {
+        get => index.ToString();
+        set => GC.KeepAlive(value);
+    }
+
+    public string this[string key]
+    {
+        get => key.ToString();
+        set => Console.WriteLine(value);
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
@@ -6,6 +6,7 @@ public class MemberTargetResolverTests
     [InlineData("Name", "Name", null, null, null, null)]
     [InlineData("Name:2", "Name", 2, null, null, null)]
     [InlineData("Name~abc123", "Name", null, "abc123", null, null)]
+    [InlineData("Name~abc123:2", "Name", 2, "abc123", null, null)]
     [InlineData("M<T>", "M", null, null, null, 1)]
     [InlineData("M<TKey,TValue>:3", "M", 3, null, null, 2)]
     [InlineData(".ctor", ".ctor", null, null, null, null)]
@@ -205,6 +206,44 @@ public class MemberTargetResolverTests
         Assert.Equal(2, result.Target.Body!.DeclaringOverloadIndex);
         // The body token names the setter accessor, not the getter (issue #3265).
         Assert.Equal(0x06000102, result.Target.Body.MetadataToken);
+    }
+
+    [Fact]
+    public void Resolve_DigestQualifiedPropertyAccessorRoundTrips()
+    {
+        var type = CreateAccessorSurface();
+        var property = type.Members.Single(member => member.Name == "Value");
+        var digest = ApiMemberIdentity
+            .GetMemberAnchor(type, property)
+            .Fingerprint;
+        var selector = MemberTargetSelector.Parse($"Value~{digest}:2");
+
+        var result = MemberTargetResolver.Resolve(type, selector);
+
+        Assert.True(result.Found);
+        Assert.Equal($"Value~{digest}:2", selector.NormalizedSelector);
+        Assert.Equal(2, result.Target!.Body!.DeclaringOverloadIndex);
+        Assert.Equal(0x06000102, result.Target.Body.MetadataToken);
+    }
+
+    [Fact]
+    public void Resolve_DigestQualifiedMethodStillRejectsOverloadIndex()
+    {
+        var type = CreateSurface().Types[0];
+        var method = type.Members.Single(member =>
+            member.Signature == "void Run(string value)");
+        var digest = ApiMemberIdentity
+            .GetMemberAnchor(type, method)
+            .Fingerprint;
+
+        var result = MemberTargetResolver.Resolve(
+            type,
+            MemberTargetSelector.Parse($"Run~{digest}:1"));
+
+        Assert.False(result.Found);
+        Assert.Equal(
+            MemberTargetDiagnosticKind.ConflictingSelectors,
+            result.Diagnostic!.Kind);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- add an additive MethodDef-token-scoped `BodyShapeSearch.Search` overload while preserving the existing public signature
- support `member ... --where "Kind=<C# Body Kinds ID>"`, decompiling only the selected method or accessor body
- emit round-tripping accessor selectors, including `Name~digest:1/2` for overloaded properties and events
- integrate Body Shapes with member selection, discovery, table/TSV/JSONL/count output, empty states, and documentation

This follows the library-scoped query introduced in #4390 and provides the token-scoped substrate for composing body kinds with typed analysis findings.

`@Decompiler` is intentionally not added to the member section catalog because it would alias only `Body Shapes`. Removing the existing library/package alias and improving that implicit-command experience will be handled separately.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore --nologo --verbosity quiet`
- full `dotnet-inspect.Tests`: 4,182 passed, 14 environment skips
- focused `MemberTargetResolverTests`: 26 passed
- Markdown lint and `git diff --check`
