### PR TITLE
Escape SignatureModel parameter names without re-lexing text

### DIFF
--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1221,10 +1221,10 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     /// <summary>
-    /// #3561: when <see cref="ApiSignature"/> is present, parameter names are escaped
-    /// from the model. A poisoned <see cref="ApiMember.Signature"/> whose comment
-    /// <c>)</c> would close the text scanner early must not be consulted, and a tuple
-    /// return must not be re-lexed.
+    /// #3561: when <see cref="ApiSignature"/> is present, the writer must not
+    /// consult <see cref="ApiMember.Signature"/>. A poisoned comment <c>)</c>
+    /// would close the text scanner early; the model still emits the escaped name
+    /// and an unmangled tuple return.
     /// </summary>
     [Fact]
     public void MemberDeclaration_SignatureModel_EscapesParametersWithoutScanningText()
@@ -1248,6 +1248,36 @@ public sealed class CSharpDeclarationWriterTests
 
         Assert.Equal(
             "public (int, string) Pair(int @event)",
+            CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
+    }
+
+    /// <summary>
+    /// Skip-vs-scan gate for #3561. An unnamed model parameter is emitted as the
+    /// type alone. Re-lexing that string treats the type keyword as a name and
+    /// produces <c>@int</c> (CS0246) — the #3489/#3528 defect on the model path.
+    /// </summary>
+    [Fact]
+    public void MemberDeclaration_SignatureModel_DoesNotEscapeUnnamedParameterType()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "M",
+            Kind = "method",
+            Signature = "void M(@int)",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "void",
+                MemberName = "M",
+                Parameters =
+                [
+                    new ApiParameter { Type = "int" }
+                ]
+            }
+        };
+
+        Assert.Equal(
+            "public void M(int)",
             CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
     }
 

--- a/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
+++ b/src/ILInspector.CSharp.Tests/CSharpDeclarationWriterTests.cs
@@ -1221,6 +1221,37 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     /// <summary>
+    /// #3561: when <see cref="ApiSignature"/> is present, parameter names are escaped
+    /// from the model. A poisoned <see cref="ApiMember.Signature"/> whose comment
+    /// <c>)</c> would close the text scanner early must not be consulted, and a tuple
+    /// return must not be re-lexed.
+    /// </summary>
+    [Fact]
+    public void MemberDeclaration_SignatureModel_EscapesParametersWithoutScanningText()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Tuples", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Pair",
+            Kind = "method",
+            Signature = "(int, string) Pair(/* ) */ int event)",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "(int, string)",
+                MemberName = "Pair",
+                Parameters =
+                [
+                    new ApiParameter { Type = "int", Name = "event" }
+                ]
+            }
+        };
+
+        Assert.Equal(
+            "public (int, string) Pair(int @event)",
+            CSharpDeclarationWriter.RenderMemberDeclaration(type, member));
+    }
+
+    /// <summary>
     /// Pins how <c>EscapeParameterLists</c> resolves a <c>(</c> preceded by whitespace,
     /// which is the one genuinely ambiguous position.
     ///

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -1136,7 +1136,9 @@ internal static class CSharpDeclarationWriter
             signature,
             preserveQualifiedIndexerKeyword: IsExplicitInterfaceProperty(member)
                 && member.SignatureModel?.MemberName == "this[]");
-        if (!options.AbbreviateSignature)
+        // Parameter names from SignatureModel are escaped in FormatParameter.
+        // Re-lexing the composed string is only for compatibility text.
+        if (!options.AbbreviateSignature && !renderedFromModel)
             signature = EscapeParameterLists(signature);
 
         List<string> attributeLines = [];
@@ -2370,7 +2372,13 @@ internal static class CSharpDeclarationWriter
     }
 
     /// <summary>
-    /// Escapes keyword-named parameters inside a member signature's parameter lists.
+    /// Best-effort parameter-name escaping for compatibility signature text —
+    /// opaque <see cref="ApiMember.Signature"/>, or a model
+    /// <see cref="TryRenderSignatureModel"/> cannot yet emit. Signatures built
+    /// from the model escape names in <see cref="FormatParameter"/> and must not
+    /// come through here.
+    /// <c>MemberDeclaration_SignatureModel_EscapesParametersWithoutScanningText</c>
+    /// is the gate.
     /// </summary>
     /// <remarks>
     /// Only a parenthesis run that actually opens a parameter list is rewritten. C#

