### PR TITLE
Remove singleton library decompiler category

### DIFF
--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -90,7 +90,7 @@ evidence unless a category is named.
 | Command | Base categories | Domain categories |
 | ------- | --------------- | ----------------- |
 | `package` | `@Package`, `@Files` | `@Dependencies`, `@Audit`, `@SourceLink` |
-| `library` | `@Library`, `@Surface` | `@Audit`, `@Performance`, `@Decompiler`, `@SourceLink`, `@Integrations`, `@Metadata`, `@Context` |
+| `library` | `@Library`, `@Surface` | `@Audit`, `@Performance`, `@SourceLink`, `@Integrations`, `@Metadata`, `@Context` |
 
 `@Package` groups `Package Info`, `Signals`, `Statistics`, `Target Frameworks`,
 `Signature`, `Dependencies`, `Vulnerabilities`, `Manifest`, `Runtime

--- a/src/dotnet-inspect.Tests/BodyShapesSectionTests.cs
+++ b/src/dotnet-inspect.Tests/BodyShapesSectionTests.cs
@@ -141,7 +141,7 @@ public sealed class BodyShapesSectionTests
                     "library",
                     FixturePath,
                     "-D",
-                    "@Decompiler",
+                    SectionNames.BodyShapes,
                     "--effective",
                 ]))
                 .InvokeAsync());

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -13853,6 +13853,18 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task BareName_DecompilerCategory_IsNotPublished()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "System.Text.Json", "-S", "@Decompiler", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Select value '@Decompiler' not found.", error, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"Body Shapes\" requires", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task LibraryCommand_PlatformFacade_LibraryInfoShowsFacadeAssemblyYes()
     {
         var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Runtime.CompilerServices.Unsafe");
@@ -14290,7 +14302,7 @@ public partial class CommandExecutionTests
             .ToArray();
         var categoryNames = categoryLines.Select(ExtractSectionName).ToArray();
         Assert.Equal(
-            new[] { "@Audit", "@Context", "@Decompiler", "@Integrations", "@Library", "@Metadata", "@Performance", "@SourceLink", "@Surface" },
+            new[] { "@Audit", "@Context", "@Integrations", "@Library", "@Metadata", "@Performance", "@SourceLink", "@Surface" },
             categoryNames);
 
         var raw = SplitOutputLines(output);

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -411,7 +411,7 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void LibraryPipeline_EverySelectableSectionBelongsToAnAuthoredCategory()
+    public void LibraryPipeline_OnlyCoordinateGatedSectionsLackAnAuthoredCategory()
     {
         var pipeline = LibrarySections.CreatePipeline();
         var categories = pipeline.GetCategoryMap()
@@ -426,9 +426,7 @@ public class SectionPipelineTests
             .Where(name => !categorized.Contains(name))
             .ToArray();
 
-        Assert.True(
-            uncategorized.Length == 0,
-            $"Library section(s) have no authored category: {string.Join(", ", uncategorized)}");
+        Assert.Equal([SectionNames.BodyShapes], uncategorized);
     }
 
     [Fact]
@@ -495,7 +493,7 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void LibraryPipeline_ExplicitDomainSelectionStillRequestsItsScanners()
+    public void LibraryPipeline_ExplicitDomainOrDirectSelectionStillRequestsItsScanners()
     {
         var pipeline = LibrarySections.CreatePipeline();
         var performance = pipeline.GetCategoryMap()[SectionCategoryNames.Performance]
@@ -509,12 +507,14 @@ public class SectionPipelineTests
             TopLeverageQuery.Definition,
             pipeline.GetRequiredQueries(Verbosity.Minimal, performance));
 
-        var decompiler = pipeline.GetCategoryMap()[SectionCategoryNames.Decompiler]
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        Assert.Equal([SectionNames.BodyShapes], decompiler);
         Assert.Contains(
             LibrarySections.ScannerBodyShapes,
-            pipeline.GetRequiredScanners(Verbosity.Minimal, decompiler));
+            pipeline.GetRequiredScanners(
+                Verbosity.Minimal,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    SectionNames.BodyShapes,
+                }));
     }
 
     [Fact]

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -174,8 +174,6 @@ public static class LibrarySections
                 SectionNames.Symbols)
             .AddCategory(SectionCategoryNames.Performance,
                 [.. PerformanceKinds.Sections, SectionNames.ArrayPoolEscapes, SectionNames.TopLeverage])
-            .AddCategory(SectionCategoryNames.Decompiler,
-                SectionNames.BodyShapes)
             .AddCategory(SectionCategoryNames.SourceLink,
                 SectionNames.SourceLinkFiles,
                 SectionNames.SourceLinkDiagnostics,

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -189,7 +189,7 @@
 - Gives `package` and `library` authored base and domain categories. Package
   exposes `@Package`, `@Files`, `@Dependencies`, `@Audit`, and `@SourceLink`;
   library exposes `@Library`, `@Surface`, `@Audit`, `@Performance`,
-  `@Decompiler`, `@SourceLink`, `@Integrations`, `@Metadata`, and `@Context`
+  `@SourceLink`, `@Integrations`, `@Metadata`, and `@Context`
   (#3838, #4061).
 - Makes discovery distinguish structural membership from effective evidence.
   `-D --schema` reports the static graph, library `--effective` runs full


### PR DESCRIPTION
## Summary

- remove the singleton `@Decompiler` category from library and package-backed library queries
- keep `Body Shapes` directly selectable and gated by `--where "Kind=..."`
- preserve the multi-section `@Decompiler` category for `vocabulary`
- cover the reported `dotnet-inspect System.Text.Json -S @Decompiler` invocation

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- 4,183 CLI tests passed across fast and slow lanes (14 environment skips)
- `npx markdownlint-cli skills/query/SKILL.md src/dotnet-inspect/release-notes.md`