### PR TITLE
Add resolve-only CLI demo list and plan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ permits a selected non-public member.
 | `depends X` | Walk type, package, or library dependency graphs; emits Mermaid diagrams. |
 | `cache` | Inspect or clear dotnet-inspect caches. |
 | `skill` | Print the base LLM skill; routes to focused skills (`skill list`, `skill source`, `skill performance`). |
+| `demo` | List product home demos (`demo list`) or resolve one by id (`demo stj-serializer`) into a package-free activation plan. |
 
 Remote dependency trees requested with `depends --package` or the legacy
 `package --dependencies` option resolve from nuspec manifests without

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -887,11 +887,13 @@ Definition records and product demos (this slice):
 - `ProductInspectionDemos` is a static id→factory registry (smooth-markdown-table
   `RendererRegistry` style) of the three home scenarios; listing is metadata-only
   and `ResolveHomeScenario` allocates only that demo's peer records; JSON remains
-  the portable load path for external definitions; and
-- `InspectionDefinitionTests` is the gate for round-trip, separation,
+  the portable load path for external definitions;
+- CLI `dotnet-inspect demo` / `demo list` / `demo <id>` lists catalog metadata and
+  prints a resolve-only activation plan (no package acquisition); and
+- `InspectionDefinitionTests` and `DemoCommandTests` gate round-trip, separation,
   demo-parity, null nested-array rejection, whole-record coordinate budget,
-  dual `rid`/`runtimeIdentifier` rejection, and fail-closed subscribe /
-  filesystem / cross-kind peer resolution.
+  dual `rid`/`runtimeIdentifier` rejection, fail-closed subscribe /
+  filesystem / cross-kind peer resolution, and the CLI list/resolve surface.
 
 The coordinate-realization slice implements the `package`, `platform`, and
 `embedded` member coordinates

--- a/src/dotnet-inspect.Tests/DemoCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DemoCommandTests.cs
@@ -100,7 +100,7 @@ public class DemoCommandTests
         var root = document.RootElement;
         Assert.Equal("stj-serializer", root.GetProperty("id").GetString());
         Assert.Equal("resolve-only", root.GetProperty("activation").GetString());
-        Assert.True(root.GetProperty("createsAssemblyContextGroup").GetBoolean());
+        Assert.True(root.GetProperty("creates_assembly_context_group").GetBoolean());
         Assert.Equal(
             "System.Text.Json.JsonSerializer",
             root.GetProperty("view").GetProperty("type").GetString());

--- a/src/dotnet-inspect.Tests/DemoCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DemoCommandTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using DotnetInspector.CommandLine;
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
 using DotnetInspector.Queries.Definitions;
