### PR TITLE
Stabilize type-targeted decode test selection

### DIFF
--- a/src/dotnet-inspect.Tests/TypeTargetedDecodeTests.cs
+++ b/src/dotnet-inspect.Tests/TypeTargetedDecodeTests.cs
@@ -22,11 +22,15 @@ public class TypeTargetedDecodeTests
             ? string.Join(";", v.Select(x => x!.ToString()).OrderBy(s => s, StringComparer.Ordinal))
             : "";
 
-    static Analysis.TypeRef LargestType(Analysis.LibraryBodyIndex full)
+    static Analysis.TypeRef TargetType(Analysis.LibraryBodyIndex full)
         => full.Methods
-            .GroupBy(m => m.DeclaringType)
-            .OrderByDescending(g => g.Count())
-            .First().Key;
+            .Single(method =>
+                method.DeclaringType.Name
+                    == nameof(Analysis.LibraryBodyIndex)
+                && method.Name
+                    == nameof(Analysis.LibraryBodyIndex
+                        .GetDirectCallsByCaller))
+            .DeclaringType;
 
     [Fact]
     public void TypeTargetedBuild_MatchesFullBuild_ForEveryMethodOfTheType()
@@ -37,7 +41,7 @@ public class TypeTargetedDecodeTests
         var fullUnsafety = full.GetUnsafetyOccurrences();
         var fullAlloc = full.GetAllocationOccurrences();
 
-        var target = LargestType(full);
+        var target = TargetType(full);
         var tokens = full.Methods.Where(m => m.DeclaringType.Equals(target)).Select(m => m.MetadataToken).ToArray();
         Assert.NotEmpty(tokens);
 
@@ -60,7 +64,7 @@ public class TypeTargetedDecodeTests
     public void TypeTargetedBuild_DecodesOnlyTheScopedType()
     {
         var full = Analysis.LibraryBodyIndex.Open(SelfPath);
-        var target = LargestType(full);
+        var target = TargetType(full);
         var inScope = full.Methods.Where(m => m.DeclaringType.Equals(target)).Select(m => m.MetadataToken).ToHashSet();
 
         var targeted = Analysis.LibraryBodyIndex.Open(SelfPath, bodyTypeScope: tr => tr.Equals(target));


### PR DESCRIPTION
## Conclusion

Pins the type-targeted decode invariant tests to `LibraryBodyIndex` instead of whichever declaring type happens to contain the most methods. This restores deterministic Linux and Windows CI without changing product behavior.

## Why

After declared-caller attribution landed, directly selecting a generated type can intentionally retain physical callers inside that scope while whole-assembly analysis attributes those calls to an owning declared method. The two existing gates require both whole-build parity and callers confined to the selected type, so their old `LargestType` selector becomes self-contradictory whenever assembly growth makes a generated type largest. Exact `main` `98067bbb2` reproduces the failure.

## Evidence

- Before: `TypeTargetedBuild_MatchesFullBuild_ForEveryMethodOfTheType` fails on exact `main` on the same assertion reported by #3924, #3993, and #4073 CI.
- After: `TypeTargetedDecodeTests` Release, 2/2 passed.
- `git diff --check`

## Non-action

No Analysis behavior, caller attribution, scope expansion, or output contract changes.