### PR TITLE
Align nested-generic and byref selector keys

### DIFF
--- a/src/CSharpText/XmlDocumentationNotation.cs
+++ b/src/CSharpText/XmlDocumentationNotation.cs
@@ -152,12 +152,24 @@ public static class XmlDocumentationNotation
         {
             var genericStart = IndexOfAny(type, '<', '{');
             if (genericStart >= 0
-                && TryGetGenericParts(type, genericStart, out var genericType, out var genericArgs))
+                && TryGetGenericParts(
+                    type,
+                    genericStart,
+                    out var genericType,
+                    out var genericArgs,
+                    out var remainder))
             {
                 var normalizedType = PrimitiveTypeNames.ToClrFullName(genericType);
                 var normalizedArgs = SplitParameters(genericArgs)
                     .Select(argument => NormalizeParameterType(argument, typeParameterMap, methodParameterMap));
                 normalized = $"{normalizedType}{{{string.Join(",", normalizedArgs)}}}";
+                if (remainder.StartsWith('.') || remainder.StartsWith('+'))
+                {
+                    normalized += "." + NormalizeParameterType(
+                        remainder[1..],
+                        typeParameterMap,
+                        methodParameterMap);
+                }
             }
             else
             {
@@ -287,7 +299,7 @@ public static class XmlDocumentationNotation
         if (genericStart < 0)
             return new Dictionary<string, int>(StringComparer.Ordinal);
 
-        if (!TryGetGenericParts(memberSegment, genericStart, out _, out var parameters))
+        if (!TryGetGenericParts(memberSegment, genericStart, out _, out var parameters, out _))
             return new Dictionary<string, int>(StringComparer.Ordinal);
 
         return SplitParameters(parameters)
@@ -334,10 +346,12 @@ public static class XmlDocumentationNotation
         string type,
         int genericStart,
         out string genericType,
-        out string genericArguments)
+        out string genericArguments,
+        out string remainder)
     {
         genericType = type[..genericStart];
         genericArguments = "";
+        remainder = "";
 
         var open = type[genericStart];
         var close = open == '<' ? '>' : '}';
@@ -353,6 +367,7 @@ public static class XmlDocumentationNotation
                 if (depth == 0)
                 {
                     genericArguments = type[(genericStart + 1)..i];
+                    remainder = type[(i + 1)..];
                     return true;
                 }
             }

--- a/src/ILInspector.Analysis.Tests/CallGraphMemberResolverTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphMemberResolverTests.cs
@@ -424,6 +424,84 @@ public sealed class CallGraphMemberResolverTests
     }
 
     [Fact]