@@ -8,6 +9,16 @@ namespace DotnetInspector.Tests;
 [Collection("Console")]
 public class DemoCommandTests
 {
+    private static async Task<(int ExitCode, string Output, string Error)> RunCliAsync(params string[] args)
+    {
+        return await ConsoleCapture.RunAsync(async () =>
+        {
+            args = CommandLineBuilder.PreprocessArgs(args);
+            var root = CommandLineBuilder.CreateRootCommand();
+            return await root.Parse(args).InvokeAsync();
+        });
+    }
+
     [Fact]
     public async Task ExecuteList_IncludesEveryHomeDemo()
     {
@@ -114,5 +125,48 @@ public class DemoCommandTests
         Assert.Equal(
             "System.Collections.Generic.List`1",
             document.RootElement.GetProperty("view").GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public void KnownCommands_ReservesDemo()
+    {
+        Assert.Contains(DemoCommand.Name, ArgumentPreprocessor.KnownCommands);
+    }
+
+    [Fact]
+    public async Task Cli_DemoList_DispatchesThroughPreprocessor()
+    {
+        var (exitCode, output, error) = await RunCliAsync("demo", "list", "--json");
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        Assert.Equal(ProductInspectionDemos.Entries.Count, document.RootElement.GetArrayLength());
+        Assert.Contains(
+            document.RootElement.EnumerateArray(),
+            element => element.GetProperty("id").GetString() == "stj-serializer");
+    }
+
+    [Fact]
+    public async Task Cli_DemoScenario_DispatchesThroughPreprocessor()
+    {
+        var (exitCode, output, error) = await RunCliAsync("demo", "extensions-callgraph", "--json");
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        Assert.Equal("extensions-callgraph", document.RootElement.GetProperty("id").GetString());
+        Assert.Equal("resolve-only", document.RootElement.GetProperty("activation").GetString());
+        Assert.Contains("74b6b4b321", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Cli_DemoBare_ListsCatalog()
+    {
+        var (exitCode, output, _) = await RunCliAsync("demo");
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("stj-serializer", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Unknown command 'demo'", output, StringComparison.Ordinal);
     }
 }

--- a/src/dotnet-inspect.Tests/DemoCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DemoCommandTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Queries.Definitions;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public class DemoCommandTests
+{
+    [Fact]
+    public async Task ExecuteList_IncludesEveryHomeDemo()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(DemoCommand.ExecuteList()));
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Home demos", output, StringComparison.Ordinal);
+        foreach (var entry in ProductInspectionDemos.Entries)
+        {
+            Assert.Contains(entry.Id, output, StringComparison.Ordinal);
+            Assert.Contains(entry.Title, output, StringComparison.Ordinal);
+            Assert.Contains(entry.Summary, output, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteList_Json_EmitsCatalogRows()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(DemoCommand.ExecuteList(OutputFormat.Json)));
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(output);
+        Assert.Equal(JsonValueKind.Array, document.RootElement.ValueKind);
+        Assert.Equal(ProductInspectionDemos.Entries.Count, document.RootElement.GetArrayLength());
+
+        string[] ids = document.RootElement.EnumerateArray()
+            .Select(element => element.GetProperty("id").GetString()!)
+            .ToArray();
+        Assert.Equal(ProductInspectionDemos.HomeScenarioIds, ids);
+    }
+
+    [Fact]
+    public async Task ExecuteScenario_ListAlias_ListsDemos()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(DemoCommand.ExecuteScenario("list")));
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("stj-serializer", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteScenario_UnknownId_FailsWithCatalog()
+    {
+        var (exitCode, _, error) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(DemoCommand.ExecuteScenario("missing-demo")));
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown home demo 'missing-demo'", error, StringComparison.Ordinal);
+        Assert.Contains("stj-serializer", error, StringComparison.Ordinal);
+        Assert.Contains("demo list", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteScenario_CallGraph_PrintsResolveOnlyPlan()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(DemoCommand.ExecuteScenario("extensions-callgraph")));
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("extensions-callgraph", output, StringComparison.Ordinal);
+        Assert.Contains("74b6b4b321", output, StringComparison.Ordinal);
+        Assert.Contains("call-graph", output, StringComparison.Ordinal);
+        Assert.Contains("Microsoft.Extensions.DependencyInjection.Abstractions", output, StringComparison.Ordinal);
+        Assert.Contains("resolve-only", output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("http://", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteScenario_Json_EmitsStructuredPlan()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(DemoCommand.ExecuteScenario("stj-serializer", OutputFormat.Json)));
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        Assert.Equal("stj-serializer", root.GetProperty("id").GetString());
+        Assert.Equal("resolve-only", root.GetProperty("activation").GetString());
+        Assert.True(root.GetProperty("createsAssemblyContextGroup").GetBoolean());
+        Assert.Equal(
+            "System.Text.Json.JsonSerializer",
+            root.GetProperty("view").GetProperty("type").GetString());
+        Assert.Equal(
+            "System.Text.Json",
+            root.GetProperty("members")[0].GetProperty("identity").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteScenario_PlatformList_IncludesPlatformMember()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(DemoCommand.ExecuteScenario("platform-list", OutputFormat.Json)));
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(output);
+        var members = document.RootElement.GetProperty("members");
+        Assert.Contains(
+            members.EnumerateArray(),
+            member => member.GetProperty("kind").GetString() == "platform"
+                && member.GetProperty("identity").GetString() == "runtime");
+        Assert.Equal(
+            "System.Collections.Generic.List`1",
+            document.RootElement.GetProperty("view").GetProperty("type").GetString());
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -137,7 +137,8 @@ public static class RouterCommandDefinition
         "implements",
         "depends",
         "cache",
-        "skill"
+        "skill",
+        DemoCommand.Name,
     ];
 
     private static string? TryGetCommandTypoSuggestion(string token)

--- a/src/dotnet-inspect/CommandLine/Commands/UtilityCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/UtilityCommandDefinitions.cs
@@ -88,4 +88,46 @@ public static class UtilityCommandDefinitions
 
         return skillCommand;
     }
+
+    public static Command CreateDemoCommand(SharedOptions opts)
+    {
+        var demoCommand = new Command(
+            DemoCommand.Name,
+            "List and resolve product home inspection demos (resolve-only plan)");
+
+        var scenarioArg = new Argument<string?>("scenario")
+        {
+            Description = "Home demo id (omit or 'list' to list demos)",
+            Arity = ArgumentArity.ZeroOrOne,
+        };
+        demoCommand.Arguments.Add(scenarioArg);
+        demoCommand.Options.Add(opts.Json);
+        opts.AddTableOptionsTo(demoCommand);
+        demoCommand.Options.Add(opts.Limit);
+
+        var listCommand = new Command("list", "List product home demos");
+        listCommand.Options.Add(opts.Json);
+        opts.AddTableOptionsTo(listCommand);
+        listCommand.Options.Add(opts.Limit);
+        listCommand.SetAction(parseResult =>
+        {
+            var format = opts.ResolveFormat(parseResult);
+            var noHeader = parseResult.GetValue(opts.NoHeaders);
+            return DemoCommand.ExecuteList(format, noHeader);
+        });
+        demoCommand.Subcommands.Add(listCommand);
+
+        demoCommand.SetAction(parseResult =>
+        {
+            var format = opts.ResolveFormat(parseResult);
+            var noHeader = parseResult.GetValue(opts.NoHeaders);
+            var scenario = parseResult.GetValue(scenarioArg);
+            if (string.IsNullOrWhiteSpace(scenario))
+                return DemoCommand.ExecuteList(format, noHeader);
+
+            return DemoCommand.ExecuteScenario(scenario, format, noHeader);
+        });
+
+        return demoCommand;
+    }
 }

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -104,7 +104,7 @@ public static class ArgumentPreprocessor
     public static readonly HashSet<string> KnownCommands = new(StringComparer.OrdinalIgnoreCase)
     {
         "audit", // removed command, reserved so it is not treated as an implicit package target
-        "package", "project", "library", "api", "type", "member", "diff", "timeline", "find", "vocabulary", "body-shape", "source", "list", "ls", "skill", "extensions", "implements", "depends", "cache", "help", "--help", "-h", "-?", "--version", "--flavor"
+        "package", "project", "library", "api", "type", "member", "diff", "timeline", "find", "vocabulary", "body-shape", "source", "list", "ls", "skill", "demo", "extensions", "implements", "depends", "cache", "help", "--help", "-h", "-?", "--version", "--flavor"
     };
 
     /// <summary>

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -208,6 +208,9 @@ public static class CommandLineBuilder
         // Skill command
         rootCommand.Subcommands.Add(UtilityCommandDefinitions.CreateSkillCommand(opts));
 
+        // Product home demos (resolve-only plan)
+        rootCommand.Subcommands.Add(UtilityCommandDefinitions.CreateDemoCommand(opts));
+
         // Override S.CL's built-in --help to use our own renderer
         var helpOption = rootCommand.Options.OfType<System.CommandLine.Help.HelpOption>().FirstOrDefault();
         if (helpOption != null)

--- a/src/dotnet-inspect/Commands/DemoCommand.cs
+++ b/src/dotnet-inspect/Commands/DemoCommand.cs
@@ -1,0 +1,286 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Queries;
+using DotnetInspector.Queries.Definitions;
+using DotnetInspector.Views;
+using Markout;
+
+namespace DotnetInspector.Commands;
+
+/// <summary>
+/// Lists and resolves product home demos from <see cref="ProductInspectionDemos"/>.
+/// Default activation is resolve-only: prints the lowered plan without acquiring
+/// packages or opening an <see cref="AssemblyContextGroup"/>.
+/// </summary>
+public static class DemoCommand
+{
+    public const string Name = "demo";
+
+    public static int ExecuteList(OutputFormat format = OutputFormat.Markdown, bool noHeader = false)
+    {
+        if (format == OutputFormat.Json)
+        {
+            var rows = ProductInspectionDemos.Entries
+                .Select(entry => new DemoListJsonRow(entry.Id, entry.Title, entry.Summary))
+                .ToList();
+            Console.WriteLine(JsonSerializer.Serialize(rows, DemoJsonContext.Default.ListDemoListJsonRow));
+            return 0;
+        }
+
+        var view = new DemoListView
+        {
+            Demos = ProductInspectionDemos.Entries
+                .Select(entry => new DemoListRow
+                {
+                    Id = entry.Id,
+                    Title = entry.Title,
+                    Summary = entry.Summary,
+                })
+                .ToList(),
+        };
+
+        WriteView(view, format, noHeader);
+        return 0;
+    }
+
+    public static int ExecuteScenario(string scenarioId, OutputFormat format = OutputFormat.Markdown, bool noHeader = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scenarioId);
+
+        if (string.Equals(scenarioId, "list", StringComparison.OrdinalIgnoreCase))
+            return ExecuteList(format, noHeader);
+
+        if (!ProductInspectionDemos.TryResolveHomeScenario(scenarioId, out var resolved))
+        {
+            CommandError.Write($"Unknown home demo '{scenarioId}'.");
+            CommandError.WriteBlankLine();
+            CommandError.WriteLine("Available demos:");
+            foreach (var entry in ProductInspectionDemos.Entries)
+                CommandError.WriteLine($"  {entry.Id}");
+            CommandError.WriteBlankLine();
+            CommandError.WriteLine("Run 'dotnet-inspect demo list' for titles and summaries.");
+            return 1;
+        }
+
+        if (format == OutputFormat.Json)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(ToJsonPlan(resolved), DemoJsonContext.Default.DemoPlanJson));
+            return 0;
+        }
+
+        WriteView(ToPlanView(resolved), format, noHeader);
+        return 0;
+    }
+
+    private static void WriteView<TView>(TView view, OutputFormat format, bool noHeader)
+        where TView : class
+    {
+        switch (format)
+        {
+            case OutputFormat.Table:
+            case OutputFormat.Tsv:
+            case OutputFormat.Jsonl:
+                var options = OutputFormatter.CreateTableWriterOptions(
+                    tsv: format == OutputFormat.Tsv,
+                    jsonl: format == OutputFormat.Jsonl);
+                MarkoutSerializer.Serialize(
+                    view,
+                    Console.Out,
+                    new TableFormatter(!noHeader),
+                    DemoViewContext.Default,
+                    options);
+                break;
+            case OutputFormat.PlainText:
+                MarkoutSerializer.Serialize(view, Console.Out, new PlainTextFormatter(), DemoViewContext.Default);
+                break;
+            default:
+                MarkoutSerializer.Serialize(view, Console.Out, DemoViewContext.Default);
+                break;
+        }
+    }
+
+    private static DemoPlanView ToPlanView(ResolvedScenario resolved)
+    {
+        var selected = resolved.SelectedContext;
+        var plan = new List<DemoPlanFieldRow>
+        {
+            new() { Field = "id", Value = resolved.ScenarioId },
+            new() { Field = "title", Value = resolved.Title ?? "" },
+            new() { Field = "description", Value = resolved.Description ?? "" },
+            new() { Field = "workspace", Value = resolved.Workspace?.Id ?? "" },
+            new() { Field = "context", Value = resolved.SelectedContextName ?? "" },
+            new() { Field = "framework", Value = selected?.Framework ?? "" },
+            new()
+            {
+                Field = "createsAssemblyContextGroup",
+                Value = resolved.CreatesAssemblyContextGroup ? "true" : "false",
+            },
+            new() { Field = "view.type", Value = resolved.View?.Type ?? "" },
+            new() { Field = "view.memberAnchor", Value = resolved.View?.MemberAnchor ?? "" },
+            new() { Field = "view.memberKey", Value = resolved.View?.MemberKey ?? "" },
+            new() { Field = "view.section", Value = resolved.View?.Section ?? "" },
+            new() { Field = "view.library", Value = resolved.View?.Library ?? "" },
+            new()
+            {
+                Field = "activation",
+                Value = "resolve-only (no package acquisition in this command)",
+            },
+        };
+
+        var members = (selected?.Members ?? Array.Empty<WorkspaceMemberCoordinate>())
+            .Select(ToMemberRow)
+            .ToList();
+
+        var navigation = new List<DemoNavigationRow>();
+        if (resolved.Navigation is { } nav)
+        {
+            foreach (var tab in nav.Tabs)
+            {
+                navigation.Add(new DemoNavigationRow
+                {
+                    Tab = tab.Id,
+                    Focus = tab.Id == nav.FocusTabId ? "yes" : "",
+                    Coordinate = FormatCoordinate(tab.Coordinate),
+                });
+            }
+        }
+
+        return new DemoPlanView
+        {
+            Title = resolved.Title is { Length: > 0 } title ? title : $"Demo {resolved.ScenarioId}",
+            Description = resolved.Description,
+            Plan = plan,
+            Members = members,
+            Navigation = navigation,
+        };
+    }
+
+    private static DemoPlanJson ToJsonPlan(ResolvedScenario resolved)
+    {
+        var selected = resolved.SelectedContext;
+        return new DemoPlanJson(
+            resolved.ScenarioId,
+            resolved.Title,
+            resolved.Description,
+            resolved.Workspace?.Id,
+            resolved.SelectedContextName,
+            selected?.Framework,
+            resolved.CreatesAssemblyContextGroup,
+            resolved.View is null
+                ? null
+                : new DemoViewJson(
+                    resolved.View.Type,
+                    resolved.View.MemberAnchor,
+                    resolved.View.MemberKey,
+                    resolved.View.Section,
+                    resolved.View.Library),
+            (selected?.Members ?? Array.Empty<WorkspaceMemberCoordinate>())
+                .Select(ToMemberJson)
+                .ToList(),
+            resolved.Navigation is null
+                ? null
+                : new DemoNavigationJson(
+                    resolved.Navigation.FocusTabId,
+                    resolved.Navigation.FocusIndex,
+                    resolved.Navigation.Tabs
+                        .Select(tab => new DemoNavigationTabJson(
+                            tab.Id,
+                            FormatCoordinate(tab.Coordinate)))
+                        .ToList()),
+            Activation: "resolve-only");
+    }
+
+    private static DemoMemberRow ToMemberRow(WorkspaceMemberCoordinate member) =>
+        member switch
+        {
+            WorkspaceMemberCoordinate.PackageMember package => new DemoMemberRow
+            {
+                Kind = "package",
+                Identity = package.PackageId,
+                Version = package.Version,
+                Framework = package.Framework,
+            },
+            WorkspaceMemberCoordinate.PlatformMember platform => new DemoMemberRow
+            {
+                Kind = "platform",
+                Identity = platform.Assembly is { Length: > 0 } assembly
+                    ? $"{platform.Family}/{assembly}"
+                    : platform.Family,
+                Version = platform.Version,
+                Framework = platform.Framework,
+            },
+            WorkspaceMemberCoordinate.EmbeddedMember embedded => new DemoMemberRow
+            {
+                Kind = "embedded",
+                Identity = embedded.DeclaredName,
+                Version = null,
+                Framework = null,
+            },
+            _ => new DemoMemberRow
+            {
+                Kind = member.GetType().Name,
+                Identity = member.ToString() ?? "",
+            },
+        };
+
+    private static DemoMemberJson ToMemberJson(WorkspaceMemberCoordinate member)
+    {
+        var row = ToMemberRow(member);
+        return new DemoMemberJson(row.Kind, row.Identity, row.Version, row.Framework);
+    }
+
+    private static string FormatCoordinate(WorkspaceMemberCoordinate coordinate)
+    {
+        var row = ToMemberRow(coordinate);
+        var version = string.IsNullOrEmpty(row.Version) ? "" : $"@{row.Version}";
+        var framework = string.IsNullOrEmpty(row.Framework) ? "" : $" ({row.Framework})";
+        return $"{row.Kind}:{row.Identity}{version}{framework}";
+    }
+}
+
+public sealed record DemoListJsonRow(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("summary")] string Summary);
+
+public sealed record DemoPlanJson(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("title")] string? Title,
+    [property: JsonPropertyName("description")] string? Description,
+    [property: JsonPropertyName("workspace")] string? Workspace,
+    [property: JsonPropertyName("context")] string? Context,
+    [property: JsonPropertyName("framework")] string? Framework,
+    [property: JsonPropertyName("createsAssemblyContextGroup")] bool CreatesAssemblyContextGroup,
+    [property: JsonPropertyName("view")] DemoViewJson? View,
+    [property: JsonPropertyName("members")] IReadOnlyList<DemoMemberJson> Members,
+    [property: JsonPropertyName("navigation")] DemoNavigationJson? Navigation,
+    [property: JsonPropertyName("activation")] string Activation);
+
+public sealed record DemoViewJson(
+    [property: JsonPropertyName("type")] string? Type,
+    [property: JsonPropertyName("memberAnchor")] string? MemberAnchor,
+    [property: JsonPropertyName("memberKey")] string? MemberKey,
+    [property: JsonPropertyName("section")] string? Section,
+    [property: JsonPropertyName("library")] string? Library);
+
+public sealed record DemoMemberJson(
+    [property: JsonPropertyName("kind")] string Kind,
+    [property: JsonPropertyName("identity")] string Identity,
+    [property: JsonPropertyName("version")] string? Version,
+    [property: JsonPropertyName("framework")] string? Framework);
+
+public sealed record DemoNavigationJson(
+    [property: JsonPropertyName("focusTabId")] string FocusTabId,
+    [property: JsonPropertyName("focusIndex")] int FocusIndex,
+    [property: JsonPropertyName("tabs")] IReadOnlyList<DemoNavigationTabJson> Tabs);
+
+public sealed record DemoNavigationTabJson(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("coordinate")] string Coordinate);
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(List<DemoListJsonRow>))]
+[JsonSerializable(typeof(DemoPlanJson))]
+internal partial class DemoJsonContext : JsonSerializerContext;

