### PR TITLE
Extract inspect-web source request coordination

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -559,6 +559,17 @@ resident-package checks, visible partial/failure results, package/platform
 routing, stale publication, and explicit Platform library scope;
 `test/spotlight-identity.test.js` gates the composition-root wiring.
 
+`src/source-inspection.ts` owns the mutually exclusive member, type, and
+call-graph source request lifecycle: shared cancellation, generation and
+per-surface identity checks, loading/error/result transitions, graph-modal
+open/close state, and focus-preserving completion. `dotnet-inspect.ts`
+validates the active selection, builds typed engine requests, supplies mutable
+state and rendering ports, and retains annotated-source coordination.
+`test/source-inspection.test.ts` gates hidden cancellation, stale member
+selection, visible failure, hidden type completion, graph close/cancellation,
+and graph failure; `test/spotlight-identity.test.js` gates engine and
+composition-root wiring.
+
 `src/spotlight.ts` owns the modal workbench search, embedded home search,
 scope/result rendering, selection, and keyboard interaction.
 `src/command-bar.ts` supplies its typed Commands-scope grammar and results;
@@ -659,9 +670,10 @@ and is not escaped).
 
 `src/graph-source.ts` owns the member source modal (the code viewer opened
 from a call graph node) as a pure, dependency-injected render function.
