### PR TITLE
Extract Metadata Explorer event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -751,24 +751,24 @@ keyboard-shortcut indices, and label escaping.
 `src/metadata-viewer.ts` owns the Metadata lens (the image-level summary of each
 assembly — format stamp, heap sizes, ECMA-335 table row counts, and PE/CLI
 headers) and the Metadata Explorer (the spatial table/heap drill-down laid over
-it) as pure, dependency-injected render functions; both describe the metadata
+it), including the explorer's rendered DOM bindings. Both describe the metadata
 image rather than the API surface within it, so they share one module the way
 `type-panel.ts` combines the type selector and the type viewer.
 `package-inspection.ts` coordinates the package-level image request, while
 `metadata-inspection.ts` coordinates type metadata and the explorer's
 table-window and heap-listing requests. `dotnet-inspect.ts` still owns `state`,
-the explorer's focus/history stack, the DOM event binding, the
-`IntersectionObserver` that hydrates cards lazily, the resize listener, and
-the global keydown handler, and passes each computed slice in explicitly; the
-shared helpers used well beyond these views (`escapeHtml`, `fmtBytes`,
+the explorer's focus/history stack, lazy `IntersectionObserver` hydration,
+resize coordination, and the global keydown handler, supplying those effects
+through typed callbacks; the shared helpers used well beyond these views
+(`escapeHtml`, `fmtBytes`,
 `platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`) stay
 in `dotnet-inspect.ts` and are injected the same way.
 `test/metadata-viewer.test.ts` gates the lens's picker, loading, failure,
 stale-scope, partial-read, and empty-image states and its heap/table ordering;
-the explorer's chips, history-button
-enablement, overview versus focus lightbox, lazy-load hooks, pager bounds, row
-highlight and selection, ref->def jump targets, cell escaping, heap addressing
-and coverage notes, and the row inspector.
+the explorer's mutually exclusive overview/focus binding shapes, chips,
+history-button enablement, overview versus focus lightbox, lazy-load hooks,
+pager bounds, row highlight and selection, ref->def jump targets, cell
+escaping, heap addressing and coverage notes, and the row inspector.
 
 `src/doc-viewer.ts` owns the package document modal (the Markdown reader
 opened from a package's documents list) as a pure, dependency-injected render

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -765,10 +765,11 @@ through typed callbacks; the shared helpers used well beyond these views
 in `dotnet-inspect.ts` and are injected the same way.
 `test/metadata-viewer.test.ts` gates the lens's picker, loading, failure,
 stale-scope, partial-read, and empty-image states and its heap/table ordering;
-the explorer's mutually exclusive overview/focus binding shapes, chips,
-history-button enablement, overview versus focus lightbox, lazy-load hooks,
-pager bounds, row highlight and selection, ref->def jump targets, cell
-escaping, heap addressing and coverage notes, and the row inspector.
+the Metadata-lens table/heap entry controls, the explorer's mutually exclusive
+overview/focus binding shapes, chips, history-button enablement, overview
+versus focus lightbox, lazy-load hooks, pager bounds, row highlight and
+selection, ref->def jump targets, cell escaping, heap addressing and coverage
+notes, and the row inspector.
 
 `src/doc-viewer.ts` owns the package document modal (the Markdown reader
 opened from a package's documents list) as a pure, dependency-injected render

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -127,6 +127,7 @@ import {
 } from "./type-panel.ts";
 import { createPackageBar, type PackageBarPackage } from "./package-bar.ts";
 import {
+  bindMetadataExplorer,
   cssEscape,
   estimateExplorerPageSize,
   EXPLORER_PAGE,
@@ -3037,67 +3038,32 @@ function renderMetadataExplorer() {
 let explorerObserver: IntersectionObserver | null = null;
 function bindMetadataExplorerEvents() {
   const ex = state.explorer;
-  document.querySelector("#mde-exit")?.addEventListener("click", closeExplorer);
-  document.querySelector("#mde-hist-back")?.addEventListener("click", explorerHistoryBack);
-  document.querySelector("#mde-hist-fwd")?.addEventListener("click", explorerHistoryForward);
+  bindMetadataExplorer(document, ex, {
+    onClose: closeExplorer,
+    onHistoryBack: explorerHistoryBack,
+    onHistoryForward: explorerHistoryForward,
+    onHeapFocus: heap => pushExplorerFocus({ heap }),
+    onJump: explorerJump,
+    onPage: (index, startRowId) =>
+      observeAsync(
+        loadExplorerWindow(index, startRowId),
+        "Loading metadata table rows"),
+    onRowFocus: (index, rowId) => {
+      if (!ex) return;
+      const already =
+        ex.detail && ex.detail.index === index && ex.detail.rowId === rowId;
+      ex.detail = already ? null : { index, rowId };
+      ex.highlight = already ? null : { index, rowId };
+      const current = ex.history[ex.historyPos];
+      if (current && current.index === index) {
+        current.rowId = already ? 0 : rowId;
+      }
+      render();
+    },
+    onShowOverview: explorerShowOverview,
+    onTableFocus: (index, rowId) => pushExplorerFocus({ index, rowId }),
+  });
   if (!ex) return;
-  document.querySelectorAll<HTMLElement>("[data-mde-chip]").forEach(chip =>
-    chip.addEventListener("click", () => pushExplorerFocus({ index: Number(chip.dataset.mdeChip), rowId: 0 })));
-  document.querySelectorAll<HTMLElement>("[data-mde-jump]").forEach(btn =>
-    btn.addEventListener("click", event => {
-      event.stopPropagation();
-      const [index, rowId] = (btn.dataset.mdeJump ?? "").split(":").map(Number);
-      explorerJump(index, rowId);
-    }));
-  // The corner ✕ on the focus panel zooms back out to the all-tables wall.
-  document.querySelectorAll<HTMLElement>("[data-mde-overview]").forEach(btn =>
-    btn.addEventListener("click", event => { event.stopPropagation(); explorerShowOverview(); }));
-  document.querySelectorAll<HTMLElement>("[data-mde-page]").forEach(btn =>
-    btn.addEventListener("click", () => {
-      const [index, start] = (btn.dataset.mdePage ?? "").split(":").map(Number);
-      observeAsync(loadExplorerWindow(index, start), "Loading metadata table rows");
-    }));
-  document.querySelectorAll<HTMLElement>("[data-mde-heap-chip]").forEach(chip =>
-    chip.addEventListener("click", () => {
-      const heap = chip.dataset.mdeHeapChip;
-      if (heap !== undefined) pushExplorerFocus({ heap });
-    }));
-
-  if (ex?.overview) {
-    // All-tables view: clicking a card head, a ref, or a row focuses that table.
-    document.querySelectorAll<HTMLElement>(".mde-wall .mde-card[data-mde-index] .mde-card-head").forEach(head =>
-      head.addEventListener("click", () => {
-        const card = head.closest<HTMLElement>(".mde-card");
-        if (card) pushExplorerFocus({ index: Number(card.dataset.mdeIndex), rowId: 0 });
-      }));
-    document.querySelectorAll<HTMLElement>(".mde-wall .mde-heap-card[data-mde-heap] .mde-card-head").forEach(head =>
-      head.addEventListener("click", () => {
-        const card = head.closest<HTMLElement>(".mde-heap-card");
-        const heap = card?.dataset.mdeHeap;
-        if (heap !== undefined) pushExplorerFocus({ heap });
-      }));
-    document.querySelectorAll<HTMLElement>(".mde-wall .mde-row[data-mde-row]").forEach(tr =>
-      tr.addEventListener("click", () => {
-        const [index, rowId] = (tr.dataset.mdeRow ?? "").split(":").map(Number);
-        pushExplorerFocus({ index, rowId });
-      }));
-  } else {
-    // Focus view: clicking anywhere on the dim wall behind the lightbox zooms out ("click away").
-    document.querySelector("#mde-canvas")?.addEventListener("click", explorerShowOverview);
-    // Selecting a row in the focus panel updates the inspector in place — it refines the current
-    // position (remembered for Back/Forward). Clicking the selected row again deselects it.
-    document.querySelectorAll<HTMLElement>(".mde-focus .mde-row[data-mde-row]").forEach(tr =>
-      tr.addEventListener("click", () => {
-        const [index, rowId] = (tr.dataset.mdeRow ?? "").split(":").map(Number);
-        const already = ex.detail && ex.detail.index === index && ex.detail.rowId === rowId;
-        ex.detail = already ? null : { index, rowId };
-        ex.highlight = already ? null : { index, rowId };
-        const cur = ex.history[ex.historyPos];
-        if (cur && cur.index === index) cur.rowId = already ? 0 : rowId;
-        render();
-      }));
-  }
-
   // Hydrate cards as they scroll into view (the "wall of tables filling in as you pan" feel).
   explorerObserver?.disconnect();
   const observer = new IntersectionObserver(entries => {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3022,8 +3022,7 @@ function syncExplorerPageSize() {
   }
 }
 
-// Renders the explorer surface owned by metadata-viewer.ts, then binds its events. The state
-// snapshot is passed explicitly; the module owns markup only.
+// Renders the explorer surface owned by metadata-viewer.ts, then binds its events.
 function renderMetadataExplorer() {
   const explorer = state.explorer;
   if (!explorer) return;
@@ -3032,11 +3031,11 @@ function renderMetadataExplorer() {
     escapeHtml,
     fmtBytes,
   });
-  bindMetadataExplorerEvents();
+  bindMetadataViewerEvents();
 }
 
 let explorerObserver: IntersectionObserver | null = null;
-function bindMetadataExplorerEvents() {
+function bindMetadataViewerEvents() {
   const ex = state.explorer;
   bindMetadataExplorer(document, ex, {
     onClose: closeExplorer,
@@ -3044,6 +3043,8 @@ function bindMetadataExplorerEvents() {
     onHistoryForward: explorerHistoryForward,
     onHeapFocus: heap => pushExplorerFocus({ heap }),
     onJump: explorerJump,
+    onOpenHeap: openExplorerHeap,
+    onOpenTable: openExplorer,
     onPage: (index, startRowId) =>
       observeAsync(
         loadExplorerWindow(index, startRowId),
@@ -3836,6 +3837,7 @@ function bindEvents() {
   bindTypePanelEvents();
   bindScopeBarEvents();
   bindSettingsPanelEvents();
+  bindMetadataViewerEvents();
   document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
     observeAsync(
       switchPackageFramework(button.dataset.frameworkChip ?? ""),
@@ -4194,18 +4196,6 @@ function bindEvents() {
   bindPlatformLensPicker("data-platform-opportunities-library", "opportunities", loadPackageOpportunities);
   bindPlatformLensPicker("data-platform-analysis-library", "analysis", loadPackagePerformance);
   bindPlatformLensPicker("data-platform-metadata-library", "metadata", loadPackageMetadata);
-  document.querySelectorAll<HTMLElement>("[data-mde-open]").forEach(btn =>
-    btn.addEventListener("click", () => {
-      const [assembly = "", tableIndex = "0"] =
-        (btn.dataset.mdeOpen ?? "").split("|");
-      openExplorer(assembly, Number(tableIndex));
-    }));
-  document.querySelectorAll<HTMLElement>("[data-mde-open-heap]").forEach(btn =>
-    btn.addEventListener("click", () => {
-      const [assembly = "", heapName = ""] =
-        (btn.dataset.mdeOpenHeap ?? "").split("|");
-      openExplorerHeap(assembly, heapName);
-    }));
   const frameworkSelect = document.querySelector<HTMLSelectElement>("#framework");
   frameworkSelect?.addEventListener("change", () => {
     observeAsync(

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -201,7 +201,7 @@ export interface MetadataExplorerBindingActions {
   onClose: () => void;
   onHistoryBack: () => void;
   onHistoryForward: () => void;
-  onHeapFocus: (heap: string | undefined) => void;
+  onHeapFocus: (heap: string) => void;
   onJump: (index: number, rowId: number) => void;
   onOpenHeap: (assembly: string, heap: string) => void;
   onOpenTable: (assembly: string, index: number) => void;
@@ -260,9 +260,10 @@ export function bindMetadataExplorer(
       actions.onPage(index, startRowId);
     }));
   root.querySelectorAll<HTMLElement>("[data-mde-heap-chip]").forEach(chip =>
-    chip.addEventListener(
-      "click",
-      () => actions.onHeapFocus(chip.dataset.mdeHeapChip)));
+    chip.addEventListener("click", () => {
+      const heap = chip.dataset.mdeHeapChip;
+      if (heap) actions.onHeapFocus(heap);
+    }));
 
   if (explorer.overview) {
     root.querySelectorAll<HTMLElement>(
@@ -275,7 +276,8 @@ export function bindMetadataExplorer(
       ".mde-wall .mde-heap-card[data-mde-heap] .mde-card-head",
     ).forEach(head => head.addEventListener("click", () => {
       const card = head.closest<HTMLElement>(".mde-heap-card");
-      if (card) actions.onHeapFocus(card.dataset.mdeHeap);
+      const heap = card?.dataset.mdeHeap;
+      if (heap) actions.onHeapFocus(heap);
     }));
     root.querySelectorAll<HTMLElement>(
       ".mde-wall .mde-row[data-mde-row]",

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -225,15 +225,17 @@ export function bindMetadataExplorer(
     actions.onHistoryForward);
   root.querySelectorAll<HTMLElement>("[data-mde-open]").forEach(button =>
     button.addEventListener("click", () => {
-      const [assembly = "", tableIndex = "0"] =
+      const [assembly = "", tableIndex = ""] =
         (button.dataset.mdeOpen ?? "").split("|");
-      actions.onOpenTable(assembly, Number(tableIndex));
+      if (!assembly || !/^\d+$/.test(tableIndex)) return;
+      const index = Number(tableIndex);
+      if (Number.isSafeInteger(index)) actions.onOpenTable(assembly, index);
     }));
   root.querySelectorAll<HTMLElement>("[data-mde-open-heap]").forEach(button =>
     button.addEventListener("click", () => {
       const [assembly = "", heap = ""] =
         (button.dataset.mdeOpenHeap ?? "").split("|");
-      actions.onOpenHeap(assembly, heap);
+      if (assembly && heap) actions.onOpenHeap(assembly, heap);
     }));
   if (!explorer) return;
 

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -9,11 +9,10 @@
 // `metadata-inspection.ts` coordinates type metadata and the explorer's table-window and
 // heap-listing requests. `dotnet-inspect.ts` keeps `state` and the explorer's focus/history
 // stack (`openExplorer`, `pushExplorerFocus`, `applyExplorerFocus`,
-// `explorerHistoryBack/Forward`, `explorerShowOverview`, `closeExplorer`), the DOM event
-// binding, the `IntersectionObserver` that hydrates cards lazily, the resize listener, and
-// the global keydown handler. This module owns only the markup shape given an explicit
-// snapshot of that state, matching how `type-panel.ts` left comparably rich navigation
-// state in `dotnet-inspect.ts`.
+// `explorerHistoryBack/Forward`, `explorerShowOverview`, `closeExplorer`), the
+// `IntersectionObserver` that hydrates cards lazily, the resize listener, and the global
+// keydown handler. This module owns the markup and its interaction mapping given explicit
+// state and action callbacks.
 //
 // The shared text helpers used well beyond these views (`escapeHtml`, `fmtBytes`) and the
 // shared lens chrome (`platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`,
@@ -196,6 +195,93 @@ export interface ExplorerState {
   historyPos: number;
   overview: boolean;
   pageSize?: number;
+}
+
+export interface MetadataExplorerBindingActions {
+  onClose: () => void;
+  onHistoryBack: () => void;
+  onHistoryForward: () => void;
+  onHeapFocus: (heap: string | undefined) => void;
+  onJump: (index: number, rowId: number) => void;
+  onPage: (index: number, startRowId: number) => void;
+  onRowFocus: (index: number, rowId: number) => void;
+  onShowOverview: () => void;
+  onTableFocus: (index: number, rowId: number) => void;
+}
+
+export function bindMetadataExplorer(
+  root: ParentNode,
+  explorer: Pick<ExplorerState, "overview"> | null,
+  actions: MetadataExplorerBindingActions,
+) {
+  root.querySelector("#mde-exit")?.addEventListener("click", actions.onClose);
+  root.querySelector("#mde-hist-back")?.addEventListener(
+    "click",
+    actions.onHistoryBack);
+  root.querySelector("#mde-hist-fwd")?.addEventListener(
+    "click",
+    actions.onHistoryForward);
+  if (!explorer) return;
+
+  root.querySelectorAll<HTMLElement>("[data-mde-chip]").forEach(chip =>
+    chip.addEventListener(
+      "click",
+      () => actions.onTableFocus(Number(chip.dataset.mdeChip), 0)));
+  root.querySelectorAll<HTMLElement>("[data-mde-jump]").forEach(button =>
+    button.addEventListener("click", event => {
+      event.stopPropagation();
+      const [index, rowId] =
+        (button.dataset.mdeJump ?? "").split(":").map(Number);
+      actions.onJump(index, rowId);
+    }));
+  root.querySelectorAll<HTMLElement>("[data-mde-overview]").forEach(button =>
+    button.addEventListener("click", event => {
+      event.stopPropagation();
+      actions.onShowOverview();
+    }));
+  root.querySelectorAll<HTMLElement>("[data-mde-page]").forEach(button =>
+    button.addEventListener("click", () => {
+      const [index, startRowId] =
+        (button.dataset.mdePage ?? "").split(":").map(Number);
+      actions.onPage(index, startRowId);
+    }));
+  root.querySelectorAll<HTMLElement>("[data-mde-heap-chip]").forEach(chip =>
+    chip.addEventListener(
+      "click",
+      () => actions.onHeapFocus(chip.dataset.mdeHeapChip)));
+
+  if (explorer.overview) {
+    root.querySelectorAll<HTMLElement>(
+      ".mde-wall .mde-card[data-mde-index] .mde-card-head",
+    ).forEach(head => head.addEventListener("click", () => {
+      const card = head.closest<HTMLElement>(".mde-card");
+      if (card) actions.onTableFocus(Number(card.dataset.mdeIndex), 0);
+    }));
+    root.querySelectorAll<HTMLElement>(
+      ".mde-wall .mde-heap-card[data-mde-heap] .mde-card-head",
+    ).forEach(head => head.addEventListener("click", () => {
+      const card = head.closest<HTMLElement>(".mde-heap-card");
+      if (card) actions.onHeapFocus(card.dataset.mdeHeap);
+    }));
+    root.querySelectorAll<HTMLElement>(
+      ".mde-wall .mde-row[data-mde-row]",
+    ).forEach(row => row.addEventListener("click", () => {
+      const [index, rowId] =
+        (row.dataset.mdeRow ?? "").split(":").map(Number);
+      actions.onTableFocus(index, rowId);
+    }));
+  } else {
+    root.querySelector("#mde-canvas")?.addEventListener(
+      "click",
+      actions.onShowOverview);
+    root.querySelectorAll<HTMLElement>(
+      ".mde-focus .mde-row[data-mde-row]",
+    ).forEach(row => row.addEventListener("click", () => {
+      const [index, rowId] =
+        (row.dataset.mdeRow ?? "").split(":").map(Number);
+      actions.onRowFocus(index, rowId);
+    }));
+  }
 }
 
 /** Everything the explorer's markup needs: the open explorer plus the shared text helpers. */

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -203,6 +203,8 @@ export interface MetadataExplorerBindingActions {
   onHistoryForward: () => void;
   onHeapFocus: (heap: string | undefined) => void;
   onJump: (index: number, rowId: number) => void;
+  onOpenHeap: (assembly: string, heap: string) => void;
+  onOpenTable: (assembly: string, index: number) => void;
   onPage: (index: number, startRowId: number) => void;
   onRowFocus: (index: number, rowId: number) => void;
   onShowOverview: () => void;
@@ -221,6 +223,18 @@ export function bindMetadataExplorer(
   root.querySelector("#mde-hist-fwd")?.addEventListener(
     "click",
     actions.onHistoryForward);
+  root.querySelectorAll<HTMLElement>("[data-mde-open]").forEach(button =>
+    button.addEventListener("click", () => {
+      const [assembly = "", tableIndex = "0"] =
+        (button.dataset.mdeOpen ?? "").split("|");
+      actions.onOpenTable(assembly, Number(tableIndex));
+    }));
+  root.querySelectorAll<HTMLElement>("[data-mde-open-heap]").forEach(button =>
+    button.addEventListener("click", () => {
+      const [assembly = "", heap = ""] =
+        (button.dataset.mdeOpenHeap ?? "").split("|");
+      actions.onOpenHeap(assembly, heap);
+    }));
   if (!explorer) return;
 
   root.querySelectorAll<HTMLElement>("[data-mde-chip]").forEach(chip =>

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -225,16 +225,16 @@ export function bindMetadataExplorer(
     actions.onHistoryForward);
   root.querySelectorAll<HTMLElement>("[data-mde-open]").forEach(button =>
     button.addEventListener("click", () => {
-      const [assembly = "", tableIndex = ""] =
-        (button.dataset.mdeOpen ?? "").split("|");
+      const assembly = button.dataset.mdeAssembly ?? "";
+      const tableIndex = button.dataset.mdeOpen ?? "";
       if (!assembly || !/^\d+$/.test(tableIndex)) return;
       const index = Number(tableIndex);
       if (Number.isSafeInteger(index)) actions.onOpenTable(assembly, index);
     }));
   root.querySelectorAll<HTMLElement>("[data-mde-open-heap]").forEach(button =>
     button.addEventListener("click", () => {
-      const [assembly = "", heap = ""] =
-        (button.dataset.mdeOpenHeap ?? "").split("|");
+      const assembly = button.dataset.mdeAssembly ?? "";
+      const heap = button.dataset.mdeOpenHeap ?? "";
       if (assembly && heap) actions.onOpenHeap(assembly, heap);
     }));
   if (!explorer) return;
@@ -444,7 +444,7 @@ export function renderAssemblyMetadataBlock(asm: MetadataAssembly, helpers: Meta
   const heapRows = (asm.heaps || [])
     .filter(heap => heap.sizeInBytes > 0)
     .map(heap => `
-      <button type="button" class="meta-heap" data-mde-open-heap="${escapeHtml(asm.assembly)}|${escapeHtml(heap.name)}" title="Browse ${escapeHtml(heapStreamName(heap.name))} in the metadata explorer">
+      <button type="button" class="meta-heap" data-mde-open-heap="${escapeHtml(heap.name)}" data-mde-assembly="${escapeHtml(asm.assembly)}" title="Browse ${escapeHtml(heapStreamName(heap.name))} in the metadata explorer">
         <span class="meta-heap-name">${escapeHtml(heapStreamName(heap.name))}</span>
         <span class="meta-heap-size">${fmtBytes(heap.sizeInBytes)}</span>
         <span class="meta-heap-addr">${escapeHtml(heap.addressing === "Index" ? "index" : "byte offset")} · max ${heap.maxAddress}</span>
@@ -452,7 +452,7 @@ export function renderAssemblyMetadataBlock(asm: MetadataAssembly, helpers: Meta
 
   const tables = (asm.tables || []).slice().sort((a, b) => b.rowCount - a.rowCount);
   const tableRows = tables.map(table => `
-    <button type="button" class="meta-table-row ${table.isProjected ? "" : "meta-table-unprojected"}" data-mde-open="${escapeHtml(asm.assembly)}|${table.index}" title="${table.isProjected ? "Open in the metadata explorer" : "Present in the image but not modeled by the projection"}">
+    <button type="button" class="meta-table-row ${table.isProjected ? "" : "meta-table-unprojected"}" data-mde-open="${table.index}" data-mde-assembly="${escapeHtml(asm.assembly)}" title="${table.isProjected ? "Open in the metadata explorer" : "Present in the image but not modeled by the projection"}">
       <span class="meta-table-name">${escapeHtml(table.name)}</span>
       <span class="meta-table-count">${table.rowCount.toLocaleString()}</span>
       <span class="meta-table-go">→</span>

--- a/prototypes/inspect-web/test/metadata-viewer.test.ts
+++ b/prototypes/inspect-web/test/metadata-viewer.test.ts
@@ -55,6 +55,7 @@ class FakeElement {
 class FakeRoot {
   private readonly single = new Map<string, FakeElement>();
   private readonly multiple = new Map<string, FakeElement[]>();
+  readonly queriedSelectors = new Set<string>();
 
   add(selector: string, element: FakeElement) {
     this.single.set(selector, element);
@@ -67,10 +68,12 @@ class FakeRoot {
   }
 
   querySelector(selector: string) {
+    this.queriedSelectors.add(selector);
     return this.single.get(selector) ?? null;
   }
 
   querySelectorAll(selector: string) {
+    this.queriedSelectors.add(selector);
     return this.multiple.get(selector) ?? [];
   }
 }
@@ -166,6 +169,10 @@ test("overview bindings dispatch explorer navigation from the wall controls", ()
     "heap:Blob",
     "table:7:8",
   ]);
+  assert.equal(root.queriedSelectors.has("#mde-canvas"), false);
+  assert.equal(
+    root.queriedSelectors.has(".mde-focus .mde-row[data-mde-row]"),
+    false);
 });
 
 test("focus bindings dispatch lightbox controls and keep inner clicks contained", () => {
@@ -204,6 +211,13 @@ test("focus bindings dispatch lightbox controls and keep inner clicks contained"
   assert.equal(jumpClick.state.stopped, true);
   assert.equal(overviewClick.state.stopped, true);
   assert.equal(pageClick.state.stopped, false);
+  for (const selector of [
+    ".mde-wall .mde-card[data-mde-index] .mde-card-head",
+    ".mde-wall .mde-heap-card[data-mde-heap] .mde-card-head",
+    ".mde-wall .mde-row[data-mde-row]",
+  ]) {
+    assert.equal(root.queriedSelectors.has(selector), false, selector);
+  }
 });
 
 test("closed explorer bindings expose only exit and history controls", () => {
@@ -225,6 +239,7 @@ test("closed explorer bindings expose only exit and history controls", () => {
   chip.dispatch("click");
 
   assert.deepEqual(calls, ["close", "back", "forward"]);
+  assert.equal(root.queriedSelectors.has("[data-mde-chip]"), false);
 });
 
 function assembly(overrides = {}) {

--- a/prototypes/inspect-web/test/metadata-viewer.test.ts
+++ b/prototypes/inspect-web/test/metadata-viewer.test.ts
@@ -20,6 +20,7 @@ import {
   sameFocus,
   type MetadataExplorerBindingActions,
 } from "../src/metadata-viewer.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;
@@ -36,7 +37,7 @@ class FakeElement {
     this.listeners.set(type, listeners);
   }
 
-  dispatch(type: string, event: Event = {} as Event) {
+  dispatch(type: string, event: Event = fakeDom.event()) {
     for (const listener of this.listeners.get(type) ?? []) {
       listener(event);
     }
@@ -47,8 +48,8 @@ class FakeElement {
     return this;
   }
 
-  closest<T>(selector: string): T | null {
-    return (this.closestElements.get(selector) as T | undefined) ?? null;
+  closest(selector: string) {
+    return this.closestElements.get(selector) ?? null;
   }
 }
 
@@ -85,10 +86,10 @@ function recordingActions(calls: string[]): MetadataExplorerBindingActions {
     onHistoryForward: () => calls.push("forward"),
     onHeapFocus: heap => calls.push(`heap:${heap}`),
     onJump: (index, rowId) => calls.push(`jump:${index}:${rowId}`),
-    onOpenHeap: (assembly, heap) =>
-      calls.push(`open-heap:${assembly}:${heap}`),
-    onOpenTable: (assembly, index) =>
-      calls.push(`open-table:${assembly}:${index}`),
+    onOpenHeap: (assemblyFileName, heap) =>
+      calls.push(`open-heap:${assemblyFileName}:${heap}`),
+    onOpenTable: (assemblyFileName, index) =>
+      calls.push(`open-table:${assemblyFileName}:${index}`),
     onPage: (index, startRowId) =>
       calls.push(`page:${index}:${startRowId}`),
     onRowFocus: (index, rowId) => calls.push(`row:${index}:${rowId}`),
@@ -100,11 +101,11 @@ function recordingActions(calls: string[]): MetadataExplorerBindingActions {
 
 function stoppableEvent() {
   const state = { stopped: false };
-  const event = {
+  const event = fakeDom.event({
     stopPropagation: () => {
       state.stopped = true;
     },
-  } as unknown as Event;
+  });
   return { event, state };
 }
 
@@ -141,15 +142,18 @@ test("overview bindings dispatch explorer navigation from the wall controls", ()
     orphanTableHead);
   const heapCard = new FakeElement({ mdeHeap: "Blob" });
   const heapHead = new FakeElement().withClosest(".mde-heap-card", heapCard);
+  const incompleteHeapHead =
+    new FakeElement().withClosest(".mde-heap-card", new FakeElement());
   root.addAll(
     ".mde-wall .mde-heap-card[data-mde-heap] .mde-card-head",
-    heapHead);
+    heapHead,
+    incompleteHeapHead);
   const row = new FakeElement({ mdeRow: "7:8" });
   root.addAll(".mde-wall .mde-row[data-mde-row]", row);
 
   const calls: string[] = [];
   bindMetadataExplorer(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     { overview: true },
     recordingActions(calls));
 
@@ -161,6 +165,7 @@ test("overview bindings dispatch explorer navigation from the wall controls", ()
   tableHead.dispatch("click");
   orphanTableHead.dispatch("click");
   heapHead.dispatch("click");
+  incompleteHeapHead.dispatch("click");
   row.dispatch("click");
 
   assert.deepEqual(calls, [
@@ -192,7 +197,7 @@ test("focus bindings dispatch lightbox controls and keep inner clicks contained"
   root.addAll(".mde-focus .mde-row[data-mde-row]", row);
   const calls: string[] = [];
   bindMetadataExplorer(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     { overview: false },
     recordingActions(calls));
   const jumpClick = stoppableEvent();
@@ -234,7 +239,7 @@ test("metadata lens bindings open table and heap explorer views", () => {
   root.addAll("[data-mde-chip]", chip);
   const calls: string[] = [];
   bindMetadataExplorer(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     null,
     recordingActions(calls));
 

--- a/prototypes/inspect-web/test/metadata-viewer.test.ts
+++ b/prototypes/inspect-web/test/metadata-viewer.test.ts
@@ -85,6 +85,10 @@ function recordingActions(calls: string[]): MetadataExplorerBindingActions {
     onHistoryForward: () => calls.push("forward"),
     onHeapFocus: heap => calls.push(`heap:${heap}`),
     onJump: (index, rowId) => calls.push(`jump:${index}:${rowId}`),
+    onOpenHeap: (assembly, heap) =>
+      calls.push(`open-heap:${assembly}:${heap}`),
+    onOpenTable: (assembly, index) =>
+      calls.push(`open-table:${assembly}:${index}`),
     onPage: (index, startRowId) =>
       calls.push(`page:${index}:${startRowId}`),
     onRowFocus: (index, rowId) => calls.push(`row:${index}:${rowId}`),
@@ -220,11 +224,12 @@ test("focus bindings dispatch lightbox controls and keep inner clicks contained"
   }
 });
 
-test("closed explorer bindings expose only exit and history controls", () => {
+test("metadata lens bindings open table and heap explorer views", () => {
   const root = new FakeRoot();
-  const exit = root.add("#mde-exit", new FakeElement());
-  const back = root.add("#mde-hist-back", new FakeElement());
-  const forward = root.add("#mde-hist-fwd", new FakeElement());
+  const table = new FakeElement({ mdeOpen: "Contoso.dll|6" });
+  root.addAll("[data-mde-open]", table);
+  const heap = new FakeElement({ mdeOpenHeap: "Contoso.dll|String" });
+  root.addAll("[data-mde-open-heap]", heap);
   const chip = new FakeElement({ mdeChip: "3" });
   root.addAll("[data-mde-chip]", chip);
   const calls: string[] = [];
@@ -233,12 +238,14 @@ test("closed explorer bindings expose only exit and history controls", () => {
     null,
     recordingActions(calls));
 
-  exit.dispatch("click");
-  back.dispatch("click");
-  forward.dispatch("click");
+  table.dispatch("click");
+  heap.dispatch("click");
   chip.dispatch("click");
 
-  assert.deepEqual(calls, ["close", "back", "forward"]);
+  assert.deepEqual(calls, [
+    "open-table:Contoso.dll:6",
+    "open-heap:Contoso.dll:String",
+  ]);
   assert.equal(root.queriedSelectors.has("[data-mde-chip]"), false);
 });
 

--- a/prototypes/inspect-web/test/metadata-viewer.test.ts
+++ b/prototypes/inspect-web/test/metadata-viewer.test.ts
@@ -234,21 +234,50 @@ test("focus bindings dispatch lightbox controls and keep inner clicks contained"
 
 test("metadata lens bindings open table and heap explorer views", () => {
   const root = new FakeRoot();
-  const table = new FakeElement({ mdeOpen: "Contoso.dll|6" });
-  const tableZero = new FakeElement({ mdeOpen: "Contoso.dll|0" });
+  const table = new FakeElement({
+    mdeAssembly: "Contoso.dll",
+    mdeOpen: "6",
+  });
+  const tableZero = new FakeElement({
+    mdeAssembly: "Contoso.dll",
+    mdeOpen: "0",
+  });
+  const pipeAssemblyTable = new FakeElement({
+    mdeAssembly: "A|6|B.dll",
+    mdeOpen: "2",
+  });
   const invalidTables = [
-    new FakeElement({ mdeOpen: "|6" }),
-    new FakeElement({ mdeOpen: "Contoso.dll|" }),
-    new FakeElement({ mdeOpen: "Contoso.dll|NaN" }),
-    new FakeElement({ mdeOpen: "Contoso.dll|9007199254740992" }),
+    new FakeElement({ mdeAssembly: "", mdeOpen: "6" }),
+    new FakeElement({ mdeAssembly: "Contoso.dll", mdeOpen: "" }),
+    new FakeElement({ mdeAssembly: "Contoso.dll", mdeOpen: "NaN" }),
+    new FakeElement({
+      mdeAssembly: "Contoso.dll",
+      mdeOpen: "9007199254740992",
+    }),
   ];
-  root.addAll("[data-mde-open]", table, tableZero, ...invalidTables);
-  const heap = new FakeElement({ mdeOpenHeap: "Contoso.dll|String" });
+  root.addAll(
+    "[data-mde-open]",
+    table,
+    tableZero,
+    pipeAssemblyTable,
+    ...invalidTables);
+  const heap = new FakeElement({
+    mdeAssembly: "Contoso.dll",
+    mdeOpenHeap: "String",
+  });
+  const pipeAssemblyHeap = new FakeElement({
+    mdeAssembly: "A|6|B.dll",
+    mdeOpenHeap: "Blob",
+  });
   const invalidHeaps = [
-    new FakeElement({ mdeOpenHeap: "|String" }),
-    new FakeElement({ mdeOpenHeap: "Contoso.dll|" }),
+    new FakeElement({ mdeAssembly: "", mdeOpenHeap: "String" }),
+    new FakeElement({ mdeAssembly: "Contoso.dll", mdeOpenHeap: "" }),
   ];
-  root.addAll("[data-mde-open-heap]", heap, ...invalidHeaps);
+  root.addAll(
+    "[data-mde-open-heap]",
+    heap,
+    pipeAssemblyHeap,
+    ...invalidHeaps);
   const chip = new FakeElement({ mdeChip: "3" });
   root.addAll("[data-mde-chip]", chip);
   const calls: string[] = [];
@@ -259,15 +288,19 @@ test("metadata lens bindings open table and heap explorer views", () => {
 
   table.dispatch("click");
   tableZero.dispatch("click");
+  pipeAssemblyTable.dispatch("click");
   for (const invalidTable of invalidTables) invalidTable.dispatch("click");
   heap.dispatch("click");
+  pipeAssemblyHeap.dispatch("click");
   for (const invalidHeap of invalidHeaps) invalidHeap.dispatch("click");
   chip.dispatch("click");
 
   assert.deepEqual(calls, [
     "open-table:Contoso.dll:6",
     "open-table:Contoso.dll:0",
+    "open-table:A|6|B.dll:2",
     "open-heap:Contoso.dll:String",
+    "open-heap:A|6|B.dll:Blob",
   ]);
   assert.equal(root.queriedSelectors.has("[data-mde-chip]"), false);
 });
@@ -387,12 +420,14 @@ test("an assembly block lists non-empty heaps and tables sorted by row count", (
   assert.match(html, /#Strings/);
   assert.match(html, /#GUID/);
   assert.doesNotMatch(html, /#Blob/);
-  assert.match(html, /data-mde-open-heap="Contoso\.dll\|String"/);
+  assert.match(
+    html,
+    /data-mde-open-heap="String" data-mde-assembly="Contoso\.dll"/);
 
   const typeDefAt = html.indexOf("TypeDef");
   const methodDefAt = html.indexOf("MethodDef");
   assert.ok(methodDefAt > 0 && methodDefAt < typeDefAt, "tables sort by descending row count");
-  assert.match(html, /data-mde-open="Contoso\.dll\|2"/);
+  assert.match(html, /data-mde-open="2" data-mde-assembly="Contoso\.dll"/);
   assert.match(html, /meta-table-unprojected/);
   assert.match(html, /2\/3 populated/);
   assert.match(html, /v2\.5 · ILOnly · entry 0x6000001/);

--- a/prototypes/inspect-web/test/metadata-viewer.test.ts
+++ b/prototypes/inspect-web/test/metadata-viewer.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  bindMetadataExplorer,
   coverageLabel,
   cssEscape,
   estimateExplorerPageSize,
@@ -17,7 +18,88 @@ import {
   renderMetadataExplorer,
   renderPackageMetadata,
   sameFocus,
+  type MetadataExplorerBindingActions,
 } from "../src/metadata-viewer.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  private readonly closestElements = new Map<string, FakeElement>();
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, event: Event = {} as Event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  withClosest(selector: string, element: FakeElement) {
+    this.closestElements.set(selector, element);
+    return this;
+  }
+
+  closest<T>(selector: string): T | null {
+    return (this.closestElements.get(selector) as T | undefined) ?? null;
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+    return element;
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+    return elements;
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+function recordingActions(calls: string[]): MetadataExplorerBindingActions {
+  return {
+    onClose: () => calls.push("close"),
+    onHistoryBack: () => calls.push("back"),
+    onHistoryForward: () => calls.push("forward"),
+    onHeapFocus: heap => calls.push(`heap:${heap}`),
+    onJump: (index, rowId) => calls.push(`jump:${index}:${rowId}`),
+    onPage: (index, startRowId) =>
+      calls.push(`page:${index}:${startRowId}`),
+    onRowFocus: (index, rowId) => calls.push(`row:${index}:${rowId}`),
+    onShowOverview: () => calls.push("overview"),
+    onTableFocus: (index, rowId) =>
+      calls.push(`table:${index}:${rowId}`),
+  };
+}
+
+function stoppableEvent() {
+  const state = { stopped: false };
+  const event = {
+    stopPropagation: () => {
+      state.stopped = true;
+    },
+  } as unknown as Event;
+  return { event, state };
+}
 
 function escapeHtml(value: unknown) {
   return String(value)
@@ -32,6 +114,118 @@ function fmtBytes(value: number) {
 }
 
 const helpers = { escapeHtml, fmtBytes };
+
+test("overview bindings dispatch explorer navigation from the wall controls", () => {
+  const root = new FakeRoot();
+  const exit = root.add("#mde-exit", new FakeElement());
+  const back = root.add("#mde-hist-back", new FakeElement());
+  const forward = root.add("#mde-hist-fwd", new FakeElement());
+  const chip = new FakeElement({ mdeChip: "3" });
+  root.addAll("[data-mde-chip]", chip);
+  const heapChip = new FakeElement({ mdeHeapChip: "String" });
+  root.addAll("[data-mde-heap-chip]", heapChip);
+
+  const tableCard = new FakeElement({ mdeIndex: "6" });
+  const tableHead = new FakeElement().withClosest(".mde-card", tableCard);
+  const orphanTableHead = new FakeElement();
+  root.addAll(
+    ".mde-wall .mde-card[data-mde-index] .mde-card-head",
+    tableHead,
+    orphanTableHead);
+  const heapCard = new FakeElement({ mdeHeap: "Blob" });
+  const heapHead = new FakeElement().withClosest(".mde-heap-card", heapCard);
+  root.addAll(
+    ".mde-wall .mde-heap-card[data-mde-heap] .mde-card-head",
+    heapHead);
+  const row = new FakeElement({ mdeRow: "7:8" });
+  root.addAll(".mde-wall .mde-row[data-mde-row]", row);
+
+  const calls: string[] = [];
+  bindMetadataExplorer(
+    root as unknown as ParentNode,
+    { overview: true },
+    recordingActions(calls));
+
+  exit.dispatch("click");
+  back.dispatch("click");
+  forward.dispatch("click");
+  chip.dispatch("click");
+  heapChip.dispatch("click");
+  tableHead.dispatch("click");
+  orphanTableHead.dispatch("click");
+  heapHead.dispatch("click");
+  row.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "close",
+    "back",
+    "forward",
+    "table:3:0",
+    "heap:String",
+    "table:6:0",
+    "heap:Blob",
+    "table:7:8",
+  ]);
+});
+
+test("focus bindings dispatch lightbox controls and keep inner clicks contained", () => {
+  const root = new FakeRoot();
+  const canvas = root.add("#mde-canvas", new FakeElement());
+  const jump = new FakeElement({ mdeJump: "2:4" });
+  root.addAll("[data-mde-jump]", jump);
+  const overview = new FakeElement();
+  root.addAll("[data-mde-overview]", overview);
+  const page = new FakeElement({ mdePage: "5:20" });
+  root.addAll("[data-mde-page]", page);
+  const row = new FakeElement({ mdeRow: "4:9" });
+  root.addAll(".mde-focus .mde-row[data-mde-row]", row);
+  const calls: string[] = [];
+  bindMetadataExplorer(
+    root as unknown as ParentNode,
+    { overview: false },
+    recordingActions(calls));
+  const jumpClick = stoppableEvent();
+  const overviewClick = stoppableEvent();
+  const pageClick = stoppableEvent();
+
+  canvas.dispatch("click");
+  jump.dispatch("click", jumpClick.event);
+  overview.dispatch("click", overviewClick.event);
+  page.dispatch("click", pageClick.event);
+  row.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "overview",
+    "jump:2:4",
+    "overview",
+    "page:5:20",
+    "row:4:9",
+  ]);
+  assert.equal(jumpClick.state.stopped, true);
+  assert.equal(overviewClick.state.stopped, true);
+  assert.equal(pageClick.state.stopped, false);
+});
+
+test("closed explorer bindings expose only exit and history controls", () => {
+  const root = new FakeRoot();
+  const exit = root.add("#mde-exit", new FakeElement());
+  const back = root.add("#mde-hist-back", new FakeElement());
+  const forward = root.add("#mde-hist-fwd", new FakeElement());
+  const chip = new FakeElement({ mdeChip: "3" });
+  root.addAll("[data-mde-chip]", chip);
+  const calls: string[] = [];
+  bindMetadataExplorer(
+    root as unknown as ParentNode,
+    null,
+    recordingActions(calls));
+
+  exit.dispatch("click");
+  back.dispatch("click");
+  forward.dispatch("click");
+  chip.dispatch("click");
+
+  assert.deepEqual(calls, ["close", "back", "forward"]);
+});
 
 function assembly(overrides = {}) {
   return {

--- a/prototypes/inspect-web/test/metadata-viewer.test.ts
+++ b/prototypes/inspect-web/test/metadata-viewer.test.ts
@@ -131,7 +131,8 @@ test("overview bindings dispatch explorer navigation from the wall controls", ()
   const chip = new FakeElement({ mdeChip: "3" });
   root.addAll("[data-mde-chip]", chip);
   const heapChip = new FakeElement({ mdeHeapChip: "String" });
-  root.addAll("[data-mde-heap-chip]", heapChip);
+  const emptyHeapChip = new FakeElement({ mdeHeapChip: "" });
+  root.addAll("[data-mde-heap-chip]", heapChip, emptyHeapChip);
 
   const tableCard = new FakeElement({ mdeIndex: "6" });
   const tableHead = new FakeElement().withClosest(".mde-card", tableCard);
@@ -142,12 +143,13 @@ test("overview bindings dispatch explorer navigation from the wall controls", ()
     orphanTableHead);
   const heapCard = new FakeElement({ mdeHeap: "Blob" });
   const heapHead = new FakeElement().withClosest(".mde-heap-card", heapCard);
-  const incompleteHeapHead =
-    new FakeElement().withClosest(".mde-heap-card", new FakeElement());
+  const emptyHeapHead = new FakeElement().withClosest(
+    ".mde-heap-card",
+    new FakeElement({ mdeHeap: "" }));
   root.addAll(
     ".mde-wall .mde-heap-card[data-mde-heap] .mde-card-head",
     heapHead,
-    incompleteHeapHead);
+    emptyHeapHead);
   const row = new FakeElement({ mdeRow: "7:8" });
   root.addAll(".mde-wall .mde-row[data-mde-row]", row);
 
@@ -162,10 +164,11 @@ test("overview bindings dispatch explorer navigation from the wall controls", ()
   forward.dispatch("click");
   chip.dispatch("click");
   heapChip.dispatch("click");
+  emptyHeapChip.dispatch("click");
   tableHead.dispatch("click");
   orphanTableHead.dispatch("click");
   heapHead.dispatch("click");
-  incompleteHeapHead.dispatch("click");
+  emptyHeapHead.dispatch("click");
   row.dispatch("click");
 
   assert.deepEqual(calls, [
@@ -232,9 +235,20 @@ test("focus bindings dispatch lightbox controls and keep inner clicks contained"
 test("metadata lens bindings open table and heap explorer views", () => {
   const root = new FakeRoot();
   const table = new FakeElement({ mdeOpen: "Contoso.dll|6" });
-  root.addAll("[data-mde-open]", table);
+  const tableZero = new FakeElement({ mdeOpen: "Contoso.dll|0" });
+  const invalidTables = [
+    new FakeElement({ mdeOpen: "|6" }),
+    new FakeElement({ mdeOpen: "Contoso.dll|" }),
+    new FakeElement({ mdeOpen: "Contoso.dll|NaN" }),
+    new FakeElement({ mdeOpen: "Contoso.dll|9007199254740992" }),
+  ];
+  root.addAll("[data-mde-open]", table, tableZero, ...invalidTables);
   const heap = new FakeElement({ mdeOpenHeap: "Contoso.dll|String" });
-  root.addAll("[data-mde-open-heap]", heap);
+  const invalidHeaps = [
+    new FakeElement({ mdeOpenHeap: "|String" }),
+    new FakeElement({ mdeOpenHeap: "Contoso.dll|" }),
+  ];
+  root.addAll("[data-mde-open-heap]", heap, ...invalidHeaps);
   const chip = new FakeElement({ mdeChip: "3" });
   root.addAll("[data-mde-chip]", chip);
   const calls: string[] = [];
@@ -244,11 +258,15 @@ test("metadata lens bindings open table and heap explorer views", () => {
     recordingActions(calls));
 
   table.dispatch("click");
+  tableZero.dispatch("click");
+  for (const invalidTable of invalidTables) invalidTable.dispatch("click");
   heap.dispatch("click");
+  for (const invalidHeap of invalidHeaps) invalidHeap.dispatch("click");
   chip.dispatch("click");
 
   assert.deepEqual(calls, [
     "open-table:Contoso.dll:6",
+    "open-table:Contoso.dll:0",
     "open-heap:Contoso.dll:String",
   ]);
   assert.equal(root.queriedSelectors.has("[data-mde-chip]"), false);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -759,6 +759,41 @@ test("typed settings panel owns its rendered control bindings", () => {
   }
 });
 
+test("metadata viewer owns its rendered explorer control bindings", () => {
+  const binding =
+    appSource.match(/function bindMetadataExplorerEvents\(\) \{[\s\S]*?\/\/ Hydrate cards/)?.[0]
+    ?? "";
+  assert.match(
+    binding,
+    /bindMetadataExplorer\(document, ex, \{[\s\S]*onClose: closeExplorer,[\s\S]*onHistoryBack: explorerHistoryBack,[\s\S]*onHistoryForward: explorerHistoryForward,[\s\S]*onHeapFocus: heap => pushExplorerFocus\(\{ heap \}\),[\s\S]*onJump: explorerJump,[\s\S]*onPage: \(index, startRowId\) => loadExplorerWindow\(index, startRowId\),[\s\S]*onRowFocus: \(index, rowId\) => \{[\s\S]*ex\.detail = already \? null : \{ index, rowId \};[\s\S]*ex\.highlight = already \? null : \{ index, rowId \};[\s\S]*onShowOverview: explorerShowOverview,[\s\S]*onTableFocus: \(index, rowId\) => pushExplorerFocus\(\{ index, rowId \}\),/);
+  assert.equal(
+    appSource.match(/\bbindMetadataExplorerEvents\b/g)?.length,
+    2);
+  assert.equal(
+    appSource.match(/\bbindMetadataExplorer\b/g)?.length,
+    2);
+  assert.match(
+    metadataViewerSource,
+    /export function bindMetadataExplorer\([\s\S]*#mde-exit[\s\S]*#mde-hist-back[\s\S]*#mde-hist-fwd[\s\S]*\[data-mde-chip\][\s\S]*\[data-mde-jump\][\s\S]*\[data-mde-overview\][\s\S]*\[data-mde-page\][\s\S]*\[data-mde-heap-chip\][\s\S]*\.mde-wall \.mde-card\[data-mde-index\] \.mde-card-head[\s\S]*\.mde-wall \.mde-heap-card\[data-mde-heap\] \.mde-card-head[\s\S]*\.mde-wall \.mde-row\[data-mde-row\][\s\S]*#mde-canvas[\s\S]*\.mde-focus \.mde-row\[data-mde-row\]/);
+  for (const selector of [
+    "#mde-exit",
+    "#mde-hist-back",
+    "#mde-hist-fwd",
+    "[data-mde-chip]",
+    "[data-mde-jump]",
+    "[data-mde-overview]",
+    "[data-mde-page]",
+    "[data-mde-heap-chip]",
+    ".mde-wall .mde-card[data-mde-index] .mde-card-head",
+    ".mde-wall .mde-heap-card[data-mde-heap] .mde-card-head",
+    ".mde-wall .mde-row[data-mde-row]",
+    ".mde-focus .mde-row[data-mde-row]",
+  ]) {
+    assert.equal(appSource.split(selector).length - 1, 0, selector);
+  }
+  assert.equal(appSource.split("#mde-canvas").length - 1, 1);
+});
+
 test("leaving package search clears its pending loading state", () => {
   assert.match(
     spotlightPackageSearchSource,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -761,14 +761,14 @@ test("typed settings panel owns its rendered control bindings", () => {
 
 test("metadata viewer owns its rendered explorer control bindings", () => {
   const binding =
-    appSource.match(/function bindMetadataExplorerEvents\(\) \{[\s\S]*?\/\/ Hydrate cards/)?.[0]
+    appSource.match(/function bindMetadataViewerEvents\(\) \{[\s\S]*?\/\/ Hydrate cards/)?.[0]
     ?? "";
   assert.match(
     binding,
-    /bindMetadataExplorer\(document, ex, \{[\s\S]*onClose: closeExplorer,[\s\S]*onHistoryBack: explorerHistoryBack,[\s\S]*onHistoryForward: explorerHistoryForward,[\s\S]*onHeapFocus: heap => pushExplorerFocus\(\{ heap \}\),[\s\S]*onJump: explorerJump,[\s\S]*onPage: \(index, startRowId\) => loadExplorerWindow\(index, startRowId\),[\s\S]*onRowFocus: \(index, rowId\) => \{[\s\S]*ex\.detail = already \? null : \{ index, rowId \};[\s\S]*ex\.highlight = already \? null : \{ index, rowId \};[\s\S]*onShowOverview: explorerShowOverview,[\s\S]*onTableFocus: \(index, rowId\) => pushExplorerFocus\(\{ index, rowId \}\),/);
+    /bindMetadataExplorer\(document, ex, \{[\s\S]*onClose: closeExplorer,[\s\S]*onHistoryBack: explorerHistoryBack,[\s\S]*onHistoryForward: explorerHistoryForward,[\s\S]*onHeapFocus: heap => pushExplorerFocus\(\{ heap \}\),[\s\S]*onJump: explorerJump,[\s\S]*onOpenHeap: openExplorerHeap,[\s\S]*onOpenTable: openExplorer,[\s\S]*onPage: \(index, startRowId\) => loadExplorerWindow\(index, startRowId\),[\s\S]*onRowFocus: \(index, rowId\) => \{[\s\S]*ex\.detail = already \? null : \{ index, rowId \};[\s\S]*ex\.highlight = already \? null : \{ index, rowId \};[\s\S]*onShowOverview: explorerShowOverview,[\s\S]*onTableFocus: \(index, rowId\) => pushExplorerFocus\(\{ index, rowId \}\),/);
   assert.equal(
-    appSource.match(/\bbindMetadataExplorerEvents\b/g)?.length,
-    2);
+    appSource.match(/\bbindMetadataViewerEvents\b/g)?.length,
+    3);
   assert.equal(
     appSource.match(/\bbindMetadataExplorer\b/g)?.length,
     2);
@@ -777,11 +777,13 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
     /\b(?:getElementById|querySelector|querySelectorAll)\s*\(|\.addEventListener\s*\(/);
   assert.match(
     metadataViewerSource,
-    /export function bindMetadataExplorer\([\s\S]*#mde-exit[\s\S]*#mde-hist-back[\s\S]*#mde-hist-fwd[\s\S]*\[data-mde-chip\][\s\S]*\[data-mde-jump\][\s\S]*\[data-mde-overview\][\s\S]*\[data-mde-page\][\s\S]*\[data-mde-heap-chip\][\s\S]*\.mde-wall \.mde-card\[data-mde-index\] \.mde-card-head[\s\S]*\.mde-wall \.mde-heap-card\[data-mde-heap\] \.mde-card-head[\s\S]*\.mde-wall \.mde-row\[data-mde-row\][\s\S]*#mde-canvas[\s\S]*\.mde-focus \.mde-row\[data-mde-row\]/);
+    /export function bindMetadataExplorer\([\s\S]*#mde-exit[\s\S]*#mde-hist-back[\s\S]*#mde-hist-fwd[\s\S]*\[data-mde-open\][\s\S]*\[data-mde-open-heap\][\s\S]*\[data-mde-chip\][\s\S]*\[data-mde-jump\][\s\S]*\[data-mde-overview\][\s\S]*\[data-mde-page\][\s\S]*\[data-mde-heap-chip\][\s\S]*\.mde-wall \.mde-card\[data-mde-index\] \.mde-card-head[\s\S]*\.mde-wall \.mde-heap-card\[data-mde-heap\] \.mde-card-head[\s\S]*\.mde-wall \.mde-row\[data-mde-row\][\s\S]*#mde-canvas[\s\S]*\.mde-focus \.mde-row\[data-mde-row\]/);
   for (const selector of [
     "#mde-exit",
     "#mde-hist-back",
     "#mde-hist-fwd",
+    "[data-mde-open]",
+    "[data-mde-open-heap]",
     "[data-mde-chip]",
     "[data-mde-jump]",
     "[data-mde-overview]",

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -772,6 +772,9 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
   assert.equal(
     appSource.match(/\bbindMetadataExplorer\b/g)?.length,
     2);
+  assert.doesNotMatch(
+    binding,
+    /\b(?:getElementById|querySelector|querySelectorAll)\s*\(|\.addEventListener\s*\(/);
   assert.match(
     metadataViewerSource,
     /export function bindMetadataExplorer\([\s\S]*#mde-exit[\s\S]*#mde-hist-back[\s\S]*#mde-hist-fwd[\s\S]*\[data-mde-chip\][\s\S]*\[data-mde-jump\][\s\S]*\[data-mde-overview\][\s\S]*\[data-mde-page\][\s\S]*\[data-mde-heap-chip\][\s\S]*\.mde-wall \.mde-card\[data-mde-index\] \.mde-card-head[\s\S]*\.mde-wall \.mde-heap-card\[data-mde-heap\] \.mde-card-head[\s\S]*\.mde-wall \.mde-row\[data-mde-row\][\s\S]*#mde-canvas[\s\S]*\.mde-focus \.mde-row\[data-mde-row\]/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -760,18 +760,98 @@ test("typed settings panel owns its rendered control bindings", () => {
 });
 
 test("metadata viewer owns its rendered explorer control bindings", () => {
-  const binding =
-    appSource.match(/function bindMetadataViewerEvents\(\) \{[\s\S]*?\/\/ Hydrate cards/)?.[0]
-    ?? "";
+  assert.deepEqual(parsedAppSource.errors, []);
+  const bindEvents = functionDeclaration("bindEvents");
+  const renderMetadata = functionDeclaration("renderMetadataExplorer");
+  const metadataEventBinder = functionDeclaration("bindMetadataViewerEvents");
+  const outerCalls = callExpressionsNamed(appSyntax, "bindMetadataViewerEvents");
+  assert.equal(outerCalls.length, 2);
+  assert.equal(
+    syntaxNodes(
+      appSyntax,
+      node => node.type === "Identifier"
+        && node.name === "bindMetadataViewerEvents").length,
+    3);
+  for (const [owner, description] of [
+    [bindEvents, "workbench metadata binder"],
+    [renderMetadata, "metadata explorer binder"],
+  ]) {
+    assert.equal(
+      callExpressionsNamed(owner, "bindMetadataViewerEvents").length,
+      1,
+      description);
+    assert.equal(
+      owner.body.body
+        .map(statement => directCallExpression(statement, "bindMetadataViewerEvents"))
+        .filter(Boolean)
+        .length,
+      1,
+      `${description} direct call`);
+  }
+  const directWorkbenchCalls = bindEvents.body.body.map(statement => {
+    if (statement.type !== "ExpressionStatement") return null;
+    const expression = statement.expression;
+    return expression.type === "CallExpression"
+      && expression.callee?.type === "Identifier"
+      ? expression.callee.name
+      : null;
+  });
+  assert.equal(
+    directWorkbenchCalls.indexOf("bindMetadataViewerEvents"),
+    directWorkbenchCalls.indexOf("bindSettingsPanelEvents") + 1);
+  const metadataRenderStatements = renderMetadata.body.body;
+  const replacementIndex = metadataRenderStatements.findIndex(
+    statement => statement.type === "ExpressionStatement"
+      && statement.expression.type === "AssignmentExpression"
+      && statement.expression.operator === "="
+      && sourceText(statement.expression.left) === "app.innerHTML");
+  const binderIndex = metadataRenderStatements.findIndex(
+    statement => directCallExpression(statement, "bindMetadataViewerEvents"));
+  assert.notEqual(replacementIndex, -1);
+  assert.equal(binderIndex, replacementIndex + 1);
+
+  const innerCalls = callExpressionsNamed(appSyntax, "bindMetadataExplorer");
+  assert.equal(innerCalls.length, 1);
+  const innerCall = innerCalls[0];
+  assert.equal(
+    metadataEventBinder.body.body
+      .map(statement => directCallExpression(statement, "bindMetadataExplorer"))
+      .filter(Boolean)
+      .length,
+    1);
+  assert.equal(innerCall.arguments.length, 3);
+  assert.equal(innerCall.arguments[0].type, "Identifier");
+  assert.equal(innerCall.arguments[0].name, "document");
+  assert.equal(innerCall.arguments[1].type, "Identifier");
+  assert.equal(innerCall.arguments[1].name, "ex");
+  const actions = innerCall.arguments[2];
+  assert.equal(actions.type, "ObjectExpression");
+  assert.equal(actions.properties.length, 11);
+  const rowFocus = callbackProperty(actions, "onRowFocus");
+  assert.deepEqual(
+    statementSignatures(rowFocus.body.body),
+    [
+      {
+        if: "!ex",
+        whenTrue: ["statement:ReturnStatement:return;"],
+        whenFalse: [],
+      },
+      "declare:const already = ex.detail && ex.detail.index === index && ex.detail.rowId === rowId",
+      "assign:ex.detail = already ? null : { index, rowId }",
+      "assign:ex.highlight = already ? null : { index, rowId }",
+      "declare:const current = ex.history[ex.historyPos]",
+      {
+        if: "current && current.index === index",
+        whenTrue: ["assign:current.rowId = already ? 0 : rowId"],
+        whenFalse: [],
+      },
+      "call:render()",
+    ]);
+
+  const binding = sourceText(innerCall);
   assert.match(
     binding,
     /bindMetadataExplorer\(document, ex, \{[\s\S]*onClose: closeExplorer,[\s\S]*onHistoryBack: explorerHistoryBack,[\s\S]*onHistoryForward: explorerHistoryForward,[\s\S]*onHeapFocus: heap => pushExplorerFocus\(\{ heap \}\),[\s\S]*onJump: explorerJump,[\s\S]*onOpenHeap: openExplorerHeap,[\s\S]*onOpenTable: openExplorer,[\s\S]*onPage: \(index, startRowId\) =>\s*observeAsync\(\s*loadExplorerWindow\(index, startRowId\),\s*"Loading metadata table rows"\),[\s\S]*onRowFocus: \(index, rowId\) => \{[\s\S]*ex\.detail = already \? null : \{ index, rowId \};[\s\S]*ex\.highlight = already \? null : \{ index, rowId \};[\s\S]*onShowOverview: explorerShowOverview,[\s\S]*onTableFocus: \(index, rowId\) => pushExplorerFocus\(\{ index, rowId \}\),/);
-  assert.equal(
-    appSource.match(/\bbindMetadataViewerEvents\b/g)?.length,
-    3);
-  assert.equal(
-    appSource.match(/\bbindMetadataExplorer\b/g)?.length,
-    2);
   assert.doesNotMatch(
     binding,
     /\b(?:getElementById|querySelector|querySelectorAll)\s*\(|\.addEventListener\s*\(/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -819,6 +819,21 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
       .filter(Boolean)
       .length,
     1);
+  assert.deepEqual(
+    statementSignatures(metadataEventBinder.body.body.slice(0, 1)),
+    ["declare:const ex = state.explorer"]);
+  assert.equal(
+    directCallExpression(metadataEventBinder.body.body[1], "bindMetadataExplorer"),
+    innerCall);
+  assert.deepEqual(
+    statementSignatures(metadataEventBinder.body.body.slice(2, 3)),
+    [
+      {
+        if: "!ex",
+        whenTrue: ["statement:ReturnStatement:return;"],
+        whenFalse: [],
+      },
+    ]);
   assert.equal(innerCall.arguments.length, 3);
   assert.equal(innerCall.arguments[0].type, "Identifier");
   assert.equal(innerCall.arguments[0].name, "document");
@@ -851,7 +866,7 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
   const binding = sourceText(innerCall);
   assert.match(
     binding,
-    /bindMetadataExplorer\(document, ex, \{[\s\S]*onClose: closeExplorer,[\s\S]*onHistoryBack: explorerHistoryBack,[\s\S]*onHistoryForward: explorerHistoryForward,[\s\S]*onHeapFocus: heap => pushExplorerFocus\(\{ heap \}\),[\s\S]*onJump: explorerJump,[\s\S]*onOpenHeap: openExplorerHeap,[\s\S]*onOpenTable: openExplorer,[\s\S]*onPage: \(index, startRowId\) =>\s*observeAsync\(\s*loadExplorerWindow\(index, startRowId\),\s*"Loading metadata table rows"\),[\s\S]*onRowFocus: \(index, rowId\) => \{[\s\S]*ex\.detail = already \? null : \{ index, rowId \};[\s\S]*ex\.highlight = already \? null : \{ index, rowId \};[\s\S]*onShowOverview: explorerShowOverview,[\s\S]*onTableFocus: \(index, rowId\) => pushExplorerFocus\(\{ index, rowId \}\),/);
+    /bindMetadataExplorer\s*\(document, ex, \{[\s\S]*onClose: closeExplorer,[\s\S]*onHistoryBack: explorerHistoryBack,[\s\S]*onHistoryForward: explorerHistoryForward,[\s\S]*onHeapFocus: heap => pushExplorerFocus\(\{ heap \}\),[\s\S]*onJump: explorerJump,[\s\S]*onOpenHeap: openExplorerHeap,[\s\S]*onOpenTable: openExplorer,[\s\S]*onPage: \(index, startRowId\) =>\s*observeAsync\(\s*loadExplorerWindow\(index, startRowId\),\s*"Loading metadata table rows"\),[\s\S]*onRowFocus: \(index, rowId\) => \{[\s\S]*ex\.detail = already \? null : \{ index, rowId \};[\s\S]*ex\.highlight = already \? null : \{ index, rowId \};[\s\S]*onShowOverview: explorerShowOverview,[\s\S]*onTableFocus: \(index, rowId\) => pushExplorerFocus\(\{ index, rowId \}\),/);
   assert.doesNotMatch(
     binding,
     /\b(?:getElementById|querySelector|querySelectorAll)\s*\(|\.addEventListener\s*\(/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -765,7 +765,7 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
     ?? "";
   assert.match(
     binding,
-    /bindMetadataExplorer\(document, ex, \{[\s\S]*onClose: closeExplorer,[\s\S]*onHistoryBack: explorerHistoryBack,[\s\S]*onHistoryForward: explorerHistoryForward,[\s\S]*onHeapFocus: heap => pushExplorerFocus\(\{ heap \}\),[\s\S]*onJump: explorerJump,[\s\S]*onOpenHeap: openExplorerHeap,[\s\S]*onOpenTable: openExplorer,[\s\S]*onPage: \(index, startRowId\) => loadExplorerWindow\(index, startRowId\),[\s\S]*onRowFocus: \(index, rowId\) => \{[\s\S]*ex\.detail = already \? null : \{ index, rowId \};[\s\S]*ex\.highlight = already \? null : \{ index, rowId \};[\s\S]*onShowOverview: explorerShowOverview,[\s\S]*onTableFocus: \(index, rowId\) => pushExplorerFocus\(\{ index, rowId \}\),/);
+    /bindMetadataExplorer\(document, ex, \{[\s\S]*onClose: closeExplorer,[\s\S]*onHistoryBack: explorerHistoryBack,[\s\S]*onHistoryForward: explorerHistoryForward,[\s\S]*onHeapFocus: heap => pushExplorerFocus\(\{ heap \}\),[\s\S]*onJump: explorerJump,[\s\S]*onOpenHeap: openExplorerHeap,[\s\S]*onOpenTable: openExplorer,[\s\S]*onPage: \(index, startRowId\) =>\s*observeAsync\(\s*loadExplorerWindow\(index, startRowId\),\s*"Loading metadata table rows"\),[\s\S]*onRowFocus: \(index, rowId\) => \{[\s\S]*ex\.detail = already \? null : \{ index, rowId \};[\s\S]*ex\.highlight = already \? null : \{ index, rowId \};[\s\S]*onShowOverview: explorerShowOverview,[\s\S]*onTableFocus: \(index, rowId\) => pushExplorerFocus\(\{ index, rowId \}\),/);
   assert.equal(
     appSource.match(/\bbindMetadataViewerEvents\b/g)?.length,
     3);


### PR DESCRIPTION
Closes a coherent DOM-ownership slice of #4504: `metadata-viewer.ts` now owns the Metadata Explorer controls it renders and maps them to typed root callbacks. `AppState`, focus/history mutation, engine requests, lazy `IntersectionObserver` hydration, resize coordination, and global keyboard effects remain in `dotnet-inspect.ts`.

The binding covers exit/history, table and heap chips, ref jumps, paging, overview/focus transitions, wall cards and rows, focus-row selection, and click propagation. Separate overview, focus-lightbox, and closed-explorer fixtures gate the mutually exclusive DOM shapes, while the composition test rejects direct or duplicate root ownership.

**Stack:** slice 13 of issue #4504; stacked on #4521. Parent: #4521. Residual after this slice: continue extracting coherent DOM/request owners from the composition root without moving authoritative application state or effect orchestration.

**Validation:** `npm test` (409/409), `npm run build`, `npx markdownlint-cli prototypes/inspect-web/README.md`, and `git diff --check`.