--- a/src/dotnet-inspect/Commands/DemoCommand.cs
+++ b/src/dotnet-inspect/Commands/DemoCommand.cs
@@ -252,7 +252,7 @@ public sealed record DemoPlanJson(
     [property: JsonPropertyName("workspace")] string? Workspace,
     [property: JsonPropertyName("context")] string? Context,
     [property: JsonPropertyName("framework")] string? Framework,
-    [property: JsonPropertyName("createsAssemblyContextGroup")] bool CreatesAssemblyContextGroup,
+    [property: JsonPropertyName("creates_assembly_context_group")] bool CreatesAssemblyContextGroup,
     [property: JsonPropertyName("view")] DemoViewJson? View,
     [property: JsonPropertyName("members")] IReadOnlyList<DemoMemberJson> Members,
     [property: JsonPropertyName("navigation")] DemoNavigationJson? Navigation,
@@ -260,8 +260,8 @@ public sealed record DemoPlanJson(
 
 public sealed record DemoViewJson(
     [property: JsonPropertyName("type")] string? Type,
-    [property: JsonPropertyName("memberAnchor")] string? MemberAnchor,
-    [property: JsonPropertyName("memberKey")] string? MemberKey,
+    [property: JsonPropertyName("member_anchor")] string? MemberAnchor,
+    [property: JsonPropertyName("member_key")] string? MemberKey,
     [property: JsonPropertyName("section")] string? Section,
     [property: JsonPropertyName("library")] string? Library);
 
@@ -272,8 +272,8 @@ public sealed record DemoMemberJson(
     [property: JsonPropertyName("framework")] string? Framework);
 
 public sealed record DemoNavigationJson(
-    [property: JsonPropertyName("focusTabId")] string FocusTabId,
-    [property: JsonPropertyName("focusIndex")] int FocusIndex,
+    [property: JsonPropertyName("focus_tab_id")] string FocusTabId,
+    [property: JsonPropertyName("focus_index")] int FocusIndex,
     [property: JsonPropertyName("tabs")] IReadOnlyList<DemoNavigationTabJson> Tabs);
 
 public sealed record DemoNavigationTabJson(

--- a/src/dotnet-inspect/Views/DemoViews.cs
+++ b/src/dotnet-inspect/Views/DemoViews.cs
@@ -1,0 +1,91 @@
+using Markout;
+
+namespace DotnetInspector.Views;
+
+/// <summary>Catalog of product home demos for <c>demo list</c>.</summary>
+[MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
+public sealed class DemoListView
+{
+    [MarkoutIgnore]
+    public string Title => "Home demos";
+
+    [MarkoutIgnore]
+    public string Description =>
+        "Product-resident inspection scenarios. Print one with "
+        + "`dotnet-inspect demo <id>` (resolve-only plan; no package download).";
+
+    [MarkoutSection(Headless = true)]
+    public List<DemoListRow> Demos { get; set; } = [];
+}
+
+public sealed class DemoListRow
+{
+    [MarkoutPropertyName("Id")]
+    public string Id { get; set; } = "";
+
+    [MarkoutPropertyName("Title")]
+    public string Title { get; set; } = "";
+
+    [MarkoutPropertyName("Summary")]
+    public string Summary { get; set; } = "";
+}
+
+/// <summary>Resolved home-demo activation plan for <c>demo &lt;id&gt;</c>.</summary>
+[MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
+public sealed class DemoPlanView
+{
+    [MarkoutIgnore]
+    public string Title { get; set; } = "Demo plan";
+
+    [MarkoutIgnore]
+    public string? Description { get; set; }
+
+    [MarkoutSection(Headless = true)]
+    public List<DemoPlanFieldRow> Plan { get; set; } = [];
+
+    [MarkoutSection(Name = "Members")]
+    public List<DemoMemberRow> Members { get; set; } = [];
+
+    [MarkoutSection(Name = "Navigation")]
+    public List<DemoNavigationRow> Navigation { get; set; } = [];
+}
+
+public sealed class DemoPlanFieldRow
+{
+    [MarkoutPropertyName("Field")]
+    public string Field { get; set; } = "";
+
+    [MarkoutPropertyName("Value")]
+    public string Value { get; set; } = "";
+}
+
+public sealed class DemoMemberRow
+{
+    [MarkoutPropertyName("Kind")]
+    public string Kind { get; set; } = "";
+
+    [MarkoutPropertyName("Identity")]
+    public string Identity { get; set; } = "";
+
+    [MarkoutPropertyName("Version")]
+    public string? Version { get; set; }
+
+    [MarkoutPropertyName("Framework")]
+    public string? Framework { get; set; }
+}
+
+public sealed class DemoNavigationRow
+{
+    [MarkoutPropertyName("Tab")]
+    public string Tab { get; set; } = "";
+
+    [MarkoutPropertyName("Focus")]
+    public string Focus { get; set; } = "";
+
+    [MarkoutPropertyName("Coordinate")]
+    public string Coordinate { get; set; } = "";
+}
+
+[MarkoutContext(typeof(DemoListView))]
+[MarkoutContext(typeof(DemoPlanView))]
+public partial class DemoViewContext : MarkoutSerializerContext;

--- a/src/dotnet-inspect/Views/DemoViews.cs
+++ b/src/dotnet-inspect/Views/DemoViews.cs
@@ -21,13 +21,13 @@ public sealed class DemoListView
 public sealed class DemoListRow
 {
     [MarkoutPropertyName("Id")]
-    public string Id { get; set; } = "";
+    public string Id { get => field; set => field = LibraryViewText.Contain(value) ?? ""; } = "";
 
     [MarkoutPropertyName("Title")]
-    public string Title { get; set; } = "";
+    public string Title { get => field; set => field = LibraryViewText.Contain(value) ?? ""; } = "";
 
     [MarkoutPropertyName("Summary")]
-    public string Summary { get; set; } = "";
+    public string Summary { get => field; set => field = LibraryViewText.Contain(value) ?? ""; } = "";
 }
 
 /// <summary>Resolved home-demo activation plan for <c>demo &lt;id&gt;</c>.</summary>
@@ -35,10 +35,18 @@ public sealed class DemoListRow
 public sealed class DemoPlanView
 {
     [MarkoutIgnore]
-    public string Title { get; set; } = "Demo plan";
+    public string Title
+    {
+        get => field;
+        set => field = LibraryViewText.Contain(value) ?? "";
+    } = "Demo plan";
 
     [MarkoutIgnore]
-    public string? Description { get; set; }
+    public string? Description
+    {
+        get => field;
+        set => field = LibraryViewText.Contain(value);
+    }
 
     [MarkoutSection(Headless = true)]
     public List<DemoPlanFieldRow> Plan { get; set; } = [];
@@ -53,37 +61,37 @@ public sealed class DemoPlanView
 public sealed class DemoPlanFieldRow
 {
     [MarkoutPropertyName("Field")]
-    public string Field { get; set; } = "";
+    public string Field { get => field; set => field = LibraryViewText.Contain(value) ?? ""; } = "";
 
     [MarkoutPropertyName("Value")]
-    public string Value { get; set; } = "";
+    public string Value { get => field; set => field = LibraryViewText.Contain(value) ?? ""; } = "";
 }
 
 public sealed class DemoMemberRow
 {
     [MarkoutPropertyName("Kind")]
-    public string Kind { get; set; } = "";
+    public string Kind { get => field; set => field = LibraryViewText.Contain(value) ?? ""; } = "";
 
     [MarkoutPropertyName("Identity")]
-    public string Identity { get; set; } = "";
+    public string Identity { get => field; set => field = LibraryViewText.Contain(value) ?? ""; } = "";
 
     [MarkoutPropertyName("Version")]
-    public string? Version { get; set; }
+    public string? Version { get => field; set => field = LibraryViewText.Contain(value); }
 
     [MarkoutPropertyName("Framework")]
-    public string? Framework { get; set; }
+    public string? Framework { get => field; set => field = LibraryViewText.Contain(value); }
 }
 
 public sealed class DemoNavigationRow
 {
     [MarkoutPropertyName("Tab")]
-    public string Tab { get; set; } = "";
+    public string Tab { get => field; set => field = LibraryViewText.Contain(value) ?? ""; } = "";
 
     [MarkoutPropertyName("Focus")]
-    public string Focus { get; set; } = "";
+    public string Focus { get => field; set => field = LibraryViewText.Contain(value) ?? ""; } = "";
 
     [MarkoutPropertyName("Coordinate")]
-    public string Coordinate { get; set; } = "";
+    public string Coordinate { get => field; set => field = LibraryViewText.Contain(value) ?? ""; } = "";
 }
 
 [MarkoutContext(typeof(DemoListView))]


### PR DESCRIPTION
## Summary
- Add `dotnet-inspect demo list` and `demo <id>` as a resolve-only consumer of `ProductInspectionDemos` (from #4419).
- Print catalog rows and lowered home-demo plans (package/platform members, view, navigation) without NuGet acquisition or opening an `AssemblyContextGroup`.
- Register the command on the root CLI surface, including typo suggestions; document in README and `workspace-definitions.md`.

## Claim
CLI operators can list product home demos and inspect each demo's resolved plan offline. Default activation is resolve-only (`activation: resolve-only` in JSON).

## Demo

```text
$ dotnet-inspect demo list
# Home demos

Product-resident inspection scenarios. Print one with `dotnet-inspect demo <id>` (resolve-only plan; no package download).

| Id | Title | Summary |
| -- | ----- | ------- |
| stj-serializer | System.Text.Json | Browse a real package API |
| extensions-callgraph | Cross-package call graph | Trace calls across three packages |
| platform-list | .NET Platform | Inspect platform BCL types |
```

```text
$ dotnet-inspect demo stj-serializer
# System.Text.Json

Browse a real package API

| Field | Value |
| ----- | ----- |
| id | stj-serializer |
| title | System.Text.Json |
| description | Browse a real package API |
| workspace | stj-serializer-workspace |
| context | stj |
| framework | net10.0 |
| createsAssemblyContextGroup | true |
| view.type | System.Text.Json.JsonSerializer |
| activation | resolve-only (no package acquisition in this command) |

## Members

| Kind | Identity | Version | Framework |
| ---- | -------- | ------- | --------- |
| package | System.Text.Json | 10.0.0 | net10.0 |
```

```text
$ dotnet-inspect demo extensions-callgraph --json
# excerpt
"id": "extensions-callgraph",
"view": {
  "type": "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
  "member_anchor": "74b6b4b321",
  "member_key": "method:TryAddEnumerable",
  "section": "call-graph"
},
"activation": "resolve-only",
"creates_assembly_context_group": true
```

## Non-action / residual
- No `--open` / package load / network path in this slice.
- inspect-web home buttons, share packet v1, group subscribe/fs/preset remain follow-ups.

## Evidence
- `dotnet build src/dotnet-inspect.Tests -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method '*DemoCommand*'` → 11 passed
- MarkoutRowContainment + JsonWireNameGate green
- `npx markdownlint-cli` on changed Markdown
- Adversarial R3 dual clean @ `2f7e6481d`; `ci-required` SUCCESS

## Base
Integrated `origin/main` @ `3e9715476` (head `2f7e6481d`).