+    public void Resolve_MatchesCompiledNestedGenericAndByRefAcrossProducers()
+    {
+        using var stream = File.OpenRead(typeof(NestedGenericKeyFixtures).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        MetadataReader mdReader = peReader.GetMetadataReader();
+        ApiSurface surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        ApiType type = Assert.Single(
+            surface.Types,
+            candidate => candidate.Name == nameof(NestedGenericKeyFixtures));
+
+        AssertCompiledSelectorAgreement(type, mdReader, nameof(NestedGenericKeyFixtures.TakeNested));
+        AssertCompiledSelectorAgreement(type, mdReader, nameof(NestedGenericKeyFixtures.TakeRefNested));
+        AssertCompiledSelectorAgreement(type, mdReader, nameof(NestedGenericKeyFixtures.TakeRefPlain));
+        AssertCompiledSelectorAgreement(type, mdReader, nameof(NestedGenericKeyFixtures.TakeList));
+        AssertCompiledSelectorAgreement(type, mdReader, nameof(NestedGenericKeyFixtures.TakeRefInt));
+        AssertCompiledSelectorAgreement(type, mdReader, "TakeHidden");
+        AssertCompiledSelectorAgreement(type, mdReader, "TakeRefHidden");
+    }
+
+    [Fact]
+    public void Selector_PlacesByRefMarkerOutsideNestedGenericDisplay()
+    {
+        var nested = Method("ref Samples.Outer<int>.Inner<string>");
+        nested.MetadataToken = 0x06000001;
+        var plus = Method("ref Samples.Outer<int>+Inner<string>");
+        plus.MetadataToken = 0x06000001;
+        var ordinary = Method("ref int");
+        ordinary.MetadataToken = 0x06000002;
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Owner",
+            Members = [nested, ordinary],
+        };
+        var plusType = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Owner",
+            Members = [plus],
+        };
+        var declaringType = TypeRef.Definition("Samples", "Samples", "Owner");
+        CallGraphMemberSelector nestedGraph = CallGraphMemberResolver.CreateSelector(new MemberRef(
+            declaringType,
+            "M",
+            [
+                TypeRef.ByRef(
+                    TypeRef.GenericInstance(
+                        TypeRef.Definition("Samples", "Samples", "Outer`1+Inner`1"),
+                        [
+                            TypeRef.CoreLib("System", "Int32"),
+                            TypeRef.CoreLib("System", "String"),
+                        ])),
+            ],
+            TypeRef.CoreLib("System", "Void"),
+            MemberKind.Method)
+        {
+            HasThis = true,
+        });
+
+        Assert.Null(nested.SignatureModel!.Parameters[0].StructuralType);
+        Assert.Equal(
+            "Samples.Outer{System.Int32}.Inner{System.String}@",
+            CallGraphMemberResolver.CreateSelector(type, nested).ParameterTypes[0]);
+        Assert.Equal(
+            CallGraphMemberResolver.CreateSelector(type, nested).Key,
+            nestedGraph.Key);
+        Assert.Equal(
+            CallGraphMemberResolver.CreateSelector(plusType, plus).Key,
+            nestedGraph.Key);
+        Assert.Equal(
+            "System.Int32@",
+            CallGraphMemberResolver.CreateSelector(type, ordinary).ParameterTypes[0]);
+        Assert.Same(
+            nested,
+            CallGraphMemberResolver.Resolve(type, nestedGraph.Name, nestedGraph.Key)!.Member);
+    }
+
+    [Fact]
     public void Selector_KeepsDisplaySpellingWhenModifiersArePresent()
     {
         var modified = TypeRef.UnsupportedModified(
@@ -1131,6 +1209,30 @@ public sealed class CallGraphMemberResolverTests
                 genericParameterCount,
                 [TypeRef.CoreLib("System", "Int32")]));
 
+    static void AssertCompiledSelectorAgreement(
+        ApiType type,
+        MetadataReader mdReader,
+        string memberName)
+    {
+        ApiMember member = Assert.Single(
+            type.Members,
+            candidate => candidate.Name == memberName);
+        foreach (CallGraphMemberBodySelector selector in
+            CallGraphMemberResolver.CreateBodySelectors(type, member))
+        {
+            MemberRef reference = MemberResolver.ResolveMethod(
+                mdReader,
+                MetadataTokens.EntityHandle(selector.BodyToken),
+                GenericScope.Empty);
+            CallGraphMemberSelector graph = CallGraphMemberResolver.CreateSelector(reference);
+            Assert.Equal(graph.Name, selector.MemberName);
+            Assert.Equal(graph.Key, selector.SelectorKey);
+            Assert.Equal(
+                selector.BodyToken,
+                CallGraphMemberResolver.Resolve(type, graph.Name, graph.Key)!.BodyToken);
+        }
+    }
+
     static ApiMember Method(string parameterType, string? structuralType = null) => new()
     {
         Name = "M",
@@ -1185,4 +1287,53 @@ public interface IExplicitAccessor
 public sealed class ExplicitAccessorFixtures : IExplicitAccessor
 {
     int IExplicitAccessor.Value => 1;
+}
+
+public sealed class NestedGenericKeyFixtures
+{
+    public sealed class Outer<T>
+    {
+        public sealed class Inner<U>
+        {
+        }
+
+        public sealed class Plain
+        {
+        }
+    }
+
+    public static void TakeNested(Outer<int>.Inner<string> value)
+    {
+    }
+
+    public static void TakeRefNested(ref Outer<int>.Inner<string> value)
+    {
+    }
+
+    public static void TakeRefPlain(ref Outer<int>.Plain value)
+    {
+    }
+
+    public static void TakeList(List<int> value)
+    {
+    }
+
+    public static void TakeRefInt(ref int value)
+    {
+    }
+
+    static void TakeHidden(HiddenOuter<int>.HiddenInner<string> value)
+    {
+    }
+
+    static void TakeRefHidden(ref HiddenOuter<int>.HiddenInner<string> value)
+    {
+    }
+
+    sealed class HiddenOuter<T>
+    {
+        public sealed class HiddenInner<U>
+        {
+        }
+    }
 }

--- a/src/ILInspector.Analysis.Tests/CallGraphMemberResolverTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphMemberResolverTests.cs
@@ -439,8 +439,15 @@ public sealed class CallGraphMemberResolverTests
         AssertCompiledSelectorAgreement(type, mdReader, nameof(NestedGenericKeyFixtures.TakeRefPlain));
         AssertCompiledSelectorAgreement(type, mdReader, nameof(NestedGenericKeyFixtures.TakeList));
         AssertCompiledSelectorAgreement(type, mdReader, nameof(NestedGenericKeyFixtures.TakeRefInt));
+        AssertCompiledSelectorAgreement(type, mdReader, nameof(NestedGenericKeyFixtures.TakeListOfOuter));
+        AssertCompiledSelectorAgreement(type, mdReader, nameof(NestedGenericKeyFixtures.TakeListOfNested));
         AssertCompiledSelectorAgreement(type, mdReader, "TakeHidden");
         AssertCompiledSelectorAgreement(type, mdReader, "TakeRefHidden");
+
+        ApiMember[] wrapped = [.. type.Members.Where(candidate => candidate.Name == "TakeWrapped")];
+        Assert.Equal(2, wrapped.Length);
+        foreach (ApiMember member in wrapped)
+            AssertCompiledSelectorAgreement(type, mdReader, member);
     }
 
     [Fact]
