### PR TITLE
Convert inspect-web annotated source view to TypeScript

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -621,6 +621,16 @@ original-versus-decompiled provenance labels, the open-source link's presence
 only when a `url` is provided, the error state's fallback message, and title
 escaping in both the header and loading status.
 
+`src/annotated-source.ts` owns the annotated source result (the
+fact-annotated C#/IL dual view shown for a member overload) as a pure,
+dependency-injected render function; it composes `annotated-source-view.ts`'s
+`buildAnnotatedView` projection into markup. `app.js` still owns `state`, the
+sequence-guarded async load lifecycle, and the medium-toggle/fact-selection
+event handlers, and passes each computed slice in explicitly.
+`test/annotated-source.test.js` gates the rejected-document fallback, the
+medium toggles and hidden-line count, the context-limitation notice, anchored
+versus unanchored fact rendering, selection state, and source-text escaping.
+
 - `Cmd/Ctrl+K` opens Spotlight in the Commands scope.
 - `Cmd/Ctrl+P` opens Spotlight in the All scope.
 - `Cmd/Ctrl+F` or `/` focuses the type filter.

--- a/prototypes/inspect-web/src/annotated-source.ts
+++ b/prototypes/inspect-web/src/annotated-source.ts
@@ -1,0 +1,68 @@
+import type {
+  AnnotatedSourceDocument,
+  AnnotatedViewState,
+} from "./annotated-source-view.ts";
+import { buildAnnotatedView, MEDIA, MEDIUM_LABELS } from "./annotated-source-view.ts";
+
+export interface AnnotatedSourceResult {
+  document: AnnotatedSourceDocument;
+  provenance: string;
+  contextLimitation?: string;
+}
+
+export interface RenderAnnotatedSourceOptions {
+  result: AnnotatedSourceResult;
+  media: AnnotatedViewState["media"];
+  selectedFactId: AnnotatedViewState["selectedFactId"];
+  selectedNodeIds: AnnotatedViewState["selectedNodeIds"];
+  escapeHtml: (value: unknown) => string;
+}
+
+export function renderAnnotatedSource(options: RenderAnnotatedSourceOptions): string {
+  const { result, media, selectedFactId, selectedNodeIds, escapeHtml } = options;
+  let view;
+  try {
+    view = buildAnnotatedView(result.document, {
+      media,
+      selectedFactId,
+      selectedNodeIds,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `<section class="document-section empty-member-section"><h2>Annotated source document rejected</h2><p>${escapeHtml(message)}</p></section>`;
+  }
+
+  const toggles = MEDIA.map(medium =>
+    `<button type="button" class="annotated-medium${view.media[medium] ? " on" : ""}" data-annotated-medium="${medium}" aria-pressed="${view.media[medium]}">${escapeHtml(MEDIUM_LABELS[medium])}</button>`).join("");
+
+  const lines = view.lines.map(line => {
+    const segments = line.segments.map(segment =>
+      `<span class="annotated-span${segment.selected ? " selected" : ""}" data-annotated-offset="${segment.start}">${escapeHtml(segment.text)}</span>`).join("");
+    return `<div class="annotated-line medium-${line.medium.toLowerCase()}"><span class="annotated-line-number">${line.number}</span><span class="annotated-line-text">${segments || "&nbsp;"}</span></div>`;
+  }).join("");
+
+  const facts = view.facts.length === 0
+    ? `<li class="annotated-fact empty">No facts were observed about this member.</li>`
+    : view.facts.map(fact =>
+      `<li><button type="button" class="annotated-fact${fact.selected ? " selected" : ""}${fact.anchored ? "" : " unanchored"}" data-annotated-fact="${fact.id}">
+          <span class="annotated-fact-descriptor">${escapeHtml(fact.descriptor)}</span>
+          <span class="annotated-fact-category">${escapeHtml(fact.category)}</span>
+          ${fact.detail ? `<span class="annotated-fact-detail">${escapeHtml(fact.detail)}</span>` : ""}
+          <span class="annotated-fact-conditionality">${escapeHtml(fact.conditionality)}</span>
+          <span class="annotated-fact-anchor">${fact.anchored ? `${fact.nodeIds.length} target${fact.nodeIds.length === 1 ? "" : "s"}` : "unanchored"}</span>
+        </button></li>`).join("");
+
+  return `<section class="document-section source-result annotated-result">
+      <div class="source-provenance"><strong>Annotated source</strong><span>${escapeHtml(result.provenance)}</span><button id="copy-annotated" type="button">copy</button></div>
+      ${result.contextLimitation ? `<p class="annotated-limitation">The whole-assembly fact context was narrowed, so this fact list is incomplete: ${escapeHtml(result.contextLimitation)}</p>` : ""}
+      <div class="annotated-controls">
+        <span class="annotated-controls-label">show</span>${toggles}
+        ${view.hiddenLines > 0 ? `<span class="annotated-hidden">${view.hiddenLines} line${view.hiddenLines === 1 ? "" : "s"} hidden</span>` : ""}
+        ${view.selectedFactId !== null || view.selectedNodeIds.length > 0 ? `<button type="button" id="annotated-clear">clear selection</button>` : ""}
+      </div>
+      <div class="annotated-body">
+        <pre class="annotated-text"><code>${lines}</code></pre>
+        <ol class="annotated-facts">${facts}</ol>
+      </div>
+    </section>`;
+}

--- a/prototypes/inspect-web/src/annotated-source.ts
+++ b/prototypes/inspect-web/src/annotated-source.ts
@@ -7,7 +7,7 @@ import { buildAnnotatedView, MEDIA, MEDIUM_LABELS } from "./annotated-source-vie
 export interface AnnotatedSourceResult {
   document: AnnotatedSourceDocument;
   provenance: string;
-  contextLimitation?: string;
+  contextLimitation?: string | null;
 }
 
 export interface RenderAnnotatedSourceOptions {

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -44,10 +44,11 @@ import {
   buildDependencyGraphMermaid,
   buildTypeGraphMermaid
 } from "./graph-mermaid.js";
-import { buildAnnotatedView, factsForNode, MEDIA, MEDIUM_LABELS, nodeAtOffset } from "/src/annotated-source-view.ts";
+import { factsForNode, MEDIA, nodeAtOffset } from "/src/annotated-source-view.ts";
 import { renderScopeBar as renderScopeBarPure } from "/src/scope-bar.ts";
 import { renderDocViewer as renderDocViewerPure } from "/src/doc-viewer.ts";
 import { renderGraphSource as renderGraphSourcePure } from "/src/graph-source.ts";
+import { renderAnnotatedSource as renderAnnotatedSourcePure } from "/src/annotated-source.ts";
 import {
   renderMemberNav,
   renderTypeMetadata,
@@ -3093,50 +3094,13 @@ function renderMember(type, member) {
 // lines from its text buffer, structural segments from its nodes, and the fact -> target -> node ->
 // span walk it defines. Coordinates, validation, and segmentation belong to document-model.js.
 function renderAnnotatedSource(result) {
-  let view;
-  try {
-    view = buildAnnotatedView(result.document, {
-      media: state.memberAnnotatedMedia,
-      selectedFactId: state.memberAnnotatedFactId,
-      selectedNodeIds: state.memberAnnotatedNodeIds
-    });
-  } catch (error) {
-    return `<section class="document-section empty-member-section"><h2>Annotated source document rejected</h2><p>${escapeHtml(String(error?.message || error))}</p></section>`;
-  }
-
-  const toggles = MEDIA.map(medium =>
-    `<button type="button" class="annotated-medium${view.media[medium] ? " on" : ""}" data-annotated-medium="${medium}" aria-pressed="${view.media[medium]}">${escapeHtml(MEDIUM_LABELS[medium])}</button>`).join("");
-
-  const lines = view.lines.map(line => {
-    const segments = line.segments.map(segment =>
-      `<span class="annotated-span${segment.selected ? " selected" : ""}" data-annotated-offset="${segment.start}">${escapeHtml(segment.text)}</span>`).join("");
-    return `<div class="annotated-line medium-${line.medium.toLowerCase()}"><span class="annotated-line-number">${line.number}</span><span class="annotated-line-text">${segments || "&nbsp;"}</span></div>`;
-  }).join("");
-
-  const facts = view.facts.length === 0
-    ? `<li class="annotated-fact empty">No facts were observed about this member.</li>`
-    : view.facts.map(fact =>
-      `<li><button type="button" class="annotated-fact${fact.selected ? " selected" : ""}${fact.anchored ? "" : " unanchored"}" data-annotated-fact="${fact.id}">
-          <span class="annotated-fact-descriptor">${escapeHtml(fact.descriptor)}</span>
-          <span class="annotated-fact-category">${escapeHtml(fact.category)}</span>
-          ${fact.detail ? `<span class="annotated-fact-detail">${escapeHtml(fact.detail)}</span>` : ""}
-          <span class="annotated-fact-conditionality">${escapeHtml(fact.conditionality)}</span>
-          <span class="annotated-fact-anchor">${fact.anchored ? `${fact.nodeIds.length} target${fact.nodeIds.length === 1 ? "" : "s"}` : "unanchored"}</span>
-        </button></li>`).join("");
-
-  return `<section class="document-section source-result annotated-result">
-      <div class="source-provenance"><strong>Annotated source</strong><span>${escapeHtml(result.provenance)}</span><button id="copy-annotated" type="button">copy</button></div>
-      ${result.contextLimitation ? `<p class="annotated-limitation">The whole-assembly fact context was narrowed, so this fact list is incomplete: ${escapeHtml(result.contextLimitation)}</p>` : ""}
-      <div class="annotated-controls">
-        <span class="annotated-controls-label">show</span>${toggles}
-        ${view.hiddenLines > 0 ? `<span class="annotated-hidden">${view.hiddenLines} line${view.hiddenLines === 1 ? "" : "s"} hidden</span>` : ""}
-        ${view.selectedFactId !== null || view.selectedNodeIds.length > 0 ? `<button type="button" id="annotated-clear">clear selection</button>` : ""}
-      </div>
-      <div class="annotated-body">
-        <pre class="annotated-text"><code>${lines}</code></pre>
-        <ol class="annotated-facts">${facts}</ol>
-      </div>
-    </section>`;
+  return renderAnnotatedSourcePure({
+    result,
+    media: state.memberAnnotatedMedia,
+    selectedFactId: state.memberAnnotatedFactId,
+    selectedNodeIds: state.memberAnnotatedNodeIds,
+    escapeHtml,
+  });
 }
 
 function renderMemberFacts(type, member, overload, overloadIndex) {

--- a/prototypes/inspect-web/test/annotated-source.test.js
+++ b/prototypes/inspect-web/test/annotated-source.test.js
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderAnnotatedSource } from "../src/annotated-source.ts";
+import { sampleDocument } from "../../annotated-source-viewer/src/sample-document.js";
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const result = { document: sampleDocument, provenance: "decompiled from IL" };
+
+test("an invalid document is rejected with a message instead of throwing", () => {
+  const html = renderAnnotatedSource({
+    result: { ...result, document: { ...sampleDocument, targets: [{ fact_id: 0, node_id: 99 }] } },
+    media: undefined,
+    selectedFactId: null,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.match(html, /Annotated source document rejected/);
+  assert.match(html, /names a node that does not exist/);
+});
+
+test("both media render by default with provenance and a copy button", () => {
+  const html = renderAnnotatedSource({
+    result,
+    media: undefined,
+    selectedFactId: null,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.match(html, /<strong>Annotated source<\/strong><span>decompiled from IL<\/span>/);
+  assert.match(html, /<button id="copy-annotated" type="button">copy<\/button>/);
+  assert.match(html, /medium-csharp/);
+  assert.match(html, /medium-il/);
+});
+
+test("hiding a medium reports the hidden-line count", () => {
+  const html = renderAnnotatedSource({
+    result,
+    media: { CSharp: true, Il: false },
+    selectedFactId: null,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.match(html, /annotated-hidden">2 lines hidden</);
+  assert.doesNotMatch(html, /medium-il/);
+});
+
+test("a context limitation renders its narrowing message, escaped", () => {
+  const html = renderAnnotatedSource({
+    result: { ...result, contextLimitation: "<b>partial</b> assembly" },
+    media: undefined,
+    selectedFactId: null,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.match(html, /annotated-limitation">The whole-assembly fact context was narrowed, so this fact list is incomplete: &lt;b&gt;partial&lt;\/b&gt; assembly</);
+});
+
+test("no context limitation renders no narrowing message", () => {
+  const html = renderAnnotatedSource({
+    result,
+    media: undefined,
+    selectedFactId: null,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /annotated-limitation/);
+});
+
+test("facts render their descriptor, category, detail, and anchored target count", () => {
+  const html = renderAnnotatedSource({
+    result,
+    media: undefined,
+    selectedFactId: null,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.match(html, /annotated-fact-descriptor">alloc\.new</);
+  assert.match(html, /annotated-fact-category">Allocation</);
+  assert.match(html, /annotated-fact-detail">object</);
+  assert.match(html, /annotated-fact-anchor">2 targets</);
+});
+
+test("an unanchored fact is marked unanchored rather than given a target count", () => {
+  const html = renderAnnotatedSource({
+    result,
+    media: undefined,
+    selectedFactId: null,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.match(html, /annotated-fact unanchored" data-annotated-fact="2"/);
+  assert.match(html, /annotated-fact-anchor">unanchored</);
+});
+
+test("selecting a fact marks it selected and shows a clear-selection control", () => {
+  const html = renderAnnotatedSource({
+    result,
+    media: undefined,
+    selectedFactId: 0,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.match(html, /annotated-fact selected" data-annotated-fact="0"/);
+  assert.match(html, /<button type="button" id="annotated-clear">clear selection<\/button>/);
+});
+
+test("with no selection, no clear-selection control is shown", () => {
+  const html = renderAnnotatedSource({
+    result,
+    media: undefined,
+    selectedFactId: null,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /annotated-clear/);
+});
+
+test("source text is escaped as it is rendered into spans", () => {
+  const html = renderAnnotatedSource({
+    result: {
+      document: {
+        ...sampleDocument,
+        text: "<script>alert(1)</script>",
+        nodes: [],
+        regions: [],
+        facts: [],
+        targets: [],
+      },
+      provenance: "decompiled from IL",
+    },
+    media: undefined,
+    selectedFactId: null,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.doesNotMatch(html, /<script>alert/);
+});

--- a/prototypes/inspect-web/test/annotated-source.test.js
+++ b/prototypes/inspect-web/test/annotated-source.test.js
@@ -78,6 +78,18 @@ test("no context limitation renders no narrowing message", () => {
   assert.doesNotMatch(html, /annotated-limitation/);
 });
 
+test("an explicit null context limitation (as the backend serializes an absent narrowing) renders no narrowing message", () => {
+  const html = renderAnnotatedSource({
+    result: { ...result, contextLimitation: null },
+    media: undefined,
+    selectedFactId: null,
+    selectedNodeIds: [],
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /annotated-limitation/);
+});
+
 test("facts render their descriptor, category, detail, and anchored target count", () => {
   const html = renderAnnotatedSource({
     result,


### PR DESCRIPTION
Continues the leaf-node TypeScript conversion series (`command-bar.ts`, `package-bar.ts`, `type-panel.ts`, `settings-panel.ts`, `metadata-viewer.ts`, `scope-bar.ts`, `doc-viewer.ts`, `graph-source.ts`).

Extracts `renderAnnotatedSource` (the fact-annotated C#/IL dual view shown for a member overload, with medium toggles and a fact list) out of `app.js` into a new pure, dependency-injected module `src/annotated-source.ts`. It composes the existing `annotated-source-view.ts` `buildAnnotatedView` projection into markup. `app.js` retains `state`, the sequence-guarded async load lifecycle, and the medium-toggle/fact-selection event handlers; a thin wrapper delegates to the pure function.

As part of this extraction, `app.js`'s import from `annotated-source-view.ts` drops the now-unused `buildAnnotatedView`/`MEDIUM_LABELS` (moved into the new module) and keeps only `MEDIA`/`factsForNode`/`nodeAtOffset`, which are still used by `app.js`'s own event handlers.

**Validation:**
- `npm run typecheck` — clean
- `node --test` — 189/189 passing (179 existing + 10 new in `test/annotated-source.test.js`)
- `npm run build` — succeeds
- `markdownlint --config .markdownlint.yaml README.md` — clean

**Non-action boundary:** No behavior change; this is a structural extraction. The rejected-document fallback, medium visibility, fact anchoring/selection, and escaping behavior are preserved exactly.
