### PR TITLE
Extract Spotlight package request coordination

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -605,13 +605,17 @@ wiring.
 
 `src/spotlight.ts` owns the modal workbench search, embedded home search,
 scope/result rendering, selection, and keyboard interaction.
+`src/spotlight-package-search.ts` owns debounced NuGet discovery, generation
+cancellation, result publication, and reset state.
 `src/command-bar.ts` supplies its typed Commands-scope grammar and results;
-`dotnet-inspect.ts` retains command effects and delegates package/network work
-to the acquisition owner so the components do not acquire engine or workspace
-authority.
-`test/spotlight.test.js` and `test/command-bar.test.ts` gate both presentation
-modes, scope ownership, completion and replacement behavior, bounded results,
-command metadata, and escaping.
+`dotnet-inspect.ts` retains command effects, the NuGet query endpoint, package
+navigation, and acquisition so the components do not acquire engine or
+workspace authority. `test/spotlight.test.js` and
+`test/command-bar.test.ts` gate both presentation modes, scope ownership,
+completion and replacement behavior, bounded results, command metadata, and
+escaping; `test/spotlight-package-search.test.ts` gates debounce, scope and
+query eligibility, cancellation, stale suppression, failure settlement, and
+mounted-result refresh.
 
 The typed `src/status-bar.ts` component renders both the full-width workspace
 data bar and the home readiness bar. The workspace bar occupies the bottom row

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -154,6 +154,7 @@ import {
   type SpotlightResult,
   visibleSpotlightPackageHits,
 } from "./spotlight.ts";
