### PR TITLE
Pin reader-construction sites instead of factory signatures

### DIFF
--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -361,17 +361,29 @@ unboundedly many cosmetic dimensions. Three consecutive review rounds on the
 fix escaped it along a different one each time: the method name, then the
 declared return type, then visibility and `Task` wrapping (issue #4464).
 `ReaderConstructionSiteTests.TrustRelevantSites_MatchThePin` replaces that with
-an observation the escapes cannot reach. It reads the compiled IL of
-`ILInspector.Decompiler` and pins every method that constructs a `PEReader` or
-calls a grant on `CoreLibraryIdentityTrust`, so a site is visible whatever it
-is called, however it is declared, and whether or not its result is wrapped.
-Both directions fail: an unpinned site is an unreviewed way to obtain a reader,
-and a pinned site that stops constructing or granting is a stale entry. Listing
-is not approval — most pinned sites deliberately do *not* classify, and the
-table records which half of the design each one is on.
-`ReaderConstructionSiteTests.Scanner_ObservesBothConstructionAndGrantSites` is
+an observation those escapes cannot reach. It reads the compiled IL of
+`ILInspector.Decompiler` and pins every method that obtains a `MetadataReader`
+or calls a grant on `CoreLibraryIdentityTrust`. Trust attaches to a reader
+instance, and a reader can only come from a `GetMetadataReader` call or from
+constructing one directly, so a site is visible whatever it is called, however
+it is declared, and whether or not its result is wrapped. Both directions fail:
+an unpinned site is an unreviewed way to obtain a reader, and a pinned site
+that stops obtaining or granting is a stale entry. Listing is not approval —
+most pinned sites deliberately do *not* classify, and the table records which
+half of the design each one is on.
+`ReaderConstructionSiteTests.Scanner_ObservesBothAcquisitionAndGrantSites` is
 its non-vacuity check, since a scan compared against a table would pass just as
-happily if the scan silently observed nothing.
+happily if the scan silently observed nothing, and
+`ReaderConstructionSiteTests.SiteKeys_AreUniquePerMethod` keeps each site key an
+identity rather than a label, so an added overload or a lowered local function
+cannot inherit an existing entry's approval.
+
+The pin is deliberately bounded: it answers where readers come from and which of
+them are classified, not whether each grant is deserved. A method that passed a
+discovered path into the raw-path designation overload would launder discovery
+into designation while neither obtaining a reader nor granting identity itself,
+so it would not appear in the pin. That property belongs to provenance, and
+`PlantedCoreLibraryIdentityTests` gates it.
 
 ### Restored manifest paths remain within their owning roots
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -354,6 +354,25 @@ gates the build-layout and corpus workflow; and
 `PlantedCoreLibraryIdentityTests.DiscoveredSibling_FollowsTheHostPolicy`
 gates both settings of the host policy.
 
+The gate that has been hardest to get right is the one asserting that *no*
+reader-creation site was overlooked, because the obvious formulation — reflect
+over the factory methods — enumerates signatures, and a signature has
+unboundedly many cosmetic dimensions. Three consecutive review rounds on the
+fix escaped it along a different one each time: the method name, then the
+declared return type, then visibility and `Task` wrapping (issue #4464).
+`ReaderConstructionSiteTests.TrustRelevantSites_MatchThePin` replaces that with
+an observation the escapes cannot reach. It reads the compiled IL of
+`ILInspector.Decompiler` and pins every method that constructs a `PEReader` or
+calls a grant on `CoreLibraryIdentityTrust`, so a site is visible whatever it
+is called, however it is declared, and whether or not its result is wrapped.
+Both directions fail: an unpinned site is an unreviewed way to obtain a reader,
+and a pinned site that stops constructing or granting is a stale entry. Listing
+is not approval — most pinned sites deliberately do *not* classify, and the
+table records which half of the design each one is on.
+`ReaderConstructionSiteTests.Scanner_ObservesBothConstructionAndGrantSites` is
+its non-vacuity check, since a scan compared against a table would pass just as
+happily if the scan silently observed nothing.
+
 ### Restored manifest paths remain within their owning roots
 
 Paths read from `.deps.json` and `project.assets.json` are relative artifact

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -379,6 +379,18 @@ happily if the scan silently observed nothing, and
 identity rather than a label, so an added overload or a lowered local function
 cannot inherit an existing entry's approval.
 
+Grants are recognised by identity too, and for the same reason. A call into
+`CoreLibraryIdentityTrust` counts as a grant unless its member appears on an
+explicit non-granting list, and
+`ReaderConstructionSiteTests.TrustTypeMembers_AreClassified` fails when the type
+declares a member that list does not account for. Round 3 of PR #4469 escaped an
+earlier `StartsWith("Grant")` test by adding a member named `Classify` that
+forwarded to the grant and calling it from a site pinned as acquisition-only:
+every test stayed green while every opened reader gained identity. Recognising a
+grant by its name reproduced, on the grant half, the same cosmetic
+non-convergence the gate exists to end — so the polarity is inverted, and an
+unclassified member is grant-relevant until someone says otherwise.
+
 The pin is deliberately bounded: it answers where readers come from and which of
 them are classified, not whether each grant is deserved. A method that passed a
 discovered path into the raw-path designation overload would launder discovery

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -364,9 +364,10 @@ declared return type, then visibility and `Task` wrapping (issue #4464).
 an observation those escapes cannot reach. It reads the compiled IL of
 `ILInspector.Decompiler` and pins every method that obtains a `MetadataReader`
 or calls a grant on `CoreLibraryIdentityTrust`. Trust attaches to a reader
-instance, and a reader can only come from a `GetMetadataReader` call or from
-constructing one directly, so a site is visible whatever it is called, however
-it is declared, and whether or not its result is wrapped. Both directions fail:
+instance, and this assembly creates one only by calling `GetMetadataReader` or
+by constructing a reader directly, so a site is visible whatever it is called,
+however it is declared, and whether or not its result is wrapped. Both
+directions fail:
 an unpinned site is an unreviewed way to obtain a reader, and a pinned site
 that stops obtaining or granting is a stale entry. Listing is not approval —
 most pinned sites deliberately do *not* classify, and the table records which
@@ -384,6 +385,16 @@ discovered path into the raw-path designation overload would launder discovery
 into designation while neither obtaining a reader nor granting identity itself,
 so it would not appear in the pin. That property belongs to provenance, and
 `PlantedCoreLibraryIdentityTests` gates it.
+
+The scan also sees creation rather than receipt, so a method handed a reader
+through a delegate, an interface, or a reflective invoke is invisible to it.
+That is sound for two reasons. A reader created outside the assembly was never
+classified, and unclassified means no core-library identity, so laundering one
+inward loses the privilege rather than gaining it. And the grant is a direct
+call into `CoreLibraryIdentityTrust` at five sites, every one of which the scan
+reports, so a reflectively-obtained reader cannot be granted identity
+invisibly. Reflection costs the completeness of the acquisition inventory, not
+the trust boundary.
 
 ### Restored manifest paths remain within their owning roots
 

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -399,9 +399,24 @@ its call sites never named the trust type at all; a static constructor that
 granted from a staged reader; and a `MayMint(MetadataReader)` overload that
 inherited the exemption belonging to the unrelated `MayMint`. Every one was a
 fresh cosmetic dimension of the call surface, which is precisely the endless
-series issue #4464 exists to stop. The field is not such a dimension — to
-confer trust you have to reach the table — so pinning its referents is complete
-by construction rather than by enumerating the ways a grant might be spelled.
+series issue #4464 exists to stop. The field is not such a dimension — a grant
+written as ordinary code has to name the table to mutate it — so within direct
+IL access the pin is complete by construction rather than by enumerating the
+ways a grant might be spelled.
+
+That completeness is bounded in two ways worth stating rather than assuming.
+Reflection over the field emits no `ldsfld`, so a reflective mutation reaches
+the table without naming it in IL. And the scan watches the grant, not the
+*consumer*: making `MayMintCoreLibraryIdentity` return `true` unconditionally,
+having `TypeRefDecoder.CanonicalSelf` mint without consulting trust, or adding a
+second trust store all confer identity while adding no referent to `s_trusted`,
+and all leave the IL gate green. Neither bound is unguarded.
+`PlantedCoreLibraryIdentityTests` owns them, and round 5 of PR #4469 confirmed
+by tampering that each of those cases fails three of its tests —
+`PlantedPlatformKey`, `DiscoveredSibling`, and `PlantedSibling`. The division of
+labour is the same one stated above: this gate asks where readers come from and
+what reaches the trust table, and that suite asks whether the identity is
+deserved.
 
 The pin is deliberately bounded: it answers where readers come from and which of
 them are classified, not whether each grant is deserved. A method that passed a

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -379,17 +379,29 @@ happily if the scan silently observed nothing, and
 identity rather than a label, so an added overload or a lowered local function
 cannot inherit an existing entry's approval.
 
-Grants are recognised by identity too, and for the same reason. A call into
-`CoreLibraryIdentityTrust` counts as a grant unless its member appears on an
-explicit non-granting list, and
-`ReaderConstructionSiteTests.TrustTypeMembers_AreClassified` fails when the type
-declares a member that list does not account for. Round 3 of PR #4469 escaped an
-earlier `StartsWith("Grant")` test by adding a member named `Classify` that
-forwarded to the grant and calling it from a site pinned as acquisition-only:
-every test stayed green while every opened reader gained identity. Recognising a
-grant by its name reproduced, on the grant half, the same cosmetic
-non-convergence the gate exists to end — so the polarity is inverted, and an
-unclassified member is grant-relevant until someone says otherwise.
+Grants are recognised by the primitive, not by the call surface, and that is
+what makes the gate converge. Core-library identity *is* membership in the
+`s_trusted` table, so `ReaderConstructionSiteTests.TrustTableAccess_IsConfinedToItsPinnedMembers`
+pins every method in the assembly whose IL reaches that field — whatever it is
+called, whatever type declares it, and whether or not it is reachable through
+the trust type's own surface. Loading the field counts as reach because mutating
+the table requires getting hold of it first; storing it is initialization, and
+is allowed only in the static constructor that creates it. A call into
+`CoreLibraryIdentityTrust` is still reported as a grant unless its full
+signature is allow-listed, and
+`ReaderConstructionSiteTests.TrustTypeMembers_AreClassified` requires the type
+to account for every member it declares and to declare no nested types.
+
+The structure was arrived at by being escaped. Rounds 3 and 4 of PR #4469 broke
+a scan keyed on calls into the trust type four times: a member named `Classify`
+that forwarded to the grant; a nested `Helper` reaching the table directly, so
+its call sites never named the trust type at all; a static constructor that
+granted from a staged reader; and a `MayMint(MetadataReader)` overload that
+inherited the exemption belonging to the unrelated `MayMint`. Every one was a
+fresh cosmetic dimension of the call surface, which is precisely the endless
+series issue #4464 exists to stop. The field is not such a dimension — to
+confer trust you have to reach the table — so pinning its referents is complete
+by construction rather than by enumerating the ways a grant might be spelled.
 
 The pin is deliberately bounded: it answers where readers come from and which of
 them are classified, not whether each grant is deserved. A method that passed a

--- a/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
@@ -9,96 +9,131 @@ namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
 /// Pins every place in <c>ILInspector.Decompiler</c> that participates in
-/// core-library identity trust: the methods that construct a
-/// <see cref="PEReader"/>, and the methods that grant identity through
+/// core-library identity trust: the methods that obtain a
+/// <see cref="MetadataReader"/>, and the methods that grant identity through
 /// <c>CoreLibraryIdentityTrust</c>.
 /// <para>
-/// <see cref="PlantedCoreLibraryIdentityTests.EveryPublicFactory_ClassifiesTheReaderItCreates"/>
+/// <c>PlantedCoreLibraryIdentityTests.EveryPublicFactory_ClassifiesTheReaderItCreates</c>
 /// enumerates <em>factory signatures</em>, and three consecutive review rounds
 /// on PR #4428 escaped it along a different cosmetic dimension each time: the
-/// method name (round 4), the declared return type (round 5), then visibility
-/// and <c>Task</c> wrapping (round 6, issue #4464). A signature has unboundedly
-/// many such dimensions, so patching one per round does not converge.
+/// method name, then the declared return type, then visibility and <c>Task</c>
+/// wrapping (issue #4464). A signature has unboundedly many such dimensions, so
+/// patching one per round does not converge.
 /// </para>
 /// <para>
-/// This gate reads the compiled IL instead. A method that builds a reader
-/// contains <c>newobj PEReader::.ctor</c> whatever it is called, however it is
-/// declared, and whether or not its result is wrapped — so the observation
-/// survives every escape above, and any future one of the same kind. Both
-/// directions fail: an unpinned site that appears is an unreviewed way to
-/// obtain a reader, and a pinned site that disappears is a stale entry.
+/// This gate reads the compiled IL instead, and keys on the operation that
+/// actually produces the thing trust attaches to. Core-library identity is
+/// recorded per <see cref="MetadataReader"/> instance, and a reader can only
+/// come from a <c>GetMetadataReader</c> call or from constructing one directly —
+/// so a site is visible whatever its method is called, however it is declared,
+/// and whether or not its result is wrapped. Both directions fail: an unpinned
+/// site is an unreviewed way to obtain a reader, and a pinned site that stops
+/// obtaining or granting is a stale entry.
 /// </para>
 /// <para>
-/// Being listed here is not approval. <see cref="Grants"/> records whether a
-/// site classifies the reader it creates, and most sites deliberately do not:
-/// an unclassified reader loses core-library identity, which is the fail-closed
-/// half of the design that <c>CoreLibraryIdentityTrust</c> documents. What the
-/// pin buys is that adding either kind of site forces someone to say which it
-/// is.
+/// Being listed here is not approval. <see cref="TrustRole.GrantsIdentity"/>
+/// records whether a site classifies the reader it obtains, and most sites
+/// deliberately do not: an unclassified reader loses core-library identity,
+/// which is the fail-closed half of the design that
+/// <c>CoreLibraryIdentityTrust</c> documents. What the pin buys is that adding
+/// either kind of site forces someone to say which it is.
+/// </para>
+/// <para>
+/// <strong>What this gate does not cover.</strong> It answers "where do readers
+/// come from, and which of them are classified", not "is each grant deserved". A
+/// method that passed a discovered path into the raw-path designation overload
+/// would launder discovery into designation while neither obtaining a reader nor
+/// granting identity itself, so it would not appear here. That property belongs
+/// to provenance, and <c>PlantedCoreLibraryIdentityTests</c> gates it — see
+/// <c>DiscoveredSibling_FollowsTheHostPolicy</c> and
+/// <c>PlantedSibling_OpenedThroughMetadataSource_LosesCoreLibraryIdentity</c>.
+/// The bound is stated deliberately: review of PR #4469 found an earlier,
+/// unbounded phrasing of this claim to be false.
 /// </para>
 /// </summary>
 public sealed class ReaderConstructionSiteTests
 {
     /// <summary>
-    /// Whether a trust-relevant site constructs a reader, grants core-library
+    /// The trust type itself. Its own helpers call the grant they implement, and
+    /// reporting them would pin the mechanism as one of its own consumers.
+    /// Compared by exact type identity: a <c>StartsWith</c> prefix test on the
+    /// display name was escaped in review by declaring a namespace with this
+    /// name.
+    /// </summary>
+    const string TrustTypeFullName = "ILInspector.Decompiler.Pipeline.CoreLibraryIdentityTrust";
+
+    /// <summary>
+    /// Whether a trust-relevant site obtains a reader, grants core-library
     /// identity, or does both.
     /// </summary>
     [Flags]
     enum TrustRole
     {
         None = 0,
-        ConstructsReader = 1,
+        ObtainsReader = 1,
         GrantsIdentity = 2,
     }
 
     /// <summary>
     /// Every trust-relevant method in <c>ILInspector.Decompiler</c>, with the
-    /// role it plays and why. Update this table in the same commit that moves a
-    /// site, and say in the reason which half of the design the new entry is
-    /// on.
+    /// role it plays and why. Keys carry the parameter list, so overloads stay
+    /// distinct. Update this table in the same commit that moves a site, and say
+    /// in the reason which half of the design the new entry is on.
     /// </summary>
     static readonly ImmutableDictionary<string, (TrustRole Role, string Reason)> s_pinned =
         new Dictionary<string, (TrustRole, string)>(StringComparer.Ordinal)
         {
-            ["Pipeline.MetadataContext.OpenDesignated"] =
+            ["Pipeline.MetadataContext.OpenDesignated(String)"] =
                 (TrustRole.GrantsIdentity,
-                 "A raw path is an explicit caller designation, so the reader "
-                 + "MetadataSource returns is trusted. This is the route that "
-                 + "opens System.Private.CoreLib.dll from a dotnet/runtime "
-                 + "build layout."),
-            ["Pipeline.MetadataContext.OpenResolved"] =
+                 "A raw path is an explicit caller designation, so the reader it "
+                 + "opens is trusted. This is the route that opens "
+                 + "System.Private.CoreLib.dll from a dotnet/runtime build layout."),
+            ["Pipeline.MetadataContext.OpenResolved(ResolvedAssemblyReference)"] =
                 (TrustRole.GrantsIdentity,
-                 "Discovery. Grants only when the acquisition entitles it, "
-                 + "through CoreLibraryIdentityTrust.GrantIfEntitled."),
-            ["Pipeline.OpenedAssembly.TryOpen"] =
-                (TrustRole.ConstructsReader,
-                 "Deliberately unclassified: a best-effort probe that carries "
-                 + "no acquisition evidence, so anything opened through it "
-                 + "fails closed and cannot mint core-library identity."),
-            ["Pipeline.MetadataSource.OpenCore"] =
-                (TrustRole.ConstructsReader | TrustRole.GrantsIdentity,
-                 "Both OpenCore overloads land here. The raw-path overload "
-                 + "grants unconditionally as an explicit designation; the "
-                 + "ResolvedAssemblyReference overload defers to "
-                 + "GrantIfEntitled because it was reached by discovery."),
-            ["Pipeline.MetadataSource.OpenFromPrefetchedImage"] =
-                (TrustRole.ConstructsReader | TrustRole.GrantsIdentity,
-                 "Designation by path plus caller-supplied bytes; its one "
-                 + "product caller, LibrarySections.ScanBodyShapes, passes the "
-                 + "designated target's own path and image."),
-            ["MemberBodyProducer.ComposeCore"] =
-                (TrustRole.ConstructsReader,
-                 "Deliberately unclassified: opens the assembly a located type "
-                 + "came from to read method bodies. This is the sibling path "
-                 + "from issue #4411, and it must not mint core-library identity."),
-            ["MemberBodyProducer.ComposeMemberCore"] =
-                (TrustRole.ConstructsReader,
-                 "Deliberately unclassified, for the same reason as "
-                 + "ComposeCore: a sibling opened to read one member's body."),
-            ["MemberBodyProducer.ComposeMembersBatch"] =
-                (TrustRole.ConstructsReader,
-                 "Deliberately unclassified, for the same reason as "
-                 + "ComposeCore: a sibling opened to read a batch of bodies."),
+                 "Discovery. Grants only when the acquisition entitles it, through "
+                 + "CoreLibraryIdentityTrust.GrantIfEntitled."),
+            ["Pipeline.OpenedAssembly.TryOpen(Func`1<Stream>)"] =
+                (TrustRole.ObtainsReader,
+                 "Obtains the reader but classifies nothing itself. Its callers "
+                 + "decide: MetadataContext.OpenDesignated grants the reader this "
+                 + "returns, because a raw path is a designation, while OpenResolved "
+                 + "defers to provenance. Reaching it any other way leaves the "
+                 + "reader unclassified, which fails closed."),
+            ["Pipeline.MetadataSource.OpenCore(String, String, Boolean, IAssemblyReferenceResolver, MetadataContext)"] =
+                (TrustRole.ObtainsReader | TrustRole.GrantsIdentity,
+                 "The raw-path overload. Grants unconditionally, as an explicit "
+                 + "caller designation."),
+            ["Pipeline.MetadataSource.OpenCore(ResolvedAssemblyReference, String, Boolean, IAssemblyBindingPolicy, MetadataContext)"] =
+                (TrustRole.ObtainsReader | TrustRole.GrantsIdentity,
+                 "The discovery overload. Defers to GrantIfEntitled, so identity "
+                 + "follows the reference's provenance and a planted sibling "
+                 + "reached by resolution gets nothing."),
+            ["Pipeline.MetadataSource.OpenFromPrefetchedImage(String, ImmutableArray`1<Byte>, String, IAssemblyReferenceResolver, MetadataContext)"] =
+                (TrustRole.ObtainsReader | TrustRole.GrantsIdentity,
+                 "Designation by path plus caller-supplied bytes; its one product "
+                 + "caller, LibrarySections.ScanBodyShapes, passes the designated "
+                 + "target's own path and image."),
+            ["Pipeline.MetadataSource.PdbReader()"] =
+                (TrustRole.ObtainsReader,
+                 "A portable PDB reader, embedded or sidecar. Deliberately "
+                 + "unclassified: a PDB carries no assembly identity, and this "
+                 + "reader is a different instance from the assembly's, so it can "
+                 + "never be mistaken for one. Surfaced only once the predicate "
+                 + "widened from PEReader construction to reader acquisition, "
+                 + "which is the point of that widening."),
+            ["MemberBodyProducer.ComposeCore(ApiType, Func`1<ResolvedTypeDefinition>, Func`3<ResolvedTypeDefinition, MetadataContext, MetadataSource>, MetadataContext, PrinterOptions)"] =
+                (TrustRole.ObtainsReader,
+                 "Deliberately unclassified: opens the assembly a located type came "
+                 + "from to read method bodies. This is the sibling path from issue "
+                 + "#4411, and it must not mint core-library identity."),
+            ["MemberBodyProducer.ComposeMemberCore(ApiType, ApiMember, Func`1<ResolvedTypeDefinition>, Func`3<ResolvedTypeDefinition, MetadataContext, MetadataSource>, MetadataContext, PrinterOptions, MemberRenderAttributeMode)"] =
+                (TrustRole.ObtainsReader,
+                 "Deliberately unclassified, for the same reason as ComposeCore: a "
+                 + "sibling opened to read one member's body."),
+            ["MemberBodyProducer.ComposeMembersBatch(ApiType, Func`1<ResolvedTypeDefinition>, Func`3<ResolvedTypeDefinition, MetadataContext, MetadataSource>, MetadataContext, MemberRenderAttributeMode)"] =
+                (TrustRole.ObtainsReader,
+                 "Deliberately unclassified, for the same reason as ComposeCore: a "
+                 + "sibling opened to read a batch of bodies."),
         }.ToImmutableDictionary(StringComparer.Ordinal);
 
     [Fact]
@@ -120,18 +155,18 @@ public sealed class ReaderConstructionSiteTests
 
             differences.Add(
                 actual == TrustRole.None
-                    ? $"  {site}: pinned as {pinned}, but no longer constructs a "
-                      + "reader or grants identity. Remove the stale entry."
+                    ? $"  {site}: pinned as {pinned}, but no longer obtains a reader "
+                      + "or grants identity. Remove the stale entry."
                     : pinned == TrustRole.None
-                        ? $"  {site}: {actual}, but is not pinned. Add it to "
-                          + "s_pinned and state whether it may mint core-library identity."
+                        ? $"  {site}: {actual}, but is not pinned. Add it to s_pinned "
+                          + "and state whether it may mint core-library identity."
                         : $"  {site}: pinned as {pinned}, observed {actual}.");
         }
 
         Assert.True(
             differences.Count == 0,
             "The core-library trust surface of ILInspector.Decompiler no longer "
-            + "matches its pin. Every method that constructs a PEReader or "
+            + "matches its pin. Every method that obtains a MetadataReader or "
             + "grants core-library identity has to be listed, because an "
             + "unreviewed one is an unreviewed way to obtain a reader:"
             + Environment.NewLine
@@ -140,31 +175,78 @@ public sealed class ReaderConstructionSiteTests
 
     /// <summary>
     /// Non-vacuity gate for <see cref="TrustRelevantSites_MatchThePin"/>. That
-    /// test compares a scan against a table, and it would pass just as happily
-    /// if the scanner silently observed nothing — a broken token comparison or
-    /// a renamed trust type would empty both sides of a set difference. This
-    /// asserts the scanner still finds the two things it looks for, so the
-    /// pin cannot go quietly vacuous.
+    /// test compares a scan against a table, and it would pass just as happily if
+    /// the scanner silently observed nothing — a broken token comparison or a
+    /// renamed trust type would empty both sides of a set difference. This
+    /// asserts the scanner still finds both things it looks for, so the pin
+    /// cannot go quietly vacuous.
     /// </summary>
     [Fact]
-    public void Scanner_ObservesBothConstructionAndGrantSites()
+    public void Scanner_ObservesBothAcquisitionAndGrantSites()
     {
         var observed = ScanTrustRelevantSites();
 
-        Assert.Contains(
-            observed,
-            e => e.Value.HasFlag(TrustRole.ConstructsReader));
-        Assert.Contains(
-            observed,
-            e => e.Value.HasFlag(TrustRole.GrantsIdentity));
+        Assert.Contains(observed, e => e.Value.HasFlag(TrustRole.ObtainsReader));
+        Assert.Contains(observed, e => e.Value.HasFlag(TrustRole.GrantsIdentity));
     }
 
     /// <summary>
-    /// Reads the compiled <c>ILInspector.Decompiler</c> assembly and reports
-    /// every method whose IL constructs a <see cref="PEReader"/> or calls into
+    /// Guards the property that makes the pin an identity rather than a label:
+    /// two distinct methods must never collapse onto one key. Review of PR #4469
+    /// escaped an earlier version twice this way — by adding an overload, and by
+    /// adding a local function whose lowered name was unmangled back to its
+    /// enclosing method — with the new method silently inheriting the pinned
+    /// approval of the one it collided with.
+    /// </summary>
+    [Fact]
+    public void SiteKeys_AreUniquePerMethod()
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var (_, key) in EnumerateMethods())
+            counts[key] = counts.TryGetValue(key, out int count) ? count + 1 : 1;
+
+        var collisions = counts
+            .Where(e => e.Value > 1)
+            .Select(e => $"  {e.Key} ({e.Value} methods)")
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            collisions.Count == 0,
+            "Distinct methods share a site key, so one could inherit another's "
+            + "pinned approval:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, collisions));
+    }
+
+    /// <summary>
+    /// Reads the compiled <c>ILInspector.Decompiler</c> assembly and reports every
+    /// method whose IL obtains a <see cref="MetadataReader"/> or calls into
     /// <c>CoreLibraryIdentityTrust</c> to grant identity.
     /// </summary>
     static ImmutableDictionary<string, TrustRole> ScanTrustRelevantSites()
