### PR TITLE
Extract inspect-web member detail request coordination

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -564,11 +564,22 @@ call-graph source request lifecycle: shared cancellation, generation and
 per-surface identity checks, loading/error/result transitions, graph-modal
 open/close state, and focus-preserving completion. `dotnet-inspect.ts`
 validates the active selection, builds typed engine requests, supplies mutable
-state and rendering ports, and retains annotated-source coordination.
+state and rendering ports, and retains source presentation.
 `test/source-inspection.test.ts` gates hidden cancellation, stale member
 selection, visible failure, hidden type completion, graph close/cancellation,
 and graph failure; `test/spotlight-identity.test.js` gates engine and
 composition-root wiring.
+
+`src/member-detail-inspection.ts` owns member XML-documentation, annotated
+source, and Facts request lifecycles: cache and request identity, current-member
+publication, loading/error/result transitions, annotated selection reset,
+runtime documentation suppression, and focus-preserving completion.
+`dotnet-inspect.ts` validates the selected overload, constructs exact engine
+requests, and retains mutable state, rendering, and annotated-source
+interaction handlers. `test/member-detail-inspection.test.ts` gates current and
+stale completion, cached failures, runtime documentation, exact request
+coordinates, cross-surface invalidation, and focus restoration;
+`test/spotlight-identity.test.js` gates composition-root wiring.
 
 `src/metadata-inspection.ts` owns the type-metadata request lifecycle and the
 Metadata Explorer's table-window and heap-listing requests, including cache
