### PR TITLE
Convert inspect-web package opportunities lens to TypeScript

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -631,6 +631,19 @@ event handlers, and passes each computed slice in explicitly.
 medium toggles and hidden-line count, the context-limitation notice, anchored
 versus unanchored fact rendering, selection state, and source-text escaping.
 
+`src/package-opportunities.ts` owns the package/platform "Integration
+opportunities" lens (the ecosystem auth/cloud/config/database/AI-client
+integration suggestions for a package or platform library) as a pure,
+dependency-injected render function, including its opportunity-row API-name
+splitting, package-chip detection, and "look for" chip rendering. `app.js`
+still owns `state`, the scan-scope-keyed async load lifecycle
+(`loadPackageOpportunities`), and the platform library picker, and passes
+each computed slice in explicitly. `test/package-opportunities.test.js` gates
+the platform pick-a-library prompt, the scanning/loading/error states (fresh
+versus stale scope), the no-opportunities and inspection-error banners, the
+category summary counts, API name splitting, package-chip versus plain-text
+kind rendering, look-for chip/wildcard/empty rendering, and text escaping.
+
 - `Cmd/Ctrl+K` opens Spotlight in the Commands scope.
 - `Cmd/Ctrl+P` opens Spotlight in the All scope.
 - `Cmd/Ctrl+F` or `/` focuses the type filter.

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -49,6 +49,7 @@ import { renderScopeBar as renderScopeBarPure } from "/src/scope-bar.ts";
 import { renderDocViewer as renderDocViewerPure } from "/src/doc-viewer.ts";
 import { renderGraphSource as renderGraphSourcePure } from "/src/graph-source.ts";
 import { renderAnnotatedSource as renderAnnotatedSourcePure } from "/src/annotated-source.ts";
