### PR TITLE
Extract inspect-web metadata request coordination

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -570,6 +570,17 @@ selection, visible failure, hidden type completion, graph close/cancellation,
 and graph failure; `test/spotlight-identity.test.js` gates engine and
 composition-root wiring.
 
+`src/metadata-inspection.ts` owns the type-metadata request lifecycle and the
+Metadata Explorer's table-window and heap-listing requests, including cache
+identity, package/platform routing, stale-explorer suppression, visible
+loading/failure state, and focus-aware completion. `dotnet-inspect.ts` supplies
+typed state, engine, rendering, and scroll ports while retaining selection
+validation, explorer focus/history navigation, and DOM effects.
+`test/metadata-inspection.test.ts` gates cached and stale type completions,
+focus preservation, explorer routing, window identity, failure publication,
+and focused scrolling; `test/spotlight-identity.test.js` gates composition-root
+wiring.
+
 `src/spotlight.ts` owns the modal workbench search, embedded home search,
 scope/result rendering, selection, and keyboard interaction.
 `src/command-bar.ts` supplies its typed Commands-scope grammar and results;
@@ -643,9 +654,10 @@ headers) and the Metadata Explorer (the spatial table/heap drill-down laid over
 it) as pure, dependency-injected render functions; both describe the metadata
 image rather than the API surface within it, so they share one module the way
 `type-panel.ts` combines the type selector and the type viewer.
