### PR TITLE
Extract inspect-web package inspection coordination

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -549,6 +549,16 @@ preservation, retry after failure, and resident-pack reuse;
 `test/spotlight-identity.test.js` gates provenance, failure adaptation, and
 composition-root wiring.
 
+`src/package-inspection.ts` owns the async request lifecycle for Dependencies,
+Integrations, Opportunities, Analysis, and package-level Metadata, including
+workspace dependency-cache population and stale-result suppression.
+`dotnet-inspect.ts` supplies the typed state, engine, platform-routing,
+diagnostics, and rendering ports while retaining lens selection and
+presentation. `test/package-inspection.test.ts` gates complete cache identity,
+resident-package checks, visible partial/failure results, package/platform
+routing, stale publication, and explicit Platform library scope;
+`test/spotlight-identity.test.js` gates the composition-root wiring.
+
 `src/spotlight.ts` owns the modal workbench search, embedded home search,
 scope/result rendering, selection, and keyboard interaction.
 `src/command-bar.ts` supplies its typed Commands-scope grammar and results;
@@ -621,16 +631,18 @@ assembly — format stamp, heap sizes, ECMA-335 table row counts, and PE/CLI
 headers) and the Metadata Explorer (the spatial table/heap drill-down laid over
 it) as pure, dependency-injected render functions; both describe the metadata
 image rather than the API surface within it, so they share one module the way
-`type-panel.ts` combines the type selector and the type viewer. `dotnet-inspect.ts` still
-owns `state`, the engine calls that fetch an image, a table row window, or a
-heap listing, the explorer's focus/history stack, the DOM event binding, the
-`IntersectionObserver` that hydrates cards lazily, the resize listener, and the
-global keydown handler, and passes each computed slice in explicitly; the shared
-helpers used well beyond these views (`escapeHtml`, `fmtBytes`,
-`platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`) stay in
-`dotnet-inspect.ts` and are injected the same way. `test/metadata-viewer.test.ts` gates the
-lens's picker, loading, failure, stale-scope, partial-read, and empty-image
-states and its heap/table ordering; the explorer's chips, history-button
+`type-panel.ts` combines the type selector and the type viewer.
+`package-inspection.ts` coordinates the package-level image request;
+`dotnet-inspect.ts` still owns `state`, table-window and heap-listing engine
+calls, the explorer's focus/history stack, the DOM event binding, the
+`IntersectionObserver` that hydrates cards lazily, the resize listener, and
+the global keydown handler, and passes each computed slice in explicitly; the
+shared helpers used well beyond these views (`escapeHtml`, `fmtBytes`,
+`platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`) stay
+in `dotnet-inspect.ts` and are injected the same way.
+`test/metadata-viewer.test.ts` gates the lens's picker, loading, failure,
+stale-scope, partial-read, and empty-image states and its heap/table ordering;
+the explorer's chips, history-button
 enablement, overview versus focus lightbox, lazy-load hooks, pager bounds, row
 highlight and selection, ref->def jump targets, cell escaping, heap addressing
 and coverage notes, and the row inspector.
@@ -669,13 +681,14 @@ opportunities" lens (the ecosystem auth/cloud/config/database/AI-client
 integration suggestions for a package or platform library) as a pure,
 dependency-injected render function, including its opportunity-row API-name
 splitting, package-chip detection, and "look for" chip rendering. `dotnet-inspect.ts`
