### PR TITLE
Pair scope bar with DOM bindings

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -741,12 +741,12 @@ close-button label, and active-style-count states.
 
 `src/scope-bar.ts` owns the scope switcher and lens strip (the segmented
 Package/Types/Member control and the buttons beside it for the active scope's
-lenses or member sections) as a pure, dependency-injected render function.
+lenses or member sections), including their rendered DOM bindings.
 `dotnet-inspect.ts` still owns the current scope, the package/type/member lens
-definitions, and the active lens/section per scope, and passes each computed
-slice in explicitly. `test/scope-bar.test.ts` gates the active scope segment,
-the active lens/section marking per scope, keyboard-shortcut indices, and
-label escaping.
+definitions, and each navigation state transition, supplying those effects
+through typed callbacks. `test/scope-bar.test.ts` gates each mutually exclusive
+binding shape, the active scope segment, active lens/section marking,
+keyboard-shortcut indices, and label escaping.
 
 `src/metadata-viewer.ts` owns the Metadata lens (the image-level summary of each
 assembly — format stamp, heap sizes, ECMA-335 table row counts, and PE/CLI

--- a/prototypes/inspect-web/package-lock.json
+++ b/prototypes/inspect-web/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@types/node": "^24.13.3",
         "knip": "^6.32.2",
+        "oxc-parser": "^0.143.0",
         "oxlint": "^1.79.0",
         "oxlint-tsgolint": "7.0.2001",
         "typescript": "7.0.2",

--- a/prototypes/inspect-web/package.json
+++ b/prototypes/inspect-web/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@types/node": "^24.13.3",
     "knip": "^6.32.2",
+    "oxc-parser": "^0.143.0",
     "oxlint": "^1.79.0",
     "oxlint-tsgolint": "7.0.2001",
     "typescript": "7.0.2",

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -100,7 +100,10 @@ import {
   nodeAtOffset,
   validateAnnotatedSourceDocument,
 } from "./annotated-source-view.ts";
-import { renderScopeBar as renderScopeBarPure } from "./scope-bar.ts";
+import {
+  bindScopeBar,
+  renderScopeBar as renderScopeBarPure,
+} from "./scope-bar.ts";
 import {
   renderDocViewer as renderDocViewerPure,
   type DocViewerMeta,
@@ -3814,34 +3817,48 @@ function bindTypePanelEvents() {
   });
 }
 