@@ -499,6 +506,73 @@ public sealed class CallGraphMemberResolverTests
         Assert.Same(
             nested,
             CallGraphMemberResolver.Resolve(type, nestedGraph.Name, nestedGraph.Key)!.Member);
+    }
+
+    [Fact]
+    public void Selector_DistinguishesNestedGenericInsideAnotherGenericArgument()
+    {
+        var outer = Method("System.Collections.Generic.List<Samples.Outer<int>>");
+        outer.MetadataToken = 0x06000001;
+        var inner = Method("System.Collections.Generic.List<Samples.Outer<int>.Inner<string>>");
+        inner.MetadataToken = 0x06000002;
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Owner",
+            Members = [outer, inner],
+        };
+        var declaringType = TypeRef.Definition("Samples", "Samples", "Owner");
+        CallGraphMemberSelector innerGraph = CallGraphMemberResolver.CreateSelector(new MemberRef(
+            declaringType,
+            "M",
+            [
+                TypeRef.GenericInstance(
+                    TypeRef.Definition("corelib", "System.Collections.Generic", "List`1"),
+                    [
+                        TypeRef.GenericInstance(
+                            TypeRef.Definition("Samples", "Samples", "Outer`1+Inner`1"),
+                            [
+                                TypeRef.CoreLib("System", "Int32"),
+                                TypeRef.CoreLib("System", "String"),
+                            ]),
+                    ]),
+            ],
+            TypeRef.CoreLib("System", "Void"),
+            MemberKind.Method)
+        {
+            HasThis = true,
+        });
+        CallGraphMemberSelector outerGraph = CallGraphMemberResolver.CreateSelector(new MemberRef(
+            declaringType,
+            "M",
+            [
+                TypeRef.GenericInstance(
+                    TypeRef.Definition("corelib", "System.Collections.Generic", "List`1"),
+                    [
+                        TypeRef.GenericInstance(
+                            TypeRef.Definition("Samples", "Samples", "Outer`1"),
+                            [TypeRef.CoreLib("System", "Int32")]),
+                    ]),
+            ],
+            TypeRef.CoreLib("System", "Void"),
+            MemberKind.Method)
+        {
+            HasThis = true,
+        });
+
+        Assert.NotEqual(outerGraph.Key, innerGraph.Key);
+        Assert.Equal(
+            CallGraphMemberResolver.CreateSelector(type, outer).Key,
+            outerGraph.Key);
+        Assert.Equal(
+            CallGraphMemberResolver.CreateSelector(type, inner).Key,
+            innerGraph.Key);
+        Assert.Same(
+            outer,
+            CallGraphMemberResolver.Resolve(type, outerGraph.Name, outerGraph.Key)!.Member);
+        Assert.Same(
+            inner,
+            CallGraphMemberResolver.Resolve(type, innerGraph.Name, innerGraph.Key)!.Member);
     }
 
     [Fact]
