### PR TITLE
Extract catalog request coordination

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -617,6 +617,15 @@ escaping; `test/spotlight-package-search.test.ts` gates debounce, scope and
 query eligibility, cancellation, stale suppression, failure settlement, and
 mounted-result refresh.
 
+`src/catalog-requests.ts` owns .NET release and package-version catalog
+lifecycles: cache and loading state, request deduplication, version ordering,
+package-residency guards, and selector-update dispatch. `dotnet-inspect.ts`
+retains the .NET release endpoint, engine version query, option rendering, DOM
+repainting, and version switching. `test/catalog-requests.test.ts` gates cache
+reuse, in-flight deduplication, sorting, current Platform refresh, package
+removal, and both silent transient-failure paths; the composition-root gate
+checks that network and DOM authority remain outside the coordinator.
+
 The typed `src/status-bar.ts` component renders both the full-width workspace
 data bar and the home readiness bar. The workspace bar occupies the bottom row
 formerly used by the persistent command prompt, giving the bar the full

--- a/prototypes/inspect-web/src/catalog-requests.ts
+++ b/prototypes/inspect-web/src/catalog-requests.ts
@@ -1,0 +1,94 @@
+export interface DotnetRelease {
+  major: number;
+  tfm: string;
+  version: string;
+}
+
+export interface CatalogPackage {
+  id: string;
+  isRuntimePack?: boolean;
+}
+
+export interface CatalogRequestState {
+  package: CatalogPackage | null;
+  packages: CatalogPackage[];
+  dotnetReleases: DotnetRelease[] | null;
+  dotnetReleasesLoading: boolean;
+  packageVersions: Record<string, string[]>;
+  packageVersionsLoading: Record<string, boolean>;
+}
+
+export interface CatalogRequestDependencies {
+  state: CatalogRequestState;
+  queryDotnetReleases: () => Promise<readonly DotnetRelease[]>;
+  queryPackageVersions: (packageId: string) => Promise<readonly string[]>;
+  updatePlatformVersionSelect: () => void;
+  updatePackageVersionSelect: (packageId: string) => void;
+}
+
+export function compareVersionsDesc(a: string, b: string) {
+  const parse = (value: string): Array<number | string> =>
+    value.split(/[.\-+]/).map(part =>
+      /^\d+$/.test(part) ? Number(part) : part);
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i];
+    const y = pb[i];
+    if (x === y) continue;
+    if (x === undefined) return 1;
+    if (y === undefined) return -1;
+    if (typeof x === "number" && typeof y === "number") return y - x;
+    return String(y).localeCompare(String(x));
+  }
+  return 0;
+}
+
+export function createCatalogRequests(
+  dependencies: CatalogRequestDependencies,
+) {
+  const { state } = dependencies;
+  const packageIsResident = (packageId: string) =>
+    state.packages.some(item => item.id.toLowerCase() === packageId);
+
+  return {
+    async ensureDotnetReleases() {
+      if (state.dotnetReleases || state.dotnetReleasesLoading) return;
+      state.dotnetReleasesLoading = true;
+      try {
+        state.dotnetReleases = [...await dependencies.queryDotnetReleases()];
+        if (state.package?.isRuntimePack) {
+          dependencies.updatePlatformVersionSelect();
+        }
+      } catch {
+        // Keep the selector on its current version when the remote index fails.
+      } finally {
+        state.dotnetReleasesLoading = false;
+      }
+    },
+
+    async ensurePackageVersions(pkg: CatalogPackage | null) {
+      if (!pkg || pkg.isRuntimePack) return;
+      const packageId = pkg.id.toLowerCase();
+      if (state.packageVersions[packageId]
+        || state.packageVersionsLoading[packageId]) return;
+      state.packageVersionsLoading[packageId] = true;
+      try {
+        const versions = [...await dependencies.queryPackageVersions(packageId)]
+          .sort(compareVersionsDesc);
+        if (packageIsResident(packageId)) {
+          state.packageVersions[packageId] = versions;
+          dependencies.updatePackageVersionSelect(packageId);
+        }
+      } catch {
+        // Keep the selector on its current version when the index query fails.
+      } finally {
+        if (packageIsResident(packageId)) {
+          state.packageVersionsLoading[packageId] = false;
+        } else {
+          delete state.packageVersionsLoading[packageId];
+        }
+      }
+    },
+  };
+}

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -155,6 +155,11 @@ import {
   visibleSpotlightPackageHits,
 } from "./spotlight.ts";
 import { createSpotlightPackageSearch } from "./spotlight-package-search.ts";
