### PR TITLE
Keep explicit-interface accessors in the extract emit set

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -683,6 +683,11 @@ public static class ApiSurfaceExtractor
                 typeDef,
                 observeDecodeWork);
 
+            // Getter/setter and adder/remover bodies are represented by their
+            // property or event rows. Raiser and Other semantic methods have no
+            // ApiMember token slots, so they stay methods.
+            var accessorMethods = GetSemanticAccessorMethods(reader, typeDef);
+
             // Methods
             foreach (var methodHandle in typeDef.GetMethods())
             {
@@ -697,9 +702,12 @@ public static class ApiSurfaceExtractor
                     method.Name,
                     observeDecodeWork);
 
-                // Skip property accessors and event accessors
-                if (methodName.StartsWith("get_") || methodName.StartsWith("set_") ||
-                    methodName.StartsWith("add_") || methodName.StartsWith("remove_"))
+                // Ordinary MethodSemantics accessors are omitted from the method
+                // list. Explicit-interface accessors stay methods because their
+                // private property or event row is hidden on the public surface.
+                // ApiSurfaceEmitSetTests is the gate.
+                if (accessorMethods.Contains(methodHandle)
+                    && !isExplicitInterfaceImplementation)
                     continue;
 
                 // Skip compiler-generated methods (lambdas, state machines, etc.)
@@ -1329,6 +1337,7 @@ public static class ApiSurfaceExtractor
         bool isExtensionClass)
     {
         var explicitImplementationBodies = GetExplicitImplementationBodies(reader, typeDef);
+        var accessorMethods = GetSemanticAccessorMethods(reader, typeDef);
 
         foreach (var methodHandle in typeDef.GetMethods())
         {
@@ -1339,10 +1348,7 @@ public static class ApiSurfaceExtractor
                 continue;
 
             string methodName = reader.GetString(method.Name);
-            if (methodName.StartsWith("get_", StringComparison.Ordinal)
-                || methodName.StartsWith("set_", StringComparison.Ordinal)
-                || methodName.StartsWith("add_", StringComparison.Ordinal)
-                || methodName.StartsWith("remove_", StringComparison.Ordinal)
+            if ((accessorMethods.Contains(methodHandle) && !isExplicitImplementation)
                 || methodName.StartsWith('<'))
             {
                 continue;
@@ -1793,6 +1799,48 @@ public static class ApiSurfaceExtractor
                 field.GetCustomAttributes(),
                 beforeDecodeWork));
         return (fieldNode.Render(), fieldNode.IsDegraded);
+    }
+
+    /// <summary>
+    /// Property getter/setter and event adder/remover bodies from
+    /// <c>MethodSemantics</c>. Ordinary accessors are represented by their
+    /// property or event row; raiser and Other semantic methods have no
+    /// <see cref="ApiMember"/> token slots, so they stay methods.
+    /// </summary>
+    /// <remarks>
+    /// <c>ApiSurfaceEmitSetTests</c> is the gate: ordinary <c>get_*</c> methods
+    /// remain methods, ordinary semantic accessors do not, and explicit-interface
+    /// accessors remain <c>explicit-interface-implementation</c> because their
+    /// private property or event row does not represent the public contract.
+    /// </remarks>
+    private static HashSet<MethodDefinitionHandle> GetSemanticAccessorMethods(
+        MetadataReader reader,
+        TypeDefinition typeDef)
+    {
+        HashSet<MethodDefinitionHandle> accessors = [];
+        foreach (PropertyDefinitionHandle propertyHandle in typeDef.GetProperties())
+        {
+            PropertyAccessors propertyAccessors =
+                reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+            Add(propertyAccessors.Getter);
+            Add(propertyAccessors.Setter);
+        }
+
+        foreach (EventDefinitionHandle eventHandle in typeDef.GetEvents())
+        {
+            EventAccessors eventAccessors =
+                reader.GetEventDefinition(eventHandle).GetAccessors();
+            Add(eventAccessors.Adder);
+            Add(eventAccessors.Remover);
+        }
+
+        return accessors;
+
+        void Add(MethodDefinitionHandle accessor)
+        {
+            if (!accessor.IsNil)
+                accessors.Add(accessor);
+        }
     }
 
     private static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -703,11 +703,14 @@ public static class ApiSurfaceExtractor
                     observeDecodeWork);
 
                 // Ordinary MethodSemantics accessors are omitted from the method
