### PR TITLE
Add StructuralCloneComparisonDocument (Slice 1 of #4304)

### DIFF
--- a/src/ILInspector.Analysis.Tests/StructuralCloneComparisonDocumentTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneComparisonDocumentTests.cs
@@ -79,6 +79,85 @@ public class StructuralCloneComparisonDocumentTests
     }
 
     [Fact]
+    public void Constructor_SameModuleVersionIdDifferentHash_Throws()
+    {
+        // A module version id alone is not a sufficient identity: MVIDs are not
+        // guaranteed globally unique, so two byte-distinct modules could otherwise
+        // slip past the A-vs-A boundary while carrying different content hashes.
+        Guid sharedModuleVersionId = Guid.NewGuid();
+        StructuralCloneModuleIdentity left =
+            new("left.dll", new string('a', 64), sharedModuleVersionId);
+        StructuralCloneModuleIdentity right =
+            new("right.dll", new string('b', 64), sharedModuleVersionId);
+
+        Assert.Throws<ArgumentException>(() => new StructuralCloneComparisonDocument(
+            StructuralCloneComparisonDocument.CurrentSchemaVersion,
+            StructuralCloneComparisonDocument.CurrentMethodologyVersion,
+            left,
+            right,
+            LeftToken: 0x06000001,
+            RightToken: 0x06000001,
+            StructuralCloneDisposition.Unsupported,
+            Relation: null,
+            Correspondence: null,
+            Alignment: null,
+            Blockers: [UnsupportedBlocker()],
+            Receipt: EmptyReceipt(),
+            AlignmentReceipt: null));
+    }
+
+    [Fact]
+    public void Constructor_NullReceipt_Throws()
+    {
+        StructuralCloneModuleIdentity identity =
+            new("fixture.dll", new string('a', 64), Guid.NewGuid());
+
+        Assert.Throws<ArgumentNullException>(() => new StructuralCloneComparisonDocument(
+            StructuralCloneComparisonDocument.CurrentSchemaVersion,
+            StructuralCloneComparisonDocument.CurrentMethodologyVersion,
+            identity,
+            identity,
+            LeftToken: 0x06000001,
+            RightToken: 0x06000002,
+            StructuralCloneDisposition.Unsupported,
+            Relation: null,
+            Correspondence: null,
+            Alignment: null,
+            Blockers: [UnsupportedBlocker()],
+            Receipt: null!,
+            AlignmentReceipt: null));
+    }
+
+    [Theory]
+    [InlineData(0x00000000)] // nil token
+    [InlineData(0x02000001)] // TypeDef, not MethodDef
+    [InlineData(unchecked((int)0x0A000001))] // MemberRef, not MethodDef
+    public void Constructor_NonMethodDefToken_Throws(int token)
+    {
+        StructuralCloneModuleIdentity identity =
+            new("fixture.dll", new string('a', 64), Guid.NewGuid());
+
+        // MetadataTokens.MethodDefinitionHandle(int) masks off a token's table bits and
+        // keeps only the row number, so a non-MethodDef token would otherwise silently
+        // round-trip into a plausible-looking MethodDef handle while LeftToken/RightToken
+        // retained the original, differently-tabled value.
+        Assert.Throws<ArgumentException>(() => new StructuralCloneComparisonDocument(
+            StructuralCloneComparisonDocument.CurrentSchemaVersion,
+            StructuralCloneComparisonDocument.CurrentMethodologyVersion,
+            identity,
+            identity,
+            LeftToken: token,
+            RightToken: 0x06000002,
+            StructuralCloneDisposition.Unsupported,
+            Relation: null,
+            Correspondence: null,
+            Alignment: null,
+            Blockers: [UnsupportedBlocker()],
+            Receipt: EmptyReceipt(),
+            AlignmentReceipt: null));
+    }
+
+    [Fact]
     public void Constructor_CompletedWithoutRelation_ThrowsViaReissue()
     {
         StructuralCloneModuleIdentity identity =

--- a/src/ILInspector.Analysis.Tests/StructuralCloneComparisonDocumentTests.cs
+++ b/src/ILInspector.Analysis.Tests/StructuralCloneComparisonDocumentTests.cs
@@ -1,0 +1,243 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Text.Json;
+
+using ILInspector.Analysis.StructuralCloneFixtures;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Analysis.Tests;
+
+public class StructuralCloneComparisonDocumentTests
+{
+    [Fact]
+    public void Create_ExactComparison_ProjectsMatchingFields()
+    {
+        using PEReader image = OpenFixture();
+        MetadataReader reader = image.GetMetadataReader();
+        StructuralCloneComparison comparison = Compare(
+            image,
+            reader,
+            nameof(StructuralCloneFixture.ExactPositiveA),
+            nameof(StructuralCloneFixture.ExactPositiveB));
+        StructuralCloneModuleIdentity identity =
+            StructuralCloneModuleIdentity.Create("fixture.dll", image, reader);
+
+        StructuralCloneComparisonDocument document =
+            StructuralCloneComparisonDocument.Create(comparison, identity, identity);
+
+        Assert.Equal(StructuralCloneComparisonDocument.CurrentSchemaVersion, document.SchemaVersion);
+        Assert.Equal(StructuralCloneComparisonDocument.CurrentMethodologyVersion, document.MethodologyVersion);
+        Assert.Equal(StructuralCloneDisposition.Completed, document.Disposition);
+        Assert.Equal(StructuralCloneRelation.Exact, document.Relation);
+        Assert.NotNull(document.Correspondence);
+        Assert.Equal(comparison.Left.Token, document.LeftToken);
+        Assert.Equal(comparison.Right.Token, document.RightToken);
+        Assert.Equal(identity.ModuleVersionId, document.Left.ModuleVersionId);
+        Assert.Equal(identity.ModuleVersionId, document.Right.ModuleVersionId);
+    }
+
+    [Fact]
+    public void Create_LeftIdentityModuleMismatch_Throws()
+    {
+        using PEReader image = OpenFixture();
+        MetadataReader reader = image.GetMetadataReader();
+        StructuralCloneComparison comparison = Compare(
+            image,
+            reader,
+            nameof(StructuralCloneFixture.ExactPositiveA),
+            nameof(StructuralCloneFixture.ExactPositiveB));
+        StructuralCloneModuleIdentity mismatched =
+            new("other.dll", new string('a', 64), Guid.NewGuid());
+
+        Assert.Throws<ArgumentException>(
+            () => StructuralCloneComparisonDocument.Create(comparison, mismatched, mismatched));
+    }
+
+    [Fact]
+    public void Constructor_DifferentModuleVersionIdsAcrossSides_Throws()
+    {
+        StructuralCloneModuleIdentity left =
+            new("left.dll", new string('a', 64), Guid.NewGuid());
+        StructuralCloneModuleIdentity right =
+            new("right.dll", new string('b', 64), Guid.NewGuid());
+
+        Assert.Throws<ArgumentException>(() => new StructuralCloneComparisonDocument(
+            StructuralCloneComparisonDocument.CurrentSchemaVersion,
+            StructuralCloneComparisonDocument.CurrentMethodologyVersion,
+            left,
+            right,
+            LeftToken: 0x06000001,
+            RightToken: 0x06000001,
+            StructuralCloneDisposition.Unsupported,
+            Relation: null,
+            Correspondence: null,
+            Alignment: null,
+            Blockers: [UnsupportedBlocker()],
+            Receipt: EmptyReceipt(),
+            AlignmentReceipt: null));
+    }
+
+    [Fact]
+    public void Constructor_CompletedWithoutRelation_ThrowsViaReissue()
+    {
+        StructuralCloneModuleIdentity identity =
+            new("fixture.dll", new string('a', 64), Guid.NewGuid());
+
+        // The document reissues its fields through the same product factory a
+        // live comparison uses; a completed disposition without a relation
+        // must fail the identical invariant StructuralCloneComparison enforces.
+        Assert.Throws<ArgumentException>(() => new StructuralCloneComparisonDocument(
+            StructuralCloneComparisonDocument.CurrentSchemaVersion,
+            StructuralCloneComparisonDocument.CurrentMethodologyVersion,
+            identity,
+            identity,
+            LeftToken: 0x06000001,
+            RightToken: 0x06000002,
+            StructuralCloneDisposition.Completed,
+            Relation: null,
+            Correspondence: null,
+            Alignment: null,
+            Blockers: [],
+            Receipt: EmptyReceipt(),
+            AlignmentReceipt: null));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2)]
+    public void Constructor_UnsupportedSchemaVersion_Throws(int schemaVersion)
+    {
+        StructuralCloneModuleIdentity identity =
+            new("fixture.dll", new string('a', 64), Guid.NewGuid());
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => new StructuralCloneComparisonDocument(
+            schemaVersion,
+            StructuralCloneComparisonDocument.CurrentMethodologyVersion,
+            identity,
+            identity,
+            LeftToken: 0x06000001,
+            RightToken: 0x06000002,
+            StructuralCloneDisposition.Unsupported,
+            Relation: null,
+            Correspondence: null,
+            Alignment: null,
+            Blockers: [UnsupportedBlocker()],
+            Receipt: EmptyReceipt(),
+            AlignmentReceipt: null));
+    }
+
+    [Fact]
+    public void ModuleIdentity_Create_ReadsFixtureHashAndModuleVersionId()
+    {
+        using PEReader image = OpenFixture();
+        MetadataReader reader = image.GetMetadataReader();
+
+        StructuralCloneModuleIdentity identity =
+            StructuralCloneModuleIdentity.Create("fixture.dll", image, reader);
+
+        Assert.Equal(64, identity.Sha256.Length);
+        Assert.Equal(
+            reader.GetGuid(reader.GetModuleDefinition().Mvid),
+            identity.ModuleVersionId);
+    }
+
+    [Theory]
+    [InlineData("", "0000000000000000000000000000000000000000000000000000000000000000")]
+    [InlineData("fixture.dll", "not-hex")]
+    [InlineData("fixture.dll", "ABCDEF0000000000000000000000000000000000000000000000000000000000")]
+    public void ModuleIdentity_InvalidFields_Throws(string fileName, string sha256)
+    {
+        Assert.ThrowsAny<ArgumentException>(
+            () => new StructuralCloneModuleIdentity(fileName, sha256, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void ModuleIdentity_EmptyModuleVersionId_Throws()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new StructuralCloneModuleIdentity("fixture.dll", new string('a', 64), Guid.Empty));
+    }
+
+    [Fact]
+    public void Document_JsonRoundTrip_PreservesRelationAndCorrespondence()
+    {
+        using PEReader image = OpenFixture();
+        MetadataReader reader = image.GetMetadataReader();
+        StructuralCloneComparison comparison = Compare(
+            image,
+            reader,
+            nameof(StructuralCloneFixture.ExactPositiveA),
+            nameof(StructuralCloneFixture.ExactPositiveB));
+        StructuralCloneModuleIdentity identity =
+            StructuralCloneModuleIdentity.Create("fixture.dll", image, reader);
+        StructuralCloneComparisonDocument document =
+            StructuralCloneComparisonDocument.Create(comparison, identity, identity);
+
+        string json = JsonSerializer.Serialize(
+            document,
+            StructuralCloneComparisonDocumentJsonContext.Default.StructuralCloneComparisonDocument);
+        StructuralCloneComparisonDocument? replayed = JsonSerializer.Deserialize(
+            json,
+            StructuralCloneComparisonDocumentJsonContext.Default.StructuralCloneComparisonDocument);
+
+        Assert.NotNull(replayed);
+        Assert.Equal(document.Relation, replayed.Relation);
+        Assert.Equal(document.Disposition, replayed.Disposition);
+        Assert.Equal(document.LeftToken, replayed.LeftToken);
+        Assert.Equal(document.RightToken, replayed.RightToken);
+        Assert.Equal(document.Left.Sha256, replayed.Left.Sha256);
+        Assert.NotNull(replayed.Correspondence);
+        Assert.Equal(
+            document.Correspondence!.Blocks.Length,
+            replayed.Correspondence!.Blocks.Length);
+    }
+
+    static StructuralCloneComparison Compare(
+        PEReader image,
+        MetadataReader reader,
+        string leftName,
+        string rightName)
+        => StructuralCloneAnalysis.Compare(
+            image,
+            Method(reader, leftName),
+            Method(reader, rightName));
+
+    static StructuralCloneBlocker UnsupportedBlocker()
+        => new(
+            StructuralCloneBlockerKind.NoMethodBody,
+            StructuralCloneSide.Left,
+            "test blocker");
+
+    static StructuralCloneVerificationReceipt EmptyReceipt()
+        => new(
+            LeftBodyBytes: 0,
+            RightBodyBytes: 0,
+            LeftInstructions: 0,
+            RightInstructions: 0,
+            LeftBlocks: 0,
+            RightBlocks: 0,
+            LeftEdges: 0,
+            RightEdges: 0,
+            LeftLocals: 0,
+            RightLocals: 0,
+            RefinementRounds: 0,
+            SearchSteps: 0,
+            SearchExhausted: true,
+            WitnessFound: false);
+
+    static PEReader OpenFixture()
+        => new(File.OpenRead(typeof(StructuralCloneFixture).Assembly.Location));
+
+    static MethodDefinitionHandle Method(MetadataReader reader, string name)
+    {
+        MethodDefinitionHandle[] matches =
+        [
+            .. reader.MethodDefinitions.Where(handle =>
+                reader.StringComparer.Equals(
+                    reader.GetMethodDefinition(handle).Name,
+                    name)),
+        ];
+        return Assert.Single(matches);
+    }
+}