-still owns `state`, the scan-scope-keyed async load lifecycle
-(`loadPackageOpportunities`), and the platform library picker, and passes
-each computed slice in explicitly. `test/package-opportunities.test.ts` gates
-the platform pick-a-library prompt, the scanning/loading/error states (fresh
-versus stale scope), the no-opportunities and inspection-error banners, the
-category summary counts, API name splitting, package-chip versus plain-text
-kind rendering, look-for chip/wildcard/empty rendering, and text escaping.
+still owns `state` and the platform library picker, `package-inspection.ts`
+owns the scan-scope-keyed async load lifecycle, and the root passes each
+computed slice into the renderer explicitly.
+`test/package-opportunities.test.ts` gates the platform pick-a-library prompt,
+the scanning/loading/error states (fresh versus stale scope), the
+no-opportunities and inspection-error banners, the category summary counts,
+API name splitting, package-chip versus plain-text kind rendering, look-for
+chip/wildcard/empty rendering, and text escaping.
 
 - `Cmd/Ctrl+K` opens Spotlight in the Commands scope.
 - `Cmd/Ctrl+P` opens Spotlight in the All scope.

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -71,6 +71,11 @@ import {
   type AppPackage,
 } from "./package-acquisition.ts";
 import {
+  createPackageInspectionCoordinator,
+  workspaceDependencyKey,
+  type PackagePerformance,
+} from "./package-inspection.ts";
+import {
   captureMemberFocus,
   createMemberFocusRestorer,
   type MemberFocusSnapshot,
@@ -383,24 +388,6 @@ interface RecentPackage {
   id: string;
   version: string;
   framework: string;
-}
-
-interface PackagePerformanceMember {
-  assembly: string;
-  typeId: string;
-  memberName: string;
-  metadataToken: number;
-  opportunityCount: number;
-  inLoopCount: number;
-  shapes: string[];
-  confidence: string;
-}
-
-interface PackagePerformance {
-  members: PackagePerformanceMember[];
-  inspectionError?: string;
-  nonPublicOpportunities: number;
-  totalOpportunities: number;
 }
 
 interface MemberFactRow {
@@ -2257,61 +2244,68 @@ function resolveDependenciesGroupIndex(
   return active?.index ?? groups[0]?.index ?? null;
 }
 
-async function loadPackageDependencies() {
-  const pkg = currentPackage();
-  const signature = packageDependenciesSignature();
-  if (state.packageDependenciesKey === signature && (state.packageDependencies || state.packageDependenciesError)) {
-    render();
-    return;
-  }
-  state.packageDependenciesKey = signature;
-  state.packageDependencies = null;
-  state.packageDependenciesError = "";
-  state.packageDependenciesLoading = true;
-  render();
-  const packageRequest = {
-    id: pkg.id,
-    version: pkg.version,
-    activeFramework: pkg.activeFramework,
-    assemblyId: pkg.assemblyId
-  };
-  const workspaceKey = workspaceDependencyKey(packageRequest);
-  try {
-    const result = await inspectPackageDependencies(
-      packageRequest.id,
-      packageRequest.version,
-      packageRequest.activeFramework,
-      packageRequest.assemblyId);
-    if (state.packageDependenciesKey === signature) state.packageDependencies = result;
-    if (result?.dependencyGroups
-      && state.packages.some(pkg => packageIdentityEquals(pkg, packageRequest))) {
-      state.workspaceDependencies[workspaceKey] = {
-        dependencyGroups: result.dependencyGroups,
-        dependencyGroupError: result.dependencyGroupError || ""
-      };
-      if (result.dependencyGroupError) {
-        state.workspaceDependencyErrors[workspaceKey] = result.dependencyGroupError;
-      } else {
-        delete state.workspaceDependencyErrors[workspaceKey];
-      }
-    }
-  } catch (error) {
-    if (state.packageDependenciesKey === signature)
-      state.packageDependenciesError = errorMessage(error);
-  } finally {
-    if (state.packageDependenciesKey === signature) state.packageDependenciesLoading = false;
-    refreshPackageStats();
-    render();
-    ensureWorkspaceDependencies();
-  }
-}
+const packageInspection = createPackageInspectionCoordinator({
+  state,
+  queryDependencies: packageModel => inspectPackageDependencies(
+    packageModel.id,
+    packageModel.version,
+    packageModel.activeFramework,
+    packageModel.assemblyId),
+  queryPackageIntegrations: packageModel => inspectPackageIntegrations(
+    packageModel.id,
+    packageModel.version,
+    packageModel.activeFramework),
+  queryPlatformIntegrations: async (framework, assemblyFileName, pack) =>
+    parseEngineJson<BrowserPackageIntegrations>(
+      await inspectPlatformIntegrations(
+        framework,
+        assemblyFileName,
+        pack)),
+  queryPackageOpportunities: packageModel => inspectPackageOpportunities(
+    packageModel.id,
+    packageModel.version,
+    packageModel.activeFramework),
+  queryPlatformOpportunities: async (framework, assemblyFileName, pack) =>
+    parseEngineJson<BrowserPackageOpportunities>(
+      await inspectPlatformOpportunities(
+        framework,
+        assemblyFileName,
+        pack)),
+  queryPackagePerformance: async packageModel =>
+    parseEngineJson<PackagePerformance>(
+      await inspectPackagePerformance(
+        packageModel.id,
+        packageModel.version,
+        packageModel.activeFramework)),
+  queryPlatformPerformance: async (framework, assemblyFileName, pack) =>
+    parseEngineJson<PackagePerformance>(
+      await inspectPlatformPerformance(
+        framework,
+        assemblyFileName,
+        pack)),
+  queryPackageMetadata: async packageModel =>
+    parseEngineJson<PackageMetadata>(
+      await inspectPackageMetadata(
+        packageModel.id,
+        packageModel.version,
+        packageModel.activeFramework)),
+  queryPlatformMetadata: async (framework, assemblyFileName, pack) =>
+    parseEngineJson<PackageMetadata>(
+      await inspectPlatformMetadata(
+        framework,
+        assemblyFileName,
+        pack)),
+  platformPackForAssembly,
+  describeError: errorMessage,
+  refreshPackageStats,
+  render,
+  renderDependencyGraph,
+});
 
-function workspaceDependencyKey(pkg: PackageIdentity) {
-  return [
-    pkg.id.toLowerCase(),
-    pkg.version.toLowerCase(),
-    pkg.activeFramework.toLowerCase()
-  ].join("@");
+async function loadPackageDependencies() {
+  return packageInspection.loadDependencies(
+    currentPackage(),
+    packageDependenciesSignature());
 }
 
 function maybeAutoLoadPackageDependencies() {
@@ -2329,50 +2323,7 @@ function maybeAutoLoadPackageDependencies() {
 // Fetches dependency manifests for every other open package so the dependency graph can
 // draw incoming "caller" edges (open packages that declare a dependency on the current one).
 async function ensureWorkspaceDependencies() {
-  const missing = state.packages.filter(item =>
-    !item.isRuntimePack
-    && !Object.hasOwn(
-      state.workspaceDependencies,
-      workspaceDependencyKey(item))
-    && !state.workspaceDependencyLoads.has(workspaceDependencyKey(item)));
-  if (!missing.length) {
-    renderDependencyGraph();
-    return;
-  }
-  for (const item of missing) {
-    const key = workspaceDependencyKey(item);
-    if (!state.packages.some(pkg => packageIdentityEquals(pkg, item))) continue;
-    state.workspaceDependencyLoads.add(key);
-    try {
-      const result = await inspectPackageDependencies(
-        item.id,
-        item.version,
-        item.activeFramework,
-        item.assemblyId);
-      if (!state.packages.some(pkg => packageIdentityEquals(pkg, item))) continue;
-      state.workspaceDependencies[key] = {
-        dependencyGroups: result?.dependencyGroups || [],
-        dependencyGroupError: result?.dependencyGroupError || ""
-      };
-      if (result?.dependencyGroupError) {
-        state.workspaceDependencyErrors[key] = result.dependencyGroupError;
-      } else {
-        delete state.workspaceDependencyErrors[key];
-      }
-    } catch (error) {
-      if (!state.packages.some(pkg => packageIdentityEquals(pkg, item))) continue;
-      state.workspaceDependencies[key] = {
-        dependencyGroups: [],
-        dependencyGroupError: ""
-      };
-      state.workspaceDependencyErrors[key] = errorMessage(error);
-    } finally {
-      state.workspaceDependencyLoads.delete(key);
-    }
-  }
-
-  if (state.atPackageRoot && state.packageLens === "dependencies") render();
-  refreshPackageStats();
+  return packageInspection.ensureWorkspaceDependencies();
 }
 
 function workspaceDependencyErrorHtml() {
@@ -2469,40 +2420,11 @@ function renderPackageIntegrations() {
 
 async function loadPackageIntegrations() {
   const pkg = currentPackage();
-  const isPlatform = pkg.isRuntimePack;
   const scopedLib = scopedPlatformLibrary();
-  // The Platform lens needs a chosen library to scan; without one the render prompts for a
-  // selection, so there is nothing to fetch yet.
-  if (isPlatform && !scopedLib) return;
-  const signature = packageIntegrationsSignature();
-  if (state.packageIntegrationsKey === signature && (state.packageIntegrations || state.packageIntegrationsError)) {
-    render();
-    return;
-  }
-  state.packageIntegrationsKey = signature;
-  state.packageIntegrations = null;
-  state.packageIntegrationsError = "";
-  state.packageIntegrationsLoading = true;
-  render();
-  try {
-    const result = isPlatform
-      ? parseEngineJson<BrowserPackageIntegrations>(
-          await inspectPlatformIntegrations(
-            pkg.activeFramework,
-            `${scopedLib}.dll`,
-            platformPackForAssembly(scopedLib ?? "")))
-      : await inspectPackageIntegrations(
-          pkg.id,
-          pkg.version,
-          pkg.activeFramework);
-    if (state.packageIntegrationsKey === signature) state.packageIntegrations = result;
-  } catch (error) {
-    if (state.packageIntegrationsKey === signature)
-      state.packageIntegrationsError = errorMessage(error);
-  } finally {
-    if (state.packageIntegrationsKey === signature) state.packageIntegrationsLoading = false;
-    render();
-  }
+  return packageInspection.loadIntegrations(
+    pkg,
+    packageIntegrationsSignature(),
+    scopedLib);
 }
 
 function maybeAutoLoadPackageIntegrations() {
@@ -2546,38 +2468,11 @@ function renderPackageOpportunities() {
 
 async function loadPackageOpportunities() {
   const pkg = currentPackage();
-  const isPlatform = pkg.isRuntimePack;
   const scopedLib = scopedPlatformLibrary();
-  if (isPlatform && !scopedLib) return;
-  const signature = packageScopeSignature();
-  if (state.packageOpportunitiesKey === signature && (state.packageOpportunities || state.packageOpportunitiesError)) {
-    render();
-    return;
-  }
-  state.packageOpportunitiesKey = signature;
-  state.packageOpportunities = null;
-  state.packageOpportunitiesError = "";
-  state.packageOpportunitiesLoading = true;
-  render();
-  try {
-    const result = isPlatform
-      ? parseEngineJson<BrowserPackageOpportunities>(
-          await inspectPlatformOpportunities(
-            pkg.activeFramework,
-            `${scopedLib}.dll`,
-            platformPackForAssembly(scopedLib ?? "")))
-      : await inspectPackageOpportunities(
-          pkg.id,
-          pkg.version,
-          pkg.activeFramework);
-    if (state.packageOpportunitiesKey === signature) state.packageOpportunities = result;
-  } catch (error) {
-    if (state.packageOpportunitiesKey === signature)
-      state.packageOpportunitiesError = errorMessage(error);
-  } finally {
-    if (state.packageOpportunitiesKey === signature) state.packageOpportunitiesLoading = false;
-    render();
-  }
+  return packageInspection.loadOpportunities(
+    pkg,
+    packageScopeSignature(),
+    scopedLib);
 }
 
 function maybeAutoLoadPackageOpportunities() {
@@ -2646,38 +2541,11 @@ function renderPackagePerformance() {
 
 async function loadPackagePerformance() {
   const pkg = currentPackage();
-  const isPlatform = pkg.isRuntimePack;
   const scopedLib = scopedPlatformLibrary();
-  if (isPlatform && !scopedLib) return;
-  const signature = packageScopeSignature();
-  if (state.packagePerformanceKey === signature && (state.packagePerformance || state.packagePerformanceError)) {
-    render();
-    return;
-  }
-  state.packagePerformanceKey = signature;
-  state.packagePerformance = null;
-  state.packagePerformanceError = "";
-  state.packagePerformanceLoading = true;
-  render();
-  try {
-    const result = parseEngineJson<PackagePerformance>(
-      isPlatform
-        ? await inspectPlatformPerformance(
-            pkg.activeFramework,
-            `${scopedLib}.dll`,
-            platformPackForAssembly(scopedLib ?? ""))
-        : await inspectPackagePerformance(
-            pkg.id,
-            pkg.version,
-            pkg.activeFramework));
-    if (state.packagePerformanceKey === signature) state.packagePerformance = result;
-  } catch (error) {
-    if (state.packagePerformanceKey === signature)
-      state.packagePerformanceError = errorMessage(error);
-  } finally {
-    if (state.packagePerformanceKey === signature) state.packagePerformanceLoading = false;
-    render();
-  }
+  return packageInspection.loadPerformance(
+    pkg,
+    packageScopeSignature(),
+    scopedLib);
 }
 
 function maybeAutoLoadPackagePerformance() {
@@ -2711,38 +2579,11 @@ function renderPackageMetadata() {
 
 async function loadPackageMetadata() {
   const pkg = currentPackage();
-  const isPlatform = pkg.isRuntimePack;
   const scopedLib = scopedPlatformLibrary();
-  if (isPlatform && !scopedLib) return;
-  const signature = packageScopeSignature();
-  if (state.packageMetadataKey === signature && (state.packageMetadata || state.packageMetadataError)) {
-    render();
-    return;
-  }
-  state.packageMetadataKey = signature;
-  state.packageMetadata = null;
-  state.packageMetadataError = "";
-  state.packageMetadataLoading = true;
-  render();
-  try {
-    const result = parseEngineJson<PackageMetadata>(
-      isPlatform
-        ? await inspectPlatformMetadata(
-            pkg.activeFramework,
-            `${scopedLib}.dll`,
-            platformPackForAssembly(scopedLib ?? ""))
-        : await inspectPackageMetadata(
-            pkg.id,
-            pkg.version,
-            pkg.activeFramework));
-    if (state.packageMetadataKey === signature) state.packageMetadata = result;
-  } catch (error) {
-    if (state.packageMetadataKey === signature)
-      state.packageMetadataError = errorMessage(error);
-  } finally {
-    if (state.packageMetadataKey === signature) state.packageMetadataLoading = false;
-    render();
-  }
+  return packageInspection.loadMetadata(
+    pkg,
+    packageScopeSignature(),
+    scopedLib);
 }
 
 function maybeAutoLoadPackageMetadata() {

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -5,14 +5,15 @@
 // the metadata image rather than the API surface within it — so they live in one module, the
 // way `type-panel.ts` combines the type selector and the type viewer.
 //
-// `dotnet-inspect.ts` keeps everything that is not markup: `state`, the engine calls that fetch a
-// metadata image, a table row window, or a heap listing (`loadPackageMetadata`,
-// `loadExplorerWindow`, `loadExplorerHeap`), the explorer's focus/history stack
-// (`openExplorer`, `pushExplorerFocus`, `applyExplorerFocus`, `explorerHistoryBack/Forward`,
-// `explorerShowOverview`, `closeExplorer`), the DOM event binding, the `IntersectionObserver`
-// that hydrates cards lazily, the resize listener, and the global keydown handler. This
-// module owns only the markup shape given an explicit snapshot of that state, matching how
-// `type-panel.ts` left comparably rich navigation state in `dotnet-inspect.ts`.
+// `package-inspection.ts` coordinates the package-level metadata request.
+// `dotnet-inspect.ts` keeps `state`, the table-window and heap-listing engine calls
+// (`loadExplorerWindow`, `loadExplorerHeap`), the explorer's focus/history stack
+// (`openExplorer`, `pushExplorerFocus`, `applyExplorerFocus`,
+// `explorerHistoryBack/Forward`, `explorerShowOverview`, `closeExplorer`), the DOM event
+// binding, the `IntersectionObserver` that hydrates cards lazily, the resize listener, and
+// the global keydown handler. This module owns only the markup shape given an explicit
+// snapshot of that state, matching how `type-panel.ts` left comparably rich navigation
+// state in `dotnet-inspect.ts`.
 //
 // The shared text helpers used well beyond these views (`escapeHtml`, `fmtBytes`) and the
 // shared lens chrome (`platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`,

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -1,0 +1,410 @@
+import {
+  packageIdentityKey,
+  type DependencyGroupData,
+  type PackageIdentity,
+} from "./data.ts";
+import type {
+  BrowserPackageDependencies,
+  BrowserPackageIntegrations,
+  BrowserPackageOpportunities,
+} from "./inspect-web-engine.d.ts";
+import type { PackageMetadata } from "./metadata-viewer.ts";
+import type { AppPackage } from "./package-acquisition.ts";
+
+export interface PackagePerformanceMember {
+  assembly: string;
+  typeId: string;
+  memberName: string;
+  metadataToken: number;
+  opportunityCount: number;
+  inLoopCount: number;
+  shapes: string[];
+  confidence: string;
+}
+
+export interface PackagePerformance {
+  members: PackagePerformanceMember[];
+  inspectionError?: string;
+  nonPublicOpportunities: number;
+  totalOpportunities: number;
+}
+
+export interface PackageInspectionState {
+  packages: AppPackage[];
+  atPackageRoot: boolean;
+  packageLens: string;
+  packageDependencies: BrowserPackageDependencies | null;
+  packageDependenciesLoading: boolean;
+  packageDependenciesError: string;
+  packageDependenciesKey: string;
+  workspaceDependencies: Record<string, DependencyGroupData>;
+  workspaceDependencyErrors: Record<string, string>;
+  workspaceDependencyLoads: Set<string>;
+  packageIntegrations: BrowserPackageIntegrations | null;
+  packageIntegrationsLoading: boolean;
+  packageIntegrationsError: string;
+  packageIntegrationsKey: string;
+  packageOpportunities: BrowserPackageOpportunities | null;
+  packageOpportunitiesLoading: boolean;
+  packageOpportunitiesError: string;
+  packageOpportunitiesKey: string;
+  packagePerformance: PackagePerformance | null;
+  packagePerformanceLoading: boolean;
+  packagePerformanceError: string;
+  packagePerformanceKey: string;
+  packageMetadata: PackageMetadata | null;
+  packageMetadataLoading: boolean;
+  packageMetadataError: string;
+  packageMetadataKey: string;
+}
+
+export interface PackageInspectionDependencies {
+  state: PackageInspectionState;
+  queryDependencies(
+    packageModel: PackageIdentity & { assemblyId: string },
+  ): Promise<BrowserPackageDependencies>;
+  queryPackageIntegrations(
+    packageModel: AppPackage,
+  ): Promise<BrowserPackageIntegrations>;
+  queryPlatformIntegrations(
+    framework: string,
+    assemblyFileName: string,
+    pack: string,
+  ): Promise<BrowserPackageIntegrations>;
+  queryPackageOpportunities(
+    packageModel: AppPackage,
+  ): Promise<BrowserPackageOpportunities>;
+  queryPlatformOpportunities(
+    framework: string,
+    assemblyFileName: string,
+    pack: string,
+  ): Promise<BrowserPackageOpportunities>;
+  queryPackagePerformance(
+    packageModel: AppPackage,
+  ): Promise<PackagePerformance>;
+  queryPlatformPerformance(
+    framework: string,
+    assemblyFileName: string,
+    pack: string,
+  ): Promise<PackagePerformance>;
+  queryPackageMetadata(packageModel: AppPackage): Promise<PackageMetadata>;
+  queryPlatformMetadata(
+    framework: string,
+    assemblyFileName: string,
+    pack: string,
+  ): Promise<PackageMetadata>;
+  platformPackForAssembly(assemblyName: string): string;
+  describeError(error: unknown): string;
+  refreshPackageStats(): void;
+  render(): void;
+  renderDependencyGraph(): void;
+}
+
+export interface PackageInspectionCoordinator {
+  loadDependencies(
+    packageModel: AppPackage,
+    signature: string,
+  ): Promise<void>;
+  ensureWorkspaceDependencies(): Promise<void>;
+  loadIntegrations(
+    packageModel: AppPackage,
+    signature: string,
+    scopedLibrary: string | null,
+  ): Promise<void>;
+  loadOpportunities(
+    packageModel: AppPackage,
+    signature: string,
+    scopedLibrary: string | null,
+  ): Promise<void>;
+  loadPerformance(
+    packageModel: AppPackage,
+    signature: string,
+    scopedLibrary: string | null,
+  ): Promise<void>;
+  loadMetadata(
+    packageModel: AppPackage,
+    signature: string,
+    scopedLibrary: string | null,
+  ): Promise<void>;
+}
+
+export function workspaceDependencyKey(packageModel: PackageIdentity): string {
+  return [
+    packageModel.id.toLowerCase(),
+    packageModel.version.toLowerCase(),
+    packageModel.activeFramework.toLowerCase(),
+  ].join("@");
+}
+
+function packageIsResident(
+  packages: readonly AppPackage[],
+  packageModel: PackageIdentity,
+): boolean {
+  const key = packageIdentityKey(packageModel);
+  return packages.some(candidate => packageIdentityKey(candidate) === key);
+}
+
+export function createPackageInspectionCoordinator(
+  dependencies: PackageInspectionDependencies,
+): PackageInspectionCoordinator {
+  const { state } = dependencies;
+
+  const platformCoordinates = (
+    packageModel: AppPackage,
+    scopedLibrary: string,
+  ) => ({
+    framework: packageModel.activeFramework,
+    assemblyFileName: `${scopedLibrary}.dll`,
+    pack: dependencies.platformPackForAssembly(scopedLibrary),
+  });
+
+  const ensureWorkspaceDependencies = async () => {
+    const missing = state.packages.filter(packageModel =>
+      !packageModel.isRuntimePack
+      && !Object.hasOwn(
+        state.workspaceDependencies,
+        workspaceDependencyKey(packageModel))
+      && !state.workspaceDependencyLoads.has(
+        workspaceDependencyKey(packageModel)));
+    if (!missing.length) {
+      dependencies.renderDependencyGraph();
+      return;
+    }
+    for (const packageModel of missing) {
+      const key = workspaceDependencyKey(packageModel);
+      if (!packageIsResident(state.packages, packageModel)) continue;
+      state.workspaceDependencyLoads.add(key);
+      try {
+        const result = await dependencies.queryDependencies(packageModel);
+        if (!packageIsResident(state.packages, packageModel)) continue;
+        state.workspaceDependencies[key] = {
+          dependencyGroups: result?.dependencyGroups || [],
+          dependencyGroupError: result?.dependencyGroupError || "",
+        };
+        if (result?.dependencyGroupError) {
+          state.workspaceDependencyErrors[key] =
+            result.dependencyGroupError;
+        } else {
+          delete state.workspaceDependencyErrors[key];
+        }
+      } catch (error) {
+        if (!packageIsResident(state.packages, packageModel)) continue;
+        state.workspaceDependencies[key] = {
+          dependencyGroups: [],
+          dependencyGroupError: "",
+        };
+        state.workspaceDependencyErrors[key] =
+          dependencies.describeError(error);
+      } finally {
+        state.workspaceDependencyLoads.delete(key);
+      }
+    }
+
+    if (state.atPackageRoot && state.packageLens === "dependencies") {
+      dependencies.render();
+    }
+    dependencies.refreshPackageStats();
+  };
+
+  return {
+    async loadDependencies(packageModel, signature) {
+      if (state.packageDependenciesKey === signature
+        && (state.packageDependencies || state.packageDependenciesError)) {
+        dependencies.render();
+        return;
+      }
+      state.packageDependenciesKey = signature;
+      state.packageDependencies = null;
+      state.packageDependenciesError = "";
+      state.packageDependenciesLoading = true;
+      dependencies.render();
+      const packageRequest = {
+        id: packageModel.id,
+        version: packageModel.version,
+        activeFramework: packageModel.activeFramework,
+        assemblyId: packageModel.assemblyId,
+      };
+      const workspaceKey = workspaceDependencyKey(packageRequest);
+      try {
+        const result = await dependencies.queryDependencies(packageRequest);
+        if (state.packageDependenciesKey === signature) {
+          state.packageDependencies = result;
+        }
+        if (result?.dependencyGroups
+          && packageIsResident(state.packages, packageRequest)) {
+          state.workspaceDependencies[workspaceKey] = {
+            dependencyGroups: result.dependencyGroups,
+            dependencyGroupError: result.dependencyGroupError || "",
+          };
+          if (result.dependencyGroupError) {
+            state.workspaceDependencyErrors[workspaceKey] =
+              result.dependencyGroupError;
+          } else {
+            delete state.workspaceDependencyErrors[workspaceKey];
+          }
+        }
+      } catch (error) {
+        if (state.packageDependenciesKey === signature) {
+          state.packageDependenciesError = dependencies.describeError(error);
+        }
+      } finally {
+        if (state.packageDependenciesKey === signature) {
+          state.packageDependenciesLoading = false;
+        }
+        dependencies.refreshPackageStats();
+        dependencies.render();
+        void ensureWorkspaceDependencies();
+      }
+    },
+
+    ensureWorkspaceDependencies,
+
+    async loadIntegrations(packageModel, signature, scopedLibrary) {
+      if (packageModel.isRuntimePack && !scopedLibrary) return;
+      if (state.packageIntegrationsKey === signature
+        && (state.packageIntegrations || state.packageIntegrationsError)) {
+        dependencies.render();
+        return;
+      }
+      state.packageIntegrationsKey = signature;
+      state.packageIntegrations = null;
+      state.packageIntegrationsError = "";
+      state.packageIntegrationsLoading = true;
+      dependencies.render();
+      try {
+        const coordinates = packageModel.isRuntimePack
+          ? platformCoordinates(packageModel, scopedLibrary ?? "")
+          : null;
+        const result = coordinates
+          ? await dependencies.queryPlatformIntegrations(
+              coordinates.framework,
+              coordinates.assemblyFileName,
+              coordinates.pack)
+          : await dependencies.queryPackageIntegrations(packageModel);
+        if (state.packageIntegrationsKey === signature) {
+          state.packageIntegrations = result;
+        }
+      } catch (error) {
+        if (state.packageIntegrationsKey === signature) {
+          state.packageIntegrationsError = dependencies.describeError(error);
+        }
+      } finally {
+        if (state.packageIntegrationsKey === signature) {
+          state.packageIntegrationsLoading = false;
+        }
+        dependencies.render();
+      }
+    },
+
+    async loadOpportunities(packageModel, signature, scopedLibrary) {
+      if (packageModel.isRuntimePack && !scopedLibrary) return;
+      if (state.packageOpportunitiesKey === signature
+        && (state.packageOpportunities || state.packageOpportunitiesError)) {
+        dependencies.render();
+        return;
+      }
+      state.packageOpportunitiesKey = signature;
+      state.packageOpportunities = null;
+      state.packageOpportunitiesError = "";
+      state.packageOpportunitiesLoading = true;
+      dependencies.render();
+      try {
+        const coordinates = packageModel.isRuntimePack
+          ? platformCoordinates(packageModel, scopedLibrary ?? "")
+          : null;
+        const result = coordinates
+          ? await dependencies.queryPlatformOpportunities(
+              coordinates.framework,
+              coordinates.assemblyFileName,
+              coordinates.pack)
+          : await dependencies.queryPackageOpportunities(packageModel);
+        if (state.packageOpportunitiesKey === signature) {
+          state.packageOpportunities = result;
+        }
+      } catch (error) {
+        if (state.packageOpportunitiesKey === signature) {
+          state.packageOpportunitiesError = dependencies.describeError(error);
+        }
+      } finally {
+        if (state.packageOpportunitiesKey === signature) {
+          state.packageOpportunitiesLoading = false;
+        }
+        dependencies.render();
+      }
+    },
+
+    async loadPerformance(packageModel, signature, scopedLibrary) {
+      if (packageModel.isRuntimePack && !scopedLibrary) return;
+      if (state.packagePerformanceKey === signature
+        && (state.packagePerformance || state.packagePerformanceError)) {
+        dependencies.render();
+        return;
+      }
+      state.packagePerformanceKey = signature;
+      state.packagePerformance = null;
+      state.packagePerformanceError = "";
+      state.packagePerformanceLoading = true;
+      dependencies.render();
+      try {
+        const coordinates = packageModel.isRuntimePack
+          ? platformCoordinates(packageModel, scopedLibrary ?? "")
+          : null;
+        const result = coordinates
+          ? await dependencies.queryPlatformPerformance(
+              coordinates.framework,
+              coordinates.assemblyFileName,
+              coordinates.pack)
+          : await dependencies.queryPackagePerformance(packageModel);
+        if (state.packagePerformanceKey === signature) {
+          state.packagePerformance = result;
+        }
+      } catch (error) {
+        if (state.packagePerformanceKey === signature) {
+          state.packagePerformanceError = dependencies.describeError(error);
+        }
+      } finally {
+        if (state.packagePerformanceKey === signature) {
+          state.packagePerformanceLoading = false;
+        }
+        dependencies.render();
+      }
+    },
+
+    async loadMetadata(packageModel, signature, scopedLibrary) {
+      if (packageModel.isRuntimePack && !scopedLibrary) return;
+      if (state.packageMetadataKey === signature
+        && (state.packageMetadata || state.packageMetadataError)) {
+        dependencies.render();
+        return;
+      }
+      state.packageMetadataKey = signature;
+      state.packageMetadata = null;
+      state.packageMetadataError = "";
+      state.packageMetadataLoading = true;
+      dependencies.render();
+      try {
+        const coordinates = packageModel.isRuntimePack
+          ? platformCoordinates(packageModel, scopedLibrary ?? "")
+          : null;
+        const result = coordinates
+          ? await dependencies.queryPlatformMetadata(
+              coordinates.framework,
+              coordinates.assemblyFileName,
+              coordinates.pack)
+          : await dependencies.queryPackageMetadata(packageModel);
+        if (state.packageMetadataKey === signature) {
+          state.packageMetadata = result;
+        }
+      } catch (error) {
+        if (state.packageMetadataKey === signature) {
+          state.packageMetadataError = dependencies.describeError(error);
+        }
+      } finally {
+        if (state.packageMetadataKey === signature) {
+          state.packageMetadataLoading = false;
+        }
+        dependencies.render();
+      }
+    },
+  };
+}

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -165,6 +165,114 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+type PackageInspectionCoordinator =
+  ReturnType<typeof createPackageInspectionCoordinator>;
+
+interface PackageLensFixture<T> {
+  name: string;
+  result: T;
+  createCoordinator:
+    (state: PackageInspectionState, query: () => Promise<T>) =>
+      PackageInspectionCoordinator;
+  load: (coordinator: PackageInspectionCoordinator, signature: string) =>
+    Promise<void>;
+  readResult: (state: PackageInspectionState) => T | null;
+  readLoading: (state: PackageInspectionState) => boolean;
+  readError: (state: PackageInspectionState) => string;
+  setKey: (state: PackageInspectionState, key: string) => void;
+  setError: (state: PackageInspectionState, error: string) => void;
+}
+
+async function verifyPackageLensLifecycle<T>(
+  fixture: PackageLensFixture<T>,
+) {
+  {
+    const state = inspectionState();
+    const coordinator = fixture.createCoordinator(
+      state,
+      async () => fixture.result);
+
+    await fixture.load(coordinator, "current");
+
+    assert.deepEqual(
+      fixture.readResult(state),
+      fixture.result,
+      `${fixture.name} current result`);
+    assert.equal(
+      fixture.readLoading(state),
+      false,
+      `${fixture.name} current loading`);
+    assert.equal(
+      fixture.readError(state),
+      "",
+      `${fixture.name} current error`);
+  }
+
+  {
+    const state = inspectionState();
+    const coordinator = fixture.createCoordinator(state, async () => {
+      throw new Error("current failure");
+    });
+
+    await fixture.load(coordinator, "current");
+
+    assert.equal(
+      fixture.readResult(state),
+      null,
+      `${fixture.name} failed result`);
+    assert.equal(
+      fixture.readLoading(state),
+      false,
+      `${fixture.name} failed loading`);
+    assert.equal(
+      fixture.readError(state),
+      "current failure",
+      `${fixture.name} current failure`);
+  }
+
+  {
+    let queries = 0;
+    const state = inspectionState();
+    fixture.setKey(state, "cached");
+    fixture.setError(state, "cached failure");
+    const coordinator = fixture.createCoordinator(state, async () => {
+      queries++;
+      return fixture.result;
+    });
+
+    await fixture.load(coordinator, "cached");
+
+    assert.equal(queries, 0, `${fixture.name} cached query`);
+    assert.equal(
+      fixture.readError(state),
+      "cached failure",
+      `${fixture.name} cached failure`);
+  }
+
+  {
+    const query = deferred<T>();
+    const state = inspectionState();
+    const coordinator = fixture.createCoordinator(
+      state,
+      async () => query.promise);
+
+    const load = fixture.load(coordinator, "first");
+    fixture.setKey(state, "second");
+    fixture.setError(state, "newer failure");
+    query.reject(new Error("stale failure"));
+    await load;
+
+    assert.equal(
+      fixture.readError(state),
+      "newer failure",
+      `${fixture.name} stale failure`);
+    assert.equal(
+      fixture.readLoading(state),
+      true,
+      `${fixture.name} stale loading`);
+  }
+}
+
 test("workspace dependency keys normalize complete package coordinates", () => {
   assert.equal(
     workspaceDependencyKey({
@@ -328,6 +436,91 @@ test("package lens loaders reuse cached failures without querying", async () => 
   assert.equal(state.packagePerformanceError, "cached failure");
 });
 
+test("every package lens preserves its complete request lifecycle", async () => {
+  const packageItem = packageModel();
+
+  await verifyPackageLensLifecycle({
+    name: "dependencies",
+    result: dependencyResult(),
+    createCoordinator: (state, query) =>
+      createPackageInspectionCoordinator(
+        inspectionDependencies(state, {
+          queryDependencies: async () => query(),
+        })),
+    load: (coordinator, signature) =>
+      coordinator.loadDependencies(packageItem, signature),
+    readResult: state => state.packageDependencies,
+    readLoading: state => state.packageDependenciesLoading,
+    readError: state => state.packageDependenciesError,
+    setKey: (state, key) => { state.packageDependenciesKey = key; },
+    setError: (state, error) => { state.packageDependenciesError = error; },
+  });
+  await verifyPackageLensLifecycle({
+    name: "integrations",
+    result: integrationsResult(),
+    createCoordinator: (state, query) =>
+      createPackageInspectionCoordinator(
+        inspectionDependencies(state, {
+          queryPackageIntegrations: async () => query(),
+        })),
+    load: (coordinator, signature) =>
+      coordinator.loadIntegrations(packageItem, signature, null),
+    readResult: state => state.packageIntegrations,
+    readLoading: state => state.packageIntegrationsLoading,
+    readError: state => state.packageIntegrationsError,
+    setKey: (state, key) => { state.packageIntegrationsKey = key; },
+    setError: (state, error) => { state.packageIntegrationsError = error; },
+  });
+  await verifyPackageLensLifecycle({
+    name: "opportunities",
+    result: opportunitiesResult(),
+    createCoordinator: (state, query) =>
+      createPackageInspectionCoordinator(
+        inspectionDependencies(state, {
+          queryPackageOpportunities: async () => query(),
+        })),
+    load: (coordinator, signature) =>
+      coordinator.loadOpportunities(packageItem, signature, null),
+    readResult: state => state.packageOpportunities,
+    readLoading: state => state.packageOpportunitiesLoading,
+    readError: state => state.packageOpportunitiesError,
+    setKey: (state, key) => { state.packageOpportunitiesKey = key; },
+    setError: (state, error) => { state.packageOpportunitiesError = error; },
+  });
+  await verifyPackageLensLifecycle({
+    name: "performance",
+    result: performanceResult(),
+    createCoordinator: (state, query) =>
+      createPackageInspectionCoordinator(
+        inspectionDependencies(state, {
+          queryPackagePerformance: async () => query(),
+        })),
+    load: (coordinator, signature) =>
+      coordinator.loadPerformance(packageItem, signature, null),
+    readResult: state => state.packagePerformance,
+    readLoading: state => state.packagePerformanceLoading,
+    readError: state => state.packagePerformanceError,
+    setKey: (state, key) => { state.packagePerformanceKey = key; },
+    setError: (state, error) => { state.packagePerformanceError = error; },
+  });
+  await verifyPackageLensLifecycle({
+    name: "metadata",
+    result: metadataResult(),
+    createCoordinator: (state, query) =>
+      createPackageInspectionCoordinator(
+        inspectionDependencies(state, {
+          queryPackageMetadata: async () => query(),
+        })),
+    load: (coordinator, signature) =>
+      coordinator.loadMetadata(packageItem, signature, null),
+    readResult: state => state.packageMetadata,
+    readLoading: state => state.packageMetadataLoading,
+    readError: state => state.packageMetadataError,
+    setKey: (state, key) => { state.packageMetadataKey = key; },
+    setError: (state, error) => { state.packageMetadataError = error; },
+  });
+});
+
 test("stale package lens rejection cannot overwrite newer state", async () => {
   const packageItem = packageModel();
   const request = deferred<PackagePerformance>();
@@ -487,6 +680,53 @@ test("removed packages cannot publish an in-flight workspace dependency result",
   assert.equal(
     Object.hasOwn(state.workspaceDependencies, workspaceDependencyKey(packageItem)),
     false);
+  assert.equal(state.workspaceDependencyLoads.size, 0);
+});
+
+test("packages removed before their workspace turn are not queried", async () => {
+  const first = packageModel({ id: "Example.First" });
+  const removed = packageModel({ id: "Example.Removed" });
+  const firstRequest = deferred<BrowserPackageDependencies>();
+  const queries: string[] = [];
+  const state = inspectionState({ packages: [first, removed] });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async packageItem => {
+        queries.push(packageItem.id);
+        return packageItem === first
+          ? firstRequest.promise
+          : dependencyResult(packageItem.id);
+      },
+    }));
+
+  const load = coordinator.ensureWorkspaceDependencies();
+  state.packages = [first];
+  firstRequest.resolve(dependencyResult(first.id));
+  await load;
+
+  assert.deepEqual(queries, [first.id]);
+  assert.equal(
+    Object.hasOwn(state.workspaceDependencies, workspaceDependencyKey(removed)),
+    false);
+});
+
+test("removed packages cannot publish rejected workspace dependency requests", async () => {
+  const packageItem = packageModel();
+  const request = deferred<BrowserPackageDependencies>();
+  const state = inspectionState({ packages: [packageItem] });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async () => request.promise,
+    }));
+
+  const load = coordinator.ensureWorkspaceDependencies();
+  state.packages = [];
+  request.reject(new Error("stale failure"));
+  await load;
+
+  const key = workspaceDependencyKey(packageItem);
+  assert.equal(Object.hasOwn(state.workspaceDependencies, key), false);
+  assert.equal(Object.hasOwn(state.workspaceDependencyErrors, key), false);
   assert.equal(state.workspaceDependencyLoads.size, 0);
 });
 

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -172,7 +172,11 @@ interface PackageLensFixture<T> {
   name: string;
   result: T;
   createCoordinator:
-    (state: PackageInspectionState, query: () => Promise<T>) =>
+    (
+      state: PackageInspectionState,
+      query: () => Promise<T>,
+      render?: () => void,
+    ) =>
       PackageInspectionCoordinator;
   load: (coordinator: PackageInspectionCoordinator, signature: string) =>
     Promise<void>;
@@ -187,12 +191,34 @@ async function verifyPackageLensLifecycle<T>(
   fixture: PackageLensFixture<T>,
 ) {
   {
+    const query = deferred<T>();
+    const events: string[] = [];
     const state = inspectionState();
+    fixture.setKey(state, "old");
+    fixture.setError(state, "old failure");
     const coordinator = fixture.createCoordinator(
       state,
-      async () => fixture.result);
+      async () => query.promise,
+      () => events.push("render"));
 
-    await fixture.load(coordinator, "current");
+    const load = fixture.load(coordinator, "current");
+
+    assert.equal(
+      fixture.readResult(state),
+      null,
+      `${fixture.name} cleared result`);
+    assert.equal(
+      fixture.readLoading(state),
+      true,
+      `${fixture.name} started loading`);
+    assert.equal(
+      fixture.readError(state),
+      "",
+      `${fixture.name} cleared error`);
+    assert.deepEqual(events, ["render"], `${fixture.name} start render`);
+
+    query.resolve(fixture.result);
+    await load;
 
     assert.deepEqual(
       fixture.readResult(state),
@@ -206,6 +232,10 @@ async function verifyPackageLensLifecycle<T>(
       fixture.readError(state),
       "",
       `${fixture.name} current error`);
+    assert.deepEqual(
+      events,
+      ["render", "render"],
+      `${fixture.name} completion render`);
   }
 
   {
@@ -318,13 +348,18 @@ test("dependency results cache for a resident package after the foreground lens 
 
 test("package lens loaders reuse cached results without querying or clearing them", async () => {
   const packageItem = packageModel();
+  const dependencies = dependencyResult();
+  const integrations = integrationsResult();
+  const opportunities = opportunitiesResult();
+  const performance = performanceResult();
+  const metadata = metadataResult();
   const cases = [
     {
       name: "dependencies",
-      cached: dependencyResult(),
+      cached: dependencies,
       state: inspectionState({
         packageDependenciesKey: "cached",
-        packageDependencies: dependencyResult(),
+        packageDependencies: dependencies,
       }),
       read: (state: PackageInspectionState) => state.packageDependencies,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
@@ -332,10 +367,10 @@ test("package lens loaders reuse cached results without querying or clearing the
     },
     {
       name: "integrations",
-      cached: integrationsResult(),
+      cached: integrations,
       state: inspectionState({
         packageIntegrationsKey: "cached",
-        packageIntegrations: integrationsResult(),
+        packageIntegrations: integrations,
       }),
       read: (state: PackageInspectionState) => state.packageIntegrations,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
@@ -343,10 +378,10 @@ test("package lens loaders reuse cached results without querying or clearing the
     },
     {
       name: "opportunities",
-      cached: opportunitiesResult(),
+      cached: opportunities,
       state: inspectionState({
         packageOpportunitiesKey: "cached",
-        packageOpportunities: opportunitiesResult(),
+        packageOpportunities: opportunities,
       }),
       read: (state: PackageInspectionState) => state.packageOpportunities,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
@@ -354,10 +389,10 @@ test("package lens loaders reuse cached results without querying or clearing the
     },
     {
       name: "performance",
-      cached: performanceResult(),
+      cached: performance,
       state: inspectionState({
         packagePerformanceKey: "cached",
-        packagePerformance: performanceResult(),
+        packagePerformance: performance,
       }),
       read: (state: PackageInspectionState) => state.packagePerformance,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
@@ -365,10 +400,10 @@ test("package lens loaders reuse cached results without querying or clearing the
     },
     {
       name: "metadata",
-      cached: metadataResult(),
+      cached: metadata,
       state: inspectionState({
         packageMetadataKey: "cached",
-        packageMetadata: metadataResult(),
+        packageMetadata: metadata,
       }),
       read: (state: PackageInspectionState) => state.packageMetadata,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
@@ -408,7 +443,7 @@ test("package lens loaders reuse cached results without querying or clearing the
 
     assert.equal(queries, 0, fixture.name);
     assert.equal(renders, 1, fixture.name);
-    assert.deepEqual(fixture.read(fixture.state), fixture.cached, fixture.name);
+    assert.strictEqual(fixture.read(fixture.state), fixture.cached, fixture.name);
   }
 });
 
@@ -442,10 +477,11 @@ test("every package lens preserves its complete request lifecycle", async () => 
   await verifyPackageLensLifecycle({
     name: "dependencies",
     result: dependencyResult(),
-    createCoordinator: (state, query) =>
+    createCoordinator: (state, query, render = () => {}) =>
       createPackageInspectionCoordinator(
         inspectionDependencies(state, {
           queryDependencies: async () => query(),
+          render,
         })),
     load: (coordinator, signature) =>
       coordinator.loadDependencies(packageItem, signature),
@@ -458,10 +494,11 @@ test("every package lens preserves its complete request lifecycle", async () => 
   await verifyPackageLensLifecycle({
     name: "integrations",
     result: integrationsResult(),
-    createCoordinator: (state, query) =>
+    createCoordinator: (state, query, render = () => {}) =>
       createPackageInspectionCoordinator(
         inspectionDependencies(state, {
           queryPackageIntegrations: async () => query(),
+          render,
         })),
     load: (coordinator, signature) =>
       coordinator.loadIntegrations(packageItem, signature, null),
@@ -474,10 +511,11 @@ test("every package lens preserves its complete request lifecycle", async () => 
   await verifyPackageLensLifecycle({
     name: "opportunities",
     result: opportunitiesResult(),
-    createCoordinator: (state, query) =>
+    createCoordinator: (state, query, render = () => {}) =>
       createPackageInspectionCoordinator(
         inspectionDependencies(state, {
           queryPackageOpportunities: async () => query(),
+          render,
         })),
     load: (coordinator, signature) =>
       coordinator.loadOpportunities(packageItem, signature, null),
@@ -490,10 +528,11 @@ test("every package lens preserves its complete request lifecycle", async () => 
   await verifyPackageLensLifecycle({
     name: "performance",
     result: performanceResult(),
-    createCoordinator: (state, query) =>
+    createCoordinator: (state, query, render = () => {}) =>
       createPackageInspectionCoordinator(
         inspectionDependencies(state, {
           queryPackagePerformance: async () => query(),
+          render,
         })),
     load: (coordinator, signature) =>
       coordinator.loadPerformance(packageItem, signature, null),
@@ -506,10 +545,11 @@ test("every package lens preserves its complete request lifecycle", async () => 
   await verifyPackageLensLifecycle({
     name: "metadata",
     result: metadataResult(),
-    createCoordinator: (state, query) =>
+    createCoordinator: (state, query, render = () => {}) =>
       createPackageInspectionCoordinator(
         inspectionDependencies(state, {
           queryPackageMetadata: async () => query(),
+          render,
         })),
     load: (coordinator, signature) =>
       coordinator.loadMetadata(packageItem, signature, null),
@@ -542,6 +582,7 @@ test("stale package lens rejection cannot overwrite newer state", async () => {
 
 test("workspace dependency loading records failures and ignores runtime packs", async () => {
   const good = packageModel({ id: "Example.Good" });
+  const partial = packageModel({ id: "Example.Partial" });
   const bad = packageModel({ id: "Example.Bad" });
   const runtime = packageModel({
     id: "Microsoft.NETCore.App",
@@ -550,7 +591,7 @@ test("workspace dependency loading records failures and ignores runtime packs", 
   });
   const events: string[] = [];
   const state = inspectionState({
-    packages: [good, bad, runtime],
+    packages: [good, partial, bad, runtime],
     atPackageRoot: true,
     packageLens: "dependencies",
   });
@@ -559,6 +600,11 @@ test("workspace dependency loading records failures and ignores runtime packs", 
       queryDependencies: async packageItem => {
         events.push(`query:${packageItem.id}`);
         if (packageItem === bad) throw new Error("dependency feed unavailable");
+        if (packageItem === partial) {
+          return dependencyResult(
+            packageItem.id,
+            "no dependency group matches net10.0");
+        }
         return dependencyResult(packageItem.id);
       },
       refreshPackageStats: () => events.push("stats"),
@@ -569,11 +615,19 @@ test("workspace dependency loading records failures and ignores runtime packs", 
 
   assert.deepEqual(events, [
     "query:Example.Good",
+    "query:Example.Partial",
     "query:Example.Bad",
     "render",
     "stats",
   ]);
   assert.ok(state.workspaceDependencies[workspaceDependencyKey(good)]);
+  const partialKey = workspaceDependencyKey(partial);
+  assert.equal(
+    state.workspaceDependencies[partialKey].dependencyGroupError,
+    "no dependency group matches net10.0");
+  assert.equal(
+    state.workspaceDependencyErrors[partialKey],
+    "no dependency group matches net10.0");
   assert.deepEqual(
     state.workspaceDependencies[workspaceDependencyKey(bad)].dependencyGroups,
     []);
@@ -674,6 +728,26 @@ test("removed packages cannot publish an in-flight workspace dependency result",
 
   const load = coordinator.ensureWorkspaceDependencies();
   state.packages = [];
+  request.resolve(dependencyResult());
+  await load;
+
+  assert.equal(
+    Object.hasOwn(state.workspaceDependencies, workspaceDependencyKey(packageItem)),
+    false);
+  assert.equal(state.workspaceDependencyLoads.size, 0);
+});
+
+test("coordinate replacement cannot publish an in-flight workspace dependency result", async () => {
+  const packageItem = packageModel();
+  const request = deferred<BrowserPackageDependencies>();
+  const state = inspectionState({ packages: [packageItem] });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async () => request.promise,
+    }));
+
+  const load = coordinator.ensureWorkspaceDependencies();
+  state.packages = [packageModel({ version: "2.0.0" })];
   request.resolve(dependencyResult());
   await load;
 

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -213,46 +213,56 @@ test("package lens loaders reuse cached results without querying or clearing the
   const cases = [
     {
       name: "dependencies",
+      cached: dependencyResult(),
       state: inspectionState({
         packageDependenciesKey: "cached",
         packageDependencies: dependencyResult(),
       }),
+      read: (state: PackageInspectionState) => state.packageDependencies,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
         coordinator.loadDependencies(packageItem, "cached"),
     },
     {
       name: "integrations",
+      cached: integrationsResult(),
       state: inspectionState({
         packageIntegrationsKey: "cached",
         packageIntegrations: integrationsResult(),
       }),
+      read: (state: PackageInspectionState) => state.packageIntegrations,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
         coordinator.loadIntegrations(packageItem, "cached", null),
     },
     {
       name: "opportunities",
+      cached: opportunitiesResult(),
       state: inspectionState({
         packageOpportunitiesKey: "cached",
         packageOpportunities: opportunitiesResult(),
       }),
+      read: (state: PackageInspectionState) => state.packageOpportunities,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
         coordinator.loadOpportunities(packageItem, "cached", null),
     },
     {
       name: "performance",
+      cached: performanceResult(),
       state: inspectionState({
         packagePerformanceKey: "cached",
         packagePerformance: performanceResult(),
       }),
+      read: (state: PackageInspectionState) => state.packagePerformance,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
         coordinator.loadPerformance(packageItem, "cached", null),
     },
     {
       name: "metadata",
+      cached: metadataResult(),
       state: inspectionState({
         packageMetadataKey: "cached",
         packageMetadata: metadataResult(),
       }),
+      read: (state: PackageInspectionState) => state.packageMetadata,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
         coordinator.loadMetadata(packageItem, "cached", null),
     },
@@ -290,6 +300,7 @@ test("package lens loaders reuse cached results without querying or clearing the
 
     assert.equal(queries, 0, fixture.name);
     assert.equal(renders, 1, fixture.name);
+    assert.deepEqual(fixture.read(fixture.state), fixture.cached, fixture.name);
   }
 });
 
@@ -441,6 +452,24 @@ test("workspace dependency loading is sequential and only renders the active len
   assert.equal(stats, 1);
 });
 
+test("workspace dependency loading does not render another active package lens", async () => {
+  const packageItem = packageModel();
+  let renders = 0;
+  const state = inspectionState({
+    packages: [packageItem],
+    atPackageRoot: true,
+    packageLens: "metadata",
+  });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      render: () => renders++,
+    }));
+
+  await coordinator.ensureWorkspaceDependencies();
+
+  assert.equal(renders, 0);
+});
+
 test("removed packages cannot publish an in-flight workspace dependency result", async () => {
   const packageItem = packageModel();
   const request = deferred<BrowserPackageDependencies>();
@@ -459,6 +488,25 @@ test("removed packages cannot publish an in-flight workspace dependency result",
     Object.hasOwn(state.workspaceDependencies, workspaceDependencyKey(packageItem)),
     false);
   assert.equal(state.workspaceDependencyLoads.size, 0);
+});
+
+test("removed packages cannot publish dependencies loaded by the foreground lens", async () => {
+  const packageItem = packageModel();
+  const request = deferred<BrowserPackageDependencies>();
+  const state = inspectionState({ packages: [packageItem] });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async () => request.promise,
+    }));
+
+  const load = coordinator.loadDependencies(packageItem, "dependencies");
+  state.packages = [];
+  request.resolve(dependencyResult());
+  await load;
+
+  assert.equal(
+    Object.hasOwn(state.workspaceDependencies, workspaceDependencyKey(packageItem)),
+    false);
 });
 
 test("scoped package lenses route platform coordinates and suppress stale results", async () => {
@@ -516,6 +564,185 @@ test("scoped package lenses route platform coordinates and suppress stale result
   assert.equal(state.packagePerformanceLoading, false);
   assert.equal(state.packageMetadata, null);
   assert.equal(state.packageMetadataLoading, true);
+});
+
+test("all scoped runtime package lenses route exact platform coordinates", async () => {
+  const runtime = packageModel({
+    id: "Microsoft.NETCore.App",
+    isRuntimePack: true,
+    source: { kind: "platform" },
+  });
+  const calls: string[] = [];
+  const state = inspectionState({ packages: [runtime] });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPlatformIntegrations: async (framework, assemblyName, pack) => {
+        calls.push(`integrations:${framework}/${assemblyName}/${pack}`);
+        return integrationsResult();
+      },
+      queryPlatformOpportunities: async (framework, assemblyName, pack) => {
+        calls.push(`opportunities:${framework}/${assemblyName}/${pack}`);
+        return opportunitiesResult();
+      },
+      queryPlatformPerformance: async (framework, assemblyName, pack) => {
+        calls.push(`performance:${framework}/${assemblyName}/${pack}`);
+        return performanceResult();
+      },
+      queryPlatformMetadata: async (framework, assemblyName, pack) => {
+        calls.push(`metadata:${framework}/${assemblyName}/${pack}`);
+        return metadataResult();
+      },
+    }));
+
+  await coordinator.loadIntegrations(runtime, "integrations", "System.Text.Json");
+  await coordinator.loadOpportunities(runtime, "opportunities", "System.Text.Json");
+  await coordinator.loadPerformance(runtime, "performance", "System.Text.Json");
+  await coordinator.loadMetadata(runtime, "metadata", "System.Text.Json");
+
+  assert.deepEqual(calls, [
+    "integrations:net10.0/System.Text.Json.dll/pack:System.Text.Json",
+    "opportunities:net10.0/System.Text.Json.dll/pack:System.Text.Json",
+    "performance:net10.0/System.Text.Json.dll/pack:System.Text.Json",
+    "metadata:net10.0/System.Text.Json.dll/pack:System.Text.Json",
+  ]);
+});
+
+test("package lens results clear before a different request completes", async () => {
+  const packageItem = packageModel();
+
+  {
+    const query = deferred<BrowserPackageDependencies>();
+    const state = inspectionState({
+      packageDependenciesKey: "old",
+      packageDependencies: dependencyResult(),
+    });
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryDependencies: async () => query.promise,
+      }));
+    const load = coordinator.loadDependencies(packageItem, "new");
+    assert.equal(state.packageDependencies, null);
+    assert.equal(state.packageDependenciesLoading, true);
+    query.resolve(dependencyResult());
+    await load;
+  }
+
+  {
+    const query = deferred<BrowserPackageIntegrations>();
+    const state = inspectionState({
+      packageIntegrationsKey: "old",
+      packageIntegrations: integrationsResult(),
+    });
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryPackageIntegrations: async () => query.promise,
+      }));
+    const load = coordinator.loadIntegrations(packageItem, "new", null);
+    assert.equal(state.packageIntegrations, null);
+    assert.equal(state.packageIntegrationsLoading, true);
+    query.resolve(integrationsResult());
+    await load;
+  }
+
+  {
+    const query = deferred<BrowserPackageOpportunities>();
+    const state = inspectionState({
+      packageOpportunitiesKey: "old",
+      packageOpportunities: opportunitiesResult(),
+    });
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryPackageOpportunities: async () => query.promise,
+      }));
+    const load = coordinator.loadOpportunities(packageItem, "new", null);
+    assert.equal(state.packageOpportunities, null);
+    assert.equal(state.packageOpportunitiesLoading, true);
+    query.resolve(opportunitiesResult());
+    await load;
+  }
+
+  {
+    const query = deferred<PackagePerformance>();
+    const state = inspectionState({
+      packagePerformanceKey: "old",
+      packagePerformance: performanceResult(),
+    });
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryPackagePerformance: async () => query.promise,
+      }));
+    const load = coordinator.loadPerformance(packageItem, "new", null);
+    assert.equal(state.packagePerformance, null);
+    assert.equal(state.packagePerformanceLoading, true);
+    query.resolve(performanceResult());
+    await load;
+  }
+
+  {
+    const query = deferred<PackageMetadata>();
+    const state = inspectionState({
+      packageMetadataKey: "old",
+      packageMetadata: metadataResult(),
+    });
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryPackageMetadata: async () => query.promise,
+      }));
+    const load = coordinator.loadMetadata(packageItem, "new", null);
+    assert.equal(state.packageMetadata, null);
+    assert.equal(state.packageMetadataLoading, true);
+    query.resolve(metadataResult());
+    await load;
+  }
+});
+
+test("package lens results require their current request key", async () => {
+  const packageItem = packageModel();
+
+  {
+    const query = deferred<BrowserPackageIntegrations>();
+    const state = inspectionState();
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryPackageIntegrations: async () => query.promise,
+      }));
+    const load = coordinator.loadIntegrations(packageItem, "first", null);
+    state.packageIntegrationsKey = "second";
+    query.resolve(integrationsResult());
+    await load;
+    assert.equal(state.packageIntegrations, null);
+    assert.equal(state.packageIntegrationsLoading, true);
+  }
+
+  {
+    const query = deferred<BrowserPackageOpportunities>();
+    const state = inspectionState();
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryPackageOpportunities: async () => query.promise,
+      }));
+    const load = coordinator.loadOpportunities(packageItem, "first", null);
+    state.packageOpportunitiesKey = "second";
+    query.resolve(opportunitiesResult());
+    await load;
+    assert.equal(state.packageOpportunities, null);
+    assert.equal(state.packageOpportunitiesLoading, true);
+  }
+
+  {
+    const query = deferred<PackagePerformance>();
+    const state = inspectionState();
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryPackagePerformance: async () => query.promise,
+      }));
+    const load = coordinator.loadPerformance(packageItem, "first", null);
+    state.packagePerformanceKey = "second";
+    query.resolve(performanceResult());
+    await load;
+    assert.equal(state.packagePerformance, null);
+    assert.equal(state.packagePerformanceLoading, true);
+  }
 });
 
 test("runtime package lenses wait for an explicit library scope", async () => {

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -157,10 +157,12 @@ function inspectionDependencies(
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>(accept => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((accept, deny) => {
     resolve = accept;
+    reject = deny;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 test("workspace dependency keys normalize complete package coordinates", () => {
@@ -204,6 +206,134 @@ test("dependency results cache for a resident package after the foreground lens 
     state.workspaceDependencyErrors[key],
     "partial dependency data");
   assert.deepEqual(events, ["render", "stats", "render", "graph"]);
+});
+
+test("package lens loaders reuse cached results without querying or clearing them", async () => {
+  const packageItem = packageModel();
+  const cases = [
+    {
+      name: "dependencies",
+      state: inspectionState({
+        packageDependenciesKey: "cached",
+        packageDependencies: dependencyResult(),
+      }),
+      load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
+        coordinator.loadDependencies(packageItem, "cached"),
+    },
+    {
+      name: "integrations",
+      state: inspectionState({
+        packageIntegrationsKey: "cached",
+        packageIntegrations: integrationsResult(),
+      }),
+      load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
+        coordinator.loadIntegrations(packageItem, "cached", null),
+    },
+    {
+      name: "opportunities",
+      state: inspectionState({
+        packageOpportunitiesKey: "cached",
+        packageOpportunities: opportunitiesResult(),
+      }),
+      load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
+        coordinator.loadOpportunities(packageItem, "cached", null),
+    },
+    {
+      name: "performance",
+      state: inspectionState({
+        packagePerformanceKey: "cached",
+        packagePerformance: performanceResult(),
+      }),
+      load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
+        coordinator.loadPerformance(packageItem, "cached", null),
+    },
+    {
+      name: "metadata",
+      state: inspectionState({
+        packageMetadataKey: "cached",
+        packageMetadata: metadataResult(),
+      }),
+      load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
+        coordinator.loadMetadata(packageItem, "cached", null),
+    },
+  ];
+
+  for (const fixture of cases) {
+    let queries = 0;
+    let renders = 0;
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(fixture.state, {
+        queryDependencies: async () => {
+          queries++;
+          return dependencyResult();
+        },
+        queryPackageIntegrations: async () => {
+          queries++;
+          return integrationsResult();
+        },
+        queryPackageOpportunities: async () => {
+          queries++;
+          return opportunitiesResult();
+        },
+        queryPackagePerformance: async () => {
+          queries++;
+          return performanceResult();
+        },
+        queryPackageMetadata: async () => {
+          queries++;
+          return metadataResult();
+        },
+        render: () => renders++,
+      }));
+
+    await fixture.load(coordinator);
+
+    assert.equal(queries, 0, fixture.name);
+    assert.equal(renders, 1, fixture.name);
+  }
+});
+
+test("package lens loaders reuse cached failures without querying", async () => {
+  const packageItem = packageModel();
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({
+    packagePerformanceKey: "cached",
+    packagePerformanceError: "cached failure",
+  });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackagePerformance: async () => {
+        queries++;
+        return performanceResult();
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.loadPerformance(packageItem, "cached", null);
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 1);
+  assert.equal(state.packagePerformanceError, "cached failure");
+});
+
+test("stale package lens rejection cannot overwrite newer state", async () => {
+  const packageItem = packageModel();
+  const request = deferred<PackagePerformance>();
+  const state = inspectionState();
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackagePerformance: async () => request.promise,
+    }));
+
+  const load = coordinator.loadPerformance(packageItem, "first", null);
+  state.packagePerformanceKey = "second";
+  state.packagePerformanceError = "newer failure";
+  request.reject(new Error("stale failure"));
+  await load;
+
+  assert.equal(state.packagePerformanceError, "newer failure");
+  assert.equal(state.packagePerformanceLoading, true);
 });
 
 test("workspace dependency loading records failures and ignores runtime packs", async () => {
@@ -250,6 +380,65 @@ test("workspace dependency loading records failures and ignores runtime packs", 
     Object.hasOwn(state.workspaceDependencies, workspaceDependencyKey(runtime)),
     false);
   assert.equal(state.workspaceDependencyLoads.size, 0);
+});
+
+test("workspace dependency loading skips keys already in flight", async () => {
+  const packageItem = packageModel();
+  const key = workspaceDependencyKey(packageItem);
+  let queries = 0;
+  let graphRenders = 0;
+  const state = inspectionState({
+    packages: [packageItem],
+    workspaceDependencyLoads: new Set([key]),
+  });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async () => {
+        queries++;
+        return dependencyResult();
+      },
+      renderDependencyGraph: () => graphRenders++,
+    }));
+
+  await coordinator.ensureWorkspaceDependencies();
+
+  assert.equal(queries, 0);
+  assert.equal(graphRenders, 1);
+  assert.deepEqual([...state.workspaceDependencyLoads], [key]);
+});
+
+test("workspace dependency loading is sequential and only renders the active lens", async () => {
+  const first = packageModel({ id: "Example.First" });
+  const second = packageModel({ id: "Example.Second" });
+  const firstRequest = deferred<BrowserPackageDependencies>();
+  const queries: string[] = [];
+  let renders = 0;
+  let stats = 0;
+  const state = inspectionState({
+    packages: [first, second],
+    atPackageRoot: false,
+    packageLens: "dependencies",
+  });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async packageItem => {
+        queries.push(packageItem.id);
+        return packageItem.id === first.id
+          ? firstRequest.promise
+          : dependencyResult(packageItem.id);
+      },
+      render: () => renders++,
+      refreshPackageStats: () => stats++,
+    }));
+
+  const load = coordinator.ensureWorkspaceDependencies();
+  assert.deepEqual(queries, [first.id]);
+  firstRequest.resolve(dependencyResult(first.id));
+  await load;
+
+  assert.deepEqual(queries, [first.id, second.id]);
+  assert.equal(renders, 0);
+  assert.equal(stats, 1);
 });
 
 test("removed packages cannot publish an in-flight workspace dependency result", async () => {

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -346,6 +346,26 @@ test("dependency results cache for a resident package after the foreground lens 
   assert.deepEqual(events, ["render", "stats", "render", "graph"]);
 });
 
+test("foreground dependency success refreshes cached groups and clears a prior error", async () => {
+  const packageItem = packageModel();
+  const key = workspaceDependencyKey(packageItem);
+  const state = inspectionState({
+    packages: [packageItem],
+    workspaceDependencyErrors: { [key]: "stale failure" },
+  });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state));
+
+  await coordinator.loadDependencies(packageItem, "current");
+
+  const workspace = state.workspaceDependencies[key];
+  assert.ok(workspace);
+  assert.equal(
+    workspace.dependencyGroups?.[0]?.dependencies?.[0]?.id,
+    "Example.Dependency");
+  assert.equal(Object.hasOwn(state.workspaceDependencyErrors, key), false);
+});
+
 test("package lens loaders reuse cached results without querying or clearing them", async () => {
   const packageItem = packageModel();
   const dependencies = dependencyResult();
@@ -590,10 +610,12 @@ test("workspace dependency loading records failures and ignores runtime packs", 
     source: { kind: "platform" },
   });
   const events: string[] = [];
+  const goodKey = workspaceDependencyKey(good);
   const state = inspectionState({
     packages: [good, partial, bad, runtime],
     atPackageRoot: true,
     packageLens: "dependencies",
+    workspaceDependencyErrors: { [goodKey]: "stale failure" },
   });
   const coordinator = createPackageInspectionCoordinator(
     inspectionDependencies(state, {
@@ -620,7 +642,12 @@ test("workspace dependency loading records failures and ignores runtime packs", 
     "render",
     "stats",
   ]);
-  assert.ok(state.workspaceDependencies[workspaceDependencyKey(good)]);
+  const goodWorkspace = state.workspaceDependencies[goodKey];
+  assert.ok(goodWorkspace);
+  assert.equal(
+    goodWorkspace.dependencyGroups?.[0]?.dependencies?.[0]?.id,
+    "Example.Dependency");
+  assert.equal(Object.hasOwn(state.workspaceDependencyErrors, goodKey), false);
   const partialKey = workspaceDependencyKey(partial);
   assert.equal(
     state.workspaceDependencies[partialKey].dependencyGroupError,

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -1,0 +1,373 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createPackageInspectionCoordinator,
+  workspaceDependencyKey,
+  type PackageInspectionDependencies,
+  type PackageInspectionState,
+  type PackagePerformance,
+} from "../src/package-inspection.ts";
+import type { AppPackage } from "../src/package-acquisition.ts";
+import type {
+  BrowserPackageDependencies,
+  BrowserPackageIntegrations,
+  BrowserPackageOpportunities,
+} from "../src/inspect-web-engine.d.ts";
+import type { PackageMetadata } from "../src/metadata-viewer.ts";
+
+function packageModel(
+  overrides: Partial<AppPackage> = {},
+): AppPackage {
+  return {
+    id: "Example.Package",
+    version: "1.2.3",
+    frameworks: ["net10.0"],
+    activeFramework: "net10.0",
+    assembly: "Example.Package",
+    assemblyId: "example-package",
+    assemblyAsset: "lib/net10.0/Example.Package.dll",
+    source: { kind: "nuget.org" },
+    assemblies: [],
+    types: [],
+    accessibility: [],
+    totalTypes: 0,
+    totalMembers: 0,
+    documents: [],
+    isRuntimePack: false,
+    ...overrides,
+  };
+}
+
+function inspectionState(
+  overrides: Partial<PackageInspectionState> = {},
+): PackageInspectionState {
+  return {
+    packages: [],
+    atPackageRoot: false,
+    packageLens: "overview",
+    packageDependencies: null,
+    packageDependenciesLoading: false,
+    packageDependenciesError: "",
+    packageDependenciesKey: "",
+    workspaceDependencies: {},
+    workspaceDependencyErrors: {},
+    workspaceDependencyLoads: new Set<string>(),
+    packageIntegrations: null,
+    packageIntegrationsLoading: false,
+    packageIntegrationsError: "",
+    packageIntegrationsKey: "",
+    packageOpportunities: null,
+    packageOpportunitiesLoading: false,
+    packageOpportunitiesError: "",
+    packageOpportunitiesKey: "",
+    packagePerformance: null,
+    packagePerformanceLoading: false,
+    packagePerformanceError: "",
+    packagePerformanceKey: "",
+    packageMetadata: null,
+    packageMetadataLoading: false,
+    packageMetadataError: "",
+    packageMetadataKey: "",
+    ...overrides,
+  };
+}
+
+function dependencyResult(
+  packageId = "Example.Package",
+  error: string | null = null,
+): BrowserPackageDependencies {
+  return {
+    package: packageId,
+    version: "1.2.3",
+    activeFramework: "net10.0",
+    assembly: `${packageId}.dll`,
+    dependencyGroups: [{
+      index: 0,
+      framework: "net10.0",
+      isActive: true,
+      dependencies: [{ id: "Example.Dependency", versionRange: "[1.0.0,)" }],
+    }],
+    assemblyReferences: [],
+    dependencyGroupError: error,
+    assemblyReferenceError: null,
+  };
+}
+
+function integrationsResult(): BrowserPackageIntegrations {
+  return {
+    package: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    categories: [],
+    totalSignals: 0,
+    isComplete: true,
+    inspectionError: null,
+  };
+}
+
+function opportunitiesResult(): BrowserPackageOpportunities {
+  return {
+    package: "Example.Package",
+    version: "1.2.3",
+    activeFramework: "net10.0",
+    categories: [],
+    totalOpportunities: 0,
+    isComplete: true,
+    inspectionError: null,
+  };
+}
+
+function performanceResult(): PackagePerformance {
+  return {
+    members: [],
+    nonPublicOpportunities: 0,
+    totalOpportunities: 0,
+  };
+}
+
+function metadataResult(): PackageMetadata {
+  return { assemblies: [] };
+}
+
+function inspectionDependencies(
+  state: PackageInspectionState,
+  overrides: Partial<Omit<PackageInspectionDependencies, "state">> = {},
+): PackageInspectionDependencies {
+  return {
+    state,
+    queryDependencies: async packageItem => dependencyResult(packageItem.id),
+    queryPackageIntegrations: async () => integrationsResult(),
+    queryPlatformIntegrations: async () => integrationsResult(),
+    queryPackageOpportunities: async () => opportunitiesResult(),
+    queryPlatformOpportunities: async () => opportunitiesResult(),
+    queryPackagePerformance: async () => performanceResult(),
+    queryPlatformPerformance: async () => performanceResult(),
+    queryPackageMetadata: async () => metadataResult(),
+    queryPlatformMetadata: async () => metadataResult(),
+    platformPackForAssembly: assemblyName => `pack:${assemblyName}`,
+    describeError: error =>
+      error instanceof Error ? error.message : String(error),
+    refreshPackageStats: () => {},
+    render: () => {},
+    renderDependencyGraph: () => {},
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(accept => {
+    resolve = accept;
+  });
+  return { promise, resolve };
+}
+
+test("workspace dependency keys normalize complete package coordinates", () => {
+  assert.equal(
+    workspaceDependencyKey({
+      id: "Example.Package",
+      version: "1.2.3-PREVIEW",
+      activeFramework: "NET10.0",
+    }),
+    "example.package@1.2.3-preview@net10.0");
+});
+
+test("dependency results cache for a resident package after the foreground lens moves", async () => {
+  const packageItem = packageModel();
+  const request = deferred<BrowserPackageDependencies>();
+  const events: string[] = [];
+  const state = inspectionState({ packages: [packageItem] });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async () => request.promise,
+      refreshPackageStats: () => events.push("stats"),
+      render: () => events.push("render"),
+      renderDependencyGraph: () => events.push("graph"),
+    }));
+
+  const load = coordinator.loadDependencies(packageItem, "first");
+  assert.equal(state.packageDependenciesLoading, true);
+  state.packageDependenciesKey = "second";
+  request.resolve(dependencyResult(packageItem.id, "partial dependency data"));
+  await load;
+
+  assert.equal(state.packageDependencies, null);
+  assert.equal(state.packageDependenciesLoading, true);
+  const key = workspaceDependencyKey(packageItem);
+  const workspace = state.workspaceDependencies[key];
+  assert.ok(workspace);
+  assert.equal(
+    workspace.dependencyGroups?.[0]?.framework,
+    "net10.0");
+  assert.equal(
+    state.workspaceDependencyErrors[key],
+    "partial dependency data");
+  assert.deepEqual(events, ["render", "stats", "render", "graph"]);
+});
+
+test("workspace dependency loading records failures and ignores runtime packs", async () => {
+  const good = packageModel({ id: "Example.Good" });
+  const bad = packageModel({ id: "Example.Bad" });
+  const runtime = packageModel({
+    id: "Microsoft.NETCore.App",
+    isRuntimePack: true,
+    source: { kind: "platform" },
+  });
+  const events: string[] = [];
+  const state = inspectionState({
+    packages: [good, bad, runtime],
+    atPackageRoot: true,
+    packageLens: "dependencies",
+  });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async packageItem => {
+        events.push(`query:${packageItem.id}`);
+        if (packageItem === bad) throw new Error("dependency feed unavailable");
+        return dependencyResult(packageItem.id);
+      },
+      refreshPackageStats: () => events.push("stats"),
+      render: () => events.push("render"),
+    }));
+
+  await coordinator.ensureWorkspaceDependencies();
+
+  assert.deepEqual(events, [
+    "query:Example.Good",
+    "query:Example.Bad",
+    "render",
+    "stats",
+  ]);
+  assert.ok(state.workspaceDependencies[workspaceDependencyKey(good)]);
+  assert.deepEqual(
+    state.workspaceDependencies[workspaceDependencyKey(bad)].dependencyGroups,
+    []);
+  assert.equal(
+    state.workspaceDependencyErrors[workspaceDependencyKey(bad)],
+    "dependency feed unavailable");
+  assert.equal(
+    Object.hasOwn(state.workspaceDependencies, workspaceDependencyKey(runtime)),
+    false);
+  assert.equal(state.workspaceDependencyLoads.size, 0);
+});
+
+test("removed packages cannot publish an in-flight workspace dependency result", async () => {
+  const packageItem = packageModel();
+  const request = deferred<BrowserPackageDependencies>();
+  const state = inspectionState({ packages: [packageItem] });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async () => request.promise,
+    }));
+
+  const load = coordinator.ensureWorkspaceDependencies();
+  state.packages = [];
+  request.resolve(dependencyResult());
+  await load;
+
+  assert.equal(
+    Object.hasOwn(state.workspaceDependencies, workspaceDependencyKey(packageItem)),
+    false);
+  assert.equal(state.workspaceDependencyLoads.size, 0);
+});
+
+test("scoped package lenses route platform coordinates and suppress stale results", async () => {
+  const packageItem = packageModel();
+  const runtime = packageModel({
+    id: "Microsoft.NETCore.App",
+    isRuntimePack: true,
+    source: { kind: "platform" },
+  });
+  const metadata = deferred<PackageMetadata>();
+  const calls: string[] = [];
+  const state = inspectionState({ packages: [packageItem, runtime] });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageIntegrations: async model => {
+        calls.push(`integrations:${model.id}`);
+        return integrationsResult();
+      },
+      queryPlatformOpportunities: async (framework, assemblyName, pack) => {
+        calls.push(`opportunities:${framework}/${assemblyName}/${pack}`);
+        return opportunitiesResult();
+      },
+      queryPackagePerformance: async model => {
+        calls.push(`performance:${model.id}`);
+        throw new Error("analysis unavailable");
+      },
+      queryPackageMetadata: async model => {
+        calls.push(`metadata:${model.id}`);
+        return metadata.promise;
+      },
+    }));
+
+  await coordinator.loadIntegrations(packageItem, "integrations", null);
+  await coordinator.loadOpportunities(
+    runtime,
+    "opportunities",
+    "System.Text.Json");
+  await coordinator.loadPerformance(packageItem, "performance", null);
+  const metadataLoad =
+    coordinator.loadMetadata(packageItem, "metadata-first", null);
+  state.packageMetadataKey = "metadata-second";
+  metadata.resolve(metadataResult());
+  await metadataLoad;
+
+  assert.deepEqual(calls, [
+    "integrations:Example.Package",
+    "opportunities:net10.0/System.Text.Json.dll/pack:System.Text.Json",
+    "performance:Example.Package",
+    "metadata:Example.Package",
+  ]);
+  assert.ok(state.packageIntegrations);
+  assert.ok(state.packageOpportunities);
+  assert.equal(state.packagePerformance, null);
+  assert.equal(state.packagePerformanceError, "analysis unavailable");
+  assert.equal(state.packagePerformanceLoading, false);
+  assert.equal(state.packageMetadata, null);
+  assert.equal(state.packageMetadataLoading, true);
+});
+
+test("runtime package lenses wait for an explicit library scope", async () => {
+  const runtime = packageModel({
+    id: "Microsoft.NETCore.App",
+    isRuntimePack: true,
+    source: { kind: "platform" },
+  });
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({ packages: [runtime] });
+  const dependencies = inspectionDependencies(state, {
+    queryPlatformIntegrations: async () => {
+      queries++;
+      return integrationsResult();
+    },
+    queryPlatformOpportunities: async () => {
+      queries++;
+      return opportunitiesResult();
+    },
+    queryPlatformPerformance: async () => {
+      queries++;
+      return performanceResult();
+    },
+    queryPlatformMetadata: async () => {
+      queries++;
+      return metadataResult();
+    },
+    render: () => renders++,
+  });
+  const coordinator = createPackageInspectionCoordinator(dependencies);
+
+  await coordinator.loadIntegrations(runtime, "integrations", null);
+  await coordinator.loadOpportunities(runtime, "opportunities", null);
+  await coordinator.loadPerformance(runtime, "performance", null);
+  await coordinator.loadMetadata(runtime, "metadata", null);
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 0);
+  assert.equal(state.packageIntegrationsKey, "");
+  assert.equal(state.packageOpportunitiesKey, "");
+  assert.equal(state.packagePerformanceKey, "");
+  assert.equal(state.packageMetadataKey, "");
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -165,6 +165,9 @@ const workspaceNavigationSource = readFileSync(
 const packageAcquisitionSource = readFileSync(
   new URL("../src/package-acquisition.ts", import.meta.url),
   "utf8");
+const packageInspectionSource = readFileSync(
+  new URL("../src/package-inspection.ts", import.meta.url),
+  "utf8");
 const memberFocusSource = readFileSync(
   new URL("../src/member-focus.ts", import.meta.url),
   "utf8");
@@ -232,6 +235,27 @@ test("workspace data bar receives package acquisition provenance", () => {
   assert.match(packageAcquisitionSource, /source: \{ kind: "platform" \}/);
   assert.doesNotMatch(appSource, /source: \{ kind: "(?:nuget\.org|platform)" \}/);
   assert.match(statusBarSource, /Source: \$\{escapeHtml\(packageSourceLabel\(model\.source\)\)\}/);
+});
+
+test("typed package inspection owns package-root request coordination", () => {
+  const dependenciesLoader =
+    appSource.match(/async function loadPackageDependencies\(\) \{[\s\S]*?\n}/)?.[0]
+    ?? "";
+  assert.match(
+    appSource,
+    /createPackageInspectionCoordinator\(\{[\s\S]*queryDependencies:[\s\S]*queryPackageIntegrations:[\s\S]*queryPlatformMetadata:/);
+  assert.match(
+    dependenciesLoader,
+    /function loadPackageDependencies\(\) \{\s*return packageInspection\.loadDependencies\(/);
+  assert.match(appSource, /packageInspection\.ensureWorkspaceDependencies\(\)/);
+  assert.match(appSource, /packageInspection\.loadIntegrations\(/);
+  assert.match(appSource, /packageInspection\.loadOpportunities\(/);
+  assert.match(appSource, /packageInspection\.loadPerformance\(/);
+  assert.match(appSource, /packageInspection\.loadMetadata\(/);
+  assert.match(
+    packageInspectionSource,
+    /async loadDependencies\(packageModel, signature\)[\s\S]*state\.packageDependenciesKey/);
+  assert.doesNotMatch(dependenciesLoader, /state\.packageDependenciesKey/);
 });
 
 test("leaving package search clears its pending loading state", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -245,6 +245,32 @@ test("typed package inspection owns package-root request coordination", () => {
     appSource,
     /createPackageInspectionCoordinator\(\{[\s\S]*queryDependencies:[\s\S]*queryPackageIntegrations:[\s\S]*queryPlatformMetadata:/);
   assert.match(
+    appSource,
+    /queryDependencies: packageModel => inspectPackageDependencies\(\s*packageModel\.id,\s*packageModel\.version,\s*packageModel\.activeFramework,\s*packageModel\.assemblyId\)/);
+  for (const engine of [
+    "inspectPackageIntegrations",
+    "inspectPackageOpportunities",
+    "inspectPackagePerformance",
+    "inspectPackageMetadata",
+  ]) {
+    assert.match(
+      appSource,
+      new RegExp(
+        `${engine}\\(\\s*packageModel\\.id,\\s*`
+        + "packageModel\\.version,\\s*packageModel\\.activeFramework\\)"));
+  }
+  for (const engine of [
+    "inspectPlatformIntegrations",
+    "inspectPlatformOpportunities",
+    "inspectPlatformPerformance",
+    "inspectPlatformMetadata",
+  ]) {
+    assert.match(
+      appSource,
+      new RegExp(
+        `${engine}\\(\\s*framework,\\s*assemblyFileName,\\s*pack\\)`));
+  }
+  assert.match(
     dependenciesLoader,
     /function loadPackageDependencies\(\) \{\s*return packageInspection\.loadDependencies\(/);
   assert.match(appSource, /packageInspection\.ensureWorkspaceDependencies\(\)/);


### PR DESCRIPTION
Moves the package-root Dependencies, Integrations, Opportunities, Analysis, and Metadata request lifecycles out of the browser composition root behind a typed coordinator. The owner preserves scan-scope keys, stale-result suppression, package/platform routing, visible failures, diagnostics refresh, and workspace dependency-cache population; `dotnet-inspect.ts` retains mutable state storage, lens selection, explorer orchestration, and presentation.

**Stack**

- Slice 3, stacked on #4509.
- Parent: #4509 (package/runtime acquisition coordination).
- Residual: type/member/source and call-graph async request controllers, then DOM event binding paired with presentation owners.

**Validation**

- `npm test` — 279/279, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.