--- a/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.CSharp/CSharpDeclarationWriter.cs
@@ -2377,8 +2377,8 @@ internal static class CSharpDeclarationWriter
     /// <see cref="TryRenderSignatureModel"/> cannot yet emit. Signatures built
     /// from the model escape names in <see cref="FormatParameter"/> and must not
     /// come through here.
-    /// <c>MemberDeclaration_SignatureModel_EscapesParametersWithoutScanningText</c>
-    /// is the gate.
+    /// <c>MemberDeclaration_SignatureModel_DoesNotEscapeUnnamedParameterType</c>
+    /// is the skip-vs-scan gate.
     /// </summary>
     /// <remarks>
     /// Only a parenthesis run that actually opens a parameter list is rewritten. C#


### PR DESCRIPTION
## Conclusion

When `TryRenderSignatureModel` builds a member declaration, parameter names are already escaped in `FormatParameter`. This PR stops `EscapeParameterLists` from re-lexing that composed string. The text scanner stays as documented best-effort for compatibility text: opaque `ApiMember.Signature`, or a model the writer cannot yet emit (extensions, EIM methods, operators).

Fixes #3561.

## Why this was a defect shape

`EscapeParameterLists` reconstructs, from rendered text, which parenthesis is a parameter list and which trailing token is a name. That is the #3489 / #3528 family: tuple returns became `(@int, @string)`, literals hid `)`, a member named `where` looked like a constraint. Each text-scan fix narrowed the gap. A comment `)` is the next hole the scanner still cannot close.

The model already has names as data. Scanning the string it just produced is the wrong owner.

## Demo

Same member, two inputs. The opaque `Signature` is poisoned with a comment `)` that would close `Matching` early:

```text
Signature      = (int, string) Pair(/* ) */ int event)
SignatureModel = return (int, string), name Pair, parameter int event
```

Before (scanner consulted, or Signature used): `public (int, string) Pair(/* ) */ int event)` — unescaped `event`.

After: `public (int, string) Pair(int @event)` — names from the model, tuple return not re-lexed.

Skip-vs-scan (unnamed model parameter; extractors do not emit this, it pins the writer):

```text
Signature      = void M(@int)
SignatureModel = return void, name M, unnamed int
```

Scanner or Signature: `public void M(@int)` (CS0246). After: `public void M(int)`.

## Evidence

- `MemberDeclaration_SignatureModel_DoesNotEscapeUnnamedParameterType` — skip-vs-scan gate; also fails if `Signature` is used
- `MemberDeclaration_SignatureModel_EscapesParametersWithoutScanningText` — model-vs-`Signature` / comment-by-construction
- Existing #3528 gates still pass on opaque `Signature`: `MemberDeclaration_EscapesParameterNamesWithoutManglingTupleTypes`, `MemberDeclaration_ClassifiesParenGroupsByTrailingContext`, `MemberDeclaration_TreatsPunctuationInsideLiteralsAsText`, `MemberDeclaration_RequiresFullConstraintShapeNotJustTheWord`
- `dotnet run --project src/ILInspector.CSharp.Tests -c Release` — 483 passed at `5738e1e3c`

## Non-action

- Does not delete `EscapeParameterLists`; opaque and unrenderable-model signatures still use it
- Does not teach the scanner comments; that path remains best-effort
- Does not extend `TryRenderSignatureModel` to extensions, EIM methods, or operators
- Does not move escaping into `ApiSurfaceExtractor`
- Does not start leftover TypedReference keys, `#4217`, interface-MethodImpl provenance, or protobuf Integration
- Extractors still coalesce missing parameter names to `arg{i}`; the unnamed-type pin is a writer contract, not a live extract shape

## Candidate

- Base: `773764420` (`origin/main`, #4436 inspect-web)
- Head: `5738e1e3c`
- Prior r1 head: `3100f77c0` (superseded — canary did not pin the skip)
- Merge of base while forming replacement: `152b4cbcf`