### PR TITLE
Separate NuGet timeout test budgets

### DIFF
--- a/src/NuGetFetch.Tests/NuGetDeadlineRaceTests.cs
+++ b/src/NuGetFetch.Tests/NuGetDeadlineRaceTests.cs
@@ -147,7 +147,7 @@ public sealed class NuGetDeadlineRaceTests
         new()
         {
             RequestTimeout = TimeSpan.FromMilliseconds(40),
-            OperationTimeout = TimeSpan.FromSeconds(2),
+            OperationTimeout = TimeSpan.FromSeconds(30),
             MetadataBodyTimeout = TimeSpan.FromMilliseconds(40),
         };
 

--- a/src/dotnet-inspect.Tests/NuGetSearchDeadlineRaceTests.cs
+++ b/src/dotnet-inspect.Tests/NuGetSearchDeadlineRaceTests.cs
@@ -34,7 +34,7 @@ public sealed class NuGetSearchDeadlineRaceTests
                         fetchOptions: new NuGetFetchOptions
                         {
                             RequestTimeout = TimeSpan.FromMilliseconds(40),
-                            OperationTimeout = TimeSpan.FromSeconds(2),
+                            OperationTimeout = TimeSpan.FromSeconds(30),
                         }));
 
                 Assert.Contains(

--- a/src/dotnet-inspect.Tests/NuGetSearchSourcesTests.cs
+++ b/src/dotnet-inspect.Tests/NuGetSearchSourcesTests.cs
@@ -424,7 +424,7 @@ public class NuGetSearchSourcesTests
                 fetchOptions: new NuGetFetchOptions
                 {
                     RequestTimeout = TimeSpan.FromMilliseconds(40),
-                    OperationTimeout = TimeSpan.FromSeconds(5),
+                    OperationTimeout = TimeSpan.FromSeconds(30),
                 }));
 
         Assert.Contains(


### PR DESCRIPTION
## Summary

Keep strict request-timeout tests focused on their 40 ms inner deadlines by moving the independent operation ceilings to 30 seconds. A stalled Windows runner previously exceeded both budgets, correctly selected operation-timeout precedence, and failed a request-specific assertion; the unchanged test passed on the next run.

The same budget separation now covers the service-index test and both dedicated delayed-callback race suites. Their strict request-timeout classifications remain intact, successful execution remains sub-second, and a broken inner deadline is still bounded by the outer ceiling. Product timeout behavior is unchanged.

Closes #4426.

## Evidence

- `NuGetSearchSourcesTests` + `NuGetSearchDeadlineRaceTests`: 116 passed
- `NuGetDeadlineRaceTests`: 5 passed
- original focused timeout gate: 50/50 repeated Release executions passed
- starvation probe: 3-second stall / 2-second operation ceiling selected operation timeout; 30-second ceiling selected request timeout
- `git diff --check`