--- a/src/ILInspector.Analysis/StructuralCloneComparisonDocument.cs
+++ b/src/ILInspector.Analysis/StructuralCloneComparisonDocument.cs
@@ -1,0 +1,281 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Security.Cryptography;
+
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Portable identity for the physical module a structural clone comparison's
+/// method belongs to. <see cref="MetadataMethodAddress"/> alone is
+/// reader-scoped: its module version id is not a cryptographic identity, and a
+/// serialized document has no live reader to bound that risk the way
+/// <see cref="MetadataMethodAddress.BelongsTo"/> does in-process. Pairing the
+/// module version id with a file name and content hash gives a portable
+/// consumer enough evidence to detect a mismatched or substituted module
+/// without re-deriving it. This mirrors the harness-only
+/// <c>StructuralCloneCoreLibArtifact</c> identity shape
+/// (<c>tools/AnalysisHarness/StructuralCloneCoreLibCorpus.cs</c>), promoted
+/// into the product because a portable document needs it too.
+/// </summary>
+public sealed record StructuralCloneModuleIdentity
+{
+    public StructuralCloneModuleIdentity(
+        string FileName,
+        string Sha256,
+        Guid ModuleVersionId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(FileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Sha256);
+        if (Sha256.Length != 64 || !IsLowerHex(Sha256))
+        {
+            throw new ArgumentException(
+                "A module identity's content hash must be a lowercase 64-character SHA-256 hex string.",
+                nameof(Sha256));
+        }
+        if (ModuleVersionId == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "A module identity requires a non-empty module version id.",
+                nameof(ModuleVersionId));
+        }
+
+        this.FileName = FileName;
+        this.Sha256 = Sha256;
+        this.ModuleVersionId = ModuleVersionId;
+    }
+
+    /// <summary>The module's file name, retained for display; not a path.</summary>
+    public string FileName { get; }
+
+    /// <summary>Lowercase hex SHA-256 over the module's entire image bytes.</summary>
+    public string Sha256 { get; }
+
+    /// <summary>The module version id read from the module's own metadata.</summary>
+    public Guid ModuleVersionId { get; }
+
+    /// <summary>Computes a module identity from a retained managed PE image.</summary>
+    public static StructuralCloneModuleIdentity Create(
+        string fileName,
+        PEReader image,
+        MetadataReader reader)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentNullException.ThrowIfNull(image);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        byte[] hash = SHA256.HashData(image.GetEntireImage().GetContent().AsSpan());
+        Guid moduleVersionId = reader.GetGuid(reader.GetModuleDefinition().Mvid);
+        return new(fileName, Convert.ToHexStringLower(hash), moduleVersionId);
+    }
+
+    static bool IsLowerHex(string value)
+    {
+        foreach (char c in value)
+        {
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')))
+                return false;
+        }
+        return true;
+    }
+}
+
+/// <summary>
+/// Portable, product-issued pairwise detail over one <see cref="StructuralCloneComparison"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Construction reissues the embedded fields through the same
+/// <see cref="StructuralCloneComparison.Completed"/>/
+/// <see cref="StructuralCloneComparison.NotCompleted"/> factories live
+/// construction uses, so a tampered or internally inconsistent field
+/// combination fails the identical invariant checks a fresh comparison would.
+/// This validates internal consistency only. It does not re-verify that the
+/// embedded correspondence is actually graph-correct against the original IL:
+/// that requires a live <see cref="PEReader"/> and
+/// <see cref="StructuralCloneAnalysis.Compare(PEReader, MethodDefinitionHandle, MethodDefinitionHandle, StructuralCloneComparisonLimits?)"/>,
+/// which is what <see cref="Create"/> performs at authoring time. Full replay
+/// from serialized normalized-graph facts alone is not implemented by this
+/// slice.
+/// </para>
+/// <para>
+/// <see cref="StructuralCloneAnalysis.Compare(PEReader, MethodDefinitionHandle, MethodDefinitionHandle, StructuralCloneComparisonLimits?)"/>
+/// is deliberately A-vs-A: both method handles come from one retained image.
+/// This document enforces the same boundary by requiring <see cref="Left"/>
+/// and <see cref="Right"/> to share one module version id; cross-module
+/// (A-vs-B) identity is a separate, not-yet-built capability.
+/// </para>
+/// </remarks>
+public sealed record StructuralCloneComparisonDocument
+{
+    /// <summary>Current JSON shape version.</summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>Current comparison methodology version.</summary>
+    public const int CurrentMethodologyVersion = 1;
+
+    /// <summary>Creates and validates one portable pairwise clone comparison.</summary>
+    public StructuralCloneComparisonDocument(
+        int SchemaVersion,
+        int MethodologyVersion,
+        StructuralCloneModuleIdentity Left,
+        StructuralCloneModuleIdentity Right,
+        int LeftToken,
+        int RightToken,
+        StructuralCloneDisposition Disposition,
+        StructuralCloneRelation? Relation,
+        StructuralCloneCorrespondence? Correspondence,
+        StructuralCloneAlignment? Alignment,
+        ImmutableArray<StructuralCloneBlocker> Blockers,
+        StructuralCloneVerificationReceipt Receipt,
+        StructuralCloneAlignmentReceipt? AlignmentReceipt)
+    {
+        if (SchemaVersion != CurrentSchemaVersion)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(SchemaVersion),
+                "Structural clone comparison document schema version is unsupported.");
+        }
+        if (MethodologyVersion != CurrentMethodologyVersion)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MethodologyVersion),
+                "Structural clone comparison document methodology version is unsupported.");
+        }
+        ArgumentNullException.ThrowIfNull(Left);
+        ArgumentNullException.ThrowIfNull(Right);
+        if (Left.ModuleVersionId != Right.ModuleVersionId)
+        {
+            throw new ArgumentException(
+                "A structural clone comparison document requires both sides to originate from the same module; cross-module comparison is not yet supported.",
+                nameof(Right));
+        }
+        if (Blockers.IsDefault)
+        {
+            throw new ArgumentException(
+                "Structural clone comparison document blockers must be initialized.",
+                nameof(Blockers));
+        }
+
+        Comparison = Disposition == StructuralCloneDisposition.Completed
+            ? StructuralCloneComparison.Completed(
+                MakeAddress(Left, LeftToken),
+                MakeAddress(Right, RightToken),
+                Relation
+                    ?? throw new ArgumentException(
+                        "A completed structural clone comparison document requires a relation.",
+                        nameof(Relation)),
+                Correspondence,
+                Receipt,
+                Alignment,
+                AlignmentReceipt)
+            : StructuralCloneComparison.NotCompleted(
+                MakeAddress(Left, LeftToken),
+                MakeAddress(Right, RightToken),
+                Disposition,
+                Blockers,
+                Receipt,
+                AlignmentReceipt);
+
+        this.SchemaVersion = SchemaVersion;
+        this.MethodologyVersion = MethodologyVersion;
+        this.Left = Left;
+        this.Right = Right;
+        this.LeftToken = LeftToken;
+        this.RightToken = RightToken;
+    }
+
+    /// <summary>JSON shape version.</summary>
+    public int SchemaVersion { get; }
+
+    /// <summary>Comparison methodology version.</summary>
+    public int MethodologyVersion { get; }
+
+    /// <summary>Portable identity of the left method's module.</summary>
+    public StructuralCloneModuleIdentity Left { get; }
+
+    /// <summary>Portable identity of the right method's module.</summary>
+    public StructuralCloneModuleIdentity Right { get; }
+
+    /// <summary>The left method's MethodDef metadata token.</summary>
+    public int LeftToken { get; }
+
+    /// <summary>The right method's MethodDef metadata token.</summary>
+    public int RightToken { get; }
+
+    /// <summary>The execution disposition of this comparison.</summary>
+    public StructuralCloneDisposition Disposition => Comparison.Disposition;
+
+    /// <summary>The structural relationship, present only when completed.</summary>
+    public StructuralCloneRelation? Relation => Comparison.Relation;
+
+    /// <summary>Block/local correspondence, present only when exact.</summary>
+    public StructuralCloneCorrespondence? Correspondence => Comparison.Correspondence;
+
+    /// <summary>One-edit alignment, present only when near.</summary>
+    public StructuralCloneAlignment? Alignment => Comparison.Alignment;
+
+    /// <summary>Visible unsupported, limit, or failure receipts.</summary>
+    public ImmutableArray<StructuralCloneBlocker> Blockers => Comparison.Blockers;
+
+    /// <summary>Bounded-work receipt for exact verification.</summary>
+    public StructuralCloneVerificationReceipt Receipt => Comparison.Receipt;
+
+    /// <summary>Bounded-work receipt for near alignment, when attempted.</summary>
+    public StructuralCloneAlignmentReceipt? AlignmentReceipt => Comparison.AlignmentReceipt;
+
+    /// <summary>
+    /// The reissued product comparison. Internal: it exists to prove the
+    /// document's fields reconstruct a valid <see cref="StructuralCloneComparison"/>,
+    /// not as additional wire shape.
+    /// </summary>
+    internal StructuralCloneComparison Comparison { get; }
+
+    /// <summary>Issues a portable document from a product-owned comparison and its module identities.</summary>
+    public static StructuralCloneComparisonDocument Create(
+        StructuralCloneComparison comparison,
+        StructuralCloneModuleIdentity left,
+        StructuralCloneModuleIdentity right)
+    {
+        ArgumentNullException.ThrowIfNull(comparison);
+        ArgumentNullException.ThrowIfNull(left);
+        ArgumentNullException.ThrowIfNull(right);
+        if (comparison.Left.ModuleVersionId != left.ModuleVersionId)
+        {
+            throw new ArgumentException(
+                "Left module identity does not match the comparison's left method module.",
+                nameof(left));
+        }
+        if (comparison.Right.ModuleVersionId != right.ModuleVersionId)
+        {
+            throw new ArgumentException(
+                "Right module identity does not match the comparison's right method module.",
+                nameof(right));
+        }
+
+        return new(
+            CurrentSchemaVersion,
+            CurrentMethodologyVersion,
+            left,
+            right,
+            comparison.Left.Token,
+            comparison.Right.Token,
+            comparison.Disposition,
+            comparison.Relation,
+            comparison.Correspondence,
+            comparison.Alignment,
+            comparison.Blockers,
+            comparison.Receipt,
+            comparison.AlignmentReceipt);
+    }
+
+    static MetadataMethodAddress MakeAddress(
+        StructuralCloneModuleIdentity identity,
+        int token)
+        => new(
+            identity.ModuleVersionId,
+            MetadataTokens.MethodDefinitionHandle(token));
+}

