### PR TITLE
Convert inspect-web home demos to workspace scenarios

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -22,9 +22,14 @@ Three consumers need a portable workspace description and are currently served
 by none (the browser workbench described below lives in the main tree under
 `prototypes/inspect-web`; claims about it cite that implementation):
 
-- The browser workbench's home demos are hand-authored base64 URL strings, and
-  one demo (`runCallGraphDemo`) is imperative code because the URL packet
-  cannot express its selection stably (only by positional overload index).
+- The browser workbench's home demos previously were hand-authored base64 URL
+  strings, and one demo (`runCallGraphDemo`) was imperative code because the
+  URL packet could not express its selection stably (only by positional
+  overload index). inspect-web now loads those three home demos from
+  declarative scenario records in `prototypes/inspect-web/src/home-demos.js`
+  and selects members by `MemberAnchor` digest; that is a browser projection
+  onto the current share packet, not yet the product-owned definition loader
+  or versioned packet contract below.
 - Share links carry a terse, unversioned packet whose two wire forms are
   distinguished by shape sniffing (`Array.isArray` vs `.t`).
 - The platform rides in package-shaped slots under the display id
@@ -852,6 +857,10 @@ Implementation must add, at minimum:
   the registry-binding open question; and
 - a demo-parity gate showing the previously imperative call-graph demo loads
   from a definition and lands on the anchor-digest-selected overload.
+  inspect-web's `home-demos.test.js` covers the browser projection of that
+  claim (scenario → multi-package packet with `d` digest, plus
+  `resolveMemberDeepLink`); the product-owned definition loader and packet
+  transposition gates above remain open.
 
 The shell-safety elimination above is the one asserted property no
 repository gate can reach — it is a claim about external tools, verified
@@ -859,6 +868,16 @@ manually (bash and zsh by transcript; PowerShell and cmd analytically) and
 otherwise falling under this note's blanket unverified marking.
 
 ### What exists today
+
+Browser home-demo projection (not a substitute for the gates above):
+
+- `prototypes/inspect-web/src/home-demos.js` registers the three home scenarios
+  as declarative workspace / navigation / view peer records and compiles them
+  to the current share-packet restore path;
+- share encode prefers MemberAnchor digest (`d`) over positional overload
+  (`o`); decode and deep-link restore accept either; and
+- `prototypes/inspect-web/test/home-demos.test.js` is the demo-parity gate for
+  that browser projection, including the former imperative call-graph demo.
 
 The coordinate-realization slice implements the `package`, `platform`, and
 `embedded` member coordinates

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -32,6 +32,20 @@ A selected malformed entry receives a path-derived identity only as a rejection
 carrier, so the workspace returns its typed failure instead of silently
 shortening the selected assembly set.
 
