### PR TITLE
Convert inspect-web package bar to TypeScript

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -525,6 +525,13 @@ the component does not acquire engine or workspace authority.
 `test/command-bar.test.js` gates the completion grammar, replacement behavior,
 bounded suggestions, command metadata, selection, and escaping.
 
+`src/package-bar.ts` owns the package tab strip (including the always-present
+Platform tab), the open-package query form, and their keyboard/mouse/wheel
+interaction. `app.js` supplies the workspace effects — selecting, closing, and
+opening a package or the runtime pack — so the component acquires no engine or
+workspace authority. `test/package-bar.test.js` gates tab markup, active/close
+state, escaping, and open-package query parsing.
+
 - `Cmd/Ctrl+K` focuses the persistent command prompt.
 - `Cmd/Ctrl+F` or `/` focuses the type filter.
 - Arrow keys select a completion, `Tab` accepts it, and `Enter` runs it.

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -47,6 +47,7 @@ import {
 } from "./graph-mermaid.js";
 import { buildAnnotatedView, factsForNode, MEDIA, MEDIUM_LABELS, nodeAtOffset } from "/src/annotated-source-view.ts";
 import { createCommandBar } from "/src/command-bar.ts";
+import { createPackageBar } from "/src/package-bar.ts";
 import { loadPlatformIndex } from "/src/platform-index.js";
 
 let initializeEngine;
@@ -670,6 +671,18 @@ const commandBar = createCommandBar({
   focusAfterDismiss: () => document.querySelector("#type-list").focus(),
 });
 