--- a/src/ILInspector.Analysis/StructuralCloneComparisonDocument.cs
+++ b/src/ILInspector.Analysis/StructuralCloneComparisonDocument.cs
@@ -147,10 +147,14 @@ public sealed record StructuralCloneComparisonDocument
         }
         ArgumentNullException.ThrowIfNull(Left);
         ArgumentNullException.ThrowIfNull(Right);
-        if (Left.ModuleVersionId != Right.ModuleVersionId)
+        // A module version id alone is not sufficient: MVIDs are not guaranteed globally
+        // unique (see MetadataMethodAddress.cs), so two byte-distinct modules could otherwise
+        // slip past this A-vs-A boundary while carrying the very content hashes meant to
+        // catch a substituted module. Require the full identity, hash included, to match.
+        if (Left != Right)
         {
             throw new ArgumentException(
-                "A structural clone comparison document requires both sides to originate from the same module; cross-module comparison is not yet supported.",
+                "A structural clone comparison document requires both sides to originate from the same module (matching file name, content hash, and module version id); cross-module comparison is not yet supported.",
                 nameof(Right));
         }
         if (Blockers.IsDefault)
@@ -158,6 +162,19 @@ public sealed record StructuralCloneComparisonDocument
             throw new ArgumentException(
                 "Structural clone comparison document blockers must be initialized.",
                 nameof(Blockers));
