### PR TITLE
Extract the Metadata lens and Metadata Explorer into metadata-viewer.ts

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -554,6 +554,25 @@ style catalog's tier grouping, byte-divergent badges, and checked state; the
 taste popover's active/default states; and the Settings page's theme segment,
 close-button label, and active-style-count states.
 
+`src/metadata-viewer.ts` owns the Metadata lens (the image-level summary of each
+assembly — format stamp, heap sizes, ECMA-335 table row counts, and PE/CLI
+headers) and the Metadata Explorer (the spatial table/heap drill-down laid over
+it) as pure, dependency-injected render functions; both describe the metadata
+image rather than the API surface within it, so they share one module the way
+`type-panel.ts` combines the type selector and the type viewer. `app.js` still
+owns `state`, the engine calls that fetch an image, a table row window, or a
+heap listing, the explorer's focus/history stack, the DOM event binding, the
+`IntersectionObserver` that hydrates cards lazily, the resize listener, and the
+global keydown handler, and passes each computed slice in explicitly; the shared
+helpers used well beyond these views (`escapeHtml`, `fmtBytes`,
+`platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`) stay in
+`app.js` and are injected the same way. `test/metadata-viewer.test.js` gates the
+lens's picker, loading, failure, stale-scope, partial-read, and empty-image
+states and its heap/table ordering; the explorer's chips, history-button
+enablement, overview versus focus lightbox, lazy-load hooks, pager bounds, row
+highlight and selection, ref->def jump targets, cell escaping, heap addressing
+and coverage notes, and the row inspector.
+
 - `Cmd/Ctrl+K` focuses the persistent command prompt.
 - `Cmd/Ctrl+F` or `/` focuses the type filter.
 - Arrow keys select a completion, `Tab` accepts it, and `Enter` runs it.

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -57,6 +57,16 @@ import {
 } from "/src/type-panel.ts";
 import { createPackageBar } from "/src/package-bar.ts";
 import {
+  cssEscape,
+  estimateExplorerPageSize,
+  EXPLORER_PAGE,
+  EXPLORER_ROW_H,
+  heapStreamName,
+  renderMetadataExplorer as renderMetadataExplorerHtml,
+  renderPackageMetadata as renderPackageMetadataHtml,
+  sameFocus,
+} from "/src/metadata-viewer.ts";
+import {
   renderSettingsView,
   renderTastePopover,
 } from "/src/settings-panel.ts";
