### PR TITLE
Pair settings panel with DOM bindings

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -731,13 +731,13 @@ workspace authority. `test/package-bar.test.ts` gates tab markup, active/close
 state, escaping, and open-package query parsing.
 
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
-popover it shares its style catalog with, as pure, dependency-injected render
-functions. `dotnet-inspect.ts` still owns `state`, localStorage persistence for theme and
-taste, and event wiring (`setTheme`, `toggleTaste`, `clearTaste`), and passes
-each computed slice in explicitly. `test/settings-panel.test.ts` gates the
-style catalog's tier grouping, byte-divergent badges, and checked state; the
-taste popover's active/default states; and the Settings page's theme segment,
-close-button label, and active-style-count states.
+popover it shares its style catalog with, including each surface's rendered DOM
+bindings. `dotnet-inspect.ts` still owns `state`, localStorage persistence, and
+the theme/taste/close effects, supplying those actions through typed callbacks.
+`test/settings-panel.test.ts` gates the mutually exclusive Settings and popover
+binding shapes, input validation, the style catalog's tier grouping,
+byte-divergent badges and checked state, the taste popover's active/default
+states, and the Settings page's theme, close, and active-style-count states.
 
 `src/scope-bar.ts` owns the scope switcher and lens strip (the segmented
 Package/Types/Member control and the buttons beside it for the active scope's

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -141,6 +141,7 @@ import {
   type PackageMetadata,
 } from "./metadata-viewer.ts";
 import {
+  bindSettingsPanel,
   renderSettingsView,
   renderTastePopover,
   type StyleOption,
@@ -3854,11 +3855,21 @@ function bindScopeBarEvents() {
   });
 }
 
+function bindSettingsPanelEvents() {
+  bindSettingsPanel(document, {
+    onClose: closeSettings,
+    onTasteClear: clearTaste,
+    onTasteToggle: toggleTaste,
+    onThemeSelect: setTheme,
+  });
+}
+
 function bindEvents() {
   bindStatusBarToggle();
   packageBar.bind(document);
   bindTypePanelEvents();
   bindScopeBarEvents();
+  bindSettingsPanelEvents();
   document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
     observeAsync(
       switchPackageFramework(button.dataset.frameworkChip ?? ""),
@@ -4272,11 +4283,6 @@ function bindEvents() {
     state.tasteOpen = !state.tasteOpen;
     render();
   });
-  document.querySelectorAll<HTMLElement>("#taste-popover [data-taste]").forEach(checkbox =>
-    checkbox.addEventListener(
-      "change",
-      () => toggleTaste(checkbox.dataset.taste ?? "")));
-  document.querySelector("#taste-clear")?.addEventListener("click", clearTaste);
   document.querySelector("#share")?.addEventListener("click", () => void share());
   document.querySelector("[data-graph-back]")?.addEventListener(
     "click",
@@ -7059,22 +7065,7 @@ function renderSettingsViewHtml() {
     },
     escapeHtml,
   });
