### PR TITLE
Redesign inspect-web status bar: compact default, click-to-expand full view

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -540,11 +540,12 @@ data bar and the home readiness bar. The workspace bar occupies the bottom row
 formerly used by the persistent command prompt, giving the bar the full
 viewport width. By default the bar shows a compact, single-line summary in
 priority order: app version/commit, package provenance, build date, and a
-one-line performance summary. Clicking (or pressing Enter/Space on) the bar
-toggles an expanded view that adds the full diagnostics breakdown
-(download/startup/precompute/total), package cache stats, active assembly,
-framework, and the "public API surface" label. Expansion state lives in
-`state.statusBarExpanded` and applies to both the workspace and home bars.
+one-line performance summary. A dedicated toggle button at the end of the bar
+(so it never overlaps the commit link) expands and collapses the view,
+adding the full diagnostics breakdown (download/startup/precompute/total),
+package cache stats, active assembly, framework, and the "public API
+surface" label. Expansion state lives in `state.statusBarExpanded` and
+applies to both the workspace and home bars.
 Package source, assembly, and framework are shown only in a workspace.
 Current browser acquisition distinguishes NuGet.org from the .NET platform;
 the typed model also reserves local-file and custom-feed provenance for

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -537,13 +537,21 @@ command metadata, and escaping.
 
 The typed `src/status-bar.ts` component renders both the full-width workspace
 data bar and the home readiness bar. The workspace bar occupies the bottom row