@@ -2223,88 +2233,19 @@ function maybeAutoLoadPackagePerformance() {
 // NuGet package it describes every active-framework lib/ assembly.
 function renderPackageMetadata() {
   const isPlatform = Boolean(state.package?.isRuntimePack);
-  const scopedLib = scopedPlatformLibrary();
-  const picker = isPlatform ? platformLensPicker("data-platform-metadata-library") : "";
-  if (isPlatform && !scopedLib) {
-    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Pick a library to inspect</h2><p>Choose a .NET platform library above to read its metadata image — format version, heaps, tables, and PE/CLI headers.</p></section>`;
-  }
-  const scanScope = isPlatform ? `${escapeHtml(scopedLib)} · ${escapeHtml(state.package.activeFramework)}` : escapeHtml(state.package.activeFramework);
-  const current = packageScopeSignature();
-  const fresh = state.packageMetadataKey === current;
-  if (state.packageMetadataLoading && fresh) {
-    return `${picker}<section class="document-section source-progress"><span class="loader"></span><h2>Reading metadata…</h2><p>Describing the metadata image — heaps, tables, and headers.</p></section>`;
-  }
-  if (fresh && state.packageMetadataError) {
-    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Metadata read failed</h2><p>${escapeHtml(state.packageMetadataError)}</p></section>`;
-  }
-  const data = fresh ? state.packageMetadata : null;
-  if (!data) {
-    return `${picker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
-  }
-
-  const assemblies = data.assemblies || [];
-  const warning = data.inspectionError
-    ? `<section class="document-section metadata-warning"><strong>⚠ Some assemblies could not be read</strong><ul><li><code>${escapeHtml(data.inspectionError)}</code></li></ul></section>`
-    : "";
-
-  if (!assemblies.length) {
-    return `${picker}${warning}<section class="document-section empty-document"><span class="large-glyph">◇</span><h2>No metadata images</h2><p>None of the assemblies in ${scanScope} carry ECMA-335 metadata (they may be native or resource-only).</p></section>`;
-  }
-
-  const blocks = assemblies.map(renderAssemblyMetadataBlock).join("");
-  const summary = `
-    <section class="document-section">
-      <div class="section-title"><h2>Metadata image</h2><span>${assemblies.length} assembl${assemblies.length === 1 ? "y" : "ies"} · ${scanScope}</span></div>
-      <p class="lens-note">The physical shape of each assembly's metadata — format stamp, heap sizes, populated ECMA-335 tables, and PE/CLI headers. This describes the container, not the API surface.</p>
-    </section>`;
-
-  return `${picker}${warning}${summary}${blocks}`;
-}
-
-function renderAssemblyMetadataBlock(asm) {
-  const heapRows = (asm.heaps || [])
-    .filter(heap => heap.sizeInBytes > 0)
-    .map(heap => `
-      <button type="button" class="meta-heap" data-mde-open-heap="${escapeHtml(asm.assembly)}|${escapeHtml(heap.name)}" title="Browse ${escapeHtml(heapStreamName(heap.name))} in the metadata explorer">
-        <span class="meta-heap-name">${escapeHtml(heapStreamName(heap.name))}</span>
-        <span class="meta-heap-size">${fmtBytes(heap.sizeInBytes)}</span>
-        <span class="meta-heap-addr">${escapeHtml(heap.addressing === "Index" ? "index" : "byte offset")} · max ${heap.maxAddress}</span>
-      </button>`).join("");
-
-  const tables = (asm.tables || []).slice().sort((a, b) => b.rowCount - a.rowCount);
-  const tableRows = tables.map(table => `
-    <button type="button" class="meta-table-row ${table.isProjected ? "" : "meta-table-unprojected"}" data-mde-open="${escapeHtml(asm.assembly)}|${table.index}" title="${table.isProjected ? "Open in the metadata explorer" : "Present in the image but not modeled by the projection"}">
-      <span class="meta-table-name">${escapeHtml(table.name)}</span>
-      <span class="meta-table-count">${table.rowCount.toLocaleString()}</span>
-      <span class="meta-table-go">→</span>
-    </button>`).join("");
-
-  const h = asm.headers || {};
-  const corLine = h.corFlags
-    ? `<span class="meta-fact"><span class="meta-fact-k">CLI</span><span class="meta-fact-v">v${h.majorRuntimeVersion}.${h.minorRuntimeVersion} · ${escapeHtml(h.corFlags)}${h.entryPointToken ? ` · entry 0x${(h.entryPointToken >>> 0).toString(16)}` : ""}</span></span>`
-    : "";
-
-  return `
-    <section class="document-section meta-assembly">
-      <div class="section-title"><h2>${escapeHtml(asm.assembly)}</h2><span>${escapeHtml(asm.kind)}${asm.isAssembly ? " · assembly manifest" : " · module"} · metadata ${fmtBytes(asm.metadataSize)}</span></div>
-      <div class="meta-facts">
-        <span class="meta-fact"><span class="meta-fact-k">Format</span><span class="meta-fact-v">${escapeHtml(asm.metadataVersion)}</span></span>
-        <span class="meta-fact"><span class="meta-fact-k">Machine</span><span class="meta-fact-v">${escapeHtml(h.machine || "—")}${h.isPE32Plus ? " · PE32+" : " · PE32"}</span></span>
-        <span class="meta-fact"><span class="meta-fact-k">Subsystem</span><span class="meta-fact-v">${escapeHtml(h.subsystem || "—")}</span></span>
-        <span class="meta-fact"><span class="meta-fact-k">Tables</span><span class="meta-fact-v">${asm.projectedTableTotal}/${tables.length} populated</span></span>
-        ${corLine}
-      </div>
-      <div class="meta-grid">
-        <div class="meta-col">
-          <h3 class="meta-col-title">Heaps</h3>
-          <div class="meta-heaps">${heapRows || '<div class="meta-empty">No non-empty heaps</div>'}</div>
-        </div>
-        <div class="meta-col">
-          <h3 class="meta-col-title">Tables <span class="meta-col-note">by row count</span></h3>
-          <div class="meta-tables">${tableRows || '<div class="meta-empty">No populated tables</div>'}</div>
-        </div>
-      </div>
-    </section>`;
+  const fresh = state.packageMetadataKey === packageScopeSignature();
+  return renderPackageMetadataHtml({
+    isPlatform,
+    scopedLibrary: scopedPlatformLibrary() || "",
+    activeFramework: state.package?.activeFramework || "",
+    pickerHtml: isPlatform ? platformLensPicker("data-platform-metadata-library") : "",
+    fresh,
+    loading: Boolean(state.packageMetadataLoading),
+    error: state.packageMetadataError || "",
+    metadata: state.packageMetadata || null,
+    escapeHtml,
+    fmtBytes,
+  });
 }
 
 async function loadPackageMetadata() {
@@ -2355,21 +2296,10 @@ function maybeAutoLoadPackageMetadata() {
 // lazy-loads each table's row window on demand, renders cells with their typed values, and
 // turns handle/range cells into ref->def jumps that transport you to the target table+row.
 
-// A conservative fallback page size; the real one adapts to the focus panel's visible height
-// (see estimateExplorerPageSize / syncExplorerPageSize) so a tall panel isn't half-empty.
-const EXPLORER_PAGE = 50;
-const EXPLORER_ROW_H = 18; // approximate grid row height (px) for the pre-render estimate
-
-// Current adaptive page size for the open explorer, falling back to the constant.
+// Current adaptive page size for the open explorer, falling back to the constant owned by
+// metadata-viewer.ts.
 function explorerPageSize() {
   return state.explorer?.pageSize || EXPLORER_PAGE;
-}
-
-// Pre-render estimate from the viewport (chrome above the grid ~ 180px), so the very first window
-// load already roughly fills the panel; syncExplorerPageSize refines it from real measurements.
-function estimateExplorerPageSize() {
-  const grid = Math.max(120, (window.innerHeight || 800) - 180);
-  return Math.max(30, Math.min(400, Math.floor(grid / EXPLORER_ROW_H) + 2));
 }
 
 // Opens the explorer over one assembly, focused on a table (and optionally a row). The table
@@ -2428,29 +2358,13 @@ function buildBaseExplorer(assemblyFileName) {
     history: [],
     historyPos: -1,
     overview: false,
-    pageSize: estimateExplorerPageSize(),
+    pageSize: estimateExplorerPageSize(window.innerHeight || 0),
   };
-}
-
-// ECMA-335 stream name for a HeapKind name, matching the product's spelling.
-function heapStreamName(name) {
-  switch (name) {
-    case "String": return "#Strings";
-    case "Blob": return "#Blob";
-    case "Guid": return "#GUID";
-    case "UserString": return "#US";
-    default: return `#${name}`;
-  }
 }
 
 function closeExplorer() {
   state.explorer = null;
   render();
-}
-
-function explorerTableName(index) {
-  const hit = state.explorer?.directory.find(t => t.index === index);
-  return hit ? hit.name : `#${index}`;
 }
 
 async function loadExplorerWindow(index, startRowId = 1, maxRows = explorerPageSize()) {
@@ -2516,13 +2430,6 @@ async function loadExplorerHeap(heapName) {
 // which otherwise look like "you didn't move").
 function explorerJump(index, rowId) {
   pushExplorerFocus({ index, rowId: rowId || 0 });
-}
-
-// A focus entry is either { index, rowId } (rowId 0 = table, no highlighted row) or { heap }.
-function sameFocus(a, b) {
-  if (!a || !b) return false;
-  if (a.heap != null || b.heap != null) return a.heap === b.heap;
-  return a.index === b.index;
 }
 
 // Move focus to a new entry, truncating any forward history (a fresh branch). Re-selecting the
@@ -2648,284 +2555,15 @@ function syncExplorerPageSize() {
   }
 }
 
-// Attribute-selector-safe heap name (heap names are simple identifiers, but be defensive).
-function cssEscape(value) {  return String(value).replace(/["\\]/g, "\\$&");
-}
-
+// Renders the explorer surface owned by metadata-viewer.ts, then binds its events. The state
+// snapshot is passed explicitly; the module owns markup only.
 function renderMetadataExplorer() {
-  const ex = state.explorer;
-  const chips = ex.directory.map(t => `
-    <button type="button" class="mde-chip ${t.index === ex.focusIndex && !ex.focusHeap ? "active" : ""} ${t.isProjected ? "" : "mde-chip-unprojected"}" data-mde-chip="${t.index}" title="${t.rowCount.toLocaleString()} rows${t.isProjected ? "" : " · not modeled"}">
-      ${escapeHtml(t.name)}<span class="mde-chip-count">${t.rowCount.toLocaleString()}</span>
-    </button>`).join("");
-  const heapChips = (ex.heaps || []).map(h => `
-    <button type="button" class="mde-chip mde-chip-heap ${ex.focusHeap === h.name ? "active" : ""}" data-mde-heap-chip="${escapeHtml(h.name)}" title="${escapeHtml(h.streamName)} · ${fmtBytes(h.sizeInBytes)}">
-      ${escapeHtml(h.streamName)}<span class="mde-chip-count">${fmtBytes(h.sizeInBytes)}</span>
-    </button>`).join("");
-
-  const cards = ex.directory.map(t => renderExplorerCard(t)).join("");
-  const heapCards = (ex.heaps || []).length
-    ? `<div class="mde-heap-divider"><span>heaps</span></div>` + ex.heaps.map(renderHeapCard).join("")
-    : "";
-
-  const canBack = ex.historyPos > 0;
-  const canForward = ex.historyPos < ex.history.length - 1;
-  const focusPanel = ex.overview ? "" : renderExplorerFocusPanel();
-  const note = ex.overview
-    ? `metadata tables · ${ex.directory.length} populated · click a table to focus · Esc to exit`
-    : `metadata tables · ${ex.directory.length} populated · click a ref to jump · Esc / click away for all tables`;
-
-  app.innerHTML = `
-    <div class="metadata-explorer">
-      <header class="mde-bar">
-        <div class="mde-nav" role="group" aria-label="Explorer navigation">
-          <button id="mde-exit" class="mde-navbtn mde-nav-exit" title="Exit the explorer">✕ Exit</button>
-          <button id="mde-hist-back" class="mde-navbtn" ${canBack ? "" : "disabled"} title="Back (Backspace)">← Back</button>
-          <button id="mde-hist-fwd" class="mde-navbtn" ${canForward ? "" : "disabled"} title="Forward (Shift+Backspace)">Forward →</button>
-        </div>
-        <div class="mde-title">
-          <span class="mde-title-asm">${escapeHtml(ex.assemblyFileName)}</span>
-          <span class="mde-title-note">${note}</span>
-        </div>
-      </header>
-      <nav class="mde-chips">${chips}${heapChips ? `<span class="mde-chip-sep"></span>${heapChips}` : ""}</nav>
-      <div class="mde-body">
-        <div class="mde-canvas mde-wall ${ex.overview ? "mde-wall-open" : ""}" id="mde-canvas">${cards}${heapCards}</div>
-        ${focusPanel}
-      </div>
-    </div>`;
+  app.innerHTML = renderMetadataExplorerHtml({
+    explorer: state.explorer,
+    escapeHtml,
+    fmtBytes,
+  });
   bindMetadataExplorerEvents();
-}
-
-// The focus lightbox: the current table (or heap) blown up front-and-center over the dim wall,
-// with the row inspector docked on its right. Corner ✕ buttons (top-right + bottom-right) zoom
-// back out to the all-tables wall. Auto-focus (every ref->def jump lands here) makes this the
-// primary reading surface — the wall behind is spatial context you can click into.
-function renderExplorerFocusPanel() {
-  const ex = state.explorer;
-  const card = ex.focusHeap
-    ? renderHeapCard(ex.heaps.find(h => h.name === ex.focusHeap) || {})
-    : renderExplorerCard(ex.directory.find(t => t.index === ex.focusIndex) || {});
-  const detail = renderExplorerDetail();
-  return `
-    <div class="mde-focus">
-      <div class="mde-focus-inner">
-        <div class="mde-focus-card">${card}</div>
-        ${detail}
-      </div>
-      <button type="button" class="mde-focus-x mde-focus-x-top" data-mde-overview="1" title="Back to all tables (Esc)">✕</button>
-      <button type="button" class="mde-focus-x mde-focus-x-bottom" data-mde-overview="1" title="Back to all tables (Esc)">✕</button>
-    </div>`;
-}
-
-// A heap card: header (stream name, size, coverage badge), a coverage caveat banner, and the
-// listed entries (address · refs · value). The value reuses the same cell renderer as the grid,
-// so a listed #Strings entry and a Name cell pointing at it render identically.
-function renderHeapCard(h) {
-  const ex = state.explorer;
-  const win = ex.heapWindows[h.name];
-  const focused = ex.focusHeap === h.name;
-  let body;
-  if (win?.loading && !win.data) {
-    body = `<div class="mde-card-empty"><span class="loader"></span> Reading ${escapeHtml(h.streamName)}…</div>`;
-  } else if (win?.error) {
-    body = `<div class="mde-card-empty mde-card-error">△ ${escapeHtml(win.error)}</div>`;
-  } else if (win?.data) {
-    body = renderHeapListing(win.data);
-  } else {
-    body = `<div class="mde-card-empty mde-card-lazy" data-mde-heap-needs-load="${escapeHtml(h.name)}"><span class="loader"></span> Loading ${escapeHtml(h.streamName)}…</div>`;
-  }
-  const coverage = win?.data?.coverage;
-  const badge = coverage
-    ? `<span class="mde-cov-badge mde-cov-${coverage.toLowerCase()}">${escapeHtml(coverageLabel(coverage))}</span>`
-    : "";
-  return `
-    <section class="mde-heap-card ${focused ? "mde-card-focus" : ""}" data-mde-heap="${escapeHtml(h.name)}">
-      <div class="mde-card-head">
-        <h3>${escapeHtml(h.streamName)}</h3>
-        <span class="mde-card-meta">heap · ${fmtBytes(h.sizeInBytes)}${badge ? " · " : ""}</span>${badge}
-      </div>
-      ${body}
-    </section>`;
-}
-
-function coverageLabel(coverage) {
-  switch (coverage) {
-    case "Complete": return "every entry";
-    case "ReferencedOnly": return "referenced only";
-    case "NotEnumerable": return "not enumerable";
-    default: return coverage;
-  }
-}
-
-// The listing body: a coverage caveat line, then the entry rows. Coverage is stated as part of
-// the answer so a referenced-only or truncated list is never read as the whole heap.
-function renderHeapListing(data) {
-  const note = heapCoverageNote(data);
-  if (data.coverage === "NotEnumerable" || !(data.entries || []).length) {
-    return `<div class="mde-heap-note">${note}</div>`;
-  }
-  const isIndex = data.heap === "Guid";
-  const sel = state.explorer?.detail;
-  const rows = data.entries.map(entry => {
-    const addr = isIndex ? `#${entry.offset}` : `0x${(entry.offset >>> 0).toString(16)}`;
-    const isSel = sel && sel.heap === data.heap && sel.offset === entry.offset;
-    return `<tr class="mde-heap-row ${isSel ? "mde-heap-row-sel" : ""}" data-mde-heap-row="${escapeHtml(data.heap)}:${entry.offset}">
-      <td class="mde-heap-addr" title="${isIndex ? "GUID index" : "heap byte offset"}">${addr}</td>
-      <td class="mde-heap-val">${renderHeapValueCell(entry.value)}</td>
-      <td class="mde-heap-refs" title="referenced by ${entry.referenceCount} projected cell${entry.referenceCount === 1 ? "" : "s"}">${entry.referenceCount.toLocaleString()}×</td>
-    </tr>`;
-  }).join("");
-  return `
-    <div class="mde-heap-note">${note}</div>
-    <div class="mde-grid-scroll"><table class="mde-grid mde-heap-grid">
-      <thead><tr><th class="mde-heap-addr">addr</th><th>value</th><th class="mde-heap-refs" title="reference count">refs</th></tr></thead>
-      <tbody>${rows}</tbody>
-    </table></div>`;
-}
-
-function heapCoverageNote(data) {
-  const parts = [];
-  switch (data.coverage) {
-    case "Complete":
-      parts.push(`Every entry in this heap is listed — the GUID heap is fixed-size records at consecutive indices, so it enumerates exactly.`);
-      break;
-    case "ReferencedOnly":
-      parts.push(`Only entries a projected table row points at are listed — the heap may hold values nothing references, still readable by address.`);
-      break;
-    case "NotEnumerable":
-      parts.push(`No entry can be listed: no ECMA-335 table column points into ${escapeHtml(data.streamName)} — its references are <code>ldstr</code> operands inside method bodies. An empty list here is a blind spot, not an empty heap.`);
-      break;
-    default:
-      break;
-  }
-  if (data.rowsTruncated) parts.push(`Reference scan did not cover every row of every table, so some references are uncounted.`);
-  if (data.entriesTruncated) parts.push(`The entry budget cut the listing short.`);
-  return parts.join(" ");
-}
-
-// A heap entry's value renders exactly like the same heap cell in a grid, minus the jump (a heap
-// value has no ref->def target). Falls back through the flat cell union defensively.
-function renderHeapValueCell(cell) {
-  if (!cell) return `<span class="mde-nil">·</span>`;
-  if (cell.kind === "heap") {
-    const val = cell.text != null ? cell.text : cell.preview;
-    const cls = `mde-cell-heap mde-heap-${(cell.heap || "").toLowerCase()}`;
-    return `<span class="${cls}" title="${cell.length} byte${cell.length === 1 ? "" : "s"}${cell.truncated ? " · truncated" : ""}">${escapeHtml(val ?? "")}${cell.truncated ? "…" : ""}</span>`;
-  }
-  return renderExplorerCell(cell, null);
-}
-
-function renderExplorerCard(t) {
-  const ex = state.explorer;
-  const win = ex.windows[t.index];
-  const focused = t.index === ex.focusIndex;
-  let body;
-  if (!t.isProjected) {
-    body = `<div class="mde-card-empty">This table has ${t.rowCount.toLocaleString()} rows but is not modeled by the projection yet.</div>`;
-  } else if (win?.loading && !win.data) {
-    body = `<div class="mde-card-empty"><span class="loader"></span> Reading rows…</div>`;
-  } else if (win?.error) {
-    body = `<div class="mde-card-empty mde-card-error">△ ${escapeHtml(win.error)}</div>`;
-  } else if (win?.data) {
-    body = renderExplorerGrid(win.data);
-  } else {
-    body = `<div class="mde-card-empty mde-card-lazy" data-mde-needs-load="${t.index}"><span class="loader"></span> Loading ${t.name}…</div>`;
-  }
-
-  const win2 = win?.data;
-  const pager = win2 && win2.rows?.length
-    ? (() => {
-        const from = win2.startRowId;
-        const to = win2.startRowId + win2.rows.length - 1;
-        const hasPrev = from > 1;
-        const hasNext = to < win2.rowCount;
-        return `<div class="mde-pager">
-          <span>rows ${from.toLocaleString()}–${to.toLocaleString()} of ${win2.rowCount.toLocaleString()}</span>
-          <span class="mde-pager-btns">
-            <button type="button" data-mde-page="${t.index}:${Math.max(1, from - win2.rows.length)}" ${hasPrev ? "" : "disabled"}>‹ prev</button>
-            <button type="button" data-mde-page="${t.index}:${to + 1}" ${hasNext ? "" : "disabled"}>next ›</button>
-          </span>
-        </div>`;
-      })()
-    : "";
-
-  return `
-    <section class="mde-card ${focused ? "mde-card-focus" : ""} ${t.isProjected ? "" : "mde-card-dim"}" data-mde-index="${t.index}">
-      <div class="mde-card-head">
-        <h3>${escapeHtml(t.name)}</h3>
-        <span class="mde-card-meta">table ${t.index} · ${t.rowCount.toLocaleString()} row${t.rowCount === 1 ? "" : "s"}</span>
-      </div>
-      ${body}
-      ${pager}
-    </section>`;
-}
-
-function renderExplorerGrid(data) {
-  const ex = state.explorer;
-  const cols = data.columns || [];
-  const header = `<tr><th class="mde-gutter">#</th>${cols.map(c => `<th title="${escapeHtml(c.kind)}${c.candidateTargets?.length ? " → " + c.candidateTargets.map(explorerTableName).join(", ") : ""}">${escapeHtml(c.name)}</th>`).join("")}</tr>`;
-  const rows = (data.rows || []).map(row => {
-    const hot = ex.highlight && ex.highlight.index === data.index && ex.highlight.rowId === row.rowId;
-    const sel = ex.detail && ex.detail.index === data.index && ex.detail.rowId === row.rowId;
-    const cells = row.cells.map((cell, i) => `<td>${renderExplorerCell(cell, cols[i])}</td>`).join("");
-    return `<tr class="mde-row ${hot ? "mde-row-hot" : ""} ${sel ? "mde-row-sel" : ""}" data-mde-row="${data.index}:${row.rowId}"><td class="mde-gutter" title="token 0x${(row.token >>> 0).toString(16)}">${row.rowId}</td>${cells}</tr>`;
-  }).join("");
-  return `<div class="mde-grid-scroll"><table class="mde-grid"><thead>${header}</thead><tbody>${rows}</tbody></table></div>`;
-}
-
-function renderExplorerCell(cell, column) {
-  if (!cell) return "";
-  switch (cell.kind) {
-    case "nil":
-      return `<span class="mde-nil">·</span>`;
-    case "scalar":
-      return `<span class="mde-cell-scalar">${escapeHtml(cell.display ?? String(cell.raw ?? ""))}</span>`;
-    case "flags":
-      return `<span class="mde-cell-flags" title="0x${((cell.raw ?? 0) >>> 0).toString(16)}">${escapeHtml(cell.decoded || String(cell.raw ?? 0))}</span>`;
-    case "heap": {
-      const val = cell.text != null ? cell.text : cell.preview;
-      const cls = `mde-cell-heap mde-heap-${(cell.heap || "").toLowerCase()}`;
-      return `<span class="${cls}" title="#${escapeHtml(cell.heap || "")} @${cell.offset} · ${cell.length} byte${cell.length === 1 ? "" : "s"}">${escapeHtml(val ?? "")}${cell.truncated ? "…" : ""}</span>`;
-    }
-    case "handle": {
-      if (!cell.targetRowId) return `<span class="mde-nil">nil</span>`;
-      const label = cell.display || `${explorerTableName(cell.targetTable)} #${cell.targetRowId}`;
-      return `<button type="button" class="mde-ref" data-mde-jump="${cell.targetTable}:${cell.targetRowId}" title="→ ${escapeHtml(explorerTableName(cell.targetTable))} #${cell.targetRowId}">${escapeHtml(label)}${cell.truncated ? "…" : ""} <span class="mde-ref-arrow">↗</span></button>`;
-    }
-    case "range": {
-      if (!cell.count) return `<span class="mde-nil">empty</span>`;
-      return `<button type="button" class="mde-ref mde-ref-range" data-mde-jump="${cell.targetTable}:${cell.startRowId}" title="→ ${escapeHtml(explorerTableName(cell.targetTable))} rows ${cell.startRowId}‥${cell.endRowId}">${escapeHtml(explorerTableName(cell.targetTable))} #${cell.startRowId}‥${cell.endRowId} <span class="mde-ref-count">${cell.count}</span></button>`;
-    }
-    case "malformed":
-      return `<span class="mde-cell-malformed" title="${escapeHtml(cell.detail || "")}">malformed</span>`;
-    default:
-      return "";
-  }
-}
-
-// The row inspector: the selected row's cells laid out vertically, labeled by column, with
-// handle/range cells still jumpable. A focused "read this one row" companion to the grid.
-function renderExplorerDetail() {
-  const ex = state.explorer;
-  if (!ex.detail) return "";
-  const win = ex.windows[ex.detail.index];
-  const row = win?.data?.rows?.find(r => r.rowId === ex.detail.rowId);
-  if (!row) return "";
-  const cols = win.data.columns || [];
-  const fields = row.cells.map((cell, i) => `
-    <div class="mde-detail-field">
-      <span class="mde-detail-k">${escapeHtml(cols[i]?.name || `col ${i}`)}</span>
-      <span class="mde-detail-v">${renderExplorerCell(cell, cols[i])}</span>
-    </div>`).join("");
-  return `
-    <aside class="mde-detail">
-      <div class="mde-detail-head">
-        <span class="mde-detail-title">${escapeHtml(win.data.name)} #${row.rowId}</span>
-      </div>
-      <div class="mde-detail-token">token 0x${(row.token >>> 0).toString(16)}</div>
-      <div class="mde-detail-fields">${fields}</div>
-    </aside>`;
 }
 
 let explorerObserver = null;

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -1,0 +1,690 @@
+// The Metadata lens (the image-level summary of each assembly — format stamp, heap sizes,
+// ECMA-335 table row counts, PE/CLI headers) and the Metadata Explorer (the spatial
+// "browse the metadata like a database" table/heap drill-down) as pure,
+// dependency-injected render functions. Both views describe the same subject — the shape of
+// the metadata image rather than the API surface within it — so they live in one module, the
+// way `type-panel.ts` combines the type selector and the type viewer.
+//
+// `app.js` keeps everything that is not markup: `state`, the engine calls that fetch a
+// metadata image, a table row window, or a heap listing (`loadPackageMetadata`,
+// `loadExplorerWindow`, `loadExplorerHeap`), the explorer's focus/history stack
+// (`openExplorer`, `pushExplorerFocus`, `applyExplorerFocus`, `explorerHistoryBack/Forward`,
+// `explorerShowOverview`, `closeExplorer`), the DOM event binding, the `IntersectionObserver`
+// that hydrates cards lazily, the resize listener, and the global keydown handler. This
+// module owns only the markup shape given an explicit snapshot of that state, matching how
+// `type-panel.ts` left comparably rich navigation state in `app.js`.
+//
+// The shared text helpers used well beyond these views (`escapeHtml`, `fmtBytes`) and the
+// shared lens chrome (`platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`,
+// `platformPackForAssembly`) stay in `app.js` and are injected rather than duplicated here.
+
+type EscapeHtml = (value: unknown) => string;
+type FormatBytes = (value: number) => string;
+
+// -- Shared injected helpers ---------------------------------------------------------------
+
+export interface MetadataTextHelpers {
+  escapeHtml: EscapeHtml;
+  fmtBytes: FormatBytes;
+}
+
+// -- Metadata lens data shapes -------------------------------------------------------------
+
+export interface MetadataHeapSummary {
+  name: string;
+  sizeInBytes: number;
+  maxAddress: number;
+  addressing: string;
+}
+
+export interface MetadataTableSummary {
+  index: number;
+  name: string;
+  rowCount: number;
+  isProjected: boolean;
+}
+
+export interface MetadataHeaders {
+  machine?: string;
+  isPE32Plus?: boolean;
+  subsystem?: string;
+  corFlags?: string;
+  majorRuntimeVersion?: number;
+  minorRuntimeVersion?: number;
+  entryPointToken?: number;
+}
+
+export interface MetadataAssembly {
+  assembly: string;
+  kind: string;
+  isAssembly: boolean;
+  metadataSize: number;
+  metadataVersion: string;
+  projectedTableTotal: number;
+  heaps?: readonly MetadataHeapSummary[];
+  tables?: readonly MetadataTableSummary[];
+  headers?: MetadataHeaders;
+}
+
+export interface PackageMetadata {
+  assemblies?: readonly MetadataAssembly[];
+  inspectionError?: string;
+}
+
+// -- Metadata Explorer data shapes ---------------------------------------------------------
+
+export interface ExplorerDirectoryEntry {
+  index: number;
+  name: string;
+  rowCount: number;
+  isProjected: boolean;
+}
+
+export interface ExplorerHeapEntry {
+  name: string;
+  streamName: string;
+  sizeInBytes: number;
+  addressing: string;
+}
+
+export interface ExplorerColumn {
+  name: string;
+  kind: string;
+  candidateTargets?: readonly number[];
+}
+
+/**
+ * The flat cell union the engine projects: `nil`, `scalar`, `flags`, `heap`, `handle`,
+ * `range`, and `malformed` each populate their own subset of these fields.
+ */
+export interface ExplorerCell {
+  kind: string;
+  display?: string;
+  raw?: number | string;
+  decoded?: string;
+  heap?: string;
+  text?: string;
+  preview?: string;
+  offset?: number;
+  length?: number;
+  truncated?: boolean;
+  targetTable?: number;
+  targetRowId?: number;
+  startRowId?: number;
+  endRowId?: number;
+  count?: number;
+  detail?: string;
+}
+
+export interface ExplorerRow {
+  rowId: number;
+  token: number;
+  cells: readonly ExplorerCell[];
+}
+
+export interface ExplorerTableData {
+  index: number;
+  name: string;
+  rowCount: number;
+  startRowId: number;
+  columns?: readonly ExplorerColumn[];
+  rows?: readonly ExplorerRow[];
+  error?: string;
+}
+
+export interface ExplorerWindow {
+  loading: boolean;
+  error: string;
+  data: ExplorerTableData | null;
+  startRowId?: number;
+  maxRows?: number;
+}
+
+export interface HeapListingEntry {
+  offset: number;
+  value: ExplorerCell | null;
+  referenceCount: number;
+}
+
+export interface HeapListingData {
+  heap: string;
+  streamName: string;
+  coverage: string;
+  entries?: readonly HeapListingEntry[];
+  rowsTruncated?: boolean;
+  entriesTruncated?: boolean;
+}
+
+export interface HeapWindow {
+  loading: boolean;
+  error: string;
+  data: HeapListingData | null;
+}
+
+/** A focus entry is either `{ index, rowId }` (rowId 0 = table, no highlighted row) or `{ heap }`. */
+export interface ExplorerFocus {
+  index?: number;
+  rowId?: number;
+  heap?: string;
+}
+
+export interface ExplorerRowRef {
+  index: number;
+  rowId: number;
+}
+
+export interface ExplorerDetailRef {
+  index?: number;
+  rowId?: number;
+  heap?: string;
+  offset?: number;
+}
+
+export interface ExplorerState {
+  open: boolean;
+  assemblyFileName: string;
+  directory: readonly ExplorerDirectoryEntry[];
+  heaps?: readonly ExplorerHeapEntry[];
+  windows: Record<number, ExplorerWindow | undefined>;
+  heapWindows: Record<string, HeapWindow | undefined>;
+  focusIndex: number;
+  focusHeap: string | null;
+  highlight: ExplorerRowRef | null;
+  detail: ExplorerDetailRef | null;
+  history: ExplorerFocus[];
+  historyPos: number;
+  overview: boolean;
+  pageSize?: number;
+}
+
+/** Everything the explorer's markup needs: the open explorer plus the shared text helpers. */
+export interface ExplorerRenderContext extends MetadataTextHelpers {
+  explorer: ExplorerState;
+}
+
+// -- Constants and pure derivation ---------------------------------------------------------
+
+/**
+ * A conservative fallback page size; the real one adapts to the focus panel's visible height
+ * (see `estimateExplorerPageSize` and `app.js`'s `syncExplorerPageSize`) so a tall panel is
+ * not left half-empty.
+ */
+export const EXPLORER_PAGE = 50;
+
+/** Approximate grid row height (px) for the pre-render page-size estimate. */
+export const EXPLORER_ROW_H = 18;
+
+/**
+ * Pre-render estimate from the viewport (chrome above the grid ~ 180px), so the very first
+ * window load already roughly fills the panel; `syncExplorerPageSize` refines it from real
+ * measurements once the focus panel is laid out.
+ */
+export function estimateExplorerPageSize(viewportHeight: number): number {
+  const grid = Math.max(120, (viewportHeight || 800) - 180);
+  return Math.max(30, Math.min(400, Math.floor(grid / EXPLORER_ROW_H) + 2));
+}
+
+/** ECMA-335 stream name for a HeapKind name, matching the product's spelling. */
+export function heapStreamName(name: string): string {
+  switch (name) {
+    case "String": return "#Strings";
+    case "Blob": return "#Blob";
+    case "Guid": return "#GUID";
+    case "UserString": return "#US";
+    default: return `#${name}`;
+  }
+}
+
+/** Two focus entries name the same place when they name the same heap, or the same table. */
+export function sameFocus(a: ExplorerFocus | null | undefined, b: ExplorerFocus | null | undefined): boolean {
+  if (!a || !b) return false;
+  if (a.heap != null || b.heap != null) return a.heap === b.heap;
+  return a.index === b.index;
+}
+
+/** The directory's name for a table index, falling back to `#index` for an unknown table. */
+export function explorerTableName(directory: readonly ExplorerDirectoryEntry[] | undefined, index: number): string {
+  const hit = directory?.find(t => t.index === index);
+  return hit ? hit.name : `#${index}`;
+}
+
+/** Attribute-selector-safe heap name (heap names are simple identifiers, but be defensive). */
+export function cssEscape(value: unknown): string {
+  return String(value).replace(/["\\]/g, "\\$&");
+}
+
+export function coverageLabel(coverage: string): string {
+  switch (coverage) {
+    case "Complete": return "every entry";
+    case "ReferencedOnly": return "referenced only";
+    case "NotEnumerable": return "not enumerable";
+    default: return coverage;
+  }
+}
+
+// -- Metadata lens ---------------------------------------------------------------------------
+
+export interface PackageMetadataOptions extends MetadataTextHelpers {
+  /** True for the runtime pack, where the lens scopes to one platform library. */
+  isPlatform: boolean;
+  /** The scoped platform library name, or "" when the platform lens has no selection yet. */
+  scopedLibrary: string;
+  activeFramework: string;
+  /** The shared `platformLensPicker` markup, rendered by `app.js` for the platform lens. */
+  pickerHtml: string;
+  /** True when the loaded metadata (or in-flight load) belongs to the current scope. */
+  fresh: boolean;
+  loading: boolean;
+  error: string;
+  metadata: PackageMetadata | null;
+}
+
+/**
+ * The Metadata lens: the image-level "container" view of each assembly — metadata format
+ * version, heap sizes, ECMA-335 table row counts, and PE/CLI header facts. This is the shape
+ * of the metadata itself, distinct from the API surface (the types within). For the platform
+ * it scopes to one runtime-pack assembly (the shared framework is ~160 assemblies); for a
+ * NuGet package it describes every active-framework `lib/` assembly.
+ */
+export function renderPackageMetadata(options: PackageMetadataOptions): string {
+  const {
+    isPlatform, scopedLibrary, activeFramework, pickerHtml, fresh, loading, error, metadata,
+    escapeHtml, fmtBytes,
+  } = options;
+  const picker = isPlatform ? pickerHtml : "";
+  if (isPlatform && !scopedLibrary) {
+    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Pick a library to inspect</h2><p>Choose a .NET platform library above to read its metadata image — format version, heaps, tables, and PE/CLI headers.</p></section>`;
+  }
+  const scanScope = isPlatform
+    ? `${escapeHtml(scopedLibrary)} · ${escapeHtml(activeFramework)}`
+    : escapeHtml(activeFramework);
+  if (loading && fresh) {
+    return `${picker}<section class="document-section source-progress"><span class="loader"></span><h2>Reading metadata…</h2><p>Describing the metadata image — heaps, tables, and headers.</p></section>`;
+  }
+  if (fresh && error) {
+    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Metadata read failed</h2><p>${escapeHtml(error)}</p></section>`;
+  }
+  const data = fresh ? metadata : null;
+  if (!data) {
+    return `${picker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
+  }
+
+  const assemblies = data.assemblies || [];
+  const warning = data.inspectionError
+    ? `<section class="document-section metadata-warning"><strong>⚠ Some assemblies could not be read</strong><ul><li><code>${escapeHtml(data.inspectionError)}</code></li></ul></section>`
+    : "";
+
+  if (!assemblies.length) {
+    return `${picker}${warning}<section class="document-section empty-document"><span class="large-glyph">◇</span><h2>No metadata images</h2><p>None of the assemblies in ${scanScope} carry ECMA-335 metadata (they may be native or resource-only).</p></section>`;
+  }
+
+  const blocks = assemblies
+    .map(asm => renderAssemblyMetadataBlock(asm, { escapeHtml, fmtBytes }))
+    .join("");
+  const summary = `
+    <section class="document-section">
+      <div class="section-title"><h2>Metadata image</h2><span>${assemblies.length} assembl${assemblies.length === 1 ? "y" : "ies"} · ${scanScope}</span></div>
+      <p class="lens-note">The physical shape of each assembly's metadata — format stamp, heap sizes, populated ECMA-335 tables, and PE/CLI headers. This describes the container, not the API surface.</p>
+    </section>`;
+
+  return `${picker}${warning}${summary}${blocks}`;
+}
+
+/**
+ * One assembly's block: its non-empty heaps, its populated tables sorted by row count, and
+ * its PE/CLI header facts. Every heap and table is a button that hands off to the explorer.
+ */
+export function renderAssemblyMetadataBlock(asm: MetadataAssembly, helpers: MetadataTextHelpers): string {
+  const { escapeHtml, fmtBytes } = helpers;
+  const heapRows = (asm.heaps || [])
+    .filter(heap => heap.sizeInBytes > 0)
+    .map(heap => `
+      <button type="button" class="meta-heap" data-mde-open-heap="${escapeHtml(asm.assembly)}|${escapeHtml(heap.name)}" title="Browse ${escapeHtml(heapStreamName(heap.name))} in the metadata explorer">
+        <span class="meta-heap-name">${escapeHtml(heapStreamName(heap.name))}</span>
+        <span class="meta-heap-size">${fmtBytes(heap.sizeInBytes)}</span>
+        <span class="meta-heap-addr">${escapeHtml(heap.addressing === "Index" ? "index" : "byte offset")} · max ${heap.maxAddress}</span>
+      </button>`).join("");
+
+  const tables = (asm.tables || []).slice().sort((a, b) => b.rowCount - a.rowCount);
+  const tableRows = tables.map(table => `
+    <button type="button" class="meta-table-row ${table.isProjected ? "" : "meta-table-unprojected"}" data-mde-open="${escapeHtml(asm.assembly)}|${table.index}" title="${table.isProjected ? "Open in the metadata explorer" : "Present in the image but not modeled by the projection"}">
+      <span class="meta-table-name">${escapeHtml(table.name)}</span>
+      <span class="meta-table-count">${table.rowCount.toLocaleString()}</span>
+      <span class="meta-table-go">→</span>
+    </button>`).join("");
+
+  const h = asm.headers || {};
+  const corLine = h.corFlags
+    ? `<span class="meta-fact"><span class="meta-fact-k">CLI</span><span class="meta-fact-v">v${h.majorRuntimeVersion}.${h.minorRuntimeVersion} · ${escapeHtml(h.corFlags)}${h.entryPointToken ? ` · entry 0x${(h.entryPointToken >>> 0).toString(16)}` : ""}</span></span>`
+    : "";
+
+  return `
+    <section class="document-section meta-assembly">
+      <div class="section-title"><h2>${escapeHtml(asm.assembly)}</h2><span>${escapeHtml(asm.kind)}${asm.isAssembly ? " · assembly manifest" : " · module"} · metadata ${fmtBytes(asm.metadataSize)}</span></div>
+      <div class="meta-facts">
+        <span class="meta-fact"><span class="meta-fact-k">Format</span><span class="meta-fact-v">${escapeHtml(asm.metadataVersion)}</span></span>
+        <span class="meta-fact"><span class="meta-fact-k">Machine</span><span class="meta-fact-v">${escapeHtml(h.machine || "—")}${h.isPE32Plus ? " · PE32+" : " · PE32"}</span></span>
+        <span class="meta-fact"><span class="meta-fact-k">Subsystem</span><span class="meta-fact-v">${escapeHtml(h.subsystem || "—")}</span></span>
+        <span class="meta-fact"><span class="meta-fact-k">Tables</span><span class="meta-fact-v">${asm.projectedTableTotal}/${tables.length} populated</span></span>
+        ${corLine}
+      </div>
+      <div class="meta-grid">
+        <div class="meta-col">
+          <h3 class="meta-col-title">Heaps</h3>
+          <div class="meta-heaps">${heapRows || '<div class="meta-empty">No non-empty heaps</div>'}</div>
+        </div>
+        <div class="meta-col">
+          <h3 class="meta-col-title">Tables <span class="meta-col-note">by row count</span></h3>
+          <div class="meta-tables">${tableRows || '<div class="meta-empty">No populated tables</div>'}</div>
+        </div>
+      </div>
+    </section>`;
+}
+
+// -- Metadata Explorer -----------------------------------------------------------------------
+// A spatial "browse the metadata like a database" view. The overview lens hands off an
+// assembly + a starting table; the explorer lays every populated table out as a card,
+// `app.js` lazy-loads each table's row window on demand, and handle/range cells render as
+// ref->def jumps that `app.js` transports you along.
+
+/**
+ * The whole explorer surface: the nav bar, the table/heap chips, the wall of cards, and (when
+ * not zoomed out to the overview) the focus lightbox. `app.js` mounts this markup and binds
+ * its events; every `data-mde-*` attribute here is a binding contract with `app.js`.
+ */
+export function renderMetadataExplorer(context: ExplorerRenderContext): string {
+  const { explorer: ex, escapeHtml, fmtBytes } = context;
+  const chips = ex.directory.map(t => `
+    <button type="button" class="mde-chip ${t.index === ex.focusIndex && !ex.focusHeap ? "active" : ""} ${t.isProjected ? "" : "mde-chip-unprojected"}" data-mde-chip="${t.index}" title="${t.rowCount.toLocaleString()} rows${t.isProjected ? "" : " · not modeled"}">
+      ${escapeHtml(t.name)}<span class="mde-chip-count">${t.rowCount.toLocaleString()}</span>
+    </button>`).join("");
+  const heapChips = (ex.heaps || []).map(h => `
+    <button type="button" class="mde-chip mde-chip-heap ${ex.focusHeap === h.name ? "active" : ""}" data-mde-heap-chip="${escapeHtml(h.name)}" title="${escapeHtml(h.streamName)} · ${fmtBytes(h.sizeInBytes)}">
+      ${escapeHtml(h.streamName)}<span class="mde-chip-count">${fmtBytes(h.sizeInBytes)}</span>
+    </button>`).join("");
+
+  const cards = ex.directory.map(t => renderExplorerCard(t, context)).join("");
+  const heapCards = (ex.heaps || []).length
+    ? `<div class="mde-heap-divider"><span>heaps</span></div>` + (ex.heaps || []).map(h => renderHeapCard(h, context)).join("")
+    : "";
+
+  const canBack = ex.historyPos > 0;
+  const canForward = ex.historyPos < ex.history.length - 1;
+  const focusPanel = ex.overview ? "" : renderExplorerFocusPanel(context);
+  const note = ex.overview
+    ? `metadata tables · ${ex.directory.length} populated · click a table to focus · Esc to exit`
+    : `metadata tables · ${ex.directory.length} populated · click a ref to jump · Esc / click away for all tables`;
+
+  return `
+    <div class="metadata-explorer">
+      <header class="mde-bar">
+        <div class="mde-nav" role="group" aria-label="Explorer navigation">
+          <button id="mde-exit" class="mde-navbtn mde-nav-exit" title="Exit the explorer">✕ Exit</button>
+          <button id="mde-hist-back" class="mde-navbtn" ${canBack ? "" : "disabled"} title="Back (Backspace)">← Back</button>
+          <button id="mde-hist-fwd" class="mde-navbtn" ${canForward ? "" : "disabled"} title="Forward (Shift+Backspace)">Forward →</button>
+        </div>
+        <div class="mde-title">
+          <span class="mde-title-asm">${escapeHtml(ex.assemblyFileName)}</span>
+          <span class="mde-title-note">${note}</span>
+        </div>
+      </header>
+      <nav class="mde-chips">${chips}${heapChips ? `<span class="mde-chip-sep"></span>${heapChips}` : ""}</nav>
+      <div class="mde-body">
+        <div class="mde-canvas mde-wall ${ex.overview ? "mde-wall-open" : ""}" id="mde-canvas">${cards}${heapCards}</div>
+        ${focusPanel}
+      </div>
+    </div>`;
+}
+
+/**
+ * The focus lightbox: the current table (or heap) blown up front-and-center over the dim wall,
+ * with the row inspector docked on its right. Corner ✕ buttons (top-right + bottom-right) zoom
+ * back out to the all-tables wall. Auto-focus (every ref->def jump lands here) makes this the
+ * primary reading surface — the wall behind is spatial context you can click into.
+ */
+export function renderExplorerFocusPanel(context: ExplorerRenderContext): string {
+  const ex = context.explorer;
+  const card = ex.focusHeap
+    ? renderHeapCard((ex.heaps || []).find(h => h.name === ex.focusHeap) || emptyHeapEntry(), context)
+    : renderExplorerCard(ex.directory.find(t => t.index === ex.focusIndex) || emptyDirectoryEntry(), context);
+  const detail = renderExplorerDetail(context);
+  return `
+    <div class="mde-focus">
+      <div class="mde-focus-inner">
+        <div class="mde-focus-card">${card}</div>
+        ${detail}
+      </div>
+      <button type="button" class="mde-focus-x mde-focus-x-top" data-mde-overview="1" title="Back to all tables (Esc)">✕</button>
+      <button type="button" class="mde-focus-x mde-focus-x-bottom" data-mde-overview="1" title="Back to all tables (Esc)">✕</button>
+    </div>`;
+}
+
+function emptyHeapEntry(): ExplorerHeapEntry {
+  return { name: "", streamName: "", sizeInBytes: 0, addressing: "" };
+}
+
+function emptyDirectoryEntry(): ExplorerDirectoryEntry {
+  return { index: NaN, name: "", rowCount: NaN, isProjected: false };
+}
+
+/**
+ * A heap card: header (stream name, size, coverage badge), a coverage caveat banner, and the
+ * listed entries (address · refs · value). The value reuses the same cell renderer as the grid,
+ * so a listed #Strings entry and a Name cell pointing at it render identically.
+ */
+export function renderHeapCard(h: ExplorerHeapEntry, context: ExplorerRenderContext): string {
+  const { explorer: ex, escapeHtml, fmtBytes } = context;
+  const win = ex.heapWindows[h.name];
+  const focused = ex.focusHeap === h.name;
+  let body: string;
+  if (win?.loading && !win.data) {
+    body = `<div class="mde-card-empty"><span class="loader"></span> Reading ${escapeHtml(h.streamName)}…</div>`;
+  } else if (win?.error) {
+    body = `<div class="mde-card-empty mde-card-error">△ ${escapeHtml(win.error)}</div>`;
+  } else if (win?.data) {
+    body = renderHeapListing(win.data, context);
+  } else {
+    body = `<div class="mde-card-empty mde-card-lazy" data-mde-heap-needs-load="${escapeHtml(h.name)}"><span class="loader"></span> Loading ${escapeHtml(h.streamName)}…</div>`;
+  }
+  const coverage = win?.data?.coverage;
+  const badge = coverage
+    ? `<span class="mde-cov-badge mde-cov-${coverage.toLowerCase()}">${escapeHtml(coverageLabel(coverage))}</span>`
+    : "";
+  return `
+    <section class="mde-heap-card ${focused ? "mde-card-focus" : ""}" data-mde-heap="${escapeHtml(h.name)}">
+      <div class="mde-card-head">
+        <h3>${escapeHtml(h.streamName)}</h3>
+        <span class="mde-card-meta">heap · ${fmtBytes(h.sizeInBytes)}${badge ? " · " : ""}</span>${badge}
+      </div>
+      ${body}
+    </section>`;
+}
+
+/**
+ * The listing body: a coverage caveat line, then the entry rows. Coverage is stated as part of
+ * the answer so a referenced-only or truncated list is never read as the whole heap.
+ */
+export function renderHeapListing(data: HeapListingData, context: ExplorerRenderContext): string {
+  const { explorer: ex, escapeHtml } = context;
+  const note = heapCoverageNote(data, escapeHtml);
+  if (data.coverage === "NotEnumerable" || !(data.entries || []).length) {
+    return `<div class="mde-heap-note">${note}</div>`;
+  }
+  const isIndex = data.heap === "Guid";
+  const sel = ex.detail;
+  const rows = (data.entries || []).map(entry => {
+    const addr = isIndex ? `#${entry.offset}` : `0x${(entry.offset >>> 0).toString(16)}`;
+    const isSel = sel && sel.heap === data.heap && sel.offset === entry.offset;
+    return `<tr class="mde-heap-row ${isSel ? "mde-heap-row-sel" : ""}" data-mde-heap-row="${escapeHtml(data.heap)}:${entry.offset}">
+      <td class="mde-heap-addr" title="${isIndex ? "GUID index" : "heap byte offset"}">${addr}</td>
+      <td class="mde-heap-val">${renderHeapValueCell(entry.value, context)}</td>
+      <td class="mde-heap-refs" title="referenced by ${entry.referenceCount} projected cell${entry.referenceCount === 1 ? "" : "s"}">${entry.referenceCount.toLocaleString()}×</td>
+    </tr>`;
+  }).join("");
+  return `
+    <div class="mde-heap-note">${note}</div>
+    <div class="mde-grid-scroll"><table class="mde-grid mde-heap-grid">
+      <thead><tr><th class="mde-heap-addr">addr</th><th>value</th><th class="mde-heap-refs" title="reference count">refs</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table></div>`;
+}
+
+/** States the listing's coverage and any truncation, so a partial answer never reads as whole. */
+export function heapCoverageNote(data: HeapListingData, escapeHtml: EscapeHtml): string {
+  const parts: string[] = [];
+  switch (data.coverage) {
+    case "Complete":
+      parts.push(`Every entry in this heap is listed — the GUID heap is fixed-size records at consecutive indices, so it enumerates exactly.`);
+      break;
+    case "ReferencedOnly":
+      parts.push(`Only entries a projected table row points at are listed — the heap may hold values nothing references, still readable by address.`);
+      break;
+    case "NotEnumerable":
+      parts.push(`No entry can be listed: no ECMA-335 table column points into ${escapeHtml(data.streamName)} — its references are <code>ldstr</code> operands inside method bodies. An empty list here is a blind spot, not an empty heap.`);
+      break;
+    default:
+      break;
+  }
+  if (data.rowsTruncated) parts.push(`Reference scan did not cover every row of every table, so some references are uncounted.`);
+  if (data.entriesTruncated) parts.push(`The entry budget cut the listing short.`);
+  return parts.join(" ");
+}
+
+/**
+ * A heap entry's value renders exactly like the same heap cell in a grid, minus the jump (a heap
+ * value has no ref->def target). Falls back through the flat cell union defensively.
+ */
+export function renderHeapValueCell(cell: ExplorerCell | null | undefined, context: ExplorerRenderContext): string {
+  const { escapeHtml } = context;
+  if (!cell) return `<span class="mde-nil">·</span>`;
+  if (cell.kind === "heap") {
+    const val = cell.text != null ? cell.text : cell.preview;
+    const cls = `mde-cell-heap mde-heap-${(cell.heap || "").toLowerCase()}`;
+    return `<span class="${cls}" title="${cell.length} byte${cell.length === 1 ? "" : "s"}${cell.truncated ? " · truncated" : ""}">${escapeHtml(val ?? "")}${cell.truncated ? "…" : ""}</span>`;
+  }
+  return renderExplorerCell(cell, null, context);
+}
+
+/** One table card on the wall: header, body (loading / error / grid / lazy stub), and pager. */
+export function renderExplorerCard(t: ExplorerDirectoryEntry, context: ExplorerRenderContext): string {
+  const { explorer: ex, escapeHtml } = context;
+  const win = ex.windows[t.index];
+  const focused = t.index === ex.focusIndex;
+  let body: string;
+  if (!t.isProjected) {
+    body = `<div class="mde-card-empty">This table has ${t.rowCount.toLocaleString()} rows but is not modeled by the projection yet.</div>`;
+  } else if (win?.loading && !win.data) {
+    body = `<div class="mde-card-empty"><span class="loader"></span> Reading rows…</div>`;
+  } else if (win?.error) {
+    body = `<div class="mde-card-empty mde-card-error">△ ${escapeHtml(win.error)}</div>`;
+  } else if (win?.data) {
+    body = renderExplorerGrid(win.data, context);
+  } else {
+    body = `<div class="mde-card-empty mde-card-lazy" data-mde-needs-load="${t.index}"><span class="loader"></span> Loading ${t.name}…</div>`;
+  }
+
+  const win2 = win?.data;
+  const pager = win2 && win2.rows?.length
+    ? (() => {
+        const rows = win2.rows || [];
+        const from = win2.startRowId;
+        const to = win2.startRowId + rows.length - 1;
+        const hasPrev = from > 1;
+        const hasNext = to < win2.rowCount;
+        return `<div class="mde-pager">
+          <span>rows ${from.toLocaleString()}–${to.toLocaleString()} of ${win2.rowCount.toLocaleString()}</span>
+          <span class="mde-pager-btns">
+            <button type="button" data-mde-page="${t.index}:${Math.max(1, from - rows.length)}" ${hasPrev ? "" : "disabled"}>‹ prev</button>
+            <button type="button" data-mde-page="${t.index}:${to + 1}" ${hasNext ? "" : "disabled"}>next ›</button>
+          </span>
+        </div>`;
+      })()
+    : "";
+
+  return `
+    <section class="mde-card ${focused ? "mde-card-focus" : ""} ${t.isProjected ? "" : "mde-card-dim"}" data-mde-index="${t.index}">
+      <div class="mde-card-head">
+        <h3>${escapeHtml(t.name)}</h3>
+        <span class="mde-card-meta">table ${t.index} · ${t.rowCount.toLocaleString()} row${t.rowCount === 1 ? "" : "s"}</span>
+      </div>
+      ${body}
+      ${pager}
+    </section>`;
+}
+
+/** One table's loaded row window as a grid, with the highlighted and selected rows marked. */
+export function renderExplorerGrid(data: ExplorerTableData, context: ExplorerRenderContext): string {
+  const { explorer: ex, escapeHtml } = context;
+  const cols = data.columns || [];
+  const header = `<tr><th class="mde-gutter">#</th>${cols.map(c => `<th title="${escapeHtml(c.kind)}${c.candidateTargets?.length ? " → " + c.candidateTargets.map(index => explorerTableName(ex.directory, index)).join(", ") : ""}">${escapeHtml(c.name)}</th>`).join("")}</tr>`;
+  const rows = (data.rows || []).map(row => {
+    const hot = ex.highlight && ex.highlight.index === data.index && ex.highlight.rowId === row.rowId;
+    const sel = ex.detail && ex.detail.index === data.index && ex.detail.rowId === row.rowId;
+    const cells = row.cells.map((cell, i) => `<td>${renderExplorerCell(cell, cols[i] ?? null, context)}</td>`).join("");
+    return `<tr class="mde-row ${hot ? "mde-row-hot" : ""} ${sel ? "mde-row-sel" : ""}" data-mde-row="${data.index}:${row.rowId}"><td class="mde-gutter" title="token 0x${(row.token >>> 0).toString(16)}">${row.rowId}</td>${cells}</tr>`;
+  }).join("");
+  return `<div class="mde-grid-scroll"><table class="mde-grid"><thead>${header}</thead><tbody>${rows}</tbody></table></div>`;
+}
+
+/** One projected cell. Handle and range cells render as ref->def jump buttons. */
+export function renderExplorerCell(
+  cell: ExplorerCell | null | undefined,
+  _column: ExplorerColumn | null,
+  context: ExplorerRenderContext,
+): string {
+  const { explorer: ex, escapeHtml } = context;
+  const tableName = (index: number | undefined) => explorerTableName(ex.directory, Number(index));
+  if (!cell) return "";
+  switch (cell.kind) {
+    case "nil":
+      return `<span class="mde-nil">·</span>`;
+    case "scalar":
+      return `<span class="mde-cell-scalar">${escapeHtml(cell.display ?? String(cell.raw ?? ""))}</span>`;
+    case "flags":
+      return `<span class="mde-cell-flags" title="0x${((Number(cell.raw) || 0) >>> 0).toString(16)}">${escapeHtml(cell.decoded || String(cell.raw ?? 0))}</span>`;
+    case "heap": {
+      const val = cell.text != null ? cell.text : cell.preview;
+      const cls = `mde-cell-heap mde-heap-${(cell.heap || "").toLowerCase()}`;
+      return `<span class="${cls}" title="#${escapeHtml(cell.heap || "")} @${cell.offset} · ${cell.length} byte${cell.length === 1 ? "" : "s"}">${escapeHtml(val ?? "")}${cell.truncated ? "…" : ""}</span>`;
+    }
+    case "handle": {
+      if (!cell.targetRowId) return `<span class="mde-nil">nil</span>`;
+      const label = cell.display || `${tableName(cell.targetTable)} #${cell.targetRowId}`;
+      return `<button type="button" class="mde-ref" data-mde-jump="${cell.targetTable}:${cell.targetRowId}" title="→ ${escapeHtml(tableName(cell.targetTable))} #${cell.targetRowId}">${escapeHtml(label)}${cell.truncated ? "…" : ""} <span class="mde-ref-arrow">↗</span></button>`;
+    }
+    case "range": {
+      if (!cell.count) return `<span class="mde-nil">empty</span>`;
+      return `<button type="button" class="mde-ref mde-ref-range" data-mde-jump="${cell.targetTable}:${cell.startRowId}" title="→ ${escapeHtml(tableName(cell.targetTable))} rows ${cell.startRowId}‥${cell.endRowId}">${escapeHtml(tableName(cell.targetTable))} #${cell.startRowId}‥${cell.endRowId} <span class="mde-ref-count">${cell.count}</span></button>`;
+    }
+    case "malformed":
+      return `<span class="mde-cell-malformed" title="${escapeHtml(cell.detail || "")}">malformed</span>`;
+    default:
+      return "";
+  }
+}
+
+/**
+ * The row inspector: the selected row's cells laid out vertically, labeled by column, with
+ * handle/range cells still jumpable. A focused "read this one row" companion to the grid.
+ */
+export function renderExplorerDetail(context: ExplorerRenderContext): string {
+  const { explorer: ex, escapeHtml } = context;
+  if (!ex.detail || ex.detail.index == null) return "";
+  const win = ex.windows[ex.detail.index];
+  const row = win?.data?.rows?.find(r => r.rowId === ex.detail?.rowId);
+  if (!row || !win?.data) return "";
+  const cols = win.data.columns || [];
+  const fields = row.cells.map((cell, i) => `
+    <div class="mde-detail-field">
+      <span class="mde-detail-k">${escapeHtml(cols[i]?.name || `col ${i}`)}</span>
+      <span class="mde-detail-v">${renderExplorerCell(cell, cols[i] ?? null, context)}</span>
+    </div>`).join("");
+  return `
+    <aside class="mde-detail">
+      <div class="mde-detail-head">
+        <span class="mde-detail-title">${escapeHtml(win.data.name)} #${row.rowId}</span>
+      </div>
+      <div class="mde-detail-token">token 0x${(row.token >>> 0).toString(16)}</div>
+      <div class="mde-detail-fields">${fields}</div>
+    </aside>`;
+}

--- a/prototypes/inspect-web/test/metadata-viewer.test.js
+++ b/prototypes/inspect-web/test/metadata-viewer.test.js
@@ -363,6 +363,17 @@ test("heap, flags, and malformed cells escape their projected text", () => {
   assert.match(malformed, /bad blob/);
 });
 
+test("flags cells coerce a non-numeric raw value the same way the prior bitwise cast did", () => {
+  const ctx = context();
+  // raw as a numeric string (e.g. round-tripped through JSON) must hex-format identically to
+  // the equivalent number, matching the ">>> 0" coercion this replaced.
+  assert.match(renderExplorerCell({ kind: "flags", raw: "255", decoded: "Public" }, null, ctx), /0xff/);
+  // A missing raw value falls back to 0 rather than throwing or printing "NaN"/"undefined".
+  const missing = renderExplorerCell({ kind: "flags", decoded: "None" }, null, ctx);
+  assert.match(missing, /0x0/);
+  assert.doesNotMatch(missing, /NaN|undefined/);
+});
+
 test("a heap listing addresses #GUID by index and other heaps by byte offset", () => {
   const ctx = context();
   const guid = renderHeapListing({

--- a/prototypes/inspect-web/test/metadata-viewer.test.js
+++ b/prototypes/inspect-web/test/metadata-viewer.test.js
@@ -1,0 +1,446 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  coverageLabel,
+  cssEscape,
+  estimateExplorerPageSize,
+  explorerTableName,
+  EXPLORER_PAGE,
+  heapCoverageNote,
+  heapStreamName,
+  renderAssemblyMetadataBlock,
+  renderExplorerCell,
+  renderExplorerDetail,
+  renderExplorerGrid,
+  renderHeapCard,
+  renderHeapListing,
+  renderMetadataExplorer,
+  renderPackageMetadata,
+  sameFocus,
+} from "../src/metadata-viewer.ts";
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function fmtBytes(value) {
+  return `${value} B`;
+}
+
+const helpers = { escapeHtml, fmtBytes };
+
+function assembly(overrides = {}) {
+  return {
+    assembly: "Contoso.dll",
+    kind: "Managed",
+    isAssembly: true,
+    metadataSize: 4096,
+    metadataVersion: "v4.0.30319",
+    projectedTableTotal: 2,
+    heaps: [
+      { name: "String", sizeInBytes: 1024, maxAddress: 900, addressing: "Offset" },
+      { name: "Guid", sizeInBytes: 16, maxAddress: 1, addressing: "Index" },
+      { name: "Blob", sizeInBytes: 0, maxAddress: 0, addressing: "Offset" },
+    ],
+    tables: [
+      { index: 2, name: "TypeDef", rowCount: 12, isProjected: true },
+      { index: 6, name: "MethodDef", rowCount: 400, isProjected: true },
+      { index: 42, name: "Unmodeled", rowCount: 3, isProjected: false },
+    ],
+    headers: {
+      machine: "Amd64",
+      isPE32Plus: true,
+      subsystem: "WindowsCui",
+      corFlags: "ILOnly",
+      majorRuntimeVersion: 2,
+      minorRuntimeVersion: 5,
+      entryPointToken: 0x06000001,
+    },
+    ...overrides,
+  };
+}
+
+function lensOptions(overrides = {}) {
+  return {
+    isPlatform: false,
+    scopedLibrary: "",
+    activeFramework: "net10.0",
+    pickerHtml: "<div id=picker></div>",
+    fresh: true,
+    loading: false,
+    error: "",
+    metadata: { assemblies: [assembly()] },
+    ...helpers,
+    ...overrides,
+  };
+}
+
+function explorerState(overrides = {}) {
+  return {
+    open: true,
+    assemblyFileName: "Contoso.dll",
+    directory: [
+      { index: 2, name: "TypeDef", rowCount: 12, isProjected: true },
+      { index: 42, name: "Unmodeled", rowCount: 3, isProjected: false },
+    ],
+    heaps: [{ name: "String", streamName: "#Strings", sizeInBytes: 1024, addressing: "Offset" }],
+    windows: {},
+    heapWindows: {},
+    focusIndex: 2,
+    focusHeap: null,
+    highlight: null,
+    detail: null,
+    history: [{ index: 2, rowId: 0 }],
+    historyPos: 0,
+    overview: false,
+    ...overrides,
+  };
+}
+
+function context(overrides = {}) {
+  return { explorer: explorerState(overrides), ...helpers };
+}
+
+// -- Metadata lens ---------------------------------------------------------------------------
+
+test("the metadata lens asks the platform to pick a library before reading an image", () => {
+  const html = renderPackageMetadata(lensOptions({ isPlatform: true, scopedLibrary: "" }));
+  assert.match(html, /Pick a library to inspect/);
+  assert.match(html, /id=picker/);
+});
+
+test("the metadata lens reports loading and failure only for the current scope", () => {
+  const loading = renderPackageMetadata(lensOptions({ loading: true, metadata: null }));
+  assert.match(loading, /Reading metadata…/);
+
+  const failed = renderPackageMetadata(lensOptions({ error: "boom & <bang>", metadata: null }));
+  assert.match(failed, /Metadata read failed/);
+  assert.match(failed, /boom &amp; &lt;bang&gt;/);
+
+  // A stale key means the loaded image belongs to a different scope, so neither the error nor
+  // the result may be shown as this scope's answer.
+  const stale = renderPackageMetadata(lensOptions({ fresh: false, error: "boom" }));
+  assert.match(stale, /Loading…/);
+  assert.doesNotMatch(stale, /boom/);
+});
+
+test("the metadata lens surfaces a partial-read warning alongside the image", () => {
+  const html = renderPackageMetadata(lensOptions({
+    metadata: { assemblies: [assembly()], inspectionError: "Native.dll unreadable" },
+  }));
+  assert.match(html, /Some assemblies could not be read/);
+  assert.match(html, /Native\.dll unreadable/);
+  assert.match(html, /1 assembly · net10\.0/);
+});
+
+test("the metadata lens reports an image with no ECMA-335 metadata", () => {
+  const html = renderPackageMetadata(lensOptions({ metadata: { assemblies: [] } }));
+  assert.match(html, /No metadata images/);
+});
+
+test("an assembly block lists non-empty heaps and tables sorted by row count", () => {
+  const html = renderAssemblyMetadataBlock(assembly(), helpers);
+  // The empty #Blob heap is omitted; #Strings and #GUID keep their ECMA-335 spellings.
+  assert.match(html, /#Strings/);
+  assert.match(html, /#GUID/);
+  assert.doesNotMatch(html, /#Blob/);
+  assert.match(html, /data-mde-open-heap="Contoso\.dll\|String"/);
+
+  const typeDefAt = html.indexOf("TypeDef");
+  const methodDefAt = html.indexOf("MethodDef");
+  assert.ok(methodDefAt > 0 && methodDefAt < typeDefAt, "tables sort by descending row count");
+  assert.match(html, /data-mde-open="Contoso\.dll\|2"/);
+  assert.match(html, /meta-table-unprojected/);
+  assert.match(html, /2\/3 populated/);
+  assert.match(html, /v2\.5 · ILOnly · entry 0x6000001/);
+  assert.match(html, /Amd64 · PE32\+/);
+});
+
+// -- Pure derivation ---------------------------------------------------------------------------
+
+test("heap stream names match the product's ECMA-335 spelling", () => {
+  assert.equal(heapStreamName("String"), "#Strings");
+  assert.equal(heapStreamName("Blob"), "#Blob");
+  assert.equal(heapStreamName("Guid"), "#GUID");
+  assert.equal(heapStreamName("UserString"), "#US");
+  assert.equal(heapStreamName("Future"), "#Future");
+});
+
+test("focus identity compares heaps by name and tables by index, ignoring the row", () => {
+  assert.equal(sameFocus({ index: 2, rowId: 1 }, { index: 2, rowId: 9 }), true);
+  assert.equal(sameFocus({ index: 2 }, { index: 3 }), false);
+  assert.equal(sameFocus({ heap: "String" }, { heap: "String" }), true);
+  // A heap and a table are never the same place, even when the table index is absent.
+  assert.equal(sameFocus({ heap: "String" }, { index: 2 }), false);
+  assert.equal(sameFocus(null, { index: 2 }), false);
+});
+
+test("an unknown table index falls back to its numeric name", () => {
+  const directory = [{ index: 2, name: "TypeDef", rowCount: 1, isProjected: true }];
+  assert.equal(explorerTableName(directory, 2), "TypeDef");
+  assert.equal(explorerTableName(directory, 9), "#9");
+  assert.equal(explorerTableName(undefined, 9), "#9");
+});
+
+test("the page-size estimate stays within its bounds for tiny and huge viewports", () => {
+  assert.equal(estimateExplorerPageSize(200), 30);
+  assert.equal(estimateExplorerPageSize(1_000_000), 400);
+  assert.ok(estimateExplorerPageSize(900) > EXPLORER_PAGE / 2);
+});
+
+test("heap names are escaped for use inside an attribute selector", () => {
+  assert.equal(cssEscape('a"b\\c'), 'a\\"b\\\\c');
+});
+
+test("coverage labels state the answer's completeness", () => {
+  assert.equal(coverageLabel("Complete"), "every entry");
+  assert.equal(coverageLabel("ReferencedOnly"), "referenced only");
+  assert.equal(coverageLabel("NotEnumerable"), "not enumerable");
+  assert.equal(coverageLabel("Novel"), "Novel");
+});
+
+test("a not-enumerable heap reports a blind spot rather than an empty heap", () => {
+  const note = heapCoverageNote(
+    { heap: "UserString", streamName: "#US", coverage: "NotEnumerable" },
+    escapeHtml);
+  assert.match(note, /blind spot, not an empty heap/);
+  assert.match(note, /#US/);
+});
+
+test("truncation caveats accumulate onto the coverage note", () => {
+  const note = heapCoverageNote(
+    {
+      heap: "String",
+      streamName: "#Strings",
+      coverage: "ReferencedOnly",
+      rowsTruncated: true,
+      entriesTruncated: true,
+    },
+    escapeHtml);
+  assert.match(note, /Only entries a projected table row points at are listed/);
+  assert.match(note, /some references are uncounted/);
+  assert.match(note, /entry budget cut the listing short/);
+});
+
+// -- Metadata Explorer ------------------------------------------------------------------------
+
+test("the explorer renders table and heap chips with the focused one active", () => {
+  const html = renderMetadataExplorer(context());
+  assert.match(html, /data-mde-chip="2"[^>]*/);
+  assert.match(html, /class="mde-chip active [^"]*" data-mde-chip="2"/);
+  assert.match(html, /mde-chip-unprojected/);
+  assert.match(html, /data-mde-heap-chip="String"/);
+  assert.match(html, /Contoso\.dll/);
+});
+
+test("the explorer disables history buttons at the ends of the stack", () => {
+  const start = renderMetadataExplorer(context());
+  assert.match(start, /id="mde-hist-back" class="mde-navbtn" disabled/);
+  assert.match(start, /id="mde-hist-fwd" class="mde-navbtn" disabled/);
+
+  const middle = renderMetadataExplorer(context({
+    history: [{ index: 2 }, { index: 42 }, { index: 2 }],
+    historyPos: 1,
+  }));
+  assert.doesNotMatch(middle, /id="mde-hist-back" class="mde-navbtn" disabled/);
+  assert.doesNotMatch(middle, /id="mde-hist-fwd" class="mde-navbtn" disabled/);
+});
+
+test("the overview drops the focus lightbox and opens the wall", () => {
+  const focused = renderMetadataExplorer(context());
+  assert.match(focused, /mde-focus/);
+  assert.match(focused, /click a ref to jump/);
+
+  const overview = renderMetadataExplorer(context({ overview: true }));
+  assert.doesNotMatch(overview, /mde-focus/);
+  assert.match(overview, /mde-wall-open/);
+  assert.match(overview, /click a table to focus/);
+});
+
+test("an unloaded table card carries the lazy-load hook the observer binds to", () => {
+  const html = renderMetadataExplorer(context());
+  assert.match(html, /data-mde-needs-load="2"/);
+  assert.match(html, /data-mde-heap-needs-load="String"/);
+});
+
+test("an unprojected table states it is unmodeled instead of loading rows", () => {
+  const html = renderMetadataExplorer(context());
+  assert.match(html, /not modeled by the projection yet/);
+  assert.doesNotMatch(html, /data-mde-needs-load="42"/);
+});
+
+test("a loaded table card pages within its row count", () => {
+  const data = {
+    index: 2,
+    name: "TypeDef",
+    rowCount: 12,
+    startRowId: 5,
+    columns: [{ name: "Name", kind: "String" }],
+    rows: [
+      { rowId: 5, token: 0x02000005, cells: [{ kind: "scalar", display: "Alpha" }] },
+      { rowId: 6, token: 0x02000006, cells: [{ kind: "scalar", display: "Beta" }] },
+    ],
+  };
+  const html = renderMetadataExplorer(context({
+    windows: { 2: { loading: false, error: "", data } },
+  }));
+  assert.match(html, /rows 5–6 of 12/);
+  assert.match(html, /data-mde-page="2:3"/);
+  assert.match(html, /data-mde-page="2:7"/);
+  assert.doesNotMatch(html, /data-mde-page="2:3" disabled/);
+});
+
+test("a table window error is shown rather than an empty grid", () => {
+  const html = renderMetadataExplorer(context({
+    windows: { 2: { loading: false, error: "table read failed", data: null } },
+  }));
+  assert.match(html, /mde-card-error/);
+  assert.match(html, /table read failed/);
+});
+
+test("the grid marks the highlighted and selected rows", () => {
+  const data = {
+    index: 2,
+    name: "TypeDef",
+    rowCount: 2,
+    startRowId: 1,
+    columns: [{ name: "Name", kind: "String" }],
+    rows: [
+      { rowId: 1, token: 0x02000001, cells: [{ kind: "scalar", display: "Alpha" }] },
+      { rowId: 2, token: 0x02000002, cells: [{ kind: "scalar", display: "Beta" }] },
+    ],
+  };
+  const html = renderExplorerGrid(data, context({
+    highlight: { index: 2, rowId: 1 },
+    detail: { index: 2, rowId: 2 },
+  }));
+  assert.match(html, /data-mde-row="2:1"/);
+  assert.match(html, /mde-row-hot/);
+  assert.match(html, /mde-row-sel/);
+  assert.match(html, /token 0x2000001/);
+});
+
+test("handle and range cells render as ref->def jumps naming the target table", () => {
+  const ctx = context();
+  const handle = renderExplorerCell(
+    { kind: "handle", targetTable: 2, targetRowId: 7 }, null, ctx);
+  assert.match(handle, /data-mde-jump="2:7"/);
+  assert.match(handle, /TypeDef #7/);
+
+  const range = renderExplorerCell(
+    { kind: "range", targetTable: 2, startRowId: 3, endRowId: 5, count: 3 }, null, ctx);
+  assert.match(range, /data-mde-jump="2:3"/);
+  assert.match(range, /TypeDef #3‥5/);
+});
+
+test("empty handle and range cells are nil rather than dead jumps", () => {
+  const ctx = context();
+  assert.match(renderExplorerCell({ kind: "handle", targetRowId: 0 }, null, ctx), /mde-nil">nil</);
+  assert.match(renderExplorerCell({ kind: "range", count: 0 }, null, ctx), /mde-nil">empty</);
+  assert.match(renderExplorerCell({ kind: "nil" }, null, ctx), /mde-nil/);
+  assert.equal(renderExplorerCell(null, null, ctx), "");
+  assert.equal(renderExplorerCell({ kind: "unknown-kind" }, null, ctx), "");
+});
+
+test("heap, flags, and malformed cells escape their projected text", () => {
+  const ctx = context();
+  const heap = renderExplorerCell(
+    { kind: "heap", heap: "String", offset: 4, length: 6, text: "<hi>", truncated: true },
+    null, ctx);
+  assert.match(heap, /&lt;hi&gt;…/);
+  assert.match(heap, /mde-heap-string/);
+
+  const flags = renderExplorerCell({ kind: "flags", raw: 255, decoded: "Public" }, null, ctx);
+  assert.match(flags, /0xff/);
+  assert.match(flags, /Public/);
+
+  const malformed = renderExplorerCell({ kind: "malformed", detail: "bad blob" }, null, ctx);
+  assert.match(malformed, /mde-cell-malformed/);
+  assert.match(malformed, /bad blob/);
+});
+
+test("a heap listing addresses #GUID by index and other heaps by byte offset", () => {
+  const ctx = context();
+  const guid = renderHeapListing({
+    heap: "Guid",
+    streamName: "#GUID",
+    coverage: "Complete",
+    entries: [{ offset: 1, referenceCount: 2, value: { kind: "scalar", display: "abc" } }],
+  }, ctx);
+  assert.match(guid, /#1</);
+  assert.match(guid, /GUID index/);
+
+  const strings = renderHeapListing({
+    heap: "String",
+    streamName: "#Strings",
+    coverage: "ReferencedOnly",
+    entries: [{ offset: 255, referenceCount: 1, value: { kind: "heap", heap: "String", text: "n", length: 1 } }],
+  }, ctx);
+  assert.match(strings, /0xff</);
+  assert.match(strings, /data-mde-heap-row="String:255"/);
+  assert.match(strings, /1×/);
+});
+
+test("a not-enumerable heap listing is the coverage note alone", () => {
+  const html = renderHeapListing(
+    { heap: "UserString", streamName: "#US", coverage: "NotEnumerable", entries: [] },
+    context());
+  assert.match(html, /blind spot/);
+  assert.doesNotMatch(html, /mde-grid-scroll/);
+});
+
+test("a heap card badges its coverage once the listing loads", () => {
+  const heap = { name: "String", streamName: "#Strings", sizeInBytes: 1024, addressing: "Offset" };
+  const html = renderHeapCard(heap, context({
+    focusHeap: "String",
+    heapWindows: {
+      String: {
+        loading: false,
+        error: "",
+        data: { heap: "String", streamName: "#Strings", coverage: "ReferencedOnly", entries: [] },
+      },
+    },
+  }));
+  assert.match(html, /mde-cov-referencedonly/);
+  assert.match(html, /referenced only/);
+  assert.match(html, /mde-card-focus/);
+});
+
+test("the row inspector renders the selected row's cells and stays empty without one", () => {
+  const data = {
+    index: 2,
+    name: "TypeDef",
+    rowCount: 1,
+    startRowId: 1,
+    columns: [{ name: "Name", kind: "String" }, { name: "Extends", kind: "Handle" }],
+    rows: [{
+      rowId: 1,
+      token: 0x02000001,
+      cells: [
+        { kind: "scalar", display: "Alpha" },
+        { kind: "handle", targetTable: 2, targetRowId: 2 },
+      ],
+    }],
+  };
+  const detailed = renderExplorerDetail(context({
+    detail: { index: 2, rowId: 1 },
+    windows: { 2: { loading: false, error: "", data } },
+  }));
+  assert.match(detailed, /TypeDef #1/);
+  assert.match(detailed, /token 0x2000001/);
+  assert.match(detailed, /Extends/);
+  assert.match(detailed, /data-mde-jump="2:2"/);
+
+  assert.equal(renderExplorerDetail(context()), "");
+  // A selected row outside the loaded window has nothing to inspect yet.
+  assert.equal(
+    renderExplorerDetail(context({
+      detail: { index: 2, rowId: 99 },
+      windows: { 2: { loading: false, error: "", data } },
+    })),
+    "");
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -128,7 +128,11 @@ const typePanelSource = readFileSync(
 const packageBarSource = readFileSync(
   new URL("../src/package-bar.ts", import.meta.url),
   "utf8");
-const applicationSources = `${appSource}\n${graphSource}\n${packageBarSource}`;
+const metadataViewerSource = readFileSync(
+  new URL("../src/metadata-viewer.ts", import.meta.url),
+  "utf8");
+const applicationSources =
+  `${appSource}\n${graphSource}\n${packageBarSource}\n${metadataViewerSource}`;
 const stylesSource = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
 const engineSource = readFileSync(
   new URL("../engine/wwwroot/engine.js", import.meta.url),


### PR DESCRIPTION
## Conclusion

The Metadata lens (the image-level summary of each assembly — format stamp, heap sizes, ECMA-335 table row counts, PE/CLI headers) and the Metadata Explorer (the spatial table/heap drill-down laid over it) are now one TypeScript module, `prototypes/inspect-web/src/metadata-viewer.ts`. Both views describe the metadata image rather than the API surface within it, so they share a module the way `src/type-panel.ts` combines the type selector and the type viewer.

## What moved, and what stayed

`metadata-viewer.ts` owns markup and pure derivation only, with explicit exported interfaces for every shape it renders:

- Lens: `renderPackageMetadata` (picker, loading, failure, stale-scope, partial-read, empty-image, and loaded states) and `renderAssemblyMetadataBlock`.
- Explorer: `renderMetadataExplorer`, `renderExplorerFocusPanel`, `renderExplorerCard`, `renderExplorerGrid`, `renderExplorerCell`, `renderExplorerDetail`, `renderHeapCard`, `renderHeapListing`, `renderHeapValueCell`.
- Derivation: `EXPLORER_PAGE`, `EXPLORER_ROW_H`, `estimateExplorerPageSize`, `heapStreamName`, `sameFocus`, `explorerTableName`, `coverageLabel`, `heapCoverageNote`, `cssEscape`.

`app.js` keeps everything that is not markup: `state`, the engine calls that fetch an image, a table row window, or a heap listing (`loadPackageMetadata`, `loadExplorerWindow`, `loadExplorerHeap`), the focus/history stack (`openExplorer`, `pushExplorerFocus`, `applyExplorerFocus`, `explorerHistoryBack/Forward`, `explorerShowOverview`, `closeExplorer`), the DOM event binding, the `IntersectionObserver` that hydrates cards lazily, the resize listener, and the global keydown handler.

This follows the `type-panel.ts` precedent rather than the `package-bar.ts` factory: the explorer owns real module-level effects (`explorerObserver`, `explorerResizeBound`), a history-stack interaction model, and network loading, and `type-panel.ts` already showed that comparably rich navigation state belongs in `app.js` with only rendering extracted. Forcing observers, history, and engine calls into a `create*(options)` contract would have moved authority, not just markup. No new factory was introduced.

The shared helpers stay in `app.js` and are injected, not duplicated: `escapeHtml`, `fmtBytes`, and (via a precomputed `pickerHtml`/`scopedLibrary`/`fresh` snapshot) `platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`, `platformPackForAssembly`.

## Validation

- `npm test` (typecheck + `node --test`): **102 passing before**, **130 passing after**, 0 failing. The 28 new tests are `test/metadata-viewer.test.js`.
- `npm run build` (typecheck + `vite build` + site-artifact verification): clean, 17 modules transformed.
- `npx markdownlint-cli README.md`: no new findings; only the file's pre-existing MD013 line-length reports remain, none on the added lines.
- `test/spotlight-identity.test.js`'s `applicationSources` bundle-inclusion list now includes `metadata-viewer.ts`, so the extracted markup stays under the identity gates (the omission previously found for `package-bar.ts`).

## Boundary / non-action

No behavior change is intended: the extracted markup is byte-for-byte the previous template output, and every `data-mde-*` attribute remains the binding contract `app.js` binds against. No engine, workspace, or navigation authority moved.

This is a non-trivial extraction across a ~800-line region with live DOM-binding contracts, so it needs a full adversarial review round.