### PR TITLE
Convert inspect-web doc viewer to TypeScript

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -582,6 +582,16 @@ enablement, overview versus focus lightbox, lazy-load hooks, pager bounds, row
 highlight and selection, ref->def jump targets, cell escaping, heap addressing
 and coverage notes, and the row inspector.
 
+`src/doc-viewer.ts` owns the package document modal (the Markdown reader
+opened from a package's documents list) as a pure, dependency-injected render
+function. `app.js` still owns `state`, fetching and rendering the document's
+Markdown and frontmatter, and the sequence-guarded async load/close
+lifecycle, and passes each computed slice in explicitly. `test/doc-viewer.test.js`
+gates the closed/no-document fallback, loading and error states, the
+frontmatter card's presence and fields, and title/subtitle/frontmatter-name
+escaping (the rendered document body is trusted, pre-sanitized Markdown HTML
+and is not escaped).
+
 - `Cmd/Ctrl+K` focuses the persistent command prompt.
 - `Cmd/Ctrl+F` or `/` focuses the type filter.
 - Arrow keys select a completion, `Tab` accepts it, and `Enter` runs it.

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -47,6 +47,7 @@ import {
 import { buildAnnotatedView, factsForNode, MEDIA, MEDIUM_LABELS, nodeAtOffset } from "/src/annotated-source-view.ts";
 import { createCommandBar } from "/src/command-bar.ts";
 import { renderScopeBar as renderScopeBarPure } from "/src/scope-bar.ts";
+import { renderDocViewer as renderDocViewerPure } from "/src/doc-viewer.ts";
 import {
   renderMemberNav,
   renderTypeMetadata,
@@ -6597,31 +6598,14 @@ function closeDocViewer() {
 }
 
 function renderDocViewer() {
-  const doc = state.docViewer;
-  const title = doc ? `${doc.name}` : "Document";
-  const subtitle = doc ? doc.path : "";
-  const meta = state.docViewerMeta;
-  const metaCard = meta
-    ? `<div class="doc-frontmatter">
-        <div class="doc-fm-head"><strong>${escapeHtml(meta.name)}</strong>${meta.version ? `<span class="doc-fm-version">v${escapeHtml(meta.version)}</span>` : ""}</div>
-        ${meta.descriptionHtml ? `<p class="doc-fm-desc">${meta.descriptionHtml}</p>` : ""}
-      </div>`
-    : "";
-  const body = state.docViewerLoading
-    ? `<div class="doc-viewer-status">Loading ${escapeHtml(title)}…</div>`
-    : state.docViewerError
-      ? `<div class="doc-viewer-status error">${escapeHtml(state.docViewerError)}</div>`
-      : `${metaCard}<article class="markdown-body">${state.docViewerHtml}</article>`;
-  return `
-    <div class="doc-viewer-backdrop" id="doc-viewer-backdrop">
-      <div class="doc-viewer" role="dialog" aria-modal="true" aria-label="Package document">
-        <div class="doc-viewer-head">
-          <span class="doc-viewer-title">${escapeHtml(title)}<small>${escapeHtml(subtitle)}</small></span>
-          <button id="doc-viewer-close" type="button" aria-label="Close">esc</button>
-        </div>
-        <div class="doc-viewer-body">${body}</div>
-      </div>
-    </div>`;
+  return renderDocViewerPure({
+    doc: state.docViewer,
+    meta: state.docViewerMeta,
+    loading: state.docViewerLoading,
+    error: state.docViewerError,
+    html: state.docViewerHtml,
+    escapeHtml,
+  });
 }
 
 // The decompiler style ("taste") catalog, grouped by tier, as checkbox rows. Shared by the

--- a/prototypes/inspect-web/src/doc-viewer.ts
+++ b/prototypes/inspect-web/src/doc-viewer.ts
@@ -1,0 +1,46 @@
+export interface DocViewerDocument {
+  name: string;
+  path: string;
+}
+
+export interface DocViewerMeta {
+  name: string;
+  version: string;
+  descriptionHtml: string;
+}
+
+export interface RenderDocViewerOptions {
+  doc: DocViewerDocument | null;
+  meta: DocViewerMeta | null;
+  loading: boolean;
+  error: string;
+  html: string;
+  escapeHtml: (value: unknown) => string;
+}
+
+export function renderDocViewer(options: RenderDocViewerOptions): string {
+  const { doc, meta, loading, error, html, escapeHtml } = options;
+  const title = doc ? `${doc.name}` : "Document";
+  const subtitle = doc ? doc.path : "";
+  const metaCard = meta
+    ? `<div class="doc-frontmatter">
+        <div class="doc-fm-head"><strong>${escapeHtml(meta.name)}</strong>${meta.version ? `<span class="doc-fm-version">v${escapeHtml(meta.version)}</span>` : ""}</div>
+        ${meta.descriptionHtml ? `<p class="doc-fm-desc">${meta.descriptionHtml}</p>` : ""}
+      </div>`
+    : "";
+  const body = loading
+    ? `<div class="doc-viewer-status">Loading ${escapeHtml(title)}…</div>`
+    : error
+      ? `<div class="doc-viewer-status error">${escapeHtml(error)}</div>`
+      : `${metaCard}<article class="markdown-body">${html}</article>`;
+  return `
+    <div class="doc-viewer-backdrop" id="doc-viewer-backdrop">
+      <div class="doc-viewer" role="dialog" aria-modal="true" aria-label="Package document">
+        <div class="doc-viewer-head">
+          <span class="doc-viewer-title">${escapeHtml(title)}<small>${escapeHtml(subtitle)}</small></span>
+          <button id="doc-viewer-close" type="button" aria-label="Close">esc</button>
+        </div>
+        <div class="doc-viewer-body">${body}</div>
+      </div>
+    </div>`;
+}

--- a/prototypes/inspect-web/test/doc-viewer.test.js
+++ b/prototypes/inspect-web/test/doc-viewer.test.js
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderDocViewer } from "../src/doc-viewer.ts";
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const doc = { name: "CHANGELOG.md", path: "docs/CHANGELOG.md" };
+
+test("closed viewer with no document falls back to a generic title and empty subtitle", () => {
+  const html = renderDocViewer({
+    doc: null,
+    meta: null,
+    loading: false,
+    error: "",
+    html: "",
+    escapeHtml,
+  });
+
+  assert.match(html, /<span class="doc-viewer-title">Document<small><\/small><\/span>/);
+});
+
+test("loading state shows a loading status scoped to the document title, not the body", () => {
+  const html = renderDocViewer({
+    doc,
+    meta: null,
+    loading: true,
+    error: "unused while loading",
+    html: "<p>unused while loading</p>",
+    escapeHtml,
+  });
+
+  assert.match(html, /doc-viewer-status">Loading CHANGELOG\.md…/);
+  assert.doesNotMatch(html, /unused while loading/);
+});
+
+test("error state reports the error instead of loading or body content", () => {
+  const html = renderDocViewer({
+    doc,
+    meta: null,
+    loading: false,
+    error: "network error",
+    html: "<p>unused on error</p>",
+    escapeHtml,
+  });
+
+  assert.match(html, /doc-viewer-status error">network error/);
+  assert.doesNotMatch(html, /unused on error/);
+});
+
+test("loaded state without frontmatter renders the body with no frontmatter card", () => {
+  const html = renderDocViewer({
+    doc,
+    meta: null,
+    loading: false,
+    error: "",
+    html: "<p>Body content.</p>",
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /doc-frontmatter/);
+  assert.match(html, /markdown-body"><p>Body content\.<\/p><\/article>/);
+});
+
+test("loaded state with frontmatter renders the name, version, and description", () => {
+  const html = renderDocViewer({
+    doc,
+    meta: { name: "Changelog", version: "1.2.3", descriptionHtml: "<p>What changed.</p>" },
+    loading: false,
+    error: "",
+    html: "<p>Body content.</p>",
+    escapeHtml,
+  });
+
+  assert.match(html, /doc-frontmatter/);
+  assert.match(html, /<strong>Changelog<\/strong>/);
+  assert.match(html, /doc-fm-version">v1\.2\.3/);
+  assert.match(html, /doc-fm-desc"><p>What changed\.<\/p>/);
+});
+
+test("frontmatter without a version omits the version badge", () => {
+  const html = renderDocViewer({
+    doc,
+    meta: { name: "Changelog", version: "", descriptionHtml: "" },
+    loading: false,
+    error: "",
+    html: "<p>Body content.</p>",
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /doc-fm-version/);
+  assert.doesNotMatch(html, /doc-fm-desc/);
+});
+
+test("the document title and subtitle are escaped", () => {
+  const html = renderDocViewer({
+    doc: { name: "<script>alert(1)</script>", path: "<b>path</b>" },
+    meta: null,
+    loading: false,
+    error: "",
+    html: "",
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /<script>/);
+  assert.doesNotMatch(html, /<b>path<\/b>/);
+  assert.match(html, /&lt;script&gt;/);
+  assert.match(html, /&lt;b&gt;path&lt;\/b&gt;/);
+});
+
+test("frontmatter name is escaped but the description HTML passes through unescaped", () => {
+  const html = renderDocViewer({
+    doc,
+    meta: { name: "<script>alert(1)</script>", version: "", descriptionHtml: "<p>trusted markdown</p>" },
+    loading: false,
+    error: "",
+    html: "",
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /<script>alert/);
+  assert.match(html, /&lt;script&gt;alert/);
+  assert.match(html, /<p>trusted markdown<\/p>/);
+});


### PR DESCRIPTION
Extracts the package document modal (the Markdown reader opened from a package's documents list) from `app.js`'s `renderDocViewer()` into a pure, dependency-injected render function in `prototypes/inspect-web/src/doc-viewer.ts`, following the pattern established by `command-bar.ts` (#4429), `package-bar.ts` (#4434), `type-panel.ts` (#4436), `settings-panel.ts` (#4447), `metadata-viewer.ts` (#4452), and `scope-bar.ts` (#4450).

## What moved

- `renderDocViewer(options)` — pure function taking `doc`, `meta`, `loading`, `error`, `html`, and `escapeHtml`, returning the modal backdrop, header (title/subtitle/close button), and body (loading/error/frontmatter+content).

## What stays in app.js

- `state`, the async `openPackageDocument`/`closeDocViewer` lifecycle (sequence-guarded engine fetch, frontmatter split, Markdown rendering), and the DOM event wiring. A thin wrapper (`renderDocViewer`, kept as the call-site name) assembles the state slice and delegates to the pure `renderDocViewerPure`.

## Tests

Added `test/doc-viewer.test.js` (8 tests): closed/no-document fallback, loading state (scoped to title, not stale body/error), error state, loaded state with/without frontmatter, frontmatter fields (name/version/description), and escaping (title/subtitle/frontmatter-name escaped; the rendered document body is trusted, pre-sanitized Markdown HTML and is intentionally not escaped, confirmed by a dedicated test).

## Validation

- `npm run typecheck` — pass
- `node --test` — 145/145 passing (up from 137; no regressions from extraction)
- `npm run build` — pass
- `npx markdownlint-cli --config .markdownlint.yaml prototypes/inspect-web/README.md` — clean

No behavior change intended; this is a pure refactor/extraction.