+    {
+        var sites = new Dictionary<string, TrustRole>(StringComparer.Ordinal);
+
+        foreach (var (method, key) in EnumerateMethods())
+        {
+            if (method.Role == TrustRole.None || method.DeclaringTypeFullName == TrustTypeFullName)
+                continue;
+
+            Assert.False(
+                sites.ContainsKey(key),
+                $"Two trust-relevant methods share the site key '{key}'.");
+
+            sites[key] = method.Role;
+        }
+
+        return sites.ToImmutableDictionary(StringComparer.Ordinal);
+    }
+
+    readonly record struct ScannedMethod(TrustRole Role, string DeclaringTypeFullName);
+
+    static IEnumerable<(ScannedMethod Method, string Key)> EnumerateMethods()
     {
         string assemblyPath = typeof(MetadataSource).Assembly.Location;
         Assert.True(
@@ -175,37 +257,21 @@ public sealed class ReaderConstructionSiteTests
         using var pe = new PEReader(stream);
         var reader = pe.GetMetadataReader();
 
-        var sites = new Dictionary<string, TrustRole>(StringComparer.Ordinal);
-
         foreach (var handle in reader.MethodDefinitions)
         {
             var method = reader.GetMethodDefinition(handle);
             if (method.RelativeVirtualAddress == 0)
                 continue;
 
-            var body = pe.GetMethodBody(method.RelativeVirtualAddress);
-            byte[] il = body.GetILBytes() ?? [];
+            byte[] il = pe.GetMethodBody(method.RelativeVirtualAddress).GetILBytes() ?? [];
             if (il.Length == 0)
                 continue;
 
-            TrustRole role = RoleOf(reader, il);
-            if (role == TrustRole.None)
-                continue;
-
-            string name = SiteName(reader, method);
-
-            // The trust type's own helpers call the grant they implement.
-            // Reporting them would pin the mechanism as one of its own
-            // consumers, which says nothing about where readers come from.
-            if (name.StartsWith("Pipeline.CoreLibraryIdentityTrust.", StringComparison.Ordinal))
-                continue;
-
-            sites[name] = sites.TryGetValue(name, out TrustRole existing)
-                ? existing | role
-                : role;
+            string declaringType = FullName(reader, method.GetDeclaringType());
+            yield return (
+                new ScannedMethod(RoleOf(reader, il), declaringType),
+                SiteKey(reader, method, declaringType));
         }
-
-        return sites.ToImmutableDictionary(StringComparer.Ordinal);
     }
 
     static TrustRole RoleOf(MetadataReader reader, byte[] il)
@@ -221,13 +287,21 @@ public sealed class ReaderConstructionSiteTests
             if (!TryDescribeMember(reader, operand, out string declaringType, out string member))
                 continue;
 
+            // Trust attaches to a MetadataReader instance, so key on the ways one
+            // can be obtained rather than on PEReader, which is merely the usual
+            // container. Review of PR #4469 escaped a PEReader-only scan through
+            // MetadataReaderProvider and through the unsafe MetadataReader
+            // constructor, neither of which constructs a PEReader.
+            if (member == "GetMetadataReader")
+                role |= TrustRole.ObtainsReader;
+
             if (instruction.OpCode == ILOpCode.Newobj
-                && declaringType == "System.Reflection.PortableExecutable.PEReader")
+                && declaringType == "System.Reflection.Metadata.MetadataReader")
             {
-                role |= TrustRole.ConstructsReader;
+                role |= TrustRole.ObtainsReader;
             }
 
