### PR TITLE
Convert inspect-web settings/taste panel to TypeScript

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -545,6 +545,15 @@ opening a package or the runtime pack — so the component acquires no engine or
 workspace authority. `test/package-bar.test.js` gates tab markup, active/close
 state, escaping, and open-package query parsing.
 
+`src/settings-panel.ts` owns the Settings page and the decompiler "taste"
+popover it shares its style catalog with, as pure, dependency-injected render
+functions. `app.js` still owns `state`, localStorage persistence for theme and
+taste, and event wiring (`setTheme`, `toggleTaste`, `clearTaste`), and passes
+each computed slice in explicitly. `test/settings-panel.test.js` gates the
+style catalog's tier grouping, byte-divergent badges, and checked state; the
+taste popover's active/default states; and the Settings page's theme segment,
+close-button label, and active-style-count states.
+
 - `Cmd/Ctrl+K` focuses the persistent command prompt.
 - `Cmd/Ctrl+F` or `/` focuses the type filter.
 - Arrow keys select a completion, `Tab` accepts it, and `Enter` runs it.

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -56,6 +56,10 @@ import {
   typeSourceSignature,
 } from "/src/type-panel.ts";
 import { createPackageBar } from "/src/package-bar.ts";
+import {
+  renderSettingsView,
+  renderTastePopover,
+} from "/src/settings-panel.ts";
 import { loadPlatformIndex } from "/src/platform-index.js";
 
 let initializeEngine;
