### PR TITLE
Extract inspect-web call graph request coordination

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -581,6 +581,17 @@ stale completion, cached failures, runtime documentation, exact request
 coordinates, cross-surface invalidation, and focus restoration;
 `test/spotlight-identity.test.js` gates composition-root wiring.
 
+`src/call-graph-inspection.ts` owns member call-graph request coordination:
+fast local publication followed by full-workspace expansion, runtime-member
+platform routing, sequence/current/key stale suppression, visible partial and
+terminal failures, and the platform drill stack. `dotnet-inspect.ts` validates
+the selected overload, constructs exact engine requests, and supplies paint,
+rendering, DOM patching, package-stat, and platform-navigation ports.
+`test/call-graph-inspection.test.ts` gates cache reuse, progressive ordering,
+workspace and runtime routing, partial failures, stale completion, drill
+navigation, and focus restoration; `test/spotlight-identity.test.js` gates
+composition-root wiring.
+
 `src/metadata-inspection.ts` owns the type-metadata request lifecycle and the
 Metadata Explorer's table-window and heap-listing requests, including cache
 identity, package/platform routing, stale-explorer suppression, visible

--- a/prototypes/inspect-web/src/call-graph-inspection.ts
+++ b/prototypes/inspect-web/src/call-graph-inspection.ts
@@ -1,0 +1,229 @@
+import type { BrowserCallGraph } from "./inspect-web-engine.d.ts";
+import type { MemberFocusSnapshot } from "./member-focus.ts";
+
+export interface PlatformStackEntry {
+  graph: BrowserCallGraph;
+  title: string;
+}
+
+export interface CallGraphWorkspacePackage {
+  package: string;
+  version: string;
+  framework: string;
+}
+
+export interface MemberCallGraphRequest {
+  signature: string;
+  isRuntimePack: boolean;
+  packageId: string;
+  version: string;
+  framework: string;
+  assembly: string;
+  typeIdentity: string;
+  type: string;
+  platformType: string;
+  member: string;
+  memberSignature: string;
+  selectorKey: string;
+  metadataToken: number;
+  workspacePackages: CallGraphWorkspacePackage[];
+  hasOtherLibraries: boolean;
+  isCurrent(): boolean;
+}
+
+export interface PlatformDrillRequest {
+  framework: string;
+  assembly: string;
+  type: string;
+  member: string;
+  selectorKey: string;
+  metadataToken: number;
+  title: string;
+  errorTarget: string;
+}
+
+export interface CallGraphInspectionState {
+  memberCallGraph: BrowserCallGraph | null;
+  memberCallGraphLoading: boolean;
+  memberCallGraphError: string;
+  memberCallGraphKey: string;
+  memberCallGraphExpanding: boolean;
+  memberCallGraphSeq: number;
+  platformStack: PlatformStackEntry[];
+  platformDrillLoading: boolean;
+  platformDrillError: string;
+}
+
+export interface CallGraphInspectionDependencies {
+  state: CallGraphInspectionState;
+  queryWorkspace(
+    request: MemberCallGraphRequest,
+    workspace: CallGraphWorkspacePackage[],
+  ): Promise<BrowserCallGraph>;
+  queryPlatform(request: {
+    framework: string;
+    assembly: string;
+    type: string;
+    member: string;
+    selectorKey: string;
+    metadataToken: number;
+  }): Promise<BrowserCallGraph>;
+  describeError(error: unknown): string;
+  render(): void;
+  renderPreservingMemberFocus(
+    fallback?: MemberFocusSnapshot | null,
+  ): MemberFocusSnapshot;
+  renderCallGraph(): Promise<void>;
+  nextPaint(): Promise<unknown>;
+  refreshPackageStats(): void;
+  patchCallGraphSection(previousMermaid: string | undefined): void;
+}
+
+export interface CallGraphInspectionCoordinator {
+  load(request: MemberCallGraphRequest): Promise<void>;
+  drill(request: PlatformDrillRequest): Promise<void>;
+  popDrill(): void;
+}
+
+export function createCallGraphInspectionCoordinator(
+  dependencies: CallGraphInspectionDependencies,
+): CallGraphInspectionCoordinator {
+  const { state } = dependencies;
+  const resetPlatformDrill = () => {
+    state.platformStack = [];
+    state.platformDrillLoading = false;
+    state.platformDrillError = "";
+  };
+
+  const loadPlatformGraph = async (request: MemberCallGraphRequest) => {
+    // Runtime members have no NuGet workspace to scan for callers; their
+    // implementation is range-fetched through the platform expansion query.
+    const sequence = ++state.memberCallGraphSeq;
+    resetPlatformDrill();
+    state.memberCallGraphLoading = true;
+    state.memberCallGraphExpanding = false;
+    state.memberCallGraphError = "";
+    const preservedFocus = dependencies.renderPreservingMemberFocus();
+    try {
+      const graph = await dependencies.queryPlatform({
+        framework: request.framework,
+        assembly: request.assembly,
+        type: request.platformType,
+        member: request.member,
+        selectorKey: request.selectorKey,
+        metadataToken: request.metadataToken,
+      });
+      if (sequence !== state.memberCallGraphSeq) return;
+      state.memberCallGraph = graph;
+      state.memberCallGraphLoading = false;
+      state.memberCallGraphExpanding = false;
+      dependencies.renderPreservingMemberFocus(preservedFocus);
+      await dependencies.renderCallGraph();
+    } catch (error) {
+      if (sequence !== state.memberCallGraphSeq) return;
+      state.memberCallGraphLoading = false;
+      state.memberCallGraphExpanding = false;
+      state.memberCallGraphError = dependencies.describeError(error);
+      dependencies.renderPreservingMemberFocus(preservedFocus);
+    }
+  };
+
+  return {
+    async load(request) {
+      if (state.memberCallGraphKey === request.signature
+        && (state.memberCallGraph || state.memberCallGraphError)) {
+        dependencies.render();
+        dependencies.renderCallGraph();
+        return;
+      }
+      state.memberCallGraphKey = request.signature;
+      state.memberCallGraph = null;
+      state.memberCallGraphError = "";
+
+      if (request.isRuntimePack) {
+        await loadPlatformGraph(request);
+        return;
+      }
+
+      const sequence = ++state.memberCallGraphSeq;
+      resetPlatformDrill();
+      state.memberCallGraphLoading = true;
+      state.memberCallGraphExpanding = false;
+      state.memberCallGraphError = "";
+      const preservedFocus = dependencies.renderPreservingMemberFocus();
+      const ownsRequest = () =>
+        sequence === state.memberCallGraphSeq
+        && request.isCurrent()
+        && state.memberCallGraphKey === request.signature;
+      try {
+        const local = await dependencies.queryWorkspace(request, []);
+        if (!ownsRequest()) return;
+        state.memberCallGraph = local;
+        state.memberCallGraphLoading = false;
+        state.memberCallGraphExpanding = request.hasOtherLibraries;
+        dependencies.renderPreservingMemberFocus(preservedFocus);
+        await dependencies.renderCallGraph();
+
+        if (request.hasOtherLibraries) {
+          // Let the local graph paint before the synchronous engine begins the
+          // broader workspace scan.
+          await dependencies.nextPaint();
+          if (!ownsRequest()) return;
+          const full = await dependencies.queryWorkspace(
+            request,
+            request.workspacePackages);
+          if (!ownsRequest()) return;
+          const previousMermaid = state.memberCallGraph?.mermaid;
+          state.memberCallGraph = full;
+          state.memberCallGraphExpanding = false;
+          dependencies.refreshPackageStats();
+          dependencies.patchCallGraphSection(previousMermaid);
+        }
+      } catch (error) {
+        if (!ownsRequest()) return;
+        state.memberCallGraphLoading = false;
+        state.memberCallGraphExpanding = false;
+        if (state.memberCallGraph) {
+          state.memberCallGraphError =
+            `Workspace expansion was incomplete: ${dependencies.describeError(error)}`;
+          dependencies.renderPreservingMemberFocus(preservedFocus);
+          await dependencies.renderCallGraph();
+        } else {
+          state.memberCallGraphError = dependencies.describeError(error);
+          dependencies.renderPreservingMemberFocus(preservedFocus);
+        }
+      }
+    },
+
+    async drill(request) {
+      if (state.platformDrillLoading) return;
+      const sequence = state.memberCallGraphSeq;
+      state.platformDrillLoading = true;
+      state.platformDrillError = "";
+      const preservedFocus = dependencies.renderPreservingMemberFocus();
+      try {
+        const graph = await dependencies.queryPlatform(request);
+        if (sequence !== state.memberCallGraphSeq) return;
+        state.platformStack.push({ graph, title: request.title });
+        state.platformDrillLoading = false;
+        dependencies.renderPreservingMemberFocus(preservedFocus);
+        await dependencies.renderCallGraph();
+      } catch (error) {
+        if (sequence !== state.memberCallGraphSeq) return;
+        state.platformDrillLoading = false;
+        state.platformDrillError =
+          `Could not descend into ${request.errorTarget}: ${dependencies.describeError(error)}`;
+        dependencies.renderPreservingMemberFocus(preservedFocus);
+        await dependencies.renderCallGraph();
+      }
+    },
+
+    popDrill() {
+      if (state.platformStack.length === 0) return;
+      state.platformStack.pop();
+      state.platformDrillError = "";
+      dependencies.render();
+      dependencies.renderCallGraph();
+    },
+  };
+}

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -86,6 +86,10 @@ import {
   type MemberFacts,
 } from "./member-detail-inspection.ts";
 import {
+  createCallGraphInspectionCoordinator,
+  type PlatformStackEntry,
+} from "./call-graph-inspection.ts";
+import {
   captureMemberFocus,
   createMemberFocusRestorer,
   type MemberFocusSnapshot,
@@ -371,11 +375,6 @@ interface DotnetRelease {
   major: number;
   tfm: string;
   version: string;
-}
-
-interface PlatformStackEntry {
-  graph: BrowserCallGraph;
-  title: string;
 }
 
 interface PlatformRecent {
@@ -724,6 +723,37 @@ const memberDetailInspection = createMemberDetailInspectionCoordinator({
   describeError: errorMessage,
   render,
   renderPreservingMemberFocus,
+});
+const callGraphInspection = createCallGraphInspectionCoordinator({
+  state,
+  queryWorkspace: (request, workspace) => inspectMemberCallGraph(
+    request.packageId,
+    request.version,
+    request.framework,
+    request.assembly,
+    request.typeIdentity,
+    request.type,
+    request.member,
+    request.memberSignature,
+    request.selectorKey,
+    request.metadataToken,
+    JSON.stringify(workspace)),
+  queryPlatform: async request =>
+    parseEngineJson<BrowserCallGraph>(
+      await inspectExpandPlatformCallGraph(
+        request.framework,
+        request.assembly,
+        request.type,
+        request.member,
+        request.selectorKey,
+        request.metadataToken)),
+  describeError: errorMessage,
+  render,
+  renderPreservingMemberFocus,
+  renderCallGraph: renderMermaidCallGraph,
+  nextPaint,
+  refreshPackageStats,
+  patchCallGraphSection,
 });
 
 function captureView(): WorkspaceView | null {
@@ -6222,162 +6252,35 @@ async function loadSelectedMemberCallGraph() {
     return;
   }
   const signature = memberRequestSignature(type, overload, true);
-  if (state.memberCallGraphKey === signature
-    && (state.memberCallGraph || state.memberCallGraphError)) {
-    render();
-    renderMermaidCallGraph();
-    return;
-  }
-  state.memberCallGraphKey = signature;
-  state.memberCallGraph = null;
-  state.memberCallGraphError = "";
-
-  // A resident runtime pack has no NuGet workspace to scan for callers; its members'
-  // implementation lives in the range-fetched platform assembly. Route them through the
-  // same platform-descent path the BCL call-graph nodes use so the graph resolves.
-  if (state.package?.isRuntimePack) {
-    await loadRuntimeMemberCallGraph(type, overload);
-    return;
-  }
-
-  // Progressive, two-stage load so live data prints quickly even with many libraries open.
-  // Stage 1 (fast) scopes the query to the target assembly only — that yields the callees and
-  // the intra-library callers without downloading/opening any other package. Stage 2 (slow)
-  // re-runs across the full workspace to add cross-library callers, then re-renders (the
-  // "flash"). A sequence token drops results once the member/overload selection has moved on.
-  const seq = ++state.memberCallGraphSeq;
-  // A fresh workspace graph invalidates any in-progress platform descent.
-  state.platformStack = [];
-  state.platformDrillLoading = false;
-  state.platformDrillError = "";
-  const base = {
-    packageId: currentPackage().id,
-    version: currentPackage().version,
-    framework: currentPackage().activeFramework,
-    assembly: type.assembly,
-    type: type.queryId ?? type.id,
-    typeIdentity: type.definitionId ?? type.id,
-    member: state.selectedBodyTarget?.memberName ?? overload.name,
-    signature: overload.signature,
-    selectorKey: state.selectedBodyTarget?.selectorKey ?? overload.graphSelectorKey,
-    metadataToken: state.selectedBodyTarget?.metadataToken
-      ?? overload.metadataToken
-      ?? 0,
-  };
+  const pkg = currentPackage();
   const workspacePackages =
     state.packages.filter(packageItem => !packageItem.isRuntimePack);
   const hasOtherLibraries =
     workspacePackages.some(packageItem => packageItem !== state.package);
-
-  state.memberCallGraphLoading = true;
-  state.memberCallGraphExpanding = false;
-  state.memberCallGraphError = "";
-  const preservedFocus = renderPreservingMemberFocus();
-  try {
-    const queryCallGraph = (workspace: Array<{
-      package: string;
-      version: string;
-      framework: string;
-    }>) => inspectMemberCallGraph(
-      base.packageId,
-      base.version,
-      base.framework,
-      base.assembly,
-      base.typeIdentity,
-      base.type,
-      base.member,
-      base.signature,
-      base.selectorKey,
-      base.metadataToken,
-      JSON.stringify(workspace));
-    const local = await queryCallGraph([]);
-    if (seq !== state.memberCallGraphSeq
-      || !memberRequestIsCurrent(signature, true)
-      || state.memberCallGraphKey !== signature) return;
-    state.memberCallGraph = local;
-    state.memberCallGraphLoading = false;
-    state.memberCallGraphExpanding = hasOtherLibraries;
-    renderPreservingMemberFocus(preservedFocus);
-    await renderMermaidCallGraph();
-
-    if (hasOtherLibraries) {
-      // The engine runs synchronously on the main thread, so yield a paint frame first —
-      // otherwise the stage-1 graph never appears before the blocking cross-library pass.
-      await nextPaint();
-      if (seq !== state.memberCallGraphSeq
-        || !memberRequestIsCurrent(signature, true)
-        || state.memberCallGraphKey !== signature) return;
-      const full = await queryCallGraph(
-        workspacePackages.map(packageItem => ({
-          package: packageItem.id,
-          version: packageItem.version,
-          framework: packageItem.activeFramework
-        })));
-      if (seq !== state.memberCallGraphSeq
-        || !memberRequestIsCurrent(signature, true)
-        || state.memberCallGraphKey !== signature) return;
-      const previousMermaid = state.memberCallGraph?.mermaid;
-      state.memberCallGraph = full;
-      state.memberCallGraphExpanding = false;
-      refreshPackageStats();
-      patchCallGraphSection(previousMermaid);
-    }
-  } catch (error) {
-    if (seq !== state.memberCallGraphSeq
-      || !memberRequestIsCurrent(signature, true)
-      || state.memberCallGraphKey !== signature) return;
-    state.memberCallGraphLoading = false;
-    state.memberCallGraphExpanding = false;
-    if (state.memberCallGraph) {
-      state.memberCallGraphError =
-        `Workspace expansion was incomplete: ${errorMessage(error)}`;
-      renderPreservingMemberFocus(preservedFocus);
-      await renderMermaidCallGraph();
-    } else {
-      state.memberCallGraphError = errorMessage(error);
-      renderPreservingMemberFocus(preservedFocus);
-    }
-  }
-}
-
-// Builds a runtime-pack member's call graph via the platform-descent engine export (which
-// range-fetches the owning platform assembly) rather than the workspace call-graph path.
-// The result is itself a platform graph, so its callees descend further (see the
-// isRuntimePack branch in the node-binding block).
-async function loadRuntimeMemberCallGraph(
-  type: BrowserTypeSurface,
-  overload: BrowserMemberSurface,
-) {
-  const seq = ++state.memberCallGraphSeq;
-  state.platformStack = [];
-  state.platformDrillLoading = false;
-  state.platformDrillError = "";
-  state.memberCallGraphLoading = true;
-  state.memberCallGraphExpanding = false;
-  state.memberCallGraphError = "";
-  const preservedFocus = renderPreservingMemberFocus();
-  try {
-    const graph = parseEngineJson<BrowserCallGraph>(
-      await inspectExpandPlatformCallGraph(
-        currentPackage().activeFramework,
-        type.assembly,
-        type.metadataId ?? type.queryId ?? type.id,
-        state.selectedBodyTarget?.memberName ?? overload.name,
-        state.selectedBodyTarget?.selectorKey ?? overload.graphSelectorKey,
-        state.selectedBodyTarget?.metadataToken ?? overload.metadataToken ?? 0));
-    if (seq !== state.memberCallGraphSeq) return;
-    state.memberCallGraph = graph;
-    state.memberCallGraphLoading = false;
-    state.memberCallGraphExpanding = false;
-    renderPreservingMemberFocus(preservedFocus);
-    await renderMermaidCallGraph();
-  } catch (error) {
-    if (seq !== state.memberCallGraphSeq) return;
-    state.memberCallGraphLoading = false;
-    state.memberCallGraphExpanding = false;
-    state.memberCallGraphError = errorMessage(error);
-    renderPreservingMemberFocus(preservedFocus);
-  }
+  return callGraphInspection.load({
+    signature,
+    isRuntimePack: Boolean(state.package?.isRuntimePack),
+    packageId: pkg.id,
+    version: pkg.version,
+    framework: pkg.activeFramework,
+    assembly: type.assembly,
+    type: type.queryId ?? type.id,
+    typeIdentity: type.definitionId ?? type.id,
+    platformType: type.metadataId ?? type.queryId ?? type.id,
+    member: state.selectedBodyTarget?.memberName ?? overload.name,
+    memberSignature: overload.signature,
+    selectorKey:
+      state.selectedBodyTarget?.selectorKey ?? overload.graphSelectorKey,
+    metadataToken:
+      state.selectedBodyTarget?.metadataToken ?? overload.metadataToken ?? 0,
+    workspacePackages: workspacePackages.map(packageItem => ({
+      package: packageItem.id,
+      version: packageItem.version,
+      framework: packageItem.activeFramework,
+    })),
+    hasOtherLibraries,
+    isCurrent: () => memberRequestIsCurrent(signature, true),
+  });
 }
 
 // Update just the call-graph section in place so the stage-2 result doesn't flash
@@ -6726,44 +6629,21 @@ function findGraphMemberSelection(
 }
 
 async function drillPlatformNode(node: BrowserCallGraphTarget) {
-  if (state.platformDrillLoading) return;
-  const seq = state.memberCallGraphSeq;
-  state.platformDrillLoading = true;
-  state.platformDrillError = "";
-  const preservedFocus = renderPreservingMemberFocus();
-  try {
-    const graph = parseEngineJson<BrowserCallGraph>(
-      await inspectExpandPlatformCallGraph(
-        currentPackage().activeFramework,
-        node.assembly,
-        callGraphTargetTypeId(node),
-        node.memberName,
-        node.selectorKey,
-        node.metadataToken ?? 0));
-    if (seq !== state.memberCallGraphSeq) return;
-    state.platformStack.push({
-      graph,
-      title: `${stripArity(node.typeFullName.split(".").pop() ?? "")}.${node.memberName}`
-    });
-    state.platformDrillLoading = false;
-    renderPreservingMemberFocus(preservedFocus);
-    await renderMermaidCallGraph();
-  } catch (error) {
-    if (seq !== state.memberCallGraphSeq) return;
-    state.platformDrillLoading = false;
-    state.platformDrillError =
-      `Could not descend into ${node.typeFullName}.${node.memberName}: ${errorMessage(error)}`;
-    renderPreservingMemberFocus(preservedFocus);
-    await renderMermaidCallGraph();
-  }
+  return callGraphInspection.drill({
+    framework: currentPackage().activeFramework,
+    assembly: node.assembly,
+    type: callGraphTargetTypeId(node),
+    member: node.memberName,
+    selectorKey: node.selectorKey,
+    metadataToken: node.metadataToken ?? 0,
+    title:
+      `${stripArity(node.typeFullName.split(".").pop() ?? "")}.${node.memberName}`,
+    errorTarget: `${node.typeFullName}.${node.memberName}`,
+  });
 }
 
 function popPlatformDrill() {
-  if (state.platformStack.length === 0) return;
-  state.platformStack.pop();
-  state.platformDrillError = "";
-  render();
-  renderMermaidCallGraph();
+  callGraphInspection.popDrill();
 }
 
 // A clicked platform (BCL) call-graph node should land the user *inside* the resident

--- a/prototypes/inspect-web/test/call-graph-inspection.test.ts
+++ b/prototypes/inspect-web/test/call-graph-inspection.test.ts
@@ -171,6 +171,31 @@ test("cached call graphs render without querying again", async () => {
   assert.deepEqual(events, ["render", "graph"]);
 });
 
+test("same-key requests in flight are not mistaken for cached results", async () => {
+  const first = deferred<BrowserCallGraph>();
+  const second = deferred<BrowserCallGraph>();
+  let queries = 0;
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async () => {
+        queries++;
+        return queries === 1 ? first.promise : second.promise;
+      },
+    }));
+
+  const firstLoad = coordinator.load(memberRequest());
+  const secondLoad = coordinator.load(memberRequest());
+
+  assert.equal(queries, 2);
+
+  first.resolve(graph("stale"));
+  second.resolve(graph("current"));
+  await Promise.all([firstLoad, secondLoad]);
+
+  assert.equal(state.memberCallGraph?.mermaid, "current");
+});
+
 test("workspace call graphs publish the fast local stage with focus intact", async () => {
   const local = graph("local");
   const preservedFocus = focusSnapshot();

--- a/prototypes/inspect-web/test/call-graph-inspection.test.ts
+++ b/prototypes/inspect-web/test/call-graph-inspection.test.ts
@@ -1,0 +1,629 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createCallGraphInspectionCoordinator,
+  type CallGraphInspectionDependencies,
+  type CallGraphInspectionState,
+  type MemberCallGraphRequest,
+  type PlatformDrillRequest,
+} from "../src/call-graph-inspection.ts";
+import type { BrowserCallGraph } from "../src/inspect-web-engine.d.ts";
+import type { MemberFocusSnapshot } from "../src/member-focus.ts";
+
+function graph(mermaid: string): BrowserCallGraph {
+  const node = {
+    label: "Example.Widget.Run",
+    status: "Analyzed",
+    inLoop: false,
+    source: null,
+    children: [],
+    assembly: "Example.Package.dll",
+    typeFullName: "Example.Widget",
+    memberName: "Run",
+  };
+  return {
+    mermaid,
+    callers: { ...node },
+    callees: { ...node },
+    scope: {
+      packages: 1,
+      assemblies: 1,
+      callerAssemblies: 1,
+      calleeScope: "target assembly",
+    },
+    targets: [],
+    diagnostics: {
+      incompleteNodes: 0,
+      incompleteEdges: 0,
+      bindingIdentityConflicts: 0,
+      hasUnexploredTraversalBoundary: false,
+      hasAnalysisFailureBoundary: false,
+      isIncomplete: false,
+    },
+    noBody: false,
+  };
+}
+
+function inspectionState(
+  overrides: Partial<CallGraphInspectionState> = {},
+): CallGraphInspectionState {
+  return {
+    memberCallGraph: null,
+    memberCallGraphLoading: false,
+    memberCallGraphError: "",
+    memberCallGraphKey: "",
+    memberCallGraphExpanding: false,
+    memberCallGraphSeq: 0,
+    platformStack: [],
+    platformDrillLoading: false,
+    platformDrillError: "",
+    ...overrides,
+  };
+}
+
+function focusSnapshot(): MemberFocusSnapshot {
+  return {
+    selector: "[data-member-id='M:Example.Widget.Run']",
+    dataTarget: null,
+    selection: null,
+    navigationScope: null,
+    navigationSelection: null,
+    navigationScrollTop: null,
+    focusLost: false,
+  };
+}
+
+function memberRequest(
+  overrides: Partial<MemberCallGraphRequest> = {},
+): MemberCallGraphRequest {
+  return {
+    signature: "member",
+    isRuntimePack: false,
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package.dll",
+    typeIdentity: "T:Example.Widget",
+    type: "Example.Widget",
+    platformType: "Example.Widget",
+    member: "Run",
+    memberSignature: "void Run()",
+    selectorKey: "Run|",
+    metadataToken: 0x06000001,
+    workspacePackages: [],
+    hasOtherLibraries: false,
+    isCurrent: () => true,
+    ...overrides,
+  };
+}
+
+function drillRequest(
+  overrides: Partial<PlatformDrillRequest> = {},
+): PlatformDrillRequest {
+  return {
+    framework: "net10.0",
+    assembly: "System.Text.Json.dll",
+    type: "T:System.Text.Json.JsonSerializer",
+    member: "Serialize",
+    selectorKey: "Serialize|System.Object",
+    metadataToken: 0x06000001,
+    title: "JsonSerializer.Serialize",
+    errorTarget: "System.Text.Json.JsonSerializer.Serialize",
+    ...overrides,
+  };
+}
+
+function inspectionDependencies(
+  state: CallGraphInspectionState,
+  overrides: Partial<Omit<CallGraphInspectionDependencies, "state">> = {},
+): CallGraphInspectionDependencies {
+  return {
+    state,
+    queryWorkspace: async () => graph("workspace"),
+    queryPlatform: async () => graph("platform"),
+    describeError: error =>
+      error instanceof Error ? error.message : String(error),
+    render: () => {},
+    renderPreservingMemberFocus: () => focusSnapshot(),
+    renderCallGraph: async () => {},
+    nextPaint: async () => {},
+    refreshPackageStats: () => {},
+    patchCallGraphSection: () => {},
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((accept, deny) => {
+    resolve = accept;
+    reject = deny;
+  });
+  return { promise, resolve, reject };
+}
+
+test("cached call graphs render without querying again", async () => {
+  let queries = 0;
+  const events: string[] = [];
+  const cached = graph("cached");
+  const state = inspectionState({
+    memberCallGraph: cached,
+    memberCallGraphKey: "member",
+  });
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async () => {
+        queries++;
+        return graph("unexpected");
+      },
+      render: () => events.push("render"),
+      renderCallGraph: async () => {
+        events.push("graph");
+      },
+    }));
+
+  await coordinator.load(memberRequest());
+
+  assert.equal(queries, 0);
+  assert.equal(state.memberCallGraph, cached);
+  assert.deepEqual(events, ["render", "graph"]);
+});
+
+test("workspace call graphs publish the fast local stage with focus intact", async () => {
+  const local = graph("local");
+  const preservedFocus = focusSnapshot();
+  const events: string[] = [];
+  const state = inspectionState({
+    platformStack: [{ graph: graph("drilled"), title: "Old" }],
+    platformDrillLoading: true,
+    platformDrillError: "old failure",
+  });
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async (request, workspace) => {
+        events.push(`query:${workspace.length}`);
+        assert.equal(request.typeIdentity, "T:Example.Widget");
+        assert.equal(request.type, "Example.Widget");
+        assert.equal(request.selectorKey, "Run|");
+        assert.equal(request.metadataToken, 0x06000001);
+        return local;
+      },
+      renderPreservingMemberFocus: fallback => {
+        events.push(fallback ? "focus:restore" : "focus:capture");
+        return preservedFocus;
+      },
+      renderCallGraph: async () => {
+        events.push("graph");
+      },
+    }));
+
+  await coordinator.load(memberRequest());
+
+  assert.equal(state.memberCallGraph, local);
+  assert.equal(state.memberCallGraphLoading, false);
+  assert.equal(state.memberCallGraphExpanding, false);
+  assert.deepEqual(state.platformStack, []);
+  assert.equal(state.platformDrillLoading, false);
+  assert.equal(state.platformDrillError, "");
+  assert.deepEqual(events, [
+    "focus:capture",
+    "query:0",
+    "focus:restore",
+    "graph",
+  ]);
+});
+
+test("workspace call graphs paint locally before expanding across packages", async () => {
+  const local = graph("local");
+  const full = graph("full");
+  const workspacePackages = [{
+    package: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+  }, {
+    package: "Example.Dependency",
+    version: "4.5.6",
+    framework: "net10.0",
+  }];
+  const events: string[] = [];
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async (_request, workspace) => {
+        events.push(`query:${workspace.length}`);
+        return workspace.length ? full : local;
+      },
+      renderPreservingMemberFocus: fallback => {
+        events.push(fallback ? "focus:restore" : "focus:capture");
+        return focusSnapshot();
+      },
+      renderCallGraph: async () => {
+        events.push("graph");
+      },
+      nextPaint: async () => {
+        events.push("paint");
+      },
+      refreshPackageStats: () => events.push("stats"),
+      patchCallGraphSection: previous =>
+        events.push(`patch:${previous}`),
+    }));
+
+  await coordinator.load(memberRequest({
+    workspacePackages,
+    hasOtherLibraries: true,
+  }));
+
+  assert.equal(state.memberCallGraph, full);
+  assert.equal(state.memberCallGraphExpanding, false);
+  assert.deepEqual(events, [
+    "focus:capture",
+    "query:0",
+    "focus:restore",
+    "graph",
+    "paint",
+    "query:2",
+    "stats",
+    "patch:local",
+  ]);
+});
+
+test("workspace expansion rechecks identity after the paint yield", async () => {
+  const paint = deferred<void>();
+  const paintEntered = deferred<void>();
+  let current = true;
+  let queries = 0;
+  const local = graph("local");
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async () => {
+        queries++;
+        return local;
+      },
+      nextPaint: () => {
+        paintEntered.resolve(undefined);
+        return paint.promise;
+      },
+    }));
+
+  const load = coordinator.load(memberRequest({
+    workspacePackages: [{
+      package: "Example.Package",
+      version: "1.2.3",
+      framework: "net10.0",
+    }],
+    hasOtherLibraries: true,
+    isCurrent: () => current,
+  }));
+  await paintEntered.promise;
+  current = false;
+  paint.resolve(undefined);
+  await load;
+
+  assert.equal(queries, 1);
+  assert.equal(state.memberCallGraph, local);
+  assert.equal(state.memberCallGraphExpanding, true);
+});
+
+test("workspace expansion failure keeps the local graph and remains visible", async () => {
+  let queries = 0;
+  let graphRenders = 0;
+  const local = graph("local");
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async () => {
+        if (queries++ === 0) return local;
+        throw new Error("workspace unavailable");
+      },
+      renderCallGraph: async () => {
+        graphRenders++;
+      },
+    }));
+
+  await coordinator.load(memberRequest({
+    workspacePackages: [{
+      package: "Example.Package",
+      version: "1.2.3",
+      framework: "net10.0",
+    }],
+    hasOtherLibraries: true,
+  }));
+
+  assert.equal(state.memberCallGraph, local);
+  assert.equal(state.memberCallGraphLoading, false);
+  assert.equal(state.memberCallGraphExpanding, false);
+  assert.equal(
+    state.memberCallGraphError,
+    "Workspace expansion was incomplete: workspace unavailable");
+  assert.equal(graphRenders, 2);
+});
+
+test("initial workspace failure remains visible without rendering a graph", async () => {
+  let focusRenders = 0;
+  let graphRenders = 0;
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async () => {
+        throw new Error("query unavailable");
+      },
+      renderPreservingMemberFocus: () => {
+        focusRenders++;
+        return focusSnapshot();
+      },
+      renderCallGraph: async () => {
+        graphRenders++;
+      },
+    }));
+
+  await coordinator.load(memberRequest());
+
+  assert.equal(state.memberCallGraph, null);
+  assert.equal(state.memberCallGraphLoading, false);
+  assert.equal(state.memberCallGraphError, "query unavailable");
+  assert.equal(focusRenders, 2);
+  assert.equal(graphRenders, 0);
+});
+
+test("stale workspace success cannot publish with the same request key", async () => {
+  const request = deferred<BrowserCallGraph>();
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async () => request.promise,
+    }));
+
+  const load = coordinator.load(memberRequest({
+    isCurrent: () => false,
+  }));
+  request.resolve(graph("stale"));
+  await load;
+
+  assert.equal(state.memberCallGraph, null);
+  assert.equal(state.memberCallGraphLoading, true);
+  assert.equal(state.memberCallGraphKey, "member");
+});
+
+test("workspace success cannot publish after its request key changes", async () => {
+  const request = deferred<BrowserCallGraph>();
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async () => request.promise,
+    }));
+
+  const load = coordinator.load(memberRequest());
+  state.memberCallGraphKey = "newer";
+  request.resolve(graph("stale"));
+  await load;
+
+  assert.equal(state.memberCallGraph, null);
+  assert.equal(state.memberCallGraphLoading, true);
+  assert.equal(state.memberCallGraphKey, "newer");
+});
+
+test("workspace success cannot publish after its sequence is superseded", async () => {
+  const request = deferred<BrowserCallGraph>();
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async () => request.promise,
+    }));
+
+  const load = coordinator.load(memberRequest());
+  state.memberCallGraphSeq++;
+  request.resolve(graph("stale"));
+  await load;
+
+  assert.equal(state.memberCallGraph, null);
+  assert.equal(state.memberCallGraphLoading, true);
+  assert.equal(state.memberCallGraphKey, "member");
+});
+
+test("runtime members route directly through platform graph expansion", async () => {
+  let workspaceQueries = 0;
+  const platform = graph("platform");
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryWorkspace: async () => {
+        workspaceQueries++;
+        return graph("unexpected");
+      },
+      queryPlatform: async request => {
+        assert.deepEqual(
+          [
+            request.framework,
+            request.assembly,
+            request.type,
+            request.member,
+            request.selectorKey,
+            request.metadataToken,
+          ],
+          [
+            "net10.0",
+            "Example.Package.dll",
+            "T:Example.Widget",
+            "Run",
+            "Run|",
+            0x06000001,
+          ]);
+        return platform;
+      },
+    }));
+
+  await coordinator.load(memberRequest({
+    isRuntimePack: true,
+    platformType: "T:Example.Widget",
+  }));
+
+  assert.equal(workspaceQueries, 0);
+  assert.equal(state.memberCallGraph, platform);
+  assert.equal(state.memberCallGraphLoading, false);
+});
+
+test("runtime graph failure remains visible", async () => {
+  let focusRenders = 0;
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPlatform: async () => {
+        throw new Error("platform unavailable");
+      },
+      renderPreservingMemberFocus: () => {
+        focusRenders++;
+        return focusSnapshot();
+      },
+    }));
+
+  await coordinator.load(memberRequest({ isRuntimePack: true }));
+
+  assert.equal(state.memberCallGraph, null);
+  assert.equal(state.memberCallGraphLoading, false);
+  assert.equal(state.memberCallGraphExpanding, false);
+  assert.equal(state.memberCallGraphError, "platform unavailable");
+  assert.equal(focusRenders, 2);
+});
+
+test("superseded runtime graph completion cannot publish", async () => {
+  const request = deferred<BrowserCallGraph>();
+  const state = inspectionState();
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPlatform: async () => request.promise,
+    }));
+
+  const load = coordinator.load(memberRequest({ isRuntimePack: true }));
+  state.memberCallGraphSeq++;
+  request.resolve(graph("stale"));
+  await load;
+
+  assert.equal(state.memberCallGraph, null);
+  assert.equal(state.memberCallGraphLoading, true);
+});
+
+test("platform drill publishes current graphs and pop restores the parent", async () => {
+  const drilled = graph("drilled");
+  const events: string[] = [];
+  const state = inspectionState({
+    memberCallGraph: graph("root"),
+    memberCallGraphSeq: 3,
+  });
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPlatform: async request => {
+        assert.deepEqual(
+          [
+            request.framework,
+            request.assembly,
+            request.type,
+            request.member,
+            request.selectorKey,
+            request.metadataToken,
+          ],
+          [
+            "net10.0",
+            "System.Text.Json.dll",
+            "T:System.Text.Json.JsonSerializer",
+            "Serialize",
+            "Serialize|System.Object",
+            0x06000001,
+          ]);
+        return drilled;
+      },
+      render: () => events.push("render"),
+      renderPreservingMemberFocus: fallback => {
+        events.push(fallback ? "focus:restore" : "focus:capture");
+        return focusSnapshot();
+      },
+      renderCallGraph: async () => {
+        events.push("graph");
+      },
+    }));
+
+  await coordinator.drill(drillRequest());
+
+  assert.equal(state.platformDrillLoading, false);
+  assert.equal(state.platformDrillError, "");
+  assert.deepEqual(state.platformStack, [{
+    graph: drilled,
+    title: "JsonSerializer.Serialize",
+  }]);
+  assert.deepEqual(events, ["focus:capture", "focus:restore", "graph"]);
+
+  coordinator.popDrill();
+  assert.deepEqual(state.platformStack, []);
+  assert.deepEqual(events, [
+    "focus:capture",
+    "focus:restore",
+    "graph",
+    "render",
+    "graph",
+  ]);
+});
+
+test("platform drill failures remain visible with the full target identity", async () => {
+  let graphRenders = 0;
+  const state = inspectionState({ memberCallGraphSeq: 4 });
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPlatform: async () => {
+        throw new Error("range fetch unavailable");
+      },
+      renderCallGraph: async () => {
+        graphRenders++;
+      },
+    }));
+
+  await coordinator.drill(drillRequest());
+
+  assert.equal(state.platformDrillLoading, false);
+  assert.equal(
+    state.platformDrillError,
+    "Could not descend into System.Text.Json.JsonSerializer.Serialize: range fetch unavailable");
+  assert.equal(graphRenders, 1);
+});
+
+test("superseded platform drill completion cannot publish", async () => {
+  const request = deferred<BrowserCallGraph>();
+  const state = inspectionState({ memberCallGraphSeq: 5 });
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPlatform: async () => request.promise,
+    }));
+
+  const load = coordinator.drill(drillRequest());
+  state.memberCallGraphSeq++;
+  request.reject(new Error("stale failure"));
+  await load;
+
+  assert.equal(state.platformStack.length, 0);
+  assert.equal(state.platformDrillLoading, true);
+  assert.equal(state.platformDrillError, "");
+});
+
+test("duplicate platform drill requests do not query or render", async () => {
+  let queries = 0;
+  let renders = 0;
+  const state = inspectionState({ platformDrillLoading: true });
+  const coordinator = createCallGraphInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPlatform: async () => {
+        queries++;
+        return graph("unexpected");
+      },
+      renderPreservingMemberFocus: () => {
+        renders++;
+        return focusSnapshot();
+      },
+    }));
+
+  await coordinator.drill(drillRequest());
+
+  assert.equal(queries, 0);
+  assert.equal(renders, 0);
+  assert.equal(state.platformDrillLoading, true);
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -177,6 +177,9 @@ const metadataInspectionSource = readFileSync(
 const memberDetailInspectionSource = readFileSync(
   new URL("../src/member-detail-inspection.ts", import.meta.url),
   "utf8");
+const callGraphInspectionSource = readFileSync(
+  new URL("../src/call-graph-inspection.ts", import.meta.url),
+  "utf8");
 const memberFocusSource = readFileSync(
   new URL("../src/member-focus.ts", import.meta.url),
   "utf8");
@@ -525,8 +528,15 @@ test("member filters retain accessible controls and focus across rerenders", () 
   const platformDrill =
     appSource.match(/async function drillPlatformNode\([\s\S]*?\n}\n\nfunction popPlatformDrill/)?.[0]
     ?? "";
+  assert.match(
+    platformDrill,
+    /return callGraphInspection\.drill\(\{[\s\S]*type: callGraphTargetTypeId\(node\)[\s\S]*metadataToken: node\.metadataToken \?\? 0/);
+  const coordinatedDrill =
+    callGraphInspectionSource.match(/async drill\(request\)[\s\S]*?\n    },/)?.[0]
+    ?? "";
   assert.equal(
-    [...platformDrill.matchAll(/renderPreservingMemberFocus\(preservedFocus\)/g)].length,
+    [...coordinatedDrill.matchAll(
+      /dependencies\.renderPreservingMemberFocus\(preservedFocus\)/g)].length,
     2);
   const platformNavigation =
     appSource.match(/async function navigateOrDrillPlatform\([\s\S]*?\n}\n\n\/\/ Enter the resident runtime pack/)?.[0]
@@ -744,6 +754,24 @@ test("metadata explorer request coordination stays outside the composition root"
   assert.match(
     metadataInspectionSource,
     /dependencies\.queryPlatformHeap[\s\S]*dependencies\.queryPackageHeap[\s\S]*state\.explorer !== explorer[\s\S]*explorer\.focusHeap === heapName/);
+});
+
+test("call graph request coordination stays outside the composition root", () => {
+  const loader =
+    appSource.match(/async function loadSelectedMemberCallGraph\([\s\S]*?\n}\n\n\/\/ Update just/)?.[0]
+    ?? "";
+  assert.match(
+    loader,
+    /return callGraphInspection\.load\(\{[\s\S]*type: type\.queryId \?\? type\.id,[\s\S]*typeIdentity: type\.definitionId \?\? type\.id,[\s\S]*platformType: type\.metadataId \?\? type\.queryId \?\? type\.id,[\s\S]*isCurrent: \(\) => memberRequestIsCurrent\(signature, true\)/);
+  assert.doesNotMatch(
+    loader,
+    /memberCallGraphSeq|inspectMemberCallGraph|inspectExpandPlatformCallGraph/);
+  assert.match(
+    callGraphInspectionSource,
+    /dependencies\.queryWorkspace\(request, \[\]\)[\s\S]*dependencies\.nextPaint\(\)[\s\S]*request\.workspacePackages[\s\S]*dependencies\.patchCallGraphSection\(previousMermaid\)/);
+  assert.match(
+    callGraphInspectionSource,
+    /request\.isRuntimePack[\s\S]*loadPlatformGraph\(request\)/);
 });
 
 test("typeless member lookup and request guards stay empty", () => {


### PR DESCRIPTION
Moves member call-graph request coordination out of the browser composition root behind a typed coordinator. Fast local publication before full-workspace expansion, runtime-member platform routing, sequence/current/key stale suppression, visible partial and terminal failures, focus preservation, and platform drill navigation are preserved; `dotnet-inspect.ts` retains overload validation, exact request construction, Mermaid rendering, DOM patching, package statistics, runtime-pack acquisition, and platform-member navigation.

**Stack**

- Slice 7, stacked on #4513.
- Parent: #4513 (member detail request coordination).
- Residual: document/package-index and Spotlight network request controllers, then DOM event binding paired with presentation owners.

**Validation**

- `npm test` — 339/339, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.

Progresses #4504.