+function bindScopeBarEvents() {
+  bindScopeBar(document, {
+    onMemberSectionSelect: section => {
+      if (section && isMemberSection(section)) applyMemberSection(section);
+    },
+    onPackageLensSelect: lens => {
+      state.packageLens = lens;
+      render();
+    },
+    onScopeSelect: target => {
+      if (target === "package") {
+        state.atPackageRoot = true;
+      } else if (target === "type") {
+        // Pop out to the type level: leave the package root and drop any open member so the
+        // type lenses (API / Metadata / Source) take the strip. Ensure a type is selected.
+        state.atPackageRoot = false;
+        if (!state.selectedTypeId) {
+          const first = filteredTypes()[0];
+          if (first) state.selectedTypeId = first.id;
+        }
+        state.selectedMemberKey = "";
+        state.memberBrowseTypeId = "";
+        state.selectedOverloadIndex = null;
+      } else if (target === "member") {
+        enterMemberScope();
+      }
+      render();
+    },
+    onTypeLensSelect: lens => {
+      state.lens = lens;
+      state.selectedMemberKey = "";
+      state.memberBrowseTypeId = "";
+      render();
+    },
+  });
+}
+
 function bindEvents() {
   bindStatusBarToggle();
   packageBar.bind(document);
   bindTypePanelEvents();
-  document.querySelectorAll<HTMLElement>("[data-scope]").forEach(button => button.addEventListener("click", () => {
-    const target = button.dataset.scope;
-    if (target === "package") {
-      state.atPackageRoot = true;
-    } else if (target === "type") {
-      // Pop out to the type level: leave the package root and drop any open member so the
-      // type lenses (API / Metadata / Source) take the strip. Ensure a type is selected.
-      state.atPackageRoot = false;
-      if (!state.selectedTypeId) {
-        const first = filteredTypes()[0];
-        if (first) state.selectedTypeId = first.id;
-      }
-      state.selectedMemberKey = "";
-      state.memberBrowseTypeId = "";
-      state.selectedOverloadIndex = null;
-    } else if (target === "member") {
-      enterMemberScope();
-    }
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-package-lens]").forEach(button => button.addEventListener("click", () => {
-    state.packageLens = button.dataset.packageLens ?? "overview";
-    render();
-  }));
+  bindScopeBarEvents();
   document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
     observeAsync(
       switchPackageFramework(button.dataset.frameworkChip ?? ""),
@@ -3896,12 +3913,6 @@ function bindEvents() {
     state.typeCursor = 0;
     const first = filteredTypes()[0];
     if (first) state.selectedTypeId = first.id;
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-lens]").forEach(button => button.addEventListener("click", () => {
-    state.lens = button.dataset.lens ?? "api";
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
     render();
   }));
   document.querySelectorAll<HTMLElement>("[data-graph-type]").forEach(button => button.addEventListener("click", () => {
@@ -4016,10 +4027,6 @@ function bindEvents() {
   }));
   document.querySelectorAll<HTMLElement>("[data-overload]").forEach(button => button.addEventListener("click", () => {
     openOverload(Number(button.dataset.overload));
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member-section]").forEach(button => button.addEventListener("click", () => {
-    const section = button.dataset.memberSection;
-    if (section && isMemberSection(section)) applyMemberSection(section);
   }));
   document.querySelector("#member-back")?.addEventListener("click", () => {
     drillOut();

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -12,6 +12,36 @@ export interface RenderScopeBarOptions {
   escapeHtml: (value: unknown) => string;
 }
 
+export interface ScopeBarBindingActions {
+  onMemberSectionSelect: (section: string | undefined) => void;
+  onPackageLensSelect: (lens: string) => void;
+  onScopeSelect: (scope: string | undefined) => void;
+  onTypeLensSelect: (lens: string) => void;
+}
+
+export function bindScopeBar(
+  root: ParentNode,
+  actions: ScopeBarBindingActions,
+) {
+  root.querySelectorAll<HTMLElement>("[data-scope]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onScopeSelect(button.dataset.scope)));
+  root.querySelectorAll<HTMLElement>("[data-package-lens]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onPackageLensSelect(
+        button.dataset.packageLens ?? "overview")));
+  root.querySelectorAll<HTMLElement>("[data-lens]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onTypeLensSelect(button.dataset.lens ?? "api")));
+  root.querySelectorAll<HTMLElement>("[data-member-section]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onMemberSectionSelect(button.dataset.memberSection)));
+}
+
 function lensButton(
   id: string,
   label: string,

--- a/prototypes/inspect-web/test/scope-bar.test.ts
+++ b/prototypes/inspect-web/test/scope-bar.test.ts
@@ -5,6 +5,7 @@ import {
   renderScopeBar,
   type ScopeBarBindingActions,
 } from "../src/scope-bar.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;
@@ -22,7 +23,7 @@ class FakeElement {
 
   dispatch(type: string) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({} as Event);
+      listener(fakeDom.event());
     }
   }
 }
@@ -72,7 +73,7 @@ test("package scope bindings dispatch only scope and package-lens controls", () 
   root.add("[data-package-lens]", dependencies);
   const calls: string[] = [];
   bindScopeBar(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   packageScope.dispatch("click");
@@ -94,7 +95,7 @@ test("type scope bindings dispatch only scope and type-lens controls", () => {
   root.add("[data-lens]", metadata);
   const calls: string[] = [];
   bindScopeBar(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   typeScope.dispatch("click");
@@ -111,7 +112,7 @@ test("member scope bindings dispatch only scope and member-section controls", ()
   root.add("[data-member-section]", facts);
   const calls: string[] = [];
   bindScopeBar(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   memberScope.dispatch("click");
@@ -123,7 +124,7 @@ test("member scope bindings dispatch only scope and member-section controls", ()
 test("scope bar binding tolerates an empty strip", () => {
   const root = new FakeRoot();
   assert.doesNotThrow(() => bindScopeBar(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions([])));
 });
 

--- a/prototypes/inspect-web/test/scope-bar.test.ts
+++ b/prototypes/inspect-web/test/scope-bar.test.ts
@@ -1,6 +1,53 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderScopeBar } from "../src/scope-bar.ts";
+import {
+  bindScopeBar,
+  renderScopeBar,
+  type ScopeBarBindingActions,
+} from "../src/scope-bar.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({} as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly elements = new Map<string, FakeElement[]>();
+
+  add(selector: string, ...elements: FakeElement[]) {
+    this.elements.set(selector, elements);
+    return elements;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.elements.get(selector) ?? [];
+  }
+}
+
+function recordingActions(calls: string[]): ScopeBarBindingActions {
+  return {
+    onMemberSectionSelect: value => calls.push(`member:${value}`),
+    onPackageLensSelect: value => calls.push(`package:${value}`),
+    onScopeSelect: value => calls.push(`scope:${value}`),
+    onTypeLensSelect: value => calls.push(`type:${value}`),
+  };
+}
 
 function escapeHtml(value: unknown) {
   return String(value)
@@ -15,6 +62,70 @@ const typeLenses = [
   ["metadata", "Metadata"],
   ["source", "Source"],
 ] as const;
+
+test("package scope bindings dispatch only scope and package-lens controls", () => {
+  const root = new FakeRoot();
+  const packageScope = new FakeElement({ scope: "package" });
+  const typeScope = new FakeElement({ scope: "type" });
+  const dependencies = new FakeElement({ packageLens: "dependencies" });
+  root.add("[data-scope]", packageScope, typeScope);
+  root.add("[data-package-lens]", dependencies);
+  const calls: string[] = [];
+  bindScopeBar(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  packageScope.dispatch("click");
+  typeScope.dispatch("click");
+  dependencies.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "scope:package",
+    "scope:type",
+    "package:dependencies",
+  ]);
+});
+
+test("type scope bindings dispatch only scope and type-lens controls", () => {
+  const root = new FakeRoot();
+  const typeScope = new FakeElement({ scope: "type" });
+  const metadata = new FakeElement({ lens: "metadata" });
+  root.add("[data-scope]", typeScope);
+  root.add("[data-lens]", metadata);
+  const calls: string[] = [];
+  bindScopeBar(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  typeScope.dispatch("click");
+  metadata.dispatch("click");
+
+  assert.deepEqual(calls, ["scope:type", "type:metadata"]);
+});
+
+test("member scope bindings dispatch only scope and member-section controls", () => {
+  const root = new FakeRoot();
+  const memberScope = new FakeElement({ scope: "member" });
+  const facts = new FakeElement({ memberSection: "facts" });
+  root.add("[data-scope]", memberScope);
+  root.add("[data-member-section]", facts);
+  const calls: string[] = [];
+  bindScopeBar(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  memberScope.dispatch("click");
+  facts.dispatch("click");
+
+  assert.deepEqual(calls, ["scope:member", "member:facts"]);
+});
+
+test("scope bar binding tolerates an empty strip", () => {
+  const root = new FakeRoot();
+  assert.doesNotThrow(() => bindScopeBar(
+    root as unknown as ParentNode,
+    recordingActions([])));
+});
 
 test("package scope marks only the package segment and the active package lens", () => {
   const html = renderScopeBar({

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -198,6 +198,9 @@ const graphSource = readFileSync(
 const typePanelSource = readFileSync(
   new URL("../src/type-panel.ts", import.meta.url),
   "utf8");
+const scopeBarSource = readFileSync(
+  new URL("../src/scope-bar.ts", import.meta.url),
+  "utf8");
 const packageBarSource = readFileSync(
   new URL("../src/package-bar.ts", import.meta.url),
   "utf8");
@@ -408,6 +411,23 @@ test("typed type panel owns its rendered control bindings", () => {
     });
   assert.equal(selectorCount("#type-filter"), 1);
   assert.equal(selectorCount("#type-list"), 5);
+});
+
+test("typed scope bar owns its rendered control bindings", () => {
+  assert.match(
+    appSource,
+    /function bindScopeBarEvents\(\) \{\s*bindScopeBar\(document, \{/);
+  assert.match(
+    scopeBarSource,
+    /export function bindScopeBar\([\s\S]*\[data-scope\][\s\S]*\[data-package-lens\][\s\S]*\[data-lens\][\s\S]*\[data-member-section\]/);
+  for (const selector of [
+    "[data-scope]",
+    "[data-package-lens]",
+    "[data-lens]",
+    "[data-member-section]",
+  ]) {
+    assert.equal(appSource.split(selector).length - 1, 0, selector);
+  }
 });
 
 test("leaving package search clears its pending loading state", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -4,6 +4,8 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { parseSync, visitorKeys } from "oxc-parser";
+
 import {
   activeSourceOperationKind,
   assemblyDescriptorForType,
@@ -159,6 +161,78 @@ test("normalizing a history entry keeps its consumed position and later entries"
 });
 
 const appSource = readFileSync(new URL("../src/dotnet-inspect.ts", import.meta.url), "utf8");
+const parsedAppSource = parseSync("dotnet-inspect.ts", appSource);
+const appSyntax = parsedAppSource.program;
+
+function walkSyntax(node, visit) {
+  if (!node) return;
+  visit(node);
+  for (const key of visitorKeys[node.type] ?? []) {
+    const child = node[key];
+    if (Array.isArray(child)) {
+      for (const item of child) walkSyntax(item, visit);
+    } else if (child) {
+      walkSyntax(child, visit);
+    }
+  }
+}
+
+function syntaxNodes(root, predicate) {
+  const matches = [];
+  walkSyntax(root, node => {
+    if (predicate(node)) matches.push(node);
+  });
+  return matches;
+}
+
+function onlySyntaxNode(nodes, description) {
+  assert.equal(nodes.length, 1, description);
+  return nodes[0];
+}
+
+function functionDeclaration(name) {
+  return onlySyntaxNode(
+    appSyntax.body.filter(
+      node => node.type === "FunctionDeclaration" && node.id?.name === name),
+    `${name} declaration`);
+}
+
+function callExpressionsNamed(root, name) {
+  return syntaxNodes(
+    root,
+    node => node.type === "CallExpression"
+      && node.callee?.type === "Identifier"
+      && node.callee.name === name);
+}
+
+function sourceText(node) {
+  return appSource.slice(node.start, node.end).replace(/\s+/g, " ");
+}
+
+function callbackProperty(actions, name) {
+  const property = onlySyntaxNode(
+    actions.properties.filter(
+      item => item.type === "Property"
+        && item.key.type === "Identifier"
+        && item.key.name === name),
+    `${name} callback`);
+  assert.equal(property.value.type, "ArrowFunctionExpression");
+  assert.equal(property.value.body.type, "BlockStatement");
+  return property.value;
+}
+
+function syntaxEffects(root) {
+  const effects = [];
+  walkSyntax(root, node => {
+    if (node.type === "AssignmentExpression") {
+      effects.push(`assign:${sourceText(node.left)} = ${sourceText(node.right)}`);
+    } else if (node.type === "CallExpression" && node.callee?.type === "Identifier") {
+      effects.push(`call:${node.callee.name}(${node.arguments.map(sourceText).join(", ")})`);
+    }
+  });
+  return effects;
+}
+
 const workspaceNavigationSource = readFileSync(
   new URL("../src/workspace-navigation.ts", import.meta.url),
   "utf8");
@@ -414,21 +488,98 @@ test("typed type panel owns its rendered control bindings", () => {
 });
 
 test("typed scope bar owns its rendered control bindings", () => {
-  const rootEventBinder =
-    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
-    ?? "";
-  assert.match(
-    appSource,
-    /function bindScopeBarEvents\(\) \{\s*bindScopeBar\(document, \{/);
+  assert.deepEqual(parsedAppSource.errors, []);
+  const rootEventBinder = functionDeclaration("bindEvents");
+  const scopeEventBinder = functionDeclaration("bindScopeBarEvents");
+  const rootScopeCalls = callExpressionsNamed(appSyntax, "bindScopeBarEvents");
+  const innerScopeCalls = callExpressionsNamed(appSyntax, "bindScopeBar");
+  assert.equal(rootScopeCalls.length, 1);
+  assert.equal(rootScopeCalls[0].arguments.length, 0);
+  assert.equal(innerScopeCalls.length, 1);
+  const innerScopeCall = innerScopeCalls[0];
+  assert.equal(innerScopeCall.arguments.length, 2);
+  assert.equal(innerScopeCall.arguments[0].type, "Identifier");
+  assert.equal(innerScopeCall.arguments[0].name, "document");
+  assert.equal(innerScopeCall.arguments[1].type, "ObjectExpression");
   assert.equal(
-    appSource.match(/\bbindScopeBarEvents\b/g)?.length,
-    2);
-  assert.equal(
-    rootEventBinder.match(/\bbindScopeBarEvents\(\)/g)?.length,
+    callExpressionsNamed(scopeEventBinder, "bindScopeBar").length,
     1);
-  assert.match(
-    rootEventBinder,
-    /bindTypePanelEvents\(\);\s*bindScopeBarEvents\(\);/);
+  assert.equal(
+    callExpressionsNamed(rootEventBinder, "bindScopeBarEvents").length,
+    1);
+  const directCallName = statement =>
+    statement.type === "ExpressionStatement"
+      && statement.expression.type === "CallExpression"
+      && statement.expression.callee?.type === "Identifier"
+      ? statement.expression.callee.name
+      : null;
+  const directRootCalls = rootEventBinder.body.body.map(directCallName);
+  const typePanelIndex = directRootCalls.indexOf("bindTypePanelEvents");
+  assert.notEqual(typePanelIndex, -1);
+  assert.equal(directRootCalls[typePanelIndex + 1], "bindScopeBarEvents");
+
+  const actions = innerScopeCall.arguments[1];
+  const memberSection = callbackProperty(actions, "onMemberSectionSelect");
+  assert.equal(memberSection.body.body.length, 1);
+  assert.equal(memberSection.body.body[0].type, "IfStatement");
+  assert.equal(
+    sourceText(memberSection.body.body[0].test),
+    "section && isMemberSection(section)");
+  assert.deepEqual(
+    syntaxEffects(memberSection.body),
+    [
+      "call:isMemberSection(section)",
+      "call:applyMemberSection(section)",
+    ]);
+
+  const packageLens = callbackProperty(actions, "onPackageLensSelect");
+  assert.deepEqual(
+    syntaxEffects(packageLens.body),
+    [
+      "assign:state.packageLens = lens",
+      "call:render()",
+    ]);
+
+  const scope = callbackProperty(actions, "onScopeSelect");
+  assert.equal(scope.body.body.length, 2);
+  const packageBranch = scope.body.body[0];
+  assert.equal(packageBranch.type, "IfStatement");
+  assert.equal(sourceText(packageBranch.test), 'target === "package"');
+  assert.deepEqual(
+    syntaxEffects(packageBranch.consequent),
+    ["assign:state.atPackageRoot = true"]);
+  const typeBranch = packageBranch.alternate;
+  assert.equal(typeBranch.type, "IfStatement");
+  assert.equal(sourceText(typeBranch.test), 'target === "type"');
+  assert.deepEqual(
+    syntaxEffects(typeBranch.consequent),
+    [
+      "assign:state.atPackageRoot = false",
+      "call:filteredTypes()",
+      "assign:state.selectedTypeId = first.id",
+      'assign:state.selectedMemberKey = ""',
+      'assign:state.memberBrowseTypeId = ""',
+      "assign:state.selectedOverloadIndex = null",
+    ]);
+  const memberBranch = typeBranch.alternate;
+  assert.equal(memberBranch.type, "IfStatement");
+  assert.equal(sourceText(memberBranch.test), 'target === "member"');
+  assert.deepEqual(
+    syntaxEffects(memberBranch.consequent),
+    ["call:enterMemberScope()"]);
+  assert.deepEqual(
+    syntaxEffects(scope.body.body[1]),
+    ["call:render()"]);
+
+  const typeLens = callbackProperty(actions, "onTypeLensSelect");
+  assert.deepEqual(
+    syntaxEffects(typeLens.body),
+    [
+      "assign:state.lens = lens",
+      'assign:state.selectedMemberKey = ""',
+      'assign:state.memberBrowseTypeId = ""',
+      "call:render()",
+    ]);
   assert.match(
     scopeBarSource,
     /export function bindScopeBar\([\s\S]*\[data-scope\][\s\S]*\[data-package-lens\][\s\S]*\[data-lens\][\s\S]*\[data-member-section\]/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -221,16 +221,52 @@ function callbackProperty(actions, name) {
   return property.value;
 }
 
-function syntaxEffects(root) {
-  const effects = [];
-  walkSyntax(root, node => {
-    if (node.type === "AssignmentExpression") {
-      effects.push(`assign:${sourceText(node.left)} = ${sourceText(node.right)}`);
-    } else if (node.type === "CallExpression" && node.callee?.type === "Identifier") {
-      effects.push(`call:${node.callee.name}(${node.arguments.map(sourceText).join(", ")})`);
+function directCallExpression(statement, name) {
+  if (statement.type !== "ExpressionStatement") return null;
+  const expression = statement.expression;
+  return expression.type === "CallExpression"
+    && expression.callee?.type === "Identifier"
+    && expression.callee.name === name
+    ? expression
+    : null;
+}
+
+function statementSignatures(statements) {
+  return statements.map(statementSignature);
+}
+
+function branchSignatures(branch) {
+  return branch.type === "BlockStatement"
+    ? statementSignatures(branch.body)
+    : [statementSignature(branch)];
+}
+
+function statementSignature(statement) {
+  if (statement.type === "ExpressionStatement") {
+    const expression = statement.expression;
+    if (expression.type === "AssignmentExpression") {
+      return `assign:${sourceText(expression.left)} ${expression.operator} ${sourceText(expression.right)}`;
     }
-  });
-  return effects;
+    if (expression.type === "CallExpression" && expression.callee?.type === "Identifier") {
+      return `call:${expression.callee.name}(${expression.arguments.map(sourceText).join(", ")})`;
+    }
+    return `expression:${sourceText(expression)}`;
+  }
+  if (statement.type === "IfStatement") {
+    return {
+      if: sourceText(statement.test),
+      whenTrue: branchSignatures(statement.consequent),
+      whenFalse: statement.alternate ? branchSignatures(statement.alternate) : [],
+    };
+  }
+  if (statement.type === "VariableDeclaration"
+      && statement.declarations.length === 1) {
+    const declaration = statement.declarations[0];
+    if (declaration.id.type === "Identifier" && declaration.init) {
+      return `declare:${statement.kind} ${declaration.id.name} = ${sourceText(declaration.init)}`;
+    }
+  }
+  return `statement:${statement.type}:${sourceText(statement)}`;
 }
 
 const workspaceNavigationSource = readFileSync(
@@ -504,6 +540,10 @@ test("typed scope bar owns its rendered control bindings", () => {
   assert.equal(
     callExpressionsNamed(scopeEventBinder, "bindScopeBar").length,
     1);
+  assert.equal(scopeEventBinder.body.body.length, 1);
+  assert.equal(
+    directCallExpression(scopeEventBinder.body.body[0], "bindScopeBar"),
+    innerScopeCall);
   assert.equal(
     callExpressionsNamed(rootEventBinder, "bindScopeBarEvents").length,
     1);
@@ -520,60 +560,68 @@ test("typed scope bar owns its rendered control bindings", () => {
 
   const actions = innerScopeCall.arguments[1];
   const memberSection = callbackProperty(actions, "onMemberSectionSelect");
-  assert.equal(memberSection.body.body.length, 1);
-  assert.equal(memberSection.body.body[0].type, "IfStatement");
-  assert.equal(
-    sourceText(memberSection.body.body[0].test),
-    "section && isMemberSection(section)");
   assert.deepEqual(
-    syntaxEffects(memberSection.body),
+    statementSignatures(memberSection.body.body),
     [
-      "call:isMemberSection(section)",
-      "call:applyMemberSection(section)",
+      {
+        if: "section && isMemberSection(section)",
+        whenTrue: ["call:applyMemberSection(section)"],
+        whenFalse: [],
+      },
     ]);
 
   const packageLens = callbackProperty(actions, "onPackageLensSelect");
   assert.deepEqual(
-    syntaxEffects(packageLens.body),
+    statementSignatures(packageLens.body.body),
     [
       "assign:state.packageLens = lens",
       "call:render()",
     ]);
 
   const scope = callbackProperty(actions, "onScopeSelect");
-  assert.equal(scope.body.body.length, 2);
-  const packageBranch = scope.body.body[0];
-  assert.equal(packageBranch.type, "IfStatement");
-  assert.equal(sourceText(packageBranch.test), 'target === "package"');
   assert.deepEqual(
-    syntaxEffects(packageBranch.consequent),
-    ["assign:state.atPackageRoot = true"]);
-  const typeBranch = packageBranch.alternate;
-  assert.equal(typeBranch.type, "IfStatement");
-  assert.equal(sourceText(typeBranch.test), 'target === "type"');
-  assert.deepEqual(
-    syntaxEffects(typeBranch.consequent),
+    statementSignatures(scope.body.body),
     [
-      "assign:state.atPackageRoot = false",
-      "call:filteredTypes()",
-      "assign:state.selectedTypeId = first.id",
-      'assign:state.selectedMemberKey = ""',
-      'assign:state.memberBrowseTypeId = ""',
-      "assign:state.selectedOverloadIndex = null",
+      {
+        if: 'target === "package"',
+        whenTrue: ["assign:state.atPackageRoot = true"],
+        whenFalse: [
+          {
+            if: 'target === "type"',
+            whenTrue: [
+              "assign:state.atPackageRoot = false",
+              {
+                if: "!state.selectedTypeId",
+                whenTrue: [
+                  "declare:const first = filteredTypes()[0]",
+                  {
+                    if: "first",
+                    whenTrue: ["assign:state.selectedTypeId = first.id"],
+                    whenFalse: [],
+                  },
+                ],
+                whenFalse: [],
+              },
+              'assign:state.selectedMemberKey = ""',
+              'assign:state.memberBrowseTypeId = ""',
+              "assign:state.selectedOverloadIndex = null",
+            ],
+            whenFalse: [
+              {
+                if: 'target === "member"',
+                whenTrue: ["call:enterMemberScope()"],
+                whenFalse: [],
+              },
+            ],
+          },
+        ],
+      },
+      "call:render()",
     ]);
-  const memberBranch = typeBranch.alternate;
-  assert.equal(memberBranch.type, "IfStatement");
-  assert.equal(sourceText(memberBranch.test), 'target === "member"');
-  assert.deepEqual(
-    syntaxEffects(memberBranch.consequent),
-    ["call:enterMemberScope()"]);
-  assert.deepEqual(
-    syntaxEffects(scope.body.body[1]),
-    ["call:render()"]);
 
   const typeLens = callbackProperty(actions, "onTypeLensSelect");
   assert.deepEqual(
-    syntaxEffects(typeLens.body),
+    statementSignatures(typeLens.body.body),
     [
       "assign:state.lens = lens",
       'assign:state.selectedMemberKey = ""',

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -414,9 +414,21 @@ test("typed type panel owns its rendered control bindings", () => {
 });
 
 test("typed scope bar owns its rendered control bindings", () => {
+  const rootEventBinder =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
   assert.match(
     appSource,
     /function bindScopeBarEvents\(\) \{\s*bindScopeBar\(document, \{/);
+  assert.equal(
+    appSource.match(/\bbindScopeBarEvents\b/g)?.length,
+    2);
+  assert.equal(
+    rootEventBinder.match(/\bbindScopeBarEvents\(\)/g)?.length,
+    1);
+  assert.match(
+    rootEventBinder,
+    /bindTypePanelEvents\(\);\s*bindScopeBarEvents\(\);/);
   assert.match(
     scopeBarSource,
     /export function bindScopeBar\([\s\S]*\[data-scope\][\s\S]*\[data-package-lens\][\s\S]*\[data-lens\][\s\S]*\[data-member-section\]/);


### PR DESCRIPTION
Pairs the Package/Types/Member scope switcher and its mutually exclusive package lens, type lens, and member-section controls with `scope-bar.ts`, the module that renders them. `dotnet-inspect.ts` retains authoritative scope, lens, selection, rendering, and navigation state transitions behind typed callbacks; selector authority moves without changing visible behavior.

**Stack**

- Slice 12, stacked on #4519.
- Parent: #4519 (type panel DOM binding).
- Residual: DOM event binding for package surfaces, member detail controls, metadata explorer, and overlays paired with their existing presentation owners.

**Validation**

- `npm test` — 401/401, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.

Progresses #4504.