@@ -1251,7 +1255,7 @@ function render() {
   // so it renders first and returns; closeSettings restores the underlying view.
   if (state.settings) {
     loadingBotSrc = null;
-    renderSettingsView();
+    renderSettingsViewHtml();
     return;
   }
   // The Metadata Explorer is a full-bleed "browse the database" view layered over the
@@ -1394,7 +1398,7 @@ function render() {
       ${state.spotlightOpen ? renderSpotlight() : ""}
       ${state.graphSourceOpen ? renderGraphSource() : ""}
       ${state.docViewerOpen ? renderDocViewer() : ""}
-      ${state.tasteOpen ? renderTastePopover() : ""}
+      ${state.tasteOpen ? renderTastePopoverHtml() : ""}
     </div>`;
 
   bindEvents();
@@ -6982,43 +6986,15 @@ function renderDocViewer() {
 // The decompiler style ("taste") catalog, grouped by tier, as checkbox rows. Shared by the
 // detail-view taste popover and the Settings page so both stay in lockstep with the engine's
 // StyleOptionCatalog (fetched once into state.styleTiers/state.styleOptions).
-function styleCatalogGroupsHtml() {
-  const tiers = state.styleTiers || [];
-  const options = state.styleOptions || [];
-  if (!tiers.length || !options.length) {
-    return state.styleCatalogError
-      ? `<div class="taste-empty">Style catalog unavailable: ${escapeHtml(state.styleCatalogError)}</div>`
-      : "";
-  }
-  return tiers
-    .filter(tier => options.some(option => option.tier === tier.id))
-    .map(tier => `
-      <div class="taste-group">
-        <div class="taste-group-head">
-          <div class="taste-group-title">${escapeHtml(tier.title)}</div>
-          ${tier.byte_divergent ? '<em class="taste-badge divergent">byte-divergent</em>' : ""}
-        </div>
-        <div class="taste-group-summary">${escapeHtml(tier.summary)}</div>
-        ${options.filter(option => option.tier === tier.id).map(option => `
-          <label class="taste-item">
-            <input type="checkbox" data-taste="${escapeHtml(option.id)}" ${state.taste.includes(option.id) ? "checked" : ""} />
-            <span class="taste-item-text">
-              <span class="taste-item-title">${escapeHtml(option.title)}${option.oracle_endorsed ? '<em class="taste-badge oracle">oracle</em>' : ""}</span>
-              <span class="taste-item-summary">${escapeHtml(option.summary)}</span>
-            </span>
-          </label>`).join("")}
-      </div>`).join("");
-}
-
-function renderTastePopover() {
-  const groups = styleCatalogGroupsHtml();
-  const body = groups || '<div class="taste-empty">Style catalog unavailable.</div>';
-  return `
-    <div class="taste-popover" id="taste-popover" role="dialog" aria-label="Decompiler taste">
-      <div class="taste-head"><strong>Taste</strong><span>decompiler style knobs</span></div>
-      <div class="taste-body">${body}</div>
-      <div class="taste-foot">${state.taste.length ? '<button id="taste-clear" type="button">reset to default</button>' : '<span>default · opcode-faithful</span>'}</div>
-    </div>`;
+function renderTastePopoverHtml() {
+  return renderTastePopover(
+    {
+      styleTiers: state.styleTiers,
+      styleOptions: state.styleOptions,
+      styleCatalogError: state.styleCatalogError,
+      taste: state.taste,
+    },
+    escapeHtml);
 }
 
 function invalidateSourceCaches() {
@@ -7102,50 +7078,18 @@ function closeSettings() {
 // localStorage (theme → inspect-theme, taste → inspect-taste) so choices survive a reload and
 // future sessions. Grouped into Appearance and Decompiler style; the latter reuses the same
 // style-option catalog the detail-view taste popover shows.
-function renderSettingsView() {
-  const catalog = styleCatalogGroupsHtml();
-  const styleBody = catalog
-    || '<div class="taste-empty">Style catalog is still loading — reopen Settings in a moment.</div>';
-  const activeCount = state.taste.length;
-  app.innerHTML = `
-    <div class="settings-page">
-      <header class="settings-bar">
-        <a class="brand" href="/" aria-label="dotnet inspect home"><span class="brand-glyph">◇</span><span>dotnet-inspect</span></a>
-        <button id="settings-close" class="settings-close">${state.settingsReturn === "workbench" ? "back to workbench" : "back to home"} ✕</button>
-      </header>
-      <main class="settings-main">
-        <div class="settings-head">
-          <h1>Settings</h1>
-          <p class="settings-lede">Preferences are stored locally in your browser and persist across sessions. Nothing is uploaded.</p>
-        </div>
-
-        <section class="settings-section">
-          <div class="settings-section-head">
-            <h2>Appearance</h2>
-            <p>Choose the color theme for the whole app.</p>
-          </div>
-          <div class="settings-control">
-            <div class="settings-segment" role="group" aria-label="Theme">
-              <button type="button" class="settings-seg ${state.theme === "dark" ? "active" : ""}" data-theme="dark" aria-pressed="${state.theme === "dark"}">Dark</button>
-              <button type="button" class="settings-seg ${state.theme === "light" ? "active" : ""}" data-theme="light" aria-pressed="${state.theme === "light"}">Light</button>
-            </div>
-          </div>
-        </section>
-
-        <section class="settings-section">
-          <div class="settings-section-head">
-            <h2>Decompiler style <span class="settings-badge">${activeCount ? `${activeCount} on` : "default"}</span></h2>
-            <p>Tune how decompiled C# is spelled and synthesized — including <strong>readable local names</strong>. These apply to every source and call-graph view. The default is opcode-faithful.</p>
-          </div>
-          <div class="settings-taste">${styleBody}</div>
-          <div class="settings-taste-foot">
-            ${activeCount
-              ? '<button id="settings-taste-clear" type="button" class="settings-reset">Reset to default</button>'
-              : '<span class="settings-muted">Default · opcode-faithful</span>'}
-          </div>
-        </section>
-      </main>
-    </div>`;
+function renderSettingsViewHtml() {
+  app.innerHTML = renderSettingsView({
+    theme: state.theme,
+    settingsReturn: state.settingsReturn,
+    styleCatalog: {
+      styleTiers: state.styleTiers,
+      styleOptions: state.styleOptions,
+      styleCatalogError: state.styleCatalogError,
+      taste: state.taste,
+    },
+    escapeHtml,
+  });
   bindSettingsEvents();
 }
 

--- a/prototypes/inspect-web/src/settings-panel.ts
+++ b/prototypes/inspect-web/src/settings-panel.ts
@@ -1,0 +1,128 @@
+// The Settings page (a persistent preferences panel) and the decompiler "taste" popover it
+// shares its style catalog with. Both are pure, dependency-injected render functions: `app.js`
+// owns `state`, localStorage persistence, and event wiring (`setTheme`, `toggleTaste`,
+// `clearTaste`, `bindSettingsEvents`), and passes each computed slice in explicitly.
+
+export interface StyleTier {
+  id: string;
+  title: string;
+  summary: string;
+  byte_divergent?: boolean;
+}
+
+export interface StyleOption {
+  id: string;
+  tier: string;
+  title: string;
+  summary: string;
+  oracle_endorsed?: boolean;
+}
+
+export interface StyleCatalogState {
+  styleTiers: readonly StyleTier[] | null;
+  styleOptions: readonly StyleOption[] | null;
+  styleCatalogError: string;
+  taste: readonly string[];
+}
+
+type EscapeHtml = (value: unknown) => string;
+
+// The decompiler style ("taste") catalog, grouped by tier, as checkbox rows. Shared by the
+// detail-view taste popover and the Settings page so both stay in lockstep with the engine's
+// StyleOptionCatalog (fetched once into state.styleTiers/state.styleOptions).
+export function styleCatalogGroupsHtml(catalog: StyleCatalogState, escapeHtml: EscapeHtml): string {
+  const tiers = catalog.styleTiers || [];
+  const options = catalog.styleOptions || [];
+  if (!tiers.length || !options.length) {
+    return catalog.styleCatalogError
+      ? `<div class="taste-empty">Style catalog unavailable: ${escapeHtml(catalog.styleCatalogError)}</div>`
+      : "";
+  }
+  return tiers
+    .filter(tier => options.some(option => option.tier === tier.id))
+    .map(tier => `
+      <div class="taste-group">
+        <div class="taste-group-head">
+          <div class="taste-group-title">${escapeHtml(tier.title)}</div>
+          ${tier.byte_divergent ? '<em class="taste-badge divergent">byte-divergent</em>' : ""}
+        </div>
+        <div class="taste-group-summary">${escapeHtml(tier.summary)}</div>
+        ${options.filter(option => option.tier === tier.id).map(option => `
+          <label class="taste-item">
+            <input type="checkbox" data-taste="${escapeHtml(option.id)}" ${catalog.taste.includes(option.id) ? "checked" : ""} />
+            <span class="taste-item-text">
+              <span class="taste-item-title">${escapeHtml(option.title)}${option.oracle_endorsed ? '<em class="taste-badge oracle">oracle</em>' : ""}</span>
+              <span class="taste-item-summary">${escapeHtml(option.summary)}</span>
+            </span>
+          </label>`).join("")}
+      </div>`).join("");
+}
+
+export function renderTastePopover(catalog: StyleCatalogState, escapeHtml: EscapeHtml): string {
+  const groups = styleCatalogGroupsHtml(catalog, escapeHtml);
+  const body = groups || '<div class="taste-empty">Style catalog unavailable.</div>';
+  return `
+    <div class="taste-popover" id="taste-popover" role="dialog" aria-label="Decompiler taste">
+      <div class="taste-head"><strong>Taste</strong><span>decompiler style knobs</span></div>
+      <div class="taste-body">${body}</div>
+      <div class="taste-foot">${catalog.taste.length ? '<button id="taste-clear" type="button">reset to default</button>' : '<span>default · opcode-faithful</span>'}</div>
+    </div>`;
+}
+
+export interface RenderSettingsViewOptions {
+  theme: string;
+  settingsReturn: string;
+  styleCatalog: StyleCatalogState;
+  escapeHtml: EscapeHtml;
+}
+
+// The Settings page: a persistent preferences panel. Every control here writes straight to
+// localStorage (theme → inspect-theme, taste → inspect-taste) so choices survive a reload and
+// future sessions. Grouped into Appearance and Decompiler style; the latter reuses the same
+// style-option catalog the detail-view taste popover shows.
+export function renderSettingsView(options: RenderSettingsViewOptions): string {
+  const { theme, settingsReturn, styleCatalog, escapeHtml } = options;
+  const catalog = styleCatalogGroupsHtml(styleCatalog, escapeHtml);
+  const styleBody = catalog
+    || '<div class="taste-empty">Style catalog is still loading — reopen Settings in a moment.</div>';
+  const activeCount = styleCatalog.taste.length;
+  return `
+    <div class="settings-page">
+      <header class="settings-bar">
+        <a class="brand" href="/" aria-label="dotnet inspect home"><span class="brand-glyph">◇</span><span>dotnet-inspect</span></a>
+        <button id="settings-close" class="settings-close">${settingsReturn === "workbench" ? "back to workbench" : "back to home"} ✕</button>
+      </header>
+      <main class="settings-main">
+        <div class="settings-head">
+          <h1>Settings</h1>
+          <p class="settings-lede">Preferences are stored locally in your browser and persist across sessions. Nothing is uploaded.</p>
+        </div>
+
+        <section class="settings-section">
+          <div class="settings-section-head">
+            <h2>Appearance</h2>
+            <p>Choose the color theme for the whole app.</p>
+          </div>
+          <div class="settings-control">
+            <div class="settings-segment" role="group" aria-label="Theme">
+              <button type="button" class="settings-seg ${theme === "dark" ? "active" : ""}" data-theme="dark" aria-pressed="${theme === "dark"}">Dark</button>
+              <button type="button" class="settings-seg ${theme === "light" ? "active" : ""}" data-theme="light" aria-pressed="${theme === "light"}">Light</button>
+            </div>
+          </div>
+        </section>
+
+        <section class="settings-section">
+          <div class="settings-section-head">
+            <h2>Decompiler style <span class="settings-badge">${activeCount ? `${activeCount} on` : "default"}</span></h2>
+            <p>Tune how decompiled C# is spelled and synthesized — including <strong>readable local names</strong>. These apply to every source and call-graph view. The default is opcode-faithful.</p>
+          </div>
+          <div class="settings-taste">${styleBody}</div>
+          <div class="settings-taste-foot">
+            ${activeCount
+              ? '<button id="settings-taste-clear" type="button" class="settings-reset">Reset to default</button>'
+              : '<span class="settings-muted">Default · opcode-faithful</span>'}
+          </div>
+        </section>
+      </main>
+    </div>`;
+}

--- a/prototypes/inspect-web/test/settings-panel.test.js
+++ b/prototypes/inspect-web/test/settings-panel.test.js
@@ -49,7 +49,11 @@ test("style catalog groups escape untrusted tier and option text", () => {
 
   assert.doesNotMatch(html, /<script>/);
   assert.doesNotMatch(html, /<img src=x>/);
+  assert.doesNotMatch(html, /<b>bold<\/b>/);
+  assert.doesNotMatch(html, /<i>italic<\/i>/);
   assert.match(html, /&lt;script&gt;/);
+  assert.match(html, /&lt;b&gt;bold&lt;\/b&gt;/);
+  assert.match(html, /&lt;i&gt;italic&lt;\/i&gt;/);
   assert.match(html, /&amp;/);
 });
 

--- a/prototypes/inspect-web/test/settings-panel.test.js
+++ b/prototypes/inspect-web/test/settings-panel.test.js
@@ -37,6 +37,40 @@ test("style catalog groups render tiers, byte-divergent badges, and checked stat
   assert.match(html, /oracle/);
 });
 
+test("style catalog groups escape untrusted tier and option text", () => {
+  const html = styleCatalogGroupsHtml(
+    {
+      styleTiers: [{ id: "naming", title: '<script>alert(1)</script>', summary: "\"quoted\" & <b>bold</b>" }],
+      styleOptions: [{ id: 'x"onmouseover=1', tier: "naming", title: "<img src=x>", summary: "<i>italic</i> & more" }],
+      styleCatalogError: "",
+      taste: [],
+    },
+    escapeHtml);
+
+  assert.doesNotMatch(html, /<script>/);
+  assert.doesNotMatch(html, /<img src=x>/);
+  assert.match(html, /&lt;script&gt;/);
+  assert.match(html, /&amp;/);
+});
+
+test("style catalog groups hide a tier with no options", () => {
+  const html = styleCatalogGroupsHtml(
+    {
+      styleTiers: [
+        ...styleTiers,
+        { id: "empty-tier", title: "Empty Tier", summary: "Has no options." },
+      ],
+      styleOptions,
+      styleCatalogError: "",
+      taste: [],
+    },
+    escapeHtml);
+
+  assert.match(html, /Naming/);
+  assert.match(html, /Layout/);
+  assert.doesNotMatch(html, /Empty Tier/);
+});
+
 test("style catalog reports an error when the catalog failed to load", () => {
   const html = styleCatalogGroupsHtml(
     { styleTiers: [], styleOptions: [], styleCatalogError: "network error", taste: [] },

--- a/prototypes/inspect-web/test/settings-panel.test.js
+++ b/prototypes/inspect-web/test/settings-panel.test.js
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  renderSettingsView,
+  renderTastePopover,
+  styleCatalogGroupsHtml,
+} from "../src/settings-panel.ts";
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const styleTiers = [
+  { id: "naming", title: "Naming", summary: "How identifiers are spelled." },
+  { id: "layout", title: "Layout", summary: "Whitespace and braces.", byte_divergent: true },
+];
+
+const styleOptions = [
+  { id: "readable-locals", tier: "naming", title: "Readable local names", summary: "Synthesize readable local names.", oracle_endorsed: true },
+  { id: "expanded-braces", tier: "layout", title: "Expanded braces", summary: "Always use braces." },
+];
+
+test("style catalog groups render tiers, byte-divergent badges, and checked state", () => {
+  const html = styleCatalogGroupsHtml(
+    { styleTiers, styleOptions, styleCatalogError: "", taste: ["readable-locals"] },
+    escapeHtml);
+
+  assert.match(html, /Naming/);
+  assert.match(html, /Layout/);
+  assert.match(html, /byte-divergent/);
+  assert.match(html, /data-taste="readable-locals" checked/);
+  assert.doesNotMatch(html, /data-taste="expanded-braces" checked/);
+  assert.match(html, /oracle/);
+});
+
+test("style catalog reports an error when the catalog failed to load", () => {
+  const html = styleCatalogGroupsHtml(
+    { styleTiers: [], styleOptions: [], styleCatalogError: "network error", taste: [] },
+    escapeHtml);
+
+  assert.match(html, /Style catalog unavailable: network error/);
+});
+
+test("style catalog renders nothing when empty without an error", () => {
+  const html = styleCatalogGroupsHtml(
+    { styleTiers: [], styleOptions: [], styleCatalogError: "", taste: [] },
+    escapeHtml);
+
+  assert.equal(html, "");
+});
+
+test("taste popover shows a reset button once a style is active", () => {
+  const html = renderTastePopover(
+    { styleTiers, styleOptions, styleCatalogError: "", taste: ["readable-locals"] },
+    escapeHtml);
+
+  assert.match(html, /id="taste-popover"/);
+  assert.match(html, /id="taste-clear"/);
+  assert.doesNotMatch(html, /opcode-faithful/);
+});
+
+test("taste popover shows the default state when nothing is active", () => {
+  const html = renderTastePopover(
+    { styleTiers, styleOptions, styleCatalogError: "", taste: [] },
+    escapeHtml);
+
+  assert.doesNotMatch(html, /id="taste-clear"/);
+  assert.match(html, /default · opcode-faithful/);
+});
+
+test("taste popover falls back to an empty-catalog message", () => {
+  const html = renderTastePopover(
+    { styleTiers: [], styleOptions: [], styleCatalogError: "", taste: [] },
+    escapeHtml);
+
+  assert.match(html, /Style catalog unavailable\.<\/div>/);
+});
+
+test("settings view marks the active theme segment", () => {
+  const html = renderSettingsView({
+    theme: "light",
+    settingsReturn: "home",
+    styleCatalog: { styleTiers, styleOptions, styleCatalogError: "", taste: [] },
+    escapeHtml,
+  });
+
+  assert.match(html, /class="settings-seg active" data-theme="light" aria-pressed="true"/);
+  assert.match(html, /class="settings-seg " data-theme="dark" aria-pressed="false"/);
+});
+
+test("settings view labels the close button by return destination", () => {
+  const workbenchHtml = renderSettingsView({
+    theme: "dark",
+    settingsReturn: "workbench",
+    styleCatalog: { styleTiers: [], styleOptions: [], styleCatalogError: "", taste: [] },
+    escapeHtml,
+  });
+  const homeHtml = renderSettingsView({
+    theme: "dark",
+    settingsReturn: "home",
+    styleCatalog: { styleTiers: [], styleOptions: [], styleCatalogError: "", taste: [] },
+    escapeHtml,
+  });
+
+  assert.match(workbenchHtml, /back to workbench ✕/);
+  assert.match(homeHtml, /back to home ✕/);
+});
+
+test("settings view reports the active style count and a reset control", () => {
+  const html = renderSettingsView({
+    theme: "dark",
+    settingsReturn: "home",
+    styleCatalog: { styleTiers, styleOptions, styleCatalogError: "", taste: ["readable-locals", "expanded-braces"] },
+    escapeHtml,
+  });
+
+  assert.match(html, /2 on/);
+  assert.match(html, /id="settings-taste-clear"/);
+});
+
+test("settings view shows the default badge and no reset control when taste is empty", () => {
+  const html = renderSettingsView({
+    theme: "dark",
+    settingsReturn: "home",
+    styleCatalog: { styleTiers, styleOptions, styleCatalogError: "", taste: [] },
+    escapeHtml,
+  });
+
+  assert.match(html, /settings-badge">default</);
+  assert.doesNotMatch(html, /id="settings-taste-clear"/);
+  assert.match(html, /Default · opcode-faithful/);
+});
+
+test("settings view surfaces a loading message while the catalog is still empty", () => {
+  const html = renderSettingsView({
+    theme: "dark",
+    settingsReturn: "home",
+    styleCatalog: { styleTiers: [], styleOptions: [], styleCatalogError: "", taste: [] },
+    escapeHtml,
+  });
+
+  assert.match(html, /Style catalog is still loading/);
+});


### PR DESCRIPTION
## Summary

Continues the inspect-web TypeScript conversion (after `command-bar.ts`, `package-bar.ts`, `type-panel.ts`) by extracting the Settings page and the decompiler "taste" popover — plus their shared style-catalog rendering — into a new pure, dependency-injected module `src/settings-panel.ts`.

## Change

- Added `src/settings-panel.ts`: typed interfaces (`StyleTier`, `StyleOption`, `StyleCatalogState`, `RenderSettingsViewOptions`) and pure render functions (`styleCatalogGroupsHtml`, `renderTastePopover`, `renderSettingsView`).
- `app.js` retains ownership of `state`, localStorage persistence (theme → `inspect-theme`, taste → `inspect-taste`), and event wiring (`setTheme`, `toggleTaste`, `clearTaste`, `bindSettingsEvents`). Thin wrappers (`renderTastePopoverHtml`, `renderSettingsViewHtml`) pass the needed state slices in explicitly — same DI pattern as the prior conversions.
- Added `test/settings-panel.test.js` (11 focused tests): style catalog tier grouping/byte-divergent badges/checked state, taste popover active/default/empty-catalog states, and Settings page theme segment/close-button label/active-style-count states.
- Updated `README.md` to document the new module.

## Validation

- `npm run typecheck`: passes.
- `node --test`: 100/100 passing (89 existing + 11 new).
- `npm run build`: passes.
- `markdownlint` on `README.md`: passes.

## Non-action boundary

Pure extraction — no behavioral change. `app.js` still owns all state mutation, persistence, and event binding for this component; only rendering moved.