+import { renderPackageOpportunities as renderPackageOpportunitiesPure } from "/src/package-opportunities.ts";
 import {
   renderMemberNav,
   renderTypeMetadata,
@@ -2046,95 +2047,18 @@ function renderPackageOpportunities() {
   const isPlatform = Boolean(state.package?.isRuntimePack);
   const scopedLib = scopedPlatformLibrary();
   const picker = isPlatform ? platformLensPicker("data-platform-opportunities-library") : "";
-  if (isPlatform && !scopedLib) {
-    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Pick a library to scan</h2><p>Choose a .NET platform library above to compare its public surface against ecosystem integration patterns.</p></section>`;
-  }
-  const scanScope = isPlatform ? `${escapeHtml(scopedLib)} · ${escapeHtml(state.package.activeFramework)}` : escapeHtml(state.package.activeFramework);
   const current = packageScopeSignature();
-  const fresh = state.packageOpportunitiesKey === current;
-  if (state.packageOpportunitiesLoading && fresh) {
-    return `${picker}<section class="document-section source-progress"><span class="loader"></span><h2>Scanning opportunities…</h2><p>Comparing the public surface against ecosystem integration patterns.</p></section>`;
-  }
-  if (fresh && state.packageOpportunitiesError) {
-    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Opportunity scan failed</h2><p>${escapeHtml(state.packageOpportunitiesError)}</p></section>`;
-  }
-  const data = fresh ? state.packageOpportunities : null;
-  if (!data) {
-    return `${picker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
-  }
-
-  const categories = data.categories || [];
-  const warning = data.inspectionError
-    ? `<section class="document-section metadata-warning"><strong>⚠ Some assemblies could not be scanned</strong><ul><li><code>${escapeHtml(data.inspectionError)}</code></li></ul></section>`
-    : "";
-
-  if (!categories.length) {
-    return `${picker}${warning}<section class="document-section empty-document"><span class="large-glyph">◇</span><h2>No integration opportunities</h2><p>The public surface of ${scanScope} shows no obvious auth, cloud-client, configuration, database, or AI-client patterns that suggest a missing ecosystem integration.</p></section>`;
-  }
-
-  const summary = `
-    <section class="document-section">
-      <div class="section-title"><h2>Integration opportunities</h2><span>${categories.length} area${categories.length === 1 ? "" : "s"} · ${data.totalOpportunities} suggestion${data.totalOpportunities === 1 ? "" : "s"} · ${scanScope}</span></div>
-      <p class="lens-note">Ecosystem areas this ${isPlatform ? "library" : "package"}'s surface suggests but does not yet integrate with. Chips are live: the type opens in this package, a suggested package loads on demand, and each "look for" API opens a search.</p>
-      <div class="type-chip-list">${categories.map(category => `<span class="type-chip">${escapeHtml(category.integration)} <span class="ns-count">${category.items.length}</span></span>`).join("")}</div>
-    </section>`;
-
-  const blocks = categories.map(category => {
-    const rows = category.items.map(renderOpportunityRow).join("");
-    return `
-    <section class="document-section">
-      <div class="section-title"><h2>${escapeHtml(category.integration)}</h2><span>${category.items.length} suggestion${category.items.length === 1 ? "" : "s"}</span></div>
-      <div class="opp-list">${rows}</div>
-    </section>`;
-  }).join("");
-
-  return `${picker}${warning}${summary}${blocks}`;
-}
-
-// Renders a single integration-opportunity as a signal-style row with live chips: the API
-// (a type in this package) navigates in place; a suggested package (a dotted namespace parsed
-// from the integration kind) loads on demand; each concrete "look for" API opens the spotlight
-// search. Naming patterns (wildcards) stay as muted, non-clickable hints.
-function renderOpportunityRow(item) {
-  const api = splitSignalName(item.api);
-  const kind = splitOpportunityKind(item.integrationType);
-  const kindHtml = kind.package
-    ? `<button class="opp-package-chip" data-opp-package="${escapeHtml(kind.package)}" title="Load ${escapeHtml(kind.package)} into the workspace">${escapeHtml(kind.package)}</button>${kind.text ? `<span class="opp-kind-text">${escapeHtml(kind.text)}</span>` : ""}`
-    : `<span class="opp-kind-text">${escapeHtml(item.integrationType)}</span>`;
-  return `
-    <div class="opp-row">
-      <span class="signal-badge signal-type">T</span>
-      <div class="opp-body">
-        <div class="opp-head">
-          <button class="opp-type-chip" data-opp-type="${escapeHtml(item.api)}" title="Open ${escapeHtml(item.api)} in this package">
-            <span class="opp-type-name">${escapeHtml(api.short)}</span>${api.qualifier ? `<span class="opp-type-ns">${escapeHtml(api.qualifier)}</span>` : ""}
-          </button>
-          <span class="opp-kind">${kindHtml}</span>
-        </div>
-        <div class="opp-lookfor"><span class="opp-lookfor-label">look for</span>${renderLookForChips(item.lookFor)}</div>
-      </div>
-    </div>`;
-}
-
-// Pulls a leading dotted namespace (a candidate package like "Microsoft.Extensions.AI") off the
-// front of an integration-kind phrase so it can render as a load-on-demand package chip. Kinds
-// with no dotted prefix (e.g. "IServiceCollection registration") stay as plain muted text.
-function splitOpportunityKind(integrationType) {
-  const match = String(integrationType || "").match(/^([A-Z][A-Za-z0-9]+(?:\.[A-Z][A-Za-z0-9]+)+)\b\s*(.*)$/);
-  return match ? { package: match[1], text: match[2].trim() } : { package: null, text: String(integrationType || "") };
-}
-
-// Turns the comma-separated "look for" hint into chips. Concrete identifiers open a spotlight
-// search (seeded on the base name, generics stripped); wildcard patterns like "Add*" render as
-// muted, non-interactive hints because they are naming shapes rather than resolvable types.
-function renderLookForChips(lookFor) {
-  const tokens = String(lookFor || "").split(",").map(token => token.trim()).filter(Boolean);
-  if (!tokens.length) return `<span class="opp-pattern">any registration surface</span>`;
-  return tokens.map(token => {
-    if (token.includes("*")) return `<span class="opp-pattern" title="Naming pattern">${escapeHtml(token)}</span>`;
-    const seed = token.replace(/<.*$/, "");
-    return `<button class="opp-chip" data-opp-lookfor="${escapeHtml(seed)}" title="Search the workspace for ${escapeHtml(token)}">${escapeHtml(token)}</button>`;
-  }).join("");
+  return renderPackageOpportunitiesPure({
+    isPlatform,
+    scopedLibrary: scopedLib,
+    activeFramework: state.package.activeFramework,
+    picker,
+    fresh: state.packageOpportunitiesKey === current,
+    loading: state.packageOpportunitiesLoading,
+    error: state.packageOpportunitiesError,
+    data: state.packageOpportunities,
+    escapeHtml,
+  });
 }
 
 async function loadPackageOpportunities() {

--- a/prototypes/inspect-web/src/package-opportunities.ts
+++ b/prototypes/inspect-web/src/package-opportunities.ts
@@ -1,0 +1,137 @@
+export interface OpportunityItem {
+  api: string;
+  integrationType: string;
+  lookFor: string;
+}
+
+export interface OpportunityCategory {
+  integration: string;
+  items: OpportunityItem[];
+}
+
+export interface PackageOpportunities {
+  categories: OpportunityCategory[];
+  totalOpportunities: number;
+  inspectionError?: string | null;
+}
+
+export interface RenderPackageOpportunitiesOptions {
+  isPlatform: boolean;
+  scopedLibrary: string | null;
+  activeFramework: string;
+  picker: string;
+  fresh: boolean;
+  loading: boolean;
+  error: string;
+  data: PackageOpportunities | null;
+  escapeHtml: (value: unknown) => string;
+}
+
+// Splits a fully-qualified API name (e.g. "System.Collections.Generic.List<T>") into a short
+// display name and its qualifier, cutting before any generic-arity or parameter-list suffix so
+// the suffix renders alongside the short name rather than the qualifier.
+function splitApiName(fullName: string): { short: string; qualifier: string } {
+  const paren = fullName.indexOf("(");
+  const angle = fullName.indexOf("<");
+  const bounds = [paren, angle].filter(i => i >= 0);
+  const cut = bounds.length ? Math.min(...bounds) : -1;
+  const head = cut < 0 ? fullName : fullName.slice(0, cut);
+  const suffix = cut < 0 ? "" : fullName.slice(cut);
+  const dot = head.lastIndexOf(".");
+  return {
+    short: (dot < 0 ? head : head.slice(dot + 1)) + suffix,
+    qualifier: dot < 0 ? "" : head.slice(0, dot),
+  };
+}
+
+// Pulls a leading dotted namespace (a candidate package like "Microsoft.Extensions.AI") off the
+// front of an integration-kind phrase so it can render as a load-on-demand package chip. Kinds
+// with no dotted prefix (e.g. "IServiceCollection registration") stay as plain muted text.
+function splitOpportunityKind(integrationType: string): { package: string | null; text: string } {
+  const match = String(integrationType || "").match(/^([A-Z][A-Za-z0-9]+(?:\.[A-Z][A-Za-z0-9]+)+)\b\s*(.*)$/);
+  return match ? { package: match[1], text: match[2].trim() } : { package: null, text: String(integrationType || "") };
+}
+
+// Turns the comma-separated "look for" hint into chips. Concrete identifiers open a spotlight
+// search (seeded on the base name, generics stripped); wildcard patterns like "Add*" render as
+// muted, non-interactive hints because they are naming shapes rather than resolvable types.
+function renderLookForChips(lookFor: string, escapeHtml: (value: unknown) => string): string {
+  const tokens = String(lookFor || "").split(",").map(token => token.trim()).filter(Boolean);
+  if (!tokens.length) return `<span class="opp-pattern">any registration surface</span>`;
+  return tokens.map(token => {
+    if (token.includes("*")) return `<span class="opp-pattern" title="Naming pattern">${escapeHtml(token)}</span>`;
+    const seed = token.replace(/<.*$/, "");
+    return `<button class="opp-chip" data-opp-lookfor="${escapeHtml(seed)}" title="Search the workspace for ${escapeHtml(token)}">${escapeHtml(token)}</button>`;
+  }).join("");
+}
+
+// Renders a single integration-opportunity as a signal-style row with live chips: the API
+// (a type in this package) navigates in place; a suggested package (a dotted namespace parsed
+// from the integration kind) loads on demand; each concrete "look for" API opens the spotlight
+// search. Naming patterns (wildcards) stay as muted, non-clickable hints.
+function renderOpportunityRow(item: OpportunityItem, escapeHtml: (value: unknown) => string): string {
+  const api = splitApiName(item.api);
+  const kind = splitOpportunityKind(item.integrationType);
+  const kindHtml = kind.package
+    ? `<button class="opp-package-chip" data-opp-package="${escapeHtml(kind.package)}" title="Load ${escapeHtml(kind.package)} into the workspace">${escapeHtml(kind.package)}</button>${kind.text ? `<span class="opp-kind-text">${escapeHtml(kind.text)}</span>` : ""}`
+    : `<span class="opp-kind-text">${escapeHtml(item.integrationType)}</span>`;
+  return `
+    <div class="opp-row">
+      <span class="signal-badge signal-type">T</span>
+      <div class="opp-body">
+        <div class="opp-head">
+          <button class="opp-type-chip" data-opp-type="${escapeHtml(item.api)}" title="Open ${escapeHtml(item.api)} in this package">
+            <span class="opp-type-name">${escapeHtml(api.short)}</span>${api.qualifier ? `<span class="opp-type-ns">${escapeHtml(api.qualifier)}</span>` : ""}
+          </button>
+          <span class="opp-kind">${kindHtml}</span>
+        </div>
+        <div class="opp-lookfor"><span class="opp-lookfor-label">look for</span>${renderLookForChips(item.lookFor, escapeHtml)}</div>
+      </div>
+    </div>`;
+}
+
+export function renderPackageOpportunities(options: RenderPackageOpportunitiesOptions): string {
+  const { isPlatform, scopedLibrary, activeFramework, picker, fresh, loading, error, data, escapeHtml } = options;
+
+  if (isPlatform && !scopedLibrary) {
+    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Pick a library to scan</h2><p>Choose a .NET platform library above to compare its public surface against ecosystem integration patterns.</p></section>`;
+  }
+  const scanScope = isPlatform ? `${escapeHtml(scopedLibrary)} · ${escapeHtml(activeFramework)}` : escapeHtml(activeFramework);
+  if (loading && fresh) {
+    return `${picker}<section class="document-section source-progress"><span class="loader"></span><h2>Scanning opportunities…</h2><p>Comparing the public surface against ecosystem integration patterns.</p></section>`;
+  }
+  if (fresh && error) {
+    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Opportunity scan failed</h2><p>${escapeHtml(error)}</p></section>`;
+  }
+  const resolved = fresh ? data : null;
+  if (!resolved) {
+    return `${picker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
+  }
+
+  const categories = resolved.categories || [];
+  const warning = resolved.inspectionError
+    ? `<section class="document-section metadata-warning"><strong>⚠ Some assemblies could not be scanned</strong><ul><li><code>${escapeHtml(resolved.inspectionError)}</code></li></ul></section>`
+    : "";
+
+  if (!categories.length) {
+    return `${picker}${warning}<section class="document-section empty-document"><span class="large-glyph">◇</span><h2>No integration opportunities</h2><p>The public surface of ${scanScope} shows no obvious auth, cloud-client, configuration, database, or AI-client patterns that suggest a missing ecosystem integration.</p></section>`;
+  }
+
+  const summary = `
+    <section class="document-section">
+      <div class="section-title"><h2>Integration opportunities</h2><span>${categories.length} area${categories.length === 1 ? "" : "s"} · ${resolved.totalOpportunities} suggestion${resolved.totalOpportunities === 1 ? "" : "s"} · ${scanScope}</span></div>
+      <p class="lens-note">Ecosystem areas this ${isPlatform ? "library" : "package"}'s surface suggests but does not yet integrate with. Chips are live: the type opens in this package, a suggested package loads on demand, and each "look for" API opens a search.</p>
+      <div class="type-chip-list">${categories.map(category => `<span class="type-chip">${escapeHtml(category.integration)} <span class="ns-count">${category.items.length}</span></span>`).join("")}</div>
+    </section>`;
+
+  const blocks = categories.map(category => {
+    const rows = category.items.map(item => renderOpportunityRow(item, escapeHtml)).join("");
+    return `
+    <section class="document-section">
+      <div class="section-title"><h2>${escapeHtml(category.integration)}</h2><span>${category.items.length} suggestion${category.items.length === 1 ? "" : "s"}</span></div>
+      <div class="opp-list">${rows}</div>
+    </section>`;
+  }).join("");
+
+  return `${picker}${warning}${summary}${blocks}`;
+}

--- a/prototypes/inspect-web/test/package-opportunities.test.js
+++ b/prototypes/inspect-web/test/package-opportunities.test.js
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderPackageOpportunities } from "../src/package-opportunities.ts";
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const baseOptions = {
+  isPlatform: false,
+  scopedLibrary: null,
+  activeFramework: "net10.0",
+  picker: "",
+  fresh: true,
+  loading: false,
+  error: "",
+  data: null,
+  escapeHtml,
+};
+
+test("a platform package with no scoped library prompts to pick one, before any scan runs", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    isPlatform: true,
+    scopedLibrary: null,
+    picker: "<PICKER>",
+    fresh: false,
+  });
+
+  assert.match(html, /^<PICKER>/);
+  assert.match(html, /Pick a library to scan/);
+});
+
+test("a fresh scan in progress shows the scanning status", () => {
+  const html = renderPackageOpportunities({ ...baseOptions, loading: true });
+
+  assert.match(html, /Scanning opportunities…/);
+});
+
+test("a loading flag from a stale (non-fresh) scope does not show the scanning status", () => {
+  const html = renderPackageOpportunities({ ...baseOptions, loading: true, fresh: false });
+
+  assert.doesNotMatch(html, /Scanning opportunities…/);
+  assert.match(html, /Loading…/);
+});
+
+test("a fresh scan error shows the failure message, escaped", () => {
+  const html = renderPackageOpportunities({ ...baseOptions, error: "<boom> failed to load" });
+
+  assert.match(html, /Opportunity scan failed/);
+  assert.match(html, /&lt;boom&gt; failed to load/);
+});
+
+test("no data yet (fresh, no error, no data) shows a generic loading placeholder", () => {
+  const html = renderPackageOpportunities(baseOptions);
+
+  assert.match(html, /Loading…/);
+});
+
+test("empty categories render the no-opportunities message with the scan scope", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    data: { categories: [], totalOpportunities: 0 },
+  });
+
+  assert.match(html, /No integration opportunities/);
+  assert.match(html, /net10\.0/);
+});
+
+test("a platform scan scope names the scoped library and framework", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    isPlatform: true,
+    scopedLibrary: "System.Text.Json",
+    data: { categories: [], totalOpportunities: 0 },
+  });
+
+  assert.match(html, /System\.Text\.Json · net10\.0/);
+});
+
+test("an inspection error renders a warning banner alongside categories", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    data: {
+      categories: [{ integration: "Auth", items: [] }],
+      totalOpportunities: 0,
+      inspectionError: "<bad> assembly",
+    },
+  });
+
+  assert.match(html, /Some assemblies could not be scanned/);
+  assert.match(html, /&lt;bad&gt; assembly/);
+});
+
+test("categories render a summary with area\/suggestion counts and a chip per category", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    data: {
+      categories: [
+        { integration: "Auth", items: [{ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "" }] },
+        { integration: "Database", items: [] },
+      ],
+      totalOpportunities: 1,
+    },
+  });
+
+  assert.match(html, /2 areas · 1 suggestion · net10\.0/);
+  assert.match(html, /<span class="type-chip">Auth <span class="ns-count">1<\/span><\/span>/);
+  assert.match(html, /<span class="type-chip">Database <span class="ns-count">0<\/span><\/span>/);
+});
+
+test("an opportunity row splits the API into short name and qualifier", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    data: {
+      categories: [{
+        integration: "AI",
+        items: [{ api: "System.ClientModel.Primitives.PipelineMessage", integrationType: "IServiceCollection registration", lookFor: "" }],
+      }],
+      totalOpportunities: 1,
+    },
+  });
+
+  assert.match(html, /<span class="opp-type-name">PipelineMessage<\/span><span class="opp-type-ns">System\.ClientModel\.Primitives<\/span>/);
+  assert.match(html, /data-opp-type="System\.ClientModel\.Primitives\.PipelineMessage"/);
+});
+
+test("an integration kind with a leading dotted namespace renders a load-on-demand package chip", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    data: {
+      categories: [{
+        integration: "AI",
+        items: [{ api: "Widget", integrationType: "Microsoft.Extensions.AI IChatClient extension", lookFor: "" }],
+      }],
+      totalOpportunities: 1,
+    },
+  });
+
+  assert.match(html, /<button class="opp-package-chip" data-opp-package="Microsoft\.Extensions\.AI"/);
+  assert.match(html, /<span class="opp-kind-text">IChatClient extension<\/span>/);
+});
+
+test("an integration kind with no dotted namespace renders as plain muted text", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    data: {
+      categories: [{
+        integration: "Config",
+        items: [{ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "" }],
+      }],
+      totalOpportunities: 1,
+    },
+  });
+
+  assert.doesNotMatch(html, /opp-package-chip/);
+  assert.match(html, /<span class="opp-kind-text">IServiceCollection registration<\/span>/);
+});
+
+test("look-for tokens render as spotlight-seeded chips, one per comma-separated identifier", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    data: {
+      categories: [{
+        integration: "AI",
+        items: [{ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "AddChatClient, AddEmbeddingGenerator" }],
+      }],
+      totalOpportunities: 1,
+    },
+  });
+
+  assert.match(html, /<button class="opp-chip" data-opp-lookfor="AddChatClient"[^>]*>AddChatClient<\/button>/);
+  assert.match(html, /<button class="opp-chip" data-opp-lookfor="AddEmbeddingGenerator"[^>]*>AddEmbeddingGenerator<\/button>/);
+});
+
+test("a wildcard look-for pattern renders as a muted, non-interactive hint", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    data: {
+      categories: [{
+        integration: "Config",
+        items: [{ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "Add*" }],
+      }],
+      totalOpportunities: 1,
+    },
+  });
+
+  assert.match(html, /<span class="opp-pattern" title="Naming pattern">Add\*<\/span>/);
+  assert.doesNotMatch(html, /opp-chip/);
+});
+
+test("an empty look-for hint renders a generic any-registration-surface hint", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    data: {
+      categories: [{
+        integration: "Config",
+        items: [{ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "" }],
+      }],
+      totalOpportunities: 1,
+    },
+  });
+
+  assert.match(html, /<span class="opp-pattern">any registration surface<\/span>/);
+});
+
+test("API and integration-type text is escaped", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    data: {
+      categories: [{
+        integration: "<Cat>",
+        items: [{ api: "<Widget>", integrationType: "<bad> kind", lookFor: "<bad>" }],
+      }],
+      totalOpportunities: 1,
+    },
+  });
+
+  assert.match(html, /&lt;Widget&gt;/);
+  assert.match(html, /&lt;bad&gt; kind/);
+  assert.match(html, /&lt;Cat&gt;/);
+  assert.doesNotMatch(html, /<Widget>/);
+});


