### PR TITLE
Extract inspect-web package acquisition coordination

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -544,8 +544,10 @@ the engine and state ports and retains mutable loading/error state, package
 activation, workspace restoration, notices, retries, and rendering.
 `test/package-acquisition.test.ts` gates package projection, publication
 ordering, runtime request serialization and merging, cancellation after queued
-or in-flight work, retry after failure, and resident-pack reuse;
-`test/spotlight-identity.test.js` gates provenance and composition-root wiring.
+or in-flight work, request-local failure reporting, replacement-slot
+preservation, retry after failure, and resident-pack reuse;
+`test/spotlight-identity.test.js` gates provenance, failure adaptation, and
+composition-root wiring.
 
 `src/spotlight.ts` owns the modal workbench search, embedded home search,
 scope/result rendering, selection, and keyboard interaction.

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -537,11 +537,22 @@ stale-entry removal, navigation cancellation, rich and legacy URL
 compatibility, visible invalid-state failures, and sandboxed history errors;
 `test/spotlight-identity.test.js` gates the composition-root wiring.
 
+`src/package-acquisition.ts` owns NuGet and runtime-pack engine invocation,
+surface-to-workspace-model projection, serialized runtime-pack loading, and
+stale-result checks at the publication boundary. `dotnet-inspect.ts` supplies
+the engine and state ports and retains mutable loading/error state, package
+activation, workspace restoration, notices, retries, and rendering.
+`test/package-acquisition.test.ts` gates package projection, publication
+ordering, runtime request serialization and merging, cancellation after queued
+or in-flight work, retry after failure, and resident-pack reuse;
+`test/spotlight-identity.test.js` gates provenance and composition-root wiring.
+
 `src/spotlight.ts` owns the modal workbench search, embedded home search,
 scope/result rendering, selection, and keyboard interaction.
 `src/command-bar.ts` supplies its typed Commands-scope grammar and results;
