### PR TITLE
Extract inspect-web document request coordination

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -694,13 +694,17 @@ and coverage notes, and the row inspector.
 
 `src/doc-viewer.ts` owns the package document modal (the Markdown reader
 opened from a package's documents list) as a pure, dependency-injected render
-function. `dotnet-inspect.ts` still owns `state`, fetching and rendering the document's
-Markdown and frontmatter, and the sequence-guarded async load/close
-lifecycle, and passes each computed slice in explicitly. `test/doc-viewer.test.ts`
-gates the closed/no-document fallback, loading and error states, the
+function. `src/document-inspection.ts` owns its sequence-guarded async
+load/close lifecycle, visible failure, and frontmatter projection.
+`dotnet-inspect.ts` validates the selected package document and supplies the
+engine, sanitized Markdown-rendering, state, and render ports.
+`test/doc-viewer.test.ts` gates the closed/no-document fallback, loading and
+error presentation, the
 frontmatter card's presence and fields, and title/subtitle/frontmatter-name
-escaping (the rendered document body is trusted, pre-sanitized Markdown HTML
-and is not escaped).
+escaping; `test/document-inspection.test.ts` gates exact request coordinates,
+frontmatter projection, stale-stage suppression, visible failures, and close
+invalidation (the rendered document body is trusted, pre-sanitized Markdown
+HTML and is not escaped).
 
 `src/graph-source.ts` owns the member source modal (the code viewer opened
 from a call graph node) as a pure, dependency-injected render function.

--- a/prototypes/inspect-web/src/document-inspection.ts
+++ b/prototypes/inspect-web/src/document-inspection.ts
@@ -1,0 +1,121 @@
+import type { DocViewerMeta } from "./doc-viewer.ts";
+import type {
+  BrowserPackageDocument,
+  BrowserPackageDocumentContent,
+} from "./inspect-web-engine.d.ts";
+
+export interface DocumentInspectionState {
+  docViewerOpen: boolean;
+  docViewer: BrowserPackageDocument | null;
+  docViewerLoading: boolean;
+  docViewerError: string;
+  docViewerHtml: string;
+  docViewerMeta: DocViewerMeta | null;
+  docViewerSeq: number;
+}
+
+export interface PackageDocumentRequest {
+  packageId: string;
+  version: string;
+  document: BrowserPackageDocument;
+}
+
+export interface DocumentInspectionDependencies {
+  state: DocumentInspectionState;
+  queryDocument:
+    (request: PackageDocumentRequest) => Promise<BrowserPackageDocumentContent>;
+  renderMarkdown: (text: unknown) => Promise<string>;
+  renderMarkdownInline: (text: unknown) => Promise<string>;
+  describeError: (error: unknown) => string;
+  render: () => void;
+}
+
+interface DocumentFrontmatter {
+  name?: string;
+  version?: string;
+  description?: string;
+  [key: string]: string | undefined;
+}
+
+// Skill files carry YAML frontmatter whose folded/literal descriptions need
+// projecting separately before the remaining body is rendered as Markdown.
+function splitFrontmatter(text: unknown) {
+  const source = String(text ?? "");
+  const match = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(source);
+  if (!match) return { meta: null, body: source };
+  const meta: DocumentFrontmatter = {};
+  const lines = match[1].split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const kv = /^([A-Za-z0-9_-]+):\s?(.*)$/.exec(lines[i]);
+    if (!kv) continue;
+    let value = kv[2];
+    if (value === ">" || value === ">-" || value === "|" || value === "|-") {
+      const folded = value.startsWith(">");
+      const buffer = [];
+      while (i + 1 < lines.length
+        && (/^\s+\S/.test(lines[i + 1]) || lines[i + 1].trim() === "")) {
+        buffer.push(lines[++i].trim());
+      }
+      value = buffer.join(folded ? " " : "\n").trim();
+    }
+    meta[kv[1]] = value.trim();
+  }
+  return { meta, body: source.slice(match[0].length) };
+}
+
+export function createDocumentInspectionCoordinator(
+  dependencies: DocumentInspectionDependencies,
+) {
+  const { state } = dependencies;
+
+  return {
+    async open(request: PackageDocumentRequest) {
+      const sequence = ++state.docViewerSeq;
+      state.docViewerOpen = true;
+      state.docViewer = request.document;
+      state.docViewerHtml = "";
+      state.docViewerMeta = null;
+      state.docViewerError = "";
+      state.docViewerLoading = true;
+      dependencies.render();
+      try {
+        const content = await dependencies.queryDocument(request);
+        if (sequence !== state.docViewerSeq) return;
+        const { meta, body } = splitFrontmatter(content.text);
+        const html = await dependencies.renderMarkdown(body);
+        if (sequence !== state.docViewerSeq) return;
+        const descriptionHtml = meta?.description
+          ? await dependencies.renderMarkdownInline(meta.description)
+          : "";
+        if (sequence !== state.docViewerSeq) return;
+        const projectedMeta = meta && (meta.name || meta.description)
+          ? {
+              name: meta.name || request.document.name,
+              version: meta.version || "",
+              descriptionHtml,
+            }
+          : null;
+        state.docViewerHtml = html;
+        state.docViewerMeta = projectedMeta;
+      } catch (error) {
+        if (sequence !== state.docViewerSeq) return;
+        state.docViewerError = dependencies.describeError(error);
+      } finally {
+        if (sequence !== state.docViewerSeq) return;
+        state.docViewerLoading = false;
+        dependencies.render();
+      }
+    },
+
+    close() {
+      state.docViewerSeq++;
+      state.docViewerOpen = false;
+      state.docViewer = null;
+      state.docViewerHtml = "";
+      state.docViewerMeta = null;
+      state.docViewerError = "";
+      state.docViewerLoading = false;
+      dependencies.render();
+    },
+  };
+}

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -89,6 +89,7 @@ import {
   createCallGraphInspectionCoordinator,
   type PlatformStackEntry,
 } from "./call-graph-inspection.ts";