-            if (declaringType.EndsWith("CoreLibraryIdentityTrust", StringComparison.Ordinal)
+            if (declaringType == TrustTypeFullName
                 && member.StartsWith("Grant", StringComparison.Ordinal))
             {
                 role |= TrustRole.GrantsIdentity;
@@ -272,15 +346,21 @@ public sealed class ReaderConstructionSiteTests
         }
     }
 
-    static string TypeNameOf(MetadataReader reader, EntityHandle handle) =>
-        handle.Kind switch
+    static string TypeNameOf(MetadataReader reader, EntityHandle handle)
+    {
+        switch (handle.Kind)
         {
-            HandleKind.TypeReference => Join(
-                reader.GetString(reader.GetTypeReference((TypeReferenceHandle)handle).Namespace),
-                reader.GetString(reader.GetTypeReference((TypeReferenceHandle)handle).Name)),
-            HandleKind.TypeDefinition => FullName(reader, (TypeDefinitionHandle)handle),
-            _ => "",
-        };
+            case HandleKind.TypeReference:
+            {
+                var reference = reader.GetTypeReference((TypeReferenceHandle)handle);
+                return Join(reader.GetString(reference.Namespace), reader.GetString(reference.Name));
+            }
+            case HandleKind.TypeDefinition:
+                return FullName(reader, (TypeDefinitionHandle)handle);
+            default:
+                return "";
+        }
+    }
 
     static string FullName(MetadataReader reader, TypeDefinitionHandle handle)
     {
@@ -295,40 +375,70 @@ public sealed class ReaderConstructionSiteTests
         string.IsNullOrEmpty(@namespace) ? name : $"{@namespace}.{name}";
 
     /// <summary>
-    /// Names a site by declaring type and method, with the root namespace
-    /// trimmed for readability. Compiler-generated members are attributed to
-    /// the method they were lowered from, so an iterator or a lambda does not
-    /// read as an unrelated site.
+    /// Identifies a site by declaring type, method name, and parameter types,
+    /// with the root namespace trimmed for readability. The parameter list is
+    /// what keeps overloads distinct, and
+    /// <see cref="SiteKeys_AreUniquePerMethod"/> is the gate on that.
+    /// Compiler-generated names are reported verbatim, so a local function or
+    /// lambda that obtains a reader becomes its own site rather than inheriting
+    /// the approval of the method it was lowered from. That makes the key
+    /// sensitive to compiler-assigned ordinals, which is the intended trade: a
+    /// trust-relevant site should not be compiler-generated, and if one ever is,
+    /// it deserves the explicit pin and the review that churn forces.
     /// </summary>
-    static string SiteName(MetadataReader reader, MethodDefinition method)
+    static string SiteKey(MetadataReader reader, MethodDefinition method, string declaringType)
     {
-        string type = FullName(reader, method.GetDeclaringType());
-        string name = reader.GetString(method.Name);
-
         const string RootNamespace = "ILInspector.Decompiler.";
-        if (type.StartsWith(RootNamespace, StringComparison.Ordinal))
-            type = type[RootNamespace.Length..];
+        string type = declaringType.StartsWith(RootNamespace, StringComparison.Ordinal)
+            ? declaringType[RootNamespace.Length..]
+            : declaringType;
 
-        return $"{Unmangle(type)}.{Unmangle(name)}";
+        var signature = method.DecodeSignature(SignatureTypeNames.Instance, genericContext: null);
+        return $"{type}.{reader.GetString(method.Name)}({string.Join(", ", signature.ParameterTypes)})";
     }
 
     /// <summary>
-    /// Recovers the authored name a compiler-generated name was lowered from.
-    /// Roslyn spells these <c>&lt;Origin&gt;g__Local|1_0</c>,
-    /// <c>&lt;Origin&gt;b__2_0</c>, or <c>&lt;Origin&gt;d__7</c>, all of which
-    /// carry ordinals that shift when unrelated members are added nearby. The
-    /// pin names the authored method so it does not churn on edits that have
-    /// nothing to do with trust.
+    /// Spells signature types by simple name — enough to separate overloads in a
+    /// site key and to stay readable in a failure message.
     /// </summary>
-    static string Unmangle(string name)
+    sealed class SignatureTypeNames : ISignatureTypeProvider<string, object?>
     {
-        if (!name.StartsWith('<'))
-            return name;
+        internal static readonly SignatureTypeNames Instance = new();
 
-        int end = name.IndexOf('>');
-        if (end <= 1)
-            return name;
+        public string GetArrayType(string elementType, ArrayShape shape) => $"{elementType}[]";
 
-        return name[1..end];
+        public string GetByReferenceType(string elementType) => $"{elementType}&";
+
+        public string GetFunctionPointerType(MethodSignature<string> signature) => "method";
+
+        public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments)
+            => $"{genericType}<{string.Join(", ", typeArguments)}>";
+
+        public string GetGenericMethodParameter(object? genericContext, int index) => $"!!{index}";
+
+        public string GetGenericTypeParameter(object? genericContext, int index) => $"!{index}";
+
+        public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+
+        public string GetPinnedType(string elementType) => elementType;
+
+        public string GetPointerType(string elementType) => $"{elementType}*";
+
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+
+        public string GetSZArrayType(string elementType) => $"{elementType}[]";
+
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+            => reader.GetString(reader.GetTypeDefinition(handle).Name);
+
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+            => reader.GetString(reader.GetTypeReference(handle).Name);
+
+        public string GetTypeFromSpecification(
+            MetadataReader reader,
+            object? genericContext,
+            TypeSpecificationHandle handle,
+            byte rawTypeKind)
+            => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
@@ -406,7 +406,11 @@ public sealed class ReaderConstructionSiteTests
     /// name. Each was a fresh cosmetic dimension on the call surface, which is
     /// the non-convergence issue #4464 exists to end. The field is not a
     /// dimension: trust <em>is</em> membership in that table, so pinning its
-    /// referents is complete by construction rather than by enumeration.
+    /// referents is complete by construction rather than by enumeration —
+    /// for a grant written as ordinary code, which is the bound stated on this
+    /// class. Reflection over the field emits no <c>ldsfld</c>, and a
+    /// consumer-side grant reaches the table not at all;
+    /// <c>PlantedCoreLibraryIdentityTests</c> owns both.
     /// </remarks>
     [Fact]
     public void TrustTableAccess_IsConfinedToItsPinnedMembers()

--- a/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
@@ -47,9 +47,25 @@ namespace ILInspector.Decompiler.Tests;
 /// <c>Classify</c>, a nested <c>Helper</c> reaching the table directly, a
 /// granting static constructor, and a <c>MayMint(MetadataReader)</c> overload
 /// inheriting a bare-name exemption. Each was a fresh cosmetic dimension, which
-/// is exactly the series that has no end. The field is not a dimension: to
-/// confer trust you must reach the table, so pinning its referents is complete
-/// by construction.
+/// is exactly the series that has no end. The field is not a dimension: a grant
+/// written as ordinary code has to name it, so within direct IL access the pin
+/// is complete by construction rather than by enumerating spellings.
+/// </para>
+/// <para>
+/// <strong>That completeness is bounded to direct IL access, and to the grant.</strong>
+/// Reflection over the field emits no <c>ldsfld</c>, so a reflective mutation
+/// reaches the table without naming it here. And nothing in this class watches
+/// the <em>consumer</em>: making <c>MayMintCoreLibraryIdentity</c> return
+/// <see langword="true"/> unconditionally, having <c>TypeRefDecoder.CanonicalSelf</c>
+/// mint without consulting trust at all, or introducing a second trust store
+/// confers identity while adding no referent to <c>s_trusted</c>, and every one
+/// of those leaves these tests green. They are not unguarded — they are
+/// <c>PlantedCoreLibraryIdentityTests</c>'s property, and round 5 of PR #4469
+/// confirmed each of those three tampers fails three of its tests
+/// (<c>PlantedPlatformKey</c>, <c>DiscoveredSibling</c>, and
+/// <c>PlantedSibling</c>). The division is deliberate: this gate asks where
+/// readers come from and what reaches the trust table, and that suite asks
+/// whether the resulting identity is deserved.
 /// </para>
 /// <para>
 /// The scan sees <em>creation</em>, not receipt. A method handed a reader —

--- a/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
@@ -23,12 +23,25 @@ namespace ILInspector.Decompiler.Tests;
 /// <para>
 /// This gate reads the compiled IL instead, and keys on the operation that
 /// actually produces the thing trust attaches to. Core-library identity is
-/// recorded per <see cref="MetadataReader"/> instance, and a reader can only
-/// come from a <c>GetMetadataReader</c> call or from constructing one directly —
-/// so a site is visible whatever its method is called, however it is declared,
-/// and whether or not its result is wrapped. Both directions fail: an unpinned
-/// site is an unreviewed way to obtain a reader, and a pinned site that stops
-/// obtaining or granting is a stale entry.
+/// recorded per <see cref="MetadataReader"/> instance, and this assembly creates
+/// one only by calling <c>GetMetadataReader</c> or by constructing a reader
+/// directly — so a site is visible whatever its method is called, however it is
+/// declared, and whether or not its result is wrapped. Both directions fail: an
+/// unpinned site is an unreviewed way to obtain a reader, and a pinned site that
+/// stops obtaining or granting is a stale entry.
+/// </para>
+/// <para>
+/// The scan sees <em>creation</em>, not receipt. A method handed a reader —
+/// through a delegate, an interface, or a reflective invoke whose IL never
+/// mentions <c>GetMetadataReader</c> — does not appear here, and round 2 of PR
+/// #4469 demonstrated exactly that. It stays sound for two reasons worth stating
+/// rather than assuming. A reader created outside this assembly was never
+/// classified, and unclassified means no core-library identity, so laundering one
+/// inward loses the privilege rather than gaining it. And the grant itself is a
+/// direct call into <c>CoreLibraryIdentityTrust</c> at five sites, every one of
+/// which this scan reports, so a reflectively-obtained reader still cannot be
+/// granted identity invisibly. What reflection defeats is the completeness of the
+/// acquisition inventory, which is a review convenience, not the trust boundary.
 /// </para>
 /// <para>
 /// Being listed here is not approval. <see cref="TrustRole.GrantsIdentity"/>
@@ -203,7 +216,7 @@ public sealed class ReaderConstructionSiteTests
     {
         var counts = new Dictionary<string, int>(StringComparer.Ordinal);
 
-        foreach (var (_, key) in EnumerateMethods())
+        foreach (var (_, key) in EnumerateMethods(typeof(MetadataSource).Assembly.Location))
             counts[key] = counts.TryGetValue(key, out int count) ? count + 1 : 1;
 
         var collisions = counts
@@ -221,6 +234,49 @@ public sealed class ReaderConstructionSiteTests
     }
 
     /// <summary>
+    /// Arms both halves of the acquisition predicate. Round 2 of PR #4469 found
+    /// that the direct-construction branch asserted nothing: no production site
+    /// constructs a <see cref="MetadataReader"/> from a pointer, so deleting that
+    /// branch left every test green even though it is the branch that closes the
+    /// unsafe-constructor escape. These specimens are never called; they exist so
+    /// the compiled IL of this test assembly contains one instance of each shape,
+    /// and <see cref="Scanner_DetectsBothAcquisitionShapes"/> fails if the
+    /// scanner stops recognising either.
+    /// </summary>
+    static class AcquisitionSpecimens
+    {
+        internal static MetadataReader ThroughGetMetadataReader(ImmutableArray<byte> image)
+            => MetadataReaderProvider.FromMetadataImage(image).GetMetadataReader();
+
+        internal static unsafe MetadataReader ThroughConstructor(byte* metadata, int length)
+            => new(metadata, length);
+    }
+
+    /// <summary>
+    /// Non-vacuity gate for the acquisition predicate itself, as distinct from
+    /// <see cref="Scanner_ObservesBothAcquisitionAndGrantSites"/>, which only
+    /// proves the scan of the product assembly is not empty. Deleting either
+    /// branch of the predicate fails this test.
+    /// </summary>
+    [Fact]
+    public void Scanner_DetectsBothAcquisitionShapes()
+    {
+        const string SpecimenType = "Tests.ReaderConstructionSiteTests+AcquisitionSpecimens";
+
+        var observed = EnumerateMethods(typeof(ReaderConstructionSiteTests).Assembly.Location)
+            .Where(e => e.Key.StartsWith($"{SpecimenType}.", StringComparison.Ordinal))
+            .ToDictionary(e => e.Key, e => e.Method.Role, StringComparer.Ordinal);
+
+        Assert.Equal(
+            TrustRole.ObtainsReader,
+            observed[$"{SpecimenType}.ThroughGetMetadataReader(ImmutableArray`1<Byte>)"]);
+
+        Assert.Equal(
+            TrustRole.ObtainsReader,
+            observed[$"{SpecimenType}.ThroughConstructor(Byte*, Int32)"]);
+    }
+
+    /// <summary>
     /// Reads the compiled <c>ILInspector.Decompiler</c> assembly and reports every
     /// method whose IL obtains a <see cref="MetadataReader"/> or calls into
     /// <c>CoreLibraryIdentityTrust</c> to grant identity.
@@ -229,7 +285,7 @@ public sealed class ReaderConstructionSiteTests
     {
         var sites = new Dictionary<string, TrustRole>(StringComparer.Ordinal);
 
-        foreach (var (method, key) in EnumerateMethods())
+        foreach (var (method, key) in EnumerateMethods(typeof(MetadataSource).Assembly.Location))
         {
             if (method.Role == TrustRole.None || method.DeclaringTypeFullName == TrustTypeFullName)
                 continue;
@@ -246,9 +302,8 @@ public sealed class ReaderConstructionSiteTests
 
     readonly record struct ScannedMethod(TrustRole Role, string DeclaringTypeFullName);
 
-    static IEnumerable<(ScannedMethod Method, string Key)> EnumerateMethods()
+    static IEnumerable<(ScannedMethod Method, string Key)> EnumerateMethods(string assemblyPath)
     {
-        string assemblyPath = typeof(MetadataSource).Assembly.Location;
         Assert.True(
             File.Exists(assemblyPath),
             $"Cannot scan the decompiler assembly at '{assemblyPath}'.");

--- a/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
@@ -1,0 +1,334 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Instructions;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pins every place in <c>ILInspector.Decompiler</c> that participates in
+/// core-library identity trust: the methods that construct a
+/// <see cref="PEReader"/>, and the methods that grant identity through
+/// <c>CoreLibraryIdentityTrust</c>.
+/// <para>
+/// <see cref="PlantedCoreLibraryIdentityTests.EveryPublicFactory_ClassifiesTheReaderItCreates"/>
+/// enumerates <em>factory signatures</em>, and three consecutive review rounds
+/// on PR #4428 escaped it along a different cosmetic dimension each time: the
+/// method name (round 4), the declared return type (round 5), then visibility
+/// and <c>Task</c> wrapping (round 6, issue #4464). A signature has unboundedly
+/// many such dimensions, so patching one per round does not converge.
+/// </para>
+/// <para>
+/// This gate reads the compiled IL instead. A method that builds a reader
+/// contains <c>newobj PEReader::.ctor</c> whatever it is called, however it is
+/// declared, and whether or not its result is wrapped — so the observation
+/// survives every escape above, and any future one of the same kind. Both
+/// directions fail: an unpinned site that appears is an unreviewed way to
+/// obtain a reader, and a pinned site that disappears is a stale entry.
+/// </para>
+/// <para>
+/// Being listed here is not approval. <see cref="Grants"/> records whether a
+/// site classifies the reader it creates, and most sites deliberately do not:
+/// an unclassified reader loses core-library identity, which is the fail-closed
+/// half of the design that <c>CoreLibraryIdentityTrust</c> documents. What the
+/// pin buys is that adding either kind of site forces someone to say which it
+/// is.
+/// </para>
+/// </summary>
+public sealed class ReaderConstructionSiteTests
+{
+    /// <summary>
+    /// Whether a trust-relevant site constructs a reader, grants core-library
+    /// identity, or does both.
+    /// </summary>
+    [Flags]
+    enum TrustRole
+    {
+        None = 0,
+        ConstructsReader = 1,
+        GrantsIdentity = 2,
+    }
+
+    /// <summary>
+    /// Every trust-relevant method in <c>ILInspector.Decompiler</c>, with the
+    /// role it plays and why. Update this table in the same commit that moves a
+    /// site, and say in the reason which half of the design the new entry is
+    /// on.
+    /// </summary>
+    static readonly ImmutableDictionary<string, (TrustRole Role, string Reason)> s_pinned =
+        new Dictionary<string, (TrustRole, string)>(StringComparer.Ordinal)
+        {
+            ["Pipeline.MetadataContext.OpenDesignated"] =
+                (TrustRole.GrantsIdentity,
+                 "A raw path is an explicit caller designation, so the reader "
+                 + "MetadataSource returns is trusted. This is the route that "
+                 + "opens System.Private.CoreLib.dll from a dotnet/runtime "
+                 + "build layout."),
+            ["Pipeline.MetadataContext.OpenResolved"] =
+                (TrustRole.GrantsIdentity,
+                 "Discovery. Grants only when the acquisition entitles it, "
+                 + "through CoreLibraryIdentityTrust.GrantIfEntitled."),
+            ["Pipeline.OpenedAssembly.TryOpen"] =
+                (TrustRole.ConstructsReader,
+                 "Deliberately unclassified: a best-effort probe that carries "
+                 + "no acquisition evidence, so anything opened through it "
+                 + "fails closed and cannot mint core-library identity."),
+            ["Pipeline.MetadataSource.OpenCore"] =
+                (TrustRole.ConstructsReader | TrustRole.GrantsIdentity,
+                 "Both OpenCore overloads land here. The raw-path overload "
+                 + "grants unconditionally as an explicit designation; the "
+                 + "ResolvedAssemblyReference overload defers to "
+                 + "GrantIfEntitled because it was reached by discovery."),
+            ["Pipeline.MetadataSource.OpenFromPrefetchedImage"] =
+                (TrustRole.ConstructsReader | TrustRole.GrantsIdentity,
+                 "Designation by path plus caller-supplied bytes; its one "
+                 + "product caller, LibrarySections.ScanBodyShapes, passes the "
+                 + "designated target's own path and image."),
+            ["MemberBodyProducer.ComposeCore"] =
+                (TrustRole.ConstructsReader,
+                 "Deliberately unclassified: opens the assembly a located type "
+                 + "came from to read method bodies. This is the sibling path "
+                 + "from issue #4411, and it must not mint core-library identity."),
+            ["MemberBodyProducer.ComposeMemberCore"] =
+                (TrustRole.ConstructsReader,
+                 "Deliberately unclassified, for the same reason as "
+                 + "ComposeCore: a sibling opened to read one member's body."),
+            ["MemberBodyProducer.ComposeMembersBatch"] =
+                (TrustRole.ConstructsReader,
+                 "Deliberately unclassified, for the same reason as "
+                 + "ComposeCore: a sibling opened to read a batch of bodies."),
+        }.ToImmutableDictionary(StringComparer.Ordinal);
+
+    [Fact]
+    public void TrustRelevantSites_MatchThePin()
+    {
+        var observed = ScanTrustRelevantSites();
+
+        Assert.NotEmpty(observed);
+
+        var expected = s_pinned.ToImmutableDictionary(e => e.Key, e => e.Value.Role);
+        var differences = new List<string>();
+
+        foreach (string site in observed.Keys.Union(expected.Keys).Order(StringComparer.Ordinal))
+        {
+            observed.TryGetValue(site, out TrustRole actual);
+            expected.TryGetValue(site, out TrustRole pinned);
+            if (actual == pinned)
+                continue;
+
+            differences.Add(
+                actual == TrustRole.None
+                    ? $"  {site}: pinned as {pinned}, but no longer constructs a "
+                      + "reader or grants identity. Remove the stale entry."
+                    : pinned == TrustRole.None
+                        ? $"  {site}: {actual}, but is not pinned. Add it to "
+                          + "s_pinned and state whether it may mint core-library identity."
+                        : $"  {site}: pinned as {pinned}, observed {actual}.");
+        }
+
+        Assert.True(
+            differences.Count == 0,
+            "The core-library trust surface of ILInspector.Decompiler no longer "
+            + "matches its pin. Every method that constructs a PEReader or "
+            + "grants core-library identity has to be listed, because an "
+            + "unreviewed one is an unreviewed way to obtain a reader:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, differences));
+    }
+
+    /// <summary>
+    /// Non-vacuity gate for <see cref="TrustRelevantSites_MatchThePin"/>. That
+    /// test compares a scan against a table, and it would pass just as happily
+    /// if the scanner silently observed nothing — a broken token comparison or
+    /// a renamed trust type would empty both sides of a set difference. This
+    /// asserts the scanner still finds the two things it looks for, so the
+    /// pin cannot go quietly vacuous.
+    /// </summary>
+    [Fact]
+    public void Scanner_ObservesBothConstructionAndGrantSites()
+    {
+        var observed = ScanTrustRelevantSites();
+
+        Assert.Contains(
+            observed,
+            e => e.Value.HasFlag(TrustRole.ConstructsReader));
+        Assert.Contains(
+            observed,
+            e => e.Value.HasFlag(TrustRole.GrantsIdentity));
+    }
+
+    /// <summary>
+    /// Reads the compiled <c>ILInspector.Decompiler</c> assembly and reports
+    /// every method whose IL constructs a <see cref="PEReader"/> or calls into
+    /// <c>CoreLibraryIdentityTrust</c> to grant identity.
+    /// </summary>
+    static ImmutableDictionary<string, TrustRole> ScanTrustRelevantSites()
+    {
+        string assemblyPath = typeof(MetadataSource).Assembly.Location;
+        Assert.True(
+            File.Exists(assemblyPath),
+            $"Cannot scan the decompiler assembly at '{assemblyPath}'.");
+
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+
+        var sites = new Dictionary<string, TrustRole>(StringComparer.Ordinal);
+
+        foreach (var handle in reader.MethodDefinitions)
+        {
+            var method = reader.GetMethodDefinition(handle);
+            if (method.RelativeVirtualAddress == 0)
+                continue;
+
+            var body = pe.GetMethodBody(method.RelativeVirtualAddress);
+            byte[] il = body.GetILBytes() ?? [];
+            if (il.Length == 0)
+                continue;
+
+            TrustRole role = RoleOf(reader, il);
+            if (role == TrustRole.None)
+                continue;
+
+            string name = SiteName(reader, method);
+
+            // The trust type's own helpers call the grant they implement.
+            // Reporting them would pin the mechanism as one of its own
+            // consumers, which says nothing about where readers come from.
+            if (name.StartsWith("Pipeline.CoreLibraryIdentityTrust.", StringComparison.Ordinal))
+                continue;
+
+            sites[name] = sites.TryGetValue(name, out TrustRole existing)
+                ? existing | role
+                : role;
+        }
+
+        return sites.ToImmutableDictionary(StringComparer.Ordinal);
+    }
+
+    static TrustRole RoleOf(MetadataReader reader, byte[] il)
+    {
+        TrustRole role = TrustRole.None;
+
+        foreach (var instruction in InstructionDecoder.Decode(il))
+        {
+            if (instruction.Operand is not (OperandKind.InlineMethod or OperandKind.InlineTok))
+                continue;
+
+            var operand = MetadataTokens.EntityHandle((int)instruction.OperandValue);
+            if (!TryDescribeMember(reader, operand, out string declaringType, out string member))
+                continue;
+
+            if (instruction.OpCode == ILOpCode.Newobj
+                && declaringType == "System.Reflection.PortableExecutable.PEReader")
+            {
+                role |= TrustRole.ConstructsReader;
+            }
+
+            if (declaringType.EndsWith("CoreLibraryIdentityTrust", StringComparison.Ordinal)
+                && member.StartsWith("Grant", StringComparison.Ordinal))
+            {
+                role |= TrustRole.GrantsIdentity;
+            }
+        }
+
+        return role;
+    }
+
+    static bool TryDescribeMember(
+        MetadataReader reader,
+        EntityHandle handle,
+        out string declaringType,
+        out string member)
+    {
+        declaringType = "";
+        member = "";
+
+        switch (handle.Kind)
+        {
+            case HandleKind.MemberReference:
+            {
+                var reference = reader.GetMemberReference((MemberReferenceHandle)handle);
+                member = reader.GetString(reference.Name);
+                declaringType = TypeNameOf(reader, reference.Parent);
+                return true;
+            }
+            case HandleKind.MethodDefinition:
+            {
+                var definition = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+                member = reader.GetString(definition.Name);
+                declaringType = FullName(reader, definition.GetDeclaringType());
+                return true;
+            }
+            case HandleKind.MethodSpecification:
+            {
+                var specification = reader.GetMethodSpecification((MethodSpecificationHandle)handle);
+                return TryDescribeMember(reader, specification.Method, out declaringType, out member);
+            }
+            default:
+                return false;
+        }
+    }
+
+    static string TypeNameOf(MetadataReader reader, EntityHandle handle) =>
+        handle.Kind switch
+        {
+            HandleKind.TypeReference => Join(
+                reader.GetString(reader.GetTypeReference((TypeReferenceHandle)handle).Namespace),
+                reader.GetString(reader.GetTypeReference((TypeReferenceHandle)handle).Name)),
+            HandleKind.TypeDefinition => FullName(reader, (TypeDefinitionHandle)handle),
+            _ => "",
+        };
+
+    static string FullName(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var type = reader.GetTypeDefinition(handle);
+        string name = reader.GetString(type.Name);
+        return type.IsNested
+            ? $"{FullName(reader, type.GetDeclaringType())}+{name}"
+            : Join(reader.GetString(type.Namespace), name);
+    }
+
+    static string Join(string @namespace, string name) =>
+        string.IsNullOrEmpty(@namespace) ? name : $"{@namespace}.{name}";
+
+    /// <summary>
+    /// Names a site by declaring type and method, with the root namespace
+    /// trimmed for readability. Compiler-generated members are attributed to
+    /// the method they were lowered from, so an iterator or a lambda does not
+    /// read as an unrelated site.
+    /// </summary>
+    static string SiteName(MetadataReader reader, MethodDefinition method)
+    {
+        string type = FullName(reader, method.GetDeclaringType());
+        string name = reader.GetString(method.Name);
+
+        const string RootNamespace = "ILInspector.Decompiler.";
+        if (type.StartsWith(RootNamespace, StringComparison.Ordinal))
+            type = type[RootNamespace.Length..];
+
+        return $"{Unmangle(type)}.{Unmangle(name)}";
+    }
+
+    /// <summary>
+    /// Recovers the authored name a compiler-generated name was lowered from.
+    /// Roslyn spells these <c>&lt;Origin&gt;g__Local|1_0</c>,
+    /// <c>&lt;Origin&gt;b__2_0</c>, or <c>&lt;Origin&gt;d__7</c>, all of which
+    /// carry ordinals that shift when unrelated members are added nearby. The
+    /// pin names the authored method so it does not churn on edits that have
+    /// nothing to do with trust.
+    /// </summary>
+    static string Unmangle(string name)
+    {
+        if (!name.StartsWith('<'))
+            return name;
+
+        int end = name.IndexOf('>');
+        if (end <= 1)
+            return name;
+
+        return name[1..end];
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
@@ -31,6 +31,16 @@ namespace ILInspector.Decompiler.Tests;
 /// stops obtaining or granting is a stale entry.
 /// </para>
 /// <para>
+/// Grants are recognised the same way, by identity rather than by spelling. A
+/// call into <c>CoreLibraryIdentityTrust</c> grants unless its member is named
+/// in <see cref="s_nonGrantingTrustMembers"/>, and
+/// <see cref="TrustTypeMembers_AreClassified"/> fails when the type gains a
+/// member that set does not account for. Round 3 of PR #4469 escaped an earlier
+/// <c>StartsWith("Grant")</c> test with a member named <c>Classify</c> that
+/// forwarded to the grant: recognising a grant by its name reproduced, on the
+/// grant half, the very non-convergence this gate exists to end.
+/// </para>
+/// <para>
 /// The scan sees <em>creation</em>, not receipt. A method handed a reader —
 /// through a delegate, an interface, or a reflective invoke whose IL never
 /// mentions <c>GetMetadataReader</c> — does not appear here, and round 2 of PR
@@ -74,6 +84,41 @@ public sealed class ReaderConstructionSiteTests
     /// name.
     /// </summary>
     const string TrustTypeFullName = "ILInspector.Decompiler.Pipeline.CoreLibraryIdentityTrust";
+
+    /// <summary>
+    /// The members of the trust type that answer a question without conferring
+    /// anything. Every other member is treated as granting, so a new member is
+    /// grant-relevant until someone classifies it here.
+    /// </summary>
+    /// <remarks>
+    /// The polarity is deliberate and was itself a review finding. Round 3 of PR
+    /// #4469 escaped a <c>StartsWith("Grant")</c> test by adding a member named
+    /// <c>Classify</c> that forwarded to the grant, and calling it from a site
+    /// pinned as acquisition-only: every test stayed green while every opened
+    /// reader gained identity. Recognising grants by their name reproduced, on
+    /// the grant half, the cosmetic non-convergence that issue #4464 exists to
+    /// end — a name is one more unbounded dimension. Listing the members that do
+    /// <em>not</em> grant is bounded, because <see cref="TrustTypeMembers_AreClassified"/>
+    /// fails when the type gains a member this set does not name.
+    /// </remarks>
+    static readonly ImmutableHashSet<string> s_nonGrantingTrustMembers =
+        ImmutableHashSet.Create(
+            StringComparer.Ordinal,
+            "MayMint",
+            "MayMintCoreLibraryIdentity");
+
+    /// <summary>
+    /// The members of the trust type that confer core-library identity. This set
+    /// is not what <see cref="RoleOf"/> tests — it treats everything outside
+    /// <see cref="s_nonGrantingTrustMembers"/> as granting — but naming it lets
+    /// <see cref="TrustTypeMembers_AreClassified"/> require that every declared
+    /// member be a deliberate entry on one side or the other.
+    /// </summary>
+    static readonly ImmutableHashSet<string> s_grantingTrustMembers =
+        ImmutableHashSet.Create(
+            StringComparer.Ordinal,
+            "GrantCoreLibraryIdentity",
+            "GrantIfEntitled");
 
     /// <summary>
     /// Whether a trust-relevant site obtains a reader, grants core-library
@@ -201,6 +246,64 @@ public sealed class ReaderConstructionSiteTests
 
         Assert.Contains(observed, e => e.Value.HasFlag(TrustRole.ObtainsReader));
         Assert.Contains(observed, e => e.Value.HasFlag(TrustRole.GrantsIdentity));
+    }
+
+    /// <summary>
+    /// Keeps <see cref="s_nonGrantingTrustMembers"/> honest by deriving the
+    /// question from the type instead of restating it. A member added to
+    /// <c>CoreLibraryIdentityTrust</c> is grant-relevant to
+    /// <see cref="RoleOf"/> until it is named here, and this test says so out
+    /// loud rather than letting the omission read as approval. Set equality, so
+    /// a stale entry for a deleted member fails too.
+    /// </summary>
+    [Fact]
+    public void TrustTypeMembers_AreClassified()
+    {
+        using var stream = File.OpenRead(typeof(MetadataSource).Assembly.Location);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+
+        var declared = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(handle);
+            if (FullName(reader, handle) != TrustTypeFullName)
+                continue;
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                string name = reader.GetString(reader.GetMethodDefinition(methodHandle).Name);
+
+                // The static constructor is emitted for the trust table itself and
+                // is never a callable grant vector, so it is not a classification
+                // anyone has to make.
+                if (name == ".cctor")
+                    continue;
+
+                declared.Add(name);
+            }
+        }
+
+        Assert.NotEmpty(declared);
+
+        var classified = s_grantingTrustMembers.Union(s_nonGrantingTrustMembers);
+
+        Assert.True(
+            declared.SetEquals(classified),
+            "The members of CoreLibraryIdentityTrust no longer match their "
+            + "classification. Every member has to be named as granting or as "
+            + "non-granting, because RoleOf treats an unclassified one as a "
+            + "grant and the pin will fail until someone decides which it is."
+            + Environment.NewLine
+            + $"  Declared but unclassified: {Format(declared.Except(classified))}"
+            + Environment.NewLine
+            + $"  Classified but not declared: {Format(classified.Except(declared))}");
+
+        static string Format(IEnumerable<string> names)
+        {
+            string joined = string.Join(", ", names.Order(StringComparer.Ordinal));
+            return joined.Length == 0 ? "(none)" : joined;
+        }
     }
 
     /// <summary>
@@ -357,7 +460,7 @@ public sealed class ReaderConstructionSiteTests
             }
 
             if (declaringType == TrustTypeFullName
-                && member.StartsWith("Grant", StringComparison.Ordinal))
+                && !s_nonGrantingTrustMembers.Contains(member))
             {
                 role |= TrustRole.GrantsIdentity;
             }

--- a/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReaderConstructionSiteTests.cs
@@ -31,14 +31,25 @@ namespace ILInspector.Decompiler.Tests;
 /// stops obtaining or granting is a stale entry.
 /// </para>
 /// <para>
-/// Grants are recognised the same way, by identity rather than by spelling. A
-/// call into <c>CoreLibraryIdentityTrust</c> grants unless its member is named
-/// in <see cref="s_nonGrantingTrustMembers"/>, and
-/// <see cref="TrustTypeMembers_AreClassified"/> fails when the type gains a
-/// member that set does not account for. Round 3 of PR #4469 escaped an earlier
-/// <c>StartsWith("Grant")</c> test with a member named <c>Classify</c> that
-/// forwarded to the grant: recognising a grant by its name reproduced, on the
-/// grant half, the very non-convergence this gate exists to end.
+/// Grants are recognised by the primitive, not by the call surface. Core-library
+/// identity <em>is</em> membership in the <c>s_trusted</c> table, so
+/// <see cref="TrustTableAccess_IsConfinedToItsPinnedMembers"/> pins every method
+/// in the assembly whose IL reaches that field, whatever it is called and
+/// whatever type declares it. A call into <c>CoreLibraryIdentityTrust</c> is
+/// still reported as a grant unless its full signature appears in
+/// <see cref="s_nonGrantingTrustMembers"/>, and
+/// <see cref="TrustTypeMembers_AreClassified"/> requires the type to account for
+/// every member it declares and to declare no nested types.
+/// </para>
+/// <para>
+/// That structure is the answer to #4464 rather than one more patch. Rounds 3
+/// and 4 escaped the call-surface scan four times — a member named
+/// <c>Classify</c>, a nested <c>Helper</c> reaching the table directly, a
+/// granting static constructor, and a <c>MayMint(MetadataReader)</c> overload
+/// inheriting a bare-name exemption. Each was a fresh cosmetic dimension, which
+/// is exactly the series that has no end. The field is not a dimension: to
+/// confer trust you must reach the table, so pinning its referents is complete
+/// by construction.
 /// </para>
 /// <para>
 /// The scan sees <em>creation</em>, not receipt. A method handed a reader —
@@ -83,6 +94,31 @@ public sealed class ReaderConstructionSiteTests
     /// display name was escaped in review by declaring a namespace with this
     /// name.
     /// </summary>
+    /// <summary>
+    /// The field that <em>is</em> the trust. Core-library identity is exactly
+    /// membership in this table, so every IL reference to it in the assembly is
+    /// pinned by <see cref="TrustTableAccess_IsConfinedToItsPinnedMembers"/>.
+    /// </summary>
+    const string TrustTableFieldName = "s_trusted";
+
+    /// <summary>
+    /// The static constructor that creates the trust table. It is the one method
+    /// allowed to store the field, because it is the method that makes it.
+    /// </summary>
+    const string TrustTableInitializerKey = "Pipeline.CoreLibraryIdentityTrust..cctor()";
+
+    /// <summary>
+    /// Every method in <c>ILInspector.Decompiler</c> permitted to touch the trust
+    /// table, keyed by full signature. Nothing else in the assembly may name the
+    /// field at all — not a nested helper, not a static constructor, not another
+    /// overload of an allow-listed name.
+    /// </summary>
+    static readonly ImmutableHashSet<string> s_trustTableAccessors =
+        ImmutableHashSet.Create(
+            StringComparer.Ordinal,
+            "Pipeline.CoreLibraryIdentityTrust.GrantCoreLibraryIdentity(MetadataReader)",
+            "Pipeline.CoreLibraryIdentityTrust.MayMintCoreLibraryIdentity(MetadataReader)");
+
     const string TrustTypeFullName = "ILInspector.Decompiler.Pipeline.CoreLibraryIdentityTrust";
 
     /// <summary>
@@ -104,8 +140,8 @@ public sealed class ReaderConstructionSiteTests
     static readonly ImmutableHashSet<string> s_nonGrantingTrustMembers =
         ImmutableHashSet.Create(
             StringComparer.Ordinal,
-            "MayMint",
-            "MayMintCoreLibraryIdentity");
+            "MayMint(AssemblyResolutionProvenance, CoreLibraryTrustPolicy)",
+            "MayMintCoreLibraryIdentity(MetadataReader)");
 
     /// <summary>
     /// The members of the trust type that confer core-library identity. This set
@@ -117,8 +153,8 @@ public sealed class ReaderConstructionSiteTests
     static readonly ImmutableHashSet<string> s_grantingTrustMembers =
         ImmutableHashSet.Create(
             StringComparer.Ordinal,
-            "GrantCoreLibraryIdentity",
-            "GrantIfEntitled");
+            "GrantCoreLibraryIdentity(MetadataReader)",
+            "GrantIfEntitled(MetadataReader, AssemblyResolutionProvenance, CoreLibraryTrustPolicy)");
 
     /// <summary>
     /// Whether a trust-relevant site obtains a reader, grants core-library
