### PR TITLE
Convert inspect-web command bar to TypeScript

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -519,6 +519,12 @@ Package tabs and the framework selector are workspace identity, not display
 state: changing either resolves a different workspace. Lenses this engine does
 not answer report the engine's failure rather than fixture results.
 
+`src/command-bar.ts` owns command completion, suggestion rendering, editing,
+and keyboard interaction. `app.js` supplies the package-navigation effects so
+the component does not acquire engine or workspace authority.
+`test/command-bar.test.js` gates the completion grammar, replacement behavior,
+bounded suggestions, command metadata, selection, and escaping.
+
 - `Cmd/Ctrl+K` focuses the persistent command prompt.
 - `Cmd/Ctrl+F` or `/` focuses the type filter.
 - Arrow keys select a completion, `Tab` accepts it, and `Enter` runs it.

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -29,7 +29,6 @@ import {
   parameterTitleHtml,
   removeWorkspacePackage,
   retainWorkspacePackage,
-  rootCommands,
   resolveLoadedGraphTargetCandidate,
   shareStateLengthError,
   scopedRequestState,
@@ -47,6 +46,7 @@ import {
   buildTypeGraphMermaid
 } from "./graph-mermaid.js";
 import { buildAnnotatedView, factsForNode, MEDIA, MEDIUM_LABELS, nodeAtOffset } from "/src/annotated-source-view.ts";
+import { createCommandBar } from "/src/command-bar.ts";
 import { loadPlatformIndex } from "/src/platform-index.js";
 
 let initializeEngine;
@@ -661,6 +661,15 @@ function escapeHtml(value) {
     .replaceAll('"', "&quot;");
 }
 
+const commandBar = createCommandBar({
+  state,
+  lenses,
+  escapeHtml,
+  execute: executeCommand,
+  render,
+  focusAfterDismiss: () => document.querySelector("#type-list").focus(),
+});
+
 function selectedType() {
   if (!state.package) return null;
   return state.package.types.find(item => item.id === state.selectedTypeId) || filteredTypes()[0] || state.package.types[0];
@@ -1210,65 +1219,6 @@ function typeDisplayName(item) {
   return item?.displayName || item?.name || "";
 }
 
-function completions() {
-  const input = state.command.trimStart();
-  const tokens = input.split(/\s+/).filter(Boolean);
-  let entries;
-
-  if (!tokens.length) {
-    entries = rootCommands.map(([value, hint]) => ({ value, hint, kind: "command" }));
-  } else if (tokens[0] === "type") {
-    entries = state.package.types.map(item => ({
-      value: item.name,
-      hint: item.namespace,
-      kind: item.kind
-    }));
-  } else if (tokens[0] === "show") {
-    entries = lenses.map(([value, label]) => ({ value, hint: `${label} lens`, kind: "lens" }));
-  } else if (tokens[0] === "framework") {
-    entries = state.package.frameworks.map(value => ({ value, hint: "compile assets", kind: "framework" }));
-  } else if (tokens[0] === "types") {
-    entries = [
-      { value: "public", hint: "public surface (default)", kind: "filter" },
-      { value: "namespace", hint: "filter to a namespace", kind: "filter" },
-      { value: "kind", hint: "filter by class, struct, interface, or enum", kind: "filter" }
-    ];
-  } else {
-    entries = rootCommands.map(([value, hint]) => ({ value, hint, kind: "command" }));
-  }
-
-  if (input.endsWith(" ")) return entries.slice(0, 8);
-  const needle = tokens.at(-1)?.toLowerCase() || "";
-  return entries.filter(entry => entry.value.toLowerCase().includes(needle)).slice(0, 8);
-}
-
-function commandSuggestionsHtml(items) {
-  return `${items.map((item, index) => `
-      <button class="suggestion ${index === state.completionIndex ? "selected" : ""}" data-completion="${escapeHtml(item.value)}">
-        <strong>${escapeHtml(item.value)}</strong><span>${escapeHtml(item.hint)}</span><small>${escapeHtml(item.kind)}</small>
-      </button>`).join("")}
-      <div class="suggestion-help"><span>↑↓ select</span><span>tab complete</span><span>enter run</span><span>esc dismiss</span></div>`;
-}
-
-function bindCommandCompletionClicks(root) {
-  root.querySelectorAll("[data-completion]").forEach(button => button.addEventListener("mousedown", event => {
-    event.preventDefault();
-    applyCompletion(button.dataset.completion);
-  }));
-}
-
-// Repaint just the completion list. The command <input> is left untouched so the caret
-// and native editing state survive (a full render() forced the caret to the end every
-// keystroke), and nothing outside the command panel is rebuilt.
-function updateCommandSuggestions() {
-  const container = document.querySelector("#command-suggestions");
-  if (!container) return;
-  state.completionIndex = Math.min(state.completionIndex, Math.max(completions().length - 1, 0));
-  container.innerHTML = commandSuggestionsHtml(completions());
-  bindCommandCompletionClicks(container);
-  container.querySelector(".suggestion.selected")?.scrollIntoView({ block: "nearest" });
-}
-
 function render() {
   if (!sourceSurfaceIsVisible(state)
     && cancelSourceRequestState(state)) {
@@ -1321,8 +1271,6 @@ function render() {
     state.packageLens = "overview";
   }
   state.typeCursor = Math.min(state.typeCursor, Math.max(visible.length - 1, 0));
-  const suggestions = completions();
-  state.completionIndex = Math.min(state.completionIndex, Math.max(suggestions.length - 1, 0));
 
   app.innerHTML = `
     <div class="workbench">
@@ -1437,19 +1385,7 @@ function render() {
         </section>
       </main>
 
-      <section class="command-area">
-        <div class="command-panel ${state.promptOpen ? "open" : ""}">
-          <div class="suggestions" id="command-suggestions" role="listbox">
-            ${commandSuggestionsHtml(suggestions)}
-          </div>
-          <div class="command-line">
-            <span class="command-scope">${escapeHtml(state.package.id)}:${escapeHtml(state.package.activeFramework)}</span>
-            <span class="prompt">›</span>
-            <input id="command" value="${escapeHtml(state.command)}" placeholder="type a command…  try “type JsonSerializer”" autocomplete="off" spellcheck="false" />
-            <kbd>⌘K</kbd>
-          </div>
-        </div>
-      </section>
+      ${commandBar.html()}
       ${state.spotlightOpen ? renderSpotlight() : ""}
       ${state.graphSourceOpen ? renderGraphSource() : ""}
       ${state.docViewerOpen ? renderDocViewer() : ""}
@@ -4165,7 +4101,7 @@ function bindEvents() {
       const [assembly, heapName] = btn.dataset.mdeOpenHeap.split("|");
       openExplorerHeap(assembly, heapName);
     }));
-  bindCommandCompletionClicks(document);
+  commandBar.bind(document);
 
   document.querySelector("#framework").addEventListener("change", event => {
     switchPackageFramework(event.target.value);
@@ -4243,18 +4179,6 @@ function bindEvents() {
     focusFilter();
   });
 
-  const command = document.querySelector("#command");
-  command.addEventListener("focus", () => {
-    state.promptOpen = true;
-    document.querySelector(".command-panel").classList.add("open");
-  });
-  command.addEventListener("input", event => {
-    state.command = event.target.value;
-    state.promptOpen = true;
-    state.completionIndex = 0;
-    updateCommandSuggestions();
-  });
-  command.addEventListener("keydown", handleCommandKeys);
   document.querySelector("#package-query").addEventListener("submit", event => {
     event.preventDefault();
     const value = document.querySelector("#package-query-input").value.trim();
@@ -5476,51 +5400,7 @@ function handleSpotlightKeys(event) {
   }
 }
 
-function handleCommandKeys(event) {
-  const items = completions();
-  if (event.key === "ArrowDown") {
-    event.preventDefault();
-    state.completionIndex = (state.completionIndex + 1) % Math.max(1, items.length);
-    updateCommandSuggestions();
-  } else if (event.key === "ArrowUp") {
-    event.preventDefault();
-    state.completionIndex = (state.completionIndex - 1 + Math.max(1, items.length)) % Math.max(1, items.length);
-    updateCommandSuggestions();
-  } else if (event.key === "Tab" && items.length) {
-    event.preventDefault();
-    applyCompletion(items[state.completionIndex].value);
-  } else if (event.key === "Enter") {
-    event.preventDefault();
-    executeCommand();
-  } else if (event.key === "Escape") {
-    state.promptOpen = false;
-    state.command = "";
-    render();
-    document.querySelector("#type-list").focus();
-  }
-}
-
-function applyCompletion(value) {
-  const tokens = state.command.trim().split(/\s+/).filter(Boolean);
-  if (!tokens.length) state.command = `${value} `;
-  else if (state.command.endsWith(" ")) state.command += `${value} `;
-  else {
-    tokens[tokens.length - 1] = value;
-    state.command = `${tokens.join(" ")} `;
-  }
-  state.completionIndex = 0;
-  state.promptOpen = true;
-  // We rewrote the command programmatically, so push it into the live input and
-  // repaint only the suggestion list (no full render / caret reset needed elsewhere).
-  const input = document.querySelector("#command");
-  if (input) input.value = state.command;
-  updateCommandSuggestions();
-  focusCommand();
-}
-
-function executeCommand() {
-  const value = state.command.trim();
-  if (!value) return;
+function executeCommand(value) {
   const [verb, ...rest] = value.split(/\s+/);
   const argument = rest.join(" ");
   if (verb === "type") {
@@ -5548,24 +5428,6 @@ function executeCommand() {
     share();
   }
   state.history = [value, ...state.history.filter(item => item !== value)].slice(0, 5);
-  state.command = "";
-  state.promptOpen = false;
-  render();
-}
-
-function openCommand(value = "") {
-  state.command = value;
-  state.promptOpen = true;
-  render();
-  focusCommand();
-}
-
-function focusCommand() {
-  requestAnimationFrame(() => {
-    const input = document.querySelector("#command");
-    input.focus();
-    input.setSelectionRange(input.value.length, input.value.length);
-  });
 }
 
 function focusFilter() {
@@ -8366,7 +8228,7 @@ document.addEventListener("keydown", event => {
     drillOut();
   } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
     event.preventDefault();
-    openCommand();
+    commandBar.open();
   } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "p") {
     event.preventDefault();
     openSpotlight();

--- a/prototypes/inspect-web/src/command-bar.ts
+++ b/prototypes/inspect-web/src/command-bar.ts
@@ -1,0 +1,283 @@
+type CommandDefinition = readonly [value: string, hint: string];
+type LensDefinition = readonly [id: string, label: string];
+
+interface CommandBarType {
+  id: string;
+  name: string;
+  namespace: string;
+  kind: string;
+}
+
+interface CommandBarPackage {
+  id: string;
+  activeFramework: string;
+  types: readonly CommandBarType[];
+  frameworks: readonly string[];
+}
+
+export interface CommandBarState {
+  command: string;
+  completionIndex: number;
+  promptOpen: boolean;
+  package: CommandBarPackage;
+}
+
+export interface CommandSuggestion {
+  value: string;
+  hint: string;
+  kind: string;
+}
+
+interface CommandBarOptions {
+  state: CommandBarState;
+  lenses: readonly LensDefinition[];
+  escapeHtml: (value: unknown) => string;
+  execute: (value: string) => void;
+  render: () => void;
+  focusAfterDismiss: () => void;
+}
+
+const ROOT_COMMANDS: readonly CommandDefinition[] = [
+  ["type", "select a public type"],
+  ["types", "filter or group the type index"],
+  ["show", "change the active lens"],
+  ["framework", "select a target framework"],
+  ["find", "search the current package"],
+  ["clear", "clear the current filter"],
+  ["share", "copy a link to this selection"],
+];
+
+export function commandCompletions(
+  state: CommandBarState,
+  lenses: readonly LensDefinition[],
+): CommandSuggestion[] {
+  const input = state.command.trimStart();
+  const tokens = input.split(/\s+/).filter(Boolean);
+  let entries: CommandSuggestion[];
+
+  if (!tokens.length) {
+    entries = ROOT_COMMANDS.map(([value, hint]) => ({ value, hint, kind: "command" }));
+  } else if (tokens[0] === "type") {
+    entries = state.package.types.map(item => ({
+      value: item.name,
+      hint: item.namespace,
+      kind: item.kind,
+    }));
+  } else if (tokens[0] === "show") {
+    entries = lenses.map(([value, label]) => ({
+      value,
+      hint: `${label} lens`,
+      kind: "lens",
+    }));
+  } else if (tokens[0] === "framework") {
+    entries = state.package.frameworks.map(value => ({
+      value,
+      hint: "compile assets",
+      kind: "framework",
+    }));
+  } else if (tokens[0] === "types") {
+    entries = [
+      { value: "public", hint: "public surface (default)", kind: "filter" },
+      { value: "namespace", hint: "filter to a namespace", kind: "filter" },
+      { value: "kind", hint: "filter by class, struct, interface, or enum", kind: "filter" },
+    ];
+  } else {
+    entries = ROOT_COMMANDS.map(([value, hint]) => ({ value, hint, kind: "command" }));
+  }
+
+  if (input.endsWith(" ")) return entries.slice(0, 8);
+  const needle = tokens.at(-1)?.toLowerCase() || "";
+  return entries
+    .filter(entry => entry.value.toLowerCase().includes(needle))
+    .slice(0, 8);
+}
+
+export function commandSuggestionsHtml(
+  items: readonly CommandSuggestion[],
+  selectedIndex: number,
+  escapeHtml: (value: unknown) => string,
+): string {
+  return `${items.map((item, index) => `
+      <button class="suggestion ${index === selectedIndex ? "selected" : ""}" data-completion="${escapeHtml(item.value)}">
+        <strong>${escapeHtml(item.value)}</strong><span>${escapeHtml(item.hint)}</span><small>${escapeHtml(item.kind)}</small>
+      </button>`).join("")}
+      <div class="suggestion-help"><span>↑↓ select</span><span>tab complete</span><span>enter run</span><span>esc dismiss</span></div>`;
+}
+
+export function commandBarHtml(
+  state: CommandBarState,
+  items: readonly CommandSuggestion[],
+  escapeHtml: (value: unknown) => string,
+): string {
+  return `
+      <section class="command-area">
+        <div class="command-panel ${state.promptOpen ? "open" : ""}">
+          <div class="suggestions" id="command-suggestions" role="listbox">
+            ${commandSuggestionsHtml(items, state.completionIndex, escapeHtml)}
+          </div>
+          <div class="command-line">
+            <span class="command-scope">${escapeHtml(state.package.id)}:${escapeHtml(state.package.activeFramework)}</span>
+            <span class="prompt">›</span>
+            <input id="command" value="${escapeHtml(state.command)}" placeholder="type a command…  try “type JsonSerializer”" autocomplete="off" spellcheck="false" />
+            <kbd>⌘K</kbd>
+          </div>
+        </div>
+      </section>`;
+}
+
+export function applyCommandCompletion(command: string, value: string): string {
+  const tokens = command.trim().split(/\s+/).filter(Boolean);
+  if (!tokens.length) return `${value} `;
+  if (command.endsWith(" ")) return `${command}${value} `;
+
+  tokens[tokens.length - 1] = value;
+  return `${tokens.join(" ")} `;
+}
+
+export function createCommandBar(options: CommandBarOptions) {
+  const {
+    state,
+    lenses,
+    escapeHtml,
+    execute,
+    render,
+    focusAfterDismiss,
+  } = options;
+
+  function completions(): CommandSuggestion[] {
+    return commandCompletions(state, lenses);
+  }
+
+  function suggestionsHtml(items: readonly CommandSuggestion[] = completions()): string {
+    return commandSuggestionsHtml(items, state.completionIndex, escapeHtml);
+  }
+
+  function html(): string {
+    const items = completions();
+    state.completionIndex = Math.min(
+      state.completionIndex,
+      Math.max(items.length - 1, 0),
+    );
+    return commandBarHtml(state, items, escapeHtml);
+  }
+
+  function focus(): void {
+    requestAnimationFrame(() => {
+      const input = document.querySelector<HTMLInputElement>("#command");
+      if (!input) throw new Error("The command bar input is unavailable.");
+      input.focus();
+      input.setSelectionRange(input.value.length, input.value.length);
+    });
+  }
+
+  function bindCompletionClicks(root: ParentNode): void {
+    root.querySelectorAll<HTMLElement>("[data-completion]").forEach(button => {
+      button.addEventListener("mousedown", event => {
+        event.preventDefault();
+        const value = button.dataset.completion;
+        if (value === undefined) {
+          throw new Error("A command completion is missing its value.");
+        }
+        applyCompletion(value);
+      });
+    });
+  }
+
+  function updateSuggestions(): void {
+    const container = document.querySelector<HTMLElement>("#command-suggestions");
+    if (!container) return;
+
+    const items = completions();
+    state.completionIndex = Math.min(
+      state.completionIndex,
+      Math.max(items.length - 1, 0),
+    );
+    container.innerHTML = suggestionsHtml(items);
+    bindCompletionClicks(container);
+    container.querySelector(".suggestion.selected")?.scrollIntoView({ block: "nearest" });
+  }
+
+  function applyCompletion(value: string): void {
+    state.command = applyCommandCompletion(state.command, value);
+    state.completionIndex = 0;
+    state.promptOpen = true;
+
+    const input = document.querySelector<HTMLInputElement>("#command");
+    if (!input) throw new Error("The command bar input is unavailable.");
+    input.value = state.command;
+    updateSuggestions();
+    focus();
+  }
+
+  function run(): void {
+    const value = state.command.trim();
+    if (!value) return;
+    execute(value);
+    state.command = "";
+    state.promptOpen = false;
+    render();
+  }
+
+  function handleKeys(event: KeyboardEvent): void {
+    const items = completions();
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      state.completionIndex = (state.completionIndex + 1) % Math.max(1, items.length);
+      updateSuggestions();
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      state.completionIndex = (
+        state.completionIndex - 1 + Math.max(1, items.length)
+      ) % Math.max(1, items.length);
+      updateSuggestions();
+    } else if (event.key === "Tab" && items.length) {
+      event.preventDefault();
+      applyCompletion(items[state.completionIndex].value);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      run();
+    } else if (event.key === "Escape") {
+      state.promptOpen = false;
+      state.command = "";
+      render();
+      focusAfterDismiss();
+    }
+  }
+
+  function bind(root: ParentNode): void {
+    bindCompletionClicks(root);
+
+    const command = root.querySelector<HTMLInputElement>("#command");
+    const panel = root.querySelector<HTMLElement>(".command-panel");
+    if (!command || !panel) {
+      throw new Error("The command bar markup is incomplete.");
+    }
+
+    command.addEventListener("focus", () => {
+      state.promptOpen = true;
+      panel.classList.add("open");
+    });
+    command.addEventListener("input", () => {
+      state.command = command.value;
+      state.promptOpen = true;
+      state.completionIndex = 0;
+      updateSuggestions();
+    });
+    command.addEventListener("keydown", handleKeys);
+  }
+
+  function open(value = ""): void {
+    state.command = value;
+    state.promptOpen = true;
+    render();
+    focus();
+  }
+
+  return {
+    bind,
+    completions,
+    html,
+    open,
+    suggestionsHtml,
+  };
+}

--- a/prototypes/inspect-web/src/data.js
+++ b/prototypes/inspect-web/src/data.js
@@ -13,16 +13,6 @@ export const packageLenses = [
   ["metadata", "Metadata"]
 ];
 
-export const rootCommands = [
-  ["type", "select a public type"],
-  ["types", "filter or group the type index"],
-  ["show", "change the active lens"],
-  ["framework", "select a target framework"],
-  ["find", "search the current package"],
-  ["clear", "clear the current filter"],
-  ["share", "copy a link to this selection"]
-];
-
 export const MAX_WORKSPACE_PACKAGES = 12;
 export const MAX_SHARE_STATE_CHARACTERS = 65536;
 

--- a/prototypes/inspect-web/test/command-bar.test.js
+++ b/prototypes/inspect-web/test/command-bar.test.js
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  applyCommandCompletion,
+  commandBarHtml,
+  commandCompletions,
+  commandSuggestionsHtml,
+} from "../src/command-bar.ts";
+
+const lenses = [
+  ["api", "API"],
+  ["metadata", "Metadata"],
+  ["source", "Source"],
+];
+
+function commandState(command, types = []) {
+  return {
+    command,
+    completionIndex: 0,
+    promptOpen: true,
+    package: {
+      id: "System.Text.Json",
+      activeFramework: "net10.0",
+      types,
+      frameworks: ["net8.0", "net9.0", "net10.0"],
+    },
+  };
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+test("the empty command bar offers the root command grammar", () => {
+  const items = commandCompletions(commandState(""), lenses);
+
+  assert.deepEqual(
+    items.map(item => item.value),
+    ["type", "types", "show", "framework", "find", "clear", "share"],
+  );
+  assert.ok(items.every(item => item.kind === "command"));
+});
+
+test("type completion filters package types and caps an open argument list", () => {
+  const types = Array.from({ length: 10 }, (_, index) => ({
+    id: `Example.Type${index}`,
+    name: index === 9 ? "JsonSerializer" : `Type${index}`,
+    namespace: "Example",
+    kind: "class",
+  }));
+
+  assert.deepEqual(
+    commandCompletions(commandState("type json", types), lenses)
+      .map(item => item.value),
+    ["JsonSerializer"],
+  );
+  assert.equal(
+    commandCompletions(commandState("type ", types), lenses).length,
+    8,
+  );
+});
+
+test("lens, framework, and type-filter arguments retain their command-specific metadata", () => {
+  assert.deepEqual(
+    commandCompletions(commandState("show "), lenses),
+    [
+      { value: "api", hint: "API lens", kind: "lens" },
+      { value: "metadata", hint: "Metadata lens", kind: "lens" },
+      { value: "source", hint: "Source lens", kind: "lens" },
+    ],
+  );
+  assert.deepEqual(
+    commandCompletions(commandState("framework net9"), lenses),
+    [{ value: "net9.0", hint: "compile assets", kind: "framework" }],
+  );
+  assert.deepEqual(
+    commandCompletions(commandState("types kind"), lenses),
+    [{ value: "kind", hint: "filter by class, struct, interface, or enum", kind: "filter" }],
+  );
+});
+
+test("completion replaces the active token and preserves the existing append behavior", () => {
+  assert.equal(applyCommandCompletion("", "type"), "type ");
+  assert.equal(
+    applyCommandCompletion("type Json", "JsonSerializer"),
+    "type JsonSerializer ",
+  );
+  assert.equal(
+    applyCommandCompletion("  type ", "JsonSerializer"),
+    "  type JsonSerializer ",
+  );
+});
+
+test("suggestion markup escapes values and marks only the selected row", () => {
+  const html = commandSuggestionsHtml(
+    [
+      { value: 'Type"<T>', hint: "A&B", kind: "class" },
+      { value: "Other", hint: "Example", kind: "struct" },
+    ],
+    1,
+    escapeHtml,
+  );
+
+  assert.match(html, /data-completion="Type&quot;&lt;T&gt;"/);
+  assert.match(html, /<span>A&amp;B<\/span>/);
+  assert.equal(html.match(/suggestion selected/g)?.length, 1);
+  assert.match(html, /suggestion selected[^>]*data-completion="Other"/);
+});
+
+test("command bar markup keeps package scope, command text, and open state inert", () => {
+  const state = commandState('type Type"<T>');
+  state.package.id = "Example&Package";
+  const html = commandBarHtml(state, [], escapeHtml);
+
+  assert.match(html, /class="command-panel open"/);
+  assert.match(html, /Example&amp;Package:net10\.0/);
+  assert.match(html, /value="type Type&quot;&lt;T&gt;"/);
+  assert.doesNotMatch(html, /value="type Type"<T>"/);
+});


### PR DESCRIPTION
## Summary

Moves the persistent inspect-web command bar into a typed component without changing its command behavior.

- `command-bar.ts` now owns command markup, completion grammar, suggestion rendering, keyboard/mouse interaction, focus, and editing state.
- `app.js` retains command effects such as package, type, lens, framework, filter, and share actions, so the component acquires no Wasm engine or workspace authority.
- Focused tests cover root and argument completions, the eight-item bound, token replacement, command metadata, selected-row rendering, package scope, open state, and HTML escaping.

**Compatibility boundary:** This is a behavior-preserving frontend migration. It adds no dependency, command, engine API, network path, or deployment change.

## Validation

- `npm ci`
- `npm test` — 72 passed
- `npm run build` — strict typecheck, Vite production bundle, artifact verification
- `npx markdownlint-cli prototypes/inspect-web/README.md`

Candidate base: `1fbe92c9edd77ed341471d656c45c168692199a7`
Candidate head: `5e0a2cf543d49be21703467ad62c5c845a28c740`