@@ -693,9 +704,10 @@ escaping in both the header and loading status.
 `src/annotated-source.ts` owns the annotated source result (the
 fact-annotated C#/IL dual view shown for a member overload) as a pure,
 dependency-injected render function; it composes `annotated-source-view.ts`'s
-`buildAnnotatedView` projection into markup. `dotnet-inspect.ts` still owns `state`, the
-sequence-guarded async load lifecycle, and the medium-toggle/fact-selection
-event handlers, and passes each computed slice in explicitly.
+`buildAnnotatedView` projection into markup. `member-detail-inspection.ts` owns
+the sequence-guarded async load lifecycle; `dotnet-inspect.ts` still owns
+`state` and the medium-toggle/fact-selection event handlers, and passes each
+computed slice in explicitly.
 `test/annotated-source.test.ts` gates the rejected-document fallback, the
 medium toggles and hidden-line count, the context-limitation notice, anchored
 versus unanchored fact rendering, selection state, and source-text escaping.

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -81,6 +81,11 @@ import {
   type AppExplorerState,
 } from "./metadata-inspection.ts";
 import {
+  createMemberDetailInspectionCoordinator,
+  type MemberFactRow,
+  type MemberFacts,
+} from "./member-detail-inspection.ts";
+import {
   captureMemberFocus,
   createMemberFocusRestorer,
   type MemberFocusSnapshot,
@@ -151,7 +156,6 @@ import type {
   BrowserBuildIdentity,
   BrowserCallGraph,
   BrowserCallGraphTarget,
-  BrowserMemberDocumentation,
   BrowserMemberSurface,
   BrowserPackageCacheStats,
   BrowserPackageDependencies,
@@ -383,38 +387,6 @@ interface RecentPackage {
   id: string;
   version: string;
   framework: string;
-}
-
-interface MemberFactRow {
-  offset: string;
-  [key: string]: unknown;
-}
-
-interface MemberFacts {
-  signals: {
-    allocations: number;
-    copies: number;
-    reflection: number;
-    throws: number;
-    catches: number;
-    finallys: number;
-    unsafe: boolean;
-    allocatesInLoop: boolean;
-  };
-  allocations: Array<MemberFactRow & { inLoop?: boolean }>;
-  calls: MemberFactRow[];
-  safety: MemberFactRow[];
-  exceptionRegions: MemberFactRow[];
-  performanceOpportunities: Array<{
-    shape: string;
-    confidence: string;
-    offset?: string;
-    evidence: string;
-    fix: string;
-    caveat?: string;
-    provenance?: string;
-    finding?: string;
-  }>;
 }
 
 interface Diagnostics {
@@ -712,6 +684,46 @@ const metadataInspection = createMetadataInspectionCoordinator({
   render,
   renderPreservingMemberFocus,
   scrollExplorerToFocus: explorerScrollToFocus,
+});
+const memberDetailInspection = createMemberDetailInspectionCoordinator({
+  state,
+  queryDocumentation: (request, documentationId) =>
+    inspectMemberDocumentation(
+      request.packageId,
+      request.version,
+      request.framework,
+      request.assembly,
+      documentationId),
+  queryAnnotated: async request => {
+    const result = await inspectMemberAnnotatedSource(
+      request.packageId,
+      request.version,
+      request.framework,
+      request.assembly,
+      request.typeIdentity,
+      request.type,
+      request.member,
+      request.memberSignature,
+      request.selectorKey,
+      request.metadataToken,
+      request.taste);
+    const document = result.document;
+    validateAnnotatedSourceDocument(document);
+    return { ...result, document };
+  },
+  queryFacts: async request =>
+    parseEngineJson<MemberFacts>(
+      await inspectMemberFacts(
+        request.packageId,
+        request.version,
+        request.framework,
+        request.assembly,
+        request.type,
+        request.member,
+        request.memberSignature)),
+  describeError: errorMessage,
+  render,
+  renderPreservingMemberFocus,
 });
 
 function captureView(): WorkspaceView | null {
@@ -5737,60 +5749,17 @@ async function loadSelectedMemberDocumentation() {
   const overload = member.overloads[state.selectedOverloadIndex ?? 0];
   if (!overload) return;
   const signature = memberRequestSignature(type, overload);
-  if (!overload?.documentationId || overload.documentationLoaded) {
-    state.memberDocumentationKey = signature;
-    state.memberDocumentationLoading = false;
-    state.memberDocumentationError = "";
-    render();
-    return;
-  }
-
-  // The runtime pseudo-package has no companion XML-documentation nupkg on nuget.org, so a
-  // doc fetch would 404. Skip it (rendering once) rather than firing a late async render()
-  // that would wipe an in-progress call-graph diagram back to its placeholder.
-  if (state.package?.isRuntimePack) {
-    overload.documentationLoaded = true;
-    state.memberDocumentationKey = signature;
-    state.memberDocumentationLoading = false;
-    state.memberDocumentationError = "";
-    render();
-    return;
-  }
-
-  if (state.memberDocumentationKey === signature && state.memberDocumentationLoading)
-    return;
   const pkg = currentPackage();
-  state.memberDocumentationKey = signature;
-  state.memberDocumentationLoading = true;
-  state.memberDocumentationError = "";
-  const preservedFocus = renderPreservingMemberFocus();
-  try {
-    const documentation = await inspectMemberDocumentation(
-      pkg.id,
-      pkg.version,
-      pkg.activeFramework,
-      type.assembly,
-      overload.documentationId);
-    if (!memberRequestIsCurrent(signature))
-      return;
-    overload.summary = documentation.summary;
-    overload.returns = documentation.returns;
-    overload.exceptions = documentation.exceptions ?? [];
-    overload.parameters = (overload.parameters ?? []).map(parameter => ({
-      ...parameter,
-      description: documentation.parameters?.[parameter.name] ?? null
-    }));
-    overload.documentationLoaded = true;
-  } catch (error) {
-    if (memberRequestIsCurrent(signature))
-      state.memberDocumentationError = errorMessage(error);
-  } finally {
-    if (state.memberDocumentationKey === signature) {
-      state.memberDocumentationLoading = false;
-      if (memberRequestIsCurrent(signature))
-        renderPreservingMemberFocus(preservedFocus);
-    }
-  }
+  return memberDetailInspection.loadDocumentation({
+    signature,
+    packageId: pkg.id,
+    version: pkg.version,
+    framework: pkg.activeFramework,
+    assembly: type.assembly,
+    overload,
+    isRuntimePack: Boolean(state.package?.isRuntimePack),
+    isCurrent: () => memberRequestIsCurrent(signature),
+  });
 }
 
 async function loadSelectedMemberSource() {
@@ -5818,6 +5787,8 @@ async function loadSelectedMemberSource() {
     member: state.selectedBodyTarget?.memberName ?? overload.name,
     selectorKey:
       state.selectedBodyTarget?.selectorKey ?? overload.graphSelectorKey,
+    // Preserve the exact MethodDef for same-image validation before structural
+    // correspondence handles differing ref/lib row numbers.
     metadataToken:
       state.selectedBodyTarget?.metadataToken ?? overload.metadataToken ?? 0,
     taste: JSON.stringify(state.taste),
@@ -5835,57 +5806,24 @@ async function loadSelectedMemberAnnotatedSource() {
     return;
   }
   const signature = memberRequestSignature(type, overload, true, true);
-  if (!sourceRequestNeedsLoad(
-      state.memberAnnotatedKey === signature,
-      state.memberAnnotatedLoading,
-      state.memberAnnotated,
-      state.memberAnnotatedError)) {
-    render();
-    return;
-  }
-
-  state.memberAnnotatedKey = signature;
-  state.memberAnnotated = null;
-  state.memberAnnotatedLoading = true;
-  state.memberAnnotatedError = "";
-  state.memberAnnotatedFactId = null;
-  state.memberAnnotatedNodeIds = [];
-  const preservedFocus = renderPreservingMemberFocus();
   const pkg = currentPackage();
-  try {
-    const result = await inspectMemberAnnotatedSource(
-      pkg.id,
-      pkg.version,
-      pkg.activeFramework,
-      type.assembly,
-      type.definitionId ?? type.id,
-      type.queryId ?? type.id,
-      overload.name,
-      overload.signature,
+  return memberDetailInspection.loadAnnotated({
+    signature,
+    packageId: pkg.id,
+    version: pkg.version,
+    framework: pkg.activeFramework,
+    assembly: type.assembly,
+    typeIdentity: type.definitionId ?? type.id,
+    type: type.queryId ?? type.id,
+    member: overload.name,
+    memberSignature: overload.signature,
+    selectorKey:
       state.selectedBodyTarget?.selectorKey ?? overload.graphSelectorKey,
-      // The exact MethodDef the product surface gave this overload, so the projection
-      // can validate a same-image match before falling back to product-owned structural
-      // correspondence when ref/ and lib/ row numbers differ.
+    metadataToken:
       state.selectedBodyTarget?.metadataToken ?? overload.metadataToken ?? 0,
-      JSON.stringify(state.taste));
-    const document = result.document;
-    validateAnnotatedSourceDocument(document);
-    if (memberRequestIsCurrent(signature, true, true)
-      && state.memberAnnotatedKey === signature) {
-      state.memberAnnotated = { ...result, document };
-    }
-  } catch (error) {
-    if (memberRequestIsCurrent(signature, true, true)
-      && state.memberAnnotatedKey === signature) {
-      state.memberAnnotatedError = errorMessage(error);
-    }
-  } finally {
-    if (state.memberAnnotatedKey === signature) {
-      state.memberAnnotatedLoading = false;
-      if (memberRequestIsCurrent(signature, true, true))
-        renderPreservingMemberFocus(preservedFocus);
-    }
-  }
+    taste: JSON.stringify(state.taste),
+    isCurrent: () => memberRequestIsCurrent(signature, true, true),
+  });
 }
 
 function memberRequestSignature(
@@ -7268,46 +7206,18 @@ async function loadSelectedMemberFacts() {
     return;
   }
   const signature = memberRequestSignature(type, overload);
-  if (state.memberFactsKey === signature
-    && (state.memberFacts || state.memberFactsError)) {
-    render();
-    return;
-  }
-
-  state.memberFactsKey = signature;
-  state.memberFacts = null;
-  state.memberFactsLoading = true;
-  state.memberFactsError = "";
-  state.memberAnnotated = null;
-  state.memberAnnotatedError = "";
-  const preservedFocus = renderPreservingMemberFocus();
   const pkg = currentPackage();
-  try {
-    const result = parseEngineJson<MemberFacts>(
-      await inspectMemberFacts(
-        pkg.id,
-        pkg.version,
-        pkg.activeFramework,
-        type.assembly,
-        type.queryId ?? type.id,
-        overload.name,
-        overload.signature));
-    if (memberRequestIsCurrent(signature)
-      && state.memberFactsKey === signature) {
-      state.memberFacts = result;
-    }
-  } catch (error) {
-    if (memberRequestIsCurrent(signature)
-      && state.memberFactsKey === signature) {
-      state.memberFactsError = errorMessage(error);
-    }
-  } finally {
-    if (state.memberFactsKey === signature) {
-      state.memberFactsLoading = false;
-      if (memberRequestIsCurrent(signature))
-        renderPreservingMemberFocus(preservedFocus);
-    }
-  }
+  return memberDetailInspection.loadFacts({
+    signature,
+    packageId: pkg.id,
+    version: pkg.version,
+    framework: pkg.activeFramework,
+    assembly: type.assembly,
+    type: type.queryId ?? type.id,
+    member: overload.name,
+    memberSignature: overload.signature,
+    isCurrent: () => memberRequestIsCurrent(signature),
+  });
 }
 
 interface LoadPackageOptions {

--- a/prototypes/inspect-web/src/member-detail-inspection.ts
+++ b/prototypes/inspect-web/src/member-detail-inspection.ts
@@ -1,0 +1,253 @@
+import { sourceRequestNeedsLoad } from "./data.ts";
+import type { AnnotatedSourceResult } from "./annotated-source.ts";
+import type {
+  BrowserMemberDocumentation,
+  BrowserMemberSurface,
+} from "./inspect-web-engine.d.ts";
+import type { MemberFocusSnapshot } from "./member-focus.ts";
+
+export interface DocumentableMemberSurface extends BrowserMemberSurface {
+  documentationLoaded?: boolean;
+}
+
+export interface MemberFactRow {
+  offset: string;
+  [key: string]: unknown;
+}
+
+export interface MemberFacts {
+  signals: {
+    allocations: number;
+    copies: number;
+    reflection: number;
+    throws: number;
+    catches: number;
+    finallys: number;
+    unsafe: boolean;
+    allocatesInLoop: boolean;
+  };
+  allocations: Array<MemberFactRow & { inLoop?: boolean }>;
+  calls: MemberFactRow[];
+  safety: MemberFactRow[];
+  exceptionRegions: MemberFactRow[];
+  performanceOpportunities: Array<{
+    shape: string;
+    confidence: string;
+    offset?: string;
+    evidence: string;
+    fix: string;
+    caveat?: string;
+    provenance?: string;
+    finding?: string;
+  }>;
+}
+
+interface MemberCoordinates {
+  packageId: string;
+  version: string;
+  framework: string;
+  assembly: string;
+  type: string;
+  member: string;
+  memberSignature: string;
+}
+
+export interface MemberDocumentationRequest {
+  signature: string;
+  packageId: string;
+  version: string;
+  framework: string;
+  assembly: string;
+  overload: DocumentableMemberSurface;
+  isRuntimePack: boolean;
+  isCurrent(): boolean;
+}
+
+export interface MemberAnnotatedRequest extends MemberCoordinates {
+  signature: string;
+  typeIdentity: string;
+  selectorKey: string;
+  metadataToken: number;
+  taste: string;
+  isCurrent(): boolean;
+}
+
+export interface MemberFactsRequest extends MemberCoordinates {
+  signature: string;
+  isCurrent(): boolean;
+}
+
+export interface MemberDetailInspectionState {
+  memberAnnotated: AnnotatedSourceResult | null;
+  memberAnnotatedLoading: boolean;
+  memberAnnotatedError: string;
+  memberAnnotatedKey: string;
+  memberAnnotatedFactId: number | null;
+  memberAnnotatedNodeIds: number[];
+  memberFacts: MemberFacts | null;
+  memberFactsLoading: boolean;
+  memberFactsError: string;
+  memberFactsKey: string;
+  memberDocumentationLoading: boolean;
+  memberDocumentationError: string;
+  memberDocumentationKey: string;
+}
+
+export interface MemberDetailInspectionDependencies {
+  state: MemberDetailInspectionState;
+  queryDocumentation(
+    request: MemberDocumentationRequest,
+    documentationId: string,
+  ): Promise<BrowserMemberDocumentation>;
+  queryAnnotated(
+    request: MemberAnnotatedRequest,
+  ): Promise<AnnotatedSourceResult>;
+  queryFacts(request: MemberFactsRequest): Promise<MemberFacts>;
+  describeError(error: unknown): string;
+  render(): void;
+  renderPreservingMemberFocus(
+    fallback?: MemberFocusSnapshot | null,
+  ): MemberFocusSnapshot;
+}
+
+export interface MemberDetailInspectionCoordinator {
+  loadDocumentation(request: MemberDocumentationRequest): Promise<void>;
+  loadAnnotated(request: MemberAnnotatedRequest): Promise<void>;
+  loadFacts(request: MemberFactsRequest): Promise<void>;
+}
+
+export function createMemberDetailInspectionCoordinator(
+  dependencies: MemberDetailInspectionDependencies,
+): MemberDetailInspectionCoordinator {
+  const { state } = dependencies;
+
+  return {
+    async loadDocumentation(request) {
+      const { overload } = request;
+      const documentationId = overload.documentationId;
+      if (!documentationId || overload.documentationLoaded) {
+        state.memberDocumentationKey = request.signature;
+        state.memberDocumentationLoading = false;
+        state.memberDocumentationError = "";
+        dependencies.render();
+        return;
+      }
+
+      // Runtime pseudo-packages have no companion XML-documentation package to query.
+      if (request.isRuntimePack) {
+        overload.documentationLoaded = true;
+        state.memberDocumentationKey = request.signature;
+        state.memberDocumentationLoading = false;
+        state.memberDocumentationError = "";
+        dependencies.render();
+        return;
+      }
+
+      if (state.memberDocumentationKey === request.signature
+        && state.memberDocumentationLoading) {
+        return;
+      }
+      state.memberDocumentationKey = request.signature;
+      state.memberDocumentationLoading = true;
+      state.memberDocumentationError = "";
+      const preservedFocus = dependencies.renderPreservingMemberFocus();
+      try {
+        const documentation =
+          await dependencies.queryDocumentation(request, documentationId);
+        if (!request.isCurrent()) return;
+        overload.summary = documentation.summary;
+        overload.returns = documentation.returns;
+        overload.exceptions = documentation.exceptions ?? [];
+        overload.parameters = (overload.parameters ?? []).map(parameter => ({
+          ...parameter,
+          description: documentation.parameters?.[parameter.name] ?? null,
+        }));
+        overload.documentationLoaded = true;
+      } catch (error) {
+        if (request.isCurrent()) {
+          state.memberDocumentationError = dependencies.describeError(error);
+        }
+      } finally {
+        if (state.memberDocumentationKey === request.signature) {
+          state.memberDocumentationLoading = false;
+          if (request.isCurrent()) {
+            dependencies.renderPreservingMemberFocus(preservedFocus);
+          }
+        }
+      }
+    },
+
+    async loadAnnotated(request) {
+      if (!sourceRequestNeedsLoad(
+          state.memberAnnotatedKey === request.signature,
+          state.memberAnnotatedLoading,
+          state.memberAnnotated,
+          state.memberAnnotatedError)) {
+        dependencies.render();
+        return;
+      }
+
+      state.memberAnnotatedKey = request.signature;
+      state.memberAnnotated = null;
+      state.memberAnnotatedLoading = true;
+      state.memberAnnotatedError = "";
+      state.memberAnnotatedFactId = null;
+      state.memberAnnotatedNodeIds = [];
+      const preservedFocus = dependencies.renderPreservingMemberFocus();
+      try {
+        const result = await dependencies.queryAnnotated(request);
+        if (request.isCurrent()
+          && state.memberAnnotatedKey === request.signature) {
+          state.memberAnnotated = result;
+        }
+      } catch (error) {
+        if (request.isCurrent()
+          && state.memberAnnotatedKey === request.signature) {
+          state.memberAnnotatedError = dependencies.describeError(error);
+        }
+      } finally {
+        if (state.memberAnnotatedKey === request.signature) {
+          state.memberAnnotatedLoading = false;
+          if (request.isCurrent()) {
+            dependencies.renderPreservingMemberFocus(preservedFocus);
+          }
+        }
+      }
+    },
+
+    async loadFacts(request) {
+      if (state.memberFactsKey === request.signature
+        && (state.memberFacts || state.memberFactsError)) {
+        dependencies.render();
+        return;
+      }
+
+      state.memberFactsKey = request.signature;
+      state.memberFacts = null;
+      state.memberFactsLoading = true;
+      state.memberFactsError = "";
+      state.memberAnnotated = null;
+      state.memberAnnotatedError = "";
+      const preservedFocus = dependencies.renderPreservingMemberFocus();
+      try {
+        const result = await dependencies.queryFacts(request);
+        if (request.isCurrent()
+          && state.memberFactsKey === request.signature) {
+          state.memberFacts = result;
+        }
+      } catch (error) {
+        if (request.isCurrent()
+          && state.memberFactsKey === request.signature) {
+          state.memberFactsError = dependencies.describeError(error);
+        }
+      } finally {
+        if (state.memberFactsKey === request.signature) {
+          state.memberFactsLoading = false;
+          if (request.isCurrent()) {
+            dependencies.renderPreservingMemberFocus(preservedFocus);
+          }
+        }
+      }
+    },
+  };
+}

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -1,0 +1,585 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sampleDocument } from "../../annotated-source-viewer/src/sample-document.js";
+import type { AnnotatedSourceResult } from "../src/annotated-source.ts";
+import { validateAnnotatedSourceDocument } from "../src/annotated-source-view.ts";
+import {
+  createMemberDetailInspectionCoordinator,
+  type DocumentableMemberSurface,
+  type MemberAnnotatedRequest,
+  type MemberDetailInspectionDependencies,
+  type MemberDetailInspectionState,
+  type MemberDocumentationRequest,
+  type MemberFacts,
+  type MemberFactsRequest,
+} from "../src/member-detail-inspection.ts";
+import type { MemberFocusSnapshot } from "../src/member-focus.ts";
+
+function memberSurface(
+  overrides: Partial<DocumentableMemberSurface> = {},
+): DocumentableMemberSurface {
+  return {
+    name: "Run",
+    kind: "Method",
+    signature: "void Run(string value)",
+    accessibility: "Public",
+    isStatic: false,
+    isUnsafe: false,
+    isVirtual: false,
+    isAbstract: false,
+    isOverride: false,
+    isExtension: false,
+    isObsolete: false,
+    genericArity: 0,
+    metadataToken: 0x06000001,
+    returnType: "void",
+    parameters: [{
+      name: "value",
+      type: "string",
+      modifier: null,
+      hasDefault: false,
+      defaultValue: null,
+      description: null,
+    }],
+    documentationId: "M:Example.Widget.Run(System.String)",
+    summary: null,
+    returns: null,
+    exceptions: [],
+    stableSelector: "Run(string)",
+    anchorDigest: "abc123",
+    canonicalSignature: "void Example.Widget.Run(string value)",
+    graphSelectorKey: "Run|System.String",
+    bodySelectors: [],
+    ...overrides,
+  };
+}
+
+function factsResult(): MemberFacts {
+  return {
+    signals: {
+      allocations: 0,
+      copies: 0,
+      reflection: 0,
+      throws: 0,
+      catches: 0,
+      finallys: 0,
+      unsafe: false,
+      allocatesInLoop: false,
+    },
+    allocations: [],
+    calls: [],
+    safety: [],
+    exceptionRegions: [],
+    performanceOpportunities: [],
+  };
+}
+
+function annotatedResult(): AnnotatedSourceResult {
+  const document: unknown = sampleDocument;
+  validateAnnotatedSourceDocument(document);
+  return {
+    document,
+    provenance: "decompiled from IL",
+    contextLimitation: null,
+  };
+}
+
+function inspectionState(
+  overrides: Partial<MemberDetailInspectionState> = {},
+): MemberDetailInspectionState {
+  return {
+    memberAnnotated: null,
+    memberAnnotatedLoading: false,
+    memberAnnotatedError: "",
+    memberAnnotatedKey: "",
+    memberAnnotatedFactId: null,
+    memberAnnotatedNodeIds: [],
+    memberFacts: null,
+    memberFactsLoading: false,
+    memberFactsError: "",
+    memberFactsKey: "",
+    memberDocumentationLoading: false,
+    memberDocumentationError: "",
+    memberDocumentationKey: "",
+    ...overrides,
+  };
+}
+
+function focusSnapshot(): MemberFocusSnapshot {
+  return {
+    selector: "[data-member-id='M:Example.Widget.Run']",
+    dataTarget: null,
+    selection: null,
+    navigationScope: null,
+    navigationSelection: null,
+    navigationScrollTop: null,
+    focusLost: false,
+  };
+}
+
+function documentationRequest(
+  overload: DocumentableMemberSurface,
+  overrides: Partial<MemberDocumentationRequest> = {},
+): MemberDocumentationRequest {
+  return {
+    signature: "documentation",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package.dll",
+    overload,
+    isRuntimePack: false,
+    isCurrent: () => true,
+    ...overrides,
+  };
+}
+
+function annotatedRequest(
+  overrides: Partial<MemberAnnotatedRequest> = {},
+): MemberAnnotatedRequest {
+  return {
+    signature: "annotated",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package.dll",
+    typeIdentity: "T:Example.Widget",
+    type: "Example.Widget",
+    member: "Run",
+    memberSignature: "void Run(string value)",
+    selectorKey: "Run|System.String",
+    metadataToken: 0x06000001,
+    taste: "[\"prefer-expression-bodied-members\"]",
+    isCurrent: () => true,
+    ...overrides,
+  };
+}
+
+function factsRequest(
+  overrides: Partial<MemberFactsRequest> = {},
+): MemberFactsRequest {
+  return {
+    signature: "facts",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package.dll",
+    type: "Example.Widget",
+    member: "Run",
+    memberSignature: "void Run(string value)",
+    isCurrent: () => true,
+    ...overrides,
+  };
+}
+
+function inspectionDependencies(
+  state: MemberDetailInspectionState,
+  overrides: Partial<Omit<MemberDetailInspectionDependencies, "state">> = {},
+): MemberDetailInspectionDependencies {
+  return {
+    state,
+    queryDocumentation: async () => ({
+      summary: "Runs the widget.",
+      returns: null,
+      parameters: { value: "The value to run." },
+      exceptions: [],
+    }),
+    queryAnnotated: async () => annotatedResult(),
+    queryFacts: async () => factsResult(),
+    describeError: error =>
+      error instanceof Error ? error.message : String(error),
+    render: () => {},
+    renderPreservingMemberFocus: () => focusSnapshot(),
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((accept, deny) => {
+    resolve = accept;
+    reject = deny;
+  });
+  return { promise, resolve, reject };
+}
+
+test("runtime members settle documentation without querying a companion package", async () => {
+  const overload = memberSurface();
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocumentation: async () => {
+        queries++;
+        throw new Error("unexpected query");
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.loadDocumentation(documentationRequest(overload, {
+    isRuntimePack: true,
+  }));
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 1);
+  assert.equal(overload.documentationLoaded, true);
+  assert.equal(state.memberDocumentationKey, "documentation");
+  assert.equal(state.memberDocumentationLoading, false);
+  assert.equal(state.memberDocumentationError, "");
+});
+
+test("members without documentation ids settle without querying", async () => {
+  const overload = memberSurface({ documentationId: null });
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocumentation: async () => {
+        queries++;
+        throw new Error("unexpected query");
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.loadDocumentation(documentationRequest(overload));
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 1);
+  assert.equal(overload.documentationLoaded, undefined);
+  assert.equal(state.memberDocumentationLoading, false);
+});
+
+test("duplicate in-flight documentation requests do not query or render", async () => {
+  const overload = memberSurface();
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({
+    memberDocumentationKey: "documentation",
+    memberDocumentationLoading: true,
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocumentation: async () => {
+        queries++;
+        throw new Error("unexpected query");
+      },
+      render: () => renders++,
+      renderPreservingMemberFocus: () => {
+        renders++;
+        return focusSnapshot();
+      },
+    }));
+
+  await coordinator.loadDocumentation(documentationRequest(overload));
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 0);
+  assert.equal(state.memberDocumentationLoading, true);
+});
+
+test("documentation completion updates the current overload and restores focus", async () => {
+  const overload = memberSurface();
+  const preservedFocus = focusSnapshot();
+  const focusCalls: (MemberFocusSnapshot | null | undefined)[] = [];
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocumentation: async (request, documentationId) => {
+        assert.equal(request.packageId, "Example.Package");
+        assert.equal(
+          documentationId,
+          "M:Example.Widget.Run(System.String)");
+        return {
+          summary: "Runs the widget.",
+          returns: "Nothing.",
+          parameters: { value: "The value to run." },
+          exceptions: [{
+            type: "System.ArgumentException",
+            description: "The value is invalid.",
+          }],
+        };
+      },
+      renderPreservingMemberFocus: fallback => {
+        focusCalls.push(fallback);
+        return preservedFocus;
+      },
+    }));
+
+  await coordinator.loadDocumentation(documentationRequest(overload));
+
+  assert.equal(overload.documentationLoaded, true);
+  assert.equal(overload.summary, "Runs the widget.");
+  assert.equal(overload.returns, "Nothing.");
+  assert.equal(overload.parameters[0]?.description, "The value to run.");
+  assert.equal(overload.exceptions[0]?.type, "System.ArgumentException");
+  assert.equal(state.memberDocumentationLoading, false);
+  assert.deepEqual(focusCalls, [undefined, preservedFocus]);
+});
+
+test("current documentation failure remains visible", async () => {
+  const overload = memberSurface();
+  let focusRenders = 0;
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocumentation: async () => {
+        throw new Error("documentation unavailable");
+      },
+      renderPreservingMemberFocus: () => {
+        focusRenders++;
+        return focusSnapshot();
+      },
+    }));
+
+  await coordinator.loadDocumentation(documentationRequest(overload));
+
+  assert.equal(state.memberDocumentationLoading, false);
+  assert.equal(
+    state.memberDocumentationError,
+    "documentation unavailable");
+  assert.equal(focusRenders, 2);
+});
+
+test("stale documentation failure cannot overwrite newer request state", async () => {
+  const overload = memberSurface();
+  const query = deferred<never>();
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocumentation: async () => query.promise,
+    }));
+
+  const load = coordinator.loadDocumentation(documentationRequest(overload, {
+    isCurrent: () => false,
+  }));
+  state.memberDocumentationKey = "newer";
+  state.memberDocumentationError = "newer failure";
+  query.reject(new Error("stale failure"));
+  await load;
+
+  assert.equal(overload.documentationLoaded, undefined);
+  assert.equal(state.memberDocumentationError, "newer failure");
+  assert.equal(state.memberDocumentationLoading, true);
+});
+
+test("annotated source publishes exact current results and resets selection", async () => {
+  const result = annotatedResult();
+  const preservedFocus = focusSnapshot();
+  const focusCalls: (MemberFocusSnapshot | null | undefined)[] = [];
+  const state = inspectionState({
+    memberAnnotatedFactId: 42,
+    memberAnnotatedNodeIds: [7, 8],
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async request => {
+        assert.deepEqual(
+          [
+            request.typeIdentity,
+            request.type,
+            request.selectorKey,
+            request.metadataToken,
+            request.taste,
+          ],
+          [
+            "T:Example.Widget",
+            "Example.Widget",
+            "Run|System.String",
+            0x06000001,
+            "[\"prefer-expression-bodied-members\"]",
+          ]);
+        return result;
+      },
+      renderPreservingMemberFocus: fallback => {
+        focusCalls.push(fallback);
+        return preservedFocus;
+      },
+    }));
+
+  await coordinator.loadAnnotated(annotatedRequest());
+
+  assert.equal(state.memberAnnotated, result);
+  assert.equal(state.memberAnnotatedLoading, false);
+  assert.equal(state.memberAnnotatedFactId, null);
+  assert.deepEqual(state.memberAnnotatedNodeIds, []);
+  assert.deepEqual(focusCalls, [undefined, preservedFocus]);
+});
+
+test("cached annotated failure renders without querying again", async () => {
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({
+    memberAnnotatedKey: "annotated",
+    memberAnnotatedError: "document rejected",
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async () => {
+        queries++;
+        return annotatedResult();
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.loadAnnotated(annotatedRequest());
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 1);
+  assert.equal(state.memberAnnotatedError, "document rejected");
+});
+
+test("current annotated rejection remains visible", async () => {
+  let focusRenders = 0;
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async () => {
+        throw new Error("document rejected");
+      },
+      renderPreservingMemberFocus: () => {
+        focusRenders++;
+        return focusSnapshot();
+      },
+    }));
+
+  await coordinator.loadAnnotated(annotatedRequest());
+
+  assert.equal(state.memberAnnotatedLoading, false);
+  assert.equal(state.memberAnnotatedError, "document rejected");
+  assert.equal(focusRenders, 2);
+});
+
+test("stale annotated rejection cannot replace a newer request", async () => {
+  const query = deferred<AnnotatedSourceResult>();
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async () => query.promise,
+    }));
+
+  const load = coordinator.loadAnnotated(annotatedRequest({
+    isCurrent: () => false,
+  }));
+  state.memberAnnotatedKey = "newer";
+  state.memberAnnotatedError = "newer failure";
+  query.reject(new Error("stale failure"));
+  await load;
+
+  assert.equal(state.memberAnnotated, null);
+  assert.equal(state.memberAnnotatedError, "newer failure");
+  assert.equal(state.memberAnnotatedLoading, true);
+});
+
+test("member facts publish current results and invalidate annotated content", async () => {
+  const result = factsResult();
+  const priorAnnotated = annotatedResult();
+  const preservedFocus = focusSnapshot();
+  const focusCalls: (MemberFocusSnapshot | null | undefined)[] = [];
+  const state = inspectionState({
+    memberAnnotated: priorAnnotated,
+    memberAnnotatedError: "old annotated failure",
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async request => {
+        assert.deepEqual(
+          [
+            request.packageId,
+            request.framework,
+            request.assembly,
+            request.type,
+            request.member,
+            request.memberSignature,
+          ],
+          [
+            "Example.Package",
+            "net10.0",
+            "Example.Package.dll",
+            "Example.Widget",
+            "Run",
+            "void Run(string value)",
+          ]);
+        return result;
+      },
+      renderPreservingMemberFocus: fallback => {
+        focusCalls.push(fallback);
+        return preservedFocus;
+      },
+    }));
+
+  await coordinator.loadFacts(factsRequest());
+
+  assert.equal(state.memberFacts, result);
+  assert.equal(state.memberFactsLoading, false);
+  assert.equal(state.memberAnnotated, null);
+  assert.equal(state.memberAnnotatedError, "");
+  assert.deepEqual(focusCalls, [undefined, preservedFocus]);
+});
+
+test("cached member facts failure renders without querying again", async () => {
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({
+    memberFactsKey: "facts",
+    memberFactsError: "facts unavailable",
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async () => {
+        queries++;
+        return factsResult();
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.loadFacts(factsRequest());
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 1);
+  assert.equal(state.memberFactsError, "facts unavailable");
+});
+
+test("current member facts failure remains visible", async () => {
+  let focusRenders = 0;
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async () => {
+        throw new Error("facts unavailable");
+      },
+      renderPreservingMemberFocus: () => {
+        focusRenders++;
+        return focusSnapshot();
+      },
+    }));
+
+  await coordinator.loadFacts(factsRequest());
+
+  assert.equal(state.memberFactsLoading, false);
+  assert.equal(state.memberFactsError, "facts unavailable");
+  assert.equal(focusRenders, 2);
+});
+
+test("stale member facts completion cannot publish over a newer key", async () => {
+  const query = deferred<MemberFacts>();
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async () => query.promise,
+    }));
+
+  const load = coordinator.loadFacts(factsRequest({
+    isCurrent: () => false,
+  }));
+  state.memberFactsKey = "newer";
+  query.resolve(factsResult());
+  await load;
+
+  assert.equal(state.memberFacts, null);
+  assert.equal(state.memberFactsKey, "newer");
+  assert.equal(state.memberFactsLoading, true);
+});

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -209,7 +209,11 @@ test("runtime members settle documentation without querying a companion package"
   const overload = memberSurface();
   let queries = 0;
   let renders = 0;
-  const state = inspectionState();
+  const state = inspectionState({
+    memberDocumentationKey: "previous",
+    memberDocumentationLoading: true,
+    memberDocumentationError: "previous failure",
+  });
   const coordinator = createMemberDetailInspectionCoordinator(
     inspectionDependencies(state, {
       queryDocumentation: async () => {
@@ -257,7 +261,11 @@ test("already-loaded member documentation renders without querying again", async
   const overload = memberSurface({ documentationLoaded: true });
   let queries = 0;
   let renders = 0;
-  const state = inspectionState();
+  const state = inspectionState({
+    memberDocumentationKey: "previous",
+    memberDocumentationLoading: true,
+    memberDocumentationError: "previous failure",
+  });
   const coordinator = createMemberDetailInspectionCoordinator(
     inspectionDependencies(state, {
       queryDocumentation: async () => {
@@ -273,6 +281,7 @@ test("already-loaded member documentation renders without querying again", async
   assert.equal(renders, 1);
   assert.equal(state.memberDocumentationKey, "documentation");
   assert.equal(state.memberDocumentationLoading, false);
+  assert.equal(state.memberDocumentationError, "");
 });
 
 test("duplicate in-flight documentation requests do not query or render", async () => {

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -563,6 +563,27 @@ test("cached annotated source renders without querying again", async () => {
   assert.deepEqual(state.memberAnnotatedNodeIds, [7, 8]);
 });
 
+test("cleared annotated source reloads for the same member", async () => {
+  const current = annotatedResult();
+  let queries = 0;
+  const state = inspectionState({
+    memberAnnotatedKey: "annotated",
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async () => {
+        queries++;
+        return current;
+      },
+    }));
+
+  await coordinator.loadAnnotated(annotatedRequest());
+
+  assert.equal(queries, 1);
+  assert.equal(state.memberAnnotated, current);
+  assert.equal(state.memberAnnotatedLoading, false);
+});
+
 test("another member does not reuse a cached annotated source", async () => {
   const cached = annotatedResult();
   const current = annotatedResult();

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -844,6 +844,54 @@ test("cached member facts failure renders without querying again", async () => {
   assert.equal(state.memberFactsError, "facts unavailable");
 });
 
+test("cached member facts render without querying or invalidating annotated content", async () => {
+  const cached = factsResult();
+  const annotated = annotatedResult();
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({
+    memberFacts: cached,
+    memberFactsKey: "facts",
+    memberAnnotated: annotated,
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async () => {
+        queries++;
+        return factsResult();
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.loadFacts(factsRequest());
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 1);
+  assert.equal(state.memberFacts, cached);
+  assert.equal(state.memberAnnotated, annotated);
+});
+
+test("cleared member facts reload for the same member", async () => {
+  const current = factsResult();
+  let queries = 0;
+  const state = inspectionState({
+    memberFactsKey: "facts",
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async () => {
+        queries++;
+        return current;
+      },
+    }));
+
+  await coordinator.loadFacts(factsRequest());
+
+  assert.equal(queries, 1);
+  assert.equal(state.memberFacts, current);
+  assert.equal(state.memberFactsLoading, false);
+});
+
 test("another member does not reuse cached member facts", async () => {
   const cached = factsResult();
   const current = factsResult();
@@ -866,6 +914,29 @@ test("another member does not reuse cached member facts", async () => {
   assert.equal(state.memberFactsKey, "facts");
   assert.equal(state.memberFacts, current);
   assert.notEqual(state.memberFacts, cached);
+  assert.equal(state.memberFactsLoading, false);
+});
+
+test("another member starts while a facts request is in flight", async () => {
+  const current = factsResult();
+  let queries = 0;
+  const state = inspectionState({
+    memberFactsKey: "previous",
+    memberFactsLoading: true,
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async () => {
+        queries++;
+        return current;
+      },
+    }));
+
+  await coordinator.loadFacts(factsRequest());
+
+  assert.equal(queries, 1);
+  assert.equal(state.memberFactsKey, "facts");
+  assert.equal(state.memberFacts, current);
   assert.equal(state.memberFactsLoading, false);
 });
 

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -506,6 +506,31 @@ test("cached annotated source renders without querying again", async () => {
   assert.deepEqual(state.memberAnnotatedNodeIds, [7, 8]);
 });
 
+test("another member does not reuse a cached annotated source", async () => {
+  const cached = annotatedResult();
+  const current = annotatedResult();
+  let queries = 0;
+  const state = inspectionState({
+    memberAnnotated: cached,
+    memberAnnotatedKey: "previous",
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async () => {
+        queries++;
+        return current;
+      },
+    }));
+
+  await coordinator.loadAnnotated(annotatedRequest());
+
+  assert.equal(queries, 1);
+  assert.equal(state.memberAnnotatedKey, "annotated");
+  assert.equal(state.memberAnnotated, current);
+  assert.notEqual(state.memberAnnotated, cached);
+  assert.equal(state.memberAnnotatedLoading, false);
+});
+
 test("duplicate in-flight annotated requests do not query or mutate state", async () => {
   let queries = 0;
   let renders = 0;
@@ -532,6 +557,41 @@ test("duplicate in-flight annotated requests do not query or mutate state", asyn
   assert.equal(renders, 1);
   assert.equal(state.memberAnnotated, null);
   assert.equal(state.memberAnnotatedLoading, true);
+});
+
+test("another member starts while an annotated request is in flight", async () => {
+  const previous = deferred<AnnotatedSourceResult>();
+  const current = deferred<AnnotatedSourceResult>();
+  let queries = 0;
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: request => {
+        queries++;
+        return request.signature === "previous"
+          ? previous.promise
+          : current.promise;
+      },
+    }));
+
+  const previousLoad = coordinator.loadAnnotated(
+    annotatedRequest({ signature: "previous" }));
+  const currentLoad = coordinator.loadAnnotated(annotatedRequest());
+
+  assert.equal(queries, 2);
+  assert.equal(state.memberAnnotatedKey, "annotated");
+  assert.equal(state.memberAnnotatedLoading, true);
+
+  previous.resolve(annotatedResult());
+  await previousLoad;
+  assert.equal(state.memberAnnotated, null);
+  assert.equal(state.memberAnnotatedLoading, true);
+
+  const currentResult = annotatedResult();
+  current.resolve(currentResult);
+  await currentLoad;
+  assert.equal(state.memberAnnotated, currentResult);
+  assert.equal(state.memberAnnotatedLoading, false);
 });
 
 test("current annotated rejection remains visible", async () => {

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -478,6 +478,62 @@ test("cached annotated failure renders without querying again", async () => {
   assert.equal(state.memberAnnotatedError, "document rejected");
 });
 
+test("cached annotated source renders without querying again", async () => {
+  const cached = annotatedResult();
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({
+    memberAnnotated: cached,
+    memberAnnotatedKey: "annotated",
+    memberAnnotatedFactId: 42,
+    memberAnnotatedNodeIds: [7, 8],
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async () => {
+        queries++;
+        return annotatedResult();
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.loadAnnotated(annotatedRequest());
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 1);
+  assert.equal(state.memberAnnotated, cached);
+  assert.equal(state.memberAnnotatedFactId, 42);
+  assert.deepEqual(state.memberAnnotatedNodeIds, [7, 8]);
+});
+
+test("duplicate in-flight annotated requests do not query or mutate state", async () => {
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({
+    memberAnnotatedKey: "annotated",
+    memberAnnotatedLoading: true,
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async () => {
+        queries++;
+        return annotatedResult();
+      },
+      render: () => renders++,
+      renderPreservingMemberFocus: () => {
+        renders++;
+        return focusSnapshot();
+      },
+    }));
+
+  await coordinator.loadAnnotated(annotatedRequest());
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 1);
+  assert.equal(state.memberAnnotated, null);
+  assert.equal(state.memberAnnotatedLoading, true);
+});
+
 test("current annotated rejection remains visible", async () => {
   let focusRenders = 0;
   const state = inspectionState();

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -303,6 +303,63 @@ test("duplicate in-flight documentation requests do not query or render", async 
   assert.equal(state.memberDocumentationLoading, true);
 });
 
+test("another member starts while documentation is in flight", async () => {
+  const overload = memberSurface();
+  let queries = 0;
+  const state = inspectionState({
+    memberDocumentationKey: "previous",
+    memberDocumentationLoading: true,
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocumentation: async () => {
+        queries++;
+        return {
+          summary: "Current member documentation.",
+          returns: null,
+          parameters: {},
+          exceptions: [],
+        };
+      },
+    }));
+
+  await coordinator.loadDocumentation(documentationRequest(overload));
+
+  assert.equal(queries, 1);
+  assert.equal(state.memberDocumentationKey, "documentation");
+  assert.equal(state.memberDocumentationLoading, false);
+  assert.equal(overload.summary, "Current member documentation.");
+  assert.equal(overload.documentationLoaded, true);
+});
+
+test("settled documentation failures can retry for the same member", async () => {
+  const overload = memberSurface();
+  let queries = 0;
+  const state = inspectionState({
+    memberDocumentationKey: "documentation",
+    memberDocumentationError: "previous failure",
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocumentation: async () => {
+        queries++;
+        return {
+          summary: "Recovered documentation.",
+          returns: null,
+          parameters: {},
+          exceptions: [],
+        };
+      },
+    }));
+
+  await coordinator.loadDocumentation(documentationRequest(overload));
+
+  assert.equal(queries, 1);
+  assert.equal(state.memberDocumentationError, "");
+  assert.equal(overload.summary, "Recovered documentation.");
+  assert.equal(overload.documentationLoaded, true);
+});
+
 test("documentation completion updates the current overload and restores focus", async () => {
   const overload = memberSurface();
   const preservedFocus = focusSnapshot();
@@ -785,6 +842,31 @@ test("cached member facts failure renders without querying again", async () => {
   assert.equal(queries, 0);
   assert.equal(renders, 1);
   assert.equal(state.memberFactsError, "facts unavailable");
+});
+
+test("another member does not reuse cached member facts", async () => {
+  const cached = factsResult();
+  const current = factsResult();
+  let queries = 0;
+  const state = inspectionState({
+    memberFacts: cached,
+    memberFactsKey: "previous",
+  });
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async () => {
+        queries++;
+        return current;
+      },
+    }));
+
+  await coordinator.loadFacts(factsRequest());
+
+  assert.equal(queries, 1);
+  assert.equal(state.memberFactsKey, "facts");
+  assert.equal(state.memberFacts, current);
+  assert.notEqual(state.memberFacts, cached);
+  assert.equal(state.memberFactsLoading, false);
 });
 
 test("current member facts failure remains visible", async () => {

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -253,6 +253,28 @@ test("members without documentation ids settle without querying", async () => {
   assert.equal(state.memberDocumentationLoading, false);
 });
 
+test("already-loaded member documentation renders without querying again", async () => {
+  const overload = memberSurface({ documentationLoaded: true });
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocumentation: async () => {
+        queries++;
+        throw new Error("unexpected query");
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.loadDocumentation(documentationRequest(overload));
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 1);
+  assert.equal(state.memberDocumentationKey, "documentation");
+  assert.equal(state.memberDocumentationLoading, false);
+});
+
 test("duplicate in-flight documentation requests do not query or render", async () => {
   const overload = memberSurface();
   let queries = 0;
@@ -342,6 +364,23 @@ test("current documentation failure remains visible", async () => {
     state.memberDocumentationError,
     "documentation unavailable");
   assert.equal(focusRenders, 2);
+});
+
+test("stale documentation success cannot mutate the selected overload", async () => {
+  const overload = memberSurface();
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state));
+
+  await coordinator.loadDocumentation(documentationRequest(overload, {
+    isCurrent: () => false,
+  }));
+
+  assert.equal(overload.summary, null);
+  assert.equal(overload.returns, null);
+  assert.equal(overload.parameters[0]?.description, null);
+  assert.equal(overload.documentationLoaded, undefined);
+  assert.equal(state.memberDocumentationLoading, false);
 });
 
 test("stale documentation failure cannot overwrite newer request state", async () => {
@@ -453,6 +492,38 @@ test("current annotated rejection remains visible", async () => {
   assert.equal(focusRenders, 2);
 });
 
+test("annotated success requires the current member even when its key is unchanged", async () => {
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state));
+
+  await coordinator.loadAnnotated(annotatedRequest({
+    isCurrent: () => false,
+  }));
+
+  assert.equal(state.memberAnnotated, null);
+  assert.equal(state.memberAnnotatedKey, "annotated");
+  assert.equal(state.memberAnnotatedLoading, false);
+});
+
+test("annotated success requires its request key even when the member is current", async () => {
+  const query = deferred<AnnotatedSourceResult>();
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async () => query.promise,
+    }));
+
+  const load = coordinator.loadAnnotated(annotatedRequest());
+  state.memberAnnotatedKey = "newer";
+  query.resolve(annotatedResult());
+  await load;
+
+  assert.equal(state.memberAnnotated, null);
+  assert.equal(state.memberAnnotatedKey, "newer");
+  assert.equal(state.memberAnnotatedLoading, true);
+});
+
 test("stale annotated rejection cannot replace a newer request", async () => {
   const query = deferred<AnnotatedSourceResult>();
   const state = inspectionState();
@@ -562,6 +633,38 @@ test("current member facts failure remains visible", async () => {
   assert.equal(state.memberFactsLoading, false);
   assert.equal(state.memberFactsError, "facts unavailable");
   assert.equal(focusRenders, 2);
+});
+
+test("member facts success requires the current member even when its key is unchanged", async () => {
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state));
+
+  await coordinator.loadFacts(factsRequest({
+    isCurrent: () => false,
+  }));
+
+  assert.equal(state.memberFacts, null);
+  assert.equal(state.memberFactsKey, "facts");
+  assert.equal(state.memberFactsLoading, false);
+});
+
+test("member facts success requires its request key even when the member is current", async () => {
+  const query = deferred<MemberFacts>();
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async () => query.promise,
+    }));
+
+  const load = coordinator.loadFacts(factsRequest());
+  state.memberFactsKey = "newer";
+  query.resolve(factsResult());
+  await load;
+
+  assert.equal(state.memberFacts, null);
+  assert.equal(state.memberFactsKey, "newer");
+  assert.equal(state.memberFactsLoading, true);
 });
 
 test("stale member facts completion cannot publish over a newer key", async () => {

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -368,9 +368,15 @@ test("current documentation failure remains visible", async () => {
 
 test("stale documentation success cannot mutate the selected overload", async () => {
   const overload = memberSurface();
+  let focusRenders = 0;
   const state = inspectionState();
   const coordinator = createMemberDetailInspectionCoordinator(
-    inspectionDependencies(state));
+    inspectionDependencies(state, {
+      renderPreservingMemberFocus: () => {
+        focusRenders++;
+        return focusSnapshot();
+      },
+    }));
 
   await coordinator.loadDocumentation(documentationRequest(overload, {
     isCurrent: () => false,
@@ -381,6 +387,7 @@ test("stale documentation success cannot mutate the selected overload", async ()
   assert.equal(overload.parameters[0]?.description, null);
   assert.equal(overload.documentationLoaded, undefined);
   assert.equal(state.memberDocumentationLoading, false);
+  assert.equal(focusRenders, 1);
 });
 
 test("stale documentation failure cannot overwrite newer request state", async () => {
@@ -493,9 +500,15 @@ test("current annotated rejection remains visible", async () => {
 });
 
 test("annotated success requires the current member even when its key is unchanged", async () => {
+  let focusRenders = 0;
   const state = inspectionState();
   const coordinator = createMemberDetailInspectionCoordinator(
-    inspectionDependencies(state));
+    inspectionDependencies(state, {
+      renderPreservingMemberFocus: () => {
+        focusRenders++;
+        return focusSnapshot();
+      },
+    }));
 
   await coordinator.loadAnnotated(annotatedRequest({
     isCurrent: () => false,
@@ -504,6 +517,7 @@ test("annotated success requires the current member even when its key is unchang
   assert.equal(state.memberAnnotated, null);
   assert.equal(state.memberAnnotatedKey, "annotated");
   assert.equal(state.memberAnnotatedLoading, false);
+  assert.equal(focusRenders, 1);
 });
 
 test("annotated success requires its request key even when the member is current", async () => {
@@ -542,6 +556,49 @@ test("stale annotated rejection cannot replace a newer request", async () => {
 
   assert.equal(state.memberAnnotated, null);
   assert.equal(state.memberAnnotatedError, "newer failure");
+  assert.equal(state.memberAnnotatedLoading, true);
+});
+
+test("annotated rejection requires the current member even when its key is unchanged", async () => {
+  let focusRenders = 0;
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async () => {
+        throw new Error("stale failure");
+      },
+      renderPreservingMemberFocus: () => {
+        focusRenders++;
+        return focusSnapshot();
+      },
+    }));
+
+  await coordinator.loadAnnotated(annotatedRequest({
+    isCurrent: () => false,
+  }));
+
+  assert.equal(state.memberAnnotatedError, "");
+  assert.equal(state.memberAnnotatedKey, "annotated");
+  assert.equal(state.memberAnnotatedLoading, false);
+  assert.equal(focusRenders, 1);
+});
+
+test("annotated rejection requires its request key even when the member is current", async () => {
+  const query = deferred<AnnotatedSourceResult>();
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryAnnotated: async () => query.promise,
+    }));
+
+  const load = coordinator.loadAnnotated(annotatedRequest());
+  state.memberAnnotatedKey = "newer";
+  state.memberAnnotatedError = "newer failure";
+  query.reject(new Error("stale failure"));
+  await load;
+
+  assert.equal(state.memberAnnotatedError, "newer failure");
+  assert.equal(state.memberAnnotatedKey, "newer");
   assert.equal(state.memberAnnotatedLoading, true);
 });
 
@@ -636,9 +693,15 @@ test("current member facts failure remains visible", async () => {
 });
 
 test("member facts success requires the current member even when its key is unchanged", async () => {
+  let focusRenders = 0;
   const state = inspectionState();
   const coordinator = createMemberDetailInspectionCoordinator(
-    inspectionDependencies(state));
+    inspectionDependencies(state, {
+      renderPreservingMemberFocus: () => {
+        focusRenders++;
+        return focusSnapshot();
+      },
+    }));
 
   await coordinator.loadFacts(factsRequest({
     isCurrent: () => false,
@@ -647,6 +710,7 @@ test("member facts success requires the current member even when its key is unch
   assert.equal(state.memberFacts, null);
   assert.equal(state.memberFactsKey, "facts");
   assert.equal(state.memberFactsLoading, false);
+  assert.equal(focusRenders, 1);
 });
 
 test("member facts success requires its request key even when the member is current", async () => {
@@ -683,6 +747,49 @@ test("stale member facts completion cannot publish over a newer key", async () =
   await load;
 
   assert.equal(state.memberFacts, null);
+  assert.equal(state.memberFactsKey, "newer");
+  assert.equal(state.memberFactsLoading, true);
+});
+
+test("member facts rejection requires the current member even when its key is unchanged", async () => {
+  let focusRenders = 0;
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async () => {
+        throw new Error("stale failure");
+      },
+      renderPreservingMemberFocus: () => {
+        focusRenders++;
+        return focusSnapshot();
+      },
+    }));
+
+  await coordinator.loadFacts(factsRequest({
+    isCurrent: () => false,
+  }));
+
+  assert.equal(state.memberFactsError, "");
+  assert.equal(state.memberFactsKey, "facts");
+  assert.equal(state.memberFactsLoading, false);
+  assert.equal(focusRenders, 1);
+});
+
+test("member facts rejection requires its request key even when the member is current", async () => {
+  const query = deferred<MemberFacts>();
+  const state = inspectionState();
+  const coordinator = createMemberDetailInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryFacts: async () => query.promise,
+    }));
+
+  const load = coordinator.loadFacts(factsRequest());
+  state.memberFactsKey = "newer";
+  state.memberFactsError = "newer failure";
+  query.reject(new Error("stale failure"));
+  await load;
+
+  assert.equal(state.memberFactsError, "newer failure");
   assert.equal(state.memberFactsKey, "newer");
   assert.equal(state.memberFactsLoading, true);
 });

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -704,7 +704,10 @@ test("current annotated rejection remains visible", async () => {
 
 test("annotated success requires the current member even when its key is unchanged", async () => {
   let focusRenders = 0;
-  const state = inspectionState();
+  const state = inspectionState({
+    memberAnnotatedKey: "previous",
+    memberAnnotated: annotatedResult(),
+  });
   const coordinator = createMemberDetailInspectionCoordinator(
     inspectionDependencies(state, {
       renderPreservingMemberFocus: () => {
@@ -764,7 +767,10 @@ test("stale annotated rejection cannot replace a newer request", async () => {
 
 test("annotated rejection requires the current member even when its key is unchanged", async () => {
   let focusRenders = 0;
-  const state = inspectionState();
+  const state = inspectionState({
+    memberAnnotatedKey: "previous",
+    memberAnnotatedError: "previous failure",
+  });
   const coordinator = createMemberDetailInspectionCoordinator(
     inspectionDependencies(state, {
       queryAnnotated: async () => {
@@ -993,7 +999,10 @@ test("current member facts failure remains visible", async () => {
 
 test("member facts success requires the current member even when its key is unchanged", async () => {
   let focusRenders = 0;
-  const state = inspectionState();
+  const state = inspectionState({
+    memberFactsKey: "previous",
+    memberFacts: factsResult(),
+  });
   const coordinator = createMemberDetailInspectionCoordinator(
     inspectionDependencies(state, {
       renderPreservingMemberFocus: () => {
@@ -1052,7 +1061,10 @@ test("stale member facts completion cannot publish over a newer key", async () =
 
 test("member facts rejection requires the current member even when its key is unchanged", async () => {
   let focusRenders = 0;
-  const state = inspectionState();
+  const state = inspectionState({
+    memberFactsKey: "previous",
+    memberFactsError: "previous failure",
+  });
   const coordinator = createMemberDetailInspectionCoordinator(
     inspectionDependencies(state, {
       queryFacts: async () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1061,6 +1061,18 @@ test("member detail adapters preserve exact engine coordinates", () => {
     appSource.match(
       /const memberDetailInspection = createMemberDetailInspectionCoordinator\(\{[\s\S]*?\n}\);/)?.[0]
     ?? "";
+  const documentationLoader =
+    appSource.match(
+      /async function loadSelectedMemberDocumentation\(\)[\s\S]*?\n}\n\nasync function loadSelectedMemberSource/)?.[0]
+    ?? "";
+  const annotatedLoader =
+    appSource.match(
+      /async function loadSelectedMemberAnnotatedSource\(\)[\s\S]*?\n}\n\nfunction memberRequestSignature/)?.[0]
+    ?? "";
+  const factsLoader =
+    appSource.match(
+      /async function loadSelectedMemberFacts\(\)[\s\S]*?\n}\n\ninterface LoadPackageOptions/)?.[0]
+    ?? "";
 
   assert.match(
     coordinator,
@@ -1071,6 +1083,15 @@ test("member detail adapters preserve exact engine coordinates", () => {
   assert.match(
     coordinator,
     /inspectMemberFacts\(\s*request\.packageId,\s*request\.version,\s*request\.framework,\s*request\.assembly,\s*request\.type,\s*request\.member,\s*request\.memberSignature\)/);
+  assert.match(
+    documentationLoader,
+    /loadDocumentation\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*overload,\s*isRuntimePack: Boolean\(state\.package\?\.isRuntimePack\),\s*isCurrent: \(\) => memberRequestIsCurrent\(signature\)/);
+  assert.match(
+    annotatedLoader,
+    /loadAnnotated\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*typeIdentity: type\.definitionId \?\? type\.id,\s*type: type\.queryId \?\? type\.id,\s*member: overload\.name,\s*memberSignature: overload\.signature/);
+  assert.match(
+    factsLoader,
+    /loadFacts\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*type: type\.queryId \?\? type\.id,\s*member: overload\.name,\s*memberSignature: overload\.signature,\s*isCurrent: \(\) => memberRequestIsCurrent\(signature\)/);
 });
 
 test("type source identity includes decompiler taste", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1091,7 +1091,7 @@ test("member detail adapters preserve exact engine coordinates", () => {
     /const signature = memberRequestSignature\(type, overload\)/);
   assert.match(
     documentationLoader,
-    /loadDocumentation\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*overload,\s*isRuntimePack: Boolean\(state\.package\?\.isRuntimePack\),\s*isCurrent: \(\) => memberRequestIsCurrent\(signature\)/);
+    /return memberDetailInspection\.loadDocumentation\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*overload,\s*isRuntimePack: Boolean\(state\.package\?\.isRuntimePack\),\s*isCurrent: \(\) => memberRequestIsCurrent\(signature\)/);
   assert.match(
     annotatedLoader,
     /loadAnnotated\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*typeIdentity: type\.definitionId \?\? type\.id,\s*type: type\.queryId \?\? type\.id,\s*member: overload\.name,\s*memberSignature: overload\.signature,[\s\S]*taste: JSON\.stringify\(state\.taste\)/);
@@ -1100,7 +1100,7 @@ test("member detail adapters preserve exact engine coordinates", () => {
     /const signature = memberRequestSignature\(type, overload\)/);
   assert.match(
     factsLoader,
-    /loadFacts\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*type: type\.queryId \?\? type\.id,\s*member: overload\.name,\s*memberSignature: overload\.signature,\s*isCurrent: \(\) => memberRequestIsCurrent\(signature\)/);
+    /return memberDetailInspection\.loadFacts\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*type: type\.queryId \?\? type\.id,\s*member: overload\.name,\s*memberSignature: overload\.signature,\s*isCurrent: \(\) => memberRequestIsCurrent\(signature\)/);
 });
 
 test("type source identity includes decompiler taste", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1082,13 +1082,22 @@ test("member detail adapters preserve exact engine coordinates", () => {
     /inspectMemberAnnotatedSource\(\s*request\.packageId,\s*request\.version,\s*request\.framework,\s*request\.assembly,\s*request\.typeIdentity,\s*request\.type,\s*request\.member,\s*request\.memberSignature,\s*request\.selectorKey,\s*request\.metadataToken,\s*request\.taste\)/);
   assert.match(
     coordinator,
+    /const document = result\.document;\s*validateAnnotatedSourceDocument\(document\);\s*return \{ \.\.\.result, document \};/);
+  assert.match(
+    coordinator,
     /inspectMemberFacts\(\s*request\.packageId,\s*request\.version,\s*request\.framework,\s*request\.assembly,\s*request\.type,\s*request\.member,\s*request\.memberSignature\)/);
+  assert.match(
+    documentationLoader,
+    /const signature = memberRequestSignature\(type, overload\)/);
   assert.match(
     documentationLoader,
     /loadDocumentation\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*overload,\s*isRuntimePack: Boolean\(state\.package\?\.isRuntimePack\),\s*isCurrent: \(\) => memberRequestIsCurrent\(signature\)/);
   assert.match(
     annotatedLoader,
-    /loadAnnotated\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*typeIdentity: type\.definitionId \?\? type\.id,\s*type: type\.queryId \?\? type\.id,\s*member: overload\.name,\s*memberSignature: overload\.signature/);
+    /loadAnnotated\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*typeIdentity: type\.definitionId \?\? type\.id,\s*type: type\.queryId \?\? type\.id,\s*member: overload\.name,\s*memberSignature: overload\.signature,[\s\S]*taste: JSON\.stringify\(state\.taste\)/);
+  assert.match(
+    factsLoader,
+    /const signature = memberRequestSignature\(type, overload\)/);
   assert.match(
     factsLoader,
     /loadFacts\(\{\s*signature,\s*packageId: pkg\.id,\s*version: pkg\.version,\s*framework: pkg\.activeFramework,\s*assembly: type\.assembly,\s*type: type\.queryId \?\? type\.id,\s*member: overload\.name,\s*memberSignature: overload\.signature,\s*isCurrent: \(\) => memberRequestIsCurrent\(signature\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -174,6 +174,9 @@ const sourceInspectionSource = readFileSync(
 const metadataInspectionSource = readFileSync(
   new URL("../src/metadata-inspection.ts", import.meta.url),
   "utf8");
+const memberDetailInspectionSource = readFileSync(
+  new URL("../src/member-detail-inspection.ts", import.meta.url),
+  "utf8");
 const memberFocusSource = readFileSync(
   new URL("../src/member-focus.ts", import.meta.url),
   "utf8");
@@ -496,8 +499,8 @@ test("member filters retain accessible controls and focus across rerenders", () 
     appSource,
     /id="clear-member-filter"[^>]*aria-label="Clear member filters"/);
   assert.match(
-    appSource,
-    /const preservedFocus = renderPreservingMemberFocus\(\);[\s\S]*state\.memberDocumentationLoading = false;\s*if \(memberRequestIsCurrent\(signature\)\)\s*renderPreservingMemberFocus\(preservedFocus\)/);
+    memberDetailInspectionSource,
+    /async loadDocumentation\(request\)[\s\S]*const preservedFocus = dependencies\.renderPreservingMemberFocus\(\);[\s\S]*state\.memberDocumentationLoading = false;[\s\S]*dependencies\.renderPreservingMemberFocus\(preservedFocus\)/);
   assert.match(
     stylesSource,
     /\.type-browser:not\(\.member-nav\) \.namespace-chips, \.pane-footer \{ display: none; \}/);
@@ -1026,13 +1029,18 @@ test("annotated source request identity includes the selected body", () => {
   assert.match(
     annotatedLoader,
     /const signature = memberRequestSignature\(type, overload, true, true\)/);
-  assert.equal(
-    [...annotatedLoader.matchAll(
-      /memberRequestIsCurrent\(signature, true, true\)/g)].length,
-    3);
+  assert.match(
+    annotatedLoader,
+    /isCurrent: \(\) => memberRequestIsCurrent\(signature, true, true\)/);
   assert.match(
     annotatedLoader,
     /state\.selectedBodyTarget\?\.selectorKey \?\? overload\.graphSelectorKey,[\s\S]*?state\.selectedBodyTarget\?\.metadataToken \?\? overload\.metadataToken/);
+  const annotatedCoordinator =
+    memberDetailInspectionSource.match(/async loadAnnotated\(request\)[\s\S]*?\n    },/)?.[0]
+    ?? "";
+  assert.equal(
+    [...annotatedCoordinator.matchAll(/request\.isCurrent\(\)/g)].length,
+    3);
 
   const request = [
     "Example.Package",
@@ -1102,10 +1110,15 @@ test("source operations cancel when superseded or hidden", () => {
     appSource.match(
       /async function loadSelectedMemberAnnotatedSource\(\)[\s\S]*?\n}\n\nfunction memberRequestSignature/)?.[0]
     ?? "";
-  assert.match(annotatedLoader, /sourceRequestNeedsLoad\(/);
-  assert.match(annotatedLoader, /state\.memberAnnotatedLoading/);
-  assert.match(annotatedLoader, /state\.memberAnnotated/);
-  assert.match(annotatedLoader, /state\.memberAnnotatedError/);
+  assert.match(
+    annotatedLoader,
+    /return memberDetailInspection\.loadAnnotated\(\{/);
+  assert.doesNotMatch(
+    annotatedLoader,
+    /sourceRequestNeedsLoad|memberAnnotatedLoading/);
+  assert.match(
+    memberDetailInspectionSource,
+    /async loadAnnotated\(request\)[\s\S]*sourceRequestNeedsLoad\([\s\S]*state\.memberAnnotatedLoading[\s\S]*state\.memberAnnotatedError/);
 
   const visible = {
     settings: false,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1056,6 +1056,23 @@ test("annotated source request identity includes the selected body", () => {
     memberRequestKey([...request, 0x06000002, "M:<Run>b__0_0"]));
 });
 
+test("member detail adapters preserve exact engine coordinates", () => {
+  const coordinator =
+    appSource.match(
+      /const memberDetailInspection = createMemberDetailInspectionCoordinator\(\{[\s\S]*?\n}\);/)?.[0]
+    ?? "";
+
+  assert.match(
+    coordinator,
+    /inspectMemberDocumentation\(\s*request\.packageId,\s*request\.version,\s*request\.framework,\s*request\.assembly,\s*documentationId\)/);
+  assert.match(
+    coordinator,
+    /inspectMemberAnnotatedSource\(\s*request\.packageId,\s*request\.version,\s*request\.framework,\s*request\.assembly,\s*request\.typeIdentity,\s*request\.type,\s*request\.member,\s*request\.memberSignature,\s*request\.selectorKey,\s*request\.metadataToken,\s*request\.taste\)/);
+  assert.match(
+    coordinator,
+    /inspectMemberFacts\(\s*request\.packageId,\s*request\.version,\s*request\.framework,\s*request\.assembly,\s*request\.type,\s*request\.member,\s*request\.memberSignature\)/);
+});
+
 test("type source identity includes decompiler taste", () => {
   const typeSignature =
     typePanelSource.match(/export function typeSourceSignature\([\s\S]*?\n}/)?.[0]


### PR DESCRIPTION
Moves member XML-documentation, annotated-source, and Facts request lifecycles out of the browser composition root behind a typed coordinator. Cache and request identity, current-member publication, visible failures, runtime-documentation suppression, annotated selection reset, cross-surface invalidation, exact engine coordinates, and focus-preserving completion are preserved; `dotnet-inspect.ts` retains overload validation, mutable state, rendering, and annotated-source interaction handlers.

**Stack**

- Slice 6, stacked on #4512.
- Parent: #4512 (metadata request coordination).
- Residual: call-graph request/platform-descent coordination and document/package-index fetch controllers, then DOM event binding paired with presentation owners.

**Validation**

- `npm test` — 316/316, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.

Progresses #4504.