-`package-inspection.ts` coordinates the package-level image request;
-`dotnet-inspect.ts` still owns `state`, table-window and heap-listing engine
-calls, the explorer's focus/history stack, the DOM event binding, the
+`package-inspection.ts` coordinates the package-level image request, while
+`metadata-inspection.ts` coordinates type metadata and the explorer's
+table-window and heap-listing requests. `dotnet-inspect.ts` still owns `state`,
+the explorer's focus/history stack, the DOM event binding, the
 `IntersectionObserver` that hydrates cards lazily, the resize listener, and
 the global keydown handler, and passes each computed slice in explicitly; the
 shared helpers used well beyond these views (`escapeHtml`, `fmtBytes`,

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -77,6 +77,10 @@ import {
   type GraphSourceRequest,
 } from "./source-inspection.ts";
 import {
+  createMetadataInspectionCoordinator,
+  type AppExplorerState,
+} from "./metadata-inspection.ts";
+import {
   captureMemberFocus,
   createMemberFocusRestorer,
   type MemberFocusSnapshot,
@@ -124,7 +128,6 @@ import {
   sameFocus,
   type ExplorerFocus,
   type ExplorerTableData,
-  type ExplorerState,
   type HeapListingData,
   type PackageMetadata,
 } from "./metadata-viewer.ts";
@@ -279,15 +282,6 @@ interface AppMemberGroup {
 
 interface AppMemberSurface extends BrowserMemberSurface {
   documentationLoaded?: boolean;
-}
-
-interface AppExplorerState extends ExplorerState {
-  isPlatform: boolean;
-  pack: string | null;
-  packageId: string;
-  version: string;
-  framework: string;
-  pendingScroll: boolean;
 }
 
 function loadStoredTaste() {
@@ -671,6 +665,53 @@ const sourceInspection = createSourceInspectionCoordinator({
   describeError: errorMessage,
   render,
   renderPreservingMemberFocus,
+});
+const metadataInspection = createMetadataInspectionCoordinator({
+  state,
+  queryTypeMetadata: request => inspectTypeProjection(
+    request.packageId,
+    request.version,
+    request.framework,
+    request.assembly,
+    request.type),
+  queryPackageTable: async (explorer, index, startRowId, maxRows) =>
+    parseEngineJson<ExplorerTableData>(
+      await inspectPackageMetadataTable(
+        explorer.packageId,
+        explorer.version,
+        explorer.framework,
+        explorer.assemblyFileName,
+        index,
+        startRowId,
+        maxRows)),
+  queryPlatformTable: async (explorer, index, startRowId, maxRows) =>
+    parseEngineJson<ExplorerTableData>(
+      await inspectPlatformMetadataTable(
+        explorer.framework,
+        explorer.assemblyFileName,
+        explorer.pack || "",
+        index,
+        startRowId,
+        maxRows)),
+  queryPackageHeap: async (explorer, heapName) =>
+    parseEngineJson<HeapListingData>(
+      await inspectPackageHeapEntries(
+        explorer.packageId,
+        explorer.version,
+        explorer.framework,
+        explorer.assemblyFileName,
+        heapName)),
+  queryPlatformHeap: async (explorer, heapName) =>
+    parseEngineJson<HeapListingData>(
+      await inspectPlatformHeapEntries(
+        explorer.framework,
+        explorer.assemblyFileName,
+        explorer.pack || "",
+        heapName)),
+  describeError: errorMessage,
+  render,
+  renderPreservingMemberFocus,
+  scrollExplorerToFocus: explorerScrollToFocus,
 });
 
 function captureView(): WorkspaceView | null {
@@ -2698,88 +2739,13 @@ async function loadExplorerWindow(
   startRowId = 1,
   maxRows = explorerPageSize(),
 ) {
-  const ex = state.explorer;
-  if (!ex) return;
-  const existing = ex.windows[index];
-  if (existing && (existing.loading
-      || (existing.data && existing.data.startRowId === startRowId && existing.maxRows === maxRows))) return;
-  ex.windows[index] = { loading: true, error: "", data: existing?.data || null, startRowId, maxRows };
-  render();
-  try {
-    const result = parseEngineJson<ExplorerTableData>(
-      ex.isPlatform
-        ? await inspectPlatformMetadataTable(
-            ex.framework,
-            ex.assemblyFileName,
-            ex.pack || "",
-            index,
-            startRowId,
-            maxRows)
-        : await inspectPackageMetadataTable(
-            ex.packageId,
-            ex.version,
-            ex.framework,
-            ex.assemblyFileName,
-            index,
-            startRowId,
-            maxRows));
-    if (state.explorer !== ex) return;
-    ex.windows[index] = { loading: false, error: result.error || "", data: result, startRowId, maxRows };
-  } catch (error) {
-    if (state.explorer !== ex) return;
-    ex.windows[index] = {
-      loading: false,
-      error: errorMessage(error),
-      data: null,
-      startRowId,
-      maxRows,
-    };
-  } finally {
-    if (state.explorer === ex) {
-      render();
-      if (index === ex.focusIndex && !ex.focusHeap) explorerScrollToFocus();
-    }
-  }
+  return metadataInspection.loadExplorerWindow(index, startRowId, maxRows);
 }
 
 // Lists one heap's entries via the engine (referenced-only for #Strings/#Blob, complete for
 // #GUID, nothing for #US). Cached per heap name; coverage/truncation travel with the result.
 async function loadExplorerHeap(heapName: string) {
-  const ex = state.explorer;
-  if (!ex) return;
-  const existing = ex.heapWindows[heapName];
-  if (existing && (existing.loading || existing.data)) return;
-  ex.heapWindows[heapName] = { loading: true, error: "", data: null };
-  render();
-  try {
-    const result = parseEngineJson<HeapListingData>(
-      ex.isPlatform
-        ? await inspectPlatformHeapEntries(
-            ex.framework,
-            ex.assemblyFileName,
-            ex.pack || "",
-            heapName)
-        : await inspectPackageHeapEntries(
-            ex.packageId,
-            ex.version,
-            ex.framework,
-            ex.assemblyFileName,
-            heapName));
-    if (state.explorer !== ex) return;
-    ex.heapWindows[heapName] = { loading: false, error: "", data: result };
-  } catch (error) {
-    if (state.explorer !== ex) return;
-    ex.heapWindows[heapName] = {
-      loading: false,
-      error: errorMessage(error),
-      data: null,
-    };
-  } finally {
-    if (state.explorer === ex) {
-      render();
-      if (ex.focusHeap === heapName) explorerScrollToFocus();
-    }
-  }
+  return metadataInspection.loadExplorerHeap(heapName);
 }
 // ref->def: transport to the target table+row. Every jump pushes a focus entry onto the
 // history stack so Back/Forward can walk the journey — essential once the focus panel hides
@@ -5993,24 +5959,16 @@ async function loadSelectedTypeMetadata() {
   }
   const pkg = currentPackage();
   const signature = typeMetadataSignature(type, pkg);
-  if (state.typeMetadataKey === signature
-    && (state.typeMetadataLoading || state.typeMetadata || state.typeMetadataError)) {
-    renderPreservingMemberFocus();
-    return;
-  }
-  const generation = ++state.typeMetadataGeneration;
-  state.typeMetadataKey = signature;
-  state.typeMetadata = null;
-  state.typeMetadataError = "";
-  state.typeMetadataLoading = true;
-  const preservedFocus = renderPreservingMemberFocus();
-  const ownsRequest = () =>
-    generation === state.typeMetadataGeneration
-    && state.typeMetadataKey === signature;
-  const isCurrent = () => {
-    const currentType = selectedType();
-    return ownsRequest()
-      && !state.home
+  return metadataInspection.loadTypeMetadata({
+    signature,
+    packageId: pkg.id,
+    version: pkg.version,
+    framework: pkg.activeFramework,
+    assembly: type.assembly,
+    type: type.queryId ?? type.id,
+    isVisible: () => {
+      const currentType = selectedType();
+      return !state.home
       && !state.settings
       && !state.explorer?.open
       && !state.loading
@@ -6018,27 +5976,10 @@ async function loadSelectedTypeMetadata() {
       && !workbenchOverlayOwnsFocus()
       && state.lens === "metadata"
       && !state.atPackageRoot
-      && currentType
+      && currentType != null
       && typeMetadataSignature(currentType, pkg) === signature;
-  };
-  try {
-    const result = await inspectTypeProjection(
-      pkg.id,
-      pkg.version,
-      pkg.activeFramework,
-      type.assembly,
-      type.queryId ?? type.id);
-    if (ownsRequest()) state.typeMetadata = result;
-  } catch (error) {
-    if (ownsRequest()) state.typeMetadataError = errorMessage(error);
-  } finally {
-    if (ownsRequest()) {
-      state.typeMetadataLoading = false;
-      if (isCurrent()) {
-        renderPreservingMemberFocus(preservedFocus);
-      }
-    }
-  }
+    },
+  });
 }
 
 // Projects the neutral type-relationship node/edge model into a Mermaid flowchart so it

--- a/prototypes/inspect-web/src/metadata-inspection.ts
+++ b/prototypes/inspect-web/src/metadata-inspection.ts
@@ -1,0 +1,217 @@
+import type {
+  BrowserTypeMetadata,
+} from "./inspect-web-engine.d.ts";
+import type { MemberFocusSnapshot } from "./member-focus.ts";
+import type {
+  ExplorerState,
+  ExplorerTableData,
+  HeapListingData,
+} from "./metadata-viewer.ts";
+
+export interface AppExplorerState extends ExplorerState {
+  isPlatform: boolean;
+  pack: string | null;
+  packageId: string;
+  version: string;
+  framework: string;
+  pendingScroll: boolean;
+}
+
+export interface TypeMetadataLoadRequest {
+  signature: string;
+  packageId: string;
+  version: string;
+  framework: string;
+  assembly: string;
+  type: string;
+  isVisible(): boolean;
+}
+
+export interface MetadataInspectionState {
+  typeMetadata: BrowserTypeMetadata | null;
+  typeMetadataLoading: boolean;
+  typeMetadataError: string;
+  typeMetadataKey: string;
+  typeMetadataGeneration: number;
+  explorer: AppExplorerState | null;
+}
+
+export interface MetadataInspectionDependencies {
+  state: MetadataInspectionState;
+  queryTypeMetadata(
+    request: TypeMetadataLoadRequest,
+  ): Promise<BrowserTypeMetadata>;
+  queryPackageTable(
+    explorer: AppExplorerState,
+    index: number,
+    startRowId: number,
+    maxRows: number,
+  ): Promise<ExplorerTableData>;
+  queryPlatformTable(
+    explorer: AppExplorerState,
+    index: number,
+    startRowId: number,
+    maxRows: number,
+  ): Promise<ExplorerTableData>;
+  queryPackageHeap(
+    explorer: AppExplorerState,
+    heapName: string,
+  ): Promise<HeapListingData>;
+  queryPlatformHeap(
+    explorer: AppExplorerState,
+    heapName: string,
+  ): Promise<HeapListingData>;
+  describeError(error: unknown): string;
+  render(): void;
+  renderPreservingMemberFocus(
+    fallback?: MemberFocusSnapshot | null,
+  ): MemberFocusSnapshot;
+  scrollExplorerToFocus(): void;
+}
+
+export interface MetadataInspectionCoordinator {
+  loadTypeMetadata(request: TypeMetadataLoadRequest): Promise<void>;
+  loadExplorerWindow(
+    index: number,
+    startRowId: number,
+    maxRows: number,
+  ): Promise<void>;
+  loadExplorerHeap(heapName: string): Promise<void>;
+}
+
+export function createMetadataInspectionCoordinator(
+  dependencies: MetadataInspectionDependencies,
+): MetadataInspectionCoordinator {
+  const { state } = dependencies;
+
+  return {
+    async loadTypeMetadata(request) {
+      if (state.typeMetadataKey === request.signature
+        && (state.typeMetadataLoading
+          || state.typeMetadata
+          || state.typeMetadataError)) {
+        dependencies.renderPreservingMemberFocus();
+        return;
+      }
+      const generation = ++state.typeMetadataGeneration;
+      state.typeMetadataKey = request.signature;
+      state.typeMetadata = null;
+      state.typeMetadataError = "";
+      state.typeMetadataLoading = true;
+      const preservedFocus = dependencies.renderPreservingMemberFocus();
+      const ownsRequest = () =>
+        generation === state.typeMetadataGeneration
+        && state.typeMetadataKey === request.signature;
+      try {
+        const result = await dependencies.queryTypeMetadata(request);
+        if (ownsRequest()) state.typeMetadata = result;
+      } catch (error) {
+        if (ownsRequest()) {
+          state.typeMetadataError = dependencies.describeError(error);
+        }
+      } finally {
+        if (ownsRequest()) {
+          state.typeMetadataLoading = false;
+          if (request.isVisible()) {
+            dependencies.renderPreservingMemberFocus(preservedFocus);
+          }
+        }
+      }
+    },
+
+    async loadExplorerWindow(index, startRowId, maxRows) {
+      const explorer = state.explorer;
+      if (!explorer) return;
+      const existing = explorer.windows[index];
+      if (existing && (existing.loading
+          || (existing.data
+            && existing.data.startRowId === startRowId
+            && existing.maxRows === maxRows))) {
+        return;
+      }
+      explorer.windows[index] = {
+        loading: true,
+        error: "",
+        data: existing?.data || null,
+        startRowId,
+        maxRows,
+      };
+      dependencies.render();
+      try {
+        const result = explorer.isPlatform
+          ? await dependencies.queryPlatformTable(
+              explorer,
+              index,
+              startRowId,
+              maxRows)
+          : await dependencies.queryPackageTable(
+              explorer,
+              index,
+              startRowId,
+              maxRows);
+        if (state.explorer !== explorer) return;
+        explorer.windows[index] = {
+          loading: false,
+          error: result.error || "",
+          data: result,
+          startRowId,
+          maxRows,
+        };
+      } catch (error) {
+        if (state.explorer !== explorer) return;
+        explorer.windows[index] = {
+          loading: false,
+          error: dependencies.describeError(error),
+          data: null,
+          startRowId,
+          maxRows,
+        };
+      } finally {
+        if (state.explorer === explorer) {
+          dependencies.render();
+          if (index === explorer.focusIndex && !explorer.focusHeap) {
+            dependencies.scrollExplorerToFocus();
+          }
+        }
+      }
+    },
+
+    async loadExplorerHeap(heapName) {
+      const explorer = state.explorer;
+      if (!explorer) return;
+      const existing = explorer.heapWindows[heapName];
+      if (existing && (existing.loading || existing.data)) return;
+      explorer.heapWindows[heapName] = {
+        loading: true,
+        error: "",
+        data: null,
+      };
+      dependencies.render();
+      try {
+        const result = explorer.isPlatform
+          ? await dependencies.queryPlatformHeap(explorer, heapName)
+          : await dependencies.queryPackageHeap(explorer, heapName);
+        if (state.explorer !== explorer) return;
+        explorer.heapWindows[heapName] = {
+          loading: false,
+          error: "",
+          data: result,
+        };
+      } catch (error) {
+        if (state.explorer !== explorer) return;
+        explorer.heapWindows[heapName] = {
+          loading: false,
+          error: dependencies.describeError(error),
+          data: null,
+        };
+      } finally {
+        if (state.explorer === explorer) {
+          dependencies.render();
+          if (explorer.focusHeap === heapName) {
+            dependencies.scrollExplorerToFocus();
+          }
+        }
+      }
+    },
+  };
+}

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -5,10 +5,10 @@
 // the metadata image rather than the API surface within it — so they live in one module, the
 // way `type-panel.ts` combines the type selector and the type viewer.
 //
-// `package-inspection.ts` coordinates the package-level metadata request.
-// `dotnet-inspect.ts` keeps `state`, the table-window and heap-listing engine calls
-// (`loadExplorerWindow`, `loadExplorerHeap`), the explorer's focus/history stack
-// (`openExplorer`, `pushExplorerFocus`, `applyExplorerFocus`,
+// `package-inspection.ts` coordinates the package-level metadata request, while
+// `metadata-inspection.ts` coordinates type metadata and the explorer's table-window and
+// heap-listing requests. `dotnet-inspect.ts` keeps `state` and the explorer's focus/history
+// stack (`openExplorer`, `pushExplorerFocus`, `applyExplorerFocus`,
 // `explorerHistoryBack/Forward`, `explorerShowOverview`, `closeExplorer`), the DOM event
 // binding, the `IntersectionObserver` that hydrates cards lazily, the resize listener, and
 // the global keydown handler. This module owns only the markup shape given an explicit

--- a/prototypes/inspect-web/test/metadata-inspection.test.ts
+++ b/prototypes/inspect-web/test/metadata-inspection.test.ts
@@ -1,0 +1,467 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createMetadataInspectionCoordinator,
+  type AppExplorerState,
+  type MetadataInspectionDependencies,
+  type MetadataInspectionState,
+  type TypeMetadataLoadRequest,
+} from "../src/metadata-inspection.ts";
+import type { BrowserTypeMetadata } from "../src/inspect-web-engine.d.ts";
+import type { MemberFocusSnapshot } from "../src/member-focus.ts";
+import type {
+  ExplorerTableData,
+  HeapListingData,
+} from "../src/metadata-viewer.ts";
+
+function metadataResult(fullName = "Example.Widget"): BrowserTypeMetadata {
+  return {
+    fullName,
+    namespace: "Example",
+    name: "Widget",
+    kind: "Class",
+    modifiers: [],
+    accessibility: "Public",
+    assembly: "Example.Package.dll",
+    baseType: null,
+    interfaces: [],
+    derivedTypes: [],
+    typeParameters: [],
+    attributes: [],
+    enumUnderlyingType: null,
+    composition: null,
+    graphNodes: [],
+    graphEdges: [],
+    inspectionFailures: [],
+  };
+}
+
+function explorerState(
+  overrides: Partial<AppExplorerState> = {},
+): AppExplorerState {
+  return {
+    open: true,
+    assemblyFileName: "Example.Package.dll",
+    directory: [],
+    windows: {},
+    heapWindows: {},
+    focusIndex: 2,
+    focusHeap: null,
+    highlight: null,
+    detail: null,
+    history: [],
+    historyPos: -1,
+    overview: false,
+    isPlatform: false,
+    pack: null,
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    pendingScroll: false,
+    ...overrides,
+  };
+}
+
+function inspectionState(
+  overrides: Partial<MetadataInspectionState> = {},
+): MetadataInspectionState {
+  return {
+    typeMetadata: null,
+    typeMetadataLoading: false,
+    typeMetadataError: "",
+    typeMetadataKey: "",
+    typeMetadataGeneration: 0,
+    explorer: null,
+    ...overrides,
+  };
+}
+
+function tableResult(
+  index = 2,
+  startRowId = 1,
+  error = "",
+): ExplorerTableData {
+  return {
+    index,
+    name: "TypeDef",
+    rowCount: 1,
+    startRowId,
+    rows: [],
+    error,
+  };
+}
+
+function heapResult(heapName = "String"): HeapListingData {
+  return {
+    heap: heapName,
+    streamName: "#Strings",
+    coverage: "Referenced",
+    entries: [],
+  };
+}
+
+function typeRequest(
+  overrides: Partial<TypeMetadataLoadRequest> = {},
+): TypeMetadataLoadRequest {
+  return {
+    signature: "Example.Widget",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package.dll",
+    type: "Example.Widget",
+    isVisible: () => true,
+    ...overrides,
+  };
+}
+
+function focusSnapshot(): MemberFocusSnapshot {
+  return {
+    selector: "[data-member-id='M:Example.Widget.Run']",
+    dataTarget: null,
+    selection: null,
+    navigationScope: null,
+    navigationSelection: null,
+    navigationScrollTop: null,
+    focusLost: false,
+  };
+}
+
+function inspectionDependencies(
+  state: MetadataInspectionState,
+  overrides: Partial<Omit<MetadataInspectionDependencies, "state">> = {},
+): MetadataInspectionDependencies {
+  return {
+    state,
+    queryTypeMetadata: async () => metadataResult(),
+    queryPackageTable: async (_explorer, index, startRowId) =>
+      tableResult(index, startRowId),
+    queryPlatformTable: async (_explorer, index, startRowId) =>
+      tableResult(index, startRowId),
+    queryPackageHeap: async (_explorer, heapName) => heapResult(heapName),
+    queryPlatformHeap: async (_explorer, heapName) => heapResult(heapName),
+    describeError: error =>
+      error instanceof Error ? error.message : String(error),
+    render: () => {},
+    renderPreservingMemberFocus: () => focusSnapshot(),
+    scrollExplorerToFocus: () => {},
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((accept, deny) => {
+    resolve = accept;
+    reject = deny;
+  });
+  return { promise, resolve, reject };
+}
+
+test("type metadata publishes the current result and restores visible focus", async () => {
+  const request = deferred<BrowserTypeMetadata>();
+  const preservedFocus = focusSnapshot();
+  const focusCalls: (MemberFocusSnapshot | null | undefined)[] = [];
+  const state = inspectionState();
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeMetadata: async value => {
+        assert.deepEqual(
+          [
+            value.packageId,
+            value.version,
+            value.framework,
+            value.assembly,
+            value.type,
+          ],
+          [
+            "Example.Package",
+            "1.2.3",
+            "net10.0",
+            "Example.Package.dll",
+            "Example.Widget",
+          ]);
+        return request.promise;
+      },
+      renderPreservingMemberFocus: fallback => {
+        focusCalls.push(fallback);
+        return preservedFocus;
+      },
+    }));
+
+  const load = coordinator.loadTypeMetadata(typeRequest());
+  assert.equal(state.typeMetadataLoading, true);
+  assert.equal(state.typeMetadataKey, "Example.Widget");
+  assert.deepEqual(focusCalls, [undefined]);
+
+  const result = metadataResult();
+  request.resolve(result);
+  await load;
+
+  assert.equal(state.typeMetadata, result);
+  assert.equal(state.typeMetadataLoading, false);
+  assert.deepEqual(focusCalls, [undefined, preservedFocus]);
+});
+
+test("hidden type metadata completion caches without repainting", async () => {
+  const request = deferred<BrowserTypeMetadata>();
+  let visible = false;
+  let renders = 0;
+  const state = inspectionState();
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeMetadata: async () => request.promise,
+      renderPreservingMemberFocus: () => {
+        renders++;
+        return focusSnapshot();
+      },
+    }));
+
+  const load = coordinator.loadTypeMetadata(typeRequest({
+    isVisible: () => visible,
+  }));
+  request.resolve(metadataResult());
+  await load;
+
+  assert.ok(state.typeMetadata);
+  assert.equal(state.typeMetadataLoading, false);
+  assert.equal(renders, 1);
+  visible = true;
+  await coordinator.loadTypeMetadata(typeRequest());
+  assert.equal(renders, 2);
+});
+
+test("newer type metadata requests suppress stale success and failure", async () => {
+  const first = deferred<BrowserTypeMetadata>();
+  const second = deferred<BrowserTypeMetadata>();
+  const state = inspectionState();
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeMetadata: request =>
+        request.signature === "first" ? first.promise : second.promise,
+    }));
+
+  const firstLoad = coordinator.loadTypeMetadata(typeRequest({
+    signature: "first",
+  }));
+  const secondLoad = coordinator.loadTypeMetadata(typeRequest({
+    signature: "second",
+  }));
+  first.reject(new Error("stale failure"));
+  second.resolve(metadataResult("Example.Current"));
+  await Promise.all([firstLoad, secondLoad]);
+
+  assert.equal(state.typeMetadata?.fullName, "Example.Current");
+  assert.equal(state.typeMetadataError, "");
+  assert.equal(state.typeMetadataLoading, false);
+  assert.equal(state.typeMetadataKey, "second");
+});
+
+test("cached type metadata failures render without querying again", async () => {
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({
+    typeMetadataKey: "Example.Widget",
+    typeMetadataError: "metadata unavailable",
+  });
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeMetadata: async () => {
+        queries++;
+        return metadataResult();
+      },
+      renderPreservingMemberFocus: () => {
+        renders++;
+        return focusSnapshot();
+      },
+    }));
+
+  await coordinator.loadTypeMetadata(typeRequest());
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 1);
+  assert.equal(state.typeMetadataError, "metadata unavailable");
+});
+
+test("explorer windows route package coordinates and publish errors", async () => {
+  const explorer = explorerState();
+  const events: string[] = [];
+  const state = inspectionState({ explorer });
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageTable: async (requestExplorer, index, startRowId, maxRows) => {
+        assert.equal(requestExplorer, explorer);
+        assert.deepEqual([index, startRowId, maxRows], [2, 51, 50]);
+        return tableResult(index, startRowId, "malformed row");
+      },
+      queryPlatformTable: async () => {
+        throw new Error("unexpected platform query");
+      },
+      render: () => events.push("render"),
+      scrollExplorerToFocus: () => events.push("scroll"),
+    }));
+
+  await coordinator.loadExplorerWindow(2, 51, 50);
+
+  assert.deepEqual(events, ["render", "render", "scroll"]);
+  assert.equal(explorer.windows[2]?.loading, false);
+  assert.equal(explorer.windows[2]?.error, "malformed row");
+  assert.equal(explorer.windows[2]?.data?.startRowId, 51);
+});
+
+test("explorer window failures remain visible for the current explorer", async () => {
+  const explorer = explorerState();
+  let renders = 0;
+  let scrolls = 0;
+  const state = inspectionState({ explorer });
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageTable: async () => {
+        throw new Error("table unavailable");
+      },
+      render: () => renders++,
+      scrollExplorerToFocus: () => scrolls++,
+    }));
+
+  await coordinator.loadExplorerWindow(2, 1, 50);
+
+  assert.equal(explorer.windows[2]?.loading, false);
+  assert.equal(explorer.windows[2]?.error, "table unavailable");
+  assert.equal(explorer.windows[2]?.data, null);
+  assert.equal(renders, 2);
+  assert.equal(scrolls, 1);
+});
+
+test("explorer window completion cannot publish after explorer replacement", async () => {
+  const explorer = explorerState({ isPlatform: true, pack: "Microsoft.NETCore.App.Ref" });
+  const request = deferred<ExplorerTableData>();
+  let renders = 0;
+  let scrolls = 0;
+  const state = inspectionState({ explorer });
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPlatformTable: async requestExplorer => {
+        assert.equal(requestExplorer.pack, "Microsoft.NETCore.App.Ref");
+        return request.promise;
+      },
+      render: () => renders++,
+      scrollExplorerToFocus: () => scrolls++,
+    }));
+
+  const load = coordinator.loadExplorerWindow(2, 1, 50);
+  state.explorer = explorerState({ packageId: "Replacement.Package" });
+  request.resolve(tableResult());
+  await load;
+
+  assert.equal(explorer.windows[2]?.loading, true);
+  assert.equal(renders, 1);
+  assert.equal(scrolls, 0);
+});
+
+test("explorer window cache requires the same row range", async () => {
+  const explorer = explorerState({
+    windows: {
+      2: {
+        loading: false,
+        error: "",
+        data: tableResult(2, 1),
+        startRowId: 1,
+        maxRows: 50,
+      },
+    },
+  });
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({ explorer });
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageTable: async (_requestExplorer, index, startRowId) => {
+        queries++;
+        return tableResult(index, startRowId);
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.loadExplorerWindow(2, 1, 50);
+  await coordinator.loadExplorerWindow(2, 51, 50);
+
+  assert.equal(queries, 1);
+  assert.equal(renders, 2);
+  assert.equal(explorer.windows[2]?.data?.startRowId, 51);
+});
+
+test("explorer heaps route platform coordinates and scroll the focused heap", async () => {
+  const explorer = explorerState({
+    isPlatform: true,
+    pack: "Microsoft.NETCore.App.Ref",
+    focusHeap: "String",
+  });
+  const events: string[] = [];
+  const state = inspectionState({ explorer });
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageHeap: async () => {
+        throw new Error("unexpected package query");
+      },
+      queryPlatformHeap: async (requestExplorer, heapName) => {
+        assert.equal(requestExplorer.pack, "Microsoft.NETCore.App.Ref");
+        return heapResult(heapName);
+      },
+      render: () => events.push("render"),
+      scrollExplorerToFocus: () => events.push("scroll"),
+    }));
+
+  await coordinator.loadExplorerHeap("String");
+  await coordinator.loadExplorerHeap("String");
+
+  assert.deepEqual(events, ["render", "render", "scroll"]);
+  assert.equal(explorer.heapWindows.String?.data?.heap, "String");
+});
+
+test("explorer heap completion cannot publish after explorer replacement", async () => {
+  const explorer = explorerState({ focusHeap: "String" });
+  const request = deferred<HeapListingData>();
+  let renders = 0;
+  let scrolls = 0;
+  const state = inspectionState({ explorer });
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageHeap: async () => request.promise,
+      render: () => renders++,
+      scrollExplorerToFocus: () => scrolls++,
+    }));
+
+  const load = coordinator.loadExplorerHeap("String");
+  state.explorer = null;
+  request.resolve(heapResult());
+  await load;
+
+  assert.equal(explorer.heapWindows.String?.loading, true);
+  assert.equal(renders, 1);
+  assert.equal(scrolls, 0);
+});
+
+test("explorer heap failures remain visible for the current explorer", async () => {
+  const explorer = explorerState({ focusHeap: "Blob" });
+  let renders = 0;
+  let scrolls = 0;
+  const state = inspectionState({ explorer });
+  const coordinator = createMetadataInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageHeap: async () => {
+        throw new Error("heap unavailable");
+      },
+      render: () => renders++,
+      scrollExplorerToFocus: () => scrolls++,
+    }));
+
+  await coordinator.loadExplorerHeap("Blob");
+
+  assert.equal(explorer.heapWindows.Blob?.loading, false);
+  assert.equal(explorer.heapWindows.Blob?.error, "heap unavailable");
+  assert.equal(explorer.heapWindows.Blob?.data, null);
+  assert.equal(renders, 2);
+  assert.equal(scrolls, 1);
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -171,6 +171,9 @@ const packageInspectionSource = readFileSync(
 const sourceInspectionSource = readFileSync(
   new URL("../src/source-inspection.ts", import.meta.url),
   "utf8");
+const metadataInspectionSource = readFileSync(
+  new URL("../src/metadata-inspection.ts", import.meta.url),
+  "utf8");
 const memberFocusSource = readFileSync(
   new URL("../src/member-focus.ts", import.meta.url),
   "utf8");
@@ -703,10 +706,41 @@ test("type projection completions render only while current and preserve navigat
     ?? "";
   assert.match(
     typeMetadata,
-    /const generation = \+\+state\.typeMetadataGeneration;[\s\S]*const preservedFocus = renderPreservingMemberFocus\(\);[\s\S]*generation === state\.typeMetadataGeneration[\s\S]*!state\.home[\s\S]*!state\.settings[\s\S]*!state\.explorer\?\.open[\s\S]*!state\.loading[\s\S]*!state\.error[\s\S]*!workbenchOverlayOwnsFocus\(\)[\s\S]*typeMetadataSignature\(currentType, pkg\) === signature[\s\S]*if \(isCurrent\(\)\) \{[\s\S]*renderPreservingMemberFocus\(preservedFocus\)/);
+    /return metadataInspection\.loadTypeMetadata\(\{[\s\S]*packageId: pkg\.id,[\s\S]*assembly: type\.assembly,[\s\S]*type: type\.queryId \?\? type\.id,[\s\S]*isVisible: \(\) => \{[\s\S]*!state\.home[\s\S]*!state\.settings[\s\S]*!state\.explorer\?\.open[\s\S]*!state\.loading[\s\S]*!state\.error[\s\S]*!workbenchOverlayOwnsFocus\(\)[\s\S]*typeMetadataSignature\(currentType, pkg\) === signature/);
+  assert.doesNotMatch(typeMetadata, /typeMetadataGeneration|inspectTypeProjection/);
+  const typeMetadataCoordinator =
+    metadataInspectionSource.match(/async loadTypeMetadata\(request\)[\s\S]*?\n    },/)?.[0]
+    ?? "";
+  assert.match(
+    typeMetadataCoordinator,
+    /const generation = \+\+state\.typeMetadataGeneration;[\s\S]*const preservedFocus = dependencies\.renderPreservingMemberFocus\(\);[\s\S]*generation === state\.typeMetadataGeneration[\s\S]*if \(ownsRequest\(\)\) state\.typeMetadata = result;[\s\S]*if \(request\.isVisible\(\)\) \{\s*dependencies\.renderPreservingMemberFocus\(preservedFocus\);/);
   assert.doesNotMatch(
-    typeMetadata,
+    typeMetadataCoordinator,
     /renderPreservingMemberFocus\(preservedFocus\);\s*if \(state\.typeMetadata\?\.graphNodes/);
+});
+
+test("metadata explorer request coordination stays outside the composition root", () => {
+  const windowLoader =
+    appSource.match(/async function loadExplorerWindow\([\s\S]*?\n}\n\n\/\/ Lists/)?.[0]
+    ?? "";
+  const heapLoader =
+    appSource.match(/async function loadExplorerHeap\([\s\S]*?\n}\n\/\/ ref->def/)?.[0]
+    ?? "";
+  assert.match(
+    windowLoader,
+    /return metadataInspection\.loadExplorerWindow\(index, startRowId, maxRows\)/);
+  assert.match(
+    heapLoader,
+    /return metadataInspection\.loadExplorerHeap\(heapName\)/);
+  assert.doesNotMatch(
+    `${windowLoader}\n${heapLoader}`,
+    /inspectPackageMetadataTable|inspectPlatformMetadataTable|inspectPackageHeapEntries|inspectPlatformHeapEntries/);
+  assert.match(
+    metadataInspectionSource,
+    /dependencies\.queryPlatformTable[\s\S]*dependencies\.queryPackageTable[\s\S]*state\.explorer !== explorer[\s\S]*index === explorer\.focusIndex && !explorer\.focusHeap/);
+  assert.match(
+    metadataInspectionSource,
+    /dependencies\.queryPlatformHeap[\s\S]*dependencies\.queryPackageHeap[\s\S]*state\.explorer !== explorer[\s\S]*explorer\.focusHeap === heapName/);
 });
 
 test("typeless member lookup and request guards stay empty", () => {


### PR DESCRIPTION
Moves type-metadata and Metadata Explorer table/heap request lifecycles out of the browser composition root behind a typed coordinator. Cache identity, generation and explorer-identity guards, package/platform routing, visible failures, focus-preserving type completion, and focus-aware explorer scrolling are preserved; `dotnet-inspect.ts` retains selection validation, explorer navigation/history, mutable state storage, rendering, and DOM effects.

**Stack**

- Slice 5, stacked on #4511.
- Parent: #4511 (source request coordination).
- Residual: annotated-source, documentation/facts, and call-graph request controllers, then DOM event binding paired with presentation owners.

**Validation**

- `npm test` — 302/302, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.

Progresses #4504.