+## Home demos
+
+The home-page demo buttons are declarative scenario records in
+`src/home-demos.js`, shaped like the peer records in
+[workspace-definitions.md](../../docs/design/workspace-definitions.md). Each
+scenario compiles to the ordinary share-packet restore path (`?package=` +
+`w=`), including the multi-package call-graph demo. Member overloads are
+selected by `MemberAnchor` digest (`d` in the packet), not by positional
+index; legacy `o` remains readable for older links.
+
+The product-owned definition loader, catalog subscriptions, and versioned
+packet contract are still ahead of this browser projection. These records are
+the first consumer-side demos on that spine.
+
 ## How a workspace is opened
 
 1. **Resolve an exact identity.** `PackageSourceCoordinateResolver` validates

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -2,13 +2,17 @@ import {
   activeSourceOperationKind,
   assemblyDescriptorForType,
   authoredSourceLimitationHtml,
+  base64UrlDecode,
+  base64UrlEncode,
   beginSourceRequestState,
+  buildSharePacket,
   cancelSourceRequestState,
   callGraphDiagnosticsMessage,
   callGraphTargetMatchesType,
   callGraphTargetTypeId,
   createDependencyGraphPendingState,
   createDependencyGraphRenderSequence,
+  deepLinkFromLocation,
   dependencyCoordinateCandidates,
   dependencyGroupSelectionMessage,
   dependencyGraphGroupSelectionIndex,
@@ -28,6 +32,7 @@ import {
   packageLenses,
   parameterTitleHtml,
   removeWorkspacePackage,
+  resolveMemberDeepLink,
   retainWorkspacePackage,
   rootCommands,
   resolveLoadedGraphTargetCandidate,
@@ -46,6 +51,7 @@ import {
   buildDependencyGraphMermaid,
   buildTypeGraphMermaid
 } from "./graph-mermaid.js";
+import { compileHomeDemo, homeDemoCatalog } from "./home-demos.js";
 import { buildAnnotatedView, factsForNode, MEDIA, MEDIUM_LABELS, nodeAtOffset } from "/src/annotated-source-view.js";
 import { loadPlatformIndex } from "/src/platform-index.js";
 
@@ -460,50 +466,31 @@ function memberSectionsFor(member) {
   return memberSectionDefs.filter(([id]) => allowed.has(id));
 }
 
-// URL-safe base64 over UTF-8 bytes. Used for the opaque share packet so a shared or
-// duplicated link can carry the full session state without bloating the visible query.
-function base64UrlEncode(text) {
-  const bytes = new TextEncoder().encode(text);
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function base64UrlDecode(value) {
-  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
-  const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return new TextDecoder().decode(bytes);
-}
-
 // Compact, opaque share packet. Carries everything needed to fully restore a session — the
 // open-tab set, which tab is active, the current view, and (only in type view) the selected
 // type/member — so the visible query stays down to a human-readable ?package=<id>. Keys are
 // terse to keep the encoded string short:
 //   t = tabs [[id, version, framework], …]   a = active tab index   v = view token
-//   y/m/o/c = selected type / member / overload / member section (type view only)
+//   y/m/d|o/c = selected type / member / MemberAnchor digest|legacy overload / member section
 function encodeShareState() {
-  const packet = {
-    t: state.packages.map(item => [item.id, item.version, item.activeFramework || ""]),
-    a: Math.max(0, state.packages.indexOf(state.package))
-  };
-  // Which platform library the runtime pack is scoped to is part of the view's provenance —
-  // capture it so refresh/back/share land on that library instead of the aggregate platform.
-  if (isRuntimePackId(state.package.id) && state.libraryScope && state.libraryScope.size === 1) {
-    packet.l = [...state.libraryScope][0];
-  }
-  if (state.atPackageRoot) {
-    packet.v = state.packageLens && state.packageLens !== "overview" ? `pkg:${state.packageLens}` : "pkg";
-  } else {
-    // Package identity/view is enough for a package-root link; a selected type only belongs
-    // to type view, so it is captured here and nowhere else.
-    if (state.lens && state.lens !== "api") packet.v = state.lens;
-    if (state.selectedTypeId) packet.y = state.selectedTypeId;
-    if (state.selectedMemberKey) packet.m = state.selectedMemberKey;
-    if (state.selectedOverloadIndex != null) packet.o = state.selectedOverloadIndex;
-    if (state.memberSection && state.memberSection !== "overview") packet.c = state.memberSection;
-  }
+  const type = selectedType();
+  const member = selectedMember(type);
+  const overload = member && state.selectedOverloadIndex != null
+    ? member.overloads[state.selectedOverloadIndex]
+    : null;
+  const packet = buildSharePacket({
+    packages: state.packages,
+    activePackage: state.package,
+    libraryScope: state.libraryScope,
+    atPackageRoot: state.atPackageRoot,
+    packageLens: state.packageLens,
+    lens: state.lens,
+    selectedTypeId: state.selectedTypeId,
+    selectedMemberKey: state.selectedMemberKey,
+    selectedOverloadIndex: state.selectedOverloadIndex,
+    selectedOverloadDigest: overload?.anchorDigest || null,
+    memberSection: state.memberSection
+  });
   return base64UrlEncode(JSON.stringify(packet));
 }
 
@@ -517,7 +504,18 @@ function decodeShareState(value) {
     if (Array.isArray(raw)) {
       const normalized = normalizeShareTabs(raw);
       if (normalized.error) return { error: normalized.error };
-      return { tabs: normalized.tabs, active: 0, view: "", rich: false, type: null, member: null, overload: null, section: null, library: null };
+      return {
+        tabs: normalized.tabs,
+        active: 0,
+        view: "",
+        rich: false,
+        type: null,
+        member: null,
+        memberAnchor: null,
+        overload: null,
+        section: null,
+        library: null
+      };
     }
     if (raw && Array.isArray(raw.t)) {
       const normalized = normalizeShareTabs(raw.t);
@@ -531,6 +529,7 @@ function decodeShareState(value) {
         rich: true,
         type: raw.y != null ? String(raw.y) : null,
         member: raw.m != null ? String(raw.m) : null,
+        memberAnchor: raw.d != null ? String(raw.d) : null,
         overload: raw.o != null ? String(raw.o) : null,
         section: raw.c != null ? String(raw.c) : null,
         library: raw.l != null ? String(raw.l) : null
@@ -566,6 +565,7 @@ function parseLocation() {
   let framework = params.get("framework");
   let type = params.get("type");
   let member = params.get("member");
+  let memberAnchor = params.get("memberAnchor") || params.get("digest");
   let overload = params.get("overload");
   let section = params.get("section");
   let viewToken = location.hash.slice(1);
@@ -584,6 +584,7 @@ function parseLocation() {
       if (share.view) viewToken = share.view;
       type = share.type;
       member = share.member;
+      memberAnchor = share.memberAnchor;
       overload = share.overload;
       section = share.section;
       library = share.library;
@@ -608,6 +609,7 @@ function parseLocation() {
     framework,
     type,
     member,
+    memberAnchor,
     overload,
     section,
     lens: view.lens,
@@ -639,12 +641,7 @@ if (initialLocation.atPackageRoot) {
 
 // Deep-link selection to restore once the first package model is available. Consumed
 // (and cleared) by the first loadPackage so later package switches start fresh.
-const initialDeepLink = {
-  type: initialLocation.type,
-  member: initialLocation.member,
-  overload: initialLocation.overload,
-  section: initialLocation.section
-};
+const initialDeepLink = deepLinkFromLocation(initialLocation);
 
 const app = document.querySelector("#app");
 let mermaidModule;
@@ -5612,7 +5609,7 @@ function syncUrl() {
 }
 
 // Apply a parsed URL selection onto the currently loaded package, validating that the
-// type/member/overload/section still exist.
+// type/member/MemberAnchor-or-overload/section still exist.
 function applyDeepLink(deep) {
   const pkg = state.package;
   if (!pkg) return;
@@ -5641,16 +5638,13 @@ function applyDeepLink(deep) {
   if (restoreType && deep) {
     const type = pkg.types.find(item => item.id === deep.type);
     const groups = memberGroups(type);
-    const group = deep.member ? groups.find(item => item.key === deep.member) : null;
-    if (group) {
-      state.selectedMemberKey = deep.member;
-      const overloadIndex = Number(deep.overload);
-      if (deep.overload != null && deep.overload !== ""
-        && Number.isInteger(overloadIndex) && overloadIndex >= 0
-        && overloadIndex < group.overloads.length) {
-        state.selectedOverloadIndex = overloadIndex;
-      }
+    const resolved = resolveMemberDeepLink(groups, deep);
+    if (resolved.memberKey) {
+      state.selectedMemberKey = resolved.memberKey;
+      state.selectedOverloadIndex = resolved.overloadIndex;
+      const group = groups.find(item => item.key === resolved.memberKey);
       if (deep.section
+        && group
         && memberSectionIdsFor(group).includes(deep.section)) {
         state.memberSection = deep.section;
       }
@@ -5789,9 +5783,9 @@ function renderHomeView() {
           <div class="home-demos">
             <span class="home-demos-label">Or jump straight into a demo</span>
             <div class="home-demo-row">
-              <button class="home-demo" data-home-demo="stj" ${enginePending ? "disabled" : ""}><strong>System.Text.Json</strong><small>Browse a real package API</small></button>
-              <button class="home-demo" data-home-demo="callgraph" ${enginePending ? "disabled" : ""}><strong>Cross-package call graph</strong><small>Trace calls across four packages</small></button>
-              <button class="home-demo" data-home-demo="runtime" ${enginePending ? "disabled" : ""}><strong>.NET Platform</strong><small>Inspect platform BCL types</small></button>
+              ${homeDemoCatalog().map(demo =>
+                `<button class="home-demo" data-home-demo="${escapeHtml(demo.id)}" ${enginePending ? "disabled" : ""}><strong>${escapeHtml(demo.title)}</strong><small>${escapeHtml(demo.summary)}</small></button>`
+              ).join("")}
             </div>
           </div>
         </div>
@@ -5854,25 +5848,16 @@ function bindHomeEvents() {
   requestAnimationFrame(() => document.querySelector("#spotlight-input")?.focus());
 }
 
-// The two package demos jump to a rich, curated deep link (open tabs + selected type +,
-// for the platform, a scoped library) so the buttons showcase the workbench, not a bare
-// package root. pushState keeps them shareable/refreshable; the workspace restore reuses
-// the same path as a shared link. The call-graph demo stays a bespoke multi-package load.
-const HOME_DEMO_LINKS = {
-  stj: "?package=System.Text.Json&w=eyJ0IjpbWyJTeXN0ZW0uVGV4dC5Kc29uIiwiMTAuMC4wIiwibmV0MTAuMCJdXSwiYSI6MCwieSI6IlN5c3RlbS5UZXh0Lkpzb24uSnNvblNlcmlhbGl6ZXIifQ",
-  runtime: "?package=Microsoft.NETCore.App&w=eyJ0IjpbWyJTeXN0ZW0uVGV4dC5Kc29uIiwiMTAuMC4wIiwibmV0MTAuMCJdLFsiTWljcm9zb2Z0Lk5FVENvcmUuQXBwIiwiMTAuMC4xMCIsIm5ldDEwLjAiXV0sImEiOjEsImwiOiJTeXN0ZW0uUHJpdmF0ZS5Db3JlTGliIiwieSI6IlN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkxpc3RgMSJ9"
-};
-
+// Home demos are declarative scenario records (see home-demos.js). Each compiles to the
+// ordinary share-packet restore path — including the multi-package call-graph demo — so
+// pushState keeps them shareable/refreshable with no demo-only loader.
 function runHomeDemo(kind) {
+  const demo = compileHomeDemo(kind);
+  if (!demo) return;
   state.home = false;
-  if (kind === "callgraph") { runCallGraphDemo(); return; }
-  const link = HOME_DEMO_LINKS[kind];
-  if (!link) return;
-  try { history.pushState(null, "", link); } catch {}
+  try { history.pushState(null, "", demo.href); } catch {}
   const loc = parseLocation();
-  restoreWorkspaceFromLocation(loc, {
-    type: loc.type, member: loc.member, overload: loc.overload, section: loc.section
-  });
+  restoreWorkspaceFromLocation(loc, deepLinkFromLocation(loc));
 }
 
 // Return to the intro/home page without tearing down the warm engine or the loaded packages.
@@ -8005,71 +7990,6 @@ async function loadRuntimePackAssembly(
   }
 }
 
-async function runCallGraphDemo() {
-  state.loading = true;
-  state.error = "";
-  state.loadingMessage = "Loading cross-package call graph demo…";
-  state.loadingSubtitle = "";
-  render();
-
-  const targetPackage = await loadPackage(
-    "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "10.0.0",
-    "net10.0",
-    { retryAction: runCallGraphDemo });
-  if (!targetPackage) {
-    state.retryAction = runCallGraphDemo;
-    render();
-    return;
-  }
-  const loggingPackage = await loadPackage(
-    "Microsoft.Extensions.Logging",
-    "10.0.0",
-    "net10.0",
-    { retryAction: runCallGraphDemo });
-  if (!loggingPackage) {
-    state.retryAction = runCallGraphDemo;
-    render();
-    return;
-  }
-  const httpPackage = await loadPackage(
-    "Microsoft.Extensions.Http",
-    "10.0.0",
-    "net10.0",
-    { retryAction: runCallGraphDemo });
-  if (!httpPackage) {
-    state.retryAction = runCallGraphDemo;
-    render();
-    return;
-  }
-
-  activatePackage(targetPackage);
-  const type = state.package.types.find(item =>
-    item.id === "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions");
-  const member = type && memberGroups(type).find(item =>
-    item.name === "TryAddEnumerable" && item.kind === "method");
-  const overloadIndex = member?.overloads.findIndex(item => item.anchorDigest === "74b6b4b321") ?? -1;
-  if (!type || !member || overloadIndex < 0) {
-    state.loading = false;
-    state.error = "The call graph demo member was not found in the selected package.";
-    state.errorTitle = "Call graph demo failed";
-    state.retryAction = runCallGraphDemo;
-    render();
-    return;
-  }
-
-  state.selectedTypeId = type.id;
-  state.selectedMemberKey = member.key;
-  state.selectedOverloadIndex = overloadIndex;
-  state.memberSection = "call-graph";
-  state.memberCallGraph = null;
-  state.memberCallGraphError = "";
-  state.memberCallGraphKey = "";
-  state.loading = false;
-  render();
-  await loadSelectedMemberCallGraph();
-}
-
 // Loads the full open-tab set described by a parsed location (opaque workspace bucket, or a
 // lone target), then restores the active tab's platform library scope and deep-link
 // selection. Shared by boot restore, refreshed/shared links, and the in-app demo buttons.
@@ -8443,21 +8363,11 @@ window.addEventListener("popstate", () => {
     return;
   }
   if (!state.package) {
-    const deep = {
-      type: loc.type,
-      member: loc.member,
-      overload: loc.overload,
-      section: loc.section
-    };
+    const deep = deepLinkFromLocation(loc);
     restoreWorkspaceFromLocation(loc, deep, navigationSeq);
     return;
   }
-  const deep = {
-    type: loc.type,
-    member: loc.member,
-    overload: loc.overload,
-    section: loc.section
-  };
+  const deep = deepLinkFromLocation(loc);
   if (loc.tabs?.length && !workspaceCoordinatesMatch(state.packages, loc.tabs)) {
     restoreWorkspaceFromLocation(loc, deep, navigationSeq);
     return;

--- a/prototypes/inspect-web/src/data.js
+++ b/prototypes/inspect-web/src/data.js
@@ -566,3 +566,125 @@ export function mermaidLabel(value) {
   }
   return encoded;
 }
+
+// URL-safe base64 over UTF-8 bytes for the opaque share packet.
+export function base64UrlEncode(text) {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function base64UrlDecode(value) {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+/**
+ * Build the opaque share packet object from workbench selection state.
+ * Prefer MemberAnchor digest (`d`) over positional overload index (`o`).
+ */
+export function buildSharePacket({
+  packages = [],
+  activePackage = null,
+  libraryScope = null,
+  atPackageRoot = false,
+  packageLens = "overview",
+  lens = "api",
+  selectedTypeId = "",
+  selectedMemberKey = "",
+  selectedOverloadIndex = null,
+  selectedOverloadDigest = null,
+  memberSection = "overview"
+} = {}) {
+  const packet = {
+    t: packages.map(item => [item.id, item.version, item.activeFramework || ""]),
+    a: Math.max(0, packages.indexOf(activePackage))
+  };
+  if (activePackage
+    && isRuntimePackPacketId(activePackage.id)
+    && libraryScope
+    && libraryScope.size === 1) {
+    packet.l = [...libraryScope][0];
+  }
+  if (atPackageRoot) {
+    packet.v = packageLens && packageLens !== "overview" ? `pkg:${packageLens}` : "pkg";
+    return packet;
+  }
+  if (lens && lens !== "api") packet.v = lens;
+  if (selectedTypeId) packet.y = selectedTypeId;
+  if (selectedMemberKey) packet.m = selectedMemberKey;
+  if (selectedOverloadDigest) packet.d = selectedOverloadDigest;
+  else if (selectedOverloadIndex != null) packet.o = selectedOverloadIndex;
+  if (memberSection && memberSection !== "overview") packet.c = memberSection;
+  return packet;
+}
+
+function isRuntimePackPacketId(id) {
+  return String(id || "").toLowerCase() === "microsoft.netcore.app"
+    || String(id || "").toLowerCase() === "microsoft.aspnetcore.app";
+}
+
+/**
+ * Resolve a deep-link member selection against member groups.
+ * Prefers MemberAnchor digest over positional overload index.
+ */
+export function resolveMemberDeepLink(groups, deep) {
+  if (!Array.isArray(groups) || !deep) {
+    return { memberKey: "", overloadIndex: null };
+  }
+
+  const anchor = deep.memberAnchor != null && deep.memberAnchor !== ""
+    ? String(deep.memberAnchor)
+    : null;
+
+  if (anchor) {
+    const matches = [];
+    for (const group of groups) {
+      if (deep.member && group.key !== deep.member) continue;
+      for (let index = 0; index < group.overloads.length; index++) {
+        if (group.overloads[index]?.anchorDigest === anchor) {
+          matches.push({ memberKey: group.key, overloadIndex: index });
+        }
+      }
+    }
+    if (matches.length === 1) return matches[0];
+    // Ambiguous or missing digest: fall through to member + positional overload.
+  }
+
+  if (!deep.member) return { memberKey: "", overloadIndex: null };
+  const group = groups.find(item => item.key === deep.member);
+  if (!group) return { memberKey: "", overloadIndex: null };
+
+  const overloadIndex = Number(deep.overload);
+  if (deep.overload != null && deep.overload !== ""
+    && Number.isInteger(overloadIndex)
+    && overloadIndex >= 0
+    && overloadIndex < group.overloads.length) {
+    return { memberKey: group.key, overloadIndex };
+  }
+  return { memberKey: group.key, overloadIndex: null };
+}
+
+/** Build the deep-link object consumed by applyDeepLink / restore paths. */
+export function deepLinkFromLocation(loc) {
+  if (!loc) {
+    return {
+      type: null,
+      member: null,
+      memberAnchor: null,
+      overload: null,
+      section: null
+    };
+  }
+  return {
+    type: loc.type ?? null,
+    member: loc.member ?? null,
+    memberAnchor: loc.memberAnchor ?? null,
+    overload: loc.overload ?? null,
+    section: loc.section ?? null
+  };
+}

--- a/prototypes/inspect-web/src/home-demos.js
+++ b/prototypes/inspect-web/src/home-demos.js
@@ -1,0 +1,227 @@
+// Declarative home demos for inspect-web.
+// Shape follows docs/design/workspace-definitions.md (scenario + peer records).
+// Activation lowers to the existing share-packet restore path — no demo-only loader.
+
+import { base64UrlEncode } from "./data.js";
+
+const pkg = (id, version, framework) => ({
+  kind: "package",
+  id,
+  version,
+  framework
+});
+
+const diAbstractions = pkg(
+  "Microsoft.Extensions.DependencyInjection.Abstractions",
+  "10.0.0",
+  "net10.0");
+const logging = pkg("Microsoft.Extensions.Logging", "10.0.0", "net10.0");
+const http = pkg("Microsoft.Extensions.Http", "10.0.0", "net10.0");
+const stj = pkg("System.Text.Json", "10.0.0", "net10.0");
+const runtime = {
+  kind: "platform",
+  // Browser still addresses the platform via the Microsoft.NETCore.App pseudo id
+  // in the current share packet; keep that wire form until group subscriptions ship.
+  id: "Microsoft.NETCore.App",
+  version: "10.0.10",
+  framework: "net10.0",
+  family: "runtime"
+};
+
+/** @type {Record<string, object>} */
+export const HOME_DEMO_SCENARIOS = Object.freeze({
+  stj: Object.freeze({
+    schemaVersion: 1,
+    kind: "scenario",
+    id: "stj",
+    title: "System.Text.Json",
+    summary: "Browse a real package API",
+    workspace: Object.freeze({
+      schemaVersion: 1,
+      kind: "workspace",
+      id: "stj-serializer-tour",
+      contexts: Object.freeze([
+        Object.freeze({
+          name: "stj",
+          members: Object.freeze([stj])
+        })
+      ])
+    }),
+    navigation: Object.freeze({
+      schemaVersion: 1,
+      kind: "navigation",
+      id: "stj-navigation",
+      tabs: Object.freeze([
+        Object.freeze({ id: "stj", coordinate: stj })
+      ]),
+      focus: "stj"
+    }),
+    view: Object.freeze({
+      schemaVersion: 1,
+      kind: "view",
+      id: "stj-serializer-view",
+      type: "System.Text.Json.JsonSerializer"
+    })
+  }),
+  runtime: Object.freeze({
+    schemaVersion: 1,
+    kind: "scenario",
+    id: "runtime",
+    title: ".NET Platform",
+    summary: "Inspect platform BCL types",
+    workspace: Object.freeze({
+      schemaVersion: 1,
+      kind: "workspace",
+      id: "platform-list-tour",
+      contexts: Object.freeze([
+        Object.freeze({
+          name: "platform",
+          members: Object.freeze([stj, runtime])
+        })
+      ])
+    }),
+    navigation: Object.freeze({
+      schemaVersion: 1,
+      kind: "navigation",
+      id: "platform-navigation",
+      tabs: Object.freeze([
+        Object.freeze({ id: "stj", coordinate: stj }),
+        Object.freeze({ id: "runtime", coordinate: runtime })
+      ]),
+      focus: "runtime"
+    }),
+    view: Object.freeze({
+      schemaVersion: 1,
+      kind: "view",
+      id: "platform-list-view",
+      library: "System.Private.CoreLib",
+      type: "System.Collections.Generic.List`1"
+    })
+  }),
+  callgraph: Object.freeze({
+    schemaVersion: 1,
+    kind: "scenario",
+    id: "callgraph",
+    title: "Cross-package call graph",
+    summary: "Trace calls across three packages",
+    workspace: Object.freeze({
+      schemaVersion: 1,
+      kind: "workspace",
+      id: "extensions-callgraph",
+      contexts: Object.freeze([
+        Object.freeze({
+          name: "extensions",
+          members: Object.freeze([diAbstractions, logging, http])
+        })
+      ])
+    }),
+    navigation: Object.freeze({
+      schemaVersion: 1,
+      kind: "navigation",
+      id: "extensions-callgraph-navigation",
+      tabs: Object.freeze([
+        Object.freeze({ id: "di", coordinate: diAbstractions }),
+        Object.freeze({ id: "logging", coordinate: logging }),
+        Object.freeze({ id: "http", coordinate: http })
+      ]),
+      focus: "di"
+    }),
+    view: Object.freeze({
+      schemaVersion: 1,
+      kind: "view",
+      id: "try-add-enumerable-call-graph",
+      type: "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
+      // member group key used by the workbench member index (kind:name)
+      memberKey: "method:TryAddEnumerable",
+      // MemberAnchor fingerprint — stable overload selector (not positional index)
+      memberAnchor: "74b6b4b321",
+      section: "call-graph"
+    })
+  })
+});
+
+export const HOME_DEMO_ORDER = Object.freeze(["stj", "callgraph", "runtime"]);
+
+function coordinateToTab(coordinate) {
+  return {
+    id: coordinate.id,
+    version: coordinate.version || "latest",
+    framework: coordinate.framework || ""
+  };
+}
+
+/**
+ * Lower a registered home-demo scenario to the current restore location + share URL.
+ * This is the browser projection of a scenario composition until the product-owned
+ * definition loader and packet v1 ship.
+ */
+export function compileHomeDemo(kind) {
+  const scenario = HOME_DEMO_SCENARIOS[kind];
+  if (!scenario) return null;
+
+  const navTabs = scenario.navigation?.tabs ?? [];
+  if (!navTabs.length) return null;
+
+  const tabs = navTabs.map(tab => coordinateToTab(tab.coordinate));
+  const focusIndex = Math.max(0, navTabs.findIndex(tab => tab.id === scenario.navigation.focus));
+  const active = focusIndex >= 0 ? focusIndex : 0;
+  const focus = tabs[active];
+  const view = scenario.view || {};
+
+  const packet = {
+    t: tabs.map(tab => [tab.id, tab.version, tab.framework]),
+    a: active
+  };
+  if (view.library) packet.l = view.library;
+  if (view.lens) packet.v = view.lens;
+  if (view.type) packet.y = view.type;
+  if (view.memberKey) packet.m = view.memberKey;
+  if (view.memberAnchor) packet.d = view.memberAnchor;
+  else if (view.overload != null && view.overload !== "") packet.o = view.overload;
+  if (view.section) packet.c = view.section;
+
+  const encoded = base64UrlEncode(JSON.stringify(packet));
+  const href = `?package=${encodeURIComponent(focus.id)}&w=${encoded}`;
+
+  return {
+    id: scenario.id,
+    title: scenario.title,
+    summary: scenario.summary,
+    href,
+    packet,
+    location: {
+      package: focus.id,
+      version: focus.version,
+      framework: focus.framework,
+      tabs,
+      active,
+      type: view.type ?? null,
+      member: view.memberKey ?? null,
+      memberAnchor: view.memberAnchor != null ? String(view.memberAnchor) : null,
+      overload: view.memberAnchor
+        ? null
+        : (view.overload != null && view.overload !== "" ? String(view.overload) : null),
+      section: view.section ?? null,
+      library: view.library ?? null,
+      lens: null,
+      atPackageRoot: false,
+      packageLens: null,
+      workspaceNotice: ""
+    },
+    deepLink: {
+      type: view.type ?? null,
+      member: view.memberKey ?? null,
+      memberAnchor: view.memberAnchor != null ? String(view.memberAnchor) : null,
+      overload: view.memberAnchor
+        ? null
+        : (view.overload != null && view.overload !== "" ? String(view.overload) : null),
+      section: view.section ?? null
+    }
+  };
+}
+
+export function homeDemoCatalog() {
+  return HOME_DEMO_ORDER
+    .map(id => compileHomeDemo(id))
+    .filter(Boolean);
+}

--- a/prototypes/inspect-web/test/home-demos.test.js
+++ b/prototypes/inspect-web/test/home-demos.test.js
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  base64UrlDecode,
+  buildSharePacket,
+  deepLinkFromLocation,
+  resolveMemberDeepLink
+} from "../src/data.js";
+import {
+  compileHomeDemo,
+  HOME_DEMO_ORDER,
+  HOME_DEMO_SCENARIOS,
+  homeDemoCatalog
+} from "../src/home-demos.js";
+
+test("home demo catalog covers the three workbench entry points", () => {
+  assert.deepEqual(HOME_DEMO_ORDER, ["stj", "callgraph", "runtime"]);
+  const catalog = homeDemoCatalog();
+  assert.equal(catalog.length, 3);
+  assert.deepEqual(catalog.map(demo => demo.id), HOME_DEMO_ORDER);
+  for (const demo of catalog) {
+    assert.ok(demo.href.startsWith("?package="));
+    assert.match(demo.href, /&w=/);
+    assert.equal(demo.location.tabs.length, demo.packet.t.length);
+  }
+});
+
+test("STJ and platform demos preserve the prior curated selection shape", () => {
+  const stj = compileHomeDemo("stj");
+  assert.equal(stj.location.package, "System.Text.Json");
+  assert.equal(stj.location.type, "System.Text.Json.JsonSerializer");
+  assert.equal(stj.location.tabs.length, 1);
+  assert.equal(stj.deepLink.memberAnchor, null);
+
+  const runtime = compileHomeDemo("runtime");
+  assert.equal(runtime.location.package, "Microsoft.NETCore.App");
+  assert.equal(runtime.location.library, "System.Private.CoreLib");
+  assert.equal(runtime.location.type, "System.Collections.Generic.List`1");
+  assert.equal(runtime.location.tabs.length, 2);
+  assert.equal(runtime.location.active, 1);
+});
+
+test("call-graph demo is a multi-package scenario selected by MemberAnchor digest", () => {
+  const demo = compileHomeDemo("callgraph");
+  assert.ok(demo);
+  assert.deepEqual(
+    demo.location.tabs.map(tab => tab.id),
+    [
+      "Microsoft.Extensions.DependencyInjection.Abstractions",
+      "Microsoft.Extensions.Logging",
+      "Microsoft.Extensions.Http"
+    ]);
+  assert.equal(demo.location.package, "Microsoft.Extensions.DependencyInjection.Abstractions");
+  assert.equal(
+    demo.location.type,
+    "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions");
+  assert.equal(demo.location.member, "method:TryAddEnumerable");
+  assert.equal(demo.location.memberAnchor, "74b6b4b321");
+  assert.equal(demo.location.section, "call-graph");
+  assert.equal(demo.location.overload, null);
+  assert.equal(demo.packet.d, "74b6b4b321");
+  assert.equal(demo.packet.c, "call-graph");
+  assert.equal("o" in demo.packet, false);
+
+  // Compiled href round-trips through the same base64 packet shape the workbench restores.
+  const encoded = new URL(demo.href, "https://inspect.example/").searchParams.get("w");
+  const packet = JSON.parse(base64UrlDecode(encoded));
+  assert.deepEqual(packet, demo.packet);
+});
+
+test("buildSharePacket prefers MemberAnchor digest over positional overload index", () => {
+  const packages = [
+    { id: "A", version: "1.0.0", activeFramework: "net10.0" },
+    { id: "B", version: "1.0.0", activeFramework: "net10.0" }
+  ];
+  const packet = buildSharePacket({
+    packages,
+    activePackage: packages[0],
+    selectedTypeId: "T",
+    selectedMemberKey: "method:M",
+    selectedOverloadIndex: 2,
+    selectedOverloadDigest: "deadbeef01",
+    memberSection: "call-graph"
+  });
+  assert.equal(packet.d, "deadbeef01");
+  assert.equal("o" in packet, false);
+  assert.equal(packet.m, "method:M");
+  assert.equal(packet.c, "call-graph");
+
+  const legacy = buildSharePacket({
+    packages,
+    activePackage: packages[0],
+    selectedTypeId: "T",
+    selectedMemberKey: "method:M",
+    selectedOverloadIndex: 2,
+    selectedOverloadDigest: null
+  });
+  assert.equal(legacy.o, 2);
+  assert.equal("d" in legacy, false);
+});
+
+test("resolveMemberDeepLink selects by digest and keeps positional overload fallback", () => {
+  const groups = [
+    {
+      key: "method:TryAddEnumerable",
+      overloads: [
+        { anchorDigest: "aaaaaaaaaa" },
+        { anchorDigest: "74b6b4b321" },
+        { anchorDigest: "bbbbbbbbbb" }
+      ]
+    },
+    {
+      key: "method:Other",
+      overloads: [{ anchorDigest: "cccccccccc" }]
+    }
+  ];
+
+  assert.deepEqual(
+    resolveMemberDeepLink(groups, {
+      member: "method:TryAddEnumerable",
+      memberAnchor: "74b6b4b321"
+    }),
+    { memberKey: "method:TryAddEnumerable", overloadIndex: 1 });
+
+  assert.deepEqual(
+    resolveMemberDeepLink(groups, {
+      memberAnchor: "74b6b4b321"
+    }),
+    { memberKey: "method:TryAddEnumerable", overloadIndex: 1 });
+
+  assert.deepEqual(
+    resolveMemberDeepLink(groups, {
+      member: "method:TryAddEnumerable",
+      overload: "2"
+    }),
+    { memberKey: "method:TryAddEnumerable", overloadIndex: 2 });
+
+  assert.deepEqual(
+    resolveMemberDeepLink(groups, {
+      member: "method:Missing",
+      overload: "0"
+    }),
+    { memberKey: "", overloadIndex: null });
+});
+
+test("deepLinkFromLocation carries memberAnchor", () => {
+  assert.deepEqual(
+    deepLinkFromLocation({
+      type: "T",
+      member: "method:M",
+      memberAnchor: "abc",
+      overload: "1",
+      section: "call-graph"
+    }),
+    {
+      type: "T",
+      member: "method:M",
+      memberAnchor: "abc",
+      overload: "1",
+      section: "call-graph"
+    });
+});
+
+test("home demo scenarios stay closed record kinds from the workspace design", () => {
+  for (const id of HOME_DEMO_ORDER) {
+    const scenario = HOME_DEMO_SCENARIOS[id];
+    assert.equal(scenario.kind, "scenario");
+    assert.equal(scenario.workspace.kind, "workspace");
+    assert.equal(scenario.navigation.kind, "navigation");
+    assert.equal(scenario.view.kind, "view");
+    assert.ok(scenario.workspace.contexts.length >= 1);
+    assert.ok(scenario.navigation.tabs.length >= 1);
+  }
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1073,7 +1073,12 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /state\.retryAction = options\.retryAction/);
   assert.match(
     appSource,
-    /state\.retryAction = runCallGraphDemo/);
+    /const demo = compileHomeDemo\(kind\);/);
+  assert.match(
+    appSource,
+    /restoreWorkspaceFromLocation\(loc, deepLinkFromLocation\(loc\)\)/);
+  assert.doesNotMatch(appSource, /runCallGraphDemo/);
+  assert.doesNotMatch(appSource, /HOME_DEMO_LINKS/);
   assert.match(
     appSource,
     /appendQueryNotice\(\s+friendly\.message,\s+options\.retryAction/);
@@ -1091,7 +1096,7 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /assemblyDescriptorForType\(pkg\.assemblies, stat\)/);
   assert.match(
     appSource,
-    /activatePackage\(targetPackage\)/);
+    /activatePackage\(targetModel, \{ resetAccessibility: true \}\)/);
 });
 
 test("member documentation state is scoped to the exact request", () => {


### PR DESCRIPTION
## Summary

Convert the three inspect-web home demos from hand-authored base64 links / an imperative call-graph loader into declarative workspace scenario records that lower through the ordinary share-packet restore path.

## Behavioral claim

- Home demos are data (`src/home-demos.js`): STJ, cross-package call graph, and .NET Platform.
- All three activate via `history.pushState` + `restoreWorkspaceFromLocation` — no `runCallGraphDemo` special case.
- Share packets prefer `MemberAnchor` digest (`d`) over positional overload index (`o`); decode/restore accept either.
- Call-graph demo is multi-package + digest-selected `TryAddEnumerable` + `call-graph` section, so it is shareable/refreshable.

## Non-action / boundary

- This is a **browser projection** onto the current unversioned share packet.
- It does **not** ship the product-owned definition loader, catalog subscriptions, hardened packet v1, or C# schema gates from `workspace-definitions.md`.
- IChatClient dual-lens demo is not added yet; this spine is the prerequisite.

## Evidence

```bash
cd prototypes/inspect-web && node --test test/home-demos.test.js test/spotlight-identity.test.js test/annotated-source-view.test.js
# 70 pass
npx markdownlint-cli docs/design/workspace-definitions.md
```

## Follow-up

1. Product-owned JSON definition loader + bundle registration.
2. Versioned share packet transposition of the same records.
3. Add locked IChatClient dual-lens scenario on this format.