@@ -1213,10 +1287,16 @@ public sealed class CallGraphMemberResolverTests
         ApiType type,
         MetadataReader mdReader,
         string memberName)
+        => AssertCompiledSelectorAgreement(
+            type,
+            mdReader,
+            Assert.Single(type.Members, candidate => candidate.Name == memberName));
+
+    static void AssertCompiledSelectorAgreement(
+        ApiType type,
+        MetadataReader mdReader,
+        ApiMember member)
     {
-        ApiMember member = Assert.Single(
-            type.Members,
-            candidate => candidate.Name == memberName);
         foreach (CallGraphMemberBodySelector selector in
             CallGraphMemberResolver.CreateBodySelectors(type, member))
         {
@@ -1319,6 +1399,22 @@ public sealed class NestedGenericKeyFixtures
     }
 
     public static void TakeRefInt(ref int value)
+    {
+    }
+
+    public static void TakeListOfOuter(List<Outer<int>> value)
+    {
+    }
+
+    public static void TakeListOfNested(List<Outer<int>.Inner<string>> value)
+    {
+    }
+
+    public static void TakeWrapped(List<Outer<int>> value)
+    {
+    }
+
+    public static void TakeWrapped(List<Outer<int>.Inner<string>> value)
     {
     }
 

--- a/src/ILInspector.Analysis/CallGraphMemberResolver.cs
+++ b/src/ILInspector.Analysis/CallGraphMemberResolver.cs
@@ -20,6 +20,8 @@ namespace ILInspector.Analysis;
 /// gates <c>init</c> setter <c>modreq(IsExternalInit)</c> identity from extract through MemberRef.
 /// <c>CallGraphMemberResolverTests.Resolve_MatchesCompiledExplicitInterfaceAccessorAcrossProducers</c>
 /// gates explicit-interface accessor MethodDef names (<c>I.get_P</c>, not <c>get_I.P</c>).
+/// <c>CallGraphMemberResolverTests.Resolve_MatchesCompiledNestedGenericAndByRefAcrossProducers</c>
+/// gates leftover extract display of nested generic arguments and byref <c>@</c> placement.
 /// </remarks>
 public static class CallGraphMemberResolver
 {
@@ -407,14 +409,39 @@ public static class CallGraphMemberResolver
         IReadOnlyDictionary<string, int> typeParameters,
         IReadOnlyDictionary<string, int> methodParameters)
     {
-        if (!value.Contains(">.", StringComparison.Ordinal))
+        bool isByRef = false;
+        string type = value;
+        foreach (string prefix in (string[])["ref readonly ", "ref ", "out ", "in "])
         {
-            return XmlDocumentationNotation.NormalizeParameterType(
-                value,
-                typeParameters,
-                methodParameters);
+            if (type.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                isByRef = true;
+                type = type[prefix.Length..].TrimStart();
+                break;
+            }
         }
 
+        if (type.EndsWith('@'))
+        {
+            isByRef = true;
+            type = type.TrimEnd('@');
+        }
+
+        string normalized = type.Contains(">.", StringComparison.Ordinal)
+            || type.Contains(">+", StringComparison.Ordinal)
+            ? NormalizeNestedGenericDisplay(type, typeParameters, methodParameters)
+            : XmlDocumentationNotation.NormalizeParameterType(
+                type,
+                typeParameters,
+                methodParameters);
+        return isByRef ? $"{normalized}@" : normalized;
+    }
+
+    static string NormalizeNestedGenericDisplay(
+        string value,
+        IReadOnlyDictionary<string, int> typeParameters,
+        IReadOnlyDictionary<string, int> methodParameters)
+    {
         var segments = new List<string>();
         int start = 0;
         int depth = 0;
@@ -426,12 +453,13 @@ public static class CallGraphMemberResolver
                 '>' => -1,
                 _ => 0,
             };
-            if (value[index] == '.' && depth == 0)
+            if (depth == 0 && value[index] is '.' or '+')
             {
                 segments.Add(value[start..index]);
                 start = index + 1;
             }
         }
