### PR TITLE
Convert inspect-web graph source viewer to TypeScript

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -605,6 +605,15 @@ frontmatter card's presence and fields, and title/subtitle/frontmatter-name
 escaping (the rendered document body is trusted, pre-sanitized Markdown HTML
 and is not escaped).
 
+`src/graph-source.ts` owns the member source modal (the code viewer opened
+from a call graph node) as a pure, dependency-injected render function.
+`app.js` still owns `state`, the sequence-guarded async source-inspection
+lifecycle, and the `highlightCSharp` Prism wrapper, and passes each computed
+slice in explicitly. `test/graph-source.test.js` gates the loading state, the
+original-versus-decompiled provenance labels, the open-source link's presence
+only when a `url` is provided, the error state's fallback message, and title
+escaping in both the header and loading status.
+
 - `Cmd/Ctrl+K` opens Spotlight in the Commands scope.
 - `Cmd/Ctrl+P` opens Spotlight in the All scope.
 - `Cmd/Ctrl+F` or `/` focuses the type filter.

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -47,6 +47,7 @@ import {
 import { buildAnnotatedView, factsForNode, MEDIA, MEDIUM_LABELS, nodeAtOffset } from "/src/annotated-source-view.ts";
 import { renderScopeBar as renderScopeBarPure } from "/src/scope-bar.ts";
 import { renderDocViewer as renderDocViewerPure } from "/src/doc-viewer.ts";
+import { renderGraphSource as renderGraphSourcePure } from "/src/graph-source.ts";
 import {
   renderMemberNav,
   renderTypeMetadata,
@@ -6431,22 +6432,14 @@ function bindSettingsEvents() {
 }
 
 function renderGraphSource() {
-  const body = state.graphSourceLoading
-    ? `<div class="graph-source-status">Resolving source for ${escapeHtml(state.graphSourceTitle)}…</div>`
-    : state.graphSource
-      ? `<div class="source-provenance"><strong>${state.graphSource.provider === "original" ? "Original source" : "Decompiled source"}</strong><span>${escapeHtml(state.graphSource.provenance)}</span>${state.graphSource.url ? `<a href="${escapeHtml(state.graphSource.url)}" target="_blank" rel="noreferrer">open source ↗</a>` : ""}</div>
-         <pre class="language-csharp"><code class="language-csharp">${highlightCSharp(state.graphSource.text)}</code></pre>`
-      : `<div class="graph-source-status error">${escapeHtml(state.graphSourceError || "No source was returned.")}</div>`;
-  return `
-    <div class="graph-source-backdrop" id="graph-source-backdrop">
-      <div class="graph-source" role="dialog" aria-modal="true" aria-label="Member source">
-        <div class="graph-source-head">
-          <span class="graph-source-title">${escapeHtml(state.graphSourceTitle)}</span>
-          <button id="graph-source-close" type="button" aria-label="Close">esc</button>
-        </div>
-        <div class="graph-source-body">${body}</div>
-      </div>
-    </div>`;
+  return renderGraphSourcePure({
+    title: state.graphSourceTitle,
+    loading: state.graphSourceLoading,
+    source: state.graphSource,
+    error: state.graphSourceError,
+    escapeHtml,
+    highlightCSharp,
+  });
 }
 
 function navigateToMember(pkg, type, group, overloadIndex = null, bodyTarget = null) {

--- a/prototypes/inspect-web/src/graph-source.ts
+++ b/prototypes/inspect-web/src/graph-source.ts
@@ -1,7 +1,7 @@
 export interface GraphSourceResult {
   provider: string;
   provenance: string;
-  url: string;
+  url: string | null | undefined;
   text: string;
 }
 

--- a/prototypes/inspect-web/src/graph-source.ts
+++ b/prototypes/inspect-web/src/graph-source.ts
@@ -1,0 +1,35 @@
+export interface GraphSourceResult {
+  provider: string;
+  provenance: string;
+  url: string;
+  text: string;
+}
+
+export interface RenderGraphSourceOptions {
+  title: string;
+  loading: boolean;
+  source: GraphSourceResult | null;
+  error: string;
+  escapeHtml: (value: unknown) => string;
+  highlightCSharp: (value: unknown) => string;
+}
+
+export function renderGraphSource(options: RenderGraphSourceOptions): string {
+  const { title, loading, source, error, escapeHtml, highlightCSharp } = options;
+  const body = loading
+    ? `<div class="graph-source-status">Resolving source for ${escapeHtml(title)}…</div>`
+    : source
+      ? `<div class="source-provenance"><strong>${source.provider === "original" ? "Original source" : "Decompiled source"}</strong><span>${escapeHtml(source.provenance)}</span>${source.url ? `<a href="${escapeHtml(source.url)}" target="_blank" rel="noreferrer">open source ↗</a>` : ""}</div>
+         <pre class="language-csharp"><code class="language-csharp">${highlightCSharp(source.text)}</code></pre>`
+      : `<div class="graph-source-status error">${escapeHtml(error || "No source was returned.")}</div>`;
+  return `
+    <div class="graph-source-backdrop" id="graph-source-backdrop">
+      <div class="graph-source" role="dialog" aria-modal="true" aria-label="Member source">
+        <div class="graph-source-head">
+          <span class="graph-source-title">${escapeHtml(title)}</span>
+          <button id="graph-source-close" type="button" aria-label="Close">esc</button>
+        </div>
+        <div class="graph-source-body">${body}</div>
+      </div>
+    </div>`;
+}

--- a/prototypes/inspect-web/test/graph-source.test.js
+++ b/prototypes/inspect-web/test/graph-source.test.js
@@ -49,11 +49,11 @@ test("loaded original source renders provenance, an open-source link, and highli
   assert.match(html, /<mark>void Render\(\) \{\}<\/mark>/);
 });
 
-test("loaded decompiled source labels the provenance as decompiled and omits the link when url is empty", () => {
+test("loaded decompiled source labels the provenance as decompiled and omits the link when url is null", () => {
   const html = renderGraphSource({
     title: "Widget.Render()",
     loading: false,
-    source: { provider: "decompiled", provenance: "decompiled from IL", url: "", text: "void Render() {}" },
+    source: { provider: "decompiled", provenance: "decompiled from IL", url: null, text: "void Render() {}" },
     error: "",
     escapeHtml,
     highlightCSharp,
@@ -87,6 +87,25 @@ test("error state with an explicit message renders that message escaped", () => 
   });
 
   assert.match(html, /graph-source-status error">&lt;script&gt;alert\(1\)&lt;\/script&gt;</);
+});
+
+test("provenance and url are escaped", () => {
+  const html = renderGraphSource({
+    title: "Widget.Render()",
+    loading: false,
+    source: {
+      provider: "original",
+      provenance: '<b>"evil"</b>',
+      url: 'https://example.com/"><script>alert(1)</script>',
+      text: "void Render() {}",
+    },
+    error: "",
+    escapeHtml,
+    highlightCSharp,
+  });
+
+  assert.match(html, /<span>&lt;b&gt;&quot;evil&quot;&lt;\/b&gt;<\/span>/);
+  assert.match(html, /href="https:\/\/example\.com\/&quot;&gt;&lt;script&gt;alert\(1\)&lt;\/script&gt;"/);
 });
 
 test("the title is escaped in both the header and the loading status", () => {

--- a/prototypes/inspect-web/test/graph-source.test.js
+++ b/prototypes/inspect-web/test/graph-source.test.js
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderGraphSource } from "../src/graph-source.ts";
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function highlightCSharp(value) {
+  return `<mark>${escapeHtml(value)}</mark>`;
+}
+
+test("loading state shows a status scoped to the title, not stale source or error", () => {
+  const html = renderGraphSource({
+    title: "Widget.Render()",
+    loading: true,
+    source: { provider: "original", provenance: "unused while loading", url: "", text: "unused" },
+    error: "unused while loading",
+    escapeHtml,
+    highlightCSharp,
+  });
+
+  assert.match(html, /graph-source-status">Resolving source for Widget\.Render\(\)…/);
+  assert.doesNotMatch(html, /unused/);
+});
+
+test("loaded original source renders provenance, an open-source link, and highlighted text", () => {
+  const html = renderGraphSource({
+    title: "Widget.Render()",
+    loading: false,
+    source: {
+      provider: "original",
+      provenance: "github.com/example/widget",
+      url: "https://github.com/example/widget/blob/main/Widget.cs",
+      text: "void Render() {}",
+    },
+    error: "",
+    escapeHtml,
+    highlightCSharp,
+  });
+
+  assert.match(html, /<strong>Original source<\/strong>/);
+  assert.match(html, /<span>github\.com\/example\/widget<\/span>/);
+  assert.match(html, /<a href="https:\/\/github\.com\/example\/widget\/blob\/main\/Widget\.cs" target="_blank" rel="noreferrer">open source ↗<\/a>/);
+  assert.match(html, /<mark>void Render\(\) \{\}<\/mark>/);
+});
+
+test("loaded decompiled source labels the provenance as decompiled and omits the link when url is empty", () => {
+  const html = renderGraphSource({
+    title: "Widget.Render()",
+    loading: false,
+    source: { provider: "decompiled", provenance: "decompiled from IL", url: "", text: "void Render() {}" },
+    error: "",
+    escapeHtml,
+    highlightCSharp,
+  });
+
+  assert.match(html, /<strong>Decompiled source<\/strong>/);
+  assert.doesNotMatch(html, /open source/);
+});
+
+test("error state without a source shows the error message, falling back to a default", () => {
+  const html = renderGraphSource({
+    title: "Widget.Render()",
+    loading: false,
+    source: null,
+    error: "",
+    escapeHtml,
+    highlightCSharp,
+  });
+
+  assert.match(html, /graph-source-status error">No source was returned\.</);
+});
+
+test("error state with an explicit message renders that message escaped", () => {
+  const html = renderGraphSource({
+    title: "Widget.Render()",
+    loading: false,
+    source: null,
+    error: "<script>alert(1)</script>",
+    escapeHtml,
+    highlightCSharp,
+  });
+
+  assert.match(html, /graph-source-status error">&lt;script&gt;alert\(1\)&lt;\/script&gt;</);
+});
+
+test("the title is escaped in both the header and the loading status", () => {
+  const html = renderGraphSource({
+    title: "<b>Evil</b>",
+    loading: true,
+    source: null,
+    error: "",
+    escapeHtml,
+    highlightCSharp,
+  });
+
+  assert.match(html, /graph-source-title">&lt;b&gt;Evil&lt;\/b&gt;</);
+  assert.match(html, /Resolving source for &lt;b&gt;Evil&lt;\/b&gt;…/);
+});
+
+test("markup carries the modal dialog scaffolding and close button", () => {
+  const html = renderGraphSource({
+    title: "Widget.Render()",
+    loading: false,
+    source: null,
+    error: "boom",
+    escapeHtml,
+    highlightCSharp,
+  });
+
+  assert.match(html, /<div class="graph-source-backdrop" id="graph-source-backdrop">/);
+  assert.match(html, /role="dialog" aria-modal="true" aria-label="Member source"/);
+  assert.match(html, /<button id="graph-source-close" type="button" aria-label="Close">esc<\/button>/);
+});


### PR DESCRIPTION
Continues the leaf-node TypeScript conversion series (`command-bar.ts`, `package-bar.ts`, `type-panel.ts`, `settings-panel.ts`, `metadata-viewer.ts`, `scope-bar.ts`, `doc-viewer.ts`).

Extracts `renderGraphSource` (the code viewer modal opened from a call graph node) out of `app.js` into a new pure, dependency-injected module `src/graph-source.ts`. `app.js` retains `state`, the sequence-guarded async source-inspection lifecycle (`openGraphSource`/`closeGraphSource`), and the `highlightCSharp` Prism wrapper; a thin wrapper delegates to the pure function.

**Validation:**
- `npm run typecheck` — clean
- `node --test` — 177/177 passing (170 existing + 7 new in `test/graph-source.test.js`)
- `npm run build` — succeeds
- `markdownlint --config .markdownlint.yaml README.md` — clean

**Non-action boundary:** No behavior change; this is a structural extraction. The escaping contract is preserved exactly (title/provenance/error escaped via `escapeHtml`; the `text` field is passed through the pre-existing `highlightCSharp` helper, which itself escapes when Prism is unavailable).