+        }
+        ArgumentNullException.ThrowIfNull(Receipt);
+        if (!IsMethodDefinitionToken(LeftToken))
+        {
+            throw new ArgumentException(
+                "Structural clone comparison document tokens must be MethodDef tokens.",
+                nameof(LeftToken));
+        }
+        if (!IsMethodDefinitionToken(RightToken))
+        {
+            throw new ArgumentException(
+                "Structural clone comparison document tokens must be MethodDef tokens.",
+                nameof(RightToken));
         }
 
         Comparison = Disposition == StructuralCloneDisposition.Completed
@@ -278,4 +295,16 @@ public sealed record StructuralCloneComparisonDocument
         => new(
             identity.ModuleVersionId,
             MetadataTokens.MethodDefinitionHandle(token));
+
+    /// <summary>
+    /// <see cref="MetadataTokens.MethodDefinitionHandle(int)"/> masks off a token's table
+    /// bits and keeps only the row number, so a non-MethodDef token (or a nil token) would
+    /// otherwise silently round-trip into a plausible-looking MethodDef handle while the
+    /// document's own <see cref="LeftToken"/>/<see cref="RightToken"/> retained the original,
+    /// differently-tabled value. Reject anything but a non-nil MethodDef token up front so the
+    /// document's stored token and its reissued handle can never disagree.
+    /// </summary>
+    static bool IsMethodDefinitionToken(int token)
+        => unchecked((uint)token & 0xFF000000) == 0x06000000
+            && ((uint)token & 0x00FFFFFF) != 0;
 }