+
         segments.Add(value[start..]);
         return string.Join(
             '.',

--- a/src/ILInspector.Analysis/CallGraphMemberResolver.cs
+++ b/src/ILInspector.Analysis/CallGraphMemberResolver.cs
@@ -22,6 +22,9 @@ namespace ILInspector.Analysis;
 /// gates explicit-interface accessor MethodDef names (<c>I.get_P</c>, not <c>get_I.P</c>).
 /// <c>CallGraphMemberResolverTests.Resolve_MatchesCompiledNestedGenericAndByRefAcrossProducers</c>
 /// gates leftover extract display of nested generic arguments and byref <c>@</c> placement.
+/// <c>CallGraphMemberResolverTests.Selector_DistinguishesNestedGenericInsideAnotherGenericArgument</c>
+/// gates a nested suffix inside another generic argument so
+/// <c>List&lt;Outer&lt;int&gt;.Inner&lt;string&gt;&gt;</c> does not alias <c>List&lt;Outer&lt;int&gt;&gt;</c>.
 /// </remarks>
 public static class CallGraphMemberResolver
 {

--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -350,8 +350,16 @@ internal sealed class GenericTypeNode(
             return IsReferenceType && IsNullableAnnotated ? $"{tuple}?" : tuple;
         }
 
-        var argsStr = string.Join(", ", arguments.Select(a => a.Render(canonicalTuples)));
-        var result = $"{baseName}<{argsStr}>{nestedSuffix}";
+        // Outer`1.Inner`1 must render as Outer<int>.Inner<string>, not
+        // Outer<int, string>.Inner<T>. ApplyGenericArguments owns that split.
+        string[] renderedArguments = [.. arguments.Select(argument => argument.Render(canonicalTuples))];
+        string result = metadataName is { Length: > 0 }
+            ? TypeResolver.ApplyGenericArguments(
+                metadataName.Replace('+', '.'),
+                renderedArguments)
+            : arguments.Length == 0
+                ? $"{baseName}{nestedSuffix}"
+                : $"{baseName}<{string.Join(", ", renderedArguments)}>{nestedSuffix}";
         return IsReferenceType && IsNullableAnnotated ? $"{result}?" : result;
     }
 

--- a/tests/CSharpText.Tests/XmlDocumentationNotationTests.cs
+++ b/tests/CSharpText.Tests/XmlDocumentationNotationTests.cs
@@ -60,6 +60,24 @@ public sealed class XmlDocumentationNotationTests
     }
 
     [Fact]
+    public void ParameterNormalization_KeepsNestedSuffixInsideGenericArguments()
+    {
+        Assert.Equal(
+            "System.Collections.Generic.List{Samples.Outer{System.Int32}.Inner{System.String}}",
+            XmlDocumentationNotation.NormalizeParameterType(
+                "System.Collections.Generic.List<Samples.Outer<int>.Inner<string>>"));
+        Assert.NotEqual(
+            XmlDocumentationNotation.NormalizeParameterType(
+                "System.Collections.Generic.List<Samples.Outer<int>>"),
+            XmlDocumentationNotation.NormalizeParameterType(
+                "System.Collections.Generic.List<Samples.Outer<int>.Inner<string>>"));
+        Assert.Equal(
+            "System.Collections.Generic.List{Samples.Outer{System.Int32}.Inner{System.String}}@",
+            XmlDocumentationNotation.NormalizeParameterType(
+                "ref System.Collections.Generic.List<Samples.Outer<int>+Inner<string>>"));
+    }
+
+    [Fact]
     public void SignatureParameterNormalization_StripsParameterNamesForFallback()
     {
         Assert.Equal(

--- a/tests/ILInspector.Metadata.Tests/StructuralTypeIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/StructuralTypeIdentityTests.cs
@@ -162,11 +162,35 @@ public sealed class StructuralTypeIdentityTests
                 "M0@"),
             required.StructuralIdentity());
         Assert.Equal("System.Collections.Generic.List{M0}", list.StructuralIdentity());