+const packageBar = createPackageBar({
+  state,
+  escapeHtml,
+  packageIdentityKey,
+  runtimePackPackage,
+  selectPackageTab,
+  closePackageTab,
+  openRuntimePack: openRuntimePackFromHome,
+  openPackage: (packageId, version) => loadPackage(packageId, version, ""),
+  showToast,
+});
+
 function selectedType() {
   if (!state.package) return null;
   return state.package.types.find(item => item.id === state.selectedTypeId) || filteredTypes()[0] || state.package.types[0];
@@ -1276,23 +1289,7 @@ function render() {
     <div class="workbench">
       <header class="titlebar">
         <a class="brand" href="/" aria-label="dotnet inspect home"><span class="brand-glyph">◇</span><span>dotnet-inspect</span></a>
-        <div class="package-tabs" role="tablist" aria-label="Package scope">
-          ${platformTabHtml()}
-          ${state.packages.filter(item => !item.isRuntimePack).map(item => `
-            <div class="package-tab ${packageIdentityEquals(item, state.package) ? "active" : ""}" data-package-key="${escapeHtml(packageIdentityKey(item))}" role="tab" tabindex="0">
-              <span class="package-cube">⬡</span>
-              <span class="tab-label">${escapeHtml(item.id)}</span>
-              <small>${escapeHtml(item.version)} · ${escapeHtml(item.activeFramework)}</small>
-              ${packageIdentityEquals(item, state.package)
-                ? `<button class="tab-close" data-package-close="${escapeHtml(packageIdentityKey(item))}" type="button" aria-label="Close ${escapeHtml(item.id)}">×</button>`
-                : ""}
-            </div>`).join("")}
-        </div>
-        <form class="package-query" id="package-query">
-          <span>+</span>
-          <input id="package-query-input" placeholder="Package or Package@version" aria-label="Open NuGet package" autocomplete="off" spellcheck="false" />
-          <button>open</button>
-        </form>
+        ${packageBar.html()}
         <div class="title-actions">
           <button id="go-home" title="Back to the home page">home</button>
           <button id="theme-toggle" aria-label="Switch to light theme">${state.theme === "dark" ? "light" : "dark"}</button>
@@ -3792,37 +3789,7 @@ function highlightCSharp(value) {
 }
 
 function bindEvents() {
-  document.querySelectorAll("[data-package-key]").forEach(tab => {
-    const activate = () => selectPackageTab(
-      state.packages.find(item => packageIdentityKey(item) === tab.dataset.packageKey));
-    tab.addEventListener("click", event => {
-      if (event.target.closest("[data-package-close]")) return;
-      activate();
-    });
-    tab.addEventListener("keydown", event => {
-      if (event.key !== "Enter" && event.key !== " ") return;
-      event.preventDefault();
-      activate();
-    });
-  });
-  document.querySelectorAll("[data-package-close]").forEach(button =>
-    button.addEventListener("click", event => {
-      event.stopPropagation();
-      closePackageTab(button.dataset.packageClose);
-    }));
-  document.querySelector("[data-platform-open]")?.addEventListener("click", () => openRuntimePackFromHome());
-  // Browser-tab behavior for a crowded strip: keep the active tab in view, and let a
-  // vertical wheel scroll the horizontal strip so hidden tabs stay reachable.
-  const tabStrip = document.querySelector(".package-tabs");
-  if (tabStrip) {
-    requestAnimationFrame(() =>
-      tabStrip.querySelector(".package-tab.active")?.scrollIntoView({ block: "nearest", inline: "nearest" }));
-    tabStrip.addEventListener("wheel", event => {
-      if (event.deltaY === 0) return;
-      event.preventDefault();
-      tabStrip.scrollLeft += event.deltaY;
-    }, { passive: false });
-  }
+  packageBar.bind(document);
   document.querySelectorAll("[data-scope]").forEach(button => button.addEventListener("click", () => {
     const target = button.dataset.scope;
     if (target === "package") {
@@ -4179,18 +4146,6 @@ function bindEvents() {
     focusFilter();
   });
 
-  document.querySelector("#package-query").addEventListener("submit", event => {
-    event.preventDefault();
-    const value = document.querySelector("#package-query-input").value.trim();
-    const separator = value.lastIndexOf("@");
-    if (!value || separator === value.length - 1) {
-      showToast("enter a package, optionally followed by @version");
-      return;
-    }
-    const packageId = separator > 0 ? value.slice(0, separator) : value;
-    const version = separator > 0 ? value.slice(separator + 1) : "latest";
-    loadPackage(packageId, version, "");
-  });
   document.querySelector("#share").addEventListener("click", share);
   document.querySelector("[data-graph-back]")?.addEventListener("click", popPlatformDrill);
   document.querySelector("#dismiss-notice")?.addEventListener("click", () => {
@@ -7684,22 +7639,6 @@ function platformLibrarySelectHtml(options = {}) {
       ${group("netcore.app", ".NET")}
       ${group("aspnetcore.app", "ASP.NET Core")}
     </select>`;
-}
-
-// The always-present, non-closable, left-most "Platform" tab. It abstracts the .NET runtime
-// packs (netcore.app, aspnetcore.app, …) behind a single surface: when a pack is resident it
-// activates it; otherwise clicking loads it lazily. Rendered separately from the normal tab
-// map so it is always first and never carries a close affordance.
-function platformTabHtml() {
-  const rt = runtimePackPackage();
-  const active = rt && state.package && state.package.id === rt.id ? "active" : "";
-  const framework = rt?.activeFramework || state.package?.activeFramework || "";
-  const attr = rt ? `data-package-key="${escapeHtml(packageIdentityKey(rt))}"` : `data-platform-open="1"`;
-  return `<button class="package-tab platform ${active}" ${attr} role="tab" title="Platform · .NET runtime libraries">
-      <span class="package-cube">◎</span>
-      <span class="tab-label">Platform</span>
-      <small>${escapeHtml(framework || "load")}</small>
-    </button>`;
 }
 
 // The resident runtime pseudo-package rides in the shared workspace/URL packet under the

--- a/prototypes/inspect-web/src/package-bar.ts
+++ b/prototypes/inspect-web/src/package-bar.ts
@@ -146,7 +146,7 @@ export function createPackageBar(options: PackageBarOptions) {
         if (target) selectPackageTab(target);
       };
       tab.addEventListener("click", event => {
-        if ((event.target as Element | null)?.closest("[data-package-close]")) return;
+        if (event.target instanceof Element && event.target.closest("[data-package-close]")) return;
         activate();
       });
       tab.addEventListener("keydown", event => {

--- a/prototypes/inspect-web/src/package-bar.ts
+++ b/prototypes/inspect-web/src/package-bar.ts
@@ -1,0 +1,198 @@
+export interface PackageBarPackage {
+  id: string;
+  version: string;
+  activeFramework: string;
+  isRuntimePack: boolean;
+}
+
+export interface PackageBarState {
+  packages: readonly PackageBarPackage[];
+  package: PackageBarPackage | null;
+}
+
+export interface ParsedPackageQuery {
+  packageId: string;
+  version: string;
+}
+
+interface PackageBarOptions {
+  state: PackageBarState;
+  escapeHtml: (value: unknown) => string;
+  packageIdentityKey: (pkg: PackageBarPackage) => string;
+  runtimePackPackage: () => PackageBarPackage | null;
+  selectPackageTab: (pkg: PackageBarPackage) => void;
+  closePackageTab: (packageKey: string) => void;
+  openRuntimePack: () => void;
+  openPackage: (packageId: string, version: string) => void;
+  showToast: (message: string) => void;
+}
+
+export function packageIdentityEquals(
+  left: PackageBarPackage | null,
+  right: PackageBarPackage | null,
+  packageIdentityKey: (pkg: PackageBarPackage) => string,
+): boolean {
+  return Boolean(left && right && packageIdentityKey(left) === packageIdentityKey(right));
+}
+
+// The always-present, non-closable, left-most "Platform" tab. It abstracts the .NET runtime
+// packs (netcore.app, aspnetcore.app, …) behind a single surface: when a pack is resident it
+// activates it; otherwise clicking loads it lazily. Rendered separately from the normal tab
+// map so it is always first and never carries a close affordance.
+export function platformTabHtml(
+  runtimePack: PackageBarPackage | null,
+  activePackage: PackageBarPackage | null,
+  escapeHtml: (value: unknown) => string,
+  packageIdentityKey: (pkg: PackageBarPackage) => string,
+): string {
+  const active = runtimePack && activePackage && activePackage.id === runtimePack.id ? "active" : "";
+  const framework = runtimePack?.activeFramework || activePackage?.activeFramework || "";
+  const attr = runtimePack
+    ? `data-package-key="${escapeHtml(packageIdentityKey(runtimePack))}"`
+    : `data-platform-open="1"`;
+  return `<button class="package-tab platform ${active}" ${attr} role="tab" title="Platform · .NET runtime libraries">
+      <span class="package-cube">◎</span>
+      <span class="tab-label">Platform</span>
+      <small>${escapeHtml(framework || "load")}</small>
+    </button>`;
+}
+
+export function packageTabHtml(
+  item: PackageBarPackage,
+  activePackage: PackageBarPackage | null,
+  escapeHtml: (value: unknown) => string,
+  packageIdentityKey: (pkg: PackageBarPackage) => string,
+): string {
+  const active = packageIdentityEquals(item, activePackage, packageIdentityKey);
+  const key = escapeHtml(packageIdentityKey(item));
+  return `
+            <div class="package-tab ${active ? "active" : ""}" data-package-key="${key}" role="tab" tabindex="0">
+              <span class="package-cube">⬡</span>
+              <span class="tab-label">${escapeHtml(item.id)}</span>
+              <small>${escapeHtml(item.version)} · ${escapeHtml(item.activeFramework)}</small>
+              ${active
+                ? `<button class="tab-close" data-package-close="${key}" type="button" aria-label="Close ${escapeHtml(item.id)}">×</button>`
+                : ""}
+            </div>`;
+}
+
+export function packageTabsHtml(
+  state: PackageBarState,
+  runtimePack: PackageBarPackage | null,
+  escapeHtml: (value: unknown) => string,
+  packageIdentityKey: (pkg: PackageBarPackage) => string,
+): string {
+  const tabs = state.packages
+    .filter(item => !item.isRuntimePack)
+    .map(item => packageTabHtml(item, state.package, escapeHtml, packageIdentityKey))
+    .join("");
+  return `${platformTabHtml(runtimePack, state.package, escapeHtml, packageIdentityKey)}${tabs}`;
+}
+
+export function packageBarHtml(
+  state: PackageBarState,
+  runtimePack: PackageBarPackage | null,
+  escapeHtml: (value: unknown) => string,
+  packageIdentityKey: (pkg: PackageBarPackage) => string,
+): string {
+  return `
+        <div class="package-tabs" role="tablist" aria-label="Package scope">
+          ${packageTabsHtml(state, runtimePack, escapeHtml, packageIdentityKey)}
+        </div>
+        <form class="package-query" id="package-query">
+          <span>+</span>
+          <input id="package-query-input" placeholder="Package or Package@version" aria-label="Open NuGet package" autocomplete="off" spellcheck="false" />
+          <button>open</button>
+        </form>`;
+}
+
+// A bare "@version" (or "package@" with nothing after it) is not a usable query: there is
+// no package id, or the version half is empty. Both are rejected the same way the inline
+// handler always has, so the toast prompt is unchanged.
+export function parsePackageQuery(value: string): ParsedPackageQuery | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const separator = trimmed.lastIndexOf("@");
+  if (separator === trimmed.length - 1) return null;
+
+  const packageId = separator > 0 ? trimmed.slice(0, separator) : trimmed;
+  const version = separator > 0 ? trimmed.slice(separator + 1) : "latest";
+  return { packageId, version };
+}
+
+export function createPackageBar(options: PackageBarOptions) {
+  const {
+    state,
+    escapeHtml,
+    packageIdentityKey,
+    runtimePackPackage,
+    selectPackageTab,
+    closePackageTab,
+    openRuntimePack,
+    openPackage,
+    showToast,
+  } = options;
+
+  function html(): string {
+    return packageBarHtml(state, runtimePackPackage(), escapeHtml, packageIdentityKey);
+  }
+
+  function bind(root: ParentNode): void {
+    root.querySelectorAll<HTMLElement>("[data-package-key]").forEach(tab => {
+      const activate = () => {
+        const target = state.packages.find(item => packageIdentityKey(item) === tab.dataset.packageKey);
+        if (target) selectPackageTab(target);
+      };
+      tab.addEventListener("click", event => {
+        if ((event.target as HTMLElement).closest("[data-package-close]")) return;
+        activate();
+      });
+      tab.addEventListener("keydown", event => {
+        if (event.key !== "Enter" && event.key !== " ") return;
+        event.preventDefault();
+        activate();
+      });
+    });
+
+    root.querySelectorAll<HTMLButtonElement>("[data-package-close]").forEach(button =>
+      button.addEventListener("click", event => {
+        event.stopPropagation();
+        const key = button.dataset.packageClose;
+        if (key !== undefined) closePackageTab(key);
+      }));
+
+    root.querySelector<HTMLElement>("[data-platform-open]")?.addEventListener("click", () => openRuntimePack());
+
+    // Browser-tab behavior for a crowded strip: keep the active tab in view, and let a
+    // vertical wheel scroll the horizontal strip so hidden tabs stay reachable.
+    const tabStrip = root.querySelector<HTMLElement>(".package-tabs");
+    if (tabStrip) {
+      requestAnimationFrame(() =>
+        tabStrip.querySelector(".package-tab.active")?.scrollIntoView({ block: "nearest", inline: "nearest" }));
+      tabStrip.addEventListener("wheel", event => {
+        if (event.deltaY === 0) return;
+        event.preventDefault();
+        tabStrip.scrollLeft += event.deltaY;
+      }, { passive: false });
+    }
+
+    const form = root.querySelector<HTMLFormElement>("#package-query");
+    if (!form) throw new Error("The package bar query form is unavailable.");
+    form.addEventListener("submit", event => {
+      event.preventDefault();
+      const input = root.querySelector<HTMLInputElement>("#package-query-input");
+      if (!input) throw new Error("The package bar query input is unavailable.");
+      const parsed = parsePackageQuery(input.value);
+      if (!parsed) {
+        showToast("enter a package, optionally followed by @version");
+        return;
+      }
+      openPackage(parsed.packageId, parsed.version);
+    });
+  }
+
+  return {
+    bind,
+    html,
+  };
+}

--- a/prototypes/inspect-web/src/package-bar.ts
+++ b/prototypes/inspect-web/src/package-bar.ts
@@ -106,9 +106,11 @@ export function packageBarHtml(
         </form>`;
 }
 
-// A bare "@version" (or "package@" with nothing after it) is not a usable query: there is
-// no package id, or the version half is empty. Both are rejected the same way the inline
-// handler always has, so the toast prompt is unchanged.
+// Only an empty query or "package@" with nothing after the "@" is rejected, matching the
+// inline handler's original bounds exactly. A leading "@" (no package id, e.g. "@1.0.0")
+// is preserved as-is rather than treated specially: separator > 0 is false, so the whole
+// trimmed string — "@" included — becomes the package id, same as the handler this
+// replaces. That is an existing quirk of the original code, not a rejection case.
 export function parsePackageQuery(value: string): ParsedPackageQuery | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
@@ -144,7 +146,7 @@ export function createPackageBar(options: PackageBarOptions) {
         if (target) selectPackageTab(target);
       };
       tab.addEventListener("click", event => {
-        if ((event.target as HTMLElement).closest("[data-package-close]")) return;
+        if ((event.target as Element | null)?.closest("[data-package-close]")) return;
         activate();
       });
       tab.addEventListener("keydown", event => {

--- a/prototypes/inspect-web/test/package-bar.test.js
+++ b/prototypes/inspect-web/test/package-bar.test.js
@@ -90,7 +90,7 @@ test("the package bar wraps the tab strip and open-package form", () => {
   assert.match(html, /id="package-query-input"/);
 });
 
-test("parsing the open-package query accepts an id, an id@version, and rejects a bare version", () => {
+test("parsing the open-package query accepts an id and an id@version, and rejects an empty query or an empty version", () => {
   assert.deepEqual(parsePackageQuery("System.Text.Json"), {
     packageId: "System.Text.Json",
     version: "latest",
@@ -102,4 +102,13 @@ test("parsing the open-package query accepts an id, an id@version, and rejects a
   assert.equal(parsePackageQuery(""), null);
   assert.equal(parsePackageQuery("   "), null);
   assert.equal(parsePackageQuery("System.Text.Json@"), null);
+});
+
+// A leading "@" (no package id) is not a rejection case: it is an existing quirk of the
+// inline handler this module replaces, preserved deliberately rather than special-cased.
+test("a leading '@' has no package id to reject, so it is preserved as the whole package id", () => {
+  assert.deepEqual(parsePackageQuery("@1.0.0"), {
+    packageId: "@1.0.0",
+    version: "latest",
+  });
 });

--- a/prototypes/inspect-web/test/package-bar.test.js
+++ b/prototypes/inspect-web/test/package-bar.test.js
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  packageBarHtml,
+  packageIdentityEquals,
+  packageTabHtml,
+  packageTabsHtml,
+  parsePackageQuery,
+  platformTabHtml,
+} from "../src/package-bar.ts";
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function packageIdentityKey(pkg) {
+  return `${pkg.id}@${pkg.version}::${pkg.activeFramework}`;
+}
+
+function pkg(id, version = "1.0.0", activeFramework = "net10.0", isRuntimePack = false) {
+  return { id, version, activeFramework, isRuntimePack };
+}
+
+test("package identity equality compares the full coordinate", () => {
+  const a = pkg("System.Text.Json");
+  const b = pkg("System.Text.Json");
+  const c = pkg("System.Text.Json", "2.0.0");
+
+  assert.equal(packageIdentityEquals(a, b, packageIdentityKey), true);
+  assert.equal(packageIdentityEquals(a, c, packageIdentityKey), false);
+  assert.equal(packageIdentityEquals(null, b, packageIdentityKey), false);
+});
+
+test("a package tab marks only the active tab and only the active tab carries a close button", () => {
+  const active = pkg("System.Text.Json");
+  const other = pkg("Newtonsoft.Json");
+
+  const activeHtml = packageTabHtml(active, active, escapeHtml, packageIdentityKey);
+  const inactiveHtml = packageTabHtml(other, active, escapeHtml, packageIdentityKey);
+
+  assert.match(activeHtml, /class="package-tab active"/);
+  assert.match(activeHtml, /data-package-close=/);
+  assert.doesNotMatch(inactiveHtml, /class="package-tab active"/);
+  assert.doesNotMatch(inactiveHtml, /data-package-close=/);
+});
+
+test("package tab markup escapes untrusted package identity text", () => {
+  const untrusted = pkg('Evil"<Package>', '1.0.0"<T>');
+  const html = packageTabHtml(untrusted, untrusted, escapeHtml, packageIdentityKey);
+
+  assert.doesNotMatch(html, /Evil"<Package>/);
+  assert.match(html, /Evil&quot;&lt;Package&gt;/);
+});
+
+test("the platform tab reflects a resident runtime pack, and lazily opens when absent", () => {
+  const runtimePack = pkg("Microsoft.NETCore.App", "10.0.0", "net10.0", true);
+
+  const resident = platformTabHtml(runtimePack, runtimePack, escapeHtml, packageIdentityKey);
+  assert.match(resident, /class="package-tab platform active"/);
+  assert.match(resident, /data-package-key=/);
+  assert.doesNotMatch(resident, /data-platform-open/);
+
+  const absent = platformTabHtml(null, null, escapeHtml, packageIdentityKey);
+  assert.match(absent, /class="package-tab platform "/);
+  assert.match(absent, /data-platform-open="1"/);
+  assert.match(absent, /<small>load<\/small>/);
+});
+
+test("the tab strip renders the platform tab first, then only non-runtime packages", () => {
+  const runtimePack = pkg("Microsoft.NETCore.App", "10.0.0", "net10.0", true);
+  const active = pkg("System.Text.Json");
+  const state = { packages: [runtimePack, active], package: active };
+
+  const html = packageTabsHtml(state, runtimePack, escapeHtml, packageIdentityKey);
+  assert.ok(html.indexOf("platform") < html.indexOf("System.Text.Json"));
+  assert.equal(html.match(/package-tab/g)?.length, 2);
+});
+
+test("the package bar wraps the tab strip and open-package form", () => {
+  const active = pkg("System.Text.Json");
+  const state = { packages: [active], package: active };
+  const html = packageBarHtml(state, null, escapeHtml, packageIdentityKey);
+
+  assert.match(html, /class="package-tabs" role="tablist"/);
+  assert.match(html, /id="package-query"/);
+  assert.match(html, /id="package-query-input"/);
+});
+
+test("parsing the open-package query accepts an id, an id@version, and rejects a bare version", () => {
+  assert.deepEqual(parsePackageQuery("System.Text.Json"), {
+    packageId: "System.Text.Json",
+    version: "latest",
+  });
+  assert.deepEqual(parsePackageQuery("System.Text.Json@8.0.0"), {
+    packageId: "System.Text.Json",
+    version: "8.0.0",
+  });
+  assert.equal(parsePackageQuery(""), null);
+  assert.equal(parsePackageQuery("   "), null);
+  assert.equal(parsePackageQuery("System.Text.Json@"), null);
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -123,6 +123,9 @@ const appSource = readFileSync(new URL("../src/app.js", import.meta.url), "utf8"
 const graphSource = readFileSync(
   new URL("../src/graph-mermaid.js", import.meta.url),
   "utf8");
+const packageBarSource = readFileSync(
+  new URL("../src/package-bar.ts", import.meta.url),
+  "utf8");
 const applicationSources = `${appSource}\n${graphSource}`;
 const stylesSource = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
 const engineSource = readFileSync(
@@ -1093,11 +1096,11 @@ test("workspace UI routes replacements and restore notices through bounded paths
     appSource,
     /appendQueryNotice\(\s+friendly\.message,\s+options\.retryAction/);
   assert.match(
-    appSource,
+    packageBarSource,
     /data-package-close=/);
   assert.match(
-    appSource,
-    /closePackageTab\(button\.dataset\.packageClose\)/);
+    packageBarSource,
+    /closePackageTab\(key\)/);
   assert.match(
     appSource,
     /const key = assemblyId \|\| `legacy:\$\{asm\}`/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -126,7 +126,7 @@ const graphSource = readFileSync(
 const packageBarSource = readFileSync(
   new URL("../src/package-bar.ts", import.meta.url),
   "utf8");
-const applicationSources = `${appSource}\n${graphSource}`;
+const applicationSources = `${appSource}\n${graphSource}\n${packageBarSource}`;
 const stylesSource = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
 const engineSource = readFileSync(
   new URL("../engine/wwwroot/engine.js", import.meta.url),


### PR DESCRIPTION
## Summary

Moves the persistent inspect-web package tab strip and open-package query
form into a typed component without changing their command behavior.

- `package-bar.ts` now owns tab/query markup, tab activation, close
  routing, wheel/scroll interaction, and open-package query parsing.
- `app.js` retains workspace effects (selecting, closing, and opening a
  package or the runtime pack), so the component acquires no Wasm engine
  or workspace authority.
- Focused tests cover tab active/close state, HTML escaping, the platform
  tab's resident/absent states, tab-strip ordering, and open-package query
  parsing (id, id@version, bare version rejection).

**Compatibility boundary:** This is a behavior-preserving frontend
migration. It adds no dependency, command, engine API, network path, or
deployment change.

## Validation

- `npm ci`
- `npm test` — 79 passed
- `npm run build` — strict typecheck, Vite production bundle, artifact
  verification
- `npx markdownlint-cli prototypes/inspect-web/README.md`

Candidate base: `df2ae6065`