--- a/src/ILInspector.Analysis/StructuralCloneComparisonDocumentJsonContext.cs
+++ b/src/ILInspector.Analysis/StructuralCloneComparisonDocumentJsonContext.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// The serialization contract for the portable <see cref="StructuralCloneComparisonDocument"/>:
+/// snake-case property names, string-spelled enums, and omitted nulls.
+/// </summary>
+/// <remarks>
+/// See <c>AnnotatedSourceDocumentJsonContext</c>
+/// (<c>src/ILInspector.Decompiler/AnnotatedSourceDocumentJsonContext.cs</c>) for the sibling
+/// document contract this mirrors: one owned set of options avoids a second place for the
+/// document's field names to drift.
+/// </remarks>
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(StructuralCloneComparisonDocument))]
+[JsonSerializable(typeof(StructuralCloneModuleIdentity))]
+public partial class StructuralCloneComparisonDocumentJsonContext : JsonSerializerContext;
+
+/// <inheritdoc cref="StructuralCloneComparisonDocumentJsonContext"/>
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(StructuralCloneComparisonDocument))]
+[JsonSerializable(typeof(StructuralCloneModuleIdentity))]
+public partial class StructuralCloneComparisonDocumentCompactJsonContext : JsonSerializerContext;


### PR DESCRIPTION
## Summary