@@ -256,6 +292,17 @@ public sealed class ReaderConstructionSiteTests
     /// loud rather than letting the omission read as approval. Set equality, so
     /// a stale entry for a deleted member fails too.
     /// </summary>
+    /// <remarks>
+    /// Keyed by full signature, not by bare name. Round 4 of PR #4469 escaped a
+    /// name-keyed version by adding a granting <c>MayMint(MetadataReader)</c>
+    /// overload, which silently inherited the exemption belonging to the
+    /// unrelated <c>MayMint(AssemblyResolutionProvenance, CoreLibraryTrustPolicy)</c>.
+    /// The trust type is also required to declare no nested types, because a
+    /// nested helper can reach the private table while its call sites never name
+    /// the trust type — the other round-4 escape. <c>.cctor</c> is skipped here
+    /// and covered by <see cref="TrustTableAccess_IsConfinedToItsPinnedMembers"/>,
+    /// which does not skip it.
+    /// </remarks>
     [Fact]
     public void TrustTypeMembers_AreClassified()
     {
@@ -264,27 +311,44 @@ public sealed class ReaderConstructionSiteTests
         var reader = pe.GetMetadataReader();
 
         var declared = new HashSet<string>(StringComparer.Ordinal);
+        var nested = new List<string>();
         foreach (var handle in reader.TypeDefinitions)
         {
             var type = reader.GetTypeDefinition(handle);
             if (FullName(reader, handle) != TrustTypeFullName)
                 continue;
 
+            foreach (var nestedHandle in type.GetNestedTypes())
+                nested.Add(FullName(reader, nestedHandle));
+
             foreach (var methodHandle in type.GetMethods())
             {
-                string name = reader.GetString(reader.GetMethodDefinition(methodHandle).Name);
+                var definition = reader.GetMethodDefinition(methodHandle);
+                string name = reader.GetString(definition.Name);
 
-                // The static constructor is emitted for the trust table itself and
-                // is never a callable grant vector, so it is not a classification
-                // anyone has to make.
+                // The static constructor initializes the trust table and cannot be
+                // called, so it is not a classification anyone has to make. It is
+                // not thereby unexamined: TrustTableAccess_IsConfinedToItsPinnedMembers
+                // scans it like any other method, so a .cctor that granted would
+                // fail there.
                 if (name == ".cctor")
                     continue;
 
-                declared.Add(name);
+                var signature = definition.DecodeSignature(
+                    new SignatureTypeNames(), genericContext: null);
+                declared.Add($"{name}({string.Join(", ", signature.ParameterTypes)})");
             }
         }
 
         Assert.NotEmpty(declared);
+
+        Assert.True(
+            nested.Count == 0,
+            "CoreLibraryIdentityTrust declares a nested type. A nested type can "
+            + "reach the private trust table while none of its call sites name "
+            + "the trust type, so the grant would not appear on the trust "
+            + "surface at all: "
+            + Format(nested));
 
         var classified = s_grantingTrustMembers.Union(s_nonGrantingTrustMembers);
 
@@ -302,6 +366,54 @@ public sealed class ReaderConstructionSiteTests
         static string Format(IEnumerable<string> names)
         {
             string joined = string.Join(", ", names.Order(StringComparer.Ordinal));
+            return joined.Length == 0 ? "(none)" : joined;
+        }
+    }
+
+    /// <summary>
+    /// Confines the grant primitive. Core-library identity is not conferred by
+    /// calling something named like a grant — it is conferred by putting a reader
+    /// into <c>s_trusted</c>, and read back by looking one up. So every method in
+    /// the assembly whose IL names that field has to be pinned here, whatever it
+    /// is called, whatever type declares it, and whether or not it is reachable
+    /// through the trust type's public surface.
+    /// </summary>
+    /// <remarks>
+    /// This is the test that makes the gate converge, and round 4 of PR #4469 is
+    /// why it exists. Both reviewers escaped a scan that keyed on calls
+    /// <em>into</em> <c>CoreLibraryIdentityTrust</c>: a nested
+    /// <c>CoreLibraryIdentityTrust.Helper.Grant</c> mutating the table directly
+    /// never names the trust type at its call site, and the type's own static
+    /// constructor was skipped outright. Sol added a third — a granting
+    /// <c>MayMint(MetadataReader)</c> overload, which inherited the exemption of
+    /// the unrelated <c>MayMint</c> because the allow list was keyed on the bare
+    /// name. Each was a fresh cosmetic dimension on the call surface, which is
+    /// the non-convergence issue #4464 exists to end. The field is not a
+    /// dimension: trust <em>is</em> membership in that table, so pinning its
+    /// referents is complete by construction rather than by enumeration.
+    /// </remarks>
+    [Fact]
+    public void TrustTableAccess_IsConfinedToItsPinnedMembers()
+    {
+        var observed = EnumerateMethods(typeof(MetadataSource).Assembly.Location)
+            .Where(e => e.Method.ReachesTrustTable)
+            .Select(e => e.Key)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.True(
+            observed.SetEquals(s_trustTableAccessors),
+            "The set of methods that touch the core-library trust table has "
+            + "changed. Granting identity means putting a reader into that "
+            + "table, so anything able to name the field can confer trust no "
+            + "matter what it is called or where it is declared."
+            + Environment.NewLine
+            + $"  Touches the table but is not pinned: {Format(observed.Except(s_trustTableAccessors))}"
+            + Environment.NewLine
+            + $"  Pinned but no longer touches it: {Format(s_trustTableAccessors.Except(observed))}");
+
+        static string Format(IEnumerable<string> keys)
+        {
+            string joined = string.Join(", ", keys.Order(StringComparer.Ordinal));
             return joined.Length == 0 ? "(none)" : joined;
         }
     }