+        Assert.Equal("System.Collections.Generic.List<TM0>", list.Render());
         Assert.Equal(
             "Samples.Outer{System.Int32}.Inner{System.String}",
             nested.StructuralIdentity());
+        Assert.Equal("Samples.Outer<int>.Inner<string>", nested.Render());
         Assert.Equal("Samples.Outer{System.Int32,System.String}", flat.StructuralIdentity());
+        Assert.Equal("Samples.Outer<int, string>", flat.Render());
         Assert.NotEqual(nested.StructuralIdentity(), flat.StructuralIdentity());
+
+        TypeNode plusNested = provider.GetGenericInstantiation(
+            new NamedTypeNode("Samples.Outer`1+Inner`1", isReferenceType: true),
+            [
+                provider.GetPrimitiveType(PrimitiveTypeCode.Int32),
+                provider.GetPrimitiveType(PrimitiveTypeCode.String),
+            ]);
+        TypeNode enumerator = provider.GetGenericInstantiation(
+            new NamedTypeNode("System.Collections.Generic.Dictionary`2.Enumerator", isReferenceType: false),
+            [
+                provider.GetPrimitiveType(PrimitiveTypeCode.Int32),
+                provider.GetPrimitiveType(PrimitiveTypeCode.String),
+            ]);
+        Assert.Equal(nested.StructuralIdentity(), plusNested.StructuralIdentity());
+        Assert.Equal("Samples.Outer<int>.Inner<string>", plusNested.Render());
+        Assert.Equal(
+            "System.Collections.Generic.Dictionary<int, string>.Enumerator",
+            enumerator.Render());
+        Assert.Equal(
+            "System.Collections.Generic.Dictionary{System.Int32,System.String}.Enumerator",
+            enumerator.StructuralIdentity());
         Assert.Contains("List{M0}", functionPointer.StructuralIdentity(), StringComparison.Ordinal);
         Assert.DoesNotContain("List{TM0}", functionPointer.StructuralIdentity(), StringComparison.Ordinal);
         Assert.False(list.HasStructuralPayload);


### PR DESCRIPTION
## Claim

Extract and MemberRef now agree on well-behaved nested generic arguments and byref `@` placement. `Outer<int>.Inner<string>` and `ref Outer<int>.Plain` resolve to the same selector key from both producers.

## Why

#4402 leftover key residue: `GenericTypeNode.Render` stuffed every argument into the first arity and left `FormatDisplayName` placeholders on the nested suffix (`Outer<int, string>.Inner<T>`). `NormalizeApiType` then split `ref Outer<int>.Inner` before normalizing, so `@` landed on the declaring segment (`Outer{int}@.Inner`) instead of the whole type (`Outer{int}.Inner@`). Structural identity already distributed arguments; ordinary extract left `StructuralType` null and used the broken display.

## Evidence

- Compiled extract-to-`MemberResolver` gate: `Resolve_MatchesCompiledNestedGenericAndByRefAcrossProducers` (public nested generic, byref nested, byref plain nested, private nested generic, plus ordinary `List<int>` / `ref int` negatives)
- Display/normalize gate: `Selector_PlacesByRefMarkerOutsideNestedGenericDisplay`
- TypeNode render/identity: `TypeNode_RecursesPositionalGenericsUnderWrappersAndGenericInstantiations` now pins `Outer<int>.Inner<string>` and `Dictionary<int, string>.Enumerator` for both `.` and `+` metadata names

## Non-action

Does not emit `StructuralType` for ordinary generics. Does not retarget generic-wrapped modifiers, VarArgs, fnptr comma-join, pinned encoding, brace encoding, #4217, or protobuf. `in` / `ref readonly` parameters remain flag modifiers, not type modreqs.

## Validation

`dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -class ILInspector.Analysis.Tests.CallGraphMemberResolverTests` (25)
`dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class ILInspector.Metadata.Tests.StructuralTypeIdentityTests` (3)
`dotnet run --project src/ILInspector.Analysis.Tests -c Release` (976, 8 corpus skips)
`dotnet run --project tests/ILInspector.Metadata.Tests -c Release` (1758)