-  bindSettingsEvents();
-}
-
-function bindSettingsEvents() {
-  document.querySelector("#settings-close")?.addEventListener("click", closeSettings);
-  document.querySelectorAll<HTMLElement>(".settings-seg[data-theme]").forEach(button =>
-    button.addEventListener("click", () => {
-      const theme = button.dataset.theme;
-      if (theme === "dark" || theme === "light") setTheme(theme);
-    }));
-  document.querySelectorAll<HTMLElement>(".settings-taste [data-taste]").forEach(checkbox =>
-    checkbox.addEventListener("change", () => {
-      const taste = checkbox.dataset.taste;
-      if (taste) toggleTaste(taste);
-    }));
-  document.querySelector("#settings-taste-clear")?.addEventListener("click", clearTaste);
+  bindSettingsPanelEvents();
 }
 
 function renderGraphSource() {

--- a/prototypes/inspect-web/src/settings-panel.ts
+++ b/prototypes/inspect-web/src/settings-panel.ts
@@ -1,7 +1,7 @@
 // The Settings page (a persistent preferences panel) and the decompiler "taste" popover it
-// shares its style catalog with. Both are pure, dependency-injected render functions: `dotnet-inspect.ts`
-// owns `state`, localStorage persistence, and event wiring (`setTheme`, `toggleTaste`,
-// `clearTaste`, `bindSettingsEvents`), and passes each computed slice in explicitly.
+// shares its style catalog with. Both are dependency-injected render functions with their
+// rendered control bindings; `dotnet-inspect.ts` owns `state`, localStorage persistence, and
+// the theme/taste effects, and passes each computed slice and action in explicitly.
 
 export interface StyleTier {
   id: string;
@@ -27,6 +27,44 @@ export interface StyleCatalogState {
 }
 
 type EscapeHtml = (value: unknown) => string;
+
+export interface SettingsPanelBindingActions {
+  onClose: () => void;
+  onTasteClear: () => void;
+  onTasteToggle: (taste: string) => void;
+  onThemeSelect: (theme: "dark" | "light") => void;
+}
+
+export function bindSettingsPanel(
+  root: ParentNode,
+  actions: SettingsPanelBindingActions,
+) {
+  root.querySelector("#settings-close")?.addEventListener(
+    "click",
+    actions.onClose);
+  root.querySelectorAll<HTMLElement>(".settings-seg[data-theme]")
+    .forEach(button => button.addEventListener("click", () => {
+      const theme = button.dataset.theme;
+      if (theme === "dark" || theme === "light") {
+        actions.onThemeSelect(theme);
+      }
+    }));
+  root.querySelectorAll<HTMLElement>(".settings-taste [data-taste]")
+    .forEach(checkbox => checkbox.addEventListener("change", () => {
+      const taste = checkbox.dataset.taste;
+      if (taste) actions.onTasteToggle(taste);
+    }));
+  root.querySelector("#settings-taste-clear")?.addEventListener(
+    "click",
+    actions.onTasteClear);
+  root.querySelectorAll<HTMLElement>("#taste-popover [data-taste]")
+    .forEach(checkbox => checkbox.addEventListener(
+      "change",
+      () => actions.onTasteToggle(checkbox.dataset.taste ?? "")));
+  root.querySelector("#taste-clear")?.addEventListener(
+    "click",
+    actions.onTasteClear);
+}
 
 // The decompiler style ("taste") catalog, grouped by tier, as checkbox rows. Shared by the
 // detail-view taste popover and the Settings page so both stay in lockstep with the engine's

--- a/prototypes/inspect-web/test/settings-panel.test.ts
+++ b/prototypes/inspect-web/test/settings-panel.test.ts
@@ -33,6 +33,7 @@ class FakeElement {
 class FakeRoot {
   private readonly single = new Map<string, FakeElement>();
   private readonly multiple = new Map<string, FakeElement[]>();
+  private readonly selectorQueries: string[] = [];
 
   add(selector: string, element: FakeElement) {
     this.single.set(selector, element);
@@ -45,11 +46,26 @@ class FakeRoot {
   }
 
   querySelector(selector: string) {
+    this.selectorQueries.push(`one:${selector}`);
     return this.single.get(selector) ?? null;
   }
 
   querySelectorAll(selector: string) {
+    this.selectorQueries.push(`all:${selector}`);
     return this.multiple.get(selector) ?? [];
+  }
+
+  assertSelectorQueries() {
+    assert.deepEqual(
+      [...this.selectorQueries].sort(),
+      [
+        "all:#taste-popover [data-taste]",
+        "all:.settings-seg[data-theme]",
+        "all:.settings-taste [data-taste]",
+        "one:#settings-close",
+        "one:#settings-taste-clear",
+        "one:#taste-clear",
+      ].sort());
   }
 }
 
@@ -99,6 +115,7 @@ test("settings bindings dispatch valid settings-page controls", () => {
   bindSettingsPanel(
     fakeDom.parentNode(root),
     recordingActions(calls));
+  root.assertSelectorQueries();
 
   close.dispatch("click");
   dark.dispatch("click");
@@ -127,6 +144,7 @@ test("taste popover bindings dispatch its optional controls", () => {
   bindSettingsPanel(
     fakeDom.parentNode(root),
     recordingActions(calls));
+  root.assertSelectorQueries();
 
   taste.dispatch("change");
   missingTaste.dispatch("change");
@@ -144,6 +162,7 @@ test("settings binding tolerates controls from the inactive surface being absent
   assert.doesNotThrow(() => bindSettingsPanel(
     fakeDom.parentNode(root),
     recordingActions([])));
+  root.assertSelectorQueries();
 });
 
 test("style catalog groups render tiers, byte-divergent badges, and checked state", () => {

--- a/prototypes/inspect-web/test/settings-panel.test.ts
+++ b/prototypes/inspect-web/test/settings-panel.test.ts
@@ -7,6 +7,7 @@ import {
   type SettingsPanelBindingActions,
   styleCatalogGroupsHtml,
 } from "../src/settings-panel.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;
@@ -24,7 +25,7 @@ class FakeElement {
 
   dispatch(type: string) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({} as Event);
+      listener(fakeDom.event());
     }
   }
 }
@@ -96,7 +97,7 @@ test("settings bindings dispatch valid settings-page controls", () => {
   const clear = root.add("#settings-taste-clear", new FakeElement());
   const calls: string[] = [];
   bindSettingsPanel(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   close.dispatch("click");
@@ -124,7 +125,7 @@ test("taste popover bindings dispatch its optional controls", () => {
   const clear = root.add("#taste-clear", new FakeElement());
   const calls: string[] = [];
   bindSettingsPanel(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   taste.dispatch("change");
@@ -141,7 +142,7 @@ test("taste popover bindings dispatch its optional controls", () => {
 test("settings binding tolerates controls from the inactive surface being absent", () => {
   const root = new FakeRoot();
   assert.doesNotThrow(() => bindSettingsPanel(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions([])));
 });
 

--- a/prototypes/inspect-web/test/settings-panel.test.ts
+++ b/prototypes/inspect-web/test/settings-panel.test.ts
@@ -1,10 +1,65 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  bindSettingsPanel,
   renderSettingsView,
   renderTastePopover,
+  type SettingsPanelBindingActions,
   styleCatalogGroupsHtml,
 } from "../src/settings-panel.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({} as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+    return element;
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+    return elements;
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+function recordingActions(calls: string[]): SettingsPanelBindingActions {
+  return {
+    onClose: () => calls.push("close"),
+    onTasteClear: () => calls.push("clear"),
+    onTasteToggle: taste => calls.push(`taste:${taste}`),
+    onThemeSelect: theme => calls.push(`theme:${theme}`),
+  };
+}
 
 function escapeHtml(value: unknown) {
   return String(value)
@@ -23,6 +78,72 @@ const styleOptions = [
   { id: "readable-locals", tier: "naming", title: "Readable local names", summary: "Synthesize readable local names.", oracle_endorsed: true },
   { id: "expanded-braces", tier: "layout", title: "Expanded braces", summary: "Always use braces." },
 ];
+
+test("settings bindings dispatch valid settings-page controls", () => {
+  const root = new FakeRoot();
+  const close = root.add("#settings-close", new FakeElement());
+  const dark = new FakeElement({ theme: "dark" });
+  const light = new FakeElement({ theme: "light" });
+  const invalidTheme = new FakeElement({ theme: "system" });
+  root.addAll(
+    ".settings-seg[data-theme]",
+    dark,
+    light,
+    invalidTheme);
+  const taste = new FakeElement({ taste: "readable-locals" });
+  const missingTaste = new FakeElement();
+  root.addAll(".settings-taste [data-taste]", taste, missingTaste);
+  const clear = root.add("#settings-taste-clear", new FakeElement());
+  const calls: string[] = [];
+  bindSettingsPanel(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  close.dispatch("click");
+  dark.dispatch("click");
+  light.dispatch("click");
+  invalidTheme.dispatch("click");
+  taste.dispatch("change");
+  missingTaste.dispatch("change");
+  clear.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "close",
+    "theme:dark",
+    "theme:light",
+    "taste:readable-locals",
+    "clear",
+  ]);
+});
+
+test("taste popover bindings dispatch its optional controls", () => {
+  const root = new FakeRoot();
+  const taste = new FakeElement({ taste: "expanded-braces" });
+  const missingTaste = new FakeElement();
+  root.addAll("#taste-popover [data-taste]", taste, missingTaste);
+  const clear = root.add("#taste-clear", new FakeElement());
+  const calls: string[] = [];
+  bindSettingsPanel(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  taste.dispatch("change");
+  missingTaste.dispatch("change");
+  clear.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "taste:expanded-braces",
+    "taste:",
+    "clear",
+  ]);
+});
+
+test("settings binding tolerates controls from the inactive surface being absent", () => {
+  const root = new FakeRoot();
+  assert.doesNotThrow(() => bindSettingsPanel(
+    root as unknown as ParentNode,
+    recordingActions([])));
+});
 
 test("style catalog groups render tiers, byte-divergent badges, and checked state", () => {
   const html = styleCatalogGroupsHtml(

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -651,6 +651,12 @@ test("typed settings panel owns its rendered control bindings", () => {
   const settingsEventBinder = functionDeclaration("bindSettingsPanelEvents");
   const eventBinderCalls = callExpressionsNamed(appSyntax, "bindSettingsPanelEvents");
   assert.equal(eventBinderCalls.length, 2);
+  assert.equal(
+    syntaxNodes(
+      appSyntax,
+      node => node.type === "Identifier"
+        && node.name === "bindSettingsPanelEvents").length,
+    3);
   for (const [owner, description] of [
     [bindEvents, "workbench settings binder"],
     [renderSettings, "settings view binder"],
@@ -667,6 +673,19 @@ test("typed settings panel owns its rendered control bindings", () => {
       1,
       `${description} direct call`);
   }
+  assert.equal(renderSettings.body.body.length, 2);
+  const renderStatement = renderSettings.body.body[0];
+  assert.equal(renderStatement.type, "ExpressionStatement");
+  assert.equal(renderStatement.expression.type, "AssignmentExpression");
+  assert.equal(renderStatement.expression.operator, "=");
+  assert.equal(sourceText(renderStatement.expression.left), "app.innerHTML");
+  assert.equal(renderStatement.expression.right.type, "CallExpression");
+  assert.equal(renderStatement.expression.right.callee.type, "Identifier");
+  assert.equal(renderStatement.expression.right.callee.name, "renderSettingsView");
+  assert.ok(
+    directCallExpression(
+      renderSettings.body.body[1],
+      "bindSettingsPanelEvents"));
 
   const innerSettingsCalls = callExpressionsNamed(appSyntax, "bindSettingsPanel");
   assert.equal(innerSettingsCalls.length, 1);
@@ -680,6 +699,7 @@ test("typed settings panel owns its rendered control bindings", () => {
   assert.equal(innerSettingsCall.arguments[0].name, "document");
   const actions = innerSettingsCall.arguments[1];
   assert.equal(actions.type, "ObjectExpression");
+  assert.equal(actions.properties.length, 4);
   for (const [name, value] of [
     ["onClose", "closeSettings"],
     ["onTasteClear", "clearTaste"],

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -645,9 +645,27 @@ test("typed scope bar owns its rendered control bindings", () => {
 });
 
 test("typed settings panel owns its rendered control bindings", () => {
+  const bindEvents =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
+  const renderSettings =
+    appSource.match(/function renderSettingsViewHtml\(\) \{[\s\S]*?\n}\n\nfunction renderGraphSource/)?.[0]
+    ?? "";
   assert.match(
     appSource,
-    /function bindSettingsPanelEvents\(\) \{\s*bindSettingsPanel\(document, \{/);
+    /function bindSettingsPanelEvents\(\) \{\s*bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onTasteClear: clearTaste,\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,/);
+  assert.equal(
+    appSource.match(/\bbindSettingsPanelEvents\b/g)?.length,
+    3);
+  assert.equal(
+    appSource.match(/\bbindSettingsPanel\b/g)?.length,
+    2);
+  assert.equal(
+    bindEvents.match(/\bbindSettingsPanelEvents\(\)/g)?.length,
+    1);
+  assert.equal(
+    renderSettings.match(/\bbindSettingsPanelEvents\(\)/g)?.length,
+    1);
   assert.match(
     settingsPanelSource,
     /export function bindSettingsPanel\([\s\S]*#settings-close[\s\S]*\.settings-seg\[data-theme\][\s\S]*\.settings-taste \[data-taste\][\s\S]*#settings-taste-clear[\s\S]*#taste-popover \[data-taste\][\s\S]*#taste-clear/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -673,6 +673,17 @@ test("typed settings panel owns its rendered control bindings", () => {
       1,
       `${description} direct call`);
   }
+  const directWorkbenchCalls = bindEvents.body.body.map(statement => {
+    if (statement.type !== "ExpressionStatement") return null;
+    const expression = statement.expression;
+    return expression.type === "CallExpression"
+      && expression.callee?.type === "Identifier"
+      ? expression.callee.name
+      : null;
+  });
+  assert.equal(
+    directWorkbenchCalls.indexOf("bindSettingsPanelEvents"),
+    directWorkbenchCalls.indexOf("bindScopeBarEvents") + 1);
   assert.equal(renderSettings.body.body.length, 2);
   const renderStatement = renderSettings.body.body[0];
   assert.equal(renderStatement.type, "ExpressionStatement");

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -645,27 +645,56 @@ test("typed scope bar owns its rendered control bindings", () => {
 });
 
 test("typed settings panel owns its rendered control bindings", () => {
-  const bindEvents =
-    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
-    ?? "";
-  const renderSettings =
-    appSource.match(/function renderSettingsViewHtml\(\) \{[\s\S]*?\n}\n\nfunction renderGraphSource/)?.[0]
-    ?? "";
-  assert.match(
-    appSource,
-    /function bindSettingsPanelEvents\(\) \{\s*bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onTasteClear: clearTaste,\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,/);
+  assert.deepEqual(parsedAppSource.errors, []);
+  const bindEvents = functionDeclaration("bindEvents");
+  const renderSettings = functionDeclaration("renderSettingsViewHtml");
+  const settingsEventBinder = functionDeclaration("bindSettingsPanelEvents");
+  const eventBinderCalls = callExpressionsNamed(appSyntax, "bindSettingsPanelEvents");
+  assert.equal(eventBinderCalls.length, 2);
+  for (const [owner, description] of [
+    [bindEvents, "workbench settings binder"],
+    [renderSettings, "settings view binder"],
+  ]) {
+    assert.equal(
+      callExpressionsNamed(owner, "bindSettingsPanelEvents").length,
+      1,
+      description);
+    assert.equal(
+      owner.body.body
+        .map(statement => directCallExpression(statement, "bindSettingsPanelEvents"))
+        .filter(Boolean)
+        .length,
+      1,
+      `${description} direct call`);
+  }
+
+  const innerSettingsCalls = callExpressionsNamed(appSyntax, "bindSettingsPanel");
+  assert.equal(innerSettingsCalls.length, 1);
+  const innerSettingsCall = innerSettingsCalls[0];
+  assert.equal(settingsEventBinder.body.body.length, 1);
   assert.equal(
-    appSource.match(/\bbindSettingsPanelEvents\b/g)?.length,
-    3);
-  assert.equal(
-    appSource.match(/\bbindSettingsPanel\b/g)?.length,
-    2);
-  assert.equal(
-    bindEvents.match(/\bbindSettingsPanelEvents\(\)/g)?.length,
-    1);
-  assert.equal(
-    renderSettings.match(/\bbindSettingsPanelEvents\(\)/g)?.length,
-    1);
+    directCallExpression(settingsEventBinder.body.body[0], "bindSettingsPanel"),
+    innerSettingsCall);
+  assert.equal(innerSettingsCall.arguments.length, 2);
+  assert.equal(innerSettingsCall.arguments[0].type, "Identifier");
+  assert.equal(innerSettingsCall.arguments[0].name, "document");
+  const actions = innerSettingsCall.arguments[1];
+  assert.equal(actions.type, "ObjectExpression");
+  for (const [name, value] of [
+    ["onClose", "closeSettings"],
+    ["onTasteClear", "clearTaste"],
+    ["onTasteToggle", "toggleTaste"],
+    ["onThemeSelect", "setTheme"],
+  ]) {
+    const property = onlySyntaxNode(
+      actions.properties.filter(
+        item => item.type === "Property"
+          && item.key.type === "Identifier"
+          && item.key.name === name),
+      `${name} settings action`);
+    assert.equal(property.value.type, "Identifier");
+    assert.equal(property.value.name, value);
+  }
   assert.match(
     settingsPanelSource,
     /export function bindSettingsPanel\([\s\S]*#settings-close[\s\S]*\.settings-seg\[data-theme\][\s\S]*\.settings-taste \[data-taste\][\s\S]*#settings-taste-clear[\s\S]*#taste-popover \[data-taste\][\s\S]*#taste-clear/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -311,6 +311,9 @@ const typePanelSource = readFileSync(
 const scopeBarSource = readFileSync(
   new URL("../src/scope-bar.ts", import.meta.url),
   "utf8");
+const settingsPanelSource = readFileSync(
+  new URL("../src/settings-panel.ts", import.meta.url),
+  "utf8");
 const packageBarSource = readFileSync(
   new URL("../src/package-bar.ts", import.meta.url),
   "utf8");
@@ -636,6 +639,25 @@ test("typed scope bar owns its rendered control bindings", () => {
     "[data-package-lens]",
     "[data-lens]",
     "[data-member-section]",
+  ]) {
+    assert.equal(appSource.split(selector).length - 1, 0, selector);
+  }
+});
+
+test("typed settings panel owns its rendered control bindings", () => {
+  assert.match(
+    appSource,
+    /function bindSettingsPanelEvents\(\) \{\s*bindSettingsPanel\(document, \{/);
+  assert.match(
+    settingsPanelSource,
+    /export function bindSettingsPanel\([\s\S]*#settings-close[\s\S]*\.settings-seg\[data-theme\][\s\S]*\.settings-taste \[data-taste\][\s\S]*#settings-taste-clear[\s\S]*#taste-popover \[data-taste\][\s\S]*#taste-clear/);
+  for (const selector of [
+    "#settings-close",
+    ".settings-seg[data-theme]",
+    ".settings-taste [data-taste]",
+    "#settings-taste-clear",
+    "#taste-popover [data-taste]",
+    "#taste-clear",
   ]) {
     assert.equal(appSource.split(selector).length - 1, 0, selector);
   }

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -649,6 +649,24 @@ test("typed settings panel owns its rendered control bindings", () => {
   const bindEvents = functionDeclaration("bindEvents");
   const renderSettings = functionDeclaration("renderSettingsViewHtml");
   const settingsEventBinder = functionDeclaration("bindSettingsPanelEvents");
+  const settingsPanelImport = onlySyntaxNode(
+    appSyntax.body.filter(
+      node => node.type === "ImportDeclaration"
+        && node.source.value === "./settings-panel.ts"),
+    "settings panel import");
+  assert.equal(
+    settingsPanelImport.specifiers.filter(
+      specifier => specifier.type === "ImportSpecifier"
+        && specifier.imported.type === "Identifier"
+        && specifier.imported.name === "bindSettingsPanel"
+        && specifier.local.name === "bindSettingsPanel").length,
+    1);
+  assert.equal(
+    syntaxNodes(
+      appSyntax,
+      node => node.type === "Identifier"
+        && node.name === "bindSettingsPanel").length,
+    3);
   const eventBinderCalls = callExpressionsNamed(appSyntax, "bindSettingsPanelEvents");
   assert.equal(eventBinderCalls.length, 2);
   assert.equal(


### PR DESCRIPTION
Pairs the Settings page and decompiler taste popover controls with `settings-panel.ts`, the module that renders both mutually exclusive surfaces. Theme-value validation, the Settings page’s non-empty taste guard, and the popover’s existing empty-value forwarding are preserved; `dotnet-inspect.ts` retains authoritative state, localStorage persistence, rerender/reload effects, and the external taste-popover opener.

**Stack**

- Slice 13, stacked on #4520.
- Parent: #4520 (scope bar DOM binding).
- Residual: DOM event binding for package surfaces, member detail controls, metadata explorer, and document/source overlays paired with their existing presentation owners.

**Validation**

- `npm test` — 405/405, including strict source and test TypeScript checks.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.

Progresses #4504.