Slice 1 of the `ResearchMatch` capability tracked in #4304: a portable,
versioned `StructuralCloneComparisonDocument` in `ILInspector.Analysis`, with
no `Research`/`Decompiler` dependency. This is the first PR in a planned stack
against #4304; later slices layer `ResearchMatch` and CLI presentation on top.

## What this adds

- **`StructuralCloneModuleIdentity`** — portable module identity (file name +
  SHA-256 content hash + module version id), mirroring the harness-only
  `StructuralCloneCoreLibArtifact` shape already used by
  `tools/AnalysisHarness/StructuralCloneCoreLibCorpus.cs`. Gives a consumer
  outside the live `PEReader` enough evidence to detect a substituted module.
- **`StructuralCloneComparisonDocument`** — versioned (schema + methodology),
  validated wrapper over a `StructuralCloneComparison`. Construction reissues
  the embedded fields through the same `StructuralCloneComparison.Completed`/
  `NotCompleted` factories used at live-construction time, so a tampered or
  internally inconsistent field combination fails the identical invariant
  checks a fresh comparison would.
- **`StructuralCloneComparisonDocumentJsonContext`** — source-generated JSON
  contract following the existing `AnnotatedSourceDocumentJsonContext`
  convention (snake_case, string enums, omit nulls).

