### PR TITLE
Convert inspect-web presentation tests to TypeScript

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -483,7 +483,7 @@ dotnet run --project prototypes/inspect-web/engine.Tests -c Release
 central-directory entry limit before archive enumeration, role preflight before identity decoding, malformed selected-participant
 visibility, reference-only retained-image budget, duplicate XML parameter
 handling, Mermaid label containment, and complete call-graph navigation targets.
-The JavaScript tests gate the annotated view helper against the shared sample
+The frontend tests gate the annotated view helper against the shared sample
 document and keep Spotlight candidate/cache identity coordinate-complete.
 `call graph diagnostics distinguish failures from expected bounds` gates that
 catalog and body-analysis failures remain visible while an expected finite
@@ -515,8 +515,8 @@ Pull requests that change the browser prototype, its shared annotated-source
 viewer, product dependencies, or repository build inputs run the `inspect-web`
 CI job. That job installs the locked Node dependencies, checks and bundles the
 TypeScript/JavaScript frontend, compiles the platform-index generator, publishes
-the Release Wasm bundle, runs the browser-engine tests, and runs both JavaScript
-suites.
+the Release Wasm bundle, runs the browser-engine tests, and runs both frontend
+test suites.
 The `eng/CiChangeDetection` gate, invoked through
 `eng/test-ci-change-detection.cs`, gates the path classification, and
 `ci-required` includes the job's result.
@@ -532,7 +532,7 @@ scope/result rendering, selection, and keyboard interaction.
 `src/command-bar.ts` supplies its typed Commands-scope grammar and results;
 `dotnet-inspect.ts` retains package queries, navigation, network acquisition, and command
 effects so the components do not acquire engine or workspace authority.
-`test/spotlight.test.js` and `test/command-bar.test.js` gate both presentation
+`test/spotlight.test.js` and `test/command-bar.test.ts` gate both presentation
 modes, scope ownership, completion and replacement behavior, bounded results,
 command metadata, and escaping.
 
@@ -563,7 +563,7 @@ click/keyboard navigation, and passes each computed slice in explicitly; the
 shared text helpers used well beyond the type panel (`kindIcon`, `shortKind`,
 `typeDisplayName`, `highlight`, `highlightCSharp`, `factRows`,
 `relatedTypeChip`) stay in `dotnet-inspect.ts` and are injected the same way.
-`test/type-panel.test.js` gates namespace grouping and selection in the type
+`test/type-panel.test.ts` gates namespace grouping and selection in the type
 list, active-group and overload selection in the member list, the type
 heading's package/library fields, the metadata- and source-signature cache
 keys, and the metadata/source panels' loading, error, and loaded states.
@@ -572,14 +572,14 @@ keys, and the metadata/source panels' loading, error, and loaded states.
 Platform tab), the open-package query form, and their keyboard/mouse/wheel
 interaction. `dotnet-inspect.ts` supplies the workspace effects — selecting, closing, and
 opening a package or the runtime pack — so the component acquires no engine or
-workspace authority. `test/package-bar.test.js` gates tab markup, active/close
+workspace authority. `test/package-bar.test.ts` gates tab markup, active/close
 state, escaping, and open-package query parsing.
 
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, as pure, dependency-injected render
 functions. `dotnet-inspect.ts` still owns `state`, localStorage persistence for theme and
 taste, and event wiring (`setTheme`, `toggleTaste`, `clearTaste`), and passes
-each computed slice in explicitly. `test/settings-panel.test.js` gates the
+each computed slice in explicitly. `test/settings-panel.test.ts` gates the
 style catalog's tier grouping, byte-divergent badges, and checked state; the
 taste popover's active/default states; and the Settings page's theme segment,
 close-button label, and active-style-count states.
@@ -589,7 +589,7 @@ Package/Types/Member control and the buttons beside it for the active scope's
 lenses or member sections) as a pure, dependency-injected render function.
 `dotnet-inspect.ts` still owns the current scope, the package/type/member lens
 definitions, and the active lens/section per scope, and passes each computed
-slice in explicitly. `test/scope-bar.test.js` gates the active scope segment,
+slice in explicitly. `test/scope-bar.test.ts` gates the active scope segment,
 the active lens/section marking per scope, keyboard-shortcut indices, and
 label escaping.
 
