### PR TITLE
Pair type panel with DOM bindings

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -710,17 +710,18 @@ Symbol/PDB acquisition status is not yet surfaced here — no backend contract
 reports it today — and is a tracked fast-follow.
 
 `src/type-panel.ts` owns the type selector (the "PUBLIC TYPES" / "MEMBERS" nav
-pane) and the type viewer (the type heading, metadata, and source sections
-shown for the "type" scope) as pure, dependency-injected render functions.
+pane), its rendered DOM control bindings, and the type viewer (the type
+heading, metadata, and source sections shown for the "type" scope).
 `dotnet-inspect.ts` still owns the type index, filtering, member grouping, and
-click/keyboard navigation, and passes each computed slice in explicitly; the
+navigation state transitions, and supplies them through typed callbacks; the
 shared text helpers used well beyond the type panel (`kindIcon`, `shortKind`,
 `typeDisplayName`, `highlight`, `highlightCSharp`, `factRows`,
 `relatedTypeChip`) stay in `dotnet-inspect.ts` and are injected the same way.
-`test/type-panel.test.ts` gates namespace grouping and selection in the type
-list, active-group and overload selection in the member list, the type
-heading's package/library fields, the metadata- and source-signature cache
-keys, and the metadata/source panels' loading, error, and loaded states.
+`test/type-panel.test.ts` gates every rendered control binding, type-filter
+keyboard behavior, namespace grouping and selection in the type list,
+active-group and overload selection in the member list, the type heading's
+package/library fields, the metadata- and source-signature cache keys, and the
+metadata/source panels' loading, error, and loaded states.
 
 `src/package-bar.ts` owns the package tab strip (including the always-present
 Platform tab), the open-package query form, and their keyboard/mouse/wheel

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3962,6 +3962,7 @@ function bindEvents() {
   });
   memberFilter?.addEventListener("keydown", event => {
     if (event.key === "Escape") {
+      if (navMode() !== "member" && memberFilter.value === "") return;
       event.preventDefault();
       if (navMode() === "member") {
         exitMemberScope();

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -112,6 +112,7 @@ import {
 } from "./annotated-source.ts";
 import { renderPackageOpportunities as renderPackageOpportunitiesPure } from "./package-opportunities.ts";
 import {
+  bindTypePanel,
   renderMemberNav,
   renderTypeMetadata,
   renderTypeNav,
@@ -3742,9 +3743,80 @@ function bindStatusBarToggle() {
   }));
 }
 
+function bindTypePanelEvents() {
+  bindTypePanel(document, {
+    onClearFilters: () => {
+      state.typeFilter = "";
+      state.namespaceFilter = "";
+      state.kindFilter = "";
+      state.libraryScope = null;
+      state.accessibilityFilter = defaultAccessibilityFilter(state.package);
+      render();
+      focusFilter();
+    },
+    onKindSelect: kind => {
+      state.kindFilter = kind;
+      state.typeCursor = 0;
+      const first = filteredTypes()[0];
+      if (first) state.selectedTypeId = first.id;
+      state.selectedMemberKey = "";
+      state.memberBrowseTypeId = "";
+      resetMemberFilters();
+      render();
+    },
+    onListKeyDown: handleTypeKeys,
+    onMemberSelect: memberKey => {
+      const group = memberGroups(selectedType())
+        .find(item => item.key === memberKey);
+      if (group) selectMemberNavEntry({ kind: "member", group }, false);
+    },
+    onNamespaceSelect: namespace => {
+      state.namespaceFilter = namespace;
+      state.typeCursor = 0;
+      const first = filteredTypes()[0];
+      if (first) state.selectedTypeId = first.id;
+      state.selectedMemberKey = "";
+      state.memberBrowseTypeId = "";
+      resetMemberFilters();
+      render();
+    },
+    onOverloadSelect: index => {
+      const group = selectedMember(selectedType());
+      if (group) selectMemberNavEntry({ kind: "overload", group, index }, false);
+    },
+    onShowTypes: exitMemberScope,
+    onTypeFilterChange: value => {
+      state.typeFilter = value;
+      state.typeCursor = 0;
+      const first = filteredTypes()[0];
+      if (first) state.selectedTypeId = first.id;
+      state.selectedMemberKey = "";
+      state.memberBrowseTypeId = "";
+      resetMemberFilters();
+      render();
+      focusFilter();
+    },
+    onTypeFilterEscape: () => {
+      state.typeFilter = "";
+      render();
+    },
+    onTypeSelect: typeId => {
+      state.atPackageRoot = false;
+      state.selectedTypeId = typeId;
+      state.selectedMemberKey = "";
+      state.memberBrowseTypeId = "";
+      resetMemberFilters();
+      state.typeCursor = filteredTypes()
+        .findIndex(item => item.id === state.selectedTypeId);
+      render();
+    },
+  });
+}
+
 function bindEvents() {
   bindStatusBarToggle();
   packageBar.bind(document);
+  bindTypePanelEvents();
   document.querySelectorAll<HTMLElement>("[data-scope]").forEach(button => button.addEventListener("click", () => {
     const target = button.dataset.scope;
     if (target === "package") {
@@ -3829,15 +3901,6 @@ function bindEvents() {
     state.lens = button.dataset.lens ?? "api";
     state.selectedMemberKey = "";
     state.memberBrowseTypeId = "";
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-type]").forEach(button => button.addEventListener("click", () => {
-    state.atPackageRoot = false;
-    state.selectedTypeId = button.dataset.type ?? "";
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    state.typeCursor = filteredTypes().findIndex(item => item.id === state.selectedTypeId);
     render();
   }));
   document.querySelectorAll<HTMLElement>("[data-graph-type]").forEach(button => button.addEventListener("click", () => {
@@ -3952,17 +4015,6 @@ function bindEvents() {
   document.querySelectorAll<HTMLElement>("[data-overload]").forEach(button => button.addEventListener("click", () => {
     openOverload(Number(button.dataset.overload));
   }));
-  document.querySelectorAll<HTMLElement>("[data-nav-member]").forEach(button => button.addEventListener("click", () => {
-    const group = memberGroups(selectedType()).find(item => item.key === button.dataset.navMember);
-    if (group) selectMemberNavEntry({ kind: "member", group }, false);
-  }));
-  document.querySelectorAll<HTMLElement>("[data-nav-overload]").forEach(button => button.addEventListener("click", () => {
-    const group = selectedMember(selectedType());
-    if (group) selectMemberNavEntry({ kind: "overload", group, index: Number(button.dataset.navOverload) }, false);
-  }));
-  document.querySelector("#nav-to-types")?.addEventListener("click", () => {
-    exitMemberScope();
-  });
   document.querySelectorAll<HTMLElement>("[data-member-section]").forEach(button => button.addEventListener("click", () => {
     const section = button.dataset.memberSection;
     if (section && isMemberSection(section)) applyMemberSection(section);
@@ -4043,37 +4095,6 @@ function bindEvents() {
   document.querySelector("#copy-type-source")?.addEventListener("click", () => {
     if (state.typeSource) void copyText(state.typeSource.text, "source copied");
   });
-  document.querySelectorAll<HTMLElement>("[data-namespace]").forEach(button => button.addEventListener("click", () => {
-    state.namespaceFilter = button.dataset.namespace ?? "";
-    state.typeCursor = 0;
-    const first = filteredTypes()[0];
-    if (first) state.selectedTypeId = first.id;
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    render();
-  }));
-  const namespaceJump = document.querySelector<HTMLSelectElement>("#namespace-jump");
-  if (namespaceJump) namespaceJump.addEventListener("change", () => {
-    state.namespaceFilter = namespaceJump.value;
-    state.typeCursor = 0;
-    const first = filteredTypes()[0];
-    if (first) state.selectedTypeId = first.id;
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    render();
-  });
-  document.querySelectorAll<HTMLElement>("[data-kind-filter]").forEach(button => button.addEventListener("click", () => {
-    state.kindFilter = button.dataset.kindFilter ?? "";
-    state.typeCursor = 0;
-    const first = filteredTypes()[0];
-    if (first) state.selectedTypeId = first.id;
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    render();
-  }));
   document.querySelectorAll<HTMLElement>("[data-library-chip]").forEach(button => button.addEventListener("click", () => {
     toggleLibraryChip(button.dataset.libraryChip ?? "");
     afterLibraryScopeChange();
@@ -4220,29 +4241,6 @@ function bindEvents() {
   observeAsync(ensurePackageVersions(state.package), "Loading package versions");
   if (state.package?.isRuntimePack)
     observeAsync(ensureDotnetReleases(), "Loading .NET release information");
-  const filter = document.querySelector<HTMLInputElement>("#type-filter");
-  filter?.addEventListener("input", () => {
-    state.typeFilter = filter.value;
-    state.typeCursor = 0;
-    const first = filteredTypes()[0];
-    if (first) state.selectedTypeId = first.id;
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    render();
-    focusFilter();
-  });
-  filter?.addEventListener("keydown", event => {
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      document.querySelector<HTMLElement>("#type-list")?.focus();
-    } else if (event.key === "Escape") {
-      state.typeFilter = "";
-      render();
-    }
-  });
-  document.querySelector<HTMLElement>("#type-list")
-    ?.addEventListener("keydown", handleTypeKeys);
   if (state.spotlightOpen) spotlight.bind(document, "modal");
   document.querySelector("#graph-source-backdrop")?.addEventListener("mousedown", event => {
     if (event.target instanceof HTMLElement
@@ -4270,16 +4268,6 @@ function bindEvents() {
       "change",
       () => toggleTaste(checkbox.dataset.taste ?? "")));
   document.querySelector("#taste-clear")?.addEventListener("click", clearTaste);
-  document.querySelector("#clear-filter")?.addEventListener("click", () => {
-    state.typeFilter = "";
-    state.namespaceFilter = "";
-    state.kindFilter = "";
-    state.libraryScope = null;
-    state.accessibilityFilter = defaultAccessibilityFilter(state.package);
-    render();
-    focusFilter();
-  });
-
   document.querySelector("#share")?.addEventListener("click", () => void share());
   document.querySelector("[data-graph-back]")?.addEventListener(
     "click",

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3799,6 +3799,7 @@ function bindTypePanelEvents() {
     onTypeFilterEscape: () => {
       state.typeFilter = "";
       render();
+      focusFilter();
     },
     onTypeSelect: typeId => {
       state.atPackageRoot = false;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3752,7 +3752,7 @@ function bindTypePanelEvents() {
       state.libraryScope = null;
       state.accessibilityFilter = defaultAccessibilityFilter(state.package);
       render();
-      focusFilter();
+      focusFilter({ immediate: true });
     },
     onKindSelect: kind => {
       state.kindFilter = kind;
@@ -3794,12 +3794,12 @@ function bindTypePanelEvents() {
       state.memberBrowseTypeId = "";
       resetMemberFilters();
       render();
-      focusFilter();
+      focusFilter({ immediate: true });
     },
     onTypeFilterEscape: () => {
       state.typeFilter = "";
       render();
-      focusFilter();
+      focusFilter({ immediate: true });
     },
     onTypeSelect: typeId => {
       state.atPackageRoot = false;
@@ -5305,14 +5305,18 @@ function executeCommand(
   return operation;
 }
 
-function focusFilter() {
-  requestAnimationFrame(() => {
+function focusFilter(
+  { immediate = false }: { immediate?: boolean } = {},
+) {
+  const focus = () => {
     const input = document.querySelector<HTMLInputElement>(
       "#member-filter, #type-filter");
     if (!input) return;
     input.focus();
     input.setSelectionRange(input.value.length, input.value.length);
-  });
+  };
+  if (immediate) focus();
+  requestAnimationFrame(focus);
 }
 
 const memberFocusRestorer = createMemberFocusRestorer();

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -5315,7 +5315,10 @@ function focusFilter(
     input.focus();
     input.setSelectionRange(input.value.length, input.value.length);
   };
-  if (immediate) focus();
+  if (immediate) {
+    focus();
+    return;
+  }
   requestAnimationFrame(focus);
 }
 

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -7813,7 +7813,7 @@ document.addEventListener("keydown", event => {
     }
     return;
   }
-  if (event.key === "Escape" && state.tasteOpen) {
+  if (event.key === "Escape" && !event.defaultPrevented && state.tasteOpen) {
     event.preventDefault();
     state.tasteOpen = false;
     render();

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -140,6 +140,7 @@ export function bindTypePanel(
       event.preventDefault();
       typeList?.focus();
     } else if (event.key === "Escape") {
+      event.preventDefault();
       actions.onTypeFilterEscape();
     }
   });

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -1,8 +1,8 @@
 // The type selector (the "PUBLIC TYPES" / "MEMBERS" nav pane) and the type viewer (the
 // type heading, metadata, and source sections shown for the "type" scope) as pure,
-// dependency-injected render functions. `dotnet-inspect.ts` owns the type index, filters, member
-// grouping, and navigation/click handling; this module owns only markup shape given an
-// explicit snapshot of the data those helpers already computed. Shared text helpers
+// dependency-injected render functions. This module also binds the controls that its nav pane
+// renders; `dotnet-inspect.ts` owns the type index, filters, member grouping, and navigation
+// state transitions behind explicit callbacks. Shared text helpers
 // (kindIcon, shortKind, typeDisplayName, highlight, highlightCSharp, factRows,
 // factEvidence, relatedTypeChip) stay in `dotnet-inspect.ts`, since they are used well beyond the
 // type panel, and are passed in rather than duplicated here.
@@ -78,6 +78,72 @@ export interface TypeSourceResult {
 type EscapeHtml = (value: unknown) => string;
 
 // -- Type selector (the "PUBLIC TYPES" / "MEMBERS" nav pane) -----------------------------
+
+export interface TypePanelBindingActions {
+  onClearFilters: () => void;
+  onKindSelect: (kind: string) => void;
+  onListKeyDown: (event: KeyboardEvent) => void;
+  onMemberSelect: (memberKey: string | undefined) => void;
+  onNamespaceSelect: (namespace: string) => void;
+  onOverloadSelect: (index: number) => void;
+  onShowTypes: () => void;
+  onTypeFilterChange: (value: string) => void;
+  onTypeFilterEscape: () => void;
+  onTypeSelect: (typeId: string) => void;
+}
+
+export function bindTypePanel(
+  root: ParentNode,
+  actions: TypePanelBindingActions,
+) {
+  root.querySelectorAll<HTMLElement>("[data-type]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onTypeSelect(button.dataset.type ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-namespace]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onNamespaceSelect(button.dataset.namespace ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-kind-filter]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onKindSelect(button.dataset.kindFilter ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-nav-member]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onMemberSelect(button.dataset.navMember)));
+  root.querySelectorAll<HTMLElement>("[data-nav-overload]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onOverloadSelect(Number(button.dataset.navOverload))));
+  root.querySelector("#nav-to-types")?.addEventListener(
+    "click",
+    actions.onShowTypes);
+  root.querySelector("#clear-filter")?.addEventListener(
+    "click",
+    actions.onClearFilters);
+
+  const namespaceJump =
+    root.querySelector<HTMLSelectElement>("#namespace-jump");
+  namespaceJump?.addEventListener(
+    "change",
+    () => actions.onNamespaceSelect(namespaceJump.value));
+
+  const typeList = root.querySelector<HTMLElement>("#type-list");
+  typeList?.addEventListener("keydown", actions.onListKeyDown);
+  const filter = root.querySelector<HTMLInputElement>("#type-filter");
+  filter?.addEventListener(
+    "input",
+    () => actions.onTypeFilterChange(filter.value));
+  filter?.addEventListener("keydown", event => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      typeList?.focus();
+    } else if (event.key === "Escape") {
+      actions.onTypeFilterEscape();
+    }
+  });
+}
 
 export interface TypeNavOptions {
   current?: TypeSummary | null;

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -139,7 +139,7 @@ export function bindTypePanel(
     if (event.key === "ArrowDown") {
       event.preventDefault();
       typeList?.focus();
-    } else if (event.key === "Escape") {
+    } else if (event.key === "Escape" && filter.value !== "") {
       event.preventDefault();
       actions.onTypeFilterEscape();
     }

--- a/prototypes/inspect-web/test/fake-dom.ts
+++ b/prototypes/inspect-web/test/fake-dom.ts
@@ -1,0 +1,27 @@
+export const fakeDom = {
+  event(values: object = {}): Event {
+    // Test fakes implement exactly the DOM subset consumed by each binder.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    return values as unknown as Event;
+  },
+  eventTarget(value: object): EventTarget {
+    // Test fakes implement exactly the DOM subset consumed by each binder.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    return value as unknown as EventTarget;
+  },
+  htmlElement(value: object): HTMLElement {
+    // Test fakes implement exactly the DOM subset consumed by each binder.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    return value as unknown as HTMLElement;
+  },
+  keyboardEvent(values: object): KeyboardEvent {
+    // Test fakes implement exactly the DOM subset consumed by each binder.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    return values as unknown as KeyboardEvent;
+  },
+  parentNode(value: object): ParentNode {
+    // Test fakes implement exactly the DOM subset consumed by each binder.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    return value as unknown as ParentNode;
+  },
+};

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -480,7 +480,7 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /if \(state\.loading \|\| state\.error\) \{\s*if \(isContainedBrowserShortcut\(event\) \|\| event\.key === "\/"\)[\s\S]*event\.preventDefault\(\);[\s\S]*return;/);
   assert.match(
     appSource,
-    /function focusFilter\([\s\S]*\{ immediate = false \}: \{ immediate\?: boolean \} = \{\},[\s\S]*const focus = \(\) => \{[\s\S]*"#member-filter, #type-filter"[\s\S]*if \(immediate\) focus\(\);\s*requestAnimationFrame\(focus\);/);
+    /function focusFilter\([\s\S]*\{ immediate = false \}: \{ immediate\?: boolean \} = \{\},[\s\S]*const focus = \(\) => \{[\s\S]*"#member-filter, #type-filter"[\s\S]*if \(immediate\) \{\s*focus\(\);\s*return;\s*}\s*requestAnimationFrame\(focus\);/);
 });
 
 test("Spotlight navigation waits for selection data before restoring focus", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -365,12 +365,31 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.match(
     typePanelSource,
     /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);
-  assert.doesNotMatch(
-    appSource,
-    /querySelectorAll<HTMLElement>\("\[data-(?:type|namespace|kind-filter|nav-member|nav-overload)\]"\)/);
-  assert.doesNotMatch(
-    appSource,
-    /querySelector(?:<[^>]+>)?\("#(?:nav-to-types|clear-filter|namespace-jump|type-filter)"\)\??\.addEventListener/);
+  const selectorCount = selector =>
+    appSource.split(selector).length - 1;
+  assert.deepEqual(
+    Object.fromEntries([
+      "[data-type]",
+      "[data-namespace]",
+      "[data-kind-filter]",
+      "[data-nav-member]",
+      "[data-nav-overload]",
+      "#nav-to-types",
+      "#clear-filter",
+      "#namespace-jump",
+    ].map(selector => [selector, selectorCount(selector)])),
+    {
+      "[data-type]": 0,
+      "[data-namespace]": 0,
+      "[data-kind-filter]": 0,
+      "[data-nav-member]": 0,
+      "[data-nav-overload]": 0,
+      "#nav-to-types": 0,
+      "#clear-filter": 0,
+      "#namespace-jump": 0,
+    });
+  assert.equal(selectorCount("#type-filter"), 1);
+  assert.equal(selectorCount("#type-list"), 5);
 });
 
 test("leaving package search clears its pending loading state", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -367,7 +367,10 @@ test("typed type panel owns its rendered control bindings", () => {
     /function bindTypePanelEvents\(\) \{\s*bindTypePanel\(document, \{/);
   assert.match(
     appSource,
-    /onTypeFilterEscape: \(\) => \{\s*state\.typeFilter = "";\s*render\(\);\s*focusFilter\(\);\s*},/);
+    /onTypeFilterChange: value => \{[\s\S]*?render\(\);\s*focusFilter\(\{ immediate: true \}\);\s*},\s*onTypeFilterEscape:/);
+  assert.match(
+    appSource,
+    /onTypeFilterEscape: \(\) => \{\s*state\.typeFilter = "";\s*render\(\);\s*focusFilter\(\{ immediate: true \}\);\s*},/);
   assert.equal(
     appSource.match(/\bbindTypePanelEvents\b/g)?.length,
     2);
@@ -474,7 +477,7 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /if \(state\.loading \|\| state\.error\) \{\s*if \(isContainedBrowserShortcut\(event\) \|\| event\.key === "\/"\)[\s\S]*event\.preventDefault\(\);[\s\S]*return;/);
   assert.match(
     appSource,
-    /function focusFilter\(\) \{[\s\S]*const input = document\.querySelector<HTMLInputElement>\([\s\S]*"#member-filter, #type-filter"\);\s*if \(!input\) return;/);
+    /function focusFilter\([\s\S]*\{ immediate = false \}: \{ immediate\?: boolean \} = \{\},[\s\S]*const focus = \(\) => \{[\s\S]*"#member-filter, #type-filter"[\s\S]*if \(immediate\) focus\(\);\s*requestAnimationFrame\(focus\);/);
 });
 
 test("Spotlight navigation waits for selection data before restoring focus", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -459,6 +459,9 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /state\.spotlightOpen[\s\S]*event\.key === "Escape"[\s\S]*closeSpotlight\(\)/);
   assert.match(
     appSource,
+    /event\.key === "Escape" && !event\.defaultPrevented && state\.tasteOpen/);
+  assert.match(
+    appSource,
     /function openSpotlight\(seed = "", spotlightScope = "all"\) \{\s*if \(state\.loading \|\| state\.error\) return;\s*state\.tasteOpen = false;/);
   assert.match(
     spotlightSource,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -632,7 +632,7 @@ test("member filters retain accessible controls and focus across rerenders", () 
     /memberFilter\?\.addEventListener\("input"[\s\S]*renderPreservingMemberFocus\(\)/);
   assert.match(
     appSource,
-    /memberFilter\?\.addEventListener\("keydown"[\s\S]*event\.key === "Escape"[\s\S]*if \(navMode\(\) === "member"\)[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*renderMemberFilterAndRestoreFocus\("#member-filter"\)[\s\S]*stepMemberNav/);
+    /memberFilter\?\.addEventListener\("keydown"[\s\S]*event\.key === "Escape"[\s\S]*if \(navMode\(\) !== "member" && memberFilter\.value === ""\) return;[\s\S]*event\.preventDefault\(\);[\s\S]*if \(navMode\(\) === "member"\)[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*renderMemberFilterAndRestoreFocus\("#member-filter"\)[\s\S]*stepMemberNav/);
   assert.match(
     appSource,
     /event\.key === "Escape" && !event\.defaultPrevented && !typing[\s\S]*if \(navMode\(\) === "member"\) exitMemberScope\(\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -358,6 +358,21 @@ test("typed catalog requests own release and package-version coordination", () =
     /\bfetch\(|\bdocument\b|inspectPackageVersions/);
 });
 
+test("typed type panel owns its rendered control bindings", () => {
+  assert.match(
+    appSource,
+    /function bindTypePanelEvents\(\) \{\s*bindTypePanel\(document, \{/);
+  assert.match(
+    typePanelSource,
+    /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);
+  assert.doesNotMatch(
+    appSource,
+    /querySelectorAll<HTMLElement>\("\[data-(?:type|namespace|kind-filter|nav-member|nav-overload)\]"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /querySelector(?:<[^>]+>)?\("#(?:nav-to-types|clear-filter|namespace-jump|type-filter)"\)\??\.addEventListener/);
+});
+
 test("leaving package search clears its pending loading state", () => {
   assert.match(
     spotlightPackageSearchSource,
@@ -583,7 +598,7 @@ test("member filters retain accessible controls and focus across rerenders", () 
     /event\.key === "Escape" && !event\.defaultPrevented && !typing[\s\S]*if \(navMode\(\) === "member"\) exitMemberScope\(\)/);
   assert.match(
     appSource,
-    /#nav-to-types"\)\?\.addEventListener\("click", \(\) => \{\s*exitMemberScope\(\)/);
+    /onShowTypes: exitMemberScope/);
   assert.match(
     appSource,
     /const renderMemberFilterAndRestoreFocus = \(selector = ""\) => \{[\s\S]*renderWithMemberFocus\(preserved\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -365,6 +365,9 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.match(
     appSource,
     /function bindTypePanelEvents\(\) \{\s*bindTypePanel\(document, \{/);
+  assert.match(
+    appSource,
+    /onTypeFilterEscape: \(\) => \{\s*state\.typeFilter = "";\s*render\(\);\s*focusFilter\(\);\s*},/);
   assert.equal(
     appSource.match(/\bbindTypePanelEvents\b/g)?.length,
     2);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -359,9 +359,21 @@ test("typed catalog requests own release and package-version coordination", () =
 });
 
 test("typed type panel owns its rendered control bindings", () => {
+  const rootEventBinder =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
   assert.match(
     appSource,
     /function bindTypePanelEvents\(\) \{\s*bindTypePanel\(document, \{/);
+  assert.equal(
+    appSource.match(/\bbindTypePanelEvents\b/g)?.length,
+    2);
+  assert.equal(
+    rootEventBinder.match(/\bbindTypePanelEvents\(\)/g)?.length,
+    1);
+  assert.match(
+    rootEventBinder,
+    /function bindEvents\(\) \{\s*bindStatusBarToggle\(\);\s*packageBar\.bind\(document\);\s*bindTypePanelEvents\(\);/);
   assert.match(
     typePanelSource,
     /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -153,27 +153,38 @@ function recordingActions(calls: string[]): TypePanelBindingActions {
 test("type panel bindings dispatch the rendered type navigation controls", () => {
   const root = new FakeRoot();
   const type = new FakeElement({ type: "System.String" });
+  const secondType = new FakeElement({ type: "System.Int32" });
   const namespace = new FakeElement({ namespace: "System" });
+  const secondNamespace = new FakeElement({ namespace: "System.Collections" });
   const kind = new FakeElement({ kindFilter: "class" });
-  root.addAll("[data-type]", type);
-  root.addAll("[data-namespace]", namespace);
-  root.addAll("[data-kind-filter]", kind);
+  const secondKind = new FakeElement({ kindFilter: "interface" });
+  root.addAll("[data-type]", type, secondType);
+  root.addAll("[data-namespace]", namespace, secondNamespace);
+  root.addAll("[data-kind-filter]", kind, secondKind);
   const clear = root.add("#clear-filter", new FakeElement());
   const namespaceJump = root.add("#namespace-jump", new FakeElement());
-  namespaceJump.value = "System.Text";
   const filter = root.add("#type-filter", new FakeElement());
-  filter.value = "json";
   const typeList = root.add("#type-list", new FakeElement());
 
   const calls: string[] = [];
-  bindTypePanel(
-    root as unknown as ParentNode,
-    recordingActions(calls));
+  let forwardedListEvent: KeyboardEvent | null = null;
+  const actions = recordingActions(calls);
+  actions.onListKeyDown = event => {
+    forwardedListEvent = event;
+    event.preventDefault();
+    calls.push(`list:${event.key}`);
+  };
+  bindTypePanel(root as unknown as ParentNode, actions);
+  namespaceJump.value = "System.Text";
+  filter.value = "json";
 
   type.dispatch("click");
+  secondType.dispatch("click");
   namespace.dispatch("click");
+  secondNamespace.dispatch("click");
   namespaceJump.dispatch("change");
   kind.dispatch("click");
+  secondKind.dispatch("click");
   clear.dispatch("click");
   filter.dispatch("input");
   const listKey = keyboardEvent("End");
@@ -181,21 +192,28 @@ test("type panel bindings dispatch the rendered type navigation controls", () =>
 
   assert.deepEqual(calls, [
     "type:System.String",
+    "type:System.Int32",
     "namespace:System",
+    "namespace:System.Collections",
     "namespace:System.Text",
     "kind:class",
+    "kind:interface",
     "clear",
     "filter:json",
     "list:End",
   ]);
+  assert.equal(forwardedListEvent, listKey.event);
+  assert.equal(listKey.state.prevented, true);
 });
 
 test("type panel bindings dispatch the rendered member navigation controls", () => {
   const root = new FakeRoot();
   const member = new FakeElement({ navMember: "M:Length" });
+  const secondMember = new FakeElement({ navMember: "M:Count" });
   const overload = new FakeElement({ navOverload: "2" });
-  root.addAll("[data-nav-member]", member);
-  root.addAll("[data-nav-overload]", overload);
+  const secondOverload = new FakeElement({ navOverload: "0" });
+  root.addAll("[data-nav-member]", member, secondMember);
+  root.addAll("[data-nav-overload]", overload, secondOverload);
   const showTypes = root.add("#nav-to-types", new FakeElement());
   const typeList = root.add("#type-list", new FakeElement());
   const calls: string[] = [];
@@ -204,13 +222,17 @@ test("type panel bindings dispatch the rendered member navigation controls", () 
     recordingActions(calls));
 
   member.dispatch("click");
+  secondMember.dispatch("click");
   overload.dispatch("click");
+  secondOverload.dispatch("click");
   showTypes.dispatch("click");
   typeList.dispatch("keydown", keyboardEvent("Home").event);
 
   assert.deepEqual(calls, [
     "member:M:Length",
+    "member:M:Count",
     "overload:2",
+    "overload:0",
     "types",
     "list:Home",
   ]);
@@ -221,8 +243,12 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   const filter = root.add("#type-filter", new FakeElement());
   const typeList = root.add("#type-list", new FakeElement());
   let escapes = 0;
+  let listKeys = 0;
   bindTypePanel(root as unknown as ParentNode, {
     ...recordingActions([]),
+    onListKeyDown: () => {
+      listKeys++;
+    },
     onTypeFilterEscape: () => {
       escapes++;
     },
@@ -233,12 +259,14 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   assert.equal(typeList.focused, false);
   assert.equal(ignored.state.prevented, false);
   assert.equal(escapes, 0);
+  assert.equal(listKeys, 0);
 
   const down = keyboardEvent("ArrowDown");
   filter.dispatch("keydown", down.event);
   assert.equal(typeList.focused, true);
   assert.equal(down.state.prevented, true);
   assert.equal(escapes, 0);
+  assert.equal(listKeys, 0);
 
   typeList.focused = false;
   const escape = keyboardEvent("Escape");
@@ -246,6 +274,7 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   assert.equal(escapes, 1);
   assert.equal(escape.state.prevented, false);
   assert.equal(typeList.focused, false);
+  assert.equal(listKeys, 0);
 });
 
 test("type panel binding tolerates controls from the inactive nav being absent", () => {
@@ -282,6 +311,10 @@ test("the type nav lists namespace groups with the current type selected", () =>
     html,
     /data-type="System\.Text\.Json\.JsonDocument" role="option" aria-selected="false"/);
   assert.match(html, /data-namespace="System\.Text\.Json"/);
+  assert.match(html, /id="clear-filter"/);
+  assert.match(html, /id="type-filter"/);
+  assert.match(html, /id="namespace-jump"/);
+  assert.match(html, /data-kind-filter="class"/);
   assert.match(html, /id="type-list" data-nav-scope="types"/);
   assert.match(html, /data-nav-selection="type:System\.Text\.Json\.JsonSerializer"/);
 });
@@ -368,6 +401,7 @@ test("the member nav marks the active group and its selected overload", () => {
   assert.match(
     html,
     /data-nav-overload="0" role="option" aria-selected="false"/);
+  assert.match(html, /id="nav-to-types"/);
   assert.match(
     html,
     /id="type-list" data-nav-scope="members:System\.Text\.Json\.JsonSerializer"/);

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -15,6 +15,7 @@ import type {
   TypePanelBindingActions,
   TypeSummary,
 } from "../src/type-panel.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;
@@ -32,7 +33,7 @@ class FakeElement {
     this.listeners.set(type, listeners);
   }
 
-  dispatch(type: string, event: Event = {} as Event) {
+  dispatch(type: string, event: Event = fakeDom.event()) {
     for (const listener of this.listeners.get(type) ?? []) {
       listener(event);
     }
@@ -68,12 +69,12 @@ class FakeRoot {
 
 function keyboardEvent(key: string) {
   const state = { prevented: false };
-  const event = {
+  const event = fakeDom.keyboardEvent({
     key,
     preventDefault: () => {
       state.prevented = true;
     },
-  } as unknown as KeyboardEvent;
+  });
   return { event, state };
 }
 
@@ -174,7 +175,7 @@ test("type panel bindings dispatch the rendered type navigation controls", () =>
     event.preventDefault();
     calls.push(`list:${event.key}`);
   };
-  bindTypePanel(root as unknown as ParentNode, actions);
+  bindTypePanel(fakeDom.parentNode(root), actions);
   namespaceJump.value = "System.Text";
   filter.value = "json";
 
@@ -218,7 +219,7 @@ test("type panel bindings dispatch the rendered member navigation controls", () 
   const typeList = root.add("#type-list", new FakeElement());
   const calls: string[] = [];
   bindTypePanel(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   member.dispatch("click");
@@ -244,7 +245,7 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   const typeList = root.add("#type-list", new FakeElement());
   let escapes = 0;
   let listKeys = 0;
-  bindTypePanel(root as unknown as ParentNode, {
+  bindTypePanel(fakeDom.parentNode(root), {
     ...recordingActions([]),
     onListKeyDown: () => {
       listKeys++;
@@ -280,7 +281,7 @@ test("type filter keys preserve list focus and Escape behavior", () => {
 test("type panel binding tolerates controls from the inactive nav being absent", () => {
   const root = new FakeRoot();
   assert.doesNotThrow(() => bindTypePanel(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions([])));
 });
 

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -135,34 +135,11 @@ const jsonDocument: TypeSummary = {
   assembly: "System.Text.Json.dll",
 };
 
-test("type panel bindings dispatch every rendered navigation control", () => {
-  const root = new FakeRoot();
-  const type = new FakeElement({ type: "System.String" });
-  const namespace = new FakeElement({ namespace: "System" });
-  const kind = new FakeElement({ kindFilter: "class" });
-  const member = new FakeElement({ navMember: "M:Length" });
-  const overload = new FakeElement({ navOverload: "2" });
-  root.addAll("[data-type]", type);
-  root.addAll("[data-namespace]", namespace);
-  root.addAll("[data-kind-filter]", kind);
-  root.addAll("[data-nav-member]", member);
-  root.addAll("[data-nav-overload]", overload);
-  const showTypes = root.add("#nav-to-types", new FakeElement());
-  const clear = root.add("#clear-filter", new FakeElement());
-  const namespaceJump = root.add("#namespace-jump", new FakeElement());
-  namespaceJump.value = "System.Text";
-  const filter = root.add("#type-filter", new FakeElement());
-  filter.value = "json";
-  const typeList = root.add("#type-list", new FakeElement());
-
-  const calls: string[] = [];
-  let listEvent: KeyboardEvent | null = null;
-  const actions: TypePanelBindingActions = {
+function recordingActions(calls: string[]): TypePanelBindingActions {
+  return {
     onClearFilters: () => calls.push("clear"),
     onKindSelect: value => calls.push(`kind:${value}`),
-    onListKeyDown: event => {
-      listEvent = event;
-    },
+    onListKeyDown: event => calls.push(`list:${event.key}`),
     onMemberSelect: value => calls.push(`member:${value}`),
     onNamespaceSelect: value => calls.push(`namespace:${value}`),
     onOverloadSelect: value => calls.push(`overload:${value}`),
@@ -171,18 +148,35 @@ test("type panel bindings dispatch every rendered navigation control", () => {
     onTypeFilterEscape: () => calls.push("escape"),
     onTypeSelect: value => calls.push(`type:${value}`),
   };
-  bindTypePanel(root as unknown as ParentNode, actions);
+}
+
+test("type panel bindings dispatch the rendered type navigation controls", () => {
+  const root = new FakeRoot();
+  const type = new FakeElement({ type: "System.String" });
+  const namespace = new FakeElement({ namespace: "System" });
+  const kind = new FakeElement({ kindFilter: "class" });
+  root.addAll("[data-type]", type);
+  root.addAll("[data-namespace]", namespace);
+  root.addAll("[data-kind-filter]", kind);
+  const clear = root.add("#clear-filter", new FakeElement());
+  const namespaceJump = root.add("#namespace-jump", new FakeElement());
+  namespaceJump.value = "System.Text";
+  const filter = root.add("#type-filter", new FakeElement());
+  filter.value = "json";
+  const typeList = root.add("#type-list", new FakeElement());
+
+  const calls: string[] = [];
+  bindTypePanel(
+    root as unknown as ParentNode,
+    recordingActions(calls));
 
   type.dispatch("click");
   namespace.dispatch("click");
   namespaceJump.dispatch("change");
   kind.dispatch("click");
-  member.dispatch("click");
-  overload.dispatch("click");
-  showTypes.dispatch("click");
   clear.dispatch("click");
   filter.dispatch("input");
-  const listKey = keyboardEvent("ArrowDown");
+  const listKey = keyboardEvent("End");
   typeList.dispatch("keydown", listKey.event);
 
   assert.deepEqual(calls, [
@@ -190,13 +184,36 @@ test("type panel bindings dispatch every rendered navigation control", () => {
     "namespace:System",
     "namespace:System.Text",
     "kind:class",
+    "clear",
+    "filter:json",
+    "list:End",
+  ]);
+});
+
+test("type panel bindings dispatch the rendered member navigation controls", () => {
+  const root = new FakeRoot();
+  const member = new FakeElement({ navMember: "M:Length" });
+  const overload = new FakeElement({ navOverload: "2" });
+  root.addAll("[data-nav-member]", member);
+  root.addAll("[data-nav-overload]", overload);
+  const showTypes = root.add("#nav-to-types", new FakeElement());
+  const typeList = root.add("#type-list", new FakeElement());
+  const calls: string[] = [];
+  bindTypePanel(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  member.dispatch("click");
+  overload.dispatch("click");
+  showTypes.dispatch("click");
+  typeList.dispatch("keydown", keyboardEvent("Home").event);
+
+  assert.deepEqual(calls, [
     "member:M:Length",
     "overload:2",
     "types",
-    "clear",
-    "filter:json",
+    "list:Home",
   ]);
-  assert.equal(listEvent, listKey.event);
 });
 
 test("type filter keys preserve list focus and Escape behavior", () => {
@@ -205,18 +222,10 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   const typeList = root.add("#type-list", new FakeElement());
   let escapes = 0;
   bindTypePanel(root as unknown as ParentNode, {
-    onClearFilters: () => {},
-    onKindSelect: () => {},
-    onListKeyDown: () => {},
-    onMemberSelect: () => {},
-    onNamespaceSelect: () => {},
-    onOverloadSelect: () => {},
-    onShowTypes: () => {},
-    onTypeFilterChange: () => {},
+    ...recordingActions([]),
     onTypeFilterEscape: () => {
       escapes++;
     },
-    onTypeSelect: () => {},
   });
 
   const ignored = keyboardEvent("a");
@@ -229,27 +238,21 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   filter.dispatch("keydown", down.event);
   assert.equal(typeList.focused, true);
   assert.equal(down.state.prevented, true);
+  assert.equal(escapes, 0);
 
+  typeList.focused = false;
   const escape = keyboardEvent("Escape");
   filter.dispatch("keydown", escape.event);
   assert.equal(escapes, 1);
   assert.equal(escape.state.prevented, false);
+  assert.equal(typeList.focused, false);
 });
 
 test("type panel binding tolerates controls from the inactive nav being absent", () => {
   const root = new FakeRoot();
-  assert.doesNotThrow(() => bindTypePanel(root as unknown as ParentNode, {
-    onClearFilters: () => {},
-    onKindSelect: () => {},
-    onListKeyDown: () => {},
-    onMemberSelect: () => {},
-    onNamespaceSelect: () => {},
-    onOverloadSelect: () => {},
-    onShowTypes: () => {},
-    onTypeFilterChange: () => {},
-    onTypeFilterEscape: () => {},
-    onTypeSelect: () => {},
-  }));
+  assert.doesNotThrow(() => bindTypePanel(
+    root as unknown as ParentNode,
+    recordingActions([])));
 });
 
 test("the type nav lists namespace groups with the current type selected", () => {

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -270,12 +270,19 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   assert.equal(listKeys, 0);
 
   typeList.focused = false;
+  filter.value = "json";
   const escape = keyboardEvent("Escape");
   filter.dispatch("keydown", escape.event);
   assert.equal(escapes, 1);
   assert.equal(escape.state.prevented, true);
   assert.equal(typeList.focused, false);
   assert.equal(listKeys, 0);
+
+  filter.value = "";
+  const emptyEscape = keyboardEvent("Escape");
+  filter.dispatch("keydown", emptyEscape.event);
+  assert.equal(escapes, 1);
+  assert.equal(emptyEscape.state.prevented, false);
 });
 
 test("type panel binding tolerates controls from the inactive nav being absent", () => {

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -273,7 +273,7 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   const escape = keyboardEvent("Escape");
   filter.dispatch("keydown", escape.event);
   assert.equal(escapes, 1);
-  assert.equal(escape.state.prevented, false);
+  assert.equal(escape.state.prevented, true);
   assert.equal(typeList.focused, false);
   assert.equal(listKeys, 0);
 });

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  bindTypePanel,
   renderMemberNav,
   renderTypeMetadata,
   renderTypeNav,
@@ -11,8 +12,70 @@ import {
 } from "../src/type-panel.ts";
 import type {
   MemberNavEntry,
+  TypePanelBindingActions,
   TypeSummary,
 } from "../src/type-panel.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  value = "";
+  focused = false;
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, event: Event = {} as Event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  focus() {
+    this.focused = true;
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+    return element;
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+    return elements;
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+function keyboardEvent(key: string) {
+  const state = { prevented: false };
+  const event = {
+    key,
+    preventDefault: () => {
+      state.prevented = true;
+    },
+  } as unknown as KeyboardEvent;
+  return { event, state };
+}
 
 function escapeHtml(value: unknown) {
   return String(value)
@@ -71,6 +134,123 @@ const jsonDocument: TypeSummary = {
   accessibility: "public",
   assembly: "System.Text.Json.dll",
 };
+
+test("type panel bindings dispatch every rendered navigation control", () => {
+  const root = new FakeRoot();
+  const type = new FakeElement({ type: "System.String" });
+  const namespace = new FakeElement({ namespace: "System" });
+  const kind = new FakeElement({ kindFilter: "class" });
+  const member = new FakeElement({ navMember: "M:Length" });
+  const overload = new FakeElement({ navOverload: "2" });
+  root.addAll("[data-type]", type);
+  root.addAll("[data-namespace]", namespace);
+  root.addAll("[data-kind-filter]", kind);
+  root.addAll("[data-nav-member]", member);
+  root.addAll("[data-nav-overload]", overload);
+  const showTypes = root.add("#nav-to-types", new FakeElement());
+  const clear = root.add("#clear-filter", new FakeElement());
+  const namespaceJump = root.add("#namespace-jump", new FakeElement());
+  namespaceJump.value = "System.Text";
+  const filter = root.add("#type-filter", new FakeElement());
+  filter.value = "json";
+  const typeList = root.add("#type-list", new FakeElement());
+
+  const calls: string[] = [];
+  let listEvent: KeyboardEvent | null = null;
+  const actions: TypePanelBindingActions = {
+    onClearFilters: () => calls.push("clear"),
+    onKindSelect: value => calls.push(`kind:${value}`),
+    onListKeyDown: event => {
+      listEvent = event;
+    },
+    onMemberSelect: value => calls.push(`member:${value}`),
+    onNamespaceSelect: value => calls.push(`namespace:${value}`),
+    onOverloadSelect: value => calls.push(`overload:${value}`),
+    onShowTypes: () => calls.push("types"),
+    onTypeFilterChange: value => calls.push(`filter:${value}`),
+    onTypeFilterEscape: () => calls.push("escape"),
+    onTypeSelect: value => calls.push(`type:${value}`),
+  };
+  bindTypePanel(root as unknown as ParentNode, actions);
+
+  type.dispatch("click");
+  namespace.dispatch("click");
+  namespaceJump.dispatch("change");
+  kind.dispatch("click");
+  member.dispatch("click");
+  overload.dispatch("click");
+  showTypes.dispatch("click");
+  clear.dispatch("click");
+  filter.dispatch("input");
+  const listKey = keyboardEvent("ArrowDown");
+  typeList.dispatch("keydown", listKey.event);
+
+  assert.deepEqual(calls, [
+    "type:System.String",
+    "namespace:System",
+    "namespace:System.Text",
+    "kind:class",
+    "member:M:Length",
+    "overload:2",
+    "types",
+    "clear",
+    "filter:json",
+  ]);
+  assert.equal(listEvent, listKey.event);
+});
+
+test("type filter keys preserve list focus and Escape behavior", () => {
+  const root = new FakeRoot();
+  const filter = root.add("#type-filter", new FakeElement());
+  const typeList = root.add("#type-list", new FakeElement());
+  let escapes = 0;
+  bindTypePanel(root as unknown as ParentNode, {
+    onClearFilters: () => {},
+    onKindSelect: () => {},
+    onListKeyDown: () => {},
+    onMemberSelect: () => {},
+    onNamespaceSelect: () => {},
+    onOverloadSelect: () => {},
+    onShowTypes: () => {},
+    onTypeFilterChange: () => {},
+    onTypeFilterEscape: () => {
+      escapes++;
+    },
+    onTypeSelect: () => {},
+  });
+
+  const ignored = keyboardEvent("a");
+  filter.dispatch("keydown", ignored.event);
+  assert.equal(typeList.focused, false);
+  assert.equal(ignored.state.prevented, false);
+  assert.equal(escapes, 0);
+
+  const down = keyboardEvent("ArrowDown");
+  filter.dispatch("keydown", down.event);
+  assert.equal(typeList.focused, true);
+  assert.equal(down.state.prevented, true);
+
+  const escape = keyboardEvent("Escape");
+  filter.dispatch("keydown", escape.event);
+  assert.equal(escapes, 1);
+  assert.equal(escape.state.prevented, false);
+});
+
+test("type panel binding tolerates controls from the inactive nav being absent", () => {
+  const root = new FakeRoot();
+  assert.doesNotThrow(() => bindTypePanel(root as unknown as ParentNode, {
+    onClearFilters: () => {},
+    onKindSelect: () => {},
+    onListKeyDown: () => {},
+    onMemberSelect: () => {},
+    onNamespaceSelect: () => {},
+    onOverloadSelect: () => {},
+    onShowTypes: () => {},
+    onTypeFilterChange: () => {},
+    onTypeFilterEscape: () => {},
+    onTypeSelect: () => {},
+  }));
+});
 
 test("the type nav lists namespace groups with the current type selected", () => {
   const html = renderTypeNav({


### PR DESCRIPTION
Pairs the type/member navigation controls with their existing typed presentation owner. `type-panel.ts` now binds every selector it renders and owns type-filter ArrowDown/Escape DOM behavior; `dotnet-inspect.ts` retains the authoritative type index, filters, member grouping, navigation transitions, rendering, and focus effects behind explicit typed callbacks. No user-visible behavior or state ownership changes.

**Stack**

- Slice 11, stacked on #4518.
- Parent: #4518 (catalog request coordination).
- Residual: DOM event binding for scope/package surfaces, member detail controls, metadata explorer, and overlays paired with their existing presentation owners.

**Validation**

- `npm test` — 395/395, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.

Progresses #4504.