### PR DESCRIPTION
Continues the leaf-node TypeScript conversion series (`command-bar.ts`, `package-bar.ts`, `type-panel.ts`, `settings-panel.ts`, `metadata-viewer.ts`, `scope-bar.ts`, `doc-viewer.ts`, `graph-source.ts`, `annotated-source.ts`).

Extracts `renderPackageOpportunities` (the package/platform "Integration opportunities" lens: ecosystem auth/cloud/config/database/AI-client integration suggestions) out of `app.js` into a new pure, dependency-injected module `src/package-opportunities.ts`. This also folds in the three helper functions the lens uses: `renderOpportunityRow`, `splitOpportunityKind`, and `renderLookForChips` (the API-name splitter was renamed `splitApiName` inside the new module, since `app.js`'s existing `splitSignalName` is still used elsewhere and stays in `app.js`).

`app.js` retains `state`, the scan-scope-keyed async load lifecycle (`loadPackageOpportunities`), and the platform library picker (`platformLensPicker`); a thin wrapper assembles the state slice and delegates to the pure function.

**Validation:**
- `npm run typecheck` — clean
- `node --test` — 206/206 passing (190 existing + 16 new in `test/package-opportunities.test.js`)
- `npm run build` — succeeds
- `markdownlint --config .markdownlint.yaml README.md` — clean

**Non-action boundary:** No behavior change; this is a structural extraction. The scanning/loading/error states, category summary, opportunity row rendering (API splitting, package-chip detection, look-for chips), and escaping behavior are preserved exactly.