+import { createDocumentInspectionCoordinator } from "./document-inspection.ts";
 import {
   captureMemberFocus,
   createMemberFocusRestorer,
@@ -165,7 +166,6 @@ import type {
   BrowserPackageDependencies,
   BrowserPackageDependencyGroup,
   BrowserPackageDocument,
-  BrowserPackageDocumentContent,
   BrowserPackageIntegrations,
   BrowserPackageOpportunities,
   BrowserPackageSurface,
@@ -754,6 +754,17 @@ const callGraphInspection = createCallGraphInspectionCoordinator({
   nextPaint,
   refreshPackageStats,
   patchCallGraphSection,
+});
+const documentInspection = createDocumentInspectionCoordinator({
+  state,
+  queryDocument: request => inspectPackageDocument(
+    request.packageId,
+    request.version,
+    request.document.path),
+  renderMarkdown,
+  renderMarkdownInline,
+  describeError: errorMessage,
+  render,
 });
 
 function captureView(): WorkspaceView | null {
@@ -6816,89 +6827,19 @@ async function renderMarkdownInline(text: unknown) {
   return DOMPurify.sanitize(html, MARKDOWN_SANITIZE_OPTIONS);
 }
 
-// Skill files carry a leading YAML frontmatter block (---\n…\n---). Rendered as Markdown it turns
-// into a mangled setext heading, so split it out: parse name/version/description (handling folded
-// >-/> and literal |/|- block scalars) and hand back the remaining body for normal rendering.
-interface DocumentFrontmatter {
-  name?: string;
-  version?: string;
-  description?: string;
-  [key: string]: string | undefined;
-}
-
-function splitFrontmatter(text: unknown) {
-  const source = String(text ?? "");
-  const match = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(source);
-  if (!match) return { meta: null, body: source };
-  const meta: DocumentFrontmatter = {};
-  const lines = match[1].split(/\r?\n/);
-  for (let i = 0; i < lines.length; i++) {
-    const kv = /^([A-Za-z0-9_-]+):\s?(.*)$/.exec(lines[i]);
-    if (!kv) continue;
-    let value = kv[2];
-    if (value === ">" || value === ">-" || value === "|" || value === "|-") {
-      const folded = value.startsWith(">");
-      const buffer = [];
-      while (i + 1 < lines.length && (/^\s+\S/.test(lines[i + 1]) || lines[i + 1].trim() === "")) {
-        buffer.push(lines[++i].trim());
-      }
-      value = buffer.join(folded ? " " : "\n").trim();
-    }
-    meta[kv[1]] = value.trim();
-  }
-  return { meta, body: source.slice(match[0].length) };
-}
-
-async function openPackageDocument(path: string) {
+function openPackageDocument(path: string) {
   const pkg = state.package;
   const doc = (pkg?.documents || []).find(candidate => candidate.path === path);
   if (!pkg || !doc) return;
-  const seq = ++state.docViewerSeq;
-  state.docViewerOpen = true;
-  state.docViewer = doc;
-  state.docViewerHtml = "";
-  state.docViewerMeta = null;
-  state.docViewerError = "";
-  state.docViewerLoading = true;
-  render();
-  try {
-    const content = await inspectPackageDocument(pkg.id, pkg.version, path);
-    if (seq !== state.docViewerSeq) return;
-    const { meta, body } = splitFrontmatter(content.text);
-    const html = await renderMarkdown(body);
-    if (seq !== state.docViewerSeq) return;
-    const descriptionHtml = meta?.description
-      ? await renderMarkdownInline(meta.description)
-      : "";
-    if (seq !== state.docViewerSeq) return;
-    const projectedMeta = meta && (meta.name || meta.description)
-      ? {
-          name: meta.name || doc.name,
-          version: meta.version || "",
-          descriptionHtml
-        }
-      : null;
-    state.docViewerHtml = html;
-    state.docViewerMeta = projectedMeta;
-  } catch (error) {
-    if (seq !== state.docViewerSeq) return;
-    state.docViewerError = errorMessage(error);
-  } finally {
-    if (seq !== state.docViewerSeq) return;
-    state.docViewerLoading = false;
-    render();
-  }
+  return documentInspection.open({
+    packageId: pkg.id,
+    version: pkg.version,
+    document: doc,
+  });
 }
 
 function closeDocViewer() {
-  state.docViewerSeq++;
-  state.docViewerOpen = false;
-  state.docViewer = null;
-  state.docViewerHtml = "";
-  state.docViewerMeta = null;
-  state.docViewerError = "";
-  state.docViewerLoading = false;
-  render();
+  documentInspection.close();
 }
 
 function renderDocViewer() {

--- a/prototypes/inspect-web/test/document-inspection.test.ts
+++ b/prototypes/inspect-web/test/document-inspection.test.ts
@@ -18,6 +18,12 @@ const document: BrowserPackageDocument = {
   size: 128,
 };
 
+const guideDocument: BrowserPackageDocument = {
+  ...document,
+  name: "GUIDE.md",
+  path: "docs/GUIDE.md",
+};
+
 function content(text: string): BrowserPackageDocumentContent {
   return {
     kind: "Markdown",
@@ -223,11 +229,6 @@ test("closing during acquisition suppresses stale document publication", async (
 
 test("a newer document remains published after an older request completes", async () => {
   const first = deferred<BrowserPackageDocumentContent>();
-  const secondDocument: BrowserPackageDocument = {
-    ...document,
-    name: "GUIDE.md",
-    path: "docs/GUIDE.md",
-  };
   const state = inspectionState();
   const coordinator = createDocumentInspectionCoordinator(
     inspectionDependencies(state, {
@@ -246,14 +247,188 @@ test("a newer document remains published after an older request completes", asyn
   await coordinator.open({
     packageId: "Example.Package",
     version: "1.2.3",
-    document: secondDocument,
+    document: guideDocument,
   });
   first.resolve(content("stale"));
   await firstOpen;
 
-  assert.equal(state.docViewer, secondDocument);
+  assert.equal(state.docViewer, guideDocument);
   assert.equal(state.docViewerHtml, "<p>current</p>");
   assert.equal(state.docViewerLoading, false);
+});
+
+test("replacement during acquisition does not enter stale rendering", async () => {
+  const first = deferred<BrowserPackageDocumentContent>();
+  const second = deferred<BrowserPackageDocumentContent>();
+  let staleBodyRenders = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async request =>
+        request.document === document ? first.promise : second.promise,
+      renderMarkdown: async text => {
+        if (text === "stale") staleBodyRenders++;
+        return `<p>${String(text)}</p>`;
+      },
+    }));
+
+  const firstOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  const secondOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document: guideDocument,
+  });
+  first.resolve(content("stale"));
+  await firstOpen;
+
+  assert.equal(staleBodyRenders, 0);
+  assert.equal(state.docViewer, guideDocument);
+  assert.equal(state.docViewerLoading, true);
+  assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+
+  second.resolve(content("current"));
+  await secondOpen;
+  assert.equal(state.docViewerHtml, "<p>current</p>");
+});
+
+test("replacement during body rendering suppresses stale description work", async () => {
+  const body = deferred<string>();
+  const bodyEntered = deferred<void>();
+  const second = deferred<BrowserPackageDocumentContent>();
+  let inlineRenders = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async request =>
+        request.document === document
+          ? content("---\ndescription: Summary\n---\nBody")
+          : second.promise,
+      renderMarkdown: async text => {
+        if (text === "Body") {
+          bodyEntered.resolve();
+          return body.promise;
+        }
+        return `<p>${String(text)}</p>`;
+      },
+      renderMarkdownInline: async () => {
+        inlineRenders++;
+        return "<p>stale description</p>";
+      },
+    }));
+
+  const firstOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  await bodyEntered.promise;
+  const secondOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document: guideDocument,
+  });
+  body.resolve("<p>stale body</p>");
+  await firstOpen;
+
+  assert.equal(inlineRenders, 0);
+  assert.equal(state.docViewer, guideDocument);
+  assert.equal(state.docViewerLoading, true);
+  assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+
+  second.resolve(content("current"));
+  await secondOpen;
+  assert.equal(state.docViewerHtml, "<p>current</p>");
+});
+
+test("replacement during description rendering suppresses stale publication", async () => {
+  const description = deferred<string>();
+  const descriptionEntered = deferred<void>();
+  const second = deferred<BrowserPackageDocumentContent>();
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async request =>
+        request.document === document
+          ? content("---\ndescription: Summary\n---\nBody")
+          : second.promise,
+      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      renderMarkdownInline: async () => {
+        descriptionEntered.resolve();
+        return description.promise;
+      },
+    }));
+
+  const firstOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  await descriptionEntered.promise;
+  const secondOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document: guideDocument,
+  });
+  description.resolve("<p>stale description</p>");
+  await firstOpen;
+
+  assert.equal(state.docViewer, guideDocument);
+  assert.equal(state.docViewerLoading, true);
+  assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+
+  second.resolve(content("current"));
+  await secondOpen;
+  assert.equal(state.docViewerHtml, "<p>current</p>");
+});
+
+test("rejected replaced documents cannot settle the current request", async () => {
+  const first = deferred<BrowserPackageDocumentContent>();
+  const second = deferred<BrowserPackageDocumentContent>();
+  let renders = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async request =>
+        request.document === document ? first.promise : second.promise,
+      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      render: () => renders++,
+    }));
+
+  const firstOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  const secondOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document: guideDocument,
+  });
+  first.reject(new Error("stale failure"));
+  await firstOpen;
+
+  assert.equal(state.docViewer, guideDocument);
+  assert.equal(state.docViewerLoading, true);
+  assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(renders, 2);
+
+  second.resolve(content("current"));
+  await secondOpen;
+  assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerHtml, "<p>current</p>");
+  assert.equal(state.docViewerLoading, false);
+  assert.equal(renders, 3);
 });
 
 test("closing during body rendering suppresses description and publication", async () => {
@@ -368,6 +543,38 @@ test("current document failures remain visible and settle loading", async () => 
   assert.equal(state.docViewerError, "Markdown renderer unavailable");
   assert.equal(state.docViewerLoading, false);
   assert.equal(renders, 2);
+});
+
+test("opening another document clears a prior visible failure", async () => {
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async request => {
+        if (request.document === document) {
+          throw new Error("Document unavailable");
+        }
+        return content("current");
+      },
+      renderMarkdown: async text => `<p>${String(text)}</p>`,
+    }));
+
+  await coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  assert.equal(state.docViewerError, "Document unavailable");
+
+  await coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document: guideDocument,
+  });
+
+  assert.equal(state.docViewer, guideDocument);
+  assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerHtml, "<p>current</p>");
+  assert.equal(state.docViewerLoading, false);
 });
 
 test("closing resets every document surface and invalidates its sequence", () => {

--- a/prototypes/inspect-web/test/document-inspection.test.ts
+++ b/prototypes/inspect-web/test/document-inspection.test.ts
@@ -258,13 +258,17 @@ test("a newer document remains published after an older request completes", asyn
 
 test("closing during body rendering suppresses description and publication", async () => {
   const body = deferred<string>();
+  const bodyEntered = deferred<void>();
   let inlineRenders = 0;
   const state = inspectionState();
   const coordinator = createDocumentInspectionCoordinator(
     inspectionDependencies(state, {
       queryDocument: async () =>
         content("---\ndescription: Summary\n---\nBody"),
-      renderMarkdown: async () => body.promise,
+      renderMarkdown: async () => {
+        bodyEntered.resolve();
+        return body.promise;
+      },
       renderMarkdownInline: async () => {
         inlineRenders++;
         return "<p>stale</p>";
@@ -276,6 +280,7 @@ test("closing during body rendering suppresses description and publication", asy
     version: "1.2.3",
     document,
   });
+  await bodyEntered.promise;
   coordinator.close();
   body.resolve("<p>stale body</p>");
   await open;
@@ -287,13 +292,17 @@ test("closing during body rendering suppresses description and publication", asy
 
 test("closing during description rendering suppresses all publication", async () => {
   const description = deferred<string>();
+  const descriptionEntered = deferred<void>();
   const state = inspectionState();
   const coordinator = createDocumentInspectionCoordinator(
     inspectionDependencies(state, {
       queryDocument: async () =>
         content("---\ndescription: Summary\n---\nBody"),
       renderMarkdown: async () => "<p>stale body</p>",
-      renderMarkdownInline: async () => description.promise,
+      renderMarkdownInline: async () => {
+        descriptionEntered.resolve();
+        return description.promise;
+      },
     }));
 
   const open = coordinator.open({
@@ -301,12 +310,42 @@ test("closing during description rendering suppresses all publication", async ()
     version: "1.2.3",
     document,
   });
+  await descriptionEntered.promise;
   coordinator.close();
   description.resolve("<p>stale description</p>");
   await open;
 
   assert.equal(state.docViewerHtml, "");
   assert.equal(state.docViewerMeta, null);
+});
+
+test("closing before a rejected request suppresses its stale failure", async () => {
+  const query = deferred<BrowserPackageDocumentContent>();
+  const queryEntered = deferred<void>();
+  let renders = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async () => {
+        queryEntered.resolve();
+        return query.promise;
+      },
+      render: () => renders++,
+    }));
+
+  const open = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  await queryEntered.promise;
+  coordinator.close();
+  query.reject(new Error("stale failure"));
+  await open;
+
+  assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerLoading, false);
+  assert.equal(renders, 2);
 });
 
 test("current document failures remain visible and settle loading", async () => {

--- a/prototypes/inspect-web/test/document-inspection.test.ts
+++ b/prototypes/inspect-web/test/document-inspection.test.ts
@@ -297,6 +297,43 @@ test("replacement during acquisition does not enter stale rendering", async () =
   assert.equal(state.docViewerHtml, "<p>current</p>");
 });
 
+test("reopening the same document during acquisition rejects stale identity", async () => {
+  const first = deferred<BrowserPackageDocumentContent>();
+  const second = deferred<BrowserPackageDocumentContent>();
+  let queries = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: () => ++queries === 1 ? first.promise : second.promise,
+      renderMarkdown: async text => `<p>${String(text)}</p>`,
+    }));
+
+  const firstOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  coordinator.close();
+  const secondOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  first.resolve(content("stale"));
+  await firstOpen;
+
+  assert.equal(state.docViewer, document);
+  assert.equal(state.docViewerLoading, true);
+  assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+
+  second.resolve(content("current"));
+  await secondOpen;
+  assert.equal(state.docViewerHtml, "<p>current</p>");
+  assert.equal(state.docViewerLoading, false);
+});
+
 test("replacement during body rendering suppresses stale description work", async () => {
   const body = deferred<string>();
   const bodyEntered = deferred<void>();
@@ -348,6 +385,56 @@ test("replacement during body rendering suppresses stale description work", asyn
   assert.equal(state.docViewerHtml, "<p>current</p>");
 });
 
+test("reopening the same document during body rendering suppresses stale work", async () => {
+  const body = deferred<string>();
+  const bodyEntered = deferred<void>();
+  const second = deferred<BrowserPackageDocumentContent>();
+  let queries = 0;
+  let inlineRenders = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: () => ++queries === 1
+        ? Promise.resolve(content("---\ndescription: Summary\n---\nBody"))
+        : second.promise,
+      renderMarkdown: async text => {
+        if (text === "Body") {
+          bodyEntered.resolve();
+          return body.promise;
+        }
+        return `<p>${String(text)}</p>`;
+      },
+      renderMarkdownInline: async () => {
+        inlineRenders++;
+        return "<p>stale description</p>";
+      },
+    }));
+
+  const firstOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  await bodyEntered.promise;
+  coordinator.close();
+  const secondOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  body.resolve("<p>stale body</p>");
+  await firstOpen;
+
+  assert.equal(inlineRenders, 0);
+  assert.equal(state.docViewer, document);
+  assert.equal(state.docViewerLoading, true);
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+
+  second.resolve(content("current"));
+  await secondOpen;
+});
+
 test("replacement during description rendering suppresses stale publication", async () => {
   const description = deferred<string>();
   const descriptionEntered = deferred<void>();
@@ -391,6 +478,48 @@ test("replacement during description rendering suppresses stale publication", as
   assert.equal(state.docViewerHtml, "<p>current</p>");
 });
 
+test("reopening the same document during description rendering suppresses stale publication", async () => {
+  const description = deferred<string>();
+  const descriptionEntered = deferred<void>();
+  const second = deferred<BrowserPackageDocumentContent>();
+  let queries = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: () => ++queries === 1
+        ? Promise.resolve(content("---\ndescription: Summary\n---\nBody"))
+        : second.promise,
+      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      renderMarkdownInline: async () => {
+        descriptionEntered.resolve();
+        return description.promise;
+      },
+    }));
+
+  const firstOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  await descriptionEntered.promise;
+  coordinator.close();
+  const secondOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  description.resolve("<p>stale description</p>");
+  await firstOpen;
+
+  assert.equal(state.docViewer, document);
+  assert.equal(state.docViewerLoading, true);
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+
+  second.resolve(content("current"));
+  await secondOpen;
+});
+
 test("rejected replaced documents cannot settle the current request", async () => {
   const first = deferred<BrowserPackageDocumentContent>();
   const second = deferred<BrowserPackageDocumentContent>();
@@ -429,6 +558,41 @@ test("rejected replaced documents cannot settle the current request", async () =
   assert.equal(state.docViewerHtml, "<p>current</p>");
   assert.equal(state.docViewerLoading, false);
   assert.equal(renders, 3);
+});
+
+test("reopening the same document suppresses a stale rejection", async () => {
+  const first = deferred<BrowserPackageDocumentContent>();
+  const second = deferred<BrowserPackageDocumentContent>();
+  let queries = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: () => ++queries === 1 ? first.promise : second.promise,
+      renderMarkdown: async text => `<p>${String(text)}</p>`,
+    }));
+
+  const firstOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  coordinator.close();
+  const secondOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  first.reject(new Error("stale failure"));
+  await firstOpen;
+
+  assert.equal(state.docViewer, document);
+  assert.equal(state.docViewerLoading, true);
+  assert.equal(state.docViewerError, "");
+
+  second.resolve(content("current"));
+  await secondOpen;
+  assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerLoading, false);
 });
 
 test("closing during body rendering suppresses description and publication", async () => {
@@ -546,6 +710,7 @@ test("current document failures remain visible and settle loading", async () => 
 });
 
 test("opening another document clears a prior visible failure", async () => {
+  const replacement = deferred<BrowserPackageDocumentContent>();
   const state = inspectionState();
   const coordinator = createDocumentInspectionCoordinator(
     inspectionDependencies(state, {
@@ -553,7 +718,7 @@ test("opening another document clears a prior visible failure", async () => {
         if (request.document === document) {
           throw new Error("Document unavailable");
         }
-        return content("current");
+        return replacement.promise;
       },
       renderMarkdown: async text => `<p>${String(text)}</p>`,
     }));
@@ -565,7 +730,7 @@ test("opening another document clears a prior visible failure", async () => {
   });
   assert.equal(state.docViewerError, "Document unavailable");
 
-  await coordinator.open({
+  const open = coordinator.open({
     packageId: "Example.Package",
     version: "1.2.3",
     document: guideDocument,
@@ -573,8 +738,49 @@ test("opening another document clears a prior visible failure", async () => {
 
   assert.equal(state.docViewer, guideDocument);
   assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerLoading, true);
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+
+  replacement.resolve(content("current"));
+  await open;
   assert.equal(state.docViewerHtml, "<p>current</p>");
   assert.equal(state.docViewerLoading, false);
+});
+
+test("opening another document clears prior published surfaces immediately", async () => {
+  const replacement = deferred<BrowserPackageDocumentContent>();
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async request =>
+        request.document === document
+          ? content("---\nname: Old\n---\nold body")
+          : replacement.promise,
+      renderMarkdown: async text => `<p>${String(text)}</p>`,
+    }));
+
+  await coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  assert.equal(state.docViewerHtml, "<p>old body</p>");
+  assert.notEqual(state.docViewerMeta, null);
+
+  const open = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document: guideDocument,
+  });
+
+  assert.equal(state.docViewerLoading, true);
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+
+  replacement.resolve(content("current"));
+  await open;
+  assert.equal(state.docViewerHtml, "<p>current</p>");
 });
 
 test("closing resets every document surface and invalidates its sequence", () => {

--- a/prototypes/inspect-web/test/document-inspection.test.ts
+++ b/prototypes/inspect-web/test/document-inspection.test.ts
@@ -1,0 +1,364 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createDocumentInspectionCoordinator,
+  type DocumentInspectionDependencies,
+  type DocumentInspectionState,
+} from "../src/document-inspection.ts";
+import type {
+  BrowserPackageDocument,
+  BrowserPackageDocumentContent,
+} from "../src/inspect-web-engine.d.ts";
+
+const document: BrowserPackageDocument = {
+  kind: "Markdown",
+  name: "README.md",
+  path: "docs/README.md",
+  size: 128,
+};
+
+function content(text: string): BrowserPackageDocumentContent {
+  return {
+    kind: "Markdown",
+    name: document.name,
+    path: document.path,
+    text,
+  };
+}
+
+function inspectionState(
+  overrides: Partial<DocumentInspectionState> = {},
+): DocumentInspectionState {
+  return {
+    docViewerOpen: false,
+    docViewer: null,
+    docViewerLoading: false,
+    docViewerError: "",
+    docViewerHtml: "",
+    docViewerMeta: null,
+    docViewerSeq: 0,
+    ...overrides,
+  };
+}
+
+function inspectionDependencies(
+  state: DocumentInspectionState,
+  overrides: Partial<Omit<DocumentInspectionDependencies, "state">> = {},
+): DocumentInspectionDependencies {
+  return {
+    state,
+    queryDocument: async () => content("# Read me"),
+    renderMarkdown: async text => `<p>${String(text)}</p>`,
+    renderMarkdownInline: async text => `<span>${String(text)}</span>`,
+    describeError: error =>
+      error instanceof Error ? error.message : String(error),
+    render: () => {},
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((accept, deny) => {
+    resolve = accept;
+    reject = deny;
+  });
+  return { promise, resolve, reject };
+}
+
+test("document requests publish sanitized body HTML for exact coordinates", async () => {
+  const events: string[] = [];
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async request => {
+        assert.deepEqual(
+          [request.packageId, request.version, request.document],
+          ["Example.Package", "1.2.3", document]);
+        events.push("query");
+        return content("# Read me");
+      },
+      renderMarkdown: async text => {
+        assert.equal(text, "# Read me");
+        events.push("markdown");
+        return "<h1>Read me</h1>";
+      },
+      renderMarkdownInline: async () => {
+        throw new Error("unexpected inline render");
+      },
+      render: () => events.push("render"),
+    }));
+
+  await coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+
+  assert.equal(state.docViewerOpen, true);
+  assert.equal(state.docViewer, document);
+  assert.equal(state.docViewerHtml, "<h1>Read me</h1>");
+  assert.equal(state.docViewerMeta, null);
+  assert.equal(state.docViewerLoading, false);
+  assert.equal(state.docViewerError, "");
+  assert.deepEqual(events, ["render", "query", "markdown", "render"]);
+});
+
+test("document frontmatter projects folded descriptions and version", async () => {
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async () => content(
+        "---\n"
+        + "name: Package guide\n"
+        + "version: 2.0\n"
+        + "description: >-\n"
+        + "  First line\n"
+        + "  second line\n"
+        + "---\n"
+        + "# Body"),
+      renderMarkdown: async text => {
+        assert.equal(text, "# Body");
+        return "<h1>Body</h1>";
+      },
+      renderMarkdownInline: async text => {
+        assert.equal(text, "First line second line");
+        return "<p>First line second line</p>";
+      },
+    }));
+
+  await coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+
+  assert.deepEqual(state.docViewerMeta, {
+    name: "Package guide",
+    version: "2.0",
+    descriptionHtml: "<p>First line second line</p>",
+  });
+  assert.equal(state.docViewerHtml, "<h1>Body</h1>");
+});
+
+test("frontmatter descriptions fall back to the document name", async () => {
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async () => content(
+        "---\n"
+        + "version: 2.0\n"
+        + "description: |-\n"
+        + "  First line\n"
+        + "  second line\n"
+        + "---\n"
+        + "Body"),
+      renderMarkdownInline: async text => {
+        assert.equal(text, "First line\nsecond line");
+        return "<p>Description</p>";
+      },
+    }));
+
+  await coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+
+  assert.deepEqual(state.docViewerMeta, {
+    name: "README.md",
+    version: "2.0",
+    descriptionHtml: "<p>Description</p>",
+  });
+});
+
+test("frontmatter with only a version does not create a metadata card", async () => {
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async () => content("---\nversion: 2.0\n---\nBody"),
+    }));
+
+  await coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+
+  assert.equal(state.docViewerMeta, null);
+});
+
+test("closing during acquisition suppresses stale document publication", async () => {
+  const query = deferred<BrowserPackageDocumentContent>();
+  let markdownRenders = 0;
+  let renders = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async () => query.promise,
+      renderMarkdown: async () => {
+        markdownRenders++;
+        return "<p>stale</p>";
+      },
+      render: () => renders++,
+    }));
+
+  const open = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  coordinator.close();
+  query.resolve(content("stale"));
+  await open;
+
+  assert.equal(markdownRenders, 0);
+  assert.equal(renders, 2);
+  assert.equal(state.docViewerOpen, false);
+  assert.equal(state.docViewer, null);
+  assert.equal(state.docViewerHtml, "");
+});
+
+test("a newer document remains published after an older request completes", async () => {
+  const first = deferred<BrowserPackageDocumentContent>();
+  const secondDocument: BrowserPackageDocument = {
+    ...document,
+    name: "GUIDE.md",
+    path: "docs/GUIDE.md",
+  };
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async request =>
+        request.document === document
+          ? first.promise
+          : content("current"),
+      renderMarkdown: async text => `<p>${String(text)}</p>`,
+    }));
+
+  const firstOpen = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  await coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document: secondDocument,
+  });
+  first.resolve(content("stale"));
+  await firstOpen;
+
+  assert.equal(state.docViewer, secondDocument);
+  assert.equal(state.docViewerHtml, "<p>current</p>");
+  assert.equal(state.docViewerLoading, false);
+});
+
+test("closing during body rendering suppresses description and publication", async () => {
+  const body = deferred<string>();
+  let inlineRenders = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async () =>
+        content("---\ndescription: Summary\n---\nBody"),
+      renderMarkdown: async () => body.promise,
+      renderMarkdownInline: async () => {
+        inlineRenders++;
+        return "<p>stale</p>";
+      },
+    }));
+
+  const open = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  coordinator.close();
+  body.resolve("<p>stale body</p>");
+  await open;
+
+  assert.equal(inlineRenders, 0);
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+});
+
+test("closing during description rendering suppresses all publication", async () => {
+  const description = deferred<string>();
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDocument: async () =>
+        content("---\ndescription: Summary\n---\nBody"),
+      renderMarkdown: async () => "<p>stale body</p>",
+      renderMarkdownInline: async () => description.promise,
+    }));
+
+  const open = coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+  coordinator.close();
+  description.resolve("<p>stale description</p>");
+  await open;
+
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+});
+
+test("current document failures remain visible and settle loading", async () => {
+  let renders = 0;
+  const state = inspectionState();
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      renderMarkdown: async () => {
+        throw new Error("Markdown renderer unavailable");
+      },
+      render: () => renders++,
+    }));
+
+  await coordinator.open({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    document,
+  });
+
+  assert.equal(state.docViewerError, "Markdown renderer unavailable");
+  assert.equal(state.docViewerLoading, false);
+  assert.equal(renders, 2);
+});
+
+test("closing resets every document surface and invalidates its sequence", () => {
+  let renders = 0;
+  const state = inspectionState({
+    docViewerOpen: true,
+    docViewer: document,
+    docViewerLoading: true,
+    docViewerError: "old error",
+    docViewerHtml: "<p>old</p>",
+    docViewerMeta: {
+      name: "Old",
+      version: "1.0",
+      descriptionHtml: "<p>old</p>",
+    },
+    docViewerSeq: 4,
+  });
+  const coordinator = createDocumentInspectionCoordinator(
+    inspectionDependencies(state, {
+      render: () => renders++,
+    }));
+
+  coordinator.close();
+
+  assert.equal(state.docViewerSeq, 5);
+  assert.equal(state.docViewerOpen, false);
+  assert.equal(state.docViewer, null);
+  assert.equal(state.docViewerLoading, false);
+  assert.equal(state.docViewerError, "");
+  assert.equal(state.docViewerHtml, "");
+  assert.equal(state.docViewerMeta, null);
+  assert.equal(renders, 1);
+});