@@ -403,7 +515,10 @@ public sealed class ReaderConstructionSiteTests
         return sites.ToImmutableDictionary(StringComparer.Ordinal);
     }
 
-    readonly record struct ScannedMethod(TrustRole Role, string DeclaringTypeFullName);
+    readonly record struct ScannedMethod(
+        TrustRole Role,
+        string DeclaringTypeFullName,
+        bool ReachesTrustTable);
 
     static IEnumerable<(ScannedMethod Method, string Key)> EnumerateMethods(string assemblyPath)
     {
@@ -426,9 +541,80 @@ public sealed class ReaderConstructionSiteTests
                 continue;
 
             string declaringType = FullName(reader, method.GetDeclaringType());
+            string key = SiteKey(reader, method, declaringType);
             yield return (
-                new ScannedMethod(RoleOf(reader, il), declaringType),
-                SiteKey(reader, method, declaringType));
+                new ScannedMethod(
+                    RoleOf(reader, il),
+                    declaringType,
+                    ReachesTrustTable(reader, il, key)),
+                key);
+        }
+    }
+
+    /// <summary>
+    /// Whether this method can reach the contents of the trust table. Loading the
+    /// field, its address, or its token all count, because mutating the table
+    /// requires getting hold of it first. Storing the field is initialization
+    /// rather than reach, and is allowed only in the static constructor that
+    /// creates the table — anywhere else, replacing the table wholesale would be
+    /// a way to install a pre-populated one.
+    /// </summary>
+    static bool ReachesTrustTable(MetadataReader reader, byte[] il, string siteKey)
+    {
+        bool loads = false;
+        bool stores = false;
+
+        foreach (var instruction in InstructionDecoder.Decode(il))
+        {
+            if (instruction.Operand is not (OperandKind.InlineField or OperandKind.InlineTok))
+                continue;
+
+            var operand = MetadataTokens.EntityHandle((int)instruction.OperandValue);
+            if (!TryDescribeField(reader, operand, out string declaringType, out string field))
+                continue;
+
+            if (declaringType != TrustTypeFullName || field != TrustTableFieldName)
+                continue;
+
+            if (instruction.OpCode is ILOpCode.Stsfld or ILOpCode.Stfld)
+                stores = true;
+            else
+                loads = true;
+        }
+
+        return loads || (stores && siteKey != TrustTableInitializerKey);
+    }
+
+    static bool TryDescribeField(
+        MetadataReader reader,
+        EntityHandle handle,
+        out string declaringType,
+        out string field)
+    {
+        declaringType = "";
+        field = "";
+
+        switch (handle.Kind)
+        {
+            case HandleKind.FieldDefinition:
+            {
+                var definition = reader.GetFieldDefinition((FieldDefinitionHandle)handle);
+                field = reader.GetString(definition.Name);
+                declaringType = FullName(reader, definition.GetDeclaringType());
+                return true;
+            }
+            case HandleKind.MemberReference:
+            {
+                var reference = reader.GetMemberReference((MemberReferenceHandle)handle);
+                if (reference.GetKind() != MemberReferenceKind.Field)
+                    return false;
+
+                field = reader.GetString(reference.Name);
+                declaringType = TypeNameOf(reader, reference.Parent);
+                return true;
+            }
+            default:
+                return false;
         }
     }
 