## Scope boundary (deliberate, not a gap)

`StructuralCloneAnalysis.Compare(PEReader, ...)` is A-vs-A only: both method
handles resolve against one retained image. This document enforces the same
boundary by requiring `Left`/`Right` to share one module version id.
Cross-module (A-vs-B) identity is a separate, not-yet-built capability noted
in #4304's motivating scenarios (migration triage, supply-chain vendoring).

Construction-time reissue validates **internal consistency only** — it does
not re-verify that the embedded correspondence is graph-correct against the
original IL bytes from scratch. That full replay would require a live
`PEReader`/`MetadataReader`, which is what `Create` performs at authoring
time. This is documented in the type's XML remarks rather than left implicit.

## Testing

- `dotnet build dotnet-inspect.slnx -c Release` (`ILInspector.Analysis` and
  `ILInspector.Analysis.Tests` projects) — succeeds, 0 warnings/errors.
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — full
  suite: 996 total, 0 failed, 8 pre-existing skips (missing external CoreLib
  corpus artifact, unrelated to this change).
- New `StructuralCloneComparisonDocumentTests.cs` covers: module identity
  validation (hash format, empty MVID), document field projection from a real
  fixture comparison, schema/methodology version rejection, the same-module
  invariant, reissue-time rejection of an internally inconsistent
  Completed/Relation combination, and JSON round-trip.

## Non-goals

- Cross-module (A-vs-B) comparison — future slice.
- `ResearchMatch`/CLI presentation — future slice(s), per #4304.
- Full replay/re-verification of correspondence from serialized data alone —
  explicitly out of scope for this slice; documented in remarks.

Closes part of #4304 (Slice 1 of the stack).
