### PR TITLE
Convert inspect-web scope bar to TypeScript

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -554,6 +554,15 @@ style catalog's tier grouping, byte-divergent badges, and checked state; the
 taste popover's active/default states; and the Settings page's theme segment,
 close-button label, and active-style-count states.
 
+`src/scope-bar.ts` owns the scope switcher and lens strip (the segmented
+Package/Types/Member control and the buttons beside it for the active scope's
+lenses or member sections) as a pure, dependency-injected render function.
+`app.js` still owns the current scope, the package/type/member lens
+definitions, and the active lens/section per scope, and passes each computed
+slice in explicitly. `test/scope-bar.test.js` gates the active scope segment,
+the active lens/section marking per scope, keyboard-shortcut indices, and
+label escaping.
+
 - `Cmd/Ctrl+K` focuses the persistent command prompt.
 - `Cmd/Ctrl+F` or `/` focuses the type filter.
 - Arrow keys select a completion, `Tab` accepts it, and `Enter` runs it.

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -46,6 +46,7 @@ import {
 } from "./graph-mermaid.js";
 import { buildAnnotatedView, factsForNode, MEDIA, MEDIUM_LABELS, nodeAtOffset } from "/src/annotated-source-view.ts";
 import { createCommandBar } from "/src/command-bar.ts";