-`dotnet-inspect.ts` still owns `state`, the sequence-guarded async source-inspection
-lifecycle, and the `highlightCSharp` Prism wrapper, and passes each computed
-slice in explicitly. `test/graph-source.test.ts` gates the loading state, the
+`source-inspection.ts` owns its sequence-guarded async lifecycle;
+`dotnet-inspect.ts` supplies `state`, the typed engine port, and the
+`highlightCSharp` Prism wrapper, and passes each computed slice explicitly.
+`test/graph-source.test.ts` gates the loading state, the
 original-versus-decompiled provenance labels, the open-source link's presence
 only when a `url` is provided, the error state's fallback message, and title
 escaping in both the header and loading status.

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -1,8 +1,6 @@
 import {
   activeSourceOperationKind,
   assemblyDescriptorForType,
-  beginSourceRequestState,
-  cancelSourceRequestState,
   callGraphDiagnosticsMessage,
   callGraphTargetMatchesType,
   callGraphTargetTypeId,
@@ -30,7 +28,6 @@ import {
   retainWorkspacePackage,
   resolveLoadedGraphTargetCandidate,
   scopedRequestState,
-  sourceSurfaceIsVisible,
   sourceReloadKind,
   sourceRequestNeedsLoad,
   selectedDependencyGroup,
@@ -75,6 +72,10 @@ import {
   workspaceDependencyKey,
   type PackagePerformance,
 } from "./package-inspection.ts";
+import {
+  createSourceInspectionCoordinator,
+  type GraphSourceRequest,
+} from "./source-inspection.ts";
 import {
   captureMemberFocus,
   createMemberFocusRestorer,
@@ -422,17 +423,6 @@ interface MemberFacts {
   }>;
 }
 
-interface GraphSourceRequest {
-  packageId: string;
-  version: string;
-  framework: string;
-  assembly: string;
-  type: string;
-  member: string;
-  selectorKey: string;
-  metadataToken: number;
-}
-
 interface Diagnostics {
   downloadMs: number;
   startupMs: number;
@@ -648,6 +638,40 @@ interface StateOverrides {
 type AppState = Omit<typeof initialState, keyof StateOverrides> & StateOverrides;
 
 const state = initialState as AppState;
+const sourceInspection = createSourceInspectionCoordinator({
+  state,
+  queryMemberSource: request => inspectMemberSource(
+    request.packageId,
+    request.version,
+    request.framework,
+    request.assembly,
+    request.type,
+    request.member,
+    request.selectorKey,
+    request.metadataToken,
+    request.taste),
+  queryTypeSource: request => inspectTypeSource(
+    request.packageId,
+    request.version,
+    request.framework,
+    request.assembly,
+    request.type,
+    request.taste),
+  queryGraphSource: (request, taste) => inspectTypeMemberSource(
+    request.packageId,
+    request.version,
+    request.framework,
+    request.assembly,
+    request.type,
+    request.member,
+    request.selectorKey,
+    request.metadataToken,
+    taste),
+  cancelEngineSourceRequest: () => cancelSourceInspection?.(),
+  describeError: errorMessage,
+  render,
+  renderPreservingMemberFocus,
+});
 
 function captureView(): WorkspaceView | null {
   if (!state.package) return null;
@@ -1729,10 +1753,7 @@ function typeDisplayName(
 }
 
 function render() {
-  if (!sourceSurfaceIsVisible(state)
-    && cancelSourceRequestState(state)) {
-    cancelSourceInspection?.();
-  }
+  sourceInspection.cancelHiddenRequest();
 
   // The Settings page is a modal-style full view layered over whatever the user came from
   // (home or a package). It owns no URL — it's a preferences panel, not shareable content —
@@ -5820,53 +5841,22 @@ async function loadSelectedMemberSource() {
     return;
   }
   const signature = memberRequestSignature(type, overload, false, true);
-  if (!sourceRequestNeedsLoad(
-      state.memberSourceKey === signature,
-      state.memberSourceLoading,
-      state.memberSource,
-      state.memberSourceError)) {
-    render();
-    return;
-  }
-
-  const generation = beginSourceRequestState(state);
-  state.memberSourceKey = signature;
-  state.memberSource = null;
-  state.memberSourceLoading = true;
-  state.memberSourceError = "";
-  const preservedFocus = renderPreservingMemberFocus();
   const pkg = currentPackage();
-  try {
-    const result = await inspectMemberSource(
-      pkg.id,
-      pkg.version,
-      pkg.activeFramework,
-      type.assembly,
-      type.definitionId ?? type.id,
-      state.selectedBodyTarget?.memberName ?? overload.name,
+  return sourceInspection.loadMemberSource({
+    signature,
+    packageId: pkg.id,
+    version: pkg.version,
+    framework: pkg.activeFramework,
+    assembly: type.assembly,
+    type: type.definitionId ?? type.id,
+    member: state.selectedBodyTarget?.memberName ?? overload.name,
+    selectorKey:
       state.selectedBodyTarget?.selectorKey ?? overload.graphSelectorKey,
+    metadataToken:
       state.selectedBodyTarget?.metadataToken ?? overload.metadataToken ?? 0,
-      JSON.stringify(state.taste));
-    if (generation === state.sourceRequestGeneration
-      && memberRequestIsCurrent(signature, false, true)
-      && state.memberSourceKey === signature) {
-      state.memberSource = result;
-    }
-  } catch (error) {
-    if (generation === state.sourceRequestGeneration
-      && memberRequestIsCurrent(signature, false, true)
-      && state.memberSourceKey === signature) {
-      state.memberSourceError = errorMessage(error);
-    }
-  } finally {
-    const current = generation === state.sourceRequestGeneration
-      && state.memberSourceKey === signature;
-    if (current) {
-      state.memberSourceLoading = false;
-      if (memberRequestIsCurrent(signature, false, true))
-        renderPreservingMemberFocus(preservedFocus);
-    }
-  }
+    taste: JSON.stringify(state.taste),
+    isCurrent: () => memberRequestIsCurrent(signature, false, true),
+  });
 }
 
 async function loadSelectedMemberAnnotatedSource() {
@@ -5981,49 +5971,18 @@ async function loadSelectedTypeSource() {
   const pkg = currentPackage();
   const signature =
     typeSourceSignature(type, pkg, state.taste, memberRequestKey);
-  if (!sourceRequestNeedsLoad(
-      state.typeSourceKey === signature,
-      state.typeSourceLoading,
-      state.typeSource,
-      state.typeSourceError)) {
-    renderPreservingMemberFocus();
-    return;
-  }
-  const generation = beginSourceRequestState(state);
-  state.typeSourceKey = signature;
-  state.typeSource = null;
-  state.typeSourceError = "";
-  state.typeSourceLoading = true;
-  const preservedFocus = renderPreservingMemberFocus();
-  const ownsRequest = () =>
-    generation === state.sourceRequestGeneration
-    && state.typeSourceKey === signature;
-  const isCurrent = () =>
-    ownsRequest()
-    && activeSourceOperationKind(state) === "type"
-    && !workbenchModalOwnsFocus();
-  try {
-    const result = await inspectTypeSource(
-      pkg.id,
-      pkg.version,
-      pkg.activeFramework,
-      type.assembly,
-      type.definitionId ?? type.id,
-      JSON.stringify(state.taste));
-    if (ownsRequest()) {
-      state.typeSource = result;
-    }
-  } catch (error) {
-    if (ownsRequest()) {
-      state.typeSourceError = errorMessage(error);
-    }
-  } finally {
-    if (ownsRequest()) {
-      state.typeSourceLoading = false;
-      if (isCurrent())
-        renderPreservingMemberFocus(preservedFocus);
-    }
-  }
+  return sourceInspection.loadTypeSource({
+    signature,
+    packageId: pkg.id,
+    version: pkg.version,
+    framework: pkg.activeFramework,
+    assembly: type.assembly,
+    type: type.definitionId ?? type.id,
+    taste: JSON.stringify(state.taste),
+    isVisible: () =>
+      activeSourceOperationKind(state) === "type"
+      && !workbenchModalOwnsFocus(),
+  });
 }
 
 async function loadSelectedTypeMetadata() {
@@ -7067,53 +7026,11 @@ function stripArity(name: string) {
 }
 
 async function openGraphSource(request: GraphSourceRequest, title: string) {
-  const generation = beginSourceRequestState(state);
-  const seq = ++state.graphSourceSeq;
-  state.graphSourceOpen = true;
-  state.graphSourceTitle = title;
-  state.graphSourceRequest = { request, title };
-  state.graphSource = null;
-  state.graphSourceError = "";
-  state.graphSourceLoading = true;
-  render();
-  try {
-    const source = await inspectTypeMemberSource(
-      request.packageId,
-      request.version,
-      request.framework,
-      request.assembly,
-      request.type,
-      request.member,
-      request.selectorKey,
-      request.metadataToken,
-      JSON.stringify(state.taste));
-    if (generation !== state.sourceRequestGeneration
-      || seq !== state.graphSourceSeq
-      || !state.graphSourceOpen) return;
-    state.graphSource = source;
-  } catch (error) {
-    if (generation !== state.sourceRequestGeneration
-      || seq !== state.graphSourceSeq
-      || !state.graphSourceOpen) return;
-    state.graphSourceError = errorMessage(error);
-  } finally {
-    if (generation !== state.sourceRequestGeneration
-      || seq !== state.graphSourceSeq
-      || !state.graphSourceOpen) return;
-    state.graphSourceLoading = false;
-    render();
-  }
+  return sourceInspection.openGraphSource(request, title);
 }
 
 function closeGraphSource() {
-  if (cancelSourceRequestState(state)) cancelSourceInspection?.();
-  state.graphSourceSeq++;
-  state.graphSourceOpen = false;
-  state.graphSource = null;
-  state.graphSourceError = "";
-  state.graphSourceLoading = false;
-  state.graphSourceRequest = null;
-  render();
+  sourceInspection.closeGraphSource();
 }
 
 // Lazily load marked + DOMPurify (mirrors the mermaid CDN-ESM pattern). marked renders GFM

--- a/prototypes/inspect-web/src/source-inspection.ts
+++ b/prototypes/inspect-web/src/source-inspection.ts
@@ -1,0 +1,230 @@
+import {
+  beginSourceRequestState,
+  cancelSourceRequestState,
+  sourceRequestNeedsLoad,
+  sourceSurfaceIsVisible,
+  type SourceRequestState,
+  type SourceWorkbenchState,
+} from "./data.ts";
+import type { BrowserSource } from "./inspect-web-engine.d.ts";
+import type { MemberFocusSnapshot } from "./member-focus.ts";
+
+interface SourceCoordinates {
+  packageId: string;
+  version: string;
+  framework: string;
+  assembly: string;
+  type: string;
+}
+
+export interface MemberSourceQuery extends SourceCoordinates {
+  member: string;
+  selectorKey: string;
+  metadataToken: number;
+  taste: string;
+}
+
+export interface TypeSourceQuery extends SourceCoordinates {
+  taste: string;
+}
+
+export interface GraphSourceRequest extends SourceCoordinates {
+  member: string;
+  selectorKey: string;
+  metadataToken: number;
+}
+
+export interface MemberSourceLoadRequest extends MemberSourceQuery {
+  signature: string;
+  isCurrent(): boolean;
+}
+
+export interface TypeSourceLoadRequest extends TypeSourceQuery {
+  signature: string;
+  isVisible(): boolean;
+}
+
+export interface SourceInspectionState
+  extends SourceRequestState, SourceWorkbenchState {
+  sourceRequestGeneration: number;
+  memberSource: BrowserSource | null;
+  memberSourceLoading: boolean;
+  memberSourceError: string;
+  memberSourceKey: string;
+  typeSource: BrowserSource | null;
+  typeSourceLoading: boolean;
+  typeSourceError: string;
+  typeSourceKey: string;
+  graphSourceOpen: boolean;
+  graphSource: BrowserSource | null;
+  graphSourceLoading: boolean;
+  graphSourceError: string;
+  graphSourceTitle: string;
+  graphSourceRequest: {
+    request: GraphSourceRequest;
+    title: string;
+  } | null;
+  graphSourceSeq: number;
+  taste: string[];
+}
+
+export interface SourceInspectionDependencies {
+  state: SourceInspectionState;
+  queryMemberSource(request: MemberSourceQuery): Promise<BrowserSource>;
+  queryTypeSource(request: TypeSourceQuery): Promise<BrowserSource>;
+  queryGraphSource(
+    request: GraphSourceRequest,
+    taste: string,
+  ): Promise<BrowserSource>;
+  cancelEngineSourceRequest(): void;
+  describeError(error: unknown): string;
+  render(): void;
+  renderPreservingMemberFocus(
+    fallback?: MemberFocusSnapshot | null,
+  ): MemberFocusSnapshot;
+}
+
+export interface SourceInspectionCoordinator {
+  cancelHiddenRequest(): void;
+  loadMemberSource(request: MemberSourceLoadRequest): Promise<void>;
+  loadTypeSource(request: TypeSourceLoadRequest): Promise<void>;
+  openGraphSource(
+    request: GraphSourceRequest,
+    title: string,
+  ): Promise<void>;
+  closeGraphSource(): void;
+}
+
+export function createSourceInspectionCoordinator(
+  dependencies: SourceInspectionDependencies,
+): SourceInspectionCoordinator {
+  const { state } = dependencies;
+
+  return {
+    cancelHiddenRequest() {
+      if (!sourceSurfaceIsVisible(state)
+        && cancelSourceRequestState(state)) {
+        dependencies.cancelEngineSourceRequest();
+      }
+    },
+
+    async loadMemberSource(request) {
+      if (!sourceRequestNeedsLoad(
+          state.memberSourceKey === request.signature,
+          state.memberSourceLoading,
+          state.memberSource,
+          state.memberSourceError)) {
+        dependencies.render();
+        return;
+      }
+
+      const generation = beginSourceRequestState(state);
+      state.memberSourceKey = request.signature;
+      state.memberSource = null;
+      state.memberSourceLoading = true;
+      state.memberSourceError = "";
+      const preservedFocus = dependencies.renderPreservingMemberFocus();
+      try {
+        const result = await dependencies.queryMemberSource(request);
+        if (generation === state.sourceRequestGeneration
+          && request.isCurrent()
+          && state.memberSourceKey === request.signature) {
+          state.memberSource = result;
+        }
+      } catch (error) {
+        if (generation === state.sourceRequestGeneration
+          && request.isCurrent()
+          && state.memberSourceKey === request.signature) {
+          state.memberSourceError = dependencies.describeError(error);
+        }
+      } finally {
+        const current = generation === state.sourceRequestGeneration
+          && state.memberSourceKey === request.signature;
+        if (current) {
+          state.memberSourceLoading = false;
+          if (request.isCurrent()) {
+            dependencies.renderPreservingMemberFocus(preservedFocus);
+          }
+        }
+      }
+    },
+
+    async loadTypeSource(request) {
+      if (!sourceRequestNeedsLoad(
+          state.typeSourceKey === request.signature,
+          state.typeSourceLoading,
+          state.typeSource,
+          state.typeSourceError)) {
+        dependencies.renderPreservingMemberFocus();
+        return;
+      }
+      const generation = beginSourceRequestState(state);
+      state.typeSourceKey = request.signature;
+      state.typeSource = null;
+      state.typeSourceError = "";
+      state.typeSourceLoading = true;
+      const preservedFocus = dependencies.renderPreservingMemberFocus();
+      const ownsRequest = () =>
+        generation === state.sourceRequestGeneration
+        && state.typeSourceKey === request.signature;
+      try {
+        const result = await dependencies.queryTypeSource(request);
+        if (ownsRequest()) state.typeSource = result;
+      } catch (error) {
+        if (ownsRequest()) {
+          state.typeSourceError = dependencies.describeError(error);
+        }
+      } finally {
+        if (ownsRequest()) {
+          state.typeSourceLoading = false;
+          if (request.isVisible()) {
+            dependencies.renderPreservingMemberFocus(preservedFocus);
+          }
+        }
+      }
+    },
+
+    async openGraphSource(request, title) {
+      const generation = beginSourceRequestState(state);
+      const sequence = ++state.graphSourceSeq;
+      state.graphSourceOpen = true;
+      state.graphSourceTitle = title;
+      state.graphSourceRequest = { request, title };
+      state.graphSource = null;
+      state.graphSourceError = "";
+      state.graphSourceLoading = true;
+      dependencies.render();
+      const isCurrent = () =>
+        generation === state.sourceRequestGeneration
+        && sequence === state.graphSourceSeq
+        && state.graphSourceOpen;
+      try {
+        const source = await dependencies.queryGraphSource(
+          request,
+          JSON.stringify(state.taste));
+        if (isCurrent()) state.graphSource = source;
+      } catch (error) {
+        if (isCurrent()) {
+          state.graphSourceError = dependencies.describeError(error);
+        }
+      } finally {
+        if (!isCurrent()) return;
+        state.graphSourceLoading = false;
+        dependencies.render();
+      }
+    },
+
+    closeGraphSource() {
+      if (cancelSourceRequestState(state)) {
+        dependencies.cancelEngineSourceRequest();
+      }
+      state.graphSourceSeq++;
+      state.graphSourceOpen = false;
+      state.graphSource = null;
+      state.graphSourceError = "";
+      state.graphSourceLoading = false;
+      state.graphSourceRequest = null;
+      dependencies.render();
+    },
+  };
+}

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSourceInspectionCoordinator,
+  type SourceInspectionDependencies,
+  type SourceInspectionState,
+} from "../src/source-inspection.ts";
+import type { BrowserSource } from "../src/inspect-web-engine.d.ts";
+import type { MemberFocusSnapshot } from "../src/member-focus.ts";
+
+function source(text: string): BrowserSource {
+  return {
+    provider: "SourceLink",
+    provenance: "original",
+    url: "https://example.test/source.cs",
+    text,
+  };
+}
+
+function focusSnapshot(selector = "#member-filter"): MemberFocusSnapshot {
+  return {
+    selector,
+    dataTarget: null,
+    selection: null,
+    navigationScope: null,
+    navigationSelection: null,
+    navigationScrollTop: null,
+    focusLost: false,
+  };
+}
+
+function inspectionState(
+  overrides: Partial<SourceInspectionState> = {},
+): SourceInspectionState {
+  return {
+    settings: false,
+    explorer: null,
+    loading: false,
+    error: "",
+    home: false,
+    package: {},
+    graphSourceOpen: false,
+    atPackageRoot: false,
+    lens: "api",
+    selectedMemberKey: "method:Build",
+    memberSection: "source",
+    sourceRequestGeneration: 0,
+    memberSource: null,
+    memberSourceLoading: false,
+    memberSourceError: "",
+    memberSourceKey: "",
+    typeSource: null,
+    typeSourceLoading: false,
+    typeSourceError: "",
+    typeSourceKey: "",
+    graphSource: null,
+    graphSourceLoading: false,
+    graphSourceError: "",
+    graphSourceTitle: "",
+    graphSourceRequest: null,
+    graphSourceSeq: 0,
+    taste: [],
+    ...overrides,
+  };
+}
+
+function inspectionDependencies(
+  state: SourceInspectionState,
+  overrides: Partial<Omit<SourceInspectionDependencies, "state">> = {},
+): SourceInspectionDependencies {
+  return {
+    state,
+    queryMemberSource: async () => source("member"),
+    queryTypeSource: async () => source("type"),
+    queryGraphSource: async () => source("graph"),
+    cancelEngineSourceRequest: () => {},
+    describeError: error =>
+      error instanceof Error ? error.message : String(error),
+    render: () => {},
+    renderPreservingMemberFocus: fallback =>
+      fallback ?? focusSnapshot(),
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(accept => {
+    resolve = accept;
+  });
+  return { promise, resolve };
+}
+
+test("hidden source work is cancelled through the shared engine boundary", () => {
+  let cancellations = 0;
+  const state = inspectionState({
+    settings: true,
+    memberSourceLoading: true,
+    memberSourceKey: "member",
+  });
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      cancelEngineSourceRequest: () => cancellations++,
+    }));
+
+  coordinator.cancelHiddenRequest();
+
+  assert.equal(cancellations, 1);
+  assert.equal(state.sourceRequestGeneration, 1);
+  assert.equal(state.memberSourceLoading, false);
+  assert.equal(state.memberSourceKey, "");
+
+  state.settings = false;
+  state.memberSourceLoading = true;
+  coordinator.cancelHiddenRequest();
+  assert.equal(cancellations, 1);
+  assert.equal(state.memberSourceLoading, true);
+});
+
+test("member source publishes only for the current member selection", async () => {
+  const query = deferred<BrowserSource>();
+  const focusRenders: Array<string | null> = [];
+  let current = true;
+  const state = inspectionState();
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryMemberSource: async request => {
+        assert.equal(request.member, "Build");
+        assert.equal(request.taste, "[\"expression-bodied-members\"]");
+        return query.promise;
+      },
+      renderPreservingMemberFocus: fallback => {
+        focusRenders.push(fallback?.selector ?? null);
+        return fallback ?? focusSnapshot();
+      },
+    }));
+
+  const load = coordinator.loadMemberSource({
+    signature: "member-signature",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member: "Build",
+    selectorKey: "method",
+    metadataToken: 42,
+    taste: "[\"expression-bodied-members\"]",
+    isCurrent: () => current,
+  });
+  assert.equal(state.memberSourceLoading, true);
+  current = false;
+  query.resolve(source("stale"));
+  await load;
+
+  assert.equal(state.memberSource, null);
+  assert.equal(state.memberSourceLoading, false);
+  assert.deepEqual(focusRenders, [null]);
+});
+
+test("current member source failures remain visible and restore focus", async () => {
+  const renders: Array<string | null> = [];
+  const state = inspectionState();
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryMemberSource: async () => {
+        throw new Error("source unavailable");
+      },
+      renderPreservingMemberFocus: fallback => {
+        renders.push(fallback?.selector ?? null);
+        return fallback ?? focusSnapshot("#type-list");
+      },
+    }));
+
+  await coordinator.loadMemberSource({
+    signature: "member-signature",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member: "Build",
+    selectorKey: "method",
+    metadataToken: 42,
+    taste: "[]",
+    isCurrent: () => true,
+  });
+
+  assert.equal(state.memberSourceError, "source unavailable");
+  assert.equal(state.memberSourceLoading, false);
+  assert.deepEqual(renders, [null, "#type-list"]);
+});
+
+test("type source caches an owned result without repainting a hidden surface", async () => {
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({
+    lens: "source",
+    selectedMemberKey: "",
+    memberSection: "overview",
+  });
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeSource: async () => {
+        queries++;
+        return source("type");
+      },
+      renderPreservingMemberFocus: fallback => {
+        renders++;
+        return fallback ?? focusSnapshot();
+      },
+    }));
+  const request = {
+    signature: "type-signature",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    taste: "[]",
+    isVisible: () => false,
+  };
+
+  await coordinator.loadTypeSource(request);
+  assert.equal(state.typeSource?.text, "type");
+  assert.equal(state.typeSourceLoading, false);
+  assert.equal(renders, 1);
+
+  await coordinator.loadTypeSource(request);
+  assert.equal(queries, 1);
+  assert.equal(renders, 2);
+});
+
+test("closing graph source invalidates its result and cancels the engine", async () => {
+  const query = deferred<BrowserSource>();
+  const events: string[] = [];
+  const state = inspectionState({
+    taste: ["expression-bodied-members"],
+  });
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryGraphSource: async (request, taste) => {
+        events.push(`query:${request.member}/${taste}`);
+        return query.promise;
+      },
+      cancelEngineSourceRequest: () => events.push("cancel"),
+      render: () => events.push("render"),
+    }));
+  const request = {
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member: "Build",
+    selectorKey: "method",
+    metadataToken: 42,
+  };
+
+  const load = coordinator.openGraphSource(request, "Example.Widget.Build");
+  assert.equal(state.graphSourceOpen, true);
+  assert.equal(state.graphSourceSeq, 1);
+  assert.deepEqual(state.graphSourceRequest, {
+    request,
+    title: "Example.Widget.Build",
+  });
+  coordinator.closeGraphSource();
+  assert.equal(state.graphSourceSeq, 3);
+  query.resolve(source("stale graph"));
+  await load;
+
+  assert.equal(state.graphSourceOpen, false);
+  assert.equal(state.graphSource, null);
+  assert.equal(state.graphSourceRequest, null);
+  assert.deepEqual(events, [
+    "render",
+    "query:Build/[\"expression-bodied-members\"]",
+    "cancel",
+    "render",
+  ]);
+});
+
+test("current graph source failures settle as visible errors", async () => {
+  let renders = 0;
+  const state = inspectionState();
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryGraphSource: async () => {
+        throw new Error("graph source unavailable");
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.openGraphSource({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member: "Build",
+    selectorKey: "method",
+    metadataToken: 42,
+  }, "Example.Widget.Build");
+
+  assert.equal(state.graphSourceError, "graph source unavailable");
+  assert.equal(state.graphSourceLoading, false);
+  assert.equal(renders, 2);
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -168,6 +168,9 @@ const packageAcquisitionSource = readFileSync(
 const packageInspectionSource = readFileSync(
   new URL("../src/package-inspection.ts", import.meta.url),
   "utf8");
+const sourceInspectionSource = readFileSync(
+  new URL("../src/source-inspection.ts", import.meta.url),
+  "utf8");
 const memberFocusSource = readFileSync(
   new URL("../src/member-focus.ts", import.meta.url),
   "utf8");
@@ -689,12 +692,12 @@ test("authoritative location restore clears filters and applies aggregate Platfo
 
 test("type projection completions render only while current and preserve navigation focus", () => {
   const typeSource =
-    appSource.match(/async function loadSelectedTypeSource\([\s\S]*?\n}\n\nasync function loadSelectedTypeMetadata/)?.[0]
+    sourceInspectionSource.match(/async loadTypeSource\(request\)[\s\S]*?\n    },/)?.[0]
     ?? "";
   assert.match(
     typeSource,
-    /const preservedFocus = renderPreservingMemberFocus\(\);[\s\S]*const ownsRequest = \(\) =>[\s\S]*const isCurrent = \(\) =>[\s\S]*if \(ownsRequest\(\)\) \{\s*state\.typeSourceLoading = false;\s*if \(isCurrent\(\)\)\s*renderPreservingMemberFocus\(preservedFocus\);/);
-  assert.doesNotMatch(typeSource, /finally \{[\s\S]*\n\s*render\(\);\s*}/);
+    /const preservedFocus = dependencies\.renderPreservingMemberFocus\(\);[\s\S]*const ownsRequest = \(\) =>[\s\S]*if \(ownsRequest\(\)\) \{\s*state\.typeSourceLoading = false;\s*if \(request\.isVisible\(\)\) \{\s*dependencies\.renderPreservingMemberFocus\(preservedFocus\);/);
+  assert.doesNotMatch(typeSource, /finally \{[\s\S]*dependencies\.render\(\)/);
   const typeMetadata =
     appSource.match(/async function loadSelectedTypeMetadata\([\s\S]*?\n}\n\n\/\/ Projects/)?.[0]
     ?? "";
@@ -761,14 +764,17 @@ test("Platform scope restoration defers selection, rendering, and data loading",
 
 test("Type Source completion settles behind workbench overlays", () => {
   const typeSource =
-    appSource.match(/async function loadSelectedTypeSource\([\s\S]*?\n}\n\nasync function loadSelectedTypeMetadata/)?.[0]
+    sourceInspectionSource.match(/async loadTypeSource\(request\)[\s\S]*?\n    },/)?.[0]
     ?? "";
   assert.match(
     appSource,
     /function workbenchOverlayOwnsFocus\(\) \{\s*return workbenchModalOwnsFocus\(\)\s*\|\| state\.tasteOpen;[\s\S]*function workbenchModalOwnsFocus\(\) \{\s*return state\.spotlightOpen\s*\|\| state\.graphSourceOpen\s*\|\| state\.docViewerOpen;/);
   assert.match(
+    appSource,
+    /sourceInspection\.loadTypeSource\(\{[\s\S]*isVisible: \(\) =>\s*activeSourceOperationKind\(state\) === "type"\s*&& !workbenchModalOwnsFocus\(\)/);
+  assert.match(
     typeSource,
-    /const ownsRequest = \(\) =>[\s\S]*const isCurrent = \(\) =>\s*ownsRequest\(\)\s*&& activeSourceOperationKind\(state\) === "type"\s*&& !workbenchModalOwnsFocus\(\);[\s\S]*if \(ownsRequest\(\)\) \{\s*state\.typeSourceLoading = false;\s*if \(isCurrent\(\)\)\s*renderPreservingMemberFocus\(preservedFocus\)/);
+    /const ownsRequest = \(\) =>[\s\S]*if \(ownsRequest\(\)\) \{\s*state\.typeSourceLoading = false;\s*if \(request\.isVisible\(\)\) \{\s*dependencies\.renderPreservingMemberFocus\(preservedFocus\)/);
   assert.match(
     appSource,
     /function isInteractiveElement\(element: Element \| null\)[\s\S]*"button, a\[href\], input, select, textarea, summary, "[\s\S]*\[role=button\][\s\S]*!isInteractiveElement\([\s\S]*event\.target instanceof Element \? event\.target : null\)[\s\S]*event\.key === "Enter"/);
@@ -1030,9 +1036,17 @@ test("source operations cancel when superseded or hidden", () => {
   const renderBody =
     appSource.match(/function render\(\)[\s\S]*?\n}/)?.[0]
     ?? "";
-  assert.match(renderBody, /sourceSurfaceIsVisible\(state\)/);
-  assert.match(renderBody, /cancelSourceRequestState\(state\)/);
-  assert.match(renderBody, /cancelSourceInspection\?\.\(\)/);
+  assert.match(renderBody, /sourceInspection\.cancelHiddenRequest\(\)/);
+  assert.match(
+    appSource,
+    /createSourceInspectionCoordinator\(\{[\s\S]*cancelEngineSourceRequest: \(\) => cancelSourceInspection\?\.\(\)/);
+  assert.match(
+    sourceInspectionSource,
+    /cancelHiddenRequest\(\)[\s\S]*sourceSurfaceIsVisible\(state\)[\s\S]*cancelSourceRequestState\(state\)/);
+  assert.match(appSource, /sourceInspection\.loadMemberSource\(\{/);
+  assert.match(appSource, /sourceInspection\.loadTypeSource\(\{/);
+  assert.match(appSource, /sourceInspection\.openGraphSource\(request, title\)/);
+  assert.match(appSource, /sourceInspection\.closeGraphSource\(\)/);
   const reloadBody =
     appSource.match(/function reloadVisibleSource\(\)[\s\S]*?\n}/)?.[0]
     ?? "";


### PR DESCRIPTION
Moves the mutually exclusive member, type, and call-graph source request lifecycles out of the browser composition root behind a typed coordinator. Shared cancellation, generation and surface-identity guards, focus-preserving completion, graph-modal open/close state, exact engine request coordinates, and visible failures are preserved; `dotnet-inspect.ts` retains active-selection validation, mutable state storage, annotated-source coordination, rendering, and DOM effects.

**Stack**

- Slice 4, stacked on #4510.
- Parent: #4510 (package-root inspection coordination).
- Residual: annotated source/documentation/facts and call-graph request controllers, then DOM event binding paired with presentation owners.

**Validation**

- `npm test` — 285/285, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.