+import { createSpotlightPackageSearch } from "./spotlight-package-search.ts";
 import { fmtBytes, statusBarHtml } from "./status-bar.ts";
 import type {
   BrowserAnnotatedSource,
@@ -970,6 +971,13 @@ function currentPackage(): AppPackage {
   return state.package;
 }
 
+const spotlightPackageSearch = createSpotlightPackageSearch({
+  state,
+  queryPackages: querySpotlightPackages,
+  schedule: (callback, delay) => setTimeout(() => void callback(), delay),
+  cancelScheduled: clearTimeout,
+  updateResults: () => spotlight.updateResults(),
+});
 const spotlight = createSpotlight({
   state,
   lenses,
@@ -982,8 +990,8 @@ const spotlight = createSpotlight({
   commandContext: () => !state.home && state.package
     ? { command: state.spotlightQuery, package: state.package }
     : null,
-  schedulePackageFetch: scheduleSpotlightPackageFetch,
-  resetPackageSearch: resetSpotlightPackageSearch,
+  schedulePackageFetch: spotlightPackageSearch.schedule,
+  resetPackageSearch: spotlightPackageSearch.reset,
   packageSearchLoading: () => state.spotlightPkgLoading,
   packageCount: () => state.packages.length,
   activeFramework: () => state.package?.activeFramework || "",
@@ -4677,51 +4685,6 @@ function spotlightResults(): SpotlightResult[] {
   return results;
 }
 
-// Debounced client-side NuGet discovery. Guards against stale queries via spotlightPkgQuery
-// and refreshes results only when the resolved query still matches the input.
-let spotlightPkgTimer: ReturnType<typeof setTimeout> | null = null;
-let spotlightPkgGeneration = 0;
-
-function resetSpotlightPackageSearch() {
-  spotlightPkgGeneration++;
-  if (spotlightPkgTimer) clearTimeout(spotlightPkgTimer);
-  spotlightPkgTimer = null;
-  state.spotlightPkgHits = [];
-  state.spotlightPkgQuery = "";
-  state.spotlightPkgLoading = false;
-}
-
-function scheduleSpotlightPackageFetch() {
-  const query = state.spotlightQuery.trim();
-  if (spotlightPkgTimer) {
-    clearTimeout(spotlightPkgTimer);
-    spotlightPkgTimer = null;
-  }
-  if (state.spotlightScope !== "all" && state.spotlightScope !== "packages") {
-    spotlightPkgGeneration++;
-    state.spotlightPkgLoading = false;
-    return;
-  }
-  if (query.length < 2) {
-    spotlightPkgGeneration++;
-    state.spotlightPkgHits = [];
-    state.spotlightPkgQuery = "";
-    state.spotlightPkgLoading = false;
-    return;
-  }
-  if (query === state.spotlightPkgQuery) {
-    spotlightPkgGeneration++;
-    state.spotlightPkgLoading = false;
-    return;
-  }
-  const generation = ++spotlightPkgGeneration;
-  state.spotlightPkgLoading = true;
-  spotlightPkgTimer = setTimeout(() => {
-    spotlightPkgTimer = null;
-    fetchSpotlightPackages(query, generation);
-  }, 220);
-}
-
 interface NugetSearchResult {
   id: string;
   version: string;
@@ -4732,32 +4695,16 @@ interface NugetSearchResponse {
   data?: NugetSearchResult[];
 }
 
-async function fetchSpotlightPackages(query: string, generation: number) {
+async function querySpotlightPackages(query: string): Promise<SpotlightPackageHit[]> {
   const url = `https://azuresearch-usnc.nuget.org/query?q=${encodeURIComponent(query)}&take=8&prerelease=true&semVerLevel=2.0.0`;
-  try {
-    const response = await fetch(url);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const payload = await response.json() as NugetSearchResponse;
-    if (generation !== spotlightPkgGeneration
-      || state.spotlightQuery.trim() !== query) return;
-    state.spotlightPkgHits = (payload.data || []).map(item => ({
-      id: item.id,
-      version: item.version,
-      description: item.description || "",
-    }));
-    state.spotlightPkgQuery = query;
-  } catch (error) {
-    if (generation !== spotlightPkgGeneration
-      || state.spotlightQuery.trim() !== query) return;
-    state.spotlightPkgHits = [];
-    state.spotlightPkgQuery = query;
-  } finally {
-    if (generation === spotlightPkgGeneration
-      && state.spotlightQuery.trim() === query) {
-      state.spotlightPkgLoading = false;
-      spotlight.updateResults();
-    }
-  }
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const payload = await response.json() as NugetSearchResponse;
+  return (payload.data || []).map(item => ({
+    id: item.id,
+    version: item.version,
+    description: item.description || "",
+  }));
 }
 
 // Compare two NuGet SemVer-ish versions descending (newest first). Falls back to string

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -975,7 +975,7 @@ const spotlightPackageSearch = createSpotlightPackageSearch({
   state,
   queryPackages: querySpotlightPackages,
   schedule: (callback, delay) => setTimeout(() => void callback(), delay),
-  cancelScheduled: clearTimeout,
+  cancelScheduled: handle => clearTimeout(handle),
   updateResults: () => spotlight.updateResults(),
 });
 const spotlight = createSpotlight({

--- a/prototypes/inspect-web/src/spotlight-package-search.ts
+++ b/prototypes/inspect-web/src/spotlight-package-search.ts
@@ -1,0 +1,89 @@
+import type { SpotlightPackageHit } from "./spotlight.ts";
+
+export interface SpotlightPackageSearchState {
+  spotlightQuery: string;
+  spotlightScope: string;
+  spotlightPkgHits: SpotlightPackageHit[];
+  spotlightPkgQuery: string;
+  spotlightPkgLoading: boolean;
+}
+
+export interface SpotlightPackageSearchDependencies<TSchedule> {
+  state: SpotlightPackageSearchState;
+  queryPackages: (query: string) => Promise<readonly SpotlightPackageHit[]>;
+  schedule: (callback: () => Promise<void>, delay: number) => TSchedule;
+  cancelScheduled: (scheduled: TSchedule) => void;
+  updateResults: () => void;
+}
+
+export function createSpotlightPackageSearch<TSchedule>(
+  dependencies: SpotlightPackageSearchDependencies<TSchedule>,
+) {
+  const { state } = dependencies;
+  let scheduled: TSchedule | null = null;
+  let generation = 0;
+
+  const fetchPackages = async (query: string, requestGeneration: number) => {
+    try {
+      const hits = await dependencies.queryPackages(query);
+      if (requestGeneration !== generation
+        || state.spotlightQuery.trim() !== query) return;
+      state.spotlightPkgHits = [...hits];
+      state.spotlightPkgQuery = query;
+    } catch {
+      if (requestGeneration !== generation
+        || state.spotlightQuery.trim() !== query) return;
+      state.spotlightPkgHits = [];
+      state.spotlightPkgQuery = query;
+    } finally {
+      if (requestGeneration === generation
+        && state.spotlightQuery.trim() === query) {
+        state.spotlightPkgLoading = false;
+        dependencies.updateResults();
+      }
+    }
+  };
+
+  return {
+    reset() {
+      generation++;
+      if (scheduled !== null) dependencies.cancelScheduled(scheduled);
+      scheduled = null;
+      state.spotlightPkgHits = [];
+      state.spotlightPkgQuery = "";
+      state.spotlightPkgLoading = false;
+    },
+
+    schedule() {
+      const query = state.spotlightQuery.trim();
+      if (scheduled !== null) {
+        dependencies.cancelScheduled(scheduled);
+        scheduled = null;
+      }
+      if (state.spotlightScope !== "all"
+        && state.spotlightScope !== "packages") {
+        generation++;
+        state.spotlightPkgLoading = false;
+        return;
+      }
+      if (query.length < 2) {
+        generation++;
+        state.spotlightPkgHits = [];
+        state.spotlightPkgQuery = "";
+        state.spotlightPkgLoading = false;
+        return;
+      }
+      if (query === state.spotlightPkgQuery) {
+        generation++;
+        state.spotlightPkgLoading = false;
+        return;
+      }
+      const requestGeneration = ++generation;
+      state.spotlightPkgLoading = true;
+      scheduled = dependencies.schedule(async () => {
+        scheduled = null;
+        await fetchPackages(query, requestGeneration);
+      }, 220);
+    },
+  };
+}

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -349,6 +349,9 @@ test("Spotlight async work is generation-gated and refreshes either mounted surf
     spotlightPackageSearchSource,
     /requestGeneration !== generation[\s\S]*state\.spotlightQuery\.trim\(\) !== query/);
   assert.doesNotMatch(appSource, /spotlightPkgGeneration|spotlightPkgTimer/);
+  assert.match(
+    appSource,
+    /if \(!state\.spotlightOpen && !state\.home\) return;[\s\S]*spotlight\.refresh\(\)/);
 });
 
 test("global workbench shortcuts respect the topmost modal", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -183,6 +183,9 @@ const callGraphInspectionSource = readFileSync(
 const documentInspectionSource = readFileSync(
   new URL("../src/document-inspection.ts", import.meta.url),
   "utf8");
+const spotlightPackageSearchSource = readFileSync(
+  new URL("../src/spotlight-package-search.ts", import.meta.url),
+  "utf8");
 const memberFocusSource = readFileSync(
   new URL("../src/member-focus.ts", import.meta.url),
   "utf8");
@@ -324,31 +327,28 @@ test("typed document inspection owns package document request coordination", () 
 });
 
 test("leaving package search clears its pending loading state", () => {
-  const scheduler =
-    appSource.match(/function scheduleSpotlightPackageFetch\(\)[\s\S]*?\n}\n\nasync function fetchSpotlightPackages/)?.[0]
-    ?? "";
   assert.match(
-    scheduler,
+    spotlightPackageSearchSource,
     /state\.spotlightScope !== "all"[\s\S]*state\.spotlightPkgLoading = false;[\s\S]*return;/);
   assert.match(
     appSource,
     /event\.key === "Escape" && !event\.defaultPrevented && !typing/);
   assert.match(
-    scheduler,
-    /query === state\.spotlightPkgQuery[\s\S]*spotlightPkgGeneration\+\+;[\s\S]*state\.spotlightPkgLoading = false;[\s\S]*return;/);
+    spotlightPackageSearchSource,
+    /query === state\.spotlightPkgQuery[\s\S]*generation\+\+;[\s\S]*state\.spotlightPkgLoading = false;[\s\S]*return;/);
   assert.match(
     appSource,
     /visibleSpotlightPackageHits\(\s*query,\s*state\.spotlightPkgQuery,\s*state\.spotlightPkgHits,\s*\)/);
 });
 
 test("Spotlight async work is generation-gated and refreshes either mounted surface", () => {
-  assert.match(appSource, /let spotlightPkgGeneration = 0/);
   assert.match(
     appSource,
-    /generation !== spotlightPkgGeneration[\s\S]*state\.spotlightQuery\.trim\(\) !== query/);
+    /createSpotlightPackageSearch\(\{[\s\S]*queryPackages: querySpotlightPackages,[\s\S]*updateResults: \(\) => spotlight\.updateResults\(\)/);
   assert.match(
-    appSource,
-    /if \(!state\.spotlightOpen && !state\.home\) return;[\s\S]*spotlight\.refresh\(\)/);
+    spotlightPackageSearchSource,
+    /requestGeneration !== generation[\s\S]*state\.spotlightQuery\.trim\(\) !== query/);
+  assert.doesNotMatch(appSource, /spotlightPkgGeneration|spotlightPkgTimer/);
 });
 
 test("global workbench shortcuts respect the topmost modal", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -346,6 +346,9 @@ test("Spotlight async work is generation-gated and refreshes either mounted surf
     appSource,
     /createSpotlightPackageSearch\(\{[\s\S]*queryPackages: querySpotlightPackages,[\s\S]*updateResults: \(\) => spotlight\.updateResults\(\)/);
   assert.match(
+    appSource,
+    /schedule: \(callback, delay\) => setTimeout\(\(\) => void callback\(\), delay\),\s*cancelScheduled: handle => clearTimeout\(handle\),/);
+  assert.match(
     spotlightPackageSearchSource,
     /requestGeneration !== generation[\s\S]*state\.spotlightQuery\.trim\(\) !== query/);
   assert.doesNotMatch(appSource, /spotlightPkgGeneration|spotlightPkgTimer/);

--- a/prototypes/inspect-web/test/spotlight-package-search.test.ts
+++ b/prototypes/inspect-web/test/spotlight-package-search.test.ts
@@ -1,0 +1,291 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSpotlightPackageSearch,
+  type SpotlightPackageSearchDependencies,
+  type SpotlightPackageSearchState,
+} from "../src/spotlight-package-search.ts";
+import type { SpotlightPackageHit } from "../src/spotlight.ts";
+
+interface ScheduledSearch {
+  id: number;
+  delay: number;
+  callback: () => Promise<void>;
+}
+
+function searchState(
+  overrides: Partial<SpotlightPackageSearchState> = {},
+): SpotlightPackageSearchState {
+  return {
+    spotlightQuery: "",
+    spotlightScope: "all",
+    spotlightPkgHits: [],
+    spotlightPkgQuery: "",
+    spotlightPkgLoading: false,
+    ...overrides,
+  };
+}
+
+function searchDependencies(
+  state: SpotlightPackageSearchState,
+  overrides:
+    Partial<Omit<SpotlightPackageSearchDependencies<number>, "state">> = {},
+) {
+  let nextId = 0;
+  const scheduled: ScheduledSearch[] = [];
+  const cancelled: number[] = [];
+  let updates = 0;
+  const dependencies: SpotlightPackageSearchDependencies<number> = {
+    state,
+    queryPackages: async query => [{ id: query, version: "1.0.0" }],
+    schedule: (callback, delay) => {
+      const id = ++nextId;
+      scheduled.push({ id, delay, callback });
+      return id;
+    },
+    cancelScheduled: id => {
+      cancelled.push(id);
+    },
+    updateResults: () => {
+      updates++;
+    },
+    ...overrides,
+  };
+  return {
+    dependencies,
+    scheduled,
+    cancelled,
+    updates: () => updates,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((accept, deny) => {
+    resolve = accept;
+    reject = deny;
+  });
+  return { promise, resolve, reject };
+}
+
+test("eligible package queries schedule one trimmed debounced request", () => {
+  let queries = 0;
+  const state = searchState({ spotlightQuery: "  Example  " });
+  const harness = searchDependencies(state, {
+    queryPackages: async () => {
+      queries++;
+      return [];
+    },
+  });
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+
+  assert.equal(queries, 0);
+  assert.equal(state.spotlightPkgLoading, true);
+  assert.equal(harness.scheduled.length, 1);
+  assert.equal(harness.scheduled[0]?.delay, 220);
+});
+
+test("rescheduling cancels the prior debounce before replacing it", () => {
+  const state = searchState({ spotlightQuery: "first" });
+  const harness = searchDependencies(state);
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  state.spotlightQuery = "second";
+  search.schedule();
+
+  assert.deepEqual(harness.cancelled, [1]);
+  assert.equal(harness.scheduled.length, 2);
+  assert.equal(state.spotlightPkgLoading, true);
+});
+
+test("ineligible scopes stop loading without clearing resolved results", () => {
+  const hits = [{ id: "Existing", version: "1.0.0" }];
+  const state = searchState({
+    spotlightQuery: "Example",
+    spotlightScope: "types",
+    spotlightPkgHits: hits,
+    spotlightPkgQuery: "Existing",
+    spotlightPkgLoading: true,
+  });
+  const harness = searchDependencies(state);
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+
+  assert.equal(state.spotlightPkgHits, hits);
+  assert.equal(state.spotlightPkgQuery, "Existing");
+  assert.equal(state.spotlightPkgLoading, false);
+  assert.equal(harness.scheduled.length, 0);
+});
+
+test("short queries clear package discovery state", () => {
+  const state = searchState({
+    spotlightQuery: "x",
+    spotlightPkgHits: [{ id: "Existing", version: "1.0.0" }],
+    spotlightPkgQuery: "Existing",
+    spotlightPkgLoading: true,
+  });
+  const harness = searchDependencies(state);
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+
+  assert.deepEqual(state.spotlightPkgHits, []);
+  assert.equal(state.spotlightPkgQuery, "");
+  assert.equal(state.spotlightPkgLoading, false);
+});
+
+test("already-resolved queries retain their results without another request", () => {
+  const hits = [{ id: "Example", version: "1.0.0" }];
+  const state = searchState({
+    spotlightQuery: "Example",
+    spotlightPkgHits: hits,
+    spotlightPkgQuery: "Example",
+    spotlightPkgLoading: true,
+  });
+  const harness = searchDependencies(state);
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+
+  assert.equal(state.spotlightPkgHits, hits);
+  assert.equal(state.spotlightPkgLoading, false);
+  assert.equal(harness.scheduled.length, 0);
+});
+
+test("current package results publish and refresh the mounted surface", async () => {
+  const hits: SpotlightPackageHit[] = [{
+    id: "Example.Package",
+    version: "2.0.0",
+  }];
+  const state = searchState({ spotlightQuery: "Example" });
+  const harness = searchDependencies(state, {
+    queryPackages: async query => {
+      assert.equal(query, "Example");
+      return hits;
+    },
+  });
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  await harness.scheduled[0]?.callback();
+
+  assert.deepEqual(state.spotlightPkgHits, hits);
+  assert.notEqual(state.spotlightPkgHits, hits);
+  assert.equal(state.spotlightPkgQuery, "Example");
+  assert.equal(state.spotlightPkgLoading, false);
+  assert.equal(harness.updates(), 1);
+});
+
+test("current package failures settle as an empty resolved query", async () => {
+  const state = searchState({
+    spotlightQuery: "Example",
+    spotlightPkgHits: [{ id: "Old", version: "1.0.0" }],
+  });
+  const harness = searchDependencies(state, {
+    queryPackages: async () => {
+      throw new Error("NuGet unavailable");
+    },
+  });
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  await harness.scheduled[0]?.callback();
+
+  assert.deepEqual(state.spotlightPkgHits, []);
+  assert.equal(state.spotlightPkgQuery, "Example");
+  assert.equal(state.spotlightPkgLoading, false);
+  assert.equal(harness.updates(), 1);
+});
+
+test("input changes independently suppress stale package results", async () => {
+  const query = deferred<readonly SpotlightPackageHit[]>();
+  const state = searchState({ spotlightQuery: "first" });
+  const harness = searchDependencies(state, {
+    queryPackages: async () => query.promise,
+  });
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  const request = harness.scheduled[0]?.callback();
+  state.spotlightQuery = "second";
+  query.resolve([{ id: "Stale", version: "1.0.0" }]);
+  await request;
+
+  assert.deepEqual(state.spotlightPkgHits, []);
+  assert.equal(state.spotlightPkgQuery, "");
+  assert.equal(state.spotlightPkgLoading, true);
+  assert.equal(harness.updates(), 0);
+});
+
+test("newer generations suppress stale success while publishing the replacement", async () => {
+  const first = deferred<readonly SpotlightPackageHit[]>();
+  const state = searchState({ spotlightQuery: "first" });
+  const harness = searchDependencies(state, {
+    queryPackages: async query =>
+      query === "first"
+        ? first.promise
+        : [{ id: "Current", version: "2.0.0" }],
+  });
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  const firstRequest = harness.scheduled[0]?.callback();
+  state.spotlightQuery = "second";
+  search.schedule();
+  await harness.scheduled[1]?.callback();
+  first.resolve([{ id: "Stale", version: "1.0.0" }]);
+  await firstRequest;
+
+  assert.deepEqual(state.spotlightPkgHits, [{
+    id: "Current",
+    version: "2.0.0",
+  }]);
+  assert.equal(state.spotlightPkgQuery, "second");
+  assert.equal(state.spotlightPkgLoading, false);
+  assert.equal(harness.updates(), 1);
+});
+
+test("reset cancels scheduled and in-flight publication", async () => {
+  const query = deferred<readonly SpotlightPackageHit[]>();
+  const state = searchState({ spotlightQuery: "Example" });
+  const harness = searchDependencies(state, {
+    queryPackages: async () => query.promise,
+  });
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  const request = harness.scheduled[0]?.callback();
+  search.reset();
+  query.resolve([{ id: "Stale", version: "1.0.0" }]);
+  await request;
+
+  assert.deepEqual(harness.cancelled, []);
+  assert.deepEqual(state.spotlightPkgHits, []);
+  assert.equal(state.spotlightPkgQuery, "");
+  assert.equal(state.spotlightPkgLoading, false);
+  assert.equal(harness.updates(), 0);
+});
+
+test("reset cancels a pending debounce and clears discovery state", () => {
+  const state = searchState({
+    spotlightQuery: "Example",
+    spotlightPkgHits: [{ id: "Old", version: "1.0.0" }],
+    spotlightPkgQuery: "Old",
+  });
+  const harness = searchDependencies(state);
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  search.reset();
+
+  assert.deepEqual(harness.cancelled, [1]);
+  assert.deepEqual(state.spotlightPkgHits, []);
+  assert.equal(state.spotlightPkgQuery, "");
+  assert.equal(state.spotlightPkgLoading, false);
+});

--- a/prototypes/inspect-web/test/spotlight-package-search.test.ts
+++ b/prototypes/inspect-web/test/spotlight-package-search.test.ts
@@ -120,6 +120,47 @@ test("rescheduling cancels the prior debounce before replacing it", () => {
   assert.equal(state.spotlightPkgLoading, true);
 });
 
+test("early-return transitions cancel a pending debounce", () => {
+  const cases: readonly {
+    name: string;
+    transition: (state: SpotlightPackageSearchState) => void;
+  }[] = [
+    {
+      name: "ineligible scope",
+      transition: state => {
+        state.spotlightScope = "types";
+      },
+    },
+    {
+      name: "short query",
+      transition: state => {
+        state.spotlightQuery = "x";
+      },
+    },
+    {
+      name: "resolved query",
+      transition: state => {
+        state.spotlightPkgQuery = "Example";
+        state.spotlightPkgHits = [{ id: "Example", version: "1.0.0" }];
+      },
+    },
+  ];
+
+  for (const scenario of cases) {
+    const state = searchState({ spotlightQuery: "Example" });
+    const harness = searchDependencies(state);
+    const search = createSpotlightPackageSearch(harness.dependencies);
+
+    search.schedule();
+    scenario.transition(state);
+    search.schedule();
+
+    assert.deepEqual(harness.cancelled, [1], scenario.name);
+    assert.equal(harness.scheduled.length, 1, scenario.name);
+    assert.equal(state.spotlightPkgLoading, false, scenario.name);
+  }
+});
+
 test("ineligible scopes stop loading without clearing resolved results", () => {
   const hits = [{ id: "Existing", version: "1.0.0" }];
   const state = searchState({

--- a/prototypes/inspect-web/test/spotlight-package-search.test.ts
+++ b/prototypes/inspect-web/test/spotlight-package-search.test.ts
@@ -70,11 +70,12 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
-test("eligible package queries schedule one trimmed debounced request", () => {
+test("eligible package queries schedule one trimmed debounced request", async () => {
   let queries = 0;
   const state = searchState({ spotlightQuery: "  Example  " });
   const harness = searchDependencies(state, {
-    queryPackages: async () => {
+    queryPackages: async query => {
+      assert.equal(query, "Example");
       queries++;
       return [];
     },
@@ -87,6 +88,22 @@ test("eligible package queries schedule one trimmed debounced request", () => {
   assert.equal(state.spotlightPkgLoading, true);
   assert.equal(harness.scheduled.length, 1);
   assert.equal(harness.scheduled[0]?.delay, 220);
+  await harness.scheduled[0]?.callback();
+  assert.equal(queries, 1);
+});
+
+test("the dedicated Packages scope schedules NuGet discovery", () => {
+  const state = searchState({
+    spotlightQuery: "Example",
+    spotlightScope: "packages",
+  });
+  const harness = searchDependencies(state);
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+
+  assert.equal(harness.scheduled.length, 1);
+  assert.equal(state.spotlightPkgLoading, true);
 });
 
 test("rescheduling cancels the prior debounce before replacing it", () => {
@@ -249,6 +266,98 @@ test("newer generations suppress stale success while publishing the replacement"
   assert.equal(state.spotlightPkgQuery, "second");
   assert.equal(state.spotlightPkgLoading, false);
   assert.equal(harness.updates(), 1);
+});
+
+test("same-input generations independently suppress stale failures", async () => {
+  const first = deferred<readonly SpotlightPackageHit[]>();
+  let queries = 0;
+  const state = searchState({ spotlightQuery: "Example" });
+  const harness = searchDependencies(state, {
+    queryPackages: async () => {
+      queries++;
+      if (queries === 1) return first.promise;
+      return [{ id: "Current", version: "2.0.0" }];
+    },
+  });
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  const firstRequest = harness.scheduled[0]?.callback();
+  search.schedule();
+  await harness.scheduled[1]?.callback();
+  first.reject(new Error("stale failure"));
+  await firstRequest;
+
+  assert.deepEqual(state.spotlightPkgHits, [{
+    id: "Current",
+    version: "2.0.0",
+  }]);
+  assert.equal(state.spotlightPkgQuery, "Example");
+  assert.equal(state.spotlightPkgLoading, false);
+  assert.equal(harness.updates(), 1);
+});
+
+test("input changes independently suppress stale failures", async () => {
+  const query = deferred<readonly SpotlightPackageHit[]>();
+  const state = searchState({ spotlightQuery: "first" });
+  const harness = searchDependencies(state, {
+    queryPackages: async () => query.promise,
+  });
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  const request = harness.scheduled[0]?.callback();
+  state.spotlightQuery = "second";
+  query.reject(new Error("stale failure"));
+  await request;
+
+  assert.deepEqual(state.spotlightPkgHits, []);
+  assert.equal(state.spotlightPkgQuery, "");
+  assert.equal(state.spotlightPkgLoading, true);
+  assert.equal(harness.updates(), 0);
+});
+
+test("leaving package scopes invalidates an in-flight request with unchanged input", async () => {
+  const query = deferred<readonly SpotlightPackageHit[]>();
+  const state = searchState({ spotlightQuery: "Example" });
+  const harness = searchDependencies(state, {
+    queryPackages: async () => query.promise,
+  });
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  const request = harness.scheduled[0]?.callback();
+  state.spotlightScope = "types";
+  search.schedule();
+  query.resolve([{ id: "Stale", version: "1.0.0" }]);
+  await request;
+
+  assert.deepEqual(state.spotlightPkgHits, []);
+  assert.equal(state.spotlightPkgQuery, "");
+  assert.equal(state.spotlightPkgLoading, false);
+  assert.equal(harness.updates(), 0);
+});
+
+test("short-query cancellation stays effective if the prior input returns", async () => {
+  const query = deferred<readonly SpotlightPackageHit[]>();
+  const state = searchState({ spotlightQuery: "Example" });
+  const harness = searchDependencies(state, {
+    queryPackages: async () => query.promise,
+  });
+  const search = createSpotlightPackageSearch(harness.dependencies);
+
+  search.schedule();
+  const request = harness.scheduled[0]?.callback();
+  state.spotlightQuery = "x";
+  search.schedule();
+  state.spotlightQuery = "Example";
+  query.resolve([{ id: "Stale", version: "1.0.0" }]);
+  await request;
+
+  assert.deepEqual(state.spotlightPkgHits, []);
+  assert.equal(state.spotlightPkgQuery, "");
+  assert.equal(state.spotlightPkgLoading, false);
+  assert.equal(harness.updates(), 0);
 });
 
 test("reset cancels scheduled and in-flight publication", async () => {


### PR DESCRIPTION
Moves Spotlight’s debounced NuGet discovery lifecycle out of the browser composition root behind a typed coordinator. Scope/query eligibility, timer replacement, generation and input stale suppression, current success/failure settlement, reset cancellation, and result refresh are preserved; `dotnet-inspect.ts` retains the NuGet endpoint/fetch mapping, package acquisition/navigation, and command effects, while `spotlight.ts` retains rendering and interaction.

**Stack**

- Slice 9, stacked on #4515.
- Parent: #4515 (document request coordination).
- Residual: package-version/release index network controllers, then DOM event binding paired with presentation owners.

**Validation**

- `npm test` — 375/375, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.

Progresses #4504.