@@ -450,7 +636,7 @@ public sealed class ReaderConstructionSiteTests
             // container. Review of PR #4469 escaped a PEReader-only scan through
             // MetadataReaderProvider and through the unsafe MetadataReader
             // constructor, neither of which constructs a PEReader.
-            if (member == "GetMetadataReader")
+            if (MemberName(member) == "GetMetadataReader")
                 role |= TrustRole.ObtainsReader;
 
             if (instruction.OpCode == ILOpCode.Newobj
@@ -469,6 +655,15 @@ public sealed class ReaderConstructionSiteTests
         return role;
     }
 
+    /// <summary>
+    /// The bare name of a signature-qualified member key.
+    /// </summary>
+    static string MemberName(string member)
+    {
+        int paren = member.IndexOf('(', StringComparison.Ordinal);
+        return paren < 0 ? member : member[..paren];
+    }
+
     static bool TryDescribeMember(
         MetadataReader reader,
         EntityHandle handle,
@@ -484,13 +679,23 @@ public sealed class ReaderConstructionSiteTests
             {
                 var reference = reader.GetMemberReference((MemberReferenceHandle)handle);
                 member = reader.GetString(reference.Name);
+                if (reference.GetKind() == MemberReferenceKind.Method)
+                {
+                    var signature = reference.DecodeMethodSignature(
+                        new SignatureTypeNames(), genericContext: null);
+                    member += $"({string.Join(", ", signature.ParameterTypes)})";
+                }
+
                 declaringType = TypeNameOf(reader, reference.Parent);
                 return true;
             }
             case HandleKind.MethodDefinition:
             {
                 var definition = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
-                member = reader.GetString(definition.Name);
+                var signature = definition.DecodeSignature(
+                    new SignatureTypeNames(), genericContext: null);
+                member = reader.GetString(definition.Name)
+                    + $"({string.Join(", ", signature.ParameterTypes)})";
                 declaringType = FullName(reader, definition.GetDeclaringType());
                 return true;
             }

--- a/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
@@ -47,8 +47,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <c>ReaderConstructionSiteTests</c>, which pins every method in this assembly
 /// whose IL obtains a <c>MetadataReader</c> or calls a grant here, so a new way
 /// to obtain a reader cannot be added without saying which half it is on. That
-/// pin covers reader acquisition and granting, not provenance: whether a grant
-/// is deserved remains <c>PlantedCoreLibraryIdentityTests</c>'s property.
+/// pin covers reader creation and granting, not provenance and not receipt:
+/// whether a grant is deserved remains <c>PlantedCoreLibraryIdentityTests</c>'s
+/// property, and a reader arriving by delegate or reflection is simply
+/// unclassified, which is the fail-closed answer.
 /// </para>
 /// </summary>
 static class CoreLibraryIdentityTrust

--- a/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
@@ -45,8 +45,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// halves — the grant and the check — and covers the resolved, designated,
 /// raw-path, and unclassified open paths, and by
 /// <c>ReaderConstructionSiteTests</c>, which pins every method in this assembly
-/// whose IL obtains a <c>MetadataReader</c> or calls a grant here, so a new way
-/// to obtain a reader cannot be added without saying which half it is on. That
+/// whose IL obtains a <c>MetadataReader</c> or calls into this type, so a new way
+/// to obtain a reader cannot be added without saying which half it is on. A call
+/// here counts as a grant unless its member is listed as non-granting, and that
+/// list is required to account for every member this type declares — so adding a
+/// grant under a name that does not look like one fails the gate. That
 /// pin covers reader creation and granting, not provenance and not receipt:
 /// whether a grant is deserved remains <c>PlantedCoreLibraryIdentityTests</c>'s
 /// property, and a reader arriving by delegate or reflection is simply

--- a/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
@@ -45,11 +45,12 @@ namespace ILInspector.Decompiler.Pipeline;
 /// halves — the grant and the check — and covers the resolved, designated,
 /// raw-path, and unclassified open paths, and by
 /// <c>ReaderConstructionSiteTests</c>, which pins every method in this assembly
-/// whose IL obtains a <c>MetadataReader</c> or calls into this type, so a new way
-/// to obtain a reader cannot be added without saying which half it is on. A call
-/// here counts as a grant unless its member is listed as non-granting, and that
-/// list is required to account for every member this type declares — so adding a
-/// grant under a name that does not look like one fails the gate. That
+/// whose IL obtains a <c>MetadataReader</c> or reaches the trust table, so a new
+/// way to obtain a reader cannot be added without saying which half it is on.
+/// Identity is exactly membership in <c>s_trusted</c>, and every method able to
+/// reach that field is pinned by signature — so a grant cannot hide behind a
+/// name, a nested helper, a static constructor, or an overload of a member that
+/// does not grant. That
 /// pin covers reader creation and granting, not provenance and not receipt:
 /// whether a grant is deserved remains <c>PlantedCoreLibraryIdentityTests</c>'s
 /// property, and a reader arriving by delegate or reflection is simply

--- a/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
@@ -43,7 +43,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <para>
 /// Gated by <c>PlantedCoreLibraryIdentityTests</c>, which tamper-verifies both
 /// halves — the grant and the check — and covers the resolved, designated,
-/// raw-path, and unclassified open paths.
+/// raw-path, and unclassified open paths, and by
+/// <c>ReaderConstructionSiteTests</c>, which pins every method in this assembly
+/// whose IL constructs a <c>PEReader</c> or calls a grant here, so a new way to
+/// obtain a reader cannot be added without saying which half it is on.
 /// </para>
 /// </summary>
 static class CoreLibraryIdentityTrust

--- a/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
@@ -48,13 +48,14 @@ namespace ILInspector.Decompiler.Pipeline;
 /// whose IL obtains a <c>MetadataReader</c> or reaches the trust table, so a new
 /// way to obtain a reader cannot be added without saying which half it is on.
 /// Identity is exactly membership in <c>s_trusted</c>, and every method able to
-/// reach that field is pinned by signature — so a grant cannot hide behind a
-/// name, a nested helper, a static constructor, or an overload of a member that
-/// does not grant. That
-/// pin covers reader creation and granting, not provenance and not receipt:
-/// whether a grant is deserved remains <c>PlantedCoreLibraryIdentityTests</c>'s
-/// property, and a reader arriving by delegate or reflection is simply
-/// unclassified, which is the fail-closed answer.
+/// reach that field in IL is pinned by signature — so a grant cannot hide behind
+/// a name, a nested helper, a static constructor, or an overload of a member
+/// that does not grant. That pin covers reader creation and direct grants, not
+/// provenance, not receipt, and not the consumer side: whether a grant is
+/// deserved, and whether the check is honoured at all, remain
+/// <c>PlantedCoreLibraryIdentityTests</c>'s property, and a reader arriving by
+/// delegate or reflection is simply unclassified, which is the fail-closed
+/// answer.
 /// </para>
 /// </summary>
 static class CoreLibraryIdentityTrust

--- a/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoreLibraryIdentityTrust.cs
@@ -45,8 +45,10 @@ namespace ILInspector.Decompiler.Pipeline;
 /// halves — the grant and the check — and covers the resolved, designated,
 /// raw-path, and unclassified open paths, and by
 /// <c>ReaderConstructionSiteTests</c>, which pins every method in this assembly
-/// whose IL constructs a <c>PEReader</c> or calls a grant here, so a new way to
-/// obtain a reader cannot be added without saying which half it is on.
+/// whose IL obtains a <c>MetadataReader</c> or calls a grant here, so a new way
+/// to obtain a reader cannot be added without saying which half it is on. That
+/// pin covers reader acquisition and granting, not provenance: whether a grant
+/// is deserved remains <c>PlantedCoreLibraryIdentityTests</c>'s property.
 /// </para>
 /// </summary>
 static class CoreLibraryIdentityTrust


### PR DESCRIPTION
## Conclusion

The gate that guarantees no reader-creation site was overlooked now reads the
compiled IL instead of enumerating factory signatures. Adding an `internal
static` factory or a `Task<MetadataSource>` factory that creates an
unclassified reader is caught; before this change, both were invisible.

Fixes #4464.

## Why the previous formulation could not converge

`EveryPublicFactory_ClassifiesTheReaderItCreates` (#4428) reflects over
`MetadataSource`'s factory methods. Three consecutive review rounds escaped it
along a different cosmetic dimension each time:

| Round | Escape | Response |
| --- | --- | --- |
| 4 | selection keyed on `name.StartsWith("Open")` — a rename dropped coverage | select on return type |
| 5 | exact `ReturnType ==` — declaring the factory `IDisposable` escaped | `IsAssignableFrom`, classify the returned object |
| 6 | `BindingFlags.Public` misses `internal`; `IsAssignableFrom` misses `Task<MetadataSource>` | *this PR* |

Each fix was correct and each was escaped again, because the enumerated surface
is open-ended: a *signature* has unboundedly many dimensions an author can
change without intending to change coverage. Patching one per round is not a
strategy.

## What replaces it

`ReaderConstructionSiteTests.TrustRelevantSites_MatchThePin` reads the compiled
`ILInspector.Decompiler` assembly and records every method whose IL contains
`newobj PEReader::.ctor` or a call to a `CoreLibraryIdentityTrust` grant. A
method that builds a reader contains that instruction whatever it is called,
however it is declared, and whether or not its result is wrapped — so all three
escapes, and any future one of the same kind, land inside the observation
rather than outside it. Decoding uses the repository's own
`ILInspector.Instructions.InstructionDecoder`, not a hand-rolled IL walk.

Both directions fail. An unpinned site is an unreviewed way to obtain a reader;
a pinned site that stops constructing or granting is a stale entry. That is the
"declaration drives enforcement" shape `AGENTS.md` asks for.

**Listing a site is not approval.** Five of the ten pinned sites deliberately
do *not* classify — an unclassified reader loses core-library identity, which is
the fail-closed half of the design — and the table records which half each site
is on, with a reason. What the pin buys is that adding either kind of site
forces someone to say which it is.

The ten sites: `MetadataContext.OpenDesignated` and `OpenResolved` (grant),
`MetadataSource.OpenCore` and `OpenFromPrefetchedImage` (construct and grant),
`OpenedAssembly.TryOpen` and `MemberBodyProducer.{ComposeCore,
ComposeMemberCore, ComposeMembersBatch}` (construct, deliberately unclassified
— the sibling path from #4411).

`Scanner_ObservesBothConstructionAndGrantSites` is the non-vacuity check: a
scan compared against a table would pass just as happily if the scan silently
observed nothing, so this asserts the scanner still finds both things it looks
for.

## Evidence

**Tamper-verified in both directions, at this head.**

Adding Gemini's two round-6 escapes — an `internal static` factory and a
`public static Task<MetadataSource>` factory, both creating a reader:

```text
=== NEW GATE ===
  ReaderConstructionSiteTests.TrustRelevantSites_MatchThePin [FAIL]
    Pipeline.MetadataSource.SneakyInternal: ConstructsReader, but is not pinned.
  Total: 2, Failed: 1
=== OLD SIGNATURE GATE ===
  Total: 8, Errors: 0, Failed: 0
```

The signature gate stays **green at 8/8** with both escapes present. That is
the finding from #4464, reproduced and then closed.

Moving a construction into a helper reports both halves:

```text
MemberBodyProducer.ComposeCore: pinned as ConstructsReader, but no longer
  constructs a reader or grants identity. Remove the stale entry.
MemberBodyProducer.OpenProbe: ConstructsReader, but is not pinned.
```

Deleting the grant in `MetadataContext.OpenDesignated`:

```text
Pipeline.MetadataContext.OpenDesignated: pinned as GrantsIdentity, but no
  longer constructs a reader or grants identity.
```

All product tampering was reverted with `git checkout --`; the gate is green on
restored sources.

**Suites:** full `ILInspector.Decompiler.Tests` **5835 passed, 0 failed**.
Focused gate re-run green after merging `origin/main`. `markdownlint` clean on
the changed doc.

## Scope and non-action

Test-only plus two documentation updates; no product behavior changes.

The scan covers `ILInspector.Decompiler`, which is the whole trust boundary:
`TypeRefDecoder` is `internal sealed` there, so `CanonicalSelf` is unreachable
from other assemblies. The ~35 `PEReader` constructions elsewhere in the
repository cannot reach it, and a reader arriving from outside is simply
unclassified — fail closed.

The signature gate is retained rather than replaced. It remains a useful
positive check that a designated core library *keeps* its identity; this gate
covers the property it could not.