@@ -605,7 +605,7 @@ heap listing, the explorer's focus/history stack, the DOM event binding, the
 global keydown handler, and passes each computed slice in explicitly; the shared
 helpers used well beyond these views (`escapeHtml`, `fmtBytes`,
 `platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`) stay in
-`dotnet-inspect.ts` and are injected the same way. `test/metadata-viewer.test.js` gates the
+`dotnet-inspect.ts` and are injected the same way. `test/metadata-viewer.test.ts` gates the
 lens's picker, loading, failure, stale-scope, partial-read, and empty-image
 states and its heap/table ordering; the explorer's chips, history-button
 enablement, overview versus focus lightbox, lazy-load hooks, pager bounds, row
@@ -616,7 +616,7 @@ and coverage notes, and the row inspector.
 opened from a package's documents list) as a pure, dependency-injected render
 function. `dotnet-inspect.ts` still owns `state`, fetching and rendering the document's
 Markdown and frontmatter, and the sequence-guarded async load/close
-lifecycle, and passes each computed slice in explicitly. `test/doc-viewer.test.js`
+lifecycle, and passes each computed slice in explicitly. `test/doc-viewer.test.ts`
 gates the closed/no-document fallback, loading and error states, the
 frontmatter card's presence and fields, and title/subtitle/frontmatter-name
 escaping (the rendered document body is trusted, pre-sanitized Markdown HTML
@@ -626,7 +626,7 @@ and is not escaped).
 from a call graph node) as a pure, dependency-injected render function.
 `dotnet-inspect.ts` still owns `state`, the sequence-guarded async source-inspection
 lifecycle, and the `highlightCSharp` Prism wrapper, and passes each computed
-slice in explicitly. `test/graph-source.test.js` gates the loading state, the
+slice in explicitly. `test/graph-source.test.ts` gates the loading state, the
 original-versus-decompiled provenance labels, the open-source link's presence
 only when a `url` is provided, the error state's fallback message, and title
 escaping in both the header and loading status.
@@ -637,7 +637,7 @@ dependency-injected render function; it composes `annotated-source-view.ts`'s
 `buildAnnotatedView` projection into markup. `dotnet-inspect.ts` still owns `state`, the
 sequence-guarded async load lifecycle, and the medium-toggle/fact-selection
 event handlers, and passes each computed slice in explicitly.
-`test/annotated-source.test.js` gates the rejected-document fallback, the
+`test/annotated-source.test.ts` gates the rejected-document fallback, the
 medium toggles and hidden-line count, the context-limitation notice, anchored
 versus unanchored fact rendering, selection state, and source-text escaping.
 
@@ -648,7 +648,7 @@ dependency-injected render function, including its opportunity-row API-name
 splitting, package-chip detection, and "look for" chip rendering. `dotnet-inspect.ts`
 still owns `state`, the scan-scope-keyed async load lifecycle
 (`loadPackageOpportunities`), and the platform library picker, and passes
-each computed slice in explicitly. `test/package-opportunities.test.js` gates
+each computed slice in explicitly. `test/package-opportunities.test.ts` gates
 the platform pick-a-library prompt, the scanning/loading/error states (fresh
 versus stale scope), the no-opportunities and inspection-error banners, the
 category summary counts, API name splitting, package-chip versus plain-text

--- a/prototypes/inspect-web/package-lock.json
+++ b/prototypes/inspect-web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dotnet-inspect-web-prototype",
       "version": "0.0.1",
       "devDependencies": {
+        "@types/node": "^24.13.3",
         "typescript": "7.0.2",
         "vite": "^7.0.6"
       },
@@ -873,6 +874,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@typescript/typescript-aix-ppc64": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
@@ -1463,6 +1474,13 @@
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.6",

--- a/prototypes/inspect-web/package.json
+++ b/prototypes/inspect-web/package.json
@@ -11,7 +11,7 @@
     "build": "npm run typecheck && vite build && node scripts/verify-site-artifact.js dist",
     "preview": "vite preview",
     "test": "npm run typecheck && node --test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",

--- a/prototypes/inspect-web/package.json
+++ b/prototypes/inspect-web/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^24.13.3",
     "typescript": "7.0.2",
     "vite": "^7.0.6"
   }

