### PR TITLE
Extract inspect-web workspace navigation owner

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -527,10 +527,20 @@ Package tabs and the framework selector are workspace identity, not display
 state: changing either resolves a different workspace. Lenses this engine does
 not answer report the engine's failure rather than fixture results.
 
+`src/workspace-navigation.ts` owns the in-memory view history, monotonic
+navigation generation, share-packet encoding and decoding, URL parsing and
+building, and the browser-history port. `dotnet-inspect.ts` remains the sole
+mutable application-state owner: it supplies typed snapshots and explicit
+transition callbacks, and retains asynchronous workspace restoration and DOM
+event binding. `test/workspace-navigation.test.ts` gates history traversal,
+stale-entry removal, navigation cancellation, rich and legacy URL
+compatibility, visible invalid-state failures, and sandboxed history errors;
+`test/spotlight-identity.test.js` gates the composition-root wiring.
+
 `src/spotlight.ts` owns the modal workbench search, embedded home search,
 scope/result rendering, selection, and keyboard interaction.
 `src/command-bar.ts` supplies its typed Commands-scope grammar and results;
-`dotnet-inspect.ts` retains package queries, navigation, network acquisition, and command
+`dotnet-inspect.ts` retains package queries, network acquisition, and command
 effects so the components do not acquire engine or workspace authority.
 `test/spotlight.test.js` and `test/command-bar.test.ts` gate both presentation
 modes, scope ownership, completion and replacement behavior, bounded results,

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -20,7 +20,6 @@ import {
   memberRequestKey,
   memberSectionIdsFor,
   mermaidLabel,
-  normalizeShareTabs,
   packageCoordinateMatchesLocation,
   packageForView,
   packageIdentityKey,
@@ -28,10 +27,8 @@ import {
   parameterTitleHtml,
   removeWorkspacePackage,
   removeAppendedNotice,
-  replaceCurrentNavigationEntry,
   retainWorkspacePackage,
   resolveLoadedGraphTargetCandidate,
-  shareStateLengthError,
   scopedRequestState,
   sourceSurfaceIsVisible,
   sourceReloadKind,
@@ -49,8 +46,6 @@ import type { CommandPaletteResult } from "./command-bar.ts";
 import {
   bodyTargetMatchesOverload,
   captureLibraryScope,
-  decodeBodyTarget,
-  encodeBodyTarget,
   filterMemberGroups,
   invalidateMemberCallGraphWork,
   MEMBER_TRAITS,
@@ -61,6 +56,16 @@ import {
   type BodyTarget,
   type FilterableMemberGroup,
 } from "./member-filtering.ts";
+import {
+  createNavigationHistory,
+  createNavigationSequence,
+  createWorkspaceLocationPersistence,
+  workspaceViewSignature,
+  type ParsedWorkspaceLocation,
+  type WorkspaceDeepLink,
+  type WorkspaceUrlState,
+  type WorkspaceView,
+} from "./workspace-navigation.ts";
 import {
   captureMemberFocus,
   createMemberFocusRestorer,
@@ -588,7 +593,6 @@ const initialState = {
   packageVersionsLoading: {},
   runtimePackLoading: false,
   runtimePackError: "",
-  navigationSeq: 0,
   selectedBodyTarget: null,
   graphSourceOpen: false,
   graphSource: null,
@@ -680,35 +684,10 @@ type AppState = Omit<typeof initialState, keyof StateOverrides> & StateOverrides
 
 const state = initialState as AppState;
 
-interface NavigationEntry {
-  sig: string;
-  view: ReturnType<typeof captureView>;
-}
-
-const nav: { stack: NavigationEntry[]; index: number } = { stack: [], index: -1 };
-
-function viewSignature() {
-  return JSON.stringify({
-    p: packageIdentityKey(state.package),
-    l: state.lens,
-    t: state.selectedTypeId,
-    m: state.selectedMemberKey,
-    mb: state.memberBrowseTypeId,
-    mk: state.memberKindFilter,
-    ma: state.memberAccessibilityFilter,
-    mr: state.memberTraitFilter,
-    o: state.selectedOverloadIndex,
-    b: encodeBodyTarget(state.selectedBodyTarget),
-    s: state.memberSection,
-    pr: state.atPackageRoot,
-    pl: state.packageLens,
-    ls: captureLibraryScope(state.libraryScope),
-  });
-}
-
-function captureView() {
+function captureView(): WorkspaceView | null {
+  if (!state.package) return null;
   return {
-    package: state.package?.id ?? "",
+    package: state.package.id,
     packageKey: packageIdentityKey(state.package),
     lens: state.lens,
     selectedTypeId: state.selectedTypeId,
@@ -727,23 +706,7 @@ function captureView() {
   };
 }
 
-function recordNav() {
-  if (!state.package) return;
-  const sig = viewSignature();
-  if (nav.index >= 0 && nav.stack[nav.index]?.sig === sig) {
-    nav.stack[nav.index].view = captureView();
-    return;
-  }
-  nav.stack = nav.stack.slice(0, nav.index + 1);
-  nav.stack.push({ sig, view: captureView() });
-  nav.index = nav.stack.length - 1;
-}
-
-function normalizeCurrentNavEntry() {
-  replaceCurrentNavigationEntry(nav, viewSignature(), captureView());
-}
-
-function applyView(view: NavigationEntry["view"]) {
+function applyView(view: WorkspaceView) {
   const pkg = packageForView(state.packages, view);
   if (!pkg) return false;
   invalidateMemberCallGraphWork(state);
@@ -784,7 +747,7 @@ function applyView(view: NavigationEntry["view"]) {
   state.memberAnnotated = null;
   state.memberAnnotatedError = "";
   state.selectedBodyTarget = memberHistory.selectedBodyTarget;
-  normalizeCurrentNavEntry();
+  navigationHistory.normalizeCurrent();
   if (!state.atPackageRoot && state.lens === "api" && state.selectedMemberKey && member) {
     if (state.memberSection === "source") loadSelectedMemberSource();
     else if (state.memberSection === "annotated") loadSelectedMemberAnnotatedSource();
@@ -797,25 +760,24 @@ function applyView(view: NavigationEntry["view"]) {
   return true;
 }
 
+const navigationHistory = createNavigationHistory({
+  capture: captureView,
+  signature: workspaceViewSignature,
+  apply: applyView,
+  onExhausted: render,
+});
+const navigationSequence = createNavigationSequence();
+
+function recordNav() {
+  navigationHistory.record();
+}
+
 function navBack() {
-  while (nav.index > 0) {
-    const candidate = nav.index - 1;
-    nav.index = candidate;
-    if (applyView(nav.stack[candidate].view)) return;
-    nav.stack.splice(candidate, 1);
-  }
-  render();
+  navigationHistory.back();
 }
 
 function navForward() {
-  while (nav.index < nav.stack.length - 1) {
-    const candidate = nav.index + 1;
-    nav.index = candidate;
-    if (applyView(nav.stack[candidate].view)) return;
-    nav.stack.splice(candidate, 1);
-    nav.index -= 1;
-  }
-  render();
+  navigationHistory.forward();
 }
 
 const memberSections: readonly MemberSection[] =
@@ -832,43 +794,6 @@ const memberSectionDefs = [
   ["annotated", "Annotated source"]
 ] as const;
 
-interface SharePacket {
-  t: string[][];
-  a: number;
-  l?: string;
-  v?: string;
-  y?: string;
-  m?: string;
-  o?: number;
-  c?: string;
-  d?: ReturnType<typeof encodeBodyTarget>;
-  b?: 1;
-  q?: string;
-  k?: string;
-  e?: string;
-  r?: string;
-}
-
-interface DecodedShareState {
-  tabs: WorkspaceTab[];
-  active: number;
-  view: string;
-  rich: boolean;
-  type: string | null;
-  member: string | null;
-  overload: string | null;
-  section: string | null;
-  bodyTarget: BodyTarget | null;
-  library: string | null;
-  memberBrowse: boolean;
-  memberTextFilter: string;
-  memberKindFilter: string;
-  memberAccessibilityFilter: string;
-  memberTraitFilter: string;
-}
-
-type ShareStateResult = DecodedShareState | { error: string } | null;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -878,216 +803,22 @@ function memberSectionsFor(member: BrowserMemberSurface | AppMemberGroup) {
   return memberSectionDefs.filter(([id]) => allowed.has(id));
 }
 
-// URL-safe base64 over UTF-8 bytes. Used for the opaque share packet so a shared or
-// duplicated link can carry the full session state without bloating the visible query.
-function base64UrlEncode(text: string) {
-  const bytes = new TextEncoder().encode(text);
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function base64UrlDecode(value: string) {
-  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
-  const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-  return new TextDecoder().decode(bytes);
-}
-
-// Compact, opaque share packet. Carries everything needed to fully restore a session — the
-// open-tab set, which tab is active, the current view, and (only in type view) the selected
-// type/member — so the visible query stays down to a human-readable ?package=<id>. Keys are
-// terse to keep the encoded string short:
-//   t = tabs [[id, version, framework], …]   a = active tab index   v = view token
-//   y/m/o/c = selected type / member / overload / member section (type view only)
-//   b/q/k/e/r = member browse scope / text / kind / accessibility / trait filters
-//   d = selected body [member name, selector key, metadata token]
-function encodeShareState() {
-  if (!state.package) return "";
-  const packet: SharePacket = {
-    t: state.packages.map(item => [item.id, item.version, item.activeFramework || ""]),
-    a: Math.max(0, state.packages.indexOf(state.package))
-  };
-  // Which platform library the runtime pack is scoped to is part of the view's provenance —
-  // capture it so refresh/back/share land on that library instead of the aggregate platform.
-  if (isRuntimePackId(state.package.id) && state.libraryScope && state.libraryScope.size === 1) {
-    packet.l = [...state.libraryScope][0];
-  }
-  if (state.atPackageRoot) {
-    packet.v = state.packageLens && state.packageLens !== "overview" ? `pkg:${state.packageLens}` : "pkg";
-  } else {
-    // Package identity/view is enough for a package-root link; a selected type only belongs
-    // to type view, so it is captured here and nowhere else.
-    if (state.lens && state.lens !== "api") packet.v = state.lens;
-    if (state.selectedTypeId) packet.y = state.selectedTypeId;
-    if (state.selectedMemberKey) packet.m = state.selectedMemberKey;
-    if (state.selectedOverloadIndex != null) packet.o = state.selectedOverloadIndex;
-    if (state.memberSection && state.memberSection !== "overview") packet.c = state.memberSection;
-    if (state.selectedBodyTarget) packet.d = encodeBodyTarget(state.selectedBodyTarget);
-    if (memberScopeIsActive(state, selectedType()?.id)) packet.b = 1;
-    if (state.memberTextFilter) packet.q = state.memberTextFilter;
-    if (state.memberKindFilter !== "all") packet.k = state.memberKindFilter;
-    if (state.memberAccessibilityFilter !== "all") packet.e = state.memberAccessibilityFilter;
-    if (state.memberTraitFilter) packet.r = state.memberTraitFilter;
-  }
-  return base64UrlEncode(JSON.stringify(packet));
-}
-
-function decodeShareState(value: string | null): ShareStateResult {
-  if (!value) return null;
-  const lengthError = shareStateLengthError(value);
-  if (lengthError) return { error: lengthError };
-  try {
-    const raw: unknown = JSON.parse(base64UrlDecode(value));
-    // Legacy form: a bare tuple array of tabs, carrying no view or selection.
-    if (Array.isArray(raw)) {
-      const normalized = normalizeShareTabs(raw);
-      if (normalized.error) return { error: normalized.error };
-      return {
-        tabs: normalized.tabs,
-        active: 0,
-        view: "",
-        rich: false,
-        type: null,
-        member: null,
-        overload: null,
-        section: null,
-        bodyTarget: null,
-        library: null,
-        memberBrowse: false,
-        memberTextFilter: "",
-        memberKindFilter: "all",
-        memberAccessibilityFilter: "all",
-        memberTraitFilter: "",
-      };
-    }
-    if (isRecord(raw) && Array.isArray(raw.t)) {
-      const normalized = normalizeShareTabs(raw.t);
-      if (normalized.error) return { error: normalized.error };
-      return {
-        tabs: normalized.tabs,
-        active: typeof raw.a === "number" && Number.isInteger(raw.a)
-          ? (normalized.sourceIndexes[raw.a] ?? 0)
-          : 0,
-        view: typeof raw.v === "string" ? raw.v : "",
-        rich: true,
-        type: raw.y != null ? String(raw.y) : null,
-        member: raw.m != null ? String(raw.m) : null,
-        overload: raw.o != null ? String(raw.o) : null,
-        section: raw.c != null ? String(raw.c) : null,
-        bodyTarget: decodeBodyTarget(raw.d),
-        library: raw.l != null ? String(raw.l) : null,
-        memberBrowse: raw.b === 1,
-        memberTextFilter: raw.q != null ? String(raw.q) : "",
-        memberKindFilter: raw.k != null ? String(raw.k) : "all",
-        memberAccessibilityFilter: raw.e != null ? String(raw.e) : "all",
-        memberTraitFilter: raw.r != null ? String(raw.r) : ""
-      };
-    }
-    return { error: "The shared workspace state is invalid and was ignored." };
-  } catch {
-    return { error: "The shared workspace state is invalid and was ignored." };
-  }
-}
-
-// Maps a view token ("pkg", "pkg:dependencies", "source", "call-graph", …) to the lens fields.
-function resolveView(token: string) {
-  const atPackageRoot = token === "pkg" || token.startsWith("pkg:");
-  return {
-    lens: lenses.some(([id]) => id === token) ? token : null,
-    atPackageRoot,
-    packageLens: atPackageRoot
-      ? (packageLenses.some(([id]) => id === token.split(":")[1]) ? token.split(":")[1] : "overview")
-      : null
-  };
-}
+const workspaceLocation = createWorkspaceLocationPersistence({
+  current: () => ({
+    href: location.href,
+    pathname: location.pathname,
+    search: location.search,
+    hash: location.hash,
+  }),
+  replace: url => history.replaceState(null, "", url),
+  push: url => history.pushState(null, "", url),
+});
 
 function parseLocation() {
-  const params = new URLSearchParams(location.search);
-  const route = location.pathname.split("/").filter(Boolean);
-  const packageAt = route.findIndex(part => part.toLowerCase() === "packages");
-  const share = decodeShareState(params.get("w"));
-
-  // Visible fallbacks for legacy/hand-typed links (?package=…, path form, bare params).
-  let pkg = packageAt >= 0 ? decodeURIComponent(route[packageAt + 1] || "") : params.get("package");
-  let version = packageAt >= 0 ? decodeURIComponent(route[packageAt + 2] || "") : params.get("version");
-  let framework = params.get("framework");
-  let type = params.get("type");
-  let member = params.get("member");
-  let overload = params.get("overload");
-  let section = params.get("section");
-  let bodyTarget: BodyTarget | null = null;
-  let viewToken = location.hash.slice(1);
-  let tabs: WorkspaceTab[] = [];
-  let active = 0;
-  let library: string | null = null;
-  let memberBrowse = false;
-  let memberTextFilter = "";
-  let memberKindFilter = "all";
-  let memberAccessibilityFilter = "all";
-  let memberTraitFilter = "";
-  let workspaceNotice = share && "error" in share ? share.error : "";
-
-  if (share && !("error" in share)) {
-    tabs = share.tabs;
-    if (share.rich) {
-      // Rich packet is fully authoritative: identity, view, and selection all come from it.
-      active = Math.min(Math.max(0, share.active), Math.max(0, tabs.length - 1));
-      const target = tabs[active];
-      if (target) { pkg = target.id; version = target.version; framework = target.framework; }
-      if (share.view) viewToken = share.view;
-      type = share.type;
-      member = share.member;
-      overload = share.overload;
-      section = share.section;
-      bodyTarget = share.bodyTarget;
-      library = share.library;
-      memberBrowse = share.memberBrowse;
-      memberTextFilter = share.memberTextFilter;
-      memberKindFilter = share.memberKindFilter;
-      memberAccessibilityFilter = share.memberAccessibilityFilter;
-      memberTraitFilter = share.memberTraitFilter;
-    } else {
-      // Legacy array packet carries only the extra tab set; the visible params stay the
-      // target. Point the active index at the visible package so it opens focused.
-      const idx = tabs.findIndex(tab => pkg && tab.id.toLowerCase() === pkg.toLowerCase());
-      active = idx >= 0 ? idx : 0;
-    }
-  }
-  if (!pkg && tabs.length) {
-    const target = tabs[Math.min(Math.max(0, active), tabs.length - 1)];
-    pkg = target.id;
-    version = target.version;
-    framework = target.framework;
-  }
-
-  const view = resolveView(viewToken);
-  return {
-    package: pkg,
-    version,
-    framework,
-    type,
-    member,
-    overload,
-    section,
-    bodyTarget,
-    lens: view.lens,
-    atPackageRoot: view.atPackageRoot,
-    packageLens: view.packageLens,
-    tabs,
-    active,
-    library,
-    memberBrowse,
-    memberTextFilter,
-    memberKindFilter,
-    memberAccessibilityFilter,
-    memberTraitFilter,
-    workspaceNotice
-  };
+  return workspaceLocation.parseCurrent();
 }
 
-type ParsedLocation = ReturnType<typeof parseLocation>;
+type ParsedLocation = ParsedWorkspaceLocation;
 
 const initialLocation = parseLocation();
 // A bare visit (no package, no shared workspace packet) lands on the intro/home page
@@ -2159,8 +1890,8 @@ function render() {
         <section class="detail-pane">
           <header class="detail-head">
             <div class="nav-history">
-              <button id="nav-back" ${nav.index > 0 ? "" : "disabled"} title="Back (Alt+←)" aria-label="Back">‹</button>
-              <button id="nav-forward" ${nav.index < nav.stack.length - 1 ? "" : "disabled"} title="Forward (Alt+→)" aria-label="Forward">›</button>
+              <button id="nav-back" ${navigationHistory.canBack() ? "" : "disabled"} title="Back (Alt+←)" aria-label="Back">‹</button>
+              <button id="nav-forward" ${navigationHistory.canForward() ? "" : "disabled"} title="Forward (Alt+→)" aria-label="Forward">›</button>
             </div>
             <div class="breadcrumbs">
               ${state.atPackageRoot
@@ -4433,9 +4164,9 @@ function bindEvents() {
           noticeRetryState.appended);
         state.queryNoticeRetryAction = null;
       }
-      const navigationSeq = ++state.navigationSeq;
+      const navigationSeq = navigationSequence.begin();
       const isCurrent = () =>
-        navigationSeq === state.navigationSeq
+        navigationSequence.isCurrent(navigationSeq)
         && !state.home
         && state.atPackageRoot
         && state.packageLens === lens
@@ -5268,7 +4999,7 @@ async function switchPlatformVersion(
 ) {
   const pkg = runtimePackPackage() ?? retryPackage;
   if (!pkg || !tfm || tfm === pkg.activeFramework) return;
-  const navigationSeq = ++state.navigationSeq;
+  const navigationSeq = navigationSequence.begin();
   state.packages = state.packages.filter(item => !item.isRuntimePack);
   state.libraryScope = null;
   state.platformStack = [];
@@ -5281,8 +5012,8 @@ async function switchPlatformVersion(
   render();
   const loaded = await loadRuntimePack(
     tfm,
-    () => navigationSeq === state.navigationSeq);
-  if (navigationSeq !== state.navigationSeq
+    () => navigationSequence.isCurrent(navigationSeq));
+  if (!navigationSequence.isCurrent(navigationSeq)
     || (state.package && state.package !== pkg)) return;
   if (!loaded) {
     state.loading = false;
@@ -5409,10 +5140,10 @@ function activateRuntimePack() {
     return;
   }
   const framework = state.package?.activeFramework || "";
-  const navigationSeq = state.navigationSeq;
+  const navigationSeq = navigationSequence.current();
   const pending = loadRuntimePack(
     framework,
-    () => navigationSeq === state.navigationSeq); // sets runtimePackLoading synchronously
+    () => navigationSequence.isCurrent(navigationSeq)); // sets runtimePackLoading synchronously
   spotlight.refresh();
   pending.then(() => {
     if (!state.spotlightOpen && !state.home) return;
@@ -5438,8 +5169,8 @@ async function openPlatformLibrary(
 ) {
   const scopeOnly = options.scopeOnly === true;
   const focusGeneration = scopeOnly ? null : beginSpotlightNavigation();
-  const navigationSeq = options.navigationSeq ?? ++state.navigationSeq;
-  if (navigationSeq !== state.navigationSeq) return;
+  const navigationSeq = options.navigationSeq ?? navigationSequence.begin();
+  if (!navigationSequence.isCurrent(navigationSeq)) return;
   spotlight.reset();
   const key = (assembly || "").replace(/\.dll$/i, "");
   const fileName = key ? `${key}.dll` : "";
@@ -5457,8 +5188,8 @@ async function openPlatformLibrary(
       tfm,
       fileName,
       pack,
-      () => navigationSeq === state.navigationSeq);
-    if (navigationSeq !== state.navigationSeq) return;
+      () => navigationSequence.isCurrent(navigationSeq));
+    if (!navigationSequence.isCurrent(navigationSeq)) return;
     if (!loaded) {
       state.loading = false;
       state.error = state.runtimePackError
@@ -5689,55 +5420,57 @@ function workbenchModalOwnsFocus() {
     || state.docViewerOpen;
 }
 
+function captureWorkspaceUrlState(): WorkspaceUrlState | null {
+  if (!state.package) return null;
+  const library = isRuntimePackId(state.package.id)
+    && state.libraryScope?.size === 1
+    ? [...state.libraryScope][0]
+    : null;
+  return {
+    package: state.package.id,
+    tabs: state.packages.map(item => ({
+      id: item.id,
+      version: item.version,
+      framework: item.activeFramework || "",
+    })),
+    active: Math.max(0, state.packages.indexOf(state.package)),
+    lens: state.lens,
+    atPackageRoot: state.atPackageRoot,
+    packageLens: state.packageLens,
+    library,
+    selectedTypeId: state.selectedTypeId,
+    selectedMemberKey: state.selectedMemberKey,
+    selectedOverloadIndex: state.selectedOverloadIndex,
+    memberSection: state.memberSection,
+    selectedBodyTarget: state.selectedBodyTarget,
+    memberBrowse: memberScopeIsActive(state, selectedType()?.id),
+    memberTextFilter: state.memberTextFilter,
+    memberKindFilter: state.memberKindFilter,
+    memberAccessibilityFilter: state.memberAccessibilityFilter,
+    memberTraitFilter: state.memberTraitFilter,
+  };
+}
+
 function buildStateUrl(base = location.href) {
-  const url = new URL(base);
-  if (!state.package) return url;
-  // Keep the deep link entirely in the query string on the root path. The end
-  // deployment is a pure static file server with no SPA fallback, so a refresh or
-  // shared link must resolve to a real file (index.html at "/"); path segments
-  // like /packages/{id} would 404. The client restores selection from the query.
-  url.pathname = "/";
-  const params = new URLSearchParams();
-  // Only the target package id is clear text — it makes the link human-readable at a glance.
-  // Everything else (version, framework, view, selection, and the full open-tab set) rides in
-  // the opaque share packet, so the visible query stays ?package=<id>&w=<packet>.
-  params.set("package", state.package.id);
-  const shareState = encodeShareState();
-  const shareError = shareStateLengthError(shareState);
-  if (shareError) throw new Error(shareError);
-  params.set("w", shareState);
-  url.search = params.toString();
-  url.hash = "";
-  return url;
+  const snapshot = captureWorkspaceUrlState();
+  return snapshot
+    ? workspaceLocation.build(snapshot, base)
+    : new URL(base);
 }
 
 // Rewrite the address bar to reflect the current selection so a refresh restores it and
 // the URL is always shareable. replaceState (not pushState) keeps the app's own
 // back/forward buttons authoritative and avoids flooding browser history on every render.
 function syncUrl() {
-  if (!state.package || state.loading) return;
+  const snapshot = captureWorkspaceUrlState();
+  if (!snapshot || state.loading) return;
   document.title = `dotnet-inspect -- ${packageDisplayName(state.package)}`;
-  try {
-    history.replaceState(null, "", buildStateUrl().toString());
-  } catch {
-    // Ignore environments that disallow history rewriting (e.g. sandboxed frames).
-  }
+  workspaceLocation.sync(snapshot);
 }
 
 // Apply a parsed URL selection onto the currently loaded package, validating that the
 // type/member/overload/section still exist.
-interface DeepLink {
-  type?: string | null;
-  member?: string | null;
-  overload?: string | null;
-  section?: string | null;
-  bodyTarget?: BodyTarget | null;
-  memberBrowse?: boolean;
-  memberTextFilter?: string;
-  memberKindFilter?: string;
-  memberAccessibilityFilter?: string;
-  memberTraitFilter?: string;
-}
+type DeepLink = WorkspaceDeepLink;
 
 function applyDeepLink(deep: DeepLink | null | undefined) {
   const pkg = state.package;
@@ -6039,7 +5772,7 @@ function runHomeDemo(kind: keyof typeof HOME_DEMO_LINKS | "callgraph") {
   if (kind === "callgraph") { runCallGraphDemo(); return; }
   const link = HOME_DEMO_LINKS[kind];
   if (!link) return;
-  try { history.pushState(null, "", link); } catch {}
+  workspaceLocation.push(link);
   const loc = parseLocation();
   restoreWorkspaceFromLocation(loc, loc);
 }
@@ -6050,14 +5783,14 @@ function runHomeDemo(kind: keyof typeof HOME_DEMO_LINKS | "callgraph") {
 function goHome() {
   state.home = true;
   spotlight.reset();
-  try { history.pushState(null, "", "/"); } catch {}
+  workspaceLocation.push("/");
   render();
 }
 
 // Loads the resident runtime pack and lands on its package Overview (the runtime pack has no
 // nupkg, so this goes through loadRuntimePack rather than loadPackage).
 async function openRuntimePackFromHome() {
-  const navigationSeq = ++state.navigationSeq;
+  const navigationSeq = navigationSequence.begin();
   state.home = false;
   state.loading = true;
   state.error = "";
@@ -6067,8 +5800,8 @@ async function openRuntimePackFromHome() {
   render();
   const pack = await loadRuntimePack(
     "net10.0",
-    () => navigationSeq === state.navigationSeq);
-  if (navigationSeq !== state.navigationSeq) return;
+    () => navigationSequence.isCurrent(navigationSeq));
+  if (!navigationSequence.isCurrent(navigationSeq)) return;
   if (!pack) {
     state.loading = false;
     state.error = "Couldn’t load the .NET runtime pack. Retry, or open a different package.";
@@ -6746,7 +6479,7 @@ async function renderDependencyGraph() {
 }
 
 function switchToPackageForDependencies(packageKey: string) {
-  state.navigationSeq++;
+  navigationSequence.invalidate();
   const target = state.packages.find(item =>
     packageIdentityKey(item) === packageKey);
   if (!target) return;
@@ -6778,7 +6511,7 @@ async function openDependencyPackage(
     switchToPackageForDependencies(packageIdentityKey(existing));
     return;
   }
-  const navigationSeq = ++state.navigationSeq;
+  const navigationSeq = navigationSequence.begin();
   state.loading = true;
   state.error = "";
   state.retryAction = null;
@@ -6788,18 +6521,18 @@ async function openDependencyPackage(
   try {
     const version =
       await resolveDependencyVersion(packageId, versionRange ?? null);
-    if (navigationSeq !== state.navigationSeq) return;
+    if (!navigationSequence.isCurrent(navigationSeq)) return;
     const model = await loadPackage(
       packageId,
       version,
       "",
       { navigationSeq });
-    if (!model || navigationSeq !== state.navigationSeq) return;
+    if (!model || !navigationSequence.isCurrent(navigationSeq)) return;
     state.atPackageRoot = true;
     state.packageLens = "dependencies";
     render();
   } catch (error) {
-    if (navigationSeq !== state.navigationSeq) return;
+    if (!navigationSequence.isCurrent(navigationSeq)) return;
     state.loading = false;
     appendQueryNotice(
       friendlyLoadError(error, packageId, versionRange).message);
@@ -7909,7 +7642,7 @@ async function loadPackage(
   // overlay up and focuses the real target once, so non-target tabs never flash into view.
   const background = options.background === true;
   const navigationSeq = options.navigationSeq
-    ?? (background ? null : ++state.navigationSeq);
+    ?? (background ? null : navigationSequence.begin());
   const prevPackage = state.package;
   const prevRequested = {
     package: state.requestedPackage,
@@ -7933,7 +7666,8 @@ async function loadPackage(
 
   try {
     const result = await inspectPackage(packageId, version, framework);
-    if (navigationSeq != null && navigationSeq !== state.navigationSeq) return null;
+    if (navigationSeq != null && !navigationSequence.isCurrent(navigationSeq))
+      return null;
     refreshPackageStats();
     const types = (result.types ?? []).map(type => ({
       ...type,
@@ -7990,7 +7724,8 @@ async function loadPackage(
     await selectionData;
     return packageModel;
   } catch (error) {
-    if (navigationSeq != null && navigationSeq !== state.navigationSeq) return null;
+    if (navigationSeq != null && !navigationSequence.isCurrent(navigationSeq))
+      return null;
     const friendly = friendlyLoadError(error, packageId, version);
     if (background) {
       const failure =
@@ -8363,9 +8098,9 @@ async function runCallGraphDemo() {
 async function restoreWorkspaceFromLocation(
   loc: ParsedLocation,
   deep: DeepLink,
-  navigationSeq = ++state.navigationSeq,
+  navigationSeq = navigationSequence.begin(),
 ) {
-  if (navigationSeq !== state.navigationSeq) return;
+  if (!navigationSequence.isCurrent(navigationSeq)) return;
   if (!loc.package) return;
   state.queryNotice = loc.workspaceNotice || "";
   state.queryNoticeRetryAction = null;
@@ -8422,8 +8157,8 @@ async function restoreWorkspaceFromLocation(
     if (isRuntimePackId(tab.id)) {
       loaded = await loadRuntimePack(
         tab.framework,
-        () => navigationSeq === state.navigationSeq);
-      if (!loaded && navigationSeq === state.navigationSeq) {
+        () => navigationSequence.isCurrent(navigationSeq));
+      if (!loaded && navigationSequence.isCurrent(navigationSeq)) {
         const failure =
           `Workspace restore was incomplete: ${tab.id}: ${state.runtimePackError || "runtime pack acquisition failed."}`;
         state.queryNotice = state.queryNotice
@@ -8436,7 +8171,7 @@ async function restoreWorkspaceFromLocation(
         navigationSeq
       });
     }
-    if (navigationSeq !== state.navigationSeq) return;
+    if (!navigationSequence.isCurrent(navigationSeq)) return;
     if (loaded && matchesTarget(tab)) loadedTargetModel = loaded;
   }
 
@@ -8453,7 +8188,7 @@ async function restoreWorkspaceFromLocation(
         loc.library,
         navigationSeq,
         () => restoreWorkspaceFromLocation(loc, deep));
-      if (navigationSeq !== state.navigationSeq) return;
+      if (!navigationSequence.isCurrent(navigationSeq)) return;
       if (!scoped) return;
       applyLocationView(loc);
     }
@@ -8766,7 +8501,7 @@ document.addEventListener("mousedown", event => {
 // hand-edited URL). Within the loaded package we mutate selection directly; a different
 // package is (re)loaded with the URL selection queued as a deep link.
 window.addEventListener("popstate", () => {
-  const navigationSeq = ++state.navigationSeq;
+  const navigationSeq = navigationSequence.begin();
   state.memberCallGraphSeq++;
   state.loading = false;
   const loc = parseLocation();
@@ -8839,8 +8574,10 @@ async function restorePlatformScopeThenDeepLink(
   const scoped = await applyPlatformLibraryScope(
     loc.library,
     navigationSeq,
-    () => restorePlatformScopeThenDeepLink(loc, state.navigationSeq));
-  if (navigationSeq !== state.navigationSeq) return;
+    () => restorePlatformScopeThenDeepLink(
+      loc,
+      navigationSequence.current()));
+  if (!navigationSequence.isCurrent(navigationSeq)) return;
   if (!scoped) return;
   applyLocationView(loc);
   applyDeepLink(loc);
@@ -8856,7 +8593,8 @@ async function applyPlatformLibraryScope(
   navigationSeq: number | null = null,
   retryAction: RetryAction = null,
 ) {
-  if (navigationSeq != null && navigationSeq !== state.navigationSeq) return;
+  if (navigationSeq != null && !navigationSequence.isCurrent(navigationSeq))
+    return;
   const key = String(libraryKey || "").replace(/\.dll$/i, "");
   if (!key) { state.libraryScope = null; return true; }
   // The pack (CoreCLR vs ASP.NET Core) is resolved from the static index roster; ensure it
@@ -8864,7 +8602,8 @@ async function applyPlatformLibraryScope(
   if (!state.platformIndex) {
     try { state.platformIndex = await loadPlatformIndex(); } catch { /* best effort; defaults to CoreCLR */ }
   }
-  if (navigationSeq != null && navigationSeq !== state.navigationSeq) return;
+  if (navigationSeq != null && !navigationSequence.isCurrent(navigationSeq))
+    return;
   return Boolean(await openPlatformLibrary(
     key,
     platformPackForAssembly(key),
@@ -8886,8 +8625,8 @@ async function restoreRuntimePackFromHistory(
 ) {
   const pack = await loadRuntimePack(
     loc.framework || "",
-    () => navigationSeq === state.navigationSeq);
-  if (navigationSeq !== state.navigationSeq) return;
+    () => navigationSequence.isCurrent(navigationSeq));
+  if (!navigationSequence.isCurrent(navigationSeq)) return;
   if (pack) {
     activatePackage(pack, { resetAccessibility: true });
     // Always resolve scope from the history entry's own library field -- even when it's
@@ -8899,8 +8638,8 @@ async function restoreRuntimePackFromHistory(
       () => restoreRuntimePackFromHistory(
         loc,
         deep,
-        state.navigationSeq));
-    if (navigationSeq !== state.navigationSeq) return;
+        navigationSequence.current()));
+    if (!navigationSequence.isCurrent(navigationSeq)) return;
     if (!scoped) return;
     applyLocationView(loc);
     applyDeepLink(deep);

--- a/prototypes/inspect-web/src/workspace-navigation.ts
+++ b/prototypes/inspect-web/src/workspace-navigation.ts
@@ -1,0 +1,504 @@
+import {
+  lenses,
+  normalizeShareTabs,
+  packageLenses,
+  replaceCurrentNavigationEntry,
+  shareStateLengthError,
+  type WorkspaceTab,
+} from "./data.ts";
+import {
+  decodeBodyTarget,
+  encodeBodyTarget,
+  type BodyTarget,
+  type EncodedBodyTarget,
+} from "./member-filtering.ts";
+
+// Owns navigation stacks and URL-backed workspace snapshots. The composition root remains
+// the sole mutable AppState owner and supplies captures plus explicit transition callbacks.
+export interface WorkspaceView {
+  package: string;
+  packageKey: string;
+  lens: string;
+  selectedTypeId: string;
+  selectedMemberKey: string;
+  memberBrowseTypeId: string;
+  memberKindFilter: string;
+  memberAccessibilityFilter: string;
+  memberTraitFilter: string;
+  memberTextFilter: string;
+  selectedOverloadIndex: number | null;
+  bodyTarget: BodyTarget | null;
+  memberSection: string;
+  atPackageRoot: boolean;
+  packageLens: string;
+  libraryScope: string[] | null;
+}
+
+export function workspaceViewSignature(view: WorkspaceView): string {
+  return JSON.stringify({
+    p: view.packageKey,
+    l: view.lens,
+    t: view.selectedTypeId,
+    m: view.selectedMemberKey,
+    mb: view.memberBrowseTypeId,
+    mk: view.memberKindFilter,
+    ma: view.memberAccessibilityFilter,
+    mr: view.memberTraitFilter,
+    o: view.selectedOverloadIndex,
+    b: encodeBodyTarget(view.bodyTarget),
+    s: view.memberSection,
+    pr: view.atPackageRoot,
+    pl: view.packageLens,
+    ls: view.libraryScope,
+  });
+}
+
+export interface NavigationSequence {
+  begin(): number;
+  invalidate(): void;
+  current(): number;
+  isCurrent(candidate: number): boolean;
+}
+
+export function createNavigationSequence(): NavigationSequence {
+  let current = 0;
+  return {
+    begin() {
+      return ++current;
+    },
+    invalidate() {
+      current++;
+    },
+    current() {
+      return current;
+    },
+    isCurrent(candidate) {
+      return candidate === current;
+    },
+  };
+}
+
+export interface NavigationHistory<TView> {
+  record(): void;
+  normalizeCurrent(): void;
+  canBack(): boolean;
+  canForward(): boolean;
+  back(): boolean;
+  forward(): boolean;
+}
+
+export interface NavigationHistoryDependencies<TView> {
+  capture(): TView | null;
+  signature(view: TView): string;
+  apply(view: TView): boolean;
+  onExhausted(): void;
+}
+
+interface NavigationEntry<TView> {
+  sig: string;
+  view: TView;
+}
+
+export function createNavigationHistory<TView>(
+  dependencies: NavigationHistoryDependencies<TView>,
+): NavigationHistory<TView> {
+  const navigation = {
+    stack: [] as NavigationEntry<TView>[],
+    index: -1,
+  };
+
+  return {
+    record() {
+      const view = dependencies.capture();
+      if (!view) return;
+      const sig = dependencies.signature(view);
+      if (navigation.index >= 0
+        && navigation.stack[navigation.index]?.sig === sig) {
+        navigation.stack[navigation.index].view = view;
+        return;
+      }
+      navigation.stack = navigation.stack.slice(0, navigation.index + 1);
+      navigation.stack.push({ sig, view });
+      navigation.index = navigation.stack.length - 1;
+    },
+    normalizeCurrent() {
+      const view = dependencies.capture();
+      if (!view) return;
+      replaceCurrentNavigationEntry(
+        navigation,
+        dependencies.signature(view),
+        view);
+    },
+    canBack() {
+      return navigation.index > 0;
+    },
+    canForward() {
+      return navigation.index < navigation.stack.length - 1;
+    },
+    back() {
+      while (navigation.index > 0) {
+        const candidate = navigation.index - 1;
+        navigation.index = candidate;
+        if (dependencies.apply(navigation.stack[candidate].view)) return true;
+        navigation.stack.splice(candidate, 1);
+      }
+      dependencies.onExhausted();
+      return false;
+    },
+    forward() {
+      while (navigation.index < navigation.stack.length - 1) {
+        const candidate = navigation.index + 1;
+        navigation.index = candidate;
+        if (dependencies.apply(navigation.stack[candidate].view)) return true;
+        navigation.stack.splice(candidate, 1);
+        navigation.index--;
+      }
+      dependencies.onExhausted();
+      return false;
+    },
+  };
+}
+
+export interface WorkspaceDeepLink {
+  type?: string | null;
+  member?: string | null;
+  overload?: string | null;
+  section?: string | null;
+  bodyTarget?: BodyTarget | null;
+  memberBrowse?: boolean;
+  memberTextFilter?: string;
+  memberKindFilter?: string;
+  memberAccessibilityFilter?: string;
+  memberTraitFilter?: string;
+}
+
+export interface WorkspaceUrlState {
+  package: string;
+  tabs: WorkspaceTab[];
+  active: number;
+  lens: string;
+  atPackageRoot: boolean;
+  packageLens: string;
+  library: string | null;
+  selectedTypeId: string;
+  selectedMemberKey: string;
+  selectedOverloadIndex: number | null;
+  memberSection: string;
+  selectedBodyTarget: BodyTarget | null;
+  memberBrowse: boolean;
+  memberTextFilter: string;
+  memberKindFilter: string;
+  memberAccessibilityFilter: string;
+  memberTraitFilter: string;
+}
+
+interface SharePacket {
+  t: string[][];
+  a: number;
+  l?: string;
+  v?: string;
+  y?: string;
+  m?: string;
+  o?: number;
+  c?: string;
+  d?: EncodedBodyTarget;
+  b?: 1;
+  q?: string;
+  k?: string;
+  e?: string;
+  r?: string;
+}
+
+interface DecodedShareState {
+  tabs: WorkspaceTab[];
+  active: number;
+  view: string;
+  rich: boolean;
+  type: string | null;
+  member: string | null;
+  overload: string | null;
+  section: string | null;
+  bodyTarget: BodyTarget | null;
+  library: string | null;
+  memberBrowse: boolean;
+  memberTextFilter: string;
+  memberKindFilter: string;
+  memberAccessibilityFilter: string;
+  memberTraitFilter: string;
+}
+
+type ShareStateResult = DecodedShareState | { error: string } | null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function base64UrlEncode(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(value: string): string {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++)
+    bytes[index] = binary.charCodeAt(index);
+  return new TextDecoder().decode(bytes);
+}
+
+export function encodeWorkspaceShareState(state: WorkspaceUrlState): string {
+  const packet: SharePacket = {
+    t: state.tabs.map(item => [item.id, item.version, item.framework || ""]),
+    a: Math.max(0, state.active),
+  };
+  if (state.library) packet.l = state.library;
+  if (state.atPackageRoot) {
+    packet.v = state.packageLens && state.packageLens !== "overview"
+      ? `pkg:${state.packageLens}`
+      : "pkg";
+  } else {
+    if (state.lens && state.lens !== "api") packet.v = state.lens;
+    if (state.selectedTypeId) packet.y = state.selectedTypeId;
+    if (state.selectedMemberKey) packet.m = state.selectedMemberKey;
+    if (state.selectedOverloadIndex != null) packet.o = state.selectedOverloadIndex;
+    if (state.memberSection && state.memberSection !== "overview")
+      packet.c = state.memberSection;
+    if (state.selectedBodyTarget) packet.d = encodeBodyTarget(state.selectedBodyTarget) ?? undefined;
+    if (state.memberBrowse) packet.b = 1;
+    if (state.memberTextFilter) packet.q = state.memberTextFilter;
+    if (state.memberKindFilter !== "all") packet.k = state.memberKindFilter;
+    if (state.memberAccessibilityFilter !== "all")
+      packet.e = state.memberAccessibilityFilter;
+    if (state.memberTraitFilter) packet.r = state.memberTraitFilter;
+  }
+  return base64UrlEncode(JSON.stringify(packet));
+}
+
+function decodeWorkspaceShareState(value: string | null): ShareStateResult {
+  if (!value) return null;
+  const lengthError = shareStateLengthError(value);
+  if (lengthError) return { error: lengthError };
+  try {
+    const raw: unknown = JSON.parse(base64UrlDecode(value));
+    if (Array.isArray(raw)) {
+      const normalized = normalizeShareTabs(raw);
+      if (normalized.error) return { error: normalized.error };
+      return {
+        tabs: normalized.tabs,
+        active: 0,
+        view: "",
+        rich: false,
+        type: null,
+        member: null,
+        overload: null,
+        section: null,
+        bodyTarget: null,
+        library: null,
+        memberBrowse: false,
+        memberTextFilter: "",
+        memberKindFilter: "all",
+        memberAccessibilityFilter: "all",
+        memberTraitFilter: "",
+      };
+    }
+    if (isRecord(raw) && Array.isArray(raw.t)) {
+      const normalized = normalizeShareTabs(raw.t);
+      if (normalized.error) return { error: normalized.error };
+      return {
+        tabs: normalized.tabs,
+        active: typeof raw.a === "number" && Number.isInteger(raw.a)
+          ? (normalized.sourceIndexes[raw.a] ?? 0)
+          : 0,
+        view: typeof raw.v === "string" ? raw.v : "",
+        rich: true,
+        type: raw.y != null ? String(raw.y) : null,
+        member: raw.m != null ? String(raw.m) : null,
+        overload: raw.o != null ? String(raw.o) : null,
+        section: raw.c != null ? String(raw.c) : null,
+        bodyTarget: decodeBodyTarget(raw.d),
+        library: raw.l != null ? String(raw.l) : null,
+        memberBrowse: raw.b === 1,
+        memberTextFilter: raw.q != null ? String(raw.q) : "",
+        memberKindFilter: raw.k != null ? String(raw.k) : "all",
+        memberAccessibilityFilter: raw.e != null ? String(raw.e) : "all",
+        memberTraitFilter: raw.r != null ? String(raw.r) : "",
+      };
+    }
+    return { error: "The shared workspace state is invalid and was ignored." };
+  } catch {
+    return { error: "The shared workspace state is invalid and was ignored." };
+  }
+}
+
+function resolveView(token: string) {
+  const atPackageRoot = token === "pkg" || token.startsWith("pkg:");
+  return {
+    lens: lenses.some(([id]) => id === token) ? token : null,
+    atPackageRoot,
+    packageLens: atPackageRoot
+      ? (packageLenses.some(([id]) => id === token.split(":")[1])
+        ? token.split(":")[1]
+        : "overview")
+      : null,
+  };
+}
+
+export interface WorkspaceLocationSnapshot {
+  href: string;
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+export function parseWorkspaceLocation(location: WorkspaceLocationSnapshot) {
+  const params = new URLSearchParams(location.search);
+  const route = location.pathname.split("/").filter(Boolean);
+  const packageAt = route.findIndex(part => part.toLowerCase() === "packages");
+  const share = decodeWorkspaceShareState(params.get("w"));
+
+  let pkg = packageAt >= 0
+    ? decodeURIComponent(route[packageAt + 1] || "")
+    : params.get("package");
+  let version = packageAt >= 0
+    ? decodeURIComponent(route[packageAt + 2] || "")
+    : params.get("version");
+  let framework = params.get("framework");
+  let type = params.get("type");
+  let member = params.get("member");
+  let overload = params.get("overload");
+  let section = params.get("section");
+  let bodyTarget: BodyTarget | null = null;
+  let viewToken = location.hash.slice(1);
+  let tabs: WorkspaceTab[] = [];
+  let active = 0;
+  let library: string | null = null;
+  let memberBrowse = false;
+  let memberTextFilter = "";
+  let memberKindFilter = "all";
+  let memberAccessibilityFilter = "all";
+  let memberTraitFilter = "";
+  const workspaceNotice = share && "error" in share ? share.error : "";
+
+  if (share && !("error" in share)) {
+    tabs = share.tabs;
+    if (share.rich) {
+      active = Math.min(Math.max(0, share.active), Math.max(0, tabs.length - 1));
+      const target = tabs[active];
+      if (target) {
+        pkg = target.id;
+        version = target.version;
+        framework = target.framework;
+      }
+      if (share.view) viewToken = share.view;
+      type = share.type;
+      member = share.member;
+      overload = share.overload;
+      section = share.section;
+      bodyTarget = share.bodyTarget;
+      library = share.library;
+      memberBrowse = share.memberBrowse;
+      memberTextFilter = share.memberTextFilter;
+      memberKindFilter = share.memberKindFilter;
+      memberAccessibilityFilter = share.memberAccessibilityFilter;
+      memberTraitFilter = share.memberTraitFilter;
+    } else {
+      const index = tabs.findIndex(tab =>
+        pkg && tab.id.toLowerCase() === pkg.toLowerCase());
+      active = index >= 0 ? index : 0;
+    }
+  }
+  if (!pkg && tabs.length) {
+    const target = tabs[Math.min(Math.max(0, active), tabs.length - 1)];
+    pkg = target.id;
+    version = target.version;
+    framework = target.framework;
+  }
+
+  const view = resolveView(viewToken);
+  return {
+    package: pkg,
+    version,
+    framework,
+    type,
+    member,
+    overload,
+    section,
+    bodyTarget,
+    lens: view.lens,
+    atPackageRoot: view.atPackageRoot,
+    packageLens: view.packageLens,
+    tabs,
+    active,
+    library,
+    memberBrowse,
+    memberTextFilter,
+    memberKindFilter,
+    memberAccessibilityFilter,
+    memberTraitFilter,
+    workspaceNotice,
+  };
+}
+
+export type ParsedWorkspaceLocation = ReturnType<typeof parseWorkspaceLocation>;
+
+export function buildWorkspaceStateUrl(
+  base: string,
+  state: WorkspaceUrlState,
+): URL {
+  const url = new URL(base);
+  url.pathname = "/";
+  const params = new URLSearchParams();
+  params.set("package", state.package);
+  const shareState = encodeWorkspaceShareState(state);
+  const shareError = shareStateLengthError(shareState);
+  if (shareError) throw new Error(shareError);
+  params.set("w", shareState);
+  url.search = params.toString();
+  url.hash = "";
+  return url;
+}
+
+export interface WorkspaceLocationPersistence {
+  parseCurrent(): ParsedWorkspaceLocation;
+  build(state: WorkspaceUrlState, base?: string): URL;
+  sync(state: WorkspaceUrlState): void;
+  push(url: string): void;
+}
+
+export interface WorkspaceLocationDependencies {
+  current(): WorkspaceLocationSnapshot;
+  replace(url: string): void;
+  push(url: string): void;
+}
+
+export function createWorkspaceLocationPersistence(
+  dependencies: WorkspaceLocationDependencies,
+): WorkspaceLocationPersistence {
+  const build = (state: WorkspaceUrlState, base?: string) =>
+    buildWorkspaceStateUrl(
+      base ?? dependencies.current().href,
+      state);
+  return {
+    parseCurrent() {
+      return parseWorkspaceLocation(dependencies.current());
+    },
+    build,
+    sync(state) {
+      try {
+        dependencies.replace(build(state).toString());
+      } catch {
+        // Sandboxed frames and overlong state can reject address-bar persistence.
+      }
+    },
+    push(url) {
+      try {
+        dependencies.push(url);
+      } catch {
+        // Sandboxed frames may reject browser-history changes.
+      }
+    },
+  };
+}

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -159,6 +159,9 @@ test("normalizing a history entry keeps its consumed position and later entries"
 });
 
 const appSource = readFileSync(new URL("../src/dotnet-inspect.ts", import.meta.url), "utf8");
+const workspaceNavigationSource = readFileSync(
+  new URL("../src/workspace-navigation.ts", import.meta.url),
+  "utf8");
 const memberFocusSource = readFileSync(
   new URL("../src/member-focus.ts", import.meta.url),
   "utf8");
@@ -467,10 +470,12 @@ test("member filters retain accessible controls and focus across rerenders", () 
 });
 
 test("shared member views retain scope and filter state", () => {
-  const encoder = appSource.match(
-    /function encodeShareState\(\)[\s\S]*?\n}\n\nfunction decodeShareState/)?.[0] ?? "";
-  const decoder = appSource.match(
-    /function decodeShareState\([\s\S]*?\n}\n\n\/\/ Maps a view token/)?.[0] ?? "";
+  const capture = appSource.match(
+    /function captureWorkspaceUrlState\(\)[\s\S]*?\n}\n\nfunction buildStateUrl/)?.[0] ?? "";
+  const encoder = workspaceNavigationSource.match(
+    /function encodeWorkspaceShareState\([\s\S]*?\n}\n\nfunction decodeWorkspaceShareState/)?.[0] ?? "";
+  const decoder = workspaceNavigationSource.match(
+    /function decodeWorkspaceShareState\([\s\S]*?\n}\n\nfunction resolveView/)?.[0] ?? "";
   const deepLink = appSource.match(
     /function applyDeepLink\([\s\S]*?\n}\n\n\/\/ Kick off/)?.[0] ?? "";
   assert.match(encoder, /packet\.b = 1/);
@@ -481,6 +486,12 @@ test("shared member views retain scope and filter state", () => {
   assert.match(encoder, /packet\.d = encodeBodyTarget\(state\.selectedBodyTarget\)/);
   assert.match(decoder, /memberBrowse: raw\.b === 1/);
   assert.match(decoder, /bodyTarget: decodeBodyTarget\(raw\.d\)/);
+  assert.match(capture, /selectedBodyTarget: state\.selectedBodyTarget/);
+  assert.match(capture, /memberBrowse: memberScopeIsActive\(state, selectedType\(\)\?\.id\)/);
+  assert.match(capture, /memberTextFilter: state\.memberTextFilter/);
+  assert.match(capture, /memberKindFilter: state\.memberKindFilter/);
+  assert.match(capture, /memberAccessibilityFilter: state\.memberAccessibilityFilter/);
+  assert.match(capture, /memberTraitFilter: state\.memberTraitFilter/);
   assert.match(appSource, /if \(deep\.memberBrowse && groups\.length\)\s*state\.memberBrowseTypeId = type\.id/);
   assert.match(
     deepLink,
@@ -642,7 +653,7 @@ test("typeless member lookup and request guards stay empty", () => {
 
 test("history validates saved type and member identity before restoring Member state", () => {
   const applyView =
-    appSource.match(/function applyView\(view: NavigationEntry\["view"\]\) \{[\s\S]*?\n}\n\nfunction navBack/)?.[0]
+    appSource.match(/function applyView\(view: WorkspaceView\) \{[\s\S]*?\n}\n\nconst navigationHistory/)?.[0]
     ?? "";
   assert.match(applyView, /const type = pkg\.types\.find\(item => item\.id === view\.selectedTypeId\)/);
   assert.match(
@@ -656,13 +667,16 @@ test("history validates saved type and member identity before restoring Member s
     /state\.selectedOverloadIndex = memberHistory\.selectedOverloadIndex;[\s\S]*state\.memberSection = isMemberSection\(memberHistory\.memberSection\)[\s\S]*\? memberHistory\.memberSection[\s\S]*state\.selectedBodyTarget = memberHistory\.selectedBodyTarget/);
   assert.match(
     applyView,
-    /normalizeCurrentNavEntry\(\);[\s\S]*loadSelectedMemberSource\(\)[\s\S]*else \{\s*render\(\)/);
+    /navigationHistory\.normalizeCurrent\(\);[\s\S]*loadSelectedMemberSource\(\)[\s\S]*else \{\s*render\(\)/);
   assert.match(
     appSource,
-    /function normalizeCurrentNavEntry\(\) \{\s*replaceCurrentNavigationEntry\(nav, viewSignature\(\), captureView\(\)\)/);
+    /const navigationHistory = createNavigationHistory\(\{\s*capture: captureView,\s*signature: workspaceViewSignature,\s*apply: applyView/);
+  assert.match(
+    workspaceNavigationSource,
+    /function workspaceViewSignature\([\s\S]*b: encodeBodyTarget\(view\.bodyTarget\)/);
   assert.match(
     appSource,
-    /function viewSignature\(\) \{[\s\S]*b: encodeBodyTarget\(state\.selectedBodyTarget\)/);
+    /function captureView\(\): WorkspaceView \| null \{[\s\S]*bodyTarget: state\.selectedBodyTarget/);
   assert.match(
     appSource,
     /else if \(state\.selectedTypeId !== current\.id\) \{\s*state\.selectedTypeId = current\.id;\s*state\.selectedMemberKey = "";\s*state\.memberBrowseTypeId = "";\s*state\.selectedOverloadIndex = null;\s*resetMemberFilters\(\);\s*resetMemberSectionState\(\)/);
@@ -817,12 +831,13 @@ test("dependency graph binds navigation to generated node identities", () => {
 });
 
 test("dependency navigation reserves identity and surfaces resolution failures", () => {
+  assert.doesNotMatch(appSource, /state\.navigationSeq/);
   assert.match(
     appSource,
-    /const navigationSeq = \+\+state\.navigationSeq;\s+state\.loading = true;[\s\S]*?await resolveDependencyVersion/);
+    /const navigationSeq = navigationSequence\.begin\(\);\s+state\.loading = true;[\s\S]*?await resolveDependencyVersion/);
   assert.match(
     appSource,
-    /if \(navigationSeq !== state\.navigationSeq\) return;\s+state\.loading = false;\s+appendQueryNotice/);
+    /if \(!navigationSequence\.isCurrent\(navigationSeq\)\) return;\s+state\.loading = false;\s+appendQueryNotice/);
   assert.match(
     graphSource,
     /packageIdentityKey\(uniqueCompatiblePackage\(\s+model\.packages,\s+dependency\.id,\s+dependency\.versionRange\)\) === target\.packageKey/);
@@ -1564,7 +1579,7 @@ test("workspace UI routes replacements and restore notices through bounded paths
     appSource,
     /type: type\.queryId \?\? type\.id,\s+typeIdentity: type\.definitionId \?\? type\.id/);
   assert.match(
-    appSource,
+    workspaceNavigationSource,
     /if \(!pkg && tabs\.length\) \{\s+const target = tabs\[/);
   assert.match(
     appSource,

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildWorkspaceStateUrl,
+  createNavigationHistory,
+  createNavigationSequence,
+  createWorkspaceLocationPersistence,
+  parseWorkspaceLocation,
+  type WorkspaceLocationSnapshot,
+  type WorkspaceUrlState,
+} from "../src/workspace-navigation.ts";
+
+interface TestView {
+  id: string;
+  revision: number;
+}
+
+function locationSnapshot(value: string | URL): WorkspaceLocationSnapshot {
+  const url = new URL(value);
+  return {
+    href: url.href,
+    pathname: url.pathname,
+    search: url.search,
+    hash: url.hash,
+  };
+}
+
+function workspaceState(
+  overrides: Partial<WorkspaceUrlState> = {},
+): WorkspaceUrlState {
+  return {
+    package: "Example.Second",
+    tabs: [
+      { id: "Example.First", version: "1.0.0", framework: "net9.0" },
+      { id: "Example.Second", version: "2.0.0", framework: "net10.0" },
+    ],
+    active: 1,
+    lens: "api",
+    atPackageRoot: false,
+    packageLens: "overview",
+    library: null,
+    selectedTypeId: "Example.Widget",
+    selectedMemberKey: "method:Build",
+    selectedOverloadIndex: 2,
+    memberSection: "facts",
+    selectedBodyTarget: {
+      memberName: "Build",
+      selectorKey: "method",
+      metadataToken: 42,
+    },
+    memberBrowse: true,
+    memberTextFilter: "build",
+    memberKindFilter: "method",
+    memberAccessibilityFilter: "public",
+    memberTraitFilter: "isStatic",
+    ...overrides,
+  };
+}
+
+test("navigation history skips stale views and truncates a forward branch", () => {
+  let current: TestView | null = { id: "first", revision: 1 };
+  const applied: TestView[] = [];
+  let exhausted = 0;
+  let history: ReturnType<typeof createNavigationHistory<TestView>>;
+  history = createNavigationHistory({
+    capture: () => current && { ...current },
+    signature: view => view.id,
+    apply: view => {
+      applied.push(view);
+      if (view.id === "stale") return false;
+      current = { ...view };
+      history.normalizeCurrent();
+      return true;
+    },
+    onExhausted: () => exhausted++,
+  });
+
+  history.record();
+  current = { id: "first", revision: 2 };
+  history.record();
+  current = { id: "stale", revision: 1 };
+  history.record();
+  current = { id: "latest", revision: 1 };
+  history.record();
+
+  assert.equal(history.canBack(), true);
+  assert.equal(history.canForward(), false);
+  assert.equal(history.back(), true);
+  assert.deepEqual(applied, [
+    { id: "stale", revision: 1 },
+    { id: "first", revision: 2 },
+  ]);
+  assert.equal(history.canBack(), false);
+  assert.equal(history.canForward(), true);
+
+  current = { id: "branch", revision: 1 };
+  history.record();
+  assert.equal(history.canForward(), false);
+  assert.equal(history.forward(), false);
+  assert.equal(exhausted, 1);
+});
+
+test("navigation sequence has one monotonic cancellation authority", () => {
+  const sequence = createNavigationSequence();
+  assert.equal(sequence.current(), 0);
+  const first = sequence.begin();
+  assert.equal(sequence.isCurrent(first), true);
+  const second = sequence.begin();
+  assert.equal(sequence.isCurrent(first), false);
+  assert.equal(sequence.isCurrent(second), true);
+  sequence.invalidate();
+  assert.equal(sequence.isCurrent(second), false);
+  assert.equal(sequence.current(), 3);
+});
+
+test("rich workspace URLs round-trip coordinates, scope, and member selection", () => {
+  const state = workspaceState({
+    library: "System.Private.CoreLib",
+  });
+  const url = buildWorkspaceStateUrl(
+    "https://inspect.example/packages/old?stale=1#metadata",
+    state);
+
+  assert.equal(url.pathname, "/");
+  assert.equal(url.searchParams.get("package"), "Example.Second");
+  assert.equal(url.hash, "");
+  const parsed = parseWorkspaceLocation(locationSnapshot(url));
+  assert.deepEqual(parsed.tabs, state.tabs);
+  assert.equal(parsed.active, 1);
+  assert.equal(parsed.package, "Example.Second");
+  assert.equal(parsed.version, "2.0.0");
+  assert.equal(parsed.framework, "net10.0");
+  assert.equal(parsed.lens, null);
+  assert.equal(parsed.library, "System.Private.CoreLib");
+  assert.equal(parsed.type, "Example.Widget");
+  assert.equal(parsed.member, "method:Build");
+  assert.equal(parsed.overload, "2");
+  assert.equal(parsed.section, "facts");
+  assert.deepEqual(parsed.bodyTarget, state.selectedBodyTarget);
+  assert.equal(parsed.memberBrowse, true);
+  assert.equal(parsed.memberTextFilter, "build");
+  assert.equal(parsed.memberKindFilter, "method");
+  assert.equal(parsed.memberAccessibilityFilter, "public");
+  assert.equal(parsed.memberTraitFilter, "isStatic");
+  assert.equal(parsed.workspaceNotice, "");
+});
+
+test("package-root URLs omit stale type selection and retain their package lens", () => {
+  const url = buildWorkspaceStateUrl(
+    "https://inspect.example/",
+    workspaceState({
+      atPackageRoot: true,
+      packageLens: "dependencies",
+    }));
+  const parsed = parseWorkspaceLocation(locationSnapshot(url));
+
+  assert.equal(parsed.atPackageRoot, true);
+  assert.equal(parsed.packageLens, "dependencies");
+  assert.equal(parsed.type, null);
+  assert.equal(parsed.member, null);
+  assert.equal(parsed.overload, null);
+  assert.equal(parsed.section, null);
+  assert.equal(parsed.bodyTarget, null);
+  assert.equal(parsed.memberBrowse, false);
+  assert.equal(parsed.memberTextFilter, "");
+  assert.equal(parsed.memberKindFilter, "all");
+  assert.equal(parsed.memberAccessibilityFilter, "all");
+  assert.equal(parsed.memberTraitFilter, "");
+});
+
+test("legacy workspace packets retain visible-location authority", () => {
+  const packet = Buffer.from(JSON.stringify([
+    ["Example.First", "1.0.0", "net9.0"],
+    ["Example.Second", "2.0.0", "net10.0"],
+  ])).toString("base64url");
+  const parsed = parseWorkspaceLocation(locationSnapshot(
+    `https://inspect.example/?package=Example.Second&version=9.9.9`
+      + `&framework=net8.0&type=Visible.Type&w=${packet}#source`));
+
+  assert.equal(parsed.package, "Example.Second");
+  assert.equal(parsed.version, "9.9.9");
+  assert.equal(parsed.framework, "net8.0");
+  assert.equal(parsed.type, "Visible.Type");
+  assert.equal(parsed.lens, "source");
+  assert.equal(parsed.active, 1);
+});
+
+test("invalid and oversized workspace packets stay visible", () => {
+  const invalid = parseWorkspaceLocation(locationSnapshot(
+    "https://inspect.example/?package=Example.Package&w=not-base64"));
+  assert.equal(invalid.package, "Example.Package");
+  assert.match(invalid.workspaceNotice, /invalid and was ignored/);
+
+  const oversized = parseWorkspaceLocation({
+    href: "https://inspect.example/",
+    pathname: "/",
+    search: `?w=${"x".repeat(65537)}`,
+    hash: "",
+  });
+  assert.match(oversized.workspaceNotice, /65536-character limit/);
+});
+
+test("location persistence contains history failures but leaves build failures visible", () => {
+  const current = locationSnapshot("https://inspect.example/");
+  const replaced: string[] = [];
+  const pushed: string[] = [];
+  const persistence = createWorkspaceLocationPersistence({
+    current: () => current,
+    replace: url => replaced.push(url),
+    push: url => pushed.push(url),
+  });
+
+  persistence.sync(workspaceState());
+  persistence.push("/");
+  assert.equal(new URL(replaced[0]).searchParams.get("package"), "Example.Second");
+  assert.deepEqual(pushed, ["/"]);
+
+  const blocked = createWorkspaceLocationPersistence({
+    current: () => current,
+    replace: () => {
+      throw new DOMException("blocked");
+    },
+    push: () => {
+      throw new DOMException("blocked");
+    },
+  });
+  assert.doesNotThrow(() => blocked.sync(workspaceState()));
+  assert.doesNotThrow(() => blocked.push("/"));
+  assert.throws(
+    () => blocked.build(workspaceState({
+      memberTextFilter: "x".repeat(65537),
+    })),
+    /65536-character limit/);
+});

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -110,7 +110,7 @@ test("navigation history skips stale views and truncates a forward branch", () =
   assert.equal(exhausted, 0);
 });
 
-test("navigation history advances past entries that become stale", () => {
+test("navigation history removes stale entries and reports exhausted directions", () => {
   let current: TestView | null = { id: "first", revision: 1 };
   const unavailable = new Set<string>();
   const applied: TestView[] = [];
@@ -143,7 +143,20 @@ test("navigation history advances past entries that become stale", () => {
     { id: "latest", revision: 1 },
   ]);
   assert.equal(history.canForward(), false);
-  assert.equal(exhausted, 0);
+
+  unavailable.delete("middle");
+  applied.length = 0;
+  assert.equal(history.back(), true);
+  assert.deepEqual(applied, [{ id: "first", revision: 1 }]);
+  assert.equal(history.back(), false);
+  assert.equal(exhausted, 1);
+
+  unavailable.add("latest");
+  applied.length = 0;
+  assert.equal(history.forward(), false);
+  assert.deepEqual(applied, [{ id: "latest", revision: 1 }]);
+  assert.equal(history.canForward(), false);
+  assert.equal(exhausted, 2);
 });
 
 test("navigation history normalizes the current captured view", () => {
@@ -151,7 +164,7 @@ test("navigation history normalizes the current captured view", () => {
   const applied: TestView[] = [];
   const history = createNavigationHistory({
     capture: () => current && { ...current },
-    signature: view => view.id,
+    signature: view => `${view.id}:${view.revision}`,
     apply: view => {
       applied.push(view);
       current = { ...view };
@@ -161,13 +174,21 @@ test("navigation history normalizes the current captured view", () => {
   });
 
   history.record();
-  current = { id: "first", revision: 2 };
-  history.normalizeCurrent();
   current = { id: "latest", revision: 1 };
   history.record();
-
   assert.equal(history.back(), true);
-  assert.deepEqual(applied, [{ id: "first", revision: 2 }]);
+  current = { id: "first", revision: 2 };
+  history.normalizeCurrent();
+  history.record();
+
+  assert.equal(history.canForward(), true);
+  assert.equal(history.forward(), true);
+  assert.equal(history.back(), true);
+  assert.deepEqual(applied, [
+    { id: "first", revision: 1 },
+    { id: "latest", revision: 1 },
+    { id: "first", revision: 2 },
+  ]);
 });
 
 test("navigation sequence has one monotonic cancellation authority", () => {

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -94,11 +94,80 @@ test("navigation history skips stale views and truncates a forward branch", () =
   assert.equal(history.canBack(), false);
   assert.equal(history.canForward(), true);
 
+  applied.length = 0;
+  assert.equal(history.forward(), true);
+  assert.deepEqual(applied, [{ id: "latest", revision: 1 }]);
+  assert.equal(history.back(), true);
+
+  applied.length = 0;
   current = { id: "branch", revision: 1 };
   history.record();
+  assert.equal(history.back(), true);
+  assert.deepEqual(applied, [{ id: "first", revision: 2 }]);
+  assert.equal(history.forward(), true);
+  assert.deepEqual(applied.at(-1), { id: "branch", revision: 1 });
   assert.equal(history.canForward(), false);
-  assert.equal(history.forward(), false);
-  assert.equal(exhausted, 1);
+  assert.equal(exhausted, 0);
+});
+
+test("navigation history advances past entries that become stale", () => {
+  let current: TestView | null = { id: "first", revision: 1 };
+  const unavailable = new Set<string>();
+  const applied: TestView[] = [];
+  let exhausted = 0;
+  const history = createNavigationHistory({
+    capture: () => current && { ...current },
+    signature: view => view.id,
+    apply: view => {
+      applied.push(view);
+      if (unavailable.has(view.id)) return false;
+      current = { ...view };
+      return true;
+    },
+    onExhausted: () => exhausted++,
+  });
+
+  history.record();
+  current = { id: "middle", revision: 1 };
+  history.record();
+  current = { id: "latest", revision: 1 };
+  history.record();
+  assert.equal(history.back(), true);
+  assert.equal(history.back(), true);
+
+  unavailable.add("middle");
+  applied.length = 0;
+  assert.equal(history.forward(), true);
+  assert.deepEqual(applied, [
+    { id: "middle", revision: 1 },
+    { id: "latest", revision: 1 },
+  ]);
+  assert.equal(history.canForward(), false);
+  assert.equal(exhausted, 0);
+});
+
+test("navigation history normalizes the current captured view", () => {
+  let current: TestView | null = { id: "first", revision: 1 };
+  const applied: TestView[] = [];
+  const history = createNavigationHistory({
+    capture: () => current && { ...current },
+    signature: view => view.id,
+    apply: view => {
+      applied.push(view);
+      current = { ...view };
+      return true;
+    },
+    onExhausted() {},
+  });
+
+  history.record();
+  current = { id: "first", revision: 2 };
+  history.normalizeCurrent();
+  current = { id: "latest", revision: 1 };
+  history.record();
+
+  assert.equal(history.back(), true);
+  assert.deepEqual(applied, [{ id: "first", revision: 2 }]);
 });
 
 test("navigation sequence has one monotonic cancellation authority", () => {
@@ -191,6 +260,11 @@ test("invalid and oversized workspace packets stay visible", () => {
     "https://inspect.example/?package=Example.Package&w=not-base64"));
   assert.equal(invalid.package, "Example.Package");
   assert.match(invalid.workspaceNotice, /invalid and was ignored/);
+
+  const structurallyInvalid = parseWorkspaceLocation(locationSnapshot(
+    "https://inspect.example/?package=Example.Package&w=e30"));
+  assert.equal(structurallyInvalid.package, "Example.Package");
+  assert.match(structurallyInvalid.workspaceNotice, /invalid and was ignored/);
 
   const oversized = parseWorkspaceLocation({
     href: "https://inspect.example/",

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -157,6 +157,11 @@ test("navigation history removes stale entries and reports exhausted directions"
   assert.deepEqual(applied, [{ id: "latest", revision: 1 }]);
   assert.equal(history.canForward(), false);
   assert.equal(exhausted, 2);
+  applied.length = 0;
+  assert.equal(history.canBack(), false);
+  assert.equal(history.back(), false);
+  assert.deepEqual(applied, []);
+  assert.equal(exhausted, 3);
 });
 
 test("navigation history normalizes the current captured view", () => {
@@ -296,7 +301,7 @@ test("invalid and oversized workspace packets stay visible", () => {
   assert.match(oversized.workspaceNotice, /65536-character limit/);
 });
 
-test("location persistence contains history failures but leaves build failures visible", () => {
+test("location persistence contains sync failures but leaves direct build failures visible", () => {
   const current = locationSnapshot("https://inspect.example/");
   const replaced: string[] = [];
   const pushed: string[] = [];
@@ -310,6 +315,11 @@ test("location persistence contains history failures but leaves build failures v
   persistence.push("/");
   assert.equal(new URL(replaced[0]).searchParams.get("package"), "Example.Second");
   assert.deepEqual(pushed, ["/"]);
+  const replacedCount = replaced.length;
+  assert.doesNotThrow(() => persistence.sync(workspaceState({
+    memberTextFilter: "x".repeat(65537),
+  })));
+  assert.equal(replaced.length, replacedCount);
 
   const blocked = createWorkspaceLocationPersistence({
     current: () => current,


### PR DESCRIPTION
## Summary

Extracts inspect-web navigation and URL-backed workspace persistence behind a typed behavior owner while keeping `dotnet-inspect.ts` as the sole mutable `AppState` authority.

- owns in-memory view history and its back/forward state
- owns the monotonic navigation generation used to suppress stale package, platform, dependency, and history work
- owns rich/legacy share-packet encoding and decoding, location parsing/building, and fallible browser-history writes
- supplies explicit capture/apply/history dependencies instead of introducing another state store

This is a behavior-preserving extraction: package/type/member restoration, visible invalid-state failures, URL shape, and sandboxed-history handling remain unchanged.

## Stack

This PR is stacked on #4505 (`inspect-web-typescript-tests-batch-1`) so its new navigation fixture is compiled by that PR's strict test TypeScript configuration. It is the first extraction slice for #4504.

Residual #4504 work remains independently landable:

1. package and runtime-pack acquisition coordination
2. asynchronous request controllers for source, metadata, and graph surfaces
3. DOM event binding paired with the existing presentation modules

## Validation

- `npm test` (265/265; strict source and test TypeScript checks)
- `npm run build` (production Vite bundle and site-artifact verification)
- `npx markdownlint-cli prototypes/inspect-web/README.md`

Fixes part of #4504.