+import { renderScopeBar as renderScopeBarPure } from "/src/scope-bar.ts";
 import {
   renderMemberNav,
   renderTypeMetadata,
@@ -1521,29 +1522,31 @@ function renderMemberNavPane(type) {
 // Call graph, …) live here too instead of inside the detail pane.
 function renderScopeBar() {
   const sc = scope();
-  const lensButton = (id, label, active, attr, index) =>
-    `<button class="lens ${active ? "active" : ""}" ${attr}="${id}">${escapeHtml(label)}<kbd>${index + 1}</kbd></button>`;
-  let strip;
   if (sc === "package") {
-    strip = packageLensesFor(state.package).map(([id, label], i) => lensButton(id, label, state.packageLens === id, "data-package-lens", i)).join("");
-  } else if (sc === "member") {
-    const sections = memberSectionsFor(selectedMember(selectedType()));
-    strip = sections.map(([id, label], i) => lensButton(id, label, state.memberSection === id, "data-member-section", i)).join("");
-  } else {
-    strip = lenses.map(([id, label], i) => lensButton(id, label, state.lens === id, "data-lens", i)).join("");
+    return renderScopeBarPure({
+      scope: sc,
+      strip: packageLensesFor(state.package),
+      activeStripId: state.packageLens,
+      stripAttribute: "data-package-lens",
+      escapeHtml,
+    });
   }
-  const seg = (id, label, active) =>
-    `<button class="scope-seg ${active ? "active" : ""}" data-scope="${id}" role="tab" aria-selected="${active}">${label}</button>`;
-  return `
-    <nav class="lensbar" aria-label="Scope and lenses">
-      <div class="scope-switch" role="tablist" aria-label="Scope">
-        ${seg("package", "Package", sc === "package")}
-        ${seg("type", "Types", sc === "type")}
-        ${sc === "member" ? seg("member", "Member", true) : ""}
-      </div>
-      <span class="lens-separator"></span>
-      ${strip}
-    </nav>`;
+  if (sc === "member") {
+    return renderScopeBarPure({
+      scope: sc,
+      strip: memberSectionsFor(selectedMember(selectedType())),
+      activeStripId: state.memberSection,
+      stripAttribute: "data-member-section",
+      escapeHtml,
+    });
+  }
+  return renderScopeBarPure({
+    scope: sc,
+    strip: lenses,
+    activeStripId: state.lens,
+    stripAttribute: "data-lens",
+    escapeHtml,
+  });
 }
 
 function packageHeading() {

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -1,0 +1,49 @@
+type LensDefinition = readonly [id: string, label: string];
+
+export type Scope = "package" | "type" | "member";
+
+export interface RenderScopeBarOptions {
+  scope: Scope;
+  strip: readonly LensDefinition[];
+  activeStripId: string | null;
+  stripAttribute: string;
+  escapeHtml: (value: unknown) => string;
+}
+
+function lensButton(
+  id: string,
+  label: string,
+  active: boolean,
+  attribute: string,
+  index: number,
+  escapeHtml: (value: unknown) => string,
+): string {
+  return `<button class="lens ${active ? "active" : ""}" ${attribute}="${id}">${escapeHtml(label)}<kbd>${index + 1}</kbd></button>`;
+}
+
+function scopeSegment(id: string, label: string, active: boolean): string {
+  return `<button class="scope-seg ${active ? "active" : ""}" data-scope="${id}" role="tab" aria-selected="${active}">${label}</button>`;
+}
+
+// The scope switcher + lens strip. The leading segmented control is the scope ladder —
+// Package (whole package), Types (one public type), and Member (a member of that type,
+// shown only once you drill in). Each segment is selectable and swaps the strip beside it:
+//   package → package lenses   type → type lenses   member → member sections
+// Keeping all three families of buttons on one strip means the member modes (Overview,
+// Call graph, …) live here too instead of inside the detail pane.
+export function renderScopeBar(options: RenderScopeBarOptions): string {
+  const { scope, strip, activeStripId, stripAttribute, escapeHtml } = options;
+  const stripHtml = strip
+    .map(([id, label], i) => lensButton(id, label, activeStripId === id, stripAttribute, i, escapeHtml))
+    .join("");
+  return `
+    <nav class="lensbar" aria-label="Scope and lenses">
+      <div class="scope-switch" role="tablist" aria-label="Scope">
+        ${scopeSegment("package", "Package", scope === "package")}
+        ${scopeSegment("type", "Types", scope === "type")}
+        ${scope === "member" ? scopeSegment("member", "Member", true) : ""}
+      </div>
+      <span class="lens-separator"></span>
+      ${stripHtml}
+    </nav>`;
+}

--- a/prototypes/inspect-web/test/scope-bar.test.js
+++ b/prototypes/inspect-web/test/scope-bar.test.js
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderScopeBar } from "../src/scope-bar.ts";
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const typeLenses = [
+  ["api", "API"],
+  ["metadata", "Metadata"],
+  ["source", "Source"],
+];
+
+test("package scope marks only the package segment and the active package lens", () => {
+  const html = renderScopeBar({
+    scope: "package",
+    strip: [["overview", "Overview"], ["dependencies", "Dependencies"]],
+    activeStripId: "dependencies",
+    stripAttribute: "data-package-lens",
+    escapeHtml,
+  });
+
+  assert.match(html, /data-scope="package" role="tab" aria-selected="true"/);
+  assert.match(html, /data-scope="type" role="tab" aria-selected="false"/);
+  assert.doesNotMatch(html, /data-scope="member"/);
+  assert.match(html, /class="lens active" data-package-lens="dependencies"/);
+  assert.doesNotMatch(html, /class="lens active" data-package-lens="overview"/);
+});
+
+test("type scope marks the type segment and renders the fixed type lenses", () => {
+  const html = renderScopeBar({
+    scope: "type",
+    strip: typeLenses,
+    activeStripId: "api",
+    stripAttribute: "data-lens",
+    escapeHtml,
+  });
+
+  assert.match(html, /data-scope="type" role="tab" aria-selected="true"/);
+  assert.doesNotMatch(html, /data-scope="member"/);
+  assert.match(html, /class="lens active" data-lens="api"/);
+  assert.match(html, /data-lens="metadata"/);
+  assert.match(html, /data-lens="source"/);
+});
+
+test("member scope adds a member segment alongside package and type", () => {
+  const html = renderScopeBar({
+    scope: "member",
+    strip: [["overview", "Overview"], ["facts", "Facts"]],
+    activeStripId: "facts",
+    stripAttribute: "data-member-section",
+    escapeHtml,
+  });
+
+  assert.match(html, /data-scope="member" role="tab" aria-selected="true"/);
+  assert.match(html, /class="lens active" data-member-section="facts"/);
+});
+
+test("lens button labels carry their keyboard shortcut index", () => {
+  const html = renderScopeBar({
+    scope: "type",
+    strip: typeLenses,
+    activeStripId: "api",
+    stripAttribute: "data-lens",
+    escapeHtml,
+  });
+
+  assert.match(html, /API<kbd>1<\/kbd>/);
+  assert.match(html, /Metadata<kbd>2<\/kbd>/);
+  assert.match(html, /Source<kbd>3<\/kbd>/);
+});
+
+test("lens button labels are escaped", () => {
+  const html = renderScopeBar({
+    scope: "type",
+    strip: [["x", '<script>alert(1)</script>']],
+    activeStripId: null,
+    stripAttribute: "data-lens",
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /<script>/);
+  assert.match(html, /&lt;script&gt;/);
+});
+
+test("no strip entry is marked active when nothing matches activeStripId", () => {
+  const html = renderScopeBar({
+    scope: "package",
+    strip: [["overview", "Overview"]],
+    activeStripId: null,
+    stripAttribute: "data-package-lens",
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /class="lens active"/);
+});


### PR DESCRIPTION
Extracts the scope switcher and lens strip (the Package/Types/Member segmented control and the buttons beside it for the active scope's lenses/sections) from `app.js`'s `renderScopeBar()` into a pure, dependency-injected render function in `prototypes/inspect-web/src/scope-bar.ts`, following the pattern established by `command-bar.ts` (#4429), `package-bar.ts` (#4434), `type-panel.ts` (#4436), and `settings-panel.ts` (#4447).

## What moved

- `renderScopeBar(options)` — pure function taking `scope`, `strip` (lens/section definitions), `activeStripId`, `stripAttribute`, and `escapeHtml`, returning the scope-segment control plus the lens/section button strip.

## What stays in app.js

- The current `scope()` computation, the package/type/member lens definitions (`lenses`, `packageLenses`, `memberSectionsFor`), and which lens/section is active per scope. A thin wrapper (`renderScopeBar`, kept as the call-site name) computes the right slice per scope and delegates to the pure `renderScopeBarPure`.

## Tests

Added `test/scope-bar.test.js` (6 tests): active scope-segment marking per scope (package/type/member), active lens/section marking, keyboard-shortcut indices, and label escaping.

## Validation

- `npm run typecheck` — pass
- `node --test` — 108/108 passing (up from 102; no regressions from extraction)
- `npm run build` — pass
- `npx markdownlint-cli --config .markdownlint.yaml prototypes/inspect-web/README.md` — clean

No behavior change intended; this is a pure refactor/extraction.