+import {
+  compareVersionsDesc,
+  createCatalogRequests,
+  type DotnetRelease,
+} from "./catalog-requests.ts";
 import { fmtBytes, statusBarHtml } from "./status-bar.ts";
 import type {
   BrowserAnnotatedSource,
@@ -370,12 +375,6 @@ interface SpotlightMemberCandidate {
 interface SpotlightMemberCache {
   signature: string;
   pool: SpotlightMemberCandidate[];
-}
-
-interface DotnetRelease {
-  major: number;
-  tfm: string;
-  version: string;
 }
 
 interface PlatformRecent {
@@ -977,6 +976,13 @@ const spotlightPackageSearch = createSpotlightPackageSearch({
   schedule: (callback, delay) => setTimeout(() => void callback(), delay),
   cancelScheduled: handle => clearTimeout(handle),
   updateResults: () => spotlight.updateResults(),
+});
+const catalogRequests = createCatalogRequests({
+  state,
+  queryDotnetReleases,
+  queryPackageVersions: packageId => inspectPackageVersions(packageId),
+  updatePlatformVersionSelect,
+  updatePackageVersionSelect: updateVersionSelect,
 });
 const spotlight = createSpotlight({
   state,
@@ -4707,26 +4713,6 @@ async function querySpotlightPackages(query: string): Promise<SpotlightPackageHi
   }));
 }
 
-// Compare two NuGet SemVer-ish versions descending (newest first). Falls back to string
-// comparison for non-numeric pre-release tails so the list stays deterministic.
-function compareVersionsDesc(a: string, b: string) {
-  const parse = (value: string): Array<number | string> =>
-    value.split(/[.\-+]/).map(part =>
-      /^\d+$/.test(part) ? Number(part) : part);
-  const pa = parse(a);
-  const pb = parse(b);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const x = pa[i];
-    const y = pb[i];
-    if (x === y) continue;
-    if (x === undefined) return 1;   // shorter (release) sorts before its prerelease
-    if (y === undefined) return -1;
-    if (typeof x === "number" && typeof y === "number") return y - x;
-    return String(y).localeCompare(String(x));
-  }
-  return 0;
-}
-
 // Build the <option> list for the version selector. Always includes the currently loaded
 // version (even before the flatcontainer index has been fetched) so the control is never empty.
 function versionOptionsHtml(pkg: AppPackage) {
@@ -4761,41 +4747,37 @@ function platformVersionOptionsHtml(pkg: AppPackage) {
     .join("");
 }
 
-// Lazily fetch the .NET release channels (latest patch per major) from the dotnet/core
-// release index (CORS-enabled), keep only in-support majors (8+), cache them, and repaint the
-// Platform version selector in place. Powers the Platform version dropdown; a transient
-// failure leaves the selector on the single current-version option.
-async function ensureDotnetReleases() {
-  if (state.dotnetReleases || state.dotnetReleasesLoading) return;
-  state.dotnetReleasesLoading = true;
-  try {
-    const url = "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/releases-index.json";
-    const response = await fetch(url);
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const payload = await response.json() as {
-      "releases-index"?: Array<{
-        "channel-version": string;
-        "latest-release": string;
-      }>;
-    };
-    const rows = (payload["releases-index"] || [])
-      .map(entry => {
-        const major = parseInt(entry["channel-version"], 10);
-        return { major, tfm: `net${entry["channel-version"]}`, version: entry["latest-release"] };
-      })
-      .filter(row => Number.isFinite(row.major) && row.major >= 8 && row.version)
-      .sort((a, b) => b.major - a.major);
-    state.dotnetReleases = rows;
-    if (state.package?.isRuntimePack) {
-      const select = document.querySelector("#package-version");
-      if (select) select.innerHTML = versionOptionsHtml(state.package);
-    }
-  } catch {
-    // Leave the selector on the single current-version option; a transient index failure
-    // must not break the workbench.
-  } finally {
-    state.dotnetReleasesLoading = false;
-  }
+async function queryDotnetReleases(): Promise<DotnetRelease[]> {
+  const url = "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/releases-index.json";
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const payload = await response.json() as {
+    "releases-index"?: Array<{
+      "channel-version": string;
+      "latest-release": string;
+    }>;
+  };
+  return (payload["releases-index"] || [])
+    .map(entry => {
+      const major = parseInt(entry["channel-version"], 10);
+      return {
+        major,
+        tfm: `net${entry["channel-version"]}`,
+        version: entry["latest-release"],
+      };
+    })
+    .filter(row => Number.isFinite(row.major) && row.major >= 8 && row.version)
+    .sort((a, b) => b.major - a.major);
+}
+
+function ensureDotnetReleases() {
+  return catalogRequests.ensureDotnetReleases();
+}
+
+function updatePlatformVersionSelect() {
+  if (!state.package?.isRuntimePack) return;
+  const select = document.querySelector("#package-version");
+  if (select) select.innerHTML = versionOptionsHtml(state.package);
 }
 
 // Switch the resident Platform to a different .NET major (by TFM). Drops the current
@@ -4856,30 +4838,8 @@ async function switchPlatformVersion(
   loadSelectionData();
 }
 
-// Lazily fetch the full published-version list through the engine's bounded acquisition owner,
-// cache it, and repaint the version selector in place.
-async function ensurePackageVersions(pkg: AppPackage | null) {
-  if (!pkg || pkg.isRuntimePack) return;
-  const idLower = pkg.id.toLowerCase();
-  if (state.packageVersions[idLower] || state.packageVersionsLoading[idLower]) return;
-  state.packageVersionsLoading[idLower] = true;
-  try {
-    const versions = (await inspectPackageVersions(idLower))
-      .slice()
-      .sort(compareVersionsDesc);
-    if (state.packages.some(item => item.id.toLowerCase() === idLower)) {
-      state.packageVersions[idLower] = versions;
-      updateVersionSelect(idLower);
-    }
-  } catch {
-    // Leave the selector on the single current-version option; a transient index failure
-    // must not break the workbench.
-  } finally {
-    if (state.packages.some(item => item.id.toLowerCase() === idLower))
-      state.packageVersionsLoading[idLower] = false;
-    else
-      delete state.packageVersionsLoading[idLower];
-  }
+function ensurePackageVersions(pkg: AppPackage | null) {
+  return catalogRequests.ensurePackageVersions(pkg);
 }
 
 // Repaint just the version <select> options without a full re-render, so an async index

--- a/prototypes/inspect-web/test/catalog-requests.test.ts
+++ b/prototypes/inspect-web/test/catalog-requests.test.ts
@@ -1,0 +1,270 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createCatalogRequests,
+  type CatalogRequestDependencies,
+  type CatalogRequestState,
+  type DotnetRelease,
+} from "../src/catalog-requests.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function createState(): CatalogRequestState {
+  return {
+    package: null,
+    packages: [],
+    dotnetReleases: null,
+    dotnetReleasesLoading: false,
+    packageVersions: {},
+    packageVersionsLoading: {},
+  };
+}
+
+function createHarness(
+  state = createState(),
+  overrides: Partial<Omit<CatalogRequestDependencies, "state">> = {},
+) {
+  let platformUpdates = 0;
+  const packageUpdates: string[] = [];
+  let releaseQueries = 0;
+  const versionQueries: string[] = [];
+  const dependencies: CatalogRequestDependencies = {
+    state,
+    queryDotnetReleases: async () => {
+      releaseQueries++;
+      return [];
+    },
+    queryPackageVersions: async packageId => {
+      versionQueries.push(packageId);
+      return [];
+    },
+    updatePlatformVersionSelect: () => {
+      platformUpdates++;
+    },
+    updatePackageVersionSelect: packageId => {
+      packageUpdates.push(packageId);
+    },
+    ...overrides,
+  };
+  return {
+    requests: createCatalogRequests(dependencies),
+    state,
+    get packageUpdates() {
+      return packageUpdates;
+    },
+    get platformUpdates() {
+      return platformUpdates;
+    },
+    get releaseQueries() {
+      return releaseQueries;
+    },
+    get versionQueries() {
+      return versionQueries;
+    },
+  };
+}
+
+test("release requests cache rows and refresh the resident Platform selector", async () => {
+  const state = createState();
+  const runtime = { id: ".NET Platform", isRuntimePack: true };
+  state.package = runtime;
+  state.packages = [runtime];
+  const rows: DotnetRelease[] = [
+    { major: 10, tfm: "net10.0", version: "10.0.4" },
+    { major: 9, tfm: "net9.0", version: "9.0.9" },
+  ];
+  const harness = createHarness(state, {
+    queryDotnetReleases: async () => rows,
+  });
+
+  await harness.requests.ensureDotnetReleases();
+
+  assert.deepEqual(state.dotnetReleases, rows);
+  assert.notEqual(state.dotnetReleases, rows);
+  assert.equal(state.dotnetReleasesLoading, false);
+  assert.equal(harness.platformUpdates, 1);
+});
+
+test("release completion does not refresh a non-Platform selector", async () => {
+  const state = createState();
+  state.package = { id: "Example.Package" };
+  const harness = createHarness(state, {
+    queryDotnetReleases: async () => [
+      { major: 9, tfm: "net9.0", version: "9.0.9" },
+    ],
+  });
+
+  await harness.requests.ensureDotnetReleases();
+
+  assert.equal(harness.platformUpdates, 0);
+  assert.equal(state.dotnetReleases?.length, 1);
+});
+
+test("release requests deduplicate in-flight work and reuse cached rows", async () => {
+  const pending = deferred<readonly DotnetRelease[]>();
+  let queryCount = 0;
+  const harness = createHarness(createState(), {
+    queryDotnetReleases: () => {
+      queryCount++;
+      return pending.promise;
+    },
+  });
+
+  const first = harness.requests.ensureDotnetReleases();
+  const second = harness.requests.ensureDotnetReleases();
+  assert.equal(harness.state.dotnetReleasesLoading, true);
+  assert.equal(queryCount, 1);
+
+  pending.resolve([]);
+  await Promise.all([first, second]);
+  await harness.requests.ensureDotnetReleases();
+
+  assert.equal(queryCount, 1);
+});
+
+test("release failures remain silent, clear loading, and allow retry", async () => {
+  let queryCount = 0;
+  const harness = createHarness(createState(), {
+    queryDotnetReleases: async () => {
+      queryCount++;
+      if (queryCount === 1) throw new Error("offline");
+      return [{ major: 8, tfm: "net8.0", version: "8.0.20" }];
+    },
+  });
+
+  await harness.requests.ensureDotnetReleases();
+  assert.equal(harness.state.dotnetReleases, null);
+  assert.equal(harness.state.dotnetReleasesLoading, false);
+  assert.equal(harness.platformUpdates, 0);
+
+  await harness.requests.ensureDotnetReleases();
+  assert.equal(queryCount, 2);
+  assert.deepEqual(harness.state.dotnetReleases, [
+    { major: 8, tfm: "net8.0", version: "8.0.20" },
+  ]);
+});
+
+test("package requests ignore missing and Platform packages", async () => {
+  const harness = createHarness();
+
+  await harness.requests.ensurePackageVersions(null);
+  await harness.requests.ensurePackageVersions({
+    id: ".NET Platform",
+    isRuntimePack: true,
+  });
+
+  assert.deepEqual(harness.versionQueries, []);
+});
+
+test("package requests normalize identity, sort versions, and refresh by identity", async () => {
+  const state = createState();
+  state.packages = [{ id: "Example.Package" }];
+  const harness = createHarness(state, {
+    queryPackageVersions: async packageId => {
+      assert.equal(packageId, "example.package");
+      return ["2.0.0", "10.0.0", "1.9.0", "2.1.0"];
+    },
+  });
+
+  await harness.requests.ensurePackageVersions({ id: "EXAMPLE.PACKAGE" });
+
+  assert.deepEqual(
+    state.packageVersions["example.package"],
+    ["10.0.0", "2.1.0", "2.0.0", "1.9.0"],
+  );
+  assert.equal(state.packageVersionsLoading["example.package"], false);
+  assert.deepEqual(harness.packageUpdates, ["example.package"]);
+});
+
+test("package requests deduplicate in-flight work and reuse cached versions", async () => {
+  const state = createState();
+  const pkg = { id: "Example.Package" };
+  state.packages = [pkg];
+  const pending = deferred<readonly string[]>();
+  let queryCount = 0;
+  const harness = createHarness(state, {
+    queryPackageVersions: () => {
+      queryCount++;
+      return pending.promise;
+    },
+  });
+
+  const first = harness.requests.ensurePackageVersions(pkg);
+  const second = harness.requests.ensurePackageVersions(pkg);
+  assert.equal(state.packageVersionsLoading["example.package"], true);
+  assert.equal(queryCount, 1);
+
+  pending.resolve(["1.0.0"]);
+  await Promise.all([first, second]);
+  await harness.requests.ensurePackageVersions(pkg);
+
+  assert.equal(queryCount, 1);
+  assert.deepEqual(harness.packageUpdates, ["example.package"]);
+});
+
+test("package success is discarded when its package is no longer resident", async () => {
+  const state = createState();
+  const pkg = { id: "Example.Package" };
+  state.packages = [pkg];
+  const pending = deferred<readonly string[]>();
+  const harness = createHarness(state, {
+    queryPackageVersions: () => pending.promise,
+  });
+
+  const request = harness.requests.ensurePackageVersions(pkg);
+  state.packages = [];
+  pending.resolve(["1.0.0"]);
+  await request;
+
+  assert.equal(state.packageVersions["example.package"], undefined);
+  assert.equal(state.packageVersionsLoading["example.package"], undefined);
+  assert.deepEqual(harness.packageUpdates, []);
+});
+
+test("package failures stay silent and keep loading state for resident packages", async () => {
+  const state = createState();
+  const pkg = { id: "Example.Package" };
+  state.packages = [pkg];
+  let queryCount = 0;
+  const harness = createHarness(state, {
+    queryPackageVersions: async () => {
+      queryCount++;
+      throw new Error("offline");
+    },
+  });
+
+  await harness.requests.ensurePackageVersions(pkg);
+  assert.equal(state.packageVersions["example.package"], undefined);
+  assert.equal(state.packageVersionsLoading["example.package"], false);
+  assert.deepEqual(harness.packageUpdates, []);
+
+  await harness.requests.ensurePackageVersions(pkg);
+  assert.equal(queryCount, 2);
+});
+
+test("package rejection removes loading state after resident removal", async () => {
+  const state = createState();
+  const pkg = { id: "Example.Package" };
+  state.packages = [pkg];
+  const pending = deferred<readonly string[]>();
+  const harness = createHarness(state, {
+    queryPackageVersions: () => pending.promise,
+  });
+
+  const request = harness.requests.ensurePackageVersions(pkg);
+  state.packages = [];
+  pending.reject(new Error("offline"));
+  await request;
+
+  assert.equal(state.packageVersionsLoading["example.package"], undefined);
+  assert.deepEqual(harness.packageUpdates, []);
+});

--- a/prototypes/inspect-web/test/catalog-requests.test.ts
+++ b/prototypes/inspect-web/test/catalog-requests.test.ts
@@ -35,6 +35,11 @@ function createHarness(
 ) {
   let platformUpdates = 0;
   const packageUpdates: string[] = [];
+  const platformUpdateSnapshots: Array<DotnetRelease[] | null> = [];
+  const packageUpdateSnapshots: Array<{
+    packageId: string;
+    versions: string[] | undefined;
+  }> = [];
   let releaseQueries = 0;
   const versionQueries: string[] = [];
   const dependencies: CatalogRequestDependencies = {
@@ -49,9 +54,14 @@ function createHarness(
     },
     updatePlatformVersionSelect: () => {
       platformUpdates++;
+      platformUpdateSnapshots.push(state.dotnetReleases);
     },
     updatePackageVersionSelect: packageId => {
       packageUpdates.push(packageId);
+      packageUpdateSnapshots.push({
+        packageId,
+        versions: state.packageVersions[packageId],
+      });
     },
     ...overrides,
   };
@@ -61,8 +71,14 @@ function createHarness(
     get packageUpdates() {
       return packageUpdates;
     },
+    get packageUpdateSnapshots() {
+      return packageUpdateSnapshots;
+    },
     get platformUpdates() {
       return platformUpdates;
+    },
+    get platformUpdateSnapshots() {
+      return platformUpdateSnapshots;
     },
     get releaseQueries() {
       return releaseQueries;
@@ -92,6 +108,7 @@ test("release requests cache rows and refresh the resident Platform selector", a
   assert.notEqual(state.dotnetReleases, rows);
   assert.equal(state.dotnetReleasesLoading, false);
   assert.equal(harness.platformUpdates, 1);
+  assert.deepEqual(harness.platformUpdateSnapshots, [rows]);
 });
 
 test("release completion does not refresh a non-Platform selector", async () => {
@@ -132,8 +149,12 @@ test("release requests deduplicate in-flight work and reuse cached rows", async 
 });
 
 test("release failures remain silent, clear loading, and allow retry", async () => {
+  const state = createState();
+  const runtime = { id: ".NET Platform", isRuntimePack: true };
+  state.package = runtime;
+  state.packages = [runtime];
   let queryCount = 0;
-  const harness = createHarness(createState(), {
+  const harness = createHarness(state, {
     queryDotnetReleases: async () => {
       queryCount++;
       if (queryCount === 1) throw new Error("offline");
@@ -151,6 +172,7 @@ test("release failures remain silent, clear loading, and allow retry", async () 
   assert.deepEqual(harness.state.dotnetReleases, [
     { major: 8, tfm: "net8.0", version: "8.0.20" },
   ]);
+  assert.equal(harness.platformUpdates, 1);
 });
 
 test("package requests ignore missing and Platform packages", async () => {
@@ -183,6 +205,10 @@ test("package requests normalize identity, sort versions, and refresh by identit
   );
   assert.equal(state.packageVersionsLoading["example.package"], false);
   assert.deepEqual(harness.packageUpdates, ["example.package"]);
+  assert.deepEqual(harness.packageUpdateSnapshots, [{
+    packageId: "example.package",
+    versions: ["10.0.0", "2.1.0", "2.0.0", "1.9.0"],
+  }]);
 });
 
 test("package requests deduplicate in-flight work and reuse cached versions", async () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -186,6 +186,9 @@ const documentInspectionSource = readFileSync(
 const spotlightPackageSearchSource = readFileSync(
   new URL("../src/spotlight-package-search.ts", import.meta.url),
   "utf8");
+const catalogRequestsSource = readFileSync(
+  new URL("../src/catalog-requests.ts", import.meta.url),
+  "utf8");
 const memberFocusSource = readFileSync(
   new URL("../src/member-focus.ts", import.meta.url),
   "utf8");
@@ -324,6 +327,35 @@ test("typed document inspection owns package document request coordination", () 
   assert.match(
     documentInspectionSource,
     /async open\(request: PackageDocumentRequest\)[\s\S]*state\.docViewerSeq/);
+});
+
+test("typed catalog requests own release and package-version coordination", () => {
+  const releaseLoader =
+    appSource.match(/function ensureDotnetReleases\(\)[\s\S]*?\n}/)?.[0]
+    ?? "";
+  const versionLoader =
+    appSource.match(/function ensurePackageVersions\(pkg: AppPackage \| null\)[\s\S]*?\n}/)?.[0]
+    ?? "";
+  assert.match(
+    appSource,
+    /createCatalogRequests\(\{[\s\S]*queryDotnetReleases,[\s\S]*queryPackageVersions: packageId => inspectPackageVersions\(packageId\),[\s\S]*updatePlatformVersionSelect,[\s\S]*updatePackageVersionSelect: updateVersionSelect,/);
+  assert.match(
+    appSource,
+    /raw\.githubusercontent\.com\/dotnet\/core\/refs\/heads\/main\/release-notes\/releases-index\.json/);
+  assert.match(releaseLoader, /return catalogRequests\.ensureDotnetReleases\(\)/);
+  assert.match(versionLoader, /return catalogRequests\.ensurePackageVersions\(pkg\)/);
+  assert.doesNotMatch(
+    `${releaseLoader}\n${versionLoader}`,
+    /dotnetReleasesLoading|packageVersionsLoading|state\.packages/);
+  assert.match(
+    catalogRequestsSource,
+    /state\.dotnetReleasesLoading = true[\s\S]*dependencies\.queryDotnetReleases\(\)[\s\S]*state\.dotnetReleasesLoading = false/);
+  assert.match(
+    catalogRequestsSource,
+    /state\.packageVersionsLoading\[packageId\] = true[\s\S]*dependencies\.queryPackageVersions\(packageId\)[\s\S]*packageIsResident\(packageId\)/);
+  assert.doesNotMatch(
+    catalogRequestsSource,
+    /\bfetch\(|\bdocument\b|inspectPackageVersions/);
 });
 
 test("leaving package search clears its pending loading state", () => {


### PR DESCRIPTION
Moves .NET release-channel and NuGet package-version request lifecycles out of the browser composition root behind a typed coordinator. Cache/loading state, request deduplication, deterministic version ordering, package-residency guards, selector-update dispatch, and existing silent transient-failure behavior are preserved; `dotnet-inspect.ts` retains the release endpoint and response projection, engine query, DOM repainting, option rendering, and version switching.

**Stack**

- Slice 10, stacked on #4516.
- Parent: #4516 (Spotlight package request coordination).
- Residual: DOM event binding paired with existing presentation owners.

**Validation**

- `npm test` — 391/391, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.

Progresses #4504.