-formerly used by the persistent command prompt, giving diagnostics, cache
-state, package source, active assembly, and framework the full viewport width.
-Package source is shown only in a workspace. Current browser acquisition
-distinguishes NuGet.org from the .NET platform; the typed model also reserves
-local-file and custom-feed provenance for future acquisition paths. Missing or
-malformed provenance is shown as `Unknown` rather than omitted so acquisition
-failures stay diagnosable.
+formerly used by the persistent command prompt, giving the bar the full
+viewport width. By default the bar shows a compact, single-line summary in
+priority order: app version/commit, package provenance, build date, and a
+one-line performance summary. Clicking (or pressing Enter/Space on) the bar
+toggles an expanded view that adds the full diagnostics breakdown
+(download/startup/precompute/total), package cache stats, active assembly,
+framework, and the "public API surface" label. Expansion state lives in
+`state.statusBarExpanded` and applies to both the workspace and home bars.
+Package source, assembly, and framework are shown only in a workspace.
+Current browser acquisition distinguishes NuGet.org from the .NET platform;
+the typed model also reserves local-file and custom-feed provenance for
+future acquisition paths. Missing or malformed provenance is shown as
+`Unknown` rather than omitted so acquisition failures stay diagnosable.
+Symbol/PDB acquisition status is not yet surfaced here — no backend contract
+reports it today — and is a tracked fast-follow.
 
 `src/type-panel.ts` owns the type selector (the "PUBLIC TYPES" / "MEMBERS" nav
 pane) and the type viewer (the type heading, metadata, and source sections

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -3172,12 +3172,14 @@ function highlightCSharp(value) {
 
 function bindStatusBarToggle() {
   document.querySelectorAll("[data-status-bar-toggle]").forEach(bar => {
-    bar.addEventListener("click", () => {
+    bar.addEventListener("click", event => {
+      if (event.target.closest("a")) return;
       state.statusBarExpanded = !state.statusBarExpanded;
       render();
     });
     bar.addEventListener("keydown", event => {
       if (event.key !== "Enter" && event.key !== " ") return;
+      if (event.target.closest("a")) return;
       event.preventDefault();
       state.statusBarExpanded = !state.statusBarExpanded;
       render();

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -234,6 +234,7 @@ function loadPlatformRecent() {
 let spotlightCache = null;
 const state = {
   theme: localStorage.getItem("inspect-theme") === "light" ? "light" : "dark",
+  statusBarExpanded: false,
   packages: [],
   package: null,
   home: false,
@@ -1452,6 +1453,7 @@ function render() {
         source: state.package.source,
         assembly: current?.assembly ?? state.package.assembly,
         framework: state.package.activeFramework,
+        expanded: state.statusBarExpanded,
       }, escapeHtml)}
       ${state.spotlightOpen ? spotlight.modalHtml() : ""}
       ${state.graphSourceOpen ? renderGraphSource() : ""}
@@ -3168,7 +3170,23 @@ function highlightCSharp(value) {
   return escapeHtml(value);
 }
 
+function bindStatusBarToggle() {
+  document.querySelectorAll("[data-status-bar-toggle]").forEach(bar => {
+    bar.addEventListener("click", () => {
+      state.statusBarExpanded = !state.statusBarExpanded;
+      render();
+    });
+    bar.addEventListener("keydown", event => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      state.statusBarExpanded = !state.statusBarExpanded;
+      render();
+    });
+  });
+}
+
 function bindEvents() {
+  bindStatusBarToggle();
   packageBar.bind(document);
   document.querySelectorAll("[data-scope]").forEach(button => button.addEventListener("click", () => {
     const target = button.dataset.scope;
@@ -4693,6 +4711,7 @@ function renderHomeView() {
         buildIdentity: state.buildIdentity,
         diagnostics: state.diag,
         compactDiagnostics: true,
+        expanded: state.statusBarExpanded,
       }, escapeHtml)}
     </div>`;
   bindHomeEvents();
@@ -4706,6 +4725,7 @@ function homeArtSvg() {
 }
 
 function bindHomeEvents() {
+  bindStatusBarToggle();
   document.querySelector("#home-theme")?.addEventListener("click", toggleTheme);
   document.querySelector("#home-settings")?.addEventListener("click", () => openSettings("home"));
   document.querySelector("#dismiss-notice")?.addEventListener("click", () => {

--- a/prototypes/inspect-web/src/app.js
+++ b/prototypes/inspect-web/src/app.js
@@ -3171,20 +3171,10 @@ function highlightCSharp(value) {
 }
 
 function bindStatusBarToggle() {
-  document.querySelectorAll("[data-status-bar-toggle]").forEach(bar => {
-    bar.addEventListener("click", event => {
-      if (event.target.closest("a")) return;
-      state.statusBarExpanded = !state.statusBarExpanded;
-      render();
-    });
-    bar.addEventListener("keydown", event => {
-      if (event.key !== "Enter" && event.key !== " ") return;
-      if (event.target.closest("a")) return;
-      event.preventDefault();
-      state.statusBarExpanded = !state.statusBarExpanded;
-      render();
-    });
-  });
+  document.querySelectorAll("[data-status-bar-toggle-button]").forEach(button => button.addEventListener("click", () => {
+    state.statusBarExpanded = !state.statusBarExpanded;
+    render();
+  }));
 }
 
 function bindEvents() {

--- a/prototypes/inspect-web/src/status-bar.ts
+++ b/prototypes/inspect-web/src/status-bar.ts
@@ -203,7 +203,7 @@ export function statusBarHtml(
     : "";
 
   return `
-    <footer class="${classes}" data-status-bar-toggle="${expanded ? "expanded" : "collapsed"}" tabindex="0" role="button" aria-expanded="${expanded}" title="Click to ${expanded ? "collapse" : "show all data"}">
+    <footer class="${classes}" data-status-bar-toggle="${expanded ? "expanded" : "collapsed"}" tabindex="0" aria-expanded="${expanded}" title="Click to ${expanded ? "collapse" : "show all data"}">
       ${ready
         ? '<span class="ready-dot"></span>'
         : '<span class="home-wasm-spinner" aria-hidden="true"></span>'}<span>${escapeHtml(statusLabel)}</span>

--- a/prototypes/inspect-web/src/status-bar.ts
+++ b/prototypes/inspect-web/src/status-bar.ts
@@ -40,6 +40,7 @@ export interface StatusBarModel {
   source?: PackageSource;
   assembly?: string;
   framework?: string;
+  expanded?: boolean;
 }
 
 export function fmtMs(milliseconds: number | null | undefined): string {
@@ -72,20 +73,46 @@ export function buildIdentityHtml(
   const commitHtml = identity.commitUrl && shortCommit
     ? `<a href="${escapeHtml(identity.commitUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(shortCommit)}</a>`
     : escapeHtml(shortCommit);
-  const parsedTimestamp = Date.parse(identity.builtAtUtc || "");
-  const builtAt = Number.isFinite(parsedTimestamp)
+  const title = [
+    `dotnet-inspect ${identity.version}`,
+    commit ? `commit ${commit}` : "",
+  ].filter(Boolean).join(" · ");
+  return `<span class="build-identity" title="${escapeHtml(title)}">v${escapeHtml(identity.version)}${shortCommit ? ` · ${commitHtml}` : ""}</span>`;
+}
+
+function builtAtLabel(builtAtUtc: string | null | undefined): string {
+  const parsedTimestamp = Date.parse(builtAtUtc || "");
+  return Number.isFinite(parsedTimestamp)
     ? new Date(parsedTimestamp).toLocaleString(undefined, {
         dateStyle: "medium",
         timeStyle: "medium",
         timeZone: "UTC",
       })
     : "";
-  const title = [
-    `dotnet-inspect ${identity.version}`,
-    commit ? `commit ${commit}` : "",
-    builtAt ? `built ${builtAt} UTC` : "",
-  ].filter(Boolean).join(" · ");
-  return `<span class="build-identity" title="${escapeHtml(title)}">v${escapeHtml(identity.version)}${shortCommit ? ` · ${commitHtml}` : ""}${builtAt ? ` · built ${escapeHtml(builtAt)} UTC` : ""}</span>`;
+}
+
+function builtAtCompactLabel(builtAtUtc: string | null | undefined): string {
+  const parsedTimestamp = Date.parse(builtAtUtc || "");
+  return Number.isFinite(parsedTimestamp)
+    ? new Date(parsedTimestamp).toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeZone: "UTC",
+      })
+    : "";
+}
+
+// Renders the build-date fact on its own (distinct from `buildIdentityHtml`'s version/commit),
+// so the data bar can order it independently: compact drops the time-of-day, expanded keeps the
+// full UTC timestamp for exact reproduction.
+function buildDateHtml(
+  identity: BuildIdentity | null | undefined,
+  escapeHtml: (value: unknown) => string,
+  expanded: boolean,
+): string {
+  if (!identity?.version) return "";
+  const builtAt = expanded ? builtAtLabel(identity.builtAtUtc) : builtAtCompactLabel(identity.builtAtUtc);
+  if (!builtAt) return "";
+  return `<span class="build-date" title="Built ${escapeHtml(builtAt)} UTC">built ${escapeHtml(builtAt)} UTC</span>`;
 }
 
 function diagnosticsHtml(
@@ -143,29 +170,47 @@ export function statusBarHtml(
   const ready = model.ready ?? true;
   const statusLabel = model.statusLabel
     ?? (ready ? "browser wasm ready" : "browser wasm loading");
-  const classes = model.variant === "home"
-    ? "data-bar home-foot"
-    : "statusbar data-bar";
-  const diagnostics = model.compactDiagnostics && model.diagnostics
-    ? `<span class="diag">⚙ ready in ${fmtMs(model.diagnostics.totalMs)}</span>`
-    : diagnosticsHtml(model.diagnostics);
-  const tail = model.variant !== "home" && model.assembly && model.framework
+  const expanded = model.expanded ?? false;
+  const classes = [
+    model.variant === "home" ? "data-bar home-foot" : "statusbar data-bar",
+    expanded ? "expanded" : "",
+  ].filter(Boolean).join(" ");
+
+  const provenance = model.variant !== "home" && model.source
+    ? `<span class="provenance" title="Package provenance">Source: ${escapeHtml(packageSourceLabel(model.source))}</span>`
+    : "";
+  const buildDate = buildDateHtml(model.buildIdentity, escapeHtml, expanded);
+
+  // The compact view always shows a one-line performance summary regardless of
+  // `compactDiagnostics` — that flag no longer distinguishes rendering modes now that
+  // expand/collapse controls verbosity; it is accepted only for call-site compatibility.
+  const perf = expanded
+    ? diagnosticsHtml(model.diagnostics)
+    : (model.diagnostics
+      ? `<span class="diag">⚙ ready in ${fmtMs(model.diagnostics.totalMs)}</span>`
+      : "");
+
+  const expandedExtras = expanded
     ? `
+      ${packageCacheHtml(model.packageCache)}
+      ${model.variant !== "home" && model.assembly && model.framework
+        ? `
       <span class="status-spacer"></span>
-      <span>Source: ${escapeHtml(packageSourceLabel(model.source))}</span>
       <span>${escapeHtml(model.assembly)}</span>
       <span>${escapeHtml(model.framework)}</span>
       <span>public API surface</span>`
+        : ""}`
     : "";
 
   return `
-    <footer class="${classes}">
+    <footer class="${classes}" data-status-bar-toggle="${expanded ? "expanded" : "collapsed"}" tabindex="0" role="button" aria-expanded="${expanded}" title="Click to ${expanded ? "collapse" : "show all data"}">
       ${ready
         ? '<span class="ready-dot"></span>'
         : '<span class="home-wasm-spinner" aria-hidden="true"></span>'}<span>${escapeHtml(statusLabel)}</span>
       ${buildIdentityHtml(model.buildIdentity, escapeHtml)}
-      ${diagnostics}
-      ${packageCacheHtml(model.packageCache)}
-      ${tail}
+      ${provenance}
+      ${buildDate}
+      ${perf}
+      ${expandedExtras}
     </footer>`;
 }

--- a/prototypes/inspect-web/src/status-bar.ts
+++ b/prototypes/inspect-web/src/status-bar.ts
@@ -203,7 +203,7 @@ export function statusBarHtml(
     : "";
 
   return `
-    <footer class="${classes}" data-status-bar-toggle="${expanded ? "expanded" : "collapsed"}" tabindex="0" aria-expanded="${expanded}" title="Click to ${expanded ? "collapse" : "show all data"}">
+    <footer class="${classes}" data-status-bar-toggle="${expanded ? "expanded" : "collapsed"}" title="Click to ${expanded ? "collapse" : "show all data"}">
       ${ready
         ? '<span class="ready-dot"></span>'
         : '<span class="home-wasm-spinner" aria-hidden="true"></span>'}<span>${escapeHtml(statusLabel)}</span>
@@ -212,5 +212,6 @@ export function statusBarHtml(
       ${buildDate}
       ${perf}
       ${expandedExtras}
+      <button type="button" class="status-bar-toggle" data-status-bar-toggle-button aria-expanded="${expanded}" title="${expanded ? "Collapse" : "Show all data"}">${expanded ? "▲" : "▼"}</button>
     </footer>`;
 }

--- a/prototypes/inspect-web/src/status-bar.ts
+++ b/prototypes/inspect-web/src/status-bar.ts
@@ -203,7 +203,7 @@ export function statusBarHtml(
     : "";
 
   return `
-    <footer class="${classes}" data-status-bar-toggle="${expanded ? "expanded" : "collapsed"}" title="Click to ${expanded ? "collapse" : "show all data"}">
+    <footer class="${classes}" data-status-bar-toggle="${expanded ? "expanded" : "collapsed"}">
       ${ready
         ? '<span class="ready-dot"></span>'
         : '<span class="home-wasm-spinner" aria-hidden="true"></span>'}<span>${escapeHtml(statusLabel)}</span>
@@ -212,6 +212,6 @@ export function statusBarHtml(
       ${buildDate}
       ${perf}
       ${expandedExtras}
-      <button type="button" class="status-bar-toggle" data-status-bar-toggle-button aria-expanded="${expanded}" title="${expanded ? "Collapse" : "Show all data"}">${expanded ? "▲" : "▼"}</button>
+      <button type="button" class="status-bar-toggle" data-status-bar-toggle-button aria-expanded="${expanded}" aria-label="${expanded ? "Collapse" : "Show all data"}" title="${expanded ? "Collapse" : "Show all data"}">${expanded ? "▲" : "▼"}</button>
     </footer>`;
 }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1038,7 +1038,7 @@ kbd {
 .empty-document code { color: var(--yellow); font-family: var(--mono); }
 .large-glyph { color: var(--dim); font: 33px var(--mono); }
 
-.statusbar { min-width: 0; min-height: 44px; display: flex; align-items: center; gap: 8px; overflow-x: auto; padding: 0 13px; border-top: 1px solid var(--line-strong); background: var(--chrome); color: var(--dim); font: 10px var(--mono); scrollbar-width: thin; cursor: pointer; }
+.statusbar { min-width: 0; min-height: 44px; display: flex; align-items: center; gap: 8px; overflow-x: auto; padding: 0 13px; border-top: 1px solid var(--line-strong); background: var(--chrome); color: var(--dim); font: 10px var(--mono); scrollbar-width: thin; }
 .statusbar.expanded { flex-wrap: wrap; overflow-x: visible; min-height: auto; padding: 6px 13px; row-gap: 4px; }
 .ready-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 7px rgba(142,187,118,.5); }
 .status-spacer { flex: 1; }
@@ -1053,6 +1053,8 @@ kbd {
 .provenance::before { content: "·"; margin-right: 8px; color: var(--line-strong); }
 .build-date { color: var(--dim); white-space: nowrap; }
 .build-date::before { content: "·"; margin-right: 8px; color: var(--line-strong); }
+.status-bar-toggle { margin-left: auto; padding: 2px 6px; background: transparent; border: 1px solid var(--line-strong); border-radius: 3px; color: var(--dim); font: 10px var(--mono); cursor: pointer; line-height: 1; }
+.status-bar-toggle:hover { color: var(--muted); border-color: var(--muted); }
 
 .toast {
   position: fixed;
@@ -1727,7 +1729,6 @@ kbd {
   border-top: 1px solid var(--line);
   color: var(--muted);
   font: 11px var(--mono);
-  cursor: pointer;
 }
 .home-foot.expanded { flex-wrap: wrap; row-gap: 4px; }
 .home-foot .diag { color: var(--dim); }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1038,7 +1038,8 @@ kbd {
 .empty-document code { color: var(--yellow); font-family: var(--mono); }
 .large-glyph { color: var(--dim); font: 33px var(--mono); }
 
-.statusbar { min-width: 0; min-height: 44px; display: flex; align-items: center; gap: 8px; overflow-x: auto; padding: 0 13px; border-top: 1px solid var(--line-strong); background: var(--chrome); color: var(--dim); font: 10px var(--mono); scrollbar-width: thin; }
+.statusbar { min-width: 0; min-height: 44px; display: flex; align-items: center; gap: 8px; overflow-x: auto; padding: 0 13px; border-top: 1px solid var(--line-strong); background: var(--chrome); color: var(--dim); font: 10px var(--mono); scrollbar-width: thin; cursor: pointer; }
+.statusbar.expanded { flex-wrap: wrap; overflow-x: visible; min-height: auto; padding: 6px 13px; row-gap: 4px; }
 .ready-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 7px rgba(142,187,118,.5); }
 .status-spacer { flex: 1; }
 .diag { color: var(--dim); white-space: nowrap; cursor: help; }
@@ -1048,6 +1049,10 @@ kbd {
 .build-identity::before { content: "·"; margin-right: 8px; color: var(--line-strong); }
 .build-identity a { color: var(--blue); text-decoration: none; }
 .build-identity a:hover { text-decoration: underline; }
+.provenance { color: var(--dim); white-space: nowrap; }
+.provenance::before { content: "·"; margin-right: 8px; color: var(--line-strong); }
+.build-date { color: var(--dim); white-space: nowrap; }
+.build-date::before { content: "·"; margin-right: 8px; color: var(--line-strong); }
 
 .toast {
   position: fixed;
@@ -1722,7 +1727,9 @@ kbd {
   border-top: 1px solid var(--line);
   color: var(--muted);
   font: 11px var(--mono);
+  cursor: pointer;
 }
+.home-foot.expanded { flex-wrap: wrap; row-gap: 4px; }
 .home-foot .diag { color: var(--dim); }
 .home-wasm-spinner {
   width: 9px;

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1053,8 +1053,9 @@ kbd {
 .provenance::before { content: "·"; margin-right: 8px; color: var(--line-strong); }
 .build-date { color: var(--dim); white-space: nowrap; }
 .build-date::before { content: "·"; margin-right: 8px; color: var(--line-strong); }
-.status-bar-toggle { margin-left: auto; padding: 2px 6px; background: transparent; border: 1px solid var(--line-strong); border-radius: 3px; color: var(--dim); font: 10px var(--mono); cursor: pointer; line-height: 1; }
+.status-bar-toggle { margin-left: auto; flex: none; position: sticky; right: 0; padding: 2px 6px; background: var(--chrome); border: 1px solid var(--line-strong); border-radius: 3px; color: var(--dim); font: 10px var(--mono); cursor: pointer; line-height: 1; }
 .status-bar-toggle:hover { color: var(--muted); border-color: var(--muted); }
+.home-foot .status-bar-toggle { background: var(--bg); }
 
 .toast {
   position: fixed;

--- a/prototypes/inspect-web/test/status-bar.test.js
+++ b/prototypes/inspect-web/test/status-bar.test.js
@@ -80,8 +80,9 @@ test("the compact workspace data bar shows version/commit, provenance, and a one
 
   assert.match(html, /class="statusbar data-bar"/);
   assert.doesNotMatch(html, /class="statusbar data-bar expanded"/);
-  assert.match(html, /tabindex="0"/);
+  assert.match(html, /data-status-bar-toggle-button/);
   assert.match(html, /aria-expanded="false"/);
+  assert.match(html, /<button type="button" class="status-bar-toggle"/);
 
   const identityIndex = html.indexOf("v1.2.3");
   const provenanceIndex = html.indexOf("Source:");
@@ -170,6 +171,6 @@ test("workspace source failures remain visible as unknown provenance", () => {
 test("the data bar exposes a click/keyboard expand affordance even with no optional fields", () => {
   const html = statusBarHtml({}, escapeHtml);
   assert.match(html, /data-status-bar-toggle="collapsed"/);
-  assert.match(html, /tabindex="0"/);
+  assert.match(html, /data-status-bar-toggle-button/);
   assert.doesNotMatch(html, /Source:/);
 });

--- a/prototypes/inspect-web/test/status-bar.test.js
+++ b/prototypes/inspect-web/test/status-bar.test.js
@@ -40,7 +40,7 @@ test("package sources disclose file, gallery, feed host, or platform provenance"
   assert.equal(packageSourceLabel({ kind: "other" }), "Unknown");
 });
 
-test("build identity keeps provenance linked and inert", () => {
+test("build identity keeps provenance linked and inert, without the build date", () => {
   const html = buildIdentityHtml({
     version: "1.2.3",
     commit: "abcdef012345",
@@ -51,12 +51,57 @@ test("build identity keeps provenance linked and inert", () => {
   assert.match(html, />v1\.2\.3 · <a /);
   assert.match(html, /href="https:\/\/example\.test\/\?q=&quot;&lt;x&gt;&amp;"/);
   assert.match(html, /target="_blank" rel="noopener noreferrer">abcdef0<\/a>/);
-  assert.match(html, /built .* UTC/);
+  // Build date now renders separately (via buildDateHtml inside statusBarHtml), not inline here.
+  assert.doesNotMatch(html, /built/);
 });
 
-test("the data bar renders the complete workspace status at full-bar ownership", () => {
+test("the compact workspace data bar shows version/commit, provenance, and a one-line performance summary, in that order", () => {
   const html = statusBarHtml({
-    buildIdentity: { version: "1.2.3" },
+    buildIdentity: { version: "1.2.3", builtAtUtc: "2026-08-19T14:00:00Z" },
+    diagnostics: {
+      assets: 4,
+      downloadMs: 20,
+      transfer: 1024,
+      decoded: 2048,
+      startupMs: 30,
+      precomputeMs: 40,
+      totalMs: 1250,
+    },
+    packageCache: {
+      packages: 3,
+      resident: 2,
+      residentBytes: 5 * 1048576,
+      workspaces: 1,
+    },
+    source: { kind: "feed", host: 'packages."<example>' },
+    assembly: 'Example"<Assembly>',
+    framework: "net10.0",
+  }, escapeHtml);
+
+  assert.match(html, /class="statusbar data-bar"/);
+  assert.doesNotMatch(html, /class="statusbar data-bar expanded"/);
+  assert.match(html, /role="button"/);
+  assert.match(html, /aria-expanded="false"/);
+
+  const identityIndex = html.indexOf("v1.2.3");
+  const provenanceIndex = html.indexOf("Source:");
+  const buildDateIndex = html.indexOf("built");
+  const perfIndex = html.indexOf("⚙ ready in");
+  assert.ok(identityIndex >= 0 && provenanceIndex > identityIndex);
+  assert.ok(buildDateIndex > provenanceIndex);
+  assert.ok(perfIndex > buildDateIndex);
+
+  assert.match(html, /⚙ ready in 1\.25 s/);
+  assert.doesNotMatch(html, /↓ download/);
+  assert.doesNotMatch(html, /3 packages · 2 resident in cache/);
+  assert.doesNotMatch(html, /Example&quot;&lt;Assembly&gt;/);
+  assert.doesNotMatch(html, /public API surface/);
+});
+
+test("the expanded workspace data bar shows every field, including full diagnostics and the package cache tail", () => {
+  const html = statusBarHtml({
+    expanded: true,
+    buildIdentity: { version: "1.2.3", builtAtUtc: "2026-08-19T14:00:00Z" },
     diagnostics: {
       assets: 4,
       downloadMs: 20,
@@ -77,16 +122,17 @@ test("the data bar renders the complete workspace status at full-bar ownership",
     framework: "net10.0",
   }, escapeHtml);
 
-  assert.match(html, /class="statusbar data-bar"/);
-  assert.match(html, /browser wasm ready/);
+  assert.match(html, /class="statusbar data-bar expanded"/);
+  assert.match(html, /aria-expanded="true"/);
   assert.match(html, /↓ download 20 ms · 1\.0 KB → 2\.0 KB/);
   assert.match(html, /3 packages · 2 resident in cache · 1 workspace/);
   assert.match(html, /Source: packages\.&quot;&lt;example&gt;/);
   assert.match(html, /Example&quot;&lt;Assembly&gt;/);
   assert.match(html, /net10\.0/);
+  assert.match(html, /built .* UTC/);
 });
 
-test("the same data bar component renders home readiness and compact diagnostics", () => {
+test("the same data bar component renders home readiness and a compact performance summary", () => {
   const html = statusBarHtml({
     variant: "home",
     ready: false,
@@ -100,9 +146,6 @@ test("the same data bar component renders home readiness and compact diagnostics
       totalMs: 1250,
     },
     compactDiagnostics: true,
-    source: { kind: "feed", host: "packages.example.test" },
-    assembly: "Should.Not.Render.dll",
-    framework: "net10.0",
   }, escapeHtml);
 
   assert.match(html, /class="data-bar home-foot"/);
@@ -116,9 +159,17 @@ test("the same data bar component renders home readiness and compact diagnostics
 
 test("workspace source failures remain visible as unknown provenance", () => {
   const html = statusBarHtml({
+    source: { kind: "unknown" },
     assembly: "Example.dll",
     framework: "net10.0",
   }, escapeHtml);
 
   assert.match(html, /Source: Unknown/);
+});
+
+test("the data bar exposes a click/keyboard expand affordance even with no optional fields", () => {
+  const html = statusBarHtml({}, escapeHtml);
+  assert.match(html, /data-status-bar-toggle="collapsed"/);
+  assert.match(html, /tabindex="0"/);
+  assert.doesNotMatch(html, /Source:/);
 });

--- a/prototypes/inspect-web/test/status-bar.test.js
+++ b/prototypes/inspect-web/test/status-bar.test.js
@@ -80,7 +80,7 @@ test("the compact workspace data bar shows version/commit, provenance, and a one
 
   assert.match(html, /class="statusbar data-bar"/);
   assert.doesNotMatch(html, /class="statusbar data-bar expanded"/);
-  assert.match(html, /role="button"/);
+  assert.match(html, /tabindex="0"/);
   assert.match(html, /aria-expanded="false"/);
 
   const identityIndex = html.indexOf("v1.2.3");

--- a/prototypes/inspect-web/test/status-bar.test.js
+++ b/prototypes/inspect-web/test/status-bar.test.js
@@ -82,6 +82,7 @@ test("the compact workspace data bar shows version/commit, provenance, and a one
   assert.doesNotMatch(html, /class="statusbar data-bar expanded"/);
   assert.match(html, /data-status-bar-toggle-button/);
   assert.match(html, /aria-expanded="false"/);
+  assert.match(html, /aria-label="Show all data"/);
   assert.match(html, /<button type="button" class="status-bar-toggle"/);
 
   const identityIndex = html.indexOf("v1.2.3");
@@ -125,6 +126,7 @@ test("the expanded workspace data bar shows every field, including full diagnost
 
   assert.match(html, /class="statusbar data-bar expanded"/);
   assert.match(html, /aria-expanded="true"/);
+  assert.match(html, /aria-label="Collapse"/);
   assert.match(html, /↓ download 20 ms · 1\.0 KB → 2\.0 KB/);
   assert.match(html, /3 packages · 2 resident in cache · 1 workspace/);
   assert.match(html, /Source: packages\.&quot;&lt;example&gt;/);


### PR DESCRIPTION
## Summary

Redesigns `src/status-bar.ts`'s data bar per user direction: it was cramped, showed always-on diagnostic (performance) data as the majority of its content, and didn't order content by importance.

**Compact (default) view** now shows, in this priority order:
1. App version/commit
2. Package provenance ("Source: X")
3. Build date (short form)
4. A one-line performance summary ("⚙ ready in Xs")

**Expanded view** (click the bar, or press Enter/Space when focused) adds the full diagnostics breakdown (download/startup/precompute/total), package cache stats, active assembly, framework, and the "public API surface" label — everything that was always-visible before.

Expansion state lives in `state.statusBarExpanded` and applies uniformly to both the workspace bar and the home readiness bar.

## Non-action / deferred

Symbol/PDB acquisition status ("were symbols acquired, from where") is explicitly **not** included — no backend contract (`BrowserSymbolStatus`-style) exists yet to source that data. This was discussed with the user and deferred as a fast-follow requiring separate engine work.

## Validation

- `npm run typecheck` — clean
- `node --test` — 208/208 passing (rewrote `test/status-bar.test.js` to cover compact vs. expanded rendering, content ordering, and the toggle affordance)
- `npm run build` — succeeds
- `npx markdownlint-cli README.md` — clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>