-`dotnet-inspect.ts` retains package queries, network acquisition, and command
-effects so the components do not acquire engine or workspace authority.
+`dotnet-inspect.ts` retains command effects and delegates package/network work
+to the acquisition owner so the components do not acquire engine or workspace
+authority.
 `test/spotlight.test.js` and `test/command-bar.test.ts` gate both presentation
 modes, scope ownership, completion and replacement behavior, bounded results,
 command metadata, and escaping.

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -67,6 +67,10 @@ import {
   type WorkspaceView,
 } from "./workspace-navigation.ts";
 import {
+  createPackageAcquisition,
+  type AppPackage,
+} from "./package-acquisition.ts";
+import {
   captureMemberFocus,
   createMemberFocusRestorer,
   type MemberFocusSnapshot,
@@ -133,9 +137,7 @@ import {
 } from "./spotlight.ts";
 import { fmtBytes, statusBarHtml } from "./status-bar.ts";
 import type {
-  BrowserAccessibilityDescriptor,
   BrowserAnnotatedSource,
-  BrowserAssemblySurface,
   BrowserAssemblyReference,
   BrowserBuildIdentity,
   BrowserCallGraph,
@@ -338,30 +340,6 @@ function loadPlatformRecent() {
 }
 
 type RetryAction = (() => unknown) | null;
-
-interface AppPackage {
-  id: string;
-  version: string;
-  frameworks: string[];
-  activeFramework: string;
-  assembly: string;
-  assemblyId: string;
-  assemblyAsset: string;
-  source:
-    | { kind: "file" }
-    | { kind: "nuget.org" }
-    | { kind: "feed"; host: string }
-    | { kind: "platform" }
-    | { kind: "unknown" };
-  assemblies: BrowserAssemblySurface[];
-  types: BrowserTypeSurface[];
-  accessibility: BrowserAccessibilityDescriptor[];
-  totalTypes: number;
-  totalMembers: number;
-  documents: BrowserPackageDocument[];
-  inspectionError?: string;
-  isRuntimePack: boolean;
-}
 
 interface SpotlightCache {
   signature: string;
@@ -7665,40 +7643,16 @@ async function loadPackage(
   }
 
   try {
-    const result = await inspectPackage(packageId, version, framework);
-    if (navigationSeq != null && !navigationSequence.isCurrent(navigationSeq))
-      return null;
-    refreshPackageStats();
-    const types = (result.types ?? []).map(type => ({
-      ...type,
-      api: type.api ?? []
-    }));
-    const defaultAssembly = (result.assemblies ?? [])
-      .find(assembly => assembly.id === result.defaultAssemblyId);
-    if (!defaultAssembly) {
-      throw new Error("The package query did not return its selected assembly descriptor.");
-    }
-    const packageModel: AppPackage = {
-      id: result.package,
-      version: result.version,
-      frameworks: result.frameworks ?? [],
-      activeFramework: result.activeFramework,
-      assembly: defaultAssembly.name,
-      assemblyId: defaultAssembly.id,
-      assemblyAsset: defaultAssembly.asset,
-      source: { kind: "nuget.org" },
-      assemblies: result.assemblies ?? [],
-      types,
-      accessibility: result.accessibility ?? [],
-      totalTypes: (result.assemblies ?? [])
-        .reduce((count, assembly) => count + (assembly.publicTypes ?? 0), 0),
-      totalMembers: result.totalMembers,
-      documents: result.documents ?? [],
-      inspectionError: result.inspectionError || "",
-      isRuntimePack: false,
-    };
-    retainPackageModel(packageModel, options.replacePackage);
-    recordRecentPackage(packageModel.id, packageModel.version, packageModel.activeFramework);
+    const packageModel = await packageAcquisition.loadPackage({
+      packageId,
+      version,
+      framework,
+      replacePackage: options.replacePackage,
+      isCurrent: navigationSeq == null
+        ? undefined
+        : () => navigationSequence.isCurrent(navigationSeq),
+    });
+    if (!packageModel) return null;
     if (background) return packageModel;
     activatePackage(packageModel, { resetAccessibility: true });
     state.typeFilter = "";
@@ -7859,169 +7813,47 @@ function isRuntimePackId(id: string | null | undefined) {
   return String(id || "").toLowerCase() === "microsoft.netcore.app";
 }
 
-// Loads the platform runtime pack (System.Private.CoreLib for the given TFM) and adds it as
-// a resident pseudo-package flagged isRuntimePack, so its BCL types become searchable in
-// Spotlight and browsable/navigable like any package. SPC is fetched eagerly; sibling pack
-// assemblies load lazily as navigation reaches them. Does not switch the active package.
-let runtimePackLoadPromise: Promise<AppPackage | null> | null = null;
-
-async function waitForRuntimePackLoad() {
-  while (runtimePackLoadPromise) {
-    const pending = runtimePackLoadPromise;
-    try { await pending; } catch {}
-  }
-}
+const packageAcquisition = createPackageAcquisition({
+  queryPackage: (packageId, version, framework) =>
+    inspectPackage(packageId, version, framework),
+  loadRuntimePack: framework => inspectLoadRuntimePack(framework),
+  loadRuntimePackAssembly: (framework, assemblyFileName, pack) =>
+    inspectLoadRuntimePackAssembly(framework, assemblyFileName, pack),
+  parseRuntimeSurface: json => parseEngineJson<BrowserPackageSurface>(json),
+  runtimePackage: runtimePackPackage,
+  retainPackage: retainPackageModel,
+  recordRecentPackage,
+  refreshPackageStats,
+  beginRuntimeLoad() {
+    state.runtimePackLoading = true;
+    state.runtimePackError = "";
+  },
+  failRuntimeLoad(error) {
+    state.runtimePackError = errorMessage(error);
+  },
+  endRuntimeLoad() {
+    state.runtimePackLoading = false;
+  },
+});
 
 async function loadRuntimePack(
   framework: string,
   isCurrent: () => boolean = () => true,
 ): Promise<AppPackage | null> {
-  if (runtimePackLoadPromise) await waitForRuntimePackLoad();
-  if (!isCurrent()) return null;
-  const requestedFramework = framework || "";
-  const existing = runtimePackPackage();
-  if (existing
-    && (!requestedFramework
-      || existing.activeFramework.toLowerCase() === requestedFramework.toLowerCase())) {
-    return existing;
-  }
-
-  state.runtimePackLoading = true;
-  state.runtimePackError = "";
-  const operation = (async () => {
-    const result = parseEngineJson<BrowserPackageSurface>(
-      await inspectLoadRuntimePack(requestedFramework));
-    if (!isCurrent()) return null;
-    refreshPackageStats();
-    const types = (result.types ?? []).map(type => ({ ...type, api: type.api ?? [] }));
-    const defaultAssembly = (result.assemblies ?? [])
-      .find(assembly => assembly.id === result.defaultAssemblyId);
-    if (!defaultAssembly) {
-      throw new Error("The platform query did not return its selected assembly descriptor.");
-    }
-    const packageModel: AppPackage = {
-      id: result.package,
-      version: result.version,
-      frameworks: result.frameworks ?? [],
-      activeFramework: result.activeFramework,
-      assembly: defaultAssembly.name,
-      assemblyId: defaultAssembly.id,
-      assemblyAsset: defaultAssembly.asset,
-      source: { kind: "platform" },
-      assemblies: result.assemblies ?? [],
-      types,
-      accessibility: result.accessibility ?? [],
-      totalTypes: types.length,
-      totalMembers: result.totalMembers,
-      documents: result.documents ?? [],
-      isRuntimePack: true
-    };
-    retainPackageModel(packageModel, existing);
-    return packageModel;
-  })();
-  runtimePackLoadPromise = operation;
-  try {
-    return await operation;
-  } catch (error) {
-    state.runtimePackError = errorMessage(error);
-    return null;
-  } finally {
-    if (runtimePackLoadPromise === operation)
-      runtimePackLoadPromise = null;
-    state.runtimePackLoading = false;
-  }
+  return packageAcquisition.loadRuntimePack(framework, isCurrent);
 }
 
-// Loads ONE named runtime-pack assembly (e.g. System.Text.Json.dll from CoreCLR, or
-// Microsoft.AspNetCore.Routing.dll from the ASP.NET Core shared framework) and folds its
-// type surface into the resident runtime pseudo-package, creating that package if it is not
-// resident yet. `pack` names the shared framework (netcore.app | aspnetcore.app), threaded
-// through so per-type/member queries later route to the right pack. This backs index-first
-// Platform drill-in: the Platform scope roster comes from the static index with no download,
-// and picking a library fetches just that assembly here. Types/assemblies are merged (deduped
-// by id/name) so the runtime pack accumulates the libraries the user visits.
 async function loadRuntimePackAssembly(
   framework: string,
   assemblyFileName: string,
   pack: string,
   isCurrent: () => boolean = () => true,
 ): Promise<AppPackage | null> {
-  if (runtimePackLoadPromise) await waitForRuntimePackLoad();
-  if (!isCurrent()) return null;
-  const requestedFramework = framework || "";
-  const resident = runtimePackPackage();
-  if (resident
-    && (!requestedFramework
-      || resident.activeFramework.toLowerCase() === requestedFramework.toLowerCase())
-    && (resident.assemblies || []).some(assembly =>
-      assembly.name.toLowerCase() === String(assemblyFileName).toLowerCase())) {
-    return resident;
-  }
-
-  state.runtimePackLoading = true;
-  state.runtimePackError = "";
-  const operation = (async () => {
-    const result = parseEngineJson<BrowserPackageSurface>(
-      await inspectLoadRuntimePackAssembly(
-        requestedFramework,
-        assemblyFileName,
-        pack || ""));
-    if (!isCurrent()) return null;
-    refreshPackageStats();
-    const newTypes = (result.types ?? []).map(type => ({ ...type, api: type.api ?? [] }));
-    const existing = runtimePackPackage();
-    if (existing
-      && (!requestedFramework
-        || existing.activeFramework.toLowerCase() === requestedFramework.toLowerCase())) {
-      const seenTypes = new Set(existing.types.map(type => type.id));
-      for (const type of newTypes) if (!seenTypes.has(type.id)) existing.types.push(type);
-      const seenAsm = new Set((existing.assemblies || []).map(item => item.name));
-      for (const asm of (result.assemblies ?? [])) if (!seenAsm.has(asm.name)) existing.assemblies.push(asm);
-      const descriptors = new Map(
-        (existing.accessibility || []).map(descriptor => [descriptor.id, descriptor]));
-      for (const descriptor of (result.accessibility ?? [])) {
-        const current = descriptors.get(descriptor.id);
-        descriptors.set(descriptor.id, current
-          ? { ...current, count: current.count + descriptor.count }
-          : descriptor);
-      }
-      existing.accessibility = [...descriptors.values()]
-        .sort((left, right) => left.order - right.order);
-      existing.totalTypes = existing.types.length;
-      existing.totalMembers = (existing.totalMembers || 0) + (result.totalMembers || 0);
-      return existing;
-    }
-    const packageModel: AppPackage = {
-      id: result.package,
-      version: result.version,
-      frameworks: result.frameworks ?? [],
-      activeFramework: result.activeFramework,
-      assembly: result.assemblies[0].name,
-      assemblyId: result.defaultAssemblyId,
-      assemblyAsset: result.assemblies[0].asset,
-      source: { kind: "platform" },
-      assemblies: result.assemblies ?? [],
-      types: newTypes,
-      accessibility: result.accessibility ?? [],
-      totalTypes: newTypes.length,
-      totalMembers: result.totalMembers,
-      documents: result.documents ?? [],
-      isRuntimePack: true
-    };
-    retainPackageModel(packageModel, existing);
-    return packageModel;
-  })();
-  runtimePackLoadPromise = operation;
-  try {
-    return await operation;
-  } catch (error) {
-    state.runtimePackError = errorMessage(error);
-    return null;
-  } finally {
-    if (runtimePackLoadPromise === operation)
-      runtimePackLoadPromise = null;
-    state.runtimePackLoading = false;
-  }
+  return packageAcquisition.loadRuntimePackAssembly(
+    framework,
+    assemblyFileName,
+    pack,
+    isCurrent);
 }
 
 async function runCallGraphDemo() {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -4152,11 +4152,12 @@ function bindEvents() {
       const key = name.replace(/\.dll$/i, "");
       const resident = (runtimePackPackage()?.types || []).some(type => libraryKey(type) === key);
       if (!resident) {
-        const loaded = await loadRuntimePackAssembly(
+        const runtimeResult = await loadRuntimePackAssembly(
           platformScopeTfm(),
           `${key}.dll`,
           pack,
           () => state.packages.includes(originPackage));
+        const loaded = runtimeResult.packageModel;
         if (!loaded) {
           if (isCurrent()) {
                   const noticeState: NoticeRetryState = {
@@ -4168,7 +4169,9 @@ function bindEvents() {
               openLibrary(name, pack, originPackage, noticeState);
             noticeState.action = retryAction;
             appendQueryNotice(
-              `Couldn’t load ${key}: ${state.runtimePackError || "runtime pack acquisition failed."}`,
+              `Couldn’t load ${key}: ${runtimeResult.failureMessage
+                || state.runtimePackError
+                || "runtime pack acquisition failed."}`,
               retryAction);
             noticeState.appended = state.queryNotice;
             render();
@@ -4988,14 +4991,17 @@ async function switchPlatformVersion(
   state.loadingMessage = "Loading the .NET Platform…";
   state.loadingSubtitle = `.NET Platform · ${tfm}`;
   render();
-  const loaded = await loadRuntimePack(
+  const runtimeResult = await loadRuntimePack(
     tfm,
     () => navigationSequence.isCurrent(navigationSeq));
+  const loaded = runtimeResult.packageModel;
   if (!navigationSequence.isCurrent(navigationSeq)
     || (state.package && state.package !== pkg)) return;
   if (!loaded) {
     state.loading = false;
-    state.error = state.runtimePackError || "Couldn’t load the .NET Platform.";
+    state.error = runtimeResult.failureMessage
+      || state.runtimePackError
+      || "Couldn’t load the .NET Platform.";
     state.errorTitle = "Platform failed";
     state.retryAction = () => switchPlatformVersion(tfm, pkg);
     render();
@@ -5162,16 +5168,19 @@ async function openPlatformLibrary(
     state.loadingMessage = "Loading the platform library…";
     state.loadingSubtitle = `${key} · ${tfm}`;
     render();
-    const loaded = await loadRuntimePackAssembly(
+    const runtimeResult = await loadRuntimePackAssembly(
       tfm,
       fileName,
       pack,
       () => navigationSequence.isCurrent(navigationSeq));
+    const loaded = runtimeResult.packageModel;
     if (!navigationSequence.isCurrent(navigationSeq)) return;
     if (!loaded) {
       state.loading = false;
-      state.error = state.runtimePackError
-        ? `Couldn’t load ${key}: ${state.runtimePackError}`
+      const failureMessage =
+        runtimeResult.failureMessage || state.runtimePackError;
+      state.error = failureMessage
+        ? `Couldn’t load ${key}: ${failureMessage}`
         : `Couldn’t load ${key} from the .NET runtime pack.`;
       state.errorTitle = "Platform library failed";
       state.retryAction = options.retryAction
@@ -5776,7 +5785,7 @@ async function openRuntimePackFromHome() {
   state.loadingMessage = "Loading the .NET Platform…";
   state.loadingSubtitle = ".NET Platform · net10.0";
   render();
-  const pack = await loadRuntimePack(
+  const { packageModel: pack } = await loadRuntimePack(
     "net10.0",
     () => navigationSequence.isCurrent(navigationSeq));
   if (!navigationSequence.isCurrent(navigationSeq)) return;
@@ -7102,9 +7111,10 @@ async function navigateOrDrillPlatform(node: BrowserCallGraphTarget) {
     state.platformDrillLoading = true;
     state.platformDrillError = "";
     const preservedFocus = renderPreservingMemberFocus();
-    pack = await loadRuntimePack(
+    const runtimeResult = await loadRuntimePack(
       framework,
       ownsNavigation);
+    pack = runtimeResult.packageModel;
     if (!ownsNavigation()) {
       if (seq === state.memberCallGraphSeq) {
         state.platformDrillLoading = false;
@@ -7114,7 +7124,9 @@ async function navigateOrDrillPlatform(node: BrowserCallGraphTarget) {
     }
     state.platformDrillLoading = false;
     if (!pack) {
-      state.platformDrillError = state.runtimePackError || "Could not load the .NET runtime pack.";
+      state.platformDrillError = runtimeResult.failureMessage
+        || state.runtimePackError
+        || "Could not load the .NET runtime pack.";
       renderPreservingMemberFocus(preservedFocus);
       await renderMermaidCallGraph();
       return;
@@ -7836,11 +7848,22 @@ const packageAcquisition = createPackageAcquisition({
   },
 });
 
+interface RuntimeLoadResult {
+  packageModel: AppPackage | null;
+  failureMessage: string;
+}
+
 async function loadRuntimePack(
   framework: string,
   isCurrent: () => boolean = () => true,
-): Promise<AppPackage | null> {
-  return packageAcquisition.loadRuntimePack(framework, isCurrent);
+): Promise<RuntimeLoadResult> {
+  const result = await packageAcquisition.loadRuntimePack(
+    framework,
+    isCurrent);
+  return {
+    packageModel: result.packageModel,
+    failureMessage: result.error === null ? "" : errorMessage(result.error),
+  };
 }
 
 async function loadRuntimePackAssembly(
@@ -7848,12 +7871,16 @@ async function loadRuntimePackAssembly(
   assemblyFileName: string,
   pack: string,
   isCurrent: () => boolean = () => true,
-): Promise<AppPackage | null> {
-  return packageAcquisition.loadRuntimePackAssembly(
+): Promise<RuntimeLoadResult> {
+  const result = await packageAcquisition.loadRuntimePackAssembly(
     framework,
     assemblyFileName,
     pack,
     isCurrent);
+  return {
+    packageModel: result.packageModel,
+    failureMessage: result.error === null ? "" : errorMessage(result.error),
+  };
 }
 
 async function runCallGraphDemo() {
@@ -7984,15 +8011,20 @@ async function restoreWorkspaceFromLocation(
   // once, below — so a non-target tab (e.g. an STJ tab on a platform-library link) never
   // flashes into view before the target resolves.
   let loadedTargetModel: AppPackage | null = null;
+  let runtimeFailureMessage = "";
   for (const tab of tabs) {
     let loaded: AppPackage | null;
     if (isRuntimePackId(tab.id)) {
-      loaded = await loadRuntimePack(
+      const runtimeResult = await loadRuntimePack(
         tab.framework,
         () => navigationSequence.isCurrent(navigationSeq));
+      loaded = runtimeResult.packageModel;
+      runtimeFailureMessage = runtimeResult.failureMessage;
       if (!loaded && navigationSequence.isCurrent(navigationSeq)) {
         const failure =
-          `Workspace restore was incomplete: ${tab.id}: ${state.runtimePackError || "runtime pack acquisition failed."}`;
+          `Workspace restore was incomplete: ${tab.id}: ${runtimeFailureMessage
+            || state.runtimePackError
+            || "runtime pack acquisition failed."}`;
         state.queryNotice = state.queryNotice
           ? `${state.queryNotice} ${failure}`
           : failure;
@@ -8039,7 +8071,9 @@ async function restoreWorkspaceFromLocation(
   } else {
     state.loading = false;
     const failure =
-      state.runtimePackError || "Couldn’t load the requested .NET Platform.";
+      runtimeFailureMessage
+      || state.runtimePackError
+      || "Couldn’t load the requested .NET Platform.";
     state.error = state.queryNotice
       ? `${state.queryNotice} ${failure}`
       : failure;
@@ -8455,9 +8489,10 @@ async function restoreRuntimePackFromHistory(
   deep: DeepLink,
   navigationSeq: number,
 ) {
-  const pack = await loadRuntimePack(
+  const runtimeResult = await loadRuntimePack(
     loc.framework || "",
     () => navigationSequence.isCurrent(navigationSeq));
+  const pack = runtimeResult.packageModel;
   if (!navigationSequence.isCurrent(navigationSeq)) return;
   if (pack) {
     activatePackage(pack, { resetAccessibility: true });
@@ -8478,7 +8513,9 @@ async function restoreRuntimePackFromHistory(
     state.loading = false;
   } else {
     appendQueryNotice(
-      `Workspace restore was incomplete: ${loc.package}: ${state.runtimePackError || "runtime pack acquisition failed."}`);
+      `Workspace restore was incomplete: ${loc.package}: ${runtimeResult.failureMessage
+        || state.runtimePackError
+        || "runtime pack acquisition failed."}`);
   }
   render();
   loadSelectionData();

--- a/prototypes/inspect-web/src/package-acquisition.ts
+++ b/prototypes/inspect-web/src/package-acquisition.ts
@@ -177,18 +177,23 @@ export interface NuGetPackageRequest {
   isCurrent?: () => boolean;
 }
 
+export interface RuntimeAcquisitionResult {
+  packageModel: AppPackage | null;
+  error: unknown | null;
+}
+
 export interface PackageAcquisition {
   loadPackage(request: NuGetPackageRequest): Promise<AppPackage | null>;
   loadRuntimePack(
     framework: string,
     isCurrent?: () => boolean,
-  ): Promise<AppPackage | null>;
+  ): Promise<RuntimeAcquisitionResult>;
   loadRuntimePackAssembly(
     framework: string,
     assemblyFileName: string,
     pack: string,
     isCurrent?: () => boolean,
-  ): Promise<AppPackage | null>;
+  ): Promise<RuntimeAcquisitionResult>;
 }
 
 export function createPackageAcquisition(
@@ -209,15 +214,21 @@ export function createPackageAcquisition(
 
   const runRuntimeOperation = async (
     operation: () => Promise<AppPackage | null>,
-  ): Promise<AppPackage | null> => {
+  ): Promise<RuntimeAcquisitionResult> => {
     dependencies.beginRuntimeLoad();
     const pending = operation();
     runtimeOperation = pending;
     try {
-      return await pending;
+      return {
+        packageModel: await pending,
+        error: null,
+      };
     } catch (error) {
       dependencies.failRuntimeLoad(error);
-      return null;
+      return {
+        packageModel: null,
+        error,
+      };
     } finally {
       if (runtimeOperation === pending) runtimeOperation = null;
       dependencies.endRuntimeLoad();
@@ -243,14 +254,14 @@ export function createPackageAcquisition(
 
     async loadRuntimePack(framework, isCurrent = () => true) {
       if (runtimeOperation) await waitForRuntimeOperation();
-      if (!isCurrent()) return null;
+      if (!isCurrent()) return { packageModel: null, error: null };
       const requestedFramework = framework || "";
       const existing = dependencies.runtimePackage();
       if (existing
         && (!requestedFramework
           || existing.activeFramework.toLowerCase()
             === requestedFramework.toLowerCase())) {
-        return existing;
+        return { packageModel: existing, error: null };
       }
 
       return runRuntimeOperation(async () => {
@@ -271,7 +282,7 @@ export function createPackageAcquisition(
       isCurrent = () => true,
     ) {
       if (runtimeOperation) await waitForRuntimeOperation();
-      if (!isCurrent()) return null;
+      if (!isCurrent()) return { packageModel: null, error: null };
       const requestedFramework = framework || "";
       const resident = dependencies.runtimePackage();
       if (resident
@@ -281,7 +292,7 @@ export function createPackageAcquisition(
         && resident.assemblies.some(assembly =>
           assembly.name.toLowerCase()
             === String(assemblyFileName).toLowerCase())) {
-        return resident;
+        return { packageModel: resident, error: null };
       }
 
       return runRuntimeOperation(async () => {

--- a/prototypes/inspect-web/src/package-acquisition.ts
+++ b/prototypes/inspect-web/src/package-acquisition.ts
@@ -1,0 +1,308 @@
+import type {
+  BrowserAccessibilityDescriptor,
+  BrowserAssemblySurface,
+  BrowserPackageDocument,
+  BrowserPackageSurface,
+  BrowserTypeSurface,
+} from "./inspect-web-engine.d.ts";
+
+export interface AppPackage {
+  id: string;
+  version: string;
+  frameworks: string[];
+  activeFramework: string;
+  assembly: string;
+  assemblyId: string;
+  assemblyAsset: string;
+  source:
+    | { kind: "file" }
+    | { kind: "nuget.org" }
+    | { kind: "feed"; host: string }
+    | { kind: "platform" }
+    | { kind: "unknown" };
+  assemblies: BrowserAssemblySurface[];
+  types: BrowserTypeSurface[];
+  accessibility: BrowserAccessibilityDescriptor[];
+  totalTypes: number;
+  totalMembers: number;
+  documents: BrowserPackageDocument[];
+  inspectionError?: string;
+  isRuntimePack: boolean;
+}
+
+function packageTypes(result: BrowserPackageSurface): BrowserTypeSurface[] {
+  return (result.types ?? []).map(type => ({
+    ...type,
+    api: type.api ?? [],
+  }));
+}
+
+function defaultAssembly(
+  result: BrowserPackageSurface,
+  failureMessage: string,
+): BrowserAssemblySurface {
+  const assembly = (result.assemblies ?? [])
+    .find(candidate => candidate.id === result.defaultAssemblyId);
+  if (!assembly) throw new Error(failureMessage);
+  return assembly;
+}
+
+export function createNuGetPackageModel(
+  result: BrowserPackageSurface,
+): AppPackage {
+  const assembly = defaultAssembly(
+    result,
+    "The package query did not return its selected assembly descriptor.");
+  return {
+    id: result.package,
+    version: result.version,
+    frameworks: result.frameworks ?? [],
+    activeFramework: result.activeFramework,
+    assembly: assembly.name,
+    assemblyId: assembly.id,
+    assemblyAsset: assembly.asset,
+    source: { kind: "nuget.org" },
+    assemblies: result.assemblies ?? [],
+    types: packageTypes(result),
+    accessibility: result.accessibility ?? [],
+    totalTypes: (result.assemblies ?? [])
+      .reduce((count, candidate) => count + (candidate.publicTypes ?? 0), 0),
+    totalMembers: result.totalMembers,
+    documents: result.documents ?? [],
+    inspectionError: result.inspectionError || "",
+    isRuntimePack: false,
+  };
+}
+
+export function createRuntimePackageModel(
+  result: BrowserPackageSurface,
+): AppPackage {
+  const assembly = defaultAssembly(
+    result,
+    "The platform query did not return its selected assembly descriptor.");
+  return createRuntimePackageModelForAssembly(result, assembly, assembly.id);
+}
+
+function createRuntimeAssemblyPackageModel(
+  result: BrowserPackageSurface,
+): AppPackage {
+  return createRuntimePackageModelForAssembly(
+    result,
+    result.assemblies[0],
+    result.defaultAssemblyId);
+}
+
+function createRuntimePackageModelForAssembly(
+  result: BrowserPackageSurface,
+  assembly: BrowserAssemblySurface,
+  assemblyId: string,
+): AppPackage {
+  const types = packageTypes(result);
+  return {
+    id: result.package,
+    version: result.version,
+    frameworks: result.frameworks ?? [],
+    activeFramework: result.activeFramework,
+    assembly: assembly.name,
+    assemblyId,
+    assemblyAsset: assembly.asset,
+    source: { kind: "platform" },
+    assemblies: result.assemblies ?? [],
+    types,
+    accessibility: result.accessibility ?? [],
+    totalTypes: types.length,
+    totalMembers: result.totalMembers,
+    documents: result.documents ?? [],
+    isRuntimePack: true,
+  };
+}
+
+export function mergeRuntimePackageSurface(
+  existing: AppPackage,
+  result: BrowserPackageSurface,
+): AppPackage {
+  const newTypes = packageTypes(result);
+  const seenTypes = new Set(existing.types.map(type => type.id));
+  for (const type of newTypes) {
+    if (!seenTypes.has(type.id)) existing.types.push(type);
+  }
+
+  const seenAssemblies = new Set(existing.assemblies.map(assembly => assembly.name));
+  for (const assembly of result.assemblies ?? []) {
+    if (!seenAssemblies.has(assembly.name)) existing.assemblies.push(assembly);
+  }
+
+  const descriptors = new Map(
+    existing.accessibility.map(descriptor => [descriptor.id, descriptor]));
+  for (const descriptor of result.accessibility ?? []) {
+    const current = descriptors.get(descriptor.id);
+    descriptors.set(descriptor.id, current
+      ? { ...current, count: current.count + descriptor.count }
+      : descriptor);
+  }
+  existing.accessibility = [...descriptors.values()]
+    .sort((left, right) => left.order - right.order);
+  existing.totalTypes = existing.types.length;
+  existing.totalMembers = (existing.totalMembers || 0) + (result.totalMembers || 0);
+  return existing;
+}
+
+export interface PackageAcquisitionDependencies {
+  queryPackage(
+    packageId: string,
+    version: string,
+    framework: string,
+  ): Promise<BrowserPackageSurface>;
+  loadRuntimePack(framework: string): Promise<string>;
+  loadRuntimePackAssembly(
+    framework: string,
+    assemblyFileName: string,
+    pack: string,
+  ): Promise<string>;
+  parseRuntimeSurface(json: string): BrowserPackageSurface;
+  runtimePackage(): AppPackage | null;
+  retainPackage(packageModel: AppPackage, replacedPackage?: AppPackage | null): void;
+  recordRecentPackage(id: string, version: string, framework: string): void;
+  refreshPackageStats(): void;
+  beginRuntimeLoad(): void;
+  failRuntimeLoad(error: unknown): void;
+  endRuntimeLoad(): void;
+}
+
+export interface NuGetPackageRequest {
+  packageId: string;
+  version: string;
+  framework: string;
+  replacePackage?: AppPackage | null;
+  isCurrent?: () => boolean;
+}
+
+export interface PackageAcquisition {
+  loadPackage(request: NuGetPackageRequest): Promise<AppPackage | null>;
+  loadRuntimePack(
+    framework: string,
+    isCurrent?: () => boolean,
+  ): Promise<AppPackage | null>;
+  loadRuntimePackAssembly(
+    framework: string,
+    assemblyFileName: string,
+    pack: string,
+    isCurrent?: () => boolean,
+  ): Promise<AppPackage | null>;
+}
+
+export function createPackageAcquisition(
+  dependencies: PackageAcquisitionDependencies,
+): PackageAcquisition {
+  let runtimeOperation: Promise<AppPackage | null> | null = null;
+
+  const waitForRuntimeOperation = async () => {
+    while (runtimeOperation) {
+      const pending = runtimeOperation;
+      try {
+        await pending;
+      } catch {
+        // The operation owner reports its failure before the next request starts.
+      }
+    }
+  };
+
+  const runRuntimeOperation = async (
+    operation: () => Promise<AppPackage | null>,
+  ): Promise<AppPackage | null> => {
+    dependencies.beginRuntimeLoad();
+    const pending = operation();
+    runtimeOperation = pending;
+    try {
+      return await pending;
+    } catch (error) {
+      dependencies.failRuntimeLoad(error);
+      return null;
+    } finally {
+      if (runtimeOperation === pending) runtimeOperation = null;
+      dependencies.endRuntimeLoad();
+    }
+  };
+
+  return {
+    async loadPackage(request) {
+      const result = await dependencies.queryPackage(
+        request.packageId,
+        request.version,
+        request.framework);
+      if (request.isCurrent && !request.isCurrent()) return null;
+      dependencies.refreshPackageStats();
+      const packageModel = createNuGetPackageModel(result);
+      dependencies.retainPackage(packageModel, request.replacePackage);
+      dependencies.recordRecentPackage(
+        packageModel.id,
+        packageModel.version,
+        packageModel.activeFramework);
+      return packageModel;
+    },
+
+    async loadRuntimePack(framework, isCurrent = () => true) {
+      if (runtimeOperation) await waitForRuntimeOperation();
+      if (!isCurrent()) return null;
+      const requestedFramework = framework || "";
+      const existing = dependencies.runtimePackage();
+      if (existing
+        && (!requestedFramework
+          || existing.activeFramework.toLowerCase()
+            === requestedFramework.toLowerCase())) {
+        return existing;
+      }
+
+      return runRuntimeOperation(async () => {
+        const result = dependencies.parseRuntimeSurface(
+          await dependencies.loadRuntimePack(requestedFramework));
+        if (!isCurrent()) return null;
+        dependencies.refreshPackageStats();
+        const packageModel = createRuntimePackageModel(result);
+        dependencies.retainPackage(packageModel, existing);
+        return packageModel;
+      });
+    },
+
+    async loadRuntimePackAssembly(
+      framework,
+      assemblyFileName,
+      pack,
+      isCurrent = () => true,
+    ) {
+      if (runtimeOperation) await waitForRuntimeOperation();
+      if (!isCurrent()) return null;
+      const requestedFramework = framework || "";
+      const resident = dependencies.runtimePackage();
+      if (resident
+        && (!requestedFramework
+          || resident.activeFramework.toLowerCase()
+            === requestedFramework.toLowerCase())
+        && resident.assemblies.some(assembly =>
+          assembly.name.toLowerCase()
+            === String(assemblyFileName).toLowerCase())) {
+        return resident;
+      }
+
+      return runRuntimeOperation(async () => {
+        const result = dependencies.parseRuntimeSurface(
+          await dependencies.loadRuntimePackAssembly(
+            requestedFramework,
+            assemblyFileName,
+            pack || ""));
+        if (!isCurrent()) return null;
+        dependencies.refreshPackageStats();
+        const existing = dependencies.runtimePackage();
+        if (existing
+          && (!requestedFramework
+            || existing.activeFramework.toLowerCase()
+              === requestedFramework.toLowerCase())) {
+          return mergeRuntimePackageSurface(existing, result);
+        }
+        const packageModel = createRuntimeAssemblyPackageModel(result);
+        dependencies.retainPackage(packageModel, existing);
+        return packageModel;
+      });
+    },
+  };
+}

--- a/prototypes/inspect-web/test/package-acquisition.test.ts
+++ b/prototypes/inspect-web/test/package-acquisition.test.ts
@@ -1,0 +1,364 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createNuGetPackageModel,
+  createPackageAcquisition,
+  createRuntimePackageModel,
+  type AppPackage,
+  type PackageAcquisitionDependencies,
+} from "../src/package-acquisition.ts";
+import type {
+  BrowserAssemblySurface,
+  BrowserPackageSurface,
+  BrowserTypeSurface,
+} from "../src/inspect-web-engine.d.ts";
+
+function assembly(
+  id: string,
+  name: string,
+  publicTypes = 1,
+): BrowserAssemblySurface {
+  return {
+    id,
+    name,
+    version: "1.0.0.0",
+    culture: null,
+    publicKeyToken: null,
+    asset: `lib/net10.0/${name}.dll`,
+    publicTypes,
+    publicMembers: publicTypes * 2,
+  };
+}
+
+function typeSurface(
+  id: string,
+  assemblyName = "Example.Core",
+): BrowserTypeSurface {
+  return {
+    id,
+    definitionId: id,
+    queryId: id,
+    metadataId: id,
+    name: id.split(".").at(-1) ?? id,
+    displayName: id,
+    namespace: id.split(".").slice(0, -1).join("."),
+    kind: "class",
+    accessibility: "public",
+    accessibilityId: "public",
+    assembly: assemblyName,
+    assemblyId: assemblyName,
+    assemblyName,
+    members: 2,
+    signature: `public class ${id}`,
+    api: [],
+  };
+}
+
+function packageSurface(
+  overrides: Partial<BrowserPackageSurface> = {},
+): BrowserPackageSurface {
+  const primary = assembly("example-core", "Example.Core", 3);
+  return {
+    package: "Example.Package",
+    version: "1.2.3",
+    frameworks: ["net9.0", "net10.0"],
+    activeFramework: "net10.0",
+    defaultAssemblyId: primary.id,
+    assemblies: [primary],
+    types: [typeSurface("Example.Widget")],
+    accessibility: [{
+      id: "public",
+      label: "Public",
+      order: 0,
+      isDefault: true,
+      count: 1,
+    }],
+    totalMembers: 2,
+    documents: [],
+    inspectionError: null,
+    ...overrides,
+  };
+}
+
+function runtimeSurface(
+  assemblyId: string,
+  assemblyName: string,
+  typeId: string,
+  totalMembers = 2,
+): BrowserPackageSurface {
+  const primary = assembly(assemblyId, assemblyName);
+  return packageSurface({
+    package: "Microsoft.NETCore.App",
+    version: "10.0.0",
+    frameworks: ["net10.0"],
+    activeFramework: "net10.0",
+    defaultAssemblyId: primary.id,
+    assemblies: [primary],
+    types: [typeSurface(typeId, assemblyName)],
+    accessibility: [{
+      id: "public",
+      label: "Public",
+      order: 0,
+      isDefault: true,
+      count: 1,
+    }],
+    totalMembers,
+  });
+}
+
+function acquisitionDependencies(
+  overrides: Partial<PackageAcquisitionDependencies> = {},
+): PackageAcquisitionDependencies {
+  return {
+    queryPackage: async () => packageSurface(),
+    loadRuntimePack: async () => JSON.stringify(
+      runtimeSurface("corelib", "System.Private.CoreLib", "System.Object")),
+    loadRuntimePackAssembly: async () => JSON.stringify(
+      runtimeSurface("json", "System.Text.Json", "System.Text.Json.JsonDocument")),
+    parseRuntimeSurface: json => JSON.parse(json),
+    runtimePackage: () => null,
+    retainPackage: () => {},
+    recordRecentPackage: () => {},
+    refreshPackageStats: () => {},
+    beginRuntimeLoad: () => {},
+    failRuntimeLoad: () => {},
+    endRuntimeLoad: () => {},
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(accept => {
+    resolve = accept;
+  });
+  return { promise, resolve };
+}
+
+test("NuGet projection selects the declared assembly and preserves package totals", () => {
+  const secondary = assembly("secondary", "Example.Secondary", 4);
+  const model = createNuGetPackageModel(packageSurface({
+    defaultAssemblyId: secondary.id,
+    assemblies: [assembly("primary", "Example.Primary", 3), secondary],
+    inspectionError: "one assembly could not be inspected",
+  }));
+
+  assert.equal(model.assembly, "Example.Secondary");
+  assert.equal(model.assemblyId, "secondary");
+  assert.equal(model.totalTypes, 7);
+  assert.equal(model.inspectionError, "one assembly could not be inspected");
+  assert.deepEqual(model.source, { kind: "nuget.org" });
+  assert.equal(model.isRuntimePack, false);
+
+  assert.throws(
+    () => createNuGetPackageModel(packageSurface({
+      defaultAssemblyId: "missing",
+    })),
+    /did not return its selected assembly descriptor/);
+});
+
+test("package acquisition publishes only current results", async () => {
+  const events: string[] = [];
+  const acquisition = createPackageAcquisition(acquisitionDependencies({
+    retainPackage: packageModel => events.push(`retain:${packageModel.id}`),
+    recordRecentPackage: (id, version, framework) =>
+      events.push(`recent:${id}@${version}/${framework}`),
+    refreshPackageStats: () => events.push("stats"),
+  }));
+
+  const stale = await acquisition.loadPackage({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    isCurrent: () => false,
+  });
+  assert.equal(stale, null);
+  assert.deepEqual(events, []);
+
+  const current = await acquisition.loadPackage({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+  });
+  assert.equal(current?.id, "Example.Package");
+  assert.deepEqual(events, [
+    "stats",
+    "retain:Example.Package",
+    "recent:Example.Package@1.2.3/net10.0",
+  ]);
+});
+
+test("runtime acquisition serializes and merges full-pack and assembly requests", async () => {
+  const fullPack = deferred<string>();
+  const calls: string[] = [];
+  const status: string[] = [];
+  let resident: AppPackage | null = null;
+  let retainCount = 0;
+  let statsCount = 0;
+  const acquisition = createPackageAcquisition(acquisitionDependencies({
+    loadRuntimePack: async framework => {
+      calls.push(`pack:${framework}`);
+      return fullPack.promise;
+    },
+    loadRuntimePackAssembly: async (framework, assemblyName, pack) => {
+      calls.push(`assembly:${framework}/${assemblyName}/${pack}`);
+      const surface = runtimeSurface(
+        "json",
+        "System.Text.Json",
+        "System.Text.Json.JsonDocument",
+        3);
+      surface.types.unshift(typeSurface("System.Object", "System.Private.CoreLib"));
+      return JSON.stringify(surface);
+    },
+    runtimePackage: () => resident,
+    retainPackage: packageModel => {
+      retainCount++;
+      resident = packageModel;
+    },
+    refreshPackageStats: () => statsCount++,
+    beginRuntimeLoad: () => status.push("begin"),
+    endRuntimeLoad: () => status.push("end"),
+  }));
+
+  const packRequest = acquisition.loadRuntimePack("net10.0");
+  const assemblyRequest = acquisition.loadRuntimePackAssembly(
+    "net10.0",
+    "System.Text.Json",
+    "netcore.app");
+  assert.deepEqual(calls, ["pack:net10.0"]);
+  assert.deepEqual(status, ["begin"]);
+
+  fullPack.resolve(JSON.stringify(
+    runtimeSurface("corelib", "System.Private.CoreLib", "System.Object")));
+  const [packModel, mergedModel] = await Promise.all([
+    packRequest,
+    assemblyRequest,
+  ]);
+
+  assert.ok(packModel);
+  assert.ok(mergedModel);
+  assert.equal(mergedModel, packModel);
+  assert.equal(resident, packModel);
+  assert.deepEqual(calls, [
+    "pack:net10.0",
+    "assembly:net10.0/System.Text.Json/netcore.app",
+  ]);
+  assert.deepEqual(status, ["begin", "end", "begin", "end"]);
+  assert.equal(retainCount, 1);
+  assert.equal(statsCount, 2);
+  assert.deepEqual(
+    mergedModel.assemblies.map(candidate => candidate.name),
+    ["System.Private.CoreLib", "System.Text.Json"]);
+  assert.deepEqual(
+    mergedModel.types.map(candidate => candidate.id),
+    ["System.Object", "System.Text.Json.JsonDocument"]);
+  assert.equal(mergedModel.totalMembers, 5);
+  assert.equal(mergedModel.accessibility[0].count, 2);
+});
+
+test("queued runtime work rechecks cancellation before invoking the engine", async () => {
+  const fullPack = deferred<string>();
+  let assemblyCalls = 0;
+  let current = true;
+  let resident: AppPackage | null = null;
+  const acquisition = createPackageAcquisition(acquisitionDependencies({
+    loadRuntimePack: async () => fullPack.promise,
+    loadRuntimePackAssembly: async () => {
+      assemblyCalls++;
+      return JSON.stringify(
+        runtimeSurface("json", "System.Text.Json", "System.Text.Json.JsonDocument"));
+    },
+    runtimePackage: () => resident,
+    retainPackage: packageModel => {
+      resident = packageModel;
+    },
+  }));
+
+  const packRequest = acquisition.loadRuntimePack("net10.0");
+  const queuedRequest = acquisition.loadRuntimePackAssembly(
+    "net10.0",
+    "System.Text.Json",
+    "netcore.app",
+    () => current);
+  current = false;
+  fullPack.resolve(JSON.stringify(
+    runtimeSurface("corelib", "System.Private.CoreLib", "System.Object")));
+
+  assert.ok(await packRequest);
+  assert.equal(await queuedRequest, null);
+  assert.equal(assemblyCalls, 0);
+});
+
+test("stale runtime results do not publish after the engine returns", async () => {
+  const fullPack = deferred<string>();
+  const events: string[] = [];
+  let current = true;
+  const acquisition = createPackageAcquisition(acquisitionDependencies({
+    loadRuntimePack: async () => fullPack.promise,
+    retainPackage: () => events.push("retain"),
+    refreshPackageStats: () => events.push("stats"),
+    beginRuntimeLoad: () => events.push("begin"),
+    endRuntimeLoad: () => events.push("end"),
+  }));
+
+  const request = acquisition.loadRuntimePack("net10.0", () => current);
+  current = false;
+  fullPack.resolve(JSON.stringify(
+    runtimeSurface("corelib", "System.Private.CoreLib", "System.Object")));
+
+  assert.equal(await request, null);
+  assert.deepEqual(events, ["begin", "end"]);
+});
+
+test("runtime failures are reported and do not block a later retry", async () => {
+  const status: string[] = [];
+  let attempts = 0;
+  let resident: AppPackage | null = null;
+  const acquisition = createPackageAcquisition(acquisitionDependencies({
+    loadRuntimePack: async () => {
+      attempts++;
+      if (attempts === 1) throw new Error("runtime feed unavailable");
+      return JSON.stringify(
+        runtimeSurface("corelib", "System.Private.CoreLib", "System.Object"));
+    },
+    runtimePackage: () => resident,
+    retainPackage: packageModel => {
+      resident = packageModel;
+    },
+    beginRuntimeLoad: () => status.push("begin"),
+    failRuntimeLoad: error =>
+      status.push(error instanceof Error ? `fail:${error.message}` : "fail"),
+    endRuntimeLoad: () => status.push("end"),
+  }));
+
+  assert.equal(await acquisition.loadRuntimePack("net10.0"), null);
+  assert.ok(await acquisition.loadRuntimePack("net10.0"));
+  assert.equal(attempts, 2);
+  assert.deepEqual(status, [
+    "begin",
+    "fail:runtime feed unavailable",
+    "end",
+    "begin",
+    "end",
+  ]);
+});
+
+test("resident runtime packs short-circuit without entering loading state", async () => {
+  const resident = createRuntimePackageModel(
+    runtimeSurface("corelib", "System.Private.CoreLib", "System.Object"));
+  let engineCalls = 0;
+  let loadingTransitions = 0;
+  const acquisition = createPackageAcquisition(acquisitionDependencies({
+    loadRuntimePack: async () => {
+      engineCalls++;
+      return "";
+    },
+    runtimePackage: () => resident,
+    beginRuntimeLoad: () => loadingTransitions++,
+  }));
+
+  assert.equal(await acquisition.loadRuntimePack("NET10.0"), resident);
+  assert.equal(engineCalls, 0);
+  assert.equal(loadingTransitions, 0);
+});

--- a/prototypes/inspect-web/test/package-acquisition.test.ts
+++ b/prototypes/inspect-web/test/package-acquisition.test.ts
@@ -160,8 +160,13 @@ test("NuGet projection selects the declared assembly and preserves package total
 
 test("package acquisition publishes only current results", async () => {
   const events: string[] = [];
+  const replacedPackage = createNuGetPackageModel(packageSurface({
+    package: "Example.Old",
+    version: "1.0.0",
+  }));
   const acquisition = createPackageAcquisition(acquisitionDependencies({
-    retainPackage: packageModel => events.push(`retain:${packageModel.id}`),
+    retainPackage: (packageModel, replaced) =>
+      events.push(`retain:${packageModel.id}/${replaced?.id ?? "none"}`),
     recordRecentPackage: (id, version, framework) =>
       events.push(`recent:${id}@${version}/${framework}`),
     refreshPackageStats: () => events.push("stats"),
@@ -180,11 +185,12 @@ test("package acquisition publishes only current results", async () => {
     packageId: "Example.Package",
     version: "1.2.3",
     framework: "net10.0",
+    replacePackage: replacedPackage,
   });
   assert.equal(current?.id, "Example.Package");
   assert.deepEqual(events, [
     "stats",
-    "retain:Example.Package",
+    "retain:Example.Package/Example.Old",
     "recent:Example.Package@1.2.3/net10.0",
   ]);
 });
@@ -231,13 +237,17 @@ test("runtime acquisition serializes and merges full-pack and assembly requests"
 
   fullPack.resolve(JSON.stringify(
     runtimeSurface("corelib", "System.Private.CoreLib", "System.Object")));
-  const [packModel, mergedModel] = await Promise.all([
+  const [packResult, mergedResult] = await Promise.all([
     packRequest,
     assemblyRequest,
   ]);
+  const packModel = packResult.packageModel;
+  const mergedModel = mergedResult.packageModel;
 
   assert.ok(packModel);
   assert.ok(mergedModel);
+  assert.equal(packResult.error, null);
+  assert.equal(mergedResult.error, null);
   assert.equal(mergedModel, packModel);
   assert.equal(resident, packModel);
   assert.deepEqual(calls, [
@@ -285,8 +295,11 @@ test("queued runtime work rechecks cancellation before invoking the engine", asy
   fullPack.resolve(JSON.stringify(
     runtimeSurface("corelib", "System.Private.CoreLib", "System.Object")));
 
-  assert.ok(await packRequest);
-  assert.equal(await queuedRequest, null);
+  assert.ok((await packRequest).packageModel);
+  assert.deepEqual(await queuedRequest, {
+    packageModel: null,
+    error: null,
+  });
   assert.equal(assemblyCalls, 0);
 });
 
@@ -307,11 +320,14 @@ test("stale runtime results do not publish after the engine returns", async () =
   fullPack.resolve(JSON.stringify(
     runtimeSurface("corelib", "System.Private.CoreLib", "System.Object")));
 
-  assert.equal(await request, null);
+  assert.deepEqual(await request, {
+    packageModel: null,
+    error: null,
+  });
   assert.deepEqual(events, ["begin", "end"]);
 });
 
-test("runtime failures are reported and do not block a later retry", async () => {
+test("queued runtime retries preserve each request's failure", async () => {
   const status: string[] = [];
   let attempts = 0;
   let resident: AppPackage | null = null;
@@ -332,8 +348,18 @@ test("runtime failures are reported and do not block a later retry", async () =>
     endRuntimeLoad: () => status.push("end"),
   }));
 
-  assert.equal(await acquisition.loadRuntimePack("net10.0"), null);
-  assert.ok(await acquisition.loadRuntimePack("net10.0"));
+  const failedRequest = acquisition.loadRuntimePack("net10.0");
+  const retryRequest = acquisition.loadRuntimePack("net10.0");
+  const [failed, retried] = await Promise.all([
+    failedRequest,
+    retryRequest,
+  ]);
+  assert.equal(failed.packageModel, null);
+  assert.match(
+    failed.error instanceof Error ? failed.error.message : "",
+    /runtime feed unavailable/);
+  assert.ok(retried.packageModel);
+  assert.equal(retried.error, null);
   assert.equal(attempts, 2);
   assert.deepEqual(status, [
     "begin",
@@ -358,7 +384,10 @@ test("resident runtime packs short-circuit without entering loading state", asyn
     beginRuntimeLoad: () => loadingTransitions++,
   }));
 
-  assert.equal(await acquisition.loadRuntimePack("NET10.0"), resident);
+  assert.deepEqual(await acquisition.loadRuntimePack("NET10.0"), {
+    packageModel: resident,
+    error: null,
+  });
   assert.equal(engineCalls, 0);
   assert.equal(loadingTransitions, 0);
 });

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -225,6 +225,9 @@ test("workspace data bar receives package acquisition provenance", () => {
   assert.match(appSource, /packageAcquisition\.loadRuntimePack\(/);
   assert.match(appSource, /packageAcquisition\.loadRuntimePackAssembly\(/);
   assert.doesNotMatch(appSource, /runtimePackLoadPromise|waitForRuntimePackLoad/);
+  assert.match(
+    appSource,
+    /interface RuntimeLoadResult \{[\s\S]*failureMessage: string;[\s\S]*const result = await packageAcquisition\.loadRuntimePack\([\s\S]*failureMessage: result\.error === null \? "" : errorMessage\(result\.error\)/);
   assert.match(packageAcquisitionSource, /source: \{ kind: "nuget\.org" \}/);
   assert.match(packageAcquisitionSource, /source: \{ kind: "platform" \}/);
   assert.doesNotMatch(appSource, /source: \{ kind: "(?:nuget\.org|platform)" \}/);
@@ -471,7 +474,7 @@ test("member filters retain accessible controls and focus across rerenders", () 
     ?? "";
   assert.match(
     platformNavigation,
-    /const originSignature = memberRequestSignature\(type, overload, true\);[\s\S]*state\.memberSection === "call-graph"[\s\S]*memberRequestIsCurrent\(originSignature, true\)[\s\S]*loadRuntimePack\([\s\S]*ownsNavigation\)[\s\S]*if \(!ownsNavigation\(\)\) \{[\s\S]*state\.platformDrillLoading = false;[\s\S]*state\.platformDrillError = state\.runtimePackError[\s\S]*renderPreservingMemberFocus\(preservedFocus\)/);
+    /const originSignature = memberRequestSignature\(type, overload, true\);[\s\S]*state\.memberSection === "call-graph"[\s\S]*memberRequestIsCurrent\(originSignature, true\)[\s\S]*loadRuntimePack\([\s\S]*ownsNavigation\)[\s\S]*if \(!ownsNavigation\(\)\) \{[\s\S]*state\.platformDrillLoading = false;[\s\S]*state\.platformDrillError = runtimeResult\.failureMessage[\s\S]*state\.runtimePackError[\s\S]*renderPreservingMemberFocus\(preservedFocus\)/);
   assert.match(
     appSource,
     /function applyMemberSection\(id: MemberSection\) \{[\s\S]*state\.memberSection === "call-graph" && id !== "call-graph"[\s\S]*invalidateMemberCallGraphWork\(state\)/);
@@ -604,7 +607,7 @@ test("lens-scoped Platform library changes reset type-specific member state", ()
     ?? "";
   assert.match(
     picker,
-    /const openLibrary = async \([\s\S]*originPackage: AppPackage = currentPackage\(\),[\s\S]*noticeRetryState: NoticeRetryState \| null = null[\s\S]*if \(!state\.packages\.includes\(originPackage\)[\s\S]*!packageIdentityEquals\(state\.package, originPackage\)[\s\S]*state\.queryNoticeRetryAction === noticeRetryState\.action[\s\S]*state\.queryNotice = removeAppendedNotice\([\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*const loaded = await loadRuntimePackAssembly\([\s\S]*\(\) => state\.packages\.includes\(originPackage\)\);[\s\S]*previous: state\.queryNotice[\s\S]*const retryAction = \(\) =>\s*openLibrary\(name, pack, originPackage, noticeState\);[\s\S]*noticeState\.appended = state\.queryNotice;[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*state\.libraryScope = new Set\(\[key\]\);[\s\S]*normalizeLibrarySelection\(\);[\s\S]*loader\(\)/);
+    /const openLibrary = async \([\s\S]*originPackage: AppPackage = currentPackage\(\),[\s\S]*noticeRetryState: NoticeRetryState \| null = null[\s\S]*if \(!state\.packages\.includes\(originPackage\)[\s\S]*!packageIdentityEquals\(state\.package, originPackage\)[\s\S]*state\.queryNoticeRetryAction === noticeRetryState\.action[\s\S]*state\.queryNotice = removeAppendedNotice\([\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*const runtimeResult = await loadRuntimePackAssembly\([\s\S]*\(\) => state\.packages\.includes\(originPackage\)\);[\s\S]*const loaded = runtimeResult\.packageModel;[\s\S]*previous: state\.queryNotice[\s\S]*const retryAction = \(\) =>\s*openLibrary\(name, pack, originPackage, noticeState\);[\s\S]*runtimeResult\.failureMessage[\s\S]*noticeState\.appended = state\.queryNotice;[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*state\.libraryScope = new Set\(\[key\]\);[\s\S]*normalizeLibrarySelection\(\);[\s\S]*loader\(\)/);
   assert.doesNotMatch(picker, /select\.isConnected/);
   assert.match(
     appSource,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -162,6 +162,9 @@ const appSource = readFileSync(new URL("../src/dotnet-inspect.ts", import.meta.u
 const workspaceNavigationSource = readFileSync(
   new URL("../src/workspace-navigation.ts", import.meta.url),
   "utf8");
+const packageAcquisitionSource = readFileSync(
+  new URL("../src/package-acquisition.ts", import.meta.url),
+  "utf8");
 const memberFocusSource = readFileSync(
   new URL("../src/member-focus.ts", import.meta.url),
   "utf8");
@@ -215,8 +218,16 @@ test("typed Spotlight owns search presentation and hosts commands", () => {
 
 test("workspace data bar receives package acquisition provenance", () => {
   assert.match(appSource, /source: pkg\.source/);
-  assert.match(appSource, /source: \{ kind: "nuget\.org" \}/);
-  assert.match(appSource, /source: \{ kind: "platform" \}/);
+  assert.match(
+    appSource,
+    /createPackageAcquisition\(\{[\s\S]*queryPackage:[\s\S]*loadRuntimePack:[\s\S]*loadRuntimePackAssembly:/);
+  assert.match(appSource, /packageAcquisition\.loadPackage\(\{/);
+  assert.match(appSource, /packageAcquisition\.loadRuntimePack\(/);
+  assert.match(appSource, /packageAcquisition\.loadRuntimePackAssembly\(/);
+  assert.doesNotMatch(appSource, /runtimePackLoadPromise|waitForRuntimePackLoad/);
+  assert.match(packageAcquisitionSource, /source: \{ kind: "nuget\.org" \}/);
+  assert.match(packageAcquisitionSource, /source: \{ kind: "platform" \}/);
+  assert.doesNotMatch(appSource, /source: \{ kind: "(?:nuget\.org|platform)" \}/);
   assert.match(statusBarSource, /Source: \$\{escapeHtml\(packageSourceLabel\(model\.source\)\)\}/);
 });
 


### PR DESCRIPTION
Closes the package/runtime acquisition slice of #4504 by moving model projection, engine invocation, stale publication guards, and serialized runtime-pack coordination out of the browser composition root. `dotnet-inspect.ts` keeps mutable UI state, activation, restoration, notices, retries, and rendering, while the new typed owner publishes only current results and preserves resident runtime-pack merging/reuse.

**Stack**

- Slice 2, stacked on #4508.
- Parent: #4508 (workspace navigation and URL state).
- Residual: async source/metadata/graph request controllers, then DOM event binding paired with presentation owners.

**Validation**

- `npm test` — 272/272, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.