### PR TITLE
Suppress expected call graph boundary errors

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -469,6 +469,9 @@ visibility, reference-only retained-image budget, duplicate XML parameter
 handling, Mermaid label containment, and complete call-graph navigation targets.
 The JavaScript tests gate the annotated view helper against the shared sample
 document and keep Spotlight candidate/cache identity coordinate-complete.
+`call graph diagnostics distinguish failures from expected bounds` gates that
+catalog and body-analysis failures remain visible while an expected finite
+traversal boundary does not become a global error.
 
 The shared product paths are gated by:
 

--- a/prototypes/inspect-web/src/data.js
+++ b/prototypes/inspect-web/src/data.js
@@ -380,16 +380,23 @@ export function authoredSourceLimitationHtml(source) {
 }
 
 export function callGraphDiagnosticsMessage(diagnostics) {
-  if (!diagnostics?.isIncomplete) return "";
-  const boundaries = [];
-  if (diagnostics.hasUnexploredTraversalBoundary)
-    boundaries.push("unexplored traversal");
+  if (!diagnostics) return "";
+  const evidence = [];
+  if (diagnostics.incompleteNodes > 0)
+    evidence.push(`${diagnostics.incompleteNodes} incomplete node${diagnostics.incompleteNodes === 1 ? "" : "s"}`);
+  if (diagnostics.incompleteEdges > 0)
+    evidence.push(`${diagnostics.incompleteEdges} incomplete edge${diagnostics.incompleteEdges === 1 ? "" : "s"}`);
+  if (diagnostics.bindingIdentityConflicts > 0)
+    evidence.push(`${diagnostics.bindingIdentityConflicts} binding identity conflict${diagnostics.bindingIdentityConflicts === 1 ? "" : "s"}`);
   if (diagnostics.hasAnalysisFailureBoundary)
-    boundaries.push("analysis failure");
-  const boundaryText = boundaries.length
-    ? ` Boundaries: ${boundaries.join(" and ")}.`
-    : "";
-  return `Partial call graph: ${diagnostics.incompleteNodes} incomplete node${diagnostics.incompleteNodes === 1 ? "" : "s"}, ${diagnostics.incompleteEdges} incomplete edge${diagnostics.incompleteEdges === 1 ? "" : "s"}, and ${diagnostics.bindingIdentityConflicts} binding identity conflict${diagnostics.bindingIdentityConflicts === 1 ? "" : "s"}.${boundaryText}`;
+    evidence.push("one or more method bodies could not be analyzed");
+  if (!evidence.length) return "";
+  const detail = evidence.length === 1
+    ? evidence[0]
+    : evidence.length === 2
+    ? `${evidence[0]} and ${evidence[1]}`
+    : `${evidence.slice(0, -1).join(", ")}, and ${evidence.at(-1)}`;
+  return `Partial call graph: ${detail}.`;
 }
 
 export function parameterTitleHtml(parameters) {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -918,21 +918,36 @@ test("relationship navigation rejects ambiguous dotted identities", () => {
   assert.equal(uniqueTypeByQueryId([first, second], "N.T"), null);
 });
 
-test("incomplete call graphs produce a visible diagnostic", () => {
+test("call graph diagnostics distinguish failures from expected bounds", () => {
   assert.equal(callGraphDiagnosticsMessage({
     isIncomplete: true,
     incompleteNodes: 2,
     incompleteEdges: 1,
-    bindingIdentityConflicts: 3
+    bindingIdentityConflicts: 3,
+    hasUnexploredTraversalBoundary: true
   }), "Partial call graph: 2 incomplete nodes, 1 incomplete edge, and 3 binding identity conflicts.");
   assert.equal(callGraphDiagnosticsMessage({
     isIncomplete: true,
     incompleteNodes: 0,
     incompleteEdges: 0,
     bindingIdentityConflicts: 0,
+    hasUnexploredTraversalBoundary: true
+  }), "");
+  assert.equal(callGraphDiagnosticsMessage({
+    isIncomplete: true,
+    incompleteNodes: 0,
+    incompleteEdges: 0,
+    bindingIdentityConflicts: 0,
+    hasAnalysisFailureBoundary: true
+  }), "Partial call graph: one or more method bodies could not be analyzed.");
+  assert.equal(callGraphDiagnosticsMessage({
+    isIncomplete: true,
+    incompleteNodes: 1,
+    incompleteEdges: 0,
+    bindingIdentityConflicts: 0,
     hasUnexploredTraversalBoundary: true,
     hasAnalysisFailureBoundary: true
-  }), "Partial call graph: 0 incomplete nodes, 0 incomplete edges, and 0 binding identity conflicts. Boundaries: unexplored traversal and analysis failure.");
+  }), "Partial call graph: 1 incomplete node and one or more method bodies could not be analyzed.");
   assert.equal(callGraphDiagnosticsMessage({ isIncomplete: false }), "");
 });
 


### PR DESCRIPTION
## Outcome

Expected finite call-graph traversal boundaries no longer render as red global
errors in the Browser/Wasm app.

The Browser engine still carries `hasUnexploredTraversalBoundary` for
completeness-sensitive consumers. The presentation now creates a global
`Partial call graph` diagnostic only from concrete incomplete catalog nodes or
edges, binding identity conflicts, or body-analysis failure. It also omits
zero-valued counters and keeps combined failure grammar readable.

## Reproduction

The workspace from #4412 selects
`TryAddEnumerable(IServiceCollection, ServiceDescriptor)`. Its graph is valid
but finite: the callee root reaches the 25-node budget, leaves reach the depth
bound, and calls outside the loaded workspace remain external. Before this
change, those expected bounds produced:

```text
Partial call graph: 0 incomplete nodes, 0 incomplete edges, and 0 binding
identity conflicts. Boundaries: unexplored traversal.
```

After this change, that boundary-only diagnostic produces no global notice.
The graph's scope and typed terminal-node statuses remain visible.

## Evidence

- Browser JavaScript tests: 63/63
- Browser engine tests: 71/71
- shared annotated-source viewer tests: 12/12
- Browser/Wasm Release publish: passed
- `call graph diagnostics distinguish failures from expected bounds` covers:
  - nonzero catalog failures remain visible;
  - traversal-boundary-only diagnostics are silent;
  - body-analysis failures remain visible;
  - combined catalog and analysis failures remain readable.
- `prototypes/inspect-web/README.md`: Markdown lint passed
- diff and clean-worktree checks: passed

## Boundary

This changes Browser presentation only. It does not widen the workspace,
increase depth or node budgets, alter graph evidence, or remove typed
completeness state from the engine contract.

Closes #4412.