--- a/prototypes/inspect-web/src/annotated-source-view.ts
+++ b/prototypes/inspect-web/src/annotated-source-view.ts
@@ -82,7 +82,7 @@ export const MEDIUM_LABELS: Readonly<Record<SourceMedium, string>> = {
 };
 
 export function buildAnnotatedView(
-  document: unknown,
+  document: AnnotatedSourceDocument,
   state: AnnotatedViewState = {},
 ): AnnotatedView {
   validateDocument(document);

--- a/prototypes/inspect-web/src/annotated-source-view.ts
+++ b/prototypes/inspect-web/src/annotated-source-view.ts
@@ -82,7 +82,7 @@ export const MEDIUM_LABELS: Readonly<Record<SourceMedium, string>> = {
 };
 
 export function buildAnnotatedView(
-  document: AnnotatedSourceDocument,
+  document: unknown,
   state: AnnotatedViewState = {},
 ): AnnotatedView {
   validateDocument(document);

--- a/prototypes/inspect-web/src/annotated-source.ts
+++ b/prototypes/inspect-web/src/annotated-source.ts
@@ -15,7 +15,7 @@ export type AnnotatedSourceResult = Omit<BrowserAnnotatedSource, "document"> & {
 };
 
 export interface RenderAnnotatedSourceOptions {
-  result: AnnotatedSourceResult;
+  result: BrowserAnnotatedSource;
   media: AnnotatedViewState["media"];
   selectedFactId: AnnotatedViewState["selectedFactId"];
   selectedNodeIds: AnnotatedViewState["selectedNodeIds"];

--- a/prototypes/inspect-web/src/annotated-source.ts
+++ b/prototypes/inspect-web/src/annotated-source.ts
@@ -14,8 +14,13 @@ export type AnnotatedSourceResult = Omit<BrowserAnnotatedSource, "document"> & {
   document: AnnotatedSourceDocument;
 };
 
+export type AnnotatedSourceRenderResult =
+  Omit<BrowserAnnotatedSource, "contextLimitation"> & {
+    contextLimitation?: BrowserAnnotatedSource["contextLimitation"];
+  };
+
 export interface RenderAnnotatedSourceOptions {
-  result: BrowserAnnotatedSource;
+  result: AnnotatedSourceRenderResult;
   media: AnnotatedViewState["media"];
   selectedFactId: AnnotatedViewState["selectedFactId"];
   selectedNodeIds: AnnotatedViewState["selectedNodeIds"];

--- a/prototypes/inspect-web/src/annotated-source.ts
+++ b/prototypes/inspect-web/src/annotated-source.ts
@@ -15,7 +15,7 @@ export type AnnotatedSourceResult = Omit<BrowserAnnotatedSource, "document"> & {
 };
 
 export type AnnotatedSourceRenderResult =
-  Omit<BrowserAnnotatedSource, "contextLimitation"> & {
+  Omit<AnnotatedSourceResult, "contextLimitation"> & {
     contextLimitation?: BrowserAnnotatedSource["contextLimitation"];
   };
 

--- a/prototypes/inspect-web/src/status-bar.ts
+++ b/prototypes/inspect-web/src/status-bar.ts
@@ -136,7 +136,7 @@ function packageCacheHtml(
       <span class="diag" title="${title}">◇ ${cache.packages} package${packagePlural} · ${cache.resident} resident in cache · ${cache.workspaces} workspace${workspacePlural}</span>`;
 }
 
-export function packageSourceLabel(source: unknown): string {
+export function packageSourceLabel(source?: unknown): string {
   if (!source || typeof source !== "object" || !("kind" in source)) {
     return "Unknown";
   }

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { renderAnnotatedSource } from "../src/annotated-source.ts";
-import { sampleDocument } from "../../annotated-source-viewer/src/sample-document.js";
+import type { AnnotatedSourceRenderResult } from "../src/annotated-source.ts";
+import { validateAnnotatedSourceDocument } from "../src/annotated-source-view.ts";
+import type { AnnotatedSourceDocument } from "../src/annotated-source-view.ts";
+import { sampleDocument as sampleDocumentFixture } from "../../annotated-source-viewer/src/sample-document.js";
+
+validateAnnotatedSourceDocument(sampleDocumentFixture);
+const sampleDocument: AnnotatedSourceDocument = sampleDocumentFixture;
 
 function escapeHtml(value: unknown) {
   return String(value)
@@ -11,10 +17,15 @@ function escapeHtml(value: unknown) {
     .replaceAll('"', "&quot;");
 }
 
-const result = {
+const result: AnnotatedSourceRenderResult = {
   document: sampleDocument,
   provenance: "decompiled from IL",
 };
+
+test("the render result preserves the validated document contract", () => {
+  const document: AnnotatedSourceDocument = result.document;
+  assert.equal(document, sampleDocument);
+});
 
 test("an invalid document is rejected with a message instead of throwing", () => {
   const html = renderAnnotatedSource({

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -14,7 +14,6 @@ function escapeHtml(value: unknown) {
 const result = {
   document: sampleDocument,
   provenance: "decompiled from IL",
-  contextLimitation: null,
 };
 
 test("an invalid document is rejected with a message instead of throwing", () => {

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { renderAnnotatedSource } from "../src/annotated-source.ts";
 import { sampleDocument } from "../../annotated-source-viewer/src/sample-document.js";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
@@ -11,7 +11,11 @@ function escapeHtml(value) {
     .replaceAll('"', "&quot;");
 }
 
-const result = { document: sampleDocument, provenance: "decompiled from IL" };
+const result = {
+  document: sampleDocument,
+  provenance: "decompiled from IL",
+  contextLimitation: null,
+};
 
 test("an invalid document is rejected with a message instead of throwing", () => {
   const html = renderAnnotatedSource({
@@ -155,6 +159,7 @@ test("source text is escaped as it is rendered into spans", () => {
         targets: [],
       },
       provenance: "decompiled from IL",
+      contextLimitation: null,
     },
     media: undefined,
     selectedFactId: null,

--- a/prototypes/inspect-web/test/command-bar.test.ts
+++ b/prototypes/inspect-web/test/command-bar.test.ts
@@ -6,14 +6,18 @@ import {
   commandPaletteResults,
   commandPaletteRowHtml,
 } from "../src/command-bar.ts";
+import type { CommandContext } from "../src/command-bar.ts";
 
 const lenses = [
   ["api", "API"],
   ["metadata", "Metadata"],
   ["source", "Source"],
-];
+] as const;
 
-function commandContext(command, types = []) {
+function commandContext(
+  command: string,
+  types: CommandContext["package"]["types"] = [],
+): CommandContext {
   return {
     command,
     package: {
@@ -25,7 +29,7 @@ function commandContext(command, types = []) {
   };
 }
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")

--- a/prototypes/inspect-web/test/doc-viewer.test.ts
+++ b/prototypes/inspect-web/test/doc-viewer.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { renderDocViewer } from "../src/doc-viewer.ts";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")

--- a/prototypes/inspect-web/test/graph-source.test.ts
+++ b/prototypes/inspect-web/test/graph-source.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { renderGraphSource } from "../src/graph-source.ts";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
@@ -10,7 +10,7 @@ function escapeHtml(value) {
     .replaceAll('"', "&quot;");
 }
 
-function highlightCSharp(value) {
+function highlightCSharp(value: unknown) {
   return `<mark>${escapeHtml(value)}</mark>`;
 }
 

--- a/prototypes/inspect-web/test/metadata-viewer.test.ts
+++ b/prototypes/inspect-web/test/metadata-viewer.test.ts
@@ -19,7 +19,7 @@ import {
   sameFocus,
 } from "../src/metadata-viewer.ts";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
@@ -27,7 +27,7 @@ function escapeHtml(value) {
     .replaceAll('"', "&quot;");
 }
 
-function fmtBytes(value) {
+function fmtBytes(value: number) {
   return `${value} B`;
 }
 

--- a/prototypes/inspect-web/test/package-bar.test.ts
+++ b/prototypes/inspect-web/test/package-bar.test.ts
@@ -8,8 +8,9 @@ import {
   parsePackageQuery,
   platformTabHtml,
 } from "../src/package-bar.ts";
+import type { PackageBarPackage } from "../src/package-bar.ts";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
@@ -17,11 +18,16 @@ function escapeHtml(value) {
     .replaceAll('"', "&quot;");
 }
 
-function packageIdentityKey(pkg) {
+function packageIdentityKey(pkg: PackageBarPackage) {
   return `${pkg.id}@${pkg.version}::${pkg.activeFramework}`;
 }
 
-function pkg(id, version = "1.0.0", activeFramework = "net10.0", isRuntimePack = false) {
+function pkg(
+  id: string,
+  version = "1.0.0",
+  activeFramework = "net10.0",
+  isRuntimePack = false,
+): PackageBarPackage {
   return { id, version, activeFramework, isRuntimePack };
 }
 

--- a/prototypes/inspect-web/test/package-opportunities.test.ts
+++ b/prototypes/inspect-web/test/package-opportunities.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { renderPackageOpportunities } from "../src/package-opportunities.ts";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
@@ -64,7 +64,7 @@ test("no data yet (fresh, no error, no data) shows a generic loading placeholder
 test("empty categories render the no-opportunities message with the scan scope", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: { categories: [], totalOpportunities: 0 },
+    data: { categories: [], totalOpportunities: 0, inspectionError: null },
   });
 
   assert.match(html, /No integration opportunities/);
@@ -76,7 +76,7 @@ test("a platform scan scope names the scoped library and framework", () => {
     ...baseOptions,
     isPlatform: true,
     scopedLibrary: "System.Text.Json",
-    data: { categories: [], totalOpportunities: 0 },
+    data: { categories: [], totalOpportunities: 0, inspectionError: null },
   });
 
   assert.match(html, /System\.Text\.Json · net10\.0/);
@@ -105,6 +105,7 @@ test("categories render a summary with area\/suggestion counts and a chip per ca
         { integration: "Database", items: [] },
       ],
       totalOpportunities: 1,
+      inspectionError: null,
     },
   });
 
@@ -122,6 +123,7 @@ test("an opportunity row splits the API into short name and qualifier", () => {
         items: [{ api: "System.ClientModel.Primitives.PipelineMessage", integrationType: "IServiceCollection registration", lookFor: "" }],
       }],
       totalOpportunities: 1,
+      inspectionError: null,
     },
   });
 
@@ -138,6 +140,7 @@ test("an integration kind with a leading dotted namespace renders a load-on-dema
         items: [{ api: "Widget", integrationType: "Microsoft.Extensions.AI IChatClient extension", lookFor: "" }],
       }],
       totalOpportunities: 1,
+      inspectionError: null,
     },
   });
 
@@ -154,6 +157,7 @@ test("an integration kind with no dotted namespace renders as plain muted text",
         items: [{ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "" }],
       }],
       totalOpportunities: 1,
+      inspectionError: null,
     },
   });
 
@@ -170,6 +174,7 @@ test("look-for tokens render as spotlight-seeded chips, one per comma-separated 
         items: [{ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "AddChatClient, AddEmbeddingGenerator" }],
       }],
       totalOpportunities: 1,
+      inspectionError: null,
     },
   });
 
@@ -186,6 +191,7 @@ test("a wildcard look-for pattern renders as a muted, non-interactive hint", () 
         items: [{ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "Add*" }],
       }],
       totalOpportunities: 1,
+      inspectionError: null,
     },
   });
 
@@ -202,6 +208,7 @@ test("an empty look-for hint renders a generic any-registration-surface hint", (
         items: [{ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "" }],
       }],
       totalOpportunities: 1,
+      inspectionError: null,
     },
   });
 
@@ -217,6 +224,7 @@ test("API and integration-type text is escaped", () => {
         items: [{ api: "<Widget>", integrationType: "<bad> kind", lookFor: "<bad>" }],
       }],
       totalOpportunities: 1,
+      inspectionError: null,
     },
   });
 

--- a/prototypes/inspect-web/test/scope-bar.test.ts
+++ b/prototypes/inspect-web/test/scope-bar.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { renderScopeBar } from "../src/scope-bar.ts";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
@@ -14,7 +14,7 @@ const typeLenses = [
   ["api", "API"],
   ["metadata", "Metadata"],
   ["source", "Source"],
-];
+] as const;
 
 test("package scope marks only the package segment and the active package lens", () => {
   const html = renderScopeBar({

--- a/prototypes/inspect-web/test/settings-panel.test.ts
+++ b/prototypes/inspect-web/test/settings-panel.test.ts
@@ -6,7 +6,7 @@ import {
   styleCatalogGroupsHtml,
 } from "../src/settings-panel.ts";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")

--- a/prototypes/inspect-web/test/status-bar.test.ts
+++ b/prototypes/inspect-web/test/status-bar.test.ts
@@ -8,7 +8,7 @@ import {
   statusBarHtml,
 } from "../src/status-bar.ts";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
@@ -57,7 +57,12 @@ test("build identity keeps provenance linked and inert, without the build date",
 
 test("the compact workspace data bar shows version/commit, provenance, and a one-line performance summary, in that order", () => {
   const html = statusBarHtml({
-    buildIdentity: { version: "1.2.3", builtAtUtc: "2026-08-19T14:00:00Z" },
+    buildIdentity: {
+      version: "1.2.3",
+      commit: null,
+      builtAtUtc: "2026-08-19T14:00:00Z",
+      commitUrl: null,
+    },
     diagnostics: {
       assets: 4,
       downloadMs: 20,
@@ -103,7 +108,12 @@ test("the compact workspace data bar shows version/commit, provenance, and a one
 test("the expanded workspace data bar shows every field, including full diagnostics and the package cache tail", () => {
   const html = statusBarHtml({
     expanded: true,
-    buildIdentity: { version: "1.2.3", builtAtUtc: "2026-08-19T14:00:00Z" },
+    buildIdentity: {
+      version: "1.2.3",
+      commit: null,
+      builtAtUtc: "2026-08-19T14:00:00Z",
+      commitUrl: null,
+    },
     diagnostics: {
       assets: 4,
       downloadMs: 20,
@@ -139,7 +149,12 @@ test("the same data bar component renders home readiness and a compact performan
   const html = statusBarHtml({
     variant: "home",
     ready: false,
-    buildIdentity: { version: "1.2.3" },
+    buildIdentity: {
+      version: "1.2.3",
+      commit: null,
+      builtAtUtc: null,
+      commitUrl: null,
+    },
     diagnostics: {
       assets: 4,
       downloadMs: 20,

--- a/prototypes/inspect-web/test/toolchain.test.js
+++ b/prototypes/inspect-web/test/toolchain.test.js
@@ -15,6 +15,15 @@ import { verifySiteArtifact } from "../scripts/verify-site-artifact.js";
 const packageLock = JSON.parse(
   readFileSync(new URL("../package-lock.json", import.meta.url), "utf8"),
 );
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+const browserTsconfig = JSON.parse(
+  readFileSync(new URL("../tsconfig.json", import.meta.url), "utf8"),
+);
+const testTsconfig = JSON.parse(
+  readFileSync(new URL("tsconfig.json", import.meta.url), "utf8"),
+);
 
 test("the package lock pins every registry artifact", () => {
   const missingArtifactIdentity = Object.entries(packageLock.packages)
@@ -25,6 +34,18 @@ test("the package lock pins every registry artifact", () => {
     .map(([path]) => path);
 
   assert.deepEqual(missingArtifactIdentity, []);
+});
+
+test("TypeScript compiler contexts keep Node globals out of browser source", () => {
+  assert.deepEqual(browserTsconfig.compilerOptions.types, []);
+  assert.deepEqual(browserTsconfig.include, ["src/**/*.ts"]);
+  assert.equal(testTsconfig.extends, "../tsconfig.json");
+  assert.deepEqual(testTsconfig.compilerOptions.types, ["node"]);
+  assert.deepEqual(testTsconfig.include, ["./**/*.ts"]);
+  assert.equal(
+    packageJson.scripts.typecheck,
+    "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
+  );
 });
 
 test("the site artifact rejects a missing Vite output", (context) => {

--- a/prototypes/inspect-web/test/tsconfig.json
+++ b/prototypes/inspect-web/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -9,8 +9,12 @@ import {
   typeMetadataSignature,
   typeSourceSignature,
 } from "../src/type-panel.ts";
+import type {
+  MemberNavEntry,
+  TypeSummary,
+} from "../src/type-panel.ts";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
@@ -18,34 +22,34 @@ function escapeHtml(value) {
     .replaceAll('"', "&quot;");
 }
 
-function typeDisplayName(item) {
+function typeDisplayName(item: TypeSummary) {
   return item?.displayName || item?.name || "";
 }
 
-function kindIcon(kind) {
+function kindIcon(kind: string) {
   if (kind.includes("struct")) return "S";
   if (kind === "enum") return "E";
   if (kind.includes("interface")) return "I";
   return "C";
 }
 
-function shortKind(kind) {
+function shortKind(kind: string) {
   return kind.replace("sealed ", "").replace("abstract ", "");
 }
 
-function highlight(value) {
+function highlight(value: string) {
   return escapeHtml(value).replace(/\b(public|class)\b/g, '<span class="kw">$1</span>');
 }
 
-function highlightCSharp(value) {
+function highlightCSharp(value: string) {
   return escapeHtml(value);
 }
 
-function factRows(rows) {
+function factRows(rows: readonly (readonly [string, string])[]) {
   return `<dl>${rows.map(([key, value]) => `<div><dt>${escapeHtml(key)}</dt><dd>${escapeHtml(value)}</dd></div>`).join("")}</dl>`;
 }
 
-const jsonSerializer = {
+const jsonSerializer: TypeSummary = {
   id: "System.Text.Json.JsonSerializer",
   name: "JsonSerializer",
   namespace: "System.Text.Json",
@@ -57,7 +61,7 @@ const jsonSerializer = {
   definitionId: "T:System.Text.Json.JsonSerializer",
 };
 
-const jsonDocument = {
+const jsonDocument: TypeSummary = {
   id: "System.Text.Json.JsonDocument",
   name: "JsonDocument",
   namespace: "System.Text.Json",
@@ -154,7 +158,7 @@ test("the member nav marks the active group and its selected overload", () => {
       { signature: "string Serialize<T>(T value)" },
     ],
   };
-  const entries = [
+  const entries: MemberNavEntry[] = [
     { kind: "member", group },
     { kind: "overload", group, index: 0 },
     { kind: "overload", group, index: 1 },
@@ -233,8 +237,11 @@ test("type metadata signature keys on the exact package, framework, and type coo
 
 test("type source signature routes through the shared decompiler-taste-aware key", () => {
   const packageContext = { id: "System.Text.Json", version: "9.0.0", activeFramework: "net9.0" };
-  const calls = [];
-  const memberRequestKey = (parts, taste) => {
+  const calls: {
+    parts: readonly string[];
+    taste: readonly string[];
+  }[] = [];
+  const memberRequestKey = (parts: readonly string[], taste: readonly string[]) => {
     calls.push({ parts, taste });
     return "computed-key";
   };
@@ -292,7 +299,7 @@ test("type metadata renders composition, interfaces, and derived types once load
         assembly: "System.Text.Json.dll",
         interfaces: ["System.IDisposable"],
         derivedTypes: ["System.Text.Json.MyJsonSerializer"],
-        composition: { total: 3, methods: 3 },
+        composition: { total: 3 },
       },
     },
     memberCompositionHtml: `

--- a/prototypes/inspect-web/tsconfig.json
+++ b/prototypes/inspect-web/tsconfig.json
@@ -13,7 +13,8 @@
     },
     "strict": true,
     "target": "ES2022",
+    "types": ["node"],
     "verbatimModuleSyntax": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/prototypes/inspect-web/tsconfig.json
+++ b/prototypes/inspect-web/tsconfig.json
@@ -13,8 +13,8 @@
     },
     "strict": true,
     "target": "ES2022",
-    "types": ["node"],
+    "types": [],
     "verbatimModuleSyntax": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- convert 11 presentation-component suites from JavaScript to strict TypeScript
- type-check test fixtures against exported frontend and generated C# contracts
- add Node 24 declarations and include TypeScript tests in the existing typecheck gate
- align two signatures exposed by strict tests: annotated rendering accepts the generated `unknown` document and validates it in its existing model owner, while source provenance explicitly accepts an absent value it already handled

The production bundle remains byte-identical.

## Sequence

- Follow-up to #4502, rebased onto its merge commit before first push
- `range-diff` shows the authored test-conversion commit is unchanged, and #4502’s reviewed head and merge commit have identical trees
- Residual: `annotated-source-view`, `member-filtering`, `member-focus`, and `spotlight` behavioral suites remain for batch 2; `spotlight-identity` and `toolchain` remain JavaScript source/toolchain canaries by design

## Validation

- `npm test` — 257 passed on the rebased head
- `npm ci --no-audit --no-fund`
- `npm run build`
- `npx markdownlint-cli --config ../../.markdownlint.yaml README.md`