--- a/prototypes/inspect-web/test/document-inspection.test.ts
+++ b/prototypes/inspect-web/test/document-inspection.test.ts
@@ -301,11 +301,15 @@ test("reopening the same document during acquisition rejects stale identity", as
   const first = deferred<BrowserPackageDocumentContent>();
   const second = deferred<BrowserPackageDocumentContent>();
   let queries = 0;
+  let staleBodyRenders = 0;
   const state = inspectionState();
   const coordinator = createDocumentInspectionCoordinator(
     inspectionDependencies(state, {
       queryDocument: () => ++queries === 1 ? first.promise : second.promise,
-      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      renderMarkdown: async text => {
+        if (text === "stale") staleBodyRenders++;
+        return `<p>${String(text)}</p>`;
+      },
     }));
 
   const firstOpen = coordinator.open({
@@ -322,6 +326,7 @@ test("reopening the same document during acquisition rejects stale identity", as
   first.resolve(content("stale"));
   await firstOpen;
 
+  assert.equal(staleBodyRenders, 0);
   assert.equal(state.docViewer, document);
   assert.equal(state.docViewerLoading, true);
   assert.equal(state.docViewerError, "");

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -312,7 +312,9 @@ test("typed document inspection owns package document request coordination", () 
   assert.match(
     appSource,
     /queryDocument: request => inspectPackageDocument\(\s*request\.packageId,\s*request\.version,\s*request\.document\.path\)/);
-  assert.match(documentLoader, /return documentInspection\.open\(\{/);
+  assert.match(
+    documentLoader,
+    /return documentInspection\.open\(\{\s*packageId: pkg\.id,\s*version: pkg\.version,\s*document: doc,\s*\}\)/);
   assert.match(documentCloser, /documentInspection\.close\(\)/);
   assert.doesNotMatch(documentLoader, /state\.docViewer(?:Seq|Open|Loading)/);
   assert.doesNotMatch(documentCloser, /state\.docViewer(?:Seq|Open|Loading)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -180,6 +180,9 @@ const memberDetailInspectionSource = readFileSync(
 const callGraphInspectionSource = readFileSync(
   new URL("../src/call-graph-inspection.ts", import.meta.url),
   "utf8");
+const documentInspectionSource = readFileSync(
+  new URL("../src/document-inspection.ts", import.meta.url),
+  "utf8");
 const memberFocusSource = readFileSync(
   new URL("../src/member-focus.ts", import.meta.url),
   "utf8");
@@ -294,6 +297,25 @@ test("typed package inspection owns package-root request coordination", () => {
     packageInspectionSource,
     /async loadDependencies\(packageModel, signature\)[\s\S]*state\.packageDependenciesKey/);
   assert.doesNotMatch(dependenciesLoader, /state\.packageDependenciesKey/);
+});
+
+test("typed document inspection owns package document request coordination", () => {
+  const documentLoader =
+    appSource.match(/function openPackageDocument\(path: string\)[\s\S]*?\n}/)?.[0]
+    ?? "";
+  const documentCloser =
+    appSource.match(/function closeDocViewer\(\)[\s\S]*?\n}/)?.[0]
+    ?? "";
+  assert.match(
+    appSource,
+    /createDocumentInspectionCoordinator\(\{[\s\S]*queryDocument:[\s\S]*renderMarkdown,[\s\S]*renderMarkdownInline,/);
+  assert.match(documentLoader, /return documentInspection\.open\(\{/);
+  assert.match(documentCloser, /documentInspection\.close\(\)/);
+  assert.doesNotMatch(documentLoader, /state\.docViewer(?:Seq|Open|Loading)/);
+  assert.doesNotMatch(documentCloser, /state\.docViewer(?:Seq|Open|Loading)/);
+  assert.match(
+    documentInspectionSource,
+    /async open\(request: PackageDocumentRequest\)[\s\S]*state\.docViewerSeq/);
 });
 
 test("leaving package search clears its pending loading state", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -309,6 +309,9 @@ test("typed document inspection owns package document request coordination", () 
   assert.match(
     appSource,
     /createDocumentInspectionCoordinator\(\{[\s\S]*queryDocument:[\s\S]*renderMarkdown,[\s\S]*renderMarkdownInline,/);
+  assert.match(
+    appSource,
+    /queryDocument: request => inspectPackageDocument\(\s*request\.packageId,\s*request\.version,\s*request\.document\.path\)/);
   assert.match(documentLoader, /return documentInspection\.open\(\{/);
   assert.match(documentCloser, /documentInspection\.close\(\)/);
   assert.doesNotMatch(documentLoader, /state\.docViewer(?:Seq|Open|Loading)/);


### PR DESCRIPTION
Moves the package document modal’s async load/close lifecycle out of the browser composition root behind a typed coordinator. Exact package/document requests, loading and visible failure state, folded/literal frontmatter projection, sequence checks after acquisition/body/description rendering, replacement suppression, and close invalidation are preserved; `dotnet-inspect.ts` retains selected-package/path validation, engine loading, sanitized Markdown rendering, modal presentation, and DOM event binding.

**Stack**

- Slice 8, stacked on #4514.
- Parent: #4514 (call-graph request coordination).
- Residual: Spotlight package/index network request controllers, then DOM event binding paired with presentation owners.

**Validation**

- `npm test` — 360/360, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.

Progresses #4504.