-                // list. Explicit-interface accessors stay methods because their
-                // private property or event row is hidden on the public surface.
-                // ApiSurfaceEmitSetTests is the gate.
+                // list. A private MethodImpl accessor is the C#/VB explicit-
+                // interface shape: its property or event row is private and would
+                // hide the public contract. Public MethodImpl accessors — static
+                // abstract implementations, covariant overrides, VB Implements —
+                // stay on that public row. ApiSurfaceEmitSetTests is the gate.
                 if (accessorMethods.Contains(methodHandle)
-                    && !isExplicitInterfaceImplementation)
+                    && !(isExplicitInterfaceImplementation
+                        && methodAccess == MethodAttributes.Private))
                     continue;
 
                 // Skip compiler-generated methods (lambdas, state machines, etc.)
@@ -1348,7 +1351,9 @@ public static class ApiSurfaceExtractor
                 continue;
 
             string methodName = reader.GetString(method.Name);
-            if ((accessorMethods.Contains(methodHandle) && !isExplicitImplementation)
+            if ((accessorMethods.Contains(methodHandle)
+                    && !(isExplicitImplementation
+                        && methodAccess == MethodAttributes.Private))
                 || methodName.StartsWith('<'))
             {
                 continue;
@@ -1809,9 +1814,10 @@ public static class ApiSurfaceExtractor
     /// </summary>
     /// <remarks>
     /// <c>ApiSurfaceEmitSetTests</c> is the gate: ordinary <c>get_*</c> methods
-    /// remain methods, ordinary semantic accessors do not, and explicit-interface
-    /// accessors remain <c>explicit-interface-implementation</c> because their
-    /// private property or event row does not represent the public contract.
+    /// remain methods, ordinary semantic accessors do not, and a private
+    /// MethodImpl accessor remains <c>explicit-interface-implementation</c>
+    /// because its property or event row does not represent the public contract.
+    /// A public MethodImpl accessor is represented by that public row.
     /// </remarks>
     private static HashSet<MethodDefinitionHandle> GetSemanticAccessorMethods(
         MetadataReader reader,

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceEmitSetTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceEmitSetTests.cs
@@ -7,9 +7,11 @@ namespace ILInspector.Metadata.Tests;
 /// Gate for #3975: method-list membership uses property/event
 /// <c>MethodSemantics</c>, not a <c>get_</c>/<c>set_</c>/<c>add_</c>/<c>remove_</c>
 /// name prefix. Ordinary prefix-named methods stay methods; ordinary accessors
-/// do not; explicit-interface accessors stay
-/// <c>explicit-interface-implementation</c> because their private property or
-/// event row would otherwise hide the public contract.
+/// do not; a private MethodImpl accessor stays
+/// <c>explicit-interface-implementation</c> because its private property or
+/// event row would otherwise hide the public contract. A public MethodImpl
+/// accessor — covariant override or static-abstract implementation — stays on
+/// that public property or event row.
 /// </summary>
 public sealed class ApiSurfaceEmitSetTests
 {
@@ -117,6 +119,37 @@ public sealed class ApiSurfaceEmitSetTests
     }
 
     [Fact]
+    public void PublicExtract_OmitsPublicMethodImplAccessors()
+    {
+        ApiType covariant = Type(PublicSurface, nameof(CovariantEmitDerived));
+        Assert.Contains(
+            covariant.Members,
+            member => member.Kind == "property"
+                && member.Name == nameof(CovariantEmitDerived.P));
+        Assert.DoesNotContain(
+            covariant.Members,
+            member => member.Name == "get_P");
+
+        ApiType staticImpl = Type(PublicSurface, nameof(StaticAbstractEmitImpl));
+        Assert.Contains(
+            staticImpl.Members,
+            member => member.Kind == "property"
+                && member.Name == nameof(StaticAbstractEmitImpl.Value));
+        Assert.DoesNotContain(
+            staticImpl.Members,
+            member => member.Name == "get_Value");
+
+        ApiType implicitImpl = Type(PublicSurface, nameof(ImplicitEmitImpl));
+        Assert.Contains(
+            implicitImpl.Members,
+            member => member.Kind == "property"
+                && member.Name == nameof(ImplicitEmitImpl.Count));
+        Assert.DoesNotContain(
+            implicitImpl.Members,
+            member => member.Name == "get_Count");
+    }
+
+    [Fact]
     public void IncludeAllExtract_StillKeepsExplicitInterfaceAccessorsAsMethods()
     {
         ApiType type = IncludeAllType();
@@ -157,14 +190,14 @@ public sealed class ApiSurfaceEmitSetTests
         Assert.Equal(publicNames, summaryNames);
     }
 
-    static ApiType PublicType() => Type(PublicSurface);
+    static ApiType PublicType() => Type(PublicSurface, nameof(EmitSetFixture));
 
-    static ApiType IncludeAllType() => Type(IncludeAllSurface);
+    static ApiType IncludeAllType() => Type(IncludeAllSurface, nameof(EmitSetFixture));
 
-    static ApiType SummaryType() => Type(SummarySurface);
+    static ApiType SummaryType() => Type(SummarySurface, nameof(EmitSetFixture));
 
-    static ApiType Type(ApiSurface surface)
-        => surface.Types.Single(type => type.Name == nameof(EmitSetFixture));
+    static ApiType Type(ApiSurface surface, string typeName)
+        => surface.Types.Single(type => type.Name == typeName);
 
     static ApiSurface Extract(string path, bool includeAll)
     {
@@ -208,4 +241,34 @@ public sealed class EmitSetFixture : IEmitSetContract
     public void remove_Standalone(EventHandler? handler)
     {
     }
+}
+
+public class CovariantEmitBase
+{
+    public virtual object P => new();
+}
+
+public sealed class CovariantEmitDerived : CovariantEmitBase
+{
+    public override string P => "";
+}
+
+public interface IStaticAbstractEmit
+{
+    static abstract int Value { get; }
+}
+
+public sealed class StaticAbstractEmitImpl : IStaticAbstractEmit
+{
+    public static int Value => 1;
+}
+
+public interface IImplicitEmit
+{
+    int Count { get; }
+}
+
+public sealed class ImplicitEmitImpl : IImplicitEmit
+{
+    public int Count => 1;
 }

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceEmitSetTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceEmitSetTests.cs
@@ -1,0 +1,211 @@
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Gate for #3975: method-list membership uses property/event
+/// <c>MethodSemantics</c>, not a <c>get_</c>/<c>set_</c>/<c>add_</c>/<c>remove_</c>
+/// name prefix. Ordinary prefix-named methods stay methods; ordinary accessors
+/// do not; explicit-interface accessors stay
+/// <c>explicit-interface-implementation</c> because their private property or
+/// event row would otherwise hide the public contract.
+/// </summary>
+public sealed class ApiSurfaceEmitSetTests
+{
+    static readonly ApiSurface PublicSurface;
+    static readonly ApiSurface IncludeAllSurface;
+    static readonly ApiSurface SummarySurface;
+
+    static ApiSurfaceEmitSetTests()
+    {
+        string path = typeof(ApiSurfaceEmitSetTests).Assembly.Location;
+        PublicSurface = Extract(path, includeAll: false);
+        IncludeAllSurface = Extract(path, includeAll: true);
+        using var stream = File.OpenRead(path);
+        using var peReader = new PEReader(stream);
+        SummarySurface = ApiSurfaceExtractor.ExtractSummary(peReader);
+    }
+
+    [Fact]
+    public void PublicExtract_KeepsOrdinaryPrefixNamedMethods()
+    {
+        ApiType type = PublicType();
+
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "method"
+                && member.Name == nameof(EmitSetFixture.get_Standalone));
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "method"
+                && member.Name == nameof(EmitSetFixture.set_Standalone));
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "method"
+                && member.Name == nameof(EmitSetFixture.add_Standalone));
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "method"
+                && member.Name == nameof(EmitSetFixture.remove_Standalone));
+    }
+
+    [Fact]
+    public void PublicExtract_OmitsOrdinarySemanticAccessorsFromMethodList()
+    {
+        ApiType type = PublicType();
+
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "property"
+                && member.Name == nameof(EmitSetFixture.Value));
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "event"
+                && member.Name == nameof(EmitSetFixture.PublicChanged));
+        Assert.DoesNotContain(
+            type.Members,
+            member => member.Kind == "method" && member.Name == "get_Value");
+        Assert.DoesNotContain(
+            type.Members,
+            member => member.Kind == "method" && member.Name == "set_Value");
+        Assert.DoesNotContain(
+            type.Members,
+            member => member.Kind == "method" && member.Name == "add_PublicChanged");
+        Assert.DoesNotContain(
+            type.Members,
+            member => member.Kind == "method" && member.Name == "remove_PublicChanged");
+    }
+
+    [Fact]
+    public void PublicExtract_KeepsExplicitInterfaceAccessorsAsMethods()
+    {
+        ApiType type = PublicType();
+
+        ApiMember propertyAccessor = Assert.Single(
+            type.Members,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(
+                    $".get_{nameof(IEmitSetContract.ExplicitValue)}",
+                    StringComparison.Ordinal));
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(
+                    $".add_{nameof(IEmitSetContract.Changed)}",
+                    StringComparison.Ordinal));
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(
+                    $".remove_{nameof(IEmitSetContract.Changed)}",
+                    StringComparison.Ordinal));
+
+        Assert.DoesNotContain(
+            type.Members,
+            member => member.Kind == "property"
+                && member.Name.EndsWith(
+                    $".{nameof(IEmitSetContract.ExplicitValue)}",
+                    StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            type.Members,
+            member => member.Kind == "event"
+                && member.Name.EndsWith(
+                    $".{nameof(IEmitSetContract.Changed)}",
+                    StringComparison.Ordinal));
+        Assert.NotNull(propertyAccessor.MetadataToken);
+    }
+
+    [Fact]
+    public void IncludeAllExtract_StillKeepsExplicitInterfaceAccessorsAsMethods()
+    {
+        ApiType type = IncludeAllType();
+
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "explicit-interface-implementation"
+                && member.Name.EndsWith(
+                    $".get_{nameof(IEmitSetContract.ExplicitValue)}",
+                    StringComparison.Ordinal));
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "property"
+                && member.Name.EndsWith(
+                    $".{nameof(IEmitSetContract.ExplicitValue)}",
+                    StringComparison.Ordinal));
+        Assert.Contains(
+            type.Members,
+            member => member.Kind == "method"
+                && member.Name == nameof(EmitSetFixture.get_Standalone));
+        Assert.DoesNotContain(
+            type.Members,
+            member => member.Kind == "method" && member.Name == "get_Value");
+    }
+
+    [Fact]
+    public void ExtractSummary_AgreesWithPublicExtractOnEmitSetMembers()
+    {
+        string[] publicNames = PublicType().Members
+            .Select(member => member.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        string[] summaryNames = SummaryType().Members
+            .Select(member => member.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(publicNames, summaryNames);
+    }
+
+    static ApiType PublicType() => Type(PublicSurface);
+
+    static ApiType IncludeAllType() => Type(IncludeAllSurface);
+
+    static ApiType SummaryType() => Type(SummarySurface);
+
+    static ApiType Type(ApiSurface surface)
+        => surface.Types.Single(type => type.Name == nameof(EmitSetFixture));
+
+    static ApiSurface Extract(string path, bool includeAll)
+    {
+        using var stream = File.OpenRead(path);
+        using var peReader = new PEReader(stream);
+        return ApiSurfaceExtractor.Extract(peReader, includeAll);
+    }
+}
+
+public interface IEmitSetContract
+{
+    int ExplicitValue { get; }
+
+    event EventHandler Changed;
+}
+
+public sealed class EmitSetFixture : IEmitSetContract
+{
+    public int Value { get; set; }
+
+    public event EventHandler? PublicChanged;
+
+    int IEmitSetContract.ExplicitValue => 42;
+
+    event EventHandler IEmitSetContract.Changed
+    {
+        add { }
+        remove { }
+    }
+
+    public int get_Standalone() => 1;
+
+    public void set_Standalone(int value)
+    {
+    }
+
+    public void add_Standalone(EventHandler? handler)
+    {
+    }
+
+    public void remove_Standalone(EventHandler? handler)
+    {
+    }
+}


### PR DESCRIPTION
## Conclusion

API extraction now decides method-list membership from property/event `MethodSemantics`, not a `get_`/`set_`/`add_`/`remove_` name prefix. Ordinary prefix-named methods stay methods. Ordinary accessors stay on their property or event row. A **private MethodImpl** accessor stays `explicit-interface-implementation` so a private property or event row cannot hide the public contract. A **public MethodImpl** accessor — covariant override, static-abstract implementation, VB `Implements` — stays on that public row.

Fixes #3975.

## Why this was dropping or leaking members

The extractor skipped any method whose name started with `get_`, `set_`, `add_`, or `remove_`. That hid ordinary methods that merely used those prefixes (`get_Standalone()`).

`#3924` switched a sibling branch to `MethodSemantics` and then dropped explicit-interface accessors, because those MethodDefs are also semantic getters/setters/adders/removers while their property or event row is private.

The first candidate (`2dfc2bb3f`) kept every MethodImpl accessor. r1 Sol and Opus reproduced leaks for well-behaved public MethodImpl accessors: covariant `override string P`, `static abstract` properties such as `Half.Epsilon`, and every VB `Implements` property/event.

## Emit set

| Member | Public extract | `--all` |
| --- | --- | --- |
| Ordinary `get_Value` accessor | omitted (property row) | omitted (property row) |
| Ordinary `get_Standalone()` method | method | method |
| Private EIM `I.get_P` accessor | `explicit-interface-implementation` | same method, plus the private property row |
| Public MethodImpl accessor (covariant / static abstract / VB Implements) | omitted (property row) | omitted (property row) |

`--all` dual-listing the private EIM MethodDef and its private property is accepted. `#4402` already resolves that pair by unique body token.

Raiser and Other semantic methods have no `ApiMember` token slots, so they stay methods.

## Demo

Compiled fixture `EmitSetFixture` after this change:

```text
Value                          property
PublicChanged                  event
get_Standalone                 method
set_Standalone                 method
add_Standalone                 method
remove_Standalone              method
IEmitSetContract.get_ExplicitValue   explicit-interface-implementation
IEmitSetContract.add_Changed         explicit-interface-implementation
IEmitSetContract.remove_Changed      explicit-interface-implementation
```

`get_Value` / `CovariantEmitDerived.get_P` / `StaticAbstractEmitImpl.get_Value` are not methods.

## Evidence

- `ApiSurfaceEmitSetTests` — prefix-named methods, ordinary accessors, private EIM retention, public MethodImpl non-retention (covariant + static abstract + implicit), `--all` dual-list, Extract/ExtractSummary name agreement
- `ApiSurfaceExtractorTests.ExtractSummary_MatchesFullPublicSurfaceCounts`
- `CallGraphMemberResolverTests.Resolve_Matches*ExplicitInterfaceAccessor*`
- `CommandExecutionTests.Type_DecompiledSource_RendersWholeTypeListing` (`bool ICollection.IsSynchronized => false`)
- r1 reproduction: covariant `Derived.get_P` leaked at `2dfc2bb3f`, absent at `cd93d1527`

## Non-action

- Does not promote private EIM property/event rows onto the public surface
- Does not change `#4402` UniqueBody resolution
- Does not start `#4217`, leftover TypedReference keys, or protobuf Integration
- Does not adopt the `#3924` MethodImpl provenance map; this slice uses the existing `GetExplicitImplementationBodies` set plus private accessibility
- Does not add a VB project fixture; the public MethodImpl C# canaries are the same emit shape

## Candidate

- Base: `48b4e4744` (`origin/main`)
- Head: `cd93d1527` (replacement after r1)
- Prior reviewed head: `2dfc2bb3f` (superseded)