### PR TITLE
Fix type-scoped lifted body attribution

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyAnalysisAccumulator.cs
+++ b/src/ILInspector.Analysis/LibraryBodyAnalysisAccumulator.cs
@@ -14,6 +14,7 @@ internal sealed class LibraryBodyAnalysisAccumulator
     readonly LibraryBodyPrimaryMetadataResolver _primaryMetadataResolver;
     readonly bool _includeMethodEvidence;
     readonly bool _includeLeakTriage;
+    readonly Func<TypeRef, bool>? _typeScope;
     readonly IReadOnlySet<string> _exceptionTypeNames;
 
     internal LibraryBodyAnalysisAccumulator(
@@ -27,6 +28,7 @@ internal sealed class LibraryBodyAnalysisAccumulator
             LibraryBodyAnalysisFeatures.MethodEvidence);
         _includeLeakTriage = plan.Includes(
             LibraryBodyAnalysisFeatures.LeakTriage);
+        _typeScope = plan.TypeScope;
         _exceptionTypeNames = _includeMethodEvidence
             ? ComputeExceptionTypeNames()
             : new HashSet<string>(StringComparer.Ordinal);
@@ -111,17 +113,23 @@ internal sealed class LibraryBodyAnalysisAccumulator
                 methods.Add(r.Caller!);
             if (!r.Calls.IsDefaultOrEmpty)
             {
-                calls.AddRange(
-                    r.Calls.Select(call =>
+                foreach (DirectCall call in r.Calls)
+                {
+                    MethodIdentity declared =
+                        ResolveDeclaredMethod(
+                            call.Caller,
+                            declaredMethodsByBody);
+                    if (_typeScope is not null
+                        && !_typeScope(
+                            declared.DeclaringType))
                     {
-                        MethodIdentity declared =
-                            ResolveDeclaredMethod(
-                                call.Caller,
-                                declaredMethodsByBody);
-                        return declared == call.Caller
+                        continue;
+                    }
+                    calls.Add(
+                        declared == call.Caller
                             ? call
-                            : call with { Caller = declared };
-                    }));
+                            : call with { Caller = declared });
+                }
             }
             if (!r.Allocations.IsDefaultOrEmpty)
                 allocationOccurrences[r.Token] = r.Allocations;

--- a/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
+++ b/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
@@ -537,6 +537,13 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
                             methodHandle,
                             methodDefinition,
                             scope);
+                    bool directlySelectedBody =
+                        plan.RequestedMethodScope?.Contains(
+                            MetadataTokens.GetToken(methodHandle))
+                            == true
+                        || plan.TypeScope?.Invoke(
+                            method.DeclaringType)
+                            == true;
                     if (_liftedSourceOwnerResolver.TryResolve(
                             methodHandle,
                             methodDefinition,
@@ -545,10 +552,7 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
                             out _,
                             plan.MethodScope,
                             plan.TypeScope,
-                            plan.RequestedMethodScope?.Contains(
-                                MetadataTokens.GetToken(
-                                    methodHandle))
-                                == true)
+                            directlySelectedBody)
                         && sourceOwner is not null)
                     {
                         ownersByBody[method] = sourceOwner;
@@ -597,11 +601,16 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
                 MethodIdentity owner)
                 in ownersByBody)
             {
-                evidenceSources[body.MetadataToken] =
+                TypeRef declaredType =
                     ResolveDeclaredMethod(
                         owner,
                         ownersByBody)
                     .DeclaringType;
+                if (plan.TypeScope(declaredType))
+                {
+                    evidenceSources[body.MetadataToken] =
+                        declaredType;
+                }
             }
         }
 

--- a/src/ILInspector.Analysis/LibraryBodyLiftedSourceOwnerResolver.cs
+++ b/src/ILInspector.Analysis/LibraryBodyLiftedSourceOwnerResolver.cs
@@ -136,6 +136,7 @@ internal sealed class LibraryBodyLiftedSourceOwnerResolver
             return false;
         }
         if (ownerTypeScope is not null
+            && !directlySelectedBody
             && !ownerTypeScope(
                 TypeRefDecoder.Instance.GetTypeFromDefinition(
                     _reader,

--- a/src/ILInspector.Analysis/LibraryMethodAnalysisRunner.cs
+++ b/src/ILInspector.Analysis/LibraryMethodAnalysisRunner.cs
@@ -270,6 +270,9 @@ internal sealed class LibraryMethodAnalysisRunner(
                         requestedMethodScope,
                         requestedMethodScope?.Contains(
                             caller.MetadataToken)
+                            == true
+                        || bodyTypeScope?.Invoke(
+                            caller.DeclaringType)
                             == true);
                 result.DeclaredMethod = declaredMethod;
                 result.DeclaredSource = declaredMethod;

--- a/src/dotnet-inspect.Tests/TypeTargetedDecodeTests.cs
+++ b/src/dotnet-inspect.Tests/TypeTargetedDecodeTests.cs
@@ -72,4 +72,51 @@ public class TypeTargetedDecodeTests
         // At least one method of the target type actually decoded (the type has bodies with calls).
         Assert.NotEmpty(targeted.GetDirectCallsByCaller());
     }
+
+    [Fact]
+    public void TypeTargetedBuild_KeepsLiftedPhysicalFactsWithoutOutOfScopeDeclaredCalls()
+    {
+        var full = Analysis.LibraryBodyIndex.Open(SelfPath);
+        Analysis.MethodIdentity evidenceMethod = Assert.Single(
+            full.DirectCalls
+                .Where(call =>
+                    call.EvidenceMethod.DeclaringType
+                        .ToQualifiedDisplayString()
+                        .EndsWith(
+                            "StructuralCloneComparisonDocumentJsonContext.<>c",
+                            StringComparison.Ordinal)
+                    && call.EvidenceMethod.Name
+                        == "<Create_StructuralCloneAlignment>b__7_0")
+                .Select(call => call.EvidenceMethod)
+                .Distinct());
+        Analysis.MethodIdentity declaredCaller = Assert.Single(
+            full.DirectCalls
+                .Where(call => call.EvidenceMethod == evidenceMethod)
+                .Select(call => call.Caller)
+                .Distinct());
+        int evidenceToken = evidenceMethod.MetadataToken;
+        Analysis.TypeRef evidenceType =
+            evidenceMethod.DeclaringType;
+        Assert.NotEqual(
+            evidenceType,
+            declaredCaller.DeclaringType);
+
+        var targeted = Analysis.LibraryBodyIndex.Open(
+            SelfPath,
+            bodyTypeScope: type => type.Equals(evidenceType));
+
+        Assert.NotEmpty(
+            full.GetDirectCallsByEvidenceMethod()[evidenceToken]);
+        Assert.False(
+            targeted.GetDirectCallsByEvidenceMethod()
+                .ContainsKey(evidenceToken));
+        Assert.Equal(
+            Facts(full.GetAllocationOccurrences(), evidenceToken),
+            Facts(targeted.GetAllocationOccurrences(), evidenceToken));
+        Assert.NotEmpty(
+            targeted.GetAllocationOccurrences()[evidenceToken]);
+        Assert.DoesNotContain(
+            targeted.DirectCalls,
+            call => call.Caller == declaredCaller);
+    }
 }


### PR DESCRIPTION
## Summary

Fix type-targeted Analysis builds so a compiler-generated method body directly selected by its physical declaring type keeps its non-call evidence even when its logical declared owner is outside that type scope.

- resolve the lifted declared owner for directly selected physical bodies
- preserve allocation and other body-local facts under the physical evidence method
- omit declared-call projections whose logical caller is outside the requested type scope
- cover the source-generator-produced `StructuralCloneComparisonDocumentJsonContext.<>c` lambda that exposed the regression

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — 1012 total, 0 failed, 8 skipped because the pinned CoreLib corpus artifact is unavailable
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -class 'DotnetInspector.Tests.TypeTargetedDecodeTests'` — 3 passed
- full Release CLI suite with repository IL/metadata oracles active — 4246 total, 0 failed, 5 platform skips, excluding only `Package_Manifest_RendersToolManifestRows`

`Package_Manifest_RendersToolManifestRows` fails identically on exact unmodified `main` (`3e54e7e5b912e4ef0599d6e7e430db36f85f653f`) because the current Azure.Mcp package output lacks the expected RID row; this PR does not alter package inspection.

## Non-action boundary

No Browser/WASM behavior, package-manifest behavior, or full-build attribution semantics change here. The fix is limited to scoped lifted-body selection and projection.
