### PR TITLE
Complete inspect-web event binding ownership

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -772,28 +772,31 @@ selection, ref->def jump targets, cell escaping, heap addressing and coverage
 notes, and the row inspector.
 
 `src/doc-viewer.ts` owns the package document modal (the Markdown reader
-opened from a package's documents list) as a pure, dependency-injected render
-function. `src/document-inspection.ts` owns its sequence-guarded async
+opened from a package's documents list), including its rendered close and
+bare-backdrop bindings. `src/document-inspection.ts` owns its sequence-guarded async
 load/close lifecycle, visible failure, and frontmatter projection.
 `dotnet-inspect.ts` validates the selected package document and supplies the
 engine, sanitized Markdown-rendering, state, and render ports.
 `test/doc-viewer.test.ts` gates the closed/no-document fallback, loading and
 error presentation, the
 frontmatter card's presence and fields, and title/subtitle/frontmatter-name
-escaping; `test/document-inspection.test.ts` gates exact request coordinates,
+escaping, plus button/backdrop close dispatch;
+`test/document-inspection.test.ts` gates exact request coordinates,
 frontmatter projection, stale-stage suppression, visible failures, and close
 invalidation (the rendered document body is trusted, pre-sanitized Markdown
 HTML and is not escaped).
 
 `src/graph-source.ts` owns the member source modal (the code viewer opened
-from a call graph node) as a pure, dependency-injected render function.
+from a call graph node), including its rendered close and bare-backdrop
+bindings.
 `source-inspection.ts` owns its sequence-guarded async lifecycle;
 `dotnet-inspect.ts` supplies `state`, the typed engine port, and the
 `highlightCSharp` Prism wrapper, and passes each computed slice explicitly.
 `test/graph-source.test.ts` gates the loading state, the
 original-versus-decompiled provenance labels, the open-source link's presence
 only when a `url` is provided, the error state's fallback message, and title
-escaping in both the header and loading status.
+escaping in both the header and loading status, plus button/backdrop close
+dispatch.
 
 `src/annotated-source.ts` owns the annotated source result (the
 fact-annotated C#/IL dual view shown for a member overload) as a pure,

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -711,8 +711,9 @@ Symbol/PDB acquisition status is not yet surfaced here — no backend contract
 reports it today — and is a tracked fast-follow.
 
 `src/type-panel.ts` owns the type selector (the "PUBLIC TYPES" / "MEMBERS" nav
-pane), its rendered DOM control bindings, and the type viewer (the type
-heading, metadata, and source sections shown for the "type" scope).
+pane), its rendered DOM control bindings (including member filters), and the
+type viewer (the type heading, metadata, and source sections shown for the
+"type" scope).
 `dotnet-inspect.ts` still owns the type index, filtering, member grouping, and
 navigation state transitions, and supplies them through typed callbacks; the
 shared text helpers used well beyond the type panel (`kindIcon`, `shortKind`,

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -808,17 +808,18 @@ versus unanchored fact rendering, selection state, and source-text escaping.
 
 `src/package-opportunities.ts` owns the package/platform "Integration
 opportunities" lens (the ecosystem auth/cloud/config/database/AI-client
-integration suggestions for a package or platform library) as a pure,
-dependency-injected render function, including its opportunity-row API-name
-splitting, package-chip detection, and "look for" chip rendering. `dotnet-inspect.ts`
-still owns `state` and the platform library picker, `package-inspection.ts`
-owns the scan-scope-keyed async load lifecycle, and the root passes each
-computed slice into the renderer explicitly.
+integration suggestions for a package or platform library), including its
+rendered DOM bindings, opportunity-row API-name splitting, package-chip
+detection, and "look for" chip rendering. `dotnet-inspect.ts` still owns
+`state`, target resolution, navigation effects, and the platform library
+picker, `package-inspection.ts` owns the scan-scope-keyed async load lifecycle,
+and the root supplies behavior through typed callbacks.
 `test/package-opportunities.test.ts` gates the platform pick-a-library prompt,
 the scanning/loading/error states (fresh versus stale scope), the
 no-opportunities and inspection-error banners, the category summary counts,
 API name splitting, package-chip versus plain-text kind rendering, look-for
-chip/wildcard/empty rendering, and text escaping.
+chip/wildcard/empty rendering, binding dispatch and empty-value behavior, and
+text escaping.
 
 - `Cmd/Ctrl+K` opens Spotlight in the Commands scope.
 - `Cmd/Ctrl+P` opens Spotlight in the All scope.

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -772,15 +772,17 @@ selection, ref->def jump targets, cell escaping, heap addressing and coverage
 notes, and the row inspector.
 
 `src/doc-viewer.ts` owns the package document modal (the Markdown reader
-opened from a package's documents list), including its rendered close and
-bare-backdrop bindings. `src/document-inspection.ts` owns its sequence-guarded async
-load/close lifecycle, visible failure, and frontmatter projection.
+opened from a package's documents list) and that list's markup, including its
+open, close, and bare-backdrop bindings. `src/document-inspection.ts` owns its
+sequence-guarded async load/close lifecycle, visible failure, and frontmatter
+projection.
 `dotnet-inspect.ts` validates the selected package document and supplies the
 engine, sanitized Markdown-rendering, state, and render ports.
 `test/doc-viewer.test.ts` gates the closed/no-document fallback, loading and
 error presentation, the
 frontmatter card's presence and fields, and title/subtitle/frontmatter-name
-escaping, plus button/backdrop close dispatch;
+escaping, package-document list output, open dispatch, and button/backdrop
+close dispatch;
 `test/document-inspection.test.ts` gates exact request coordinates,
 frontmatter projection, stale-stage suppression, visible failures, and close
 invalidation (the rendered document body is trusted, pre-sanitized Markdown

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -749,6 +749,15 @@ callbacks. `test/library-controls.test.ts` gates selector mapping, pack
 provenance/defaults, empty selections, inactive surfaces, and no eager
 dispatch.
 
+`src/shell-controls.ts` owns the rendered workbench chrome, home demo/theme
+controls, and load-error retry/query/detail bindings. It reuses the package
+query grammar from `package-bar.ts`; `dotnet-inspect.ts` still owns notice and
+package state, navigation/history, sharing, theme effects, demo orchestration,
+retry selection, and package loading behind typed callbacks.
+`test/shell-controls.test.ts` gates every selector, valid and invalid home demo
+identities, replacement-package parsing, local error-detail state, inactive
+surfaces, and no eager dispatch.
+
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM
 bindings and the home/workbench controls that open them. `dotnet-inspect.ts`

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -711,7 +711,8 @@ Symbol/PDB acquisition status is not yet surfaced here — no backend contract
 reports it today — and is a tracked fast-follow.
 
 `src/type-panel.ts` owns the type selector (the "PUBLIC TYPES" / "MEMBERS" nav
-pane), its rendered DOM control bindings (including member filters), and the
+pane), its rendered DOM control bindings (including member filters,
+composition jumps, member navigation, and member/type copy controls), and the
 type viewer (the type heading, metadata, and source sections shown for the
 "type" scope).
 `dotnet-inspect.ts` still owns the type index, filtering, member grouping, and

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -691,9 +691,10 @@ removal, and both silent transient-failure paths; the composition-root gate
 checks that network and DOM authority remain outside the coordinator.
 
 The typed `src/status-bar.ts` component renders both the full-width workspace
-data bar and the home readiness bar. The workspace bar occupies the bottom row
-formerly used by the persistent command prompt, giving the bar the full
-viewport width. By default the bar shows a compact, single-line summary in
+data bar and the home readiness bar and owns their rendered toggle binding.
+The workspace bar occupies the bottom row formerly used by the persistent
+command prompt, giving the bar the full viewport width. By default the bar
+shows a compact, single-line summary in
 priority order: app version/commit, package provenance, build date, and a
 one-line performance summary. A dedicated toggle button at the end of the bar
 (so it never overlaps the commit link) expands and collapses the view,

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -741,6 +741,14 @@ inspection effects behind typed callbacks. `test/package-view.test.ts` gates
 dataset decoding, missing values, replacement dependency-list binding, inactive
 surfaces, and no eager dispatch.
 
+`src/library-controls.ts` owns library/accessibility filters, the primary
+Platform library selector, and the lens-scoped Platform library selectors.
+`dotnet-inspect.ts` still owns filter mutation, runtime-pack acquisition,
+generation checks, visible retry state, and lens reload effects behind typed
+callbacks. `test/library-controls.test.ts` gates selector mapping, pack
+provenance/defaults, empty selections, inactive surfaces, and no eager
+dispatch.
+
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM
 bindings and the home/workbench controls that open them. `dotnet-inspect.ts`

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -734,6 +734,13 @@ runtime pack — so the component acquires no engine or workspace authority.
 `test/package-bar.test.ts` gates tab markup, active/close state, escaping,
 open-package query parsing, and package selection dispatch.
 
+`src/package-view.ts` owns package-level dependency, overview, type-graph, and
+performance navigation bindings. `dotnet-inspect.ts` still owns package and
+filter state, in-place dependency updates, navigation effects, and member
+inspection effects behind typed callbacks. `test/package-view.test.ts` gates
+dataset decoding, missing values, replacement dependency-list binding, inactive
+surfaces, and no eager dispatch.
+
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM
 bindings and the home/workbench controls that open them. `dotnet-inspect.ts`

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -725,11 +725,12 @@ package/library fields, the metadata- and source-signature cache keys, and the
 metadata/source panels' loading, error, and loaded states.
 
 `src/package-bar.ts` owns the package tab strip (including the always-present
-Platform tab), the open-package query form, and their keyboard/mouse/wheel
-interaction. `dotnet-inspect.ts` supplies the workspace effects — selecting, closing, and
-opening a package or the runtime pack — so the component acquires no engine or
-workspace authority. `test/package-bar.test.ts` gates tab markup, active/close
-state, escaping, and open-package query parsing.
+Platform tab), the open-package query form, package framework/version controls,
+and their keyboard/mouse/wheel interaction. `dotnet-inspect.ts` supplies the
+workspace effects — selecting, closing, opening, or changing a package or the
+runtime pack — so the component acquires no engine or workspace authority.
+`test/package-bar.test.ts` gates tab markup, active/close state, escaping,
+open-package query parsing, and package selection dispatch.
 
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -735,8 +735,9 @@ open-package query parsing, and package selection dispatch.
 
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM
-bindings. `dotnet-inspect.ts` still owns `state`, localStorage persistence, and
-the theme/taste/close effects, supplying those actions through typed callbacks.
+bindings and the home/workbench controls that open them. `dotnet-inspect.ts`
+still owns `state`, localStorage persistence, and the
+theme/taste/open/close effects, supplying those actions through typed callbacks.
 `test/settings-panel.test.ts` gates the mutually exclusive Settings and popover
 binding shapes, input validation, the style catalog's tier grouping,
 byte-divergent badges and checked state, the taste popover's active/default

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -758,6 +758,15 @@ retry selection, and package loading behind typed callbacks.
 identities, replacement-package parsing, local error-detail state, inactive
 surfaces, and no eager dispatch.
 
+`src/graph-interactions.ts` owns graph-back, pan/zoom, pointer, keyboard, zoom
+button, and rendered Mermaid node bindings for type, dependency, and call
+graphs. `dotnet-inspect.ts` still owns typed graph-target resolution, package
+and member navigation, platform descent, graph rendering, and stale-render
+suppression behind callback resolvers. `test/graph-interactions.test.ts` gates
+stable Mermaid node identity decoding, navigable and informational nodes,
+drag-click suppression, every pan/zoom input, inactive surfaces, and no eager
+dispatch.
+
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM
 bindings and the home/workbench controls that open them. `dotnet-inspect.ts`

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -799,15 +799,17 @@ escaping in both the header and loading status, plus button/backdrop close
 dispatch.
 
 `src/annotated-source.ts` owns the annotated source result (the
-fact-annotated C#/IL dual view shown for a member overload) as a pure,
-dependency-injected render function; it composes `annotated-source-view.ts`'s
-`buildAnnotatedView` projection into markup. `member-detail-inspection.ts` owns
-the sequence-guarded async load lifecycle; `dotnet-inspect.ts` still owns
-`state` and the medium-toggle/fact-selection event handlers, and passes each
-computed slice in explicitly.
+fact-annotated C#/IL dual view shown for a member overload), including its
+rendered copy, medium, fact, source-offset, and clear-selection bindings; it
+composes `annotated-source-view.ts`'s `buildAnnotatedView` projection into
+markup. `member-detail-inspection.ts` owns the sequence-guarded async load
+lifecycle; `dotnet-inspect.ts` still owns `state`, document interpretation,
+copy/render effects, and the selection transitions, supplying them through
+typed callbacks.
 `test/annotated-source.test.ts` gates the rejected-document fallback, the
 medium toggles and hidden-line count, the context-limitation notice, anchored
-versus unanchored fact rendering, selection state, and source-text escaping.
+versus unanchored fact rendering, selection state, binding dispatch and
+malformed dataset behavior, and source-text escaping.
 
 `src/package-opportunities.ts` owns the package/platform "Integration
 opportunities" lens (the ecosystem auth/cloud/config/database/AI-client

--- a/prototypes/inspect-web/src/annotated-source.ts
+++ b/prototypes/inspect-web/src/annotated-source.ts
@@ -27,6 +27,38 @@ export interface RenderAnnotatedSourceOptions {
   escapeHtml: (value: unknown) => string;
 }
 
+export interface AnnotatedSourceBindingActions {
+  onClearSelection: () => void;
+  onCopy: () => void;
+  onFactSelect: (factId: number) => void;
+  onMediumToggle: (medium: string) => void;
+  onOffsetSelect: (offset: number) => void;
+}
+
+export function bindAnnotatedSource(
+  root: ParentNode,
+  actions: AnnotatedSourceBindingActions,
+) {
+  root.querySelector("#copy-annotated")?.addEventListener(
+    "click",
+    actions.onCopy);
+  root.querySelectorAll<HTMLElement>("[data-annotated-medium]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onMediumToggle(button.dataset.annotatedMedium ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-annotated-fact]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onFactSelect(Number(button.dataset.annotatedFact))));
+  root.querySelectorAll<HTMLElement>("[data-annotated-offset]").forEach(span =>
+    span.addEventListener(
+      "click",
+      () => actions.onOffsetSelect(Number(span.dataset.annotatedOffset))));
+  root.querySelector("#annotated-clear")?.addEventListener(
+    "click",
+    actions.onClearSelection);
+}
+
 export function renderAnnotatedSource(options: RenderAnnotatedSourceOptions): string {
   const { result, media, selectedFactId, selectedNodeIds, escapeHtml } = options;
   let view;

--- a/prototypes/inspect-web/src/doc-viewer.ts
+++ b/prototypes/inspect-web/src/doc-viewer.ts
@@ -1,6 +1,10 @@
 import type { BrowserPackageDocument } from "./inspect-web-engine.d.ts";
 
 type DocViewerDocument = Pick<BrowserPackageDocument, "name" | "path">;
+type PackageDocumentSummary = Pick<
+  BrowserPackageDocument,
+  "kind" | "name" | "path" | "size"
+>;
 
 export interface DocViewerMeta {
   name: string;
@@ -19,6 +23,7 @@ export interface RenderDocViewerOptions {
 
 export interface DocViewerBindingActions {
   onClose: () => void;
+  onOpenDocument: (path: string) => void;
 }
 
 export function bindDocViewer(
@@ -33,6 +38,39 @@ export function bindDocViewer(
   root.querySelector("#doc-viewer-close")?.addEventListener(
     "click",
     actions.onClose);
+  root.querySelectorAll<HTMLElement>("[data-doc-path]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onOpenDocument(button.dataset.docPath ?? "")));
+}
+
+export function renderPackageDocuments(
+  documents: readonly PackageDocumentSummary[],
+  escapeHtml: (value: unknown) => string,
+): string {
+  if (!documents.length) return "";
+  const kindLabels = new Map([
+    ["readme", "Readme"],
+    ["package", "Package"],
+    ["skill", "Skill"],
+  ]);
+  const kindGlyphs = new Map([
+    ["readme", "▤"],
+    ["package", "▤"],
+    ["skill", "◆"],
+  ]);
+  const chips = documents
+    .map(document => `
+      <button class="doc-chip doc-${escapeHtml(document.kind)}" data-doc-path="${escapeHtml(document.path)}" title="${escapeHtml(document.path)} · ${document.size.toLocaleString()} bytes">
+        <span class="doc-glyph">${kindGlyphs.get(document.kind) ?? "▤"}</span>
+        <span class="doc-name">${escapeHtml(document.name)}</span>
+        <span class="doc-kind">${escapeHtml(kindLabels.get(document.kind) ?? document.kind)}</span>
+      </button>`)
+    .join("");
+  return `<section class="document-section">
+      <div class="section-title"><h2>Documentation</h2><span>${documents.length} file${documents.length === 1 ? "" : "s"} — click to read</span></div>
+      <div class="doc-chip-list">${chips}</div>
+    </section>`;
 }
 
 export function renderDocViewer(options: RenderDocViewerOptions): string {

--- a/prototypes/inspect-web/src/doc-viewer.ts
+++ b/prototypes/inspect-web/src/doc-viewer.ts
@@ -17,6 +17,24 @@ export interface RenderDocViewerOptions {
   escapeHtml: (value: unknown) => string;
 }
 
+export interface DocViewerBindingActions {
+  onClose: () => void;
+}
+
+export function bindDocViewer(
+  root: ParentNode,
+  actions: DocViewerBindingActions,
+) {
+  const backdrop =
+    root.querySelector<HTMLElement>("#doc-viewer-backdrop");
+  backdrop?.addEventListener("mousedown", event => {
+    if (event.target === backdrop) actions.onClose();
+  });
+  root.querySelector("#doc-viewer-close")?.addEventListener(
+    "click",
+    actions.onClose);
+}
+
 export function renderDocViewer(options: RenderDocViewerOptions): string {
   const { doc, meta, loading, error, html, escapeHtml } = options;
   const title = doc ? doc.name : "Document";

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -69,6 +69,11 @@ import {
   type PackagePerformance,
 } from "./package-inspection.ts";
 import {
+  bindPackageDependencyList,
+  bindPackageView,
+  type PackageViewBindingActions,
+} from "./package-view.ts";
+import {
   createSourceInspectionCoordinator,
   type GraphSourceRequest,
 } from "./source-inspection.ts";
@@ -2436,26 +2441,8 @@ function patchDependenciesGroup() {
       "active",
       Number(button.dataset.depGroup) === selectedGroupIndex));
   listSection.outerHTML = dependencyListSectionHtml(groups, selectedGroupIndex);
-  bindDependencyListHandlers();
+  bindPackageDependencyListEvents();
   observeAsync(renderDependencyGraph(), "Rendering the dependency graph");
-}
-
-function bindDependencyListHandlers() {
-  document.querySelectorAll<HTMLElement>("[data-dep-open]").forEach(button => {
-    button.onclick = () => {
-      const key = button.dataset.depOpen;
-      if (key) switchToPackageForDependencies(key);
-    };
-  });
-  document.querySelectorAll<HTMLElement>("[data-dep-load]").forEach(button => {
-    button.onclick = () => {
-      const id = button.dataset.depLoad;
-      if (id)
-        observeAsync(
-          openDependencyPackage(id, button.dataset.depVersion || ""),
-          "Opening a dependency package");
-    };
-  });
 }
 
 function resolveDependenciesGroupIndex(
@@ -3713,6 +3700,77 @@ function highlightCSharp(value: string) {
   return escapeHtml(source);
 }
 
+const packageViewActions: PackageViewBindingActions = {
+  onDependencyGroupSelect: index => {
+    if (state.dependenciesGroupIndex === index) return;
+    state.dependenciesGroupIndex = index;
+    patchDependenciesGroup();
+  },
+  onDependencyLoad: (id, version) =>
+    observeAsync(
+      openDependencyPackage(id, version),
+      "Opening a dependency package"),
+  onDependencyOpen: switchToPackageForDependencies,
+  onGraphTypeSelect: navigateToTypeByName,
+  onKindJump: kind => {
+    state.atPackageRoot = false;
+    state.kindFilter = kind;
+    state.namespaceFilter = "";
+    state.typeFilter = "";
+    state.selectedMemberKey = "";
+    state.memberBrowseTypeId = "";
+    resetMemberFilters();
+    state.typeCursor = 0;
+    const first = filteredTypes()[0];
+    if (first) state.selectedTypeId = first.id;
+    render();
+  },
+  onLibraryScopeSelect: (library, kind) => {
+    state.atPackageRoot = false;
+    if (!library) return;
+    state.libraryScope = new Set([library]);
+    if (state.package?.isRuntimePack)
+      recordPlatformRecent(library, platformPackForAssembly(library));
+    state.kindFilter = kind;
+    state.namespaceFilter = "";
+    state.typeFilter = "";
+    state.selectedMemberKey = "";
+    state.memberBrowseTypeId = "";
+    resetMemberFilters();
+    state.typeCursor = 0;
+    const first = filteredTypes()[0];
+    if (first) state.selectedTypeId = first.id;
+    render();
+  },
+  onNamespaceJump: namespace => {
+    state.atPackageRoot = false;
+    state.namespaceFilter = namespace;
+    state.kindFilter = "";
+    state.typeFilter = "";
+    state.selectedMemberKey = "";
+    state.memberBrowseTypeId = "";
+    resetMemberFilters();
+    state.typeCursor = 0;
+    const first = filteredTypes()[0];
+    if (first) state.selectedTypeId = first.id;
+    render();
+  },
+  onPerformanceMemberSelect: target => {
+    drillToPerfMember(
+      target.metadataToken,
+      target.assembly,
+      target.typeId);
+  },
+};
+
+function bindPackageViewEvents() {
+  bindPackageView(document, packageViewActions);
+}
+
+function bindPackageDependencyListEvents() {
+  bindPackageDependencyList(document, packageViewActions);
+}
+
 function bindStatusBarEvents() {
   bindStatusBar(document, {
     onToggle: () => {
@@ -4053,66 +4111,7 @@ function bindEvents() {
   bindGraphSourceEvents();
   bindDocViewerEvents();
   bindAnnotatedSourceEvents();
-  document.querySelectorAll<HTMLElement>("[data-dep-group]").forEach(button => button.addEventListener("click", () => {
-    const index = Number(button.dataset.depGroup);
-    if (state.dependenciesGroupIndex === index) return;
-    state.dependenciesGroupIndex = index;
-    patchDependenciesGroup();
-  }));
-  bindDependencyListHandlers();
-  document.querySelectorAll<HTMLElement>("[data-kind-jump]").forEach(button => button.addEventListener("click", () => {
-    state.atPackageRoot = false;
-    state.kindFilter = button.dataset.kindJump ?? "";
-    state.namespaceFilter = "";
-    state.typeFilter = "";
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    state.typeCursor = 0;
-    const first = filteredTypes()[0];
-    if (first) state.selectedTypeId = first.id;
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-namespace-jump]").forEach(button => button.addEventListener("click", () => {
-    state.atPackageRoot = false;
-    state.namespaceFilter = button.dataset.namespaceJump ?? "";
-    state.kindFilter = "";
-    state.typeFilter = "";
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    state.typeCursor = 0;
-    const first = filteredTypes()[0];
-    if (first) state.selectedTypeId = first.id;
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-lib-scope]").forEach(button => button.addEventListener("click", () => {
-    state.atPackageRoot = false;
-    const library = button.dataset.libScope;
-    if (!library) return;
-    state.libraryScope = new Set([library]);
-    if (state.package?.isRuntimePack)
-      recordPlatformRecent(library, platformPackForAssembly(library));
-    state.kindFilter = button.dataset.libKind || "";
-    state.namespaceFilter = "";
-    state.typeFilter = "";
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    state.typeCursor = 0;
-    const first = filteredTypes()[0];
-    if (first) state.selectedTypeId = first.id;
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-graph-type]").forEach(button => button.addEventListener("click", () => {
-    navigateToTypeByName(button.dataset.graphType ?? "");
-  }));
-  document.querySelectorAll<HTMLElement>("[data-perf-token]").forEach(button => button.addEventListener("click", () => {
-    drillToPerfMember(
-      button.dataset.perfToken ?? "",
-      button.dataset.perfAssembly ?? "",
-      button.dataset.perfType ?? "");
-  }));
+  bindPackageViewEvents();
   document.querySelectorAll<HTMLElement>("[data-library-chip]").forEach(button => button.addEventListener("click", () => {
     toggleLibraryChip(button.dataset.libraryChip ?? "");
     afterLibraryScopeChange();

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -113,6 +113,14 @@ import {
   buildTypeGraphMermaid
 } from "./graph-mermaid.ts";
 import {
+  bindDependencyGraphNodes,
+  bindGraphBack,
+  bindGraphPanZoom,
+  bindTypeGraphNodes,
+  type CallGraphNodeBinding,
+  type GraphBackBindingActions,
+} from "./graph-interactions.ts";
+import {
   factsForNode,
   MEDIA,
   nodeAtOffset,
@@ -4252,6 +4260,10 @@ const workbenchShellActions: WorkbenchShellBindingActions = {
   onToggleTheme: toggleTheme,
 };
 
+const graphBackActions: GraphBackBindingActions = {
+  onBack: popPlatformDrill,
+};
+
 function bindEvents() {
   bindStatusBarEvents();
   packageBar.bind(document);
@@ -4266,13 +4278,11 @@ function bindEvents() {
   bindPackageViewEvents();
   bindLibraryControlsEvents();
   bindWorkbenchShell(document, workbenchShellActions);
+  bindGraphBack(document, graphBackActions);
   observeAsync(ensurePackageVersions(state.package), "Loading package versions");
   if (state.package?.isRuntimePack)
     observeAsync(ensureDotnetReleases(), "Loading .NET release information");
   if (state.spotlightOpen) spotlight.bind(document, "modal");
-  document.querySelector("[data-graph-back]")?.addEventListener(
-    "click",
-    popPlatformDrill);
 }
 
 function toggleTheme() {
@@ -6039,31 +6049,21 @@ async function renderTypeGraph() {
       container.querySelector<HTMLElement>(".graph-viewport");
     if (!viewport) return;
     viewport.innerHTML = svg;
-    attachGraphPanZoom(container, viewport);
-    viewport.querySelectorAll<SVGGElement>("g.node").forEach(node => {
-      const dataId = node.getAttribute("data-id");
-      const idMatch = node.id.match(/(?:^|flowchart-)(t\d+)(?:-|$)/);
-      const nodeId = dataId || idMatch?.[1];
+    bindGraphPanZoom(container, viewport);
+    bindTypeGraphNodes(viewport, nodeId => {
       const graphNode = nodeId ? graphNodeOf.get(nodeId) : null;
-      if (!graphNode) return;
+      if (!graphNode) return null;
       const fullName = graphNode.id;
       const pkg = currentPackage();
       const target = graphNode.role === "self"
         ? selectedType()
         : uniqueTypeByQueryId(pkg.types, fullName);
-      if (target) {
-        node.classList.add("nav-node");
-        node.style.cursor = "pointer";
-        node.addEventListener("click", () => navigateToType(target));
-        return;
-      }
-      // Reported by metadata but not in the browsable surface (internal type or a
-      // type in another assembly). Mark it non-navigable with a native tooltip so
-      // the dead node reads as informational rather than broken.
-      node.classList.add("non-nav");
-      const title = document.createElementNS("http://www.w3.org/2000/svg", "title");
-      title.textContent = `${fullName} — not in the browsable public surface`;
-      node.insertBefore(title, node.firstChild);
+      return target
+        ? { onSelect: () => navigateToType(target) }
+        : {
+            unavailableLabel:
+              `${fullName} — not in the browsable public surface`,
+          };
     });
   } catch (error) {
     if (document.querySelector("#type-graph-diagram") === container) {
@@ -6199,23 +6199,20 @@ async function renderDependencyGraph() {
     if (!viewport) return;
     viewport.innerHTML = svg;
     container.dataset.graphDef = signature;
-    attachGraphPanZoom(container, viewport);
-    viewport.querySelectorAll<SVGGElement>("g.node").forEach(node => {
-      const dataId = node.getAttribute("data-id");
-      const idMatch = node.id.match(/(?:^|flowchart-)(d\d+)(?:-|$)/);
-      const nodeId = dataId || idMatch?.[1];
+    bindGraphPanZoom(container, viewport);
+    bindDependencyGraphNodes(viewport, nodeId => {
       const info = nodeId ? built.nodeInfoById.get(nodeId) : null;
-      if (!info || info.kind === "self") return;
-      node.classList.add("nav-node");
-      node.style.cursor = "pointer";
-      node.addEventListener("click", () => {
-        if (info.kind === "open" && info.packageKey)
-          switchToPackageForDependencies(info.packageKey);
-        else if (info.id)
-          observeAsync(
-            openDependencyPackage(info.id, info.versionRange),
-            "Opening a dependency package");
-      });
+      if (!info || info.kind === "self") return null;
+      return {
+        onSelect: () => {
+          if (info.kind === "open" && info.packageKey)
+            switchToPackageForDependencies(info.packageKey);
+          else if (info.id)
+            observeAsync(
+              openDependencyPackage(info.id, info.versionRange),
+              "Opening a dependency package");
+        },
+      };
     });
   } catch (error) {
     // Only surface the error if this is still the latest render and nothing else has drawn a graph.
@@ -6417,7 +6414,10 @@ async function renderMermaidCallGraph() {
       if (!viewport) return;
       viewport.innerHTML = svg;
       container.dataset.graphDef = active.mermaid;
-      attachGraphPanZoom(container, viewport, true, active);
+      bindGraphPanZoom(container, viewport, {
+        resolveCallGraphNode: nodeId =>
+          callGraphNodeBinding(active, nodeId),
+      });
     }
   } catch (error) {
     if (seq === callGraphRenderSeq
@@ -6433,194 +6433,65 @@ async function renderMermaidCallGraph() {
   }
 }
 
-function attachGraphPanZoom(
-  container: HTMLElement,
-  viewport: HTMLElement,
-  bindCallGraphNodes = false,
-  callGraph: BrowserCallGraph | null = null,
-) {
-  const svg = viewport.querySelector<SVGSVGElement>("svg");
-  if (!svg) return;
-  const renderedSvg = svg;
+function callGraphNodeBinding(
+  callGraph: BrowserCallGraph,
+  nodeId: string,
+): CallGraphNodeBinding | null {
+  const target =
+    callGraph.targets?.find(candidate => candidate.id === nodeId) ?? null;
+  if (!target) return null;
+  const typeId = callGraphTargetTypeId(target);
 
-  const box = svg.viewBox?.baseVal;
-  const naturalWidth = box && box.width ? box.width : svg.getBoundingClientRect().width;
-  const naturalHeight = box && box.height ? box.height : svg.getBoundingClientRect().height;
-  svg.setAttribute("width", String(naturalWidth));
-  svg.setAttribute("height", String(naturalHeight));
-
-  const minScale = 0.2;
-  const maxScale = 8;
-  const view = { scale: 1, x: 0, y: 0 };
-  const clampScale = (value: number) =>
-    Math.min(maxScale, Math.max(minScale, value));
-
-  function apply() {
-    renderedSvg.style.transform =
-      `translate(${view.x}px, ${view.y}px) scale(${view.scale})`;
+  // Inside a platform descent the whole graph lives in the runtime pack, not
+  // the workspace, so clicked callees descend through the platform graph.
+  const drilled =
+    state.platformStack.length > 0 || Boolean(state.package?.isRuntimePack);
+  if (drilled) {
+    if (target.id === "n0" || !target.assembly || !typeId) return null;
+    return {
+      platform: true,
+      onSelect: () =>
+        observeAsync(
+          navigateOrDrillPlatform(target),
+          "Opening a platform call-graph target"),
+    };
   }
 
-  function fit() {
-    const rect = viewport.getBoundingClientRect();
-    if (!naturalWidth || !naturalHeight || !rect.width) return;
-    // Cap at 1:1 so a tiny graph (e.g. two nodes) renders at its natural size,
-    // centered, instead of being upscaled to fill the tall viewport.
-    const fitScale = Math.min(rect.width / naturalWidth, rect.height / naturalHeight) * 0.92;
-    view.scale = clampScale(Math.min(fitScale, 1));
-    view.x = (rect.width - naturalWidth * view.scale) / 2;
-    view.y = (rect.height - naturalHeight * view.scale) / 2;
-    apply();
-  }
-
-  function zoomAt(px: number, py: number, factor: number) {
-    const next = clampScale(view.scale * factor);
-    const ratio = next / view.scale;
-    view.x = px - (px - view.x) * ratio;
-    view.y = py - (py - view.y) * ratio;
-    view.scale = next;
-    apply();
-  }
-
-  viewport.addEventListener("wheel", event => {
-    event.preventDefault();
-    const rect = viewport.getBoundingClientRect();
-    zoomAt(event.clientX - rect.left, event.clientY - rect.top, Math.exp(-event.deltaY * 0.0015));
-  }, { passive: false });
-
-  let pointerId: number | null = null;
-  let moved = false;
-  let capturing = false;
-  const panThreshold = 5;
-  const start = { x: 0, y: 0, vx: 0, vy: 0 };
-  viewport.addEventListener("pointerdown", event => {
-    if (event.button !== 0) return;
-    pointerId = event.pointerId;
-    moved = false;
-    capturing = false;
-    start.x = event.clientX;
-    start.y = event.clientY;
-    start.vx = view.x;
-    start.vy = view.y;
-  });
-  viewport.addEventListener("pointermove", event => {
-    if (pointerId !== event.pointerId) return;
-    const dx = event.clientX - start.x;
-    const dy = event.clientY - start.y;
-    if (!capturing) {
-      if (Math.abs(dx) + Math.abs(dy) <= panThreshold) return;
-      capturing = true;
-      moved = true;
-      viewport.setPointerCapture(pointerId);
-      viewport.classList.add("panning");
-    }
-    view.x = start.vx + dx;
-    view.y = start.vy + dy;
-    apply();
-  });
-  function endPan(event: PointerEvent) {
-    if (pointerId !== event.pointerId) return;
-    if (capturing) {
-      viewport.releasePointerCapture(pointerId);
-      viewport.classList.remove("panning");
-    }
-    capturing = false;
-    pointerId = null;
-  }
-  viewport.addEventListener("pointerup", endPan);
-  viewport.addEventListener("pointercancel", endPan);
-
-  container.querySelectorAll<HTMLElement>(".graph-controls button")
-    .forEach(button => {
-    button.addEventListener("click", () => {
-      const rect = viewport.getBoundingClientRect();
-      const mode = button.dataset.zoom;
-      if (mode === "in") zoomAt(rect.width / 2, rect.height / 2, 1.25);
-      else if (mode === "out") zoomAt(rect.width / 2, rect.height / 2, 0.8);
-      else fit();
-    });
-  });
-
-  viewport.tabIndex = 0;
-  viewport.addEventListener("keydown", event => {
-    const rect = viewport.getBoundingClientRect();
-    const step = 45;
-    if (event.key === "+" || event.key === "=") zoomAt(rect.width / 2, rect.height / 2, 1.25);
-    else if (event.key === "-" || event.key === "_") zoomAt(rect.width / 2, rect.height / 2, 0.8);
-    else if (event.key === "0") fit();
-    else if (event.key === "ArrowLeft") { view.x += step; apply(); }
-    else if (event.key === "ArrowRight") { view.x -= step; apply(); }
-    else if (event.key === "ArrowUp") { view.y += step; apply(); }
-    else if (event.key === "ArrowDown") { view.y -= step; apply(); }
-    else return;
-    event.preventDefault();
-  });
-
-  if (bindCallGraphNodes) {
-    // Inside a platform descent the whole graph lives in the runtime pack, not the
-    // workspace, so a clicked callee must resolve against the active platform graph
-    // and descend further — routing it through the workspace resolvers would look the
-    // type up in the loaded package and fail (e.g. "Type 'TextWriter' is not in Markout.dll").
-    // A resident runtime pack's base member graph is itself a platform graph, so its
-    // callees descend the same way from the start.
-    const drilled = state.platformStack.length > 0 || Boolean(state.package?.isRuntimePack);
-    svg.querySelectorAll<SVGGElement>("g.node").forEach(node => {
-      const target = graphTargetForSvgNode(callGraph, node);
-      if (!target) return;
-      const typeId = callGraphTargetTypeId(target);
-      if (drilled) {
-        if (target.id === "n0" || !target.assembly || !typeId)
-          return;
-        node.classList.add("nav-node", "platform-node");
-        node.style.cursor = "pointer";
-        node.addEventListener("click", () => {
-          if (moved) return;
-          observeAsync(
-            navigateOrDrillPlatform(target),
-            "Opening a platform call-graph target");
-        });
-        return;
-      }
-      const packages = [
-        state.package,
-        ...state.packages.filter(item => item !== state.package),
-      ].filter((pkg): pkg is AppPackage => pkg != null);
-      const candidate =
-        resolveLoadedGraphTargetCandidate<AppPackage, BrowserTypeSurface>(
-          packages,
+  const packages = [
+    state.package,
+    ...state.packages.filter(item => item !== state.package),
+  ].filter((pkg): pkg is AppPackage => pkg != null);
+  const candidate =
+    resolveLoadedGraphTargetCandidate<AppPackage, BrowserTypeSurface>(
+      packages,
+      target);
+  const disposition = graphTargetNavigationDisposition(candidate, target);
+  if (disposition === "blocked" || disposition === "none") return null;
+  const loaded = disposition === "loaded" && candidate.status === "unique"
+    ? resolveLoadedGraphTarget(target, candidate)
+    : null;
+  const platform = disposition === "platform";
+  return {
+    platform,
+    onSelect: () => {
+      if (loaded?.group) {
+        navigateToMember(
+          loaded.pkg,
+          loaded.type,
+          loaded.group,
+          loaded.overloadIndex,
           target);
-      const disposition = graphTargetNavigationDisposition(candidate, target);
-      if (disposition === "blocked" || disposition === "none") return;
-      const loaded = disposition === "loaded"
-        && candidate.status === "unique"
-        ? resolveLoadedGraphTarget(target, candidate)
-        : null;
-      const platform = disposition === "platform";
-      node.classList.add("nav-node");
-      if (platform) node.classList.add("platform-node");
-      node.style.cursor = "pointer";
-      node.addEventListener("click", () => {
-        if (moved) return;
-        if (loaded?.group) {
-          navigateToMember(
-            loaded.pkg,
-            loaded.type,
-            loaded.group,
-            loaded.overloadIndex,
-            target);
-        } else if (loaded) {
-          observeAsync(
-            openGraphSource(loaded.request, loaded.title),
-            "Loading graph source");
-        } else if (platform) {
-          observeAsync(
-            navigateOrDrillPlatform(target),
-            "Opening a platform call-graph target");
-        }
-      });
-    });
-  }
-
-  fit();
+      } else if (loaded) {
+        observeAsync(
+          openGraphSource(loaded.request, loaded.title),
+          "Loading graph source");
+      } else if (platform) {
+        observeAsync(
+          navigateOrDrillPlatform(target),
+          "Opening a platform call-graph target");
+      }
+    },
+  };
 }
 
 function currentCallGraph() {
@@ -6634,18 +6505,6 @@ function platformCrumbTrail() {
     ? state.memberCallGraph.callees.label.replace(/\(.*$/, "")
     : "member";
   return [root, ...state.platformStack.map(entry => entry.title)].join(" › ");
-}
-
-function graphTargetForSvgNode(
-  graph: BrowserCallGraph | null,
-  node: Element,
-) {
-  const dataId = node.getAttribute("data-id");
-  const idMatch = node.id.match(/(?:^|flowchart-)(n\d+)(?:-|$)/);
-  const nodeId = dataId || idMatch?.[1];
-  return nodeId
-    ? graph?.targets?.find(target => target.id === nodeId) ?? null
-    : null;
 }
 
 function resolveLoadedGraphTarget(

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3883,7 +3883,12 @@ function bindScopeBarEvents() {
 function bindSettingsPanelEvents() {
   bindSettingsPanel(document, {
     onClose: closeSettings,
+    onOpen: openSettings,
     onTasteClear: clearTaste,
+    onTasteOpenToggle: () => {
+      state.tasteOpen = !state.tasteOpen;
+      render();
+    },
     onTasteToggle: toggleTaste,
     onThemeSelect: setTheme,
   });
@@ -4229,11 +4234,6 @@ function bindEvents() {
   if (state.package?.isRuntimePack)
     observeAsync(ensureDotnetReleases(), "Loading .NET release information");
   if (state.spotlightOpen) spotlight.bind(document, "modal");
-  document.querySelector("#taste-btn")?.addEventListener("click", event => {
-    event.stopPropagation();
-    state.tasteOpen = !state.tasteOpen;
-    render();
-  });
   document.querySelector("#share")?.addEventListener("click", () => void share());
   document.querySelector("[data-graph-back]")?.addEventListener(
     "click",
@@ -4255,7 +4255,6 @@ function bindEvents() {
   document.querySelector("#nav-forward")?.addEventListener("click", navForward);
   document.querySelector("#go-home")?.addEventListener("click", goHome);
   document.querySelector("#theme-toggle")?.addEventListener("click", toggleTheme);
-  document.querySelector("#open-settings")?.addEventListener("click", () => openSettings("workbench"));
   document.querySelector("#help")?.addEventListener("click", () => showToast("⌘K command · ⌘P / type to find a type · ⌘F filter · 1—5 lenses · ↑↓ types · Alt+←/→ back/forward · graph: wheel zoom, click node to open, +/− zoom, 0 fit, arrows pan"));
 }
 
@@ -5636,8 +5635,8 @@ function homeArtSvg() {
 
 function bindHomeEvents() {
   bindStatusBarEvents();
+  bindSettingsPanelEvents();
   document.querySelector("#home-theme")?.addEventListener("click", toggleTheme);
-  document.querySelector("#home-settings")?.addEventListener("click", () => openSettings("home"));
   document.querySelector("#dismiss-notice")?.addEventListener("click", () => {
     state.queryNotice = "";
     state.queryNoticeRetryAction = null;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -170,7 +170,7 @@ import {
   createCatalogRequests,
   type DotnetRelease,
 } from "./catalog-requests.ts";
-import { fmtBytes, statusBarHtml } from "./status-bar.ts";
+import { bindStatusBar, fmtBytes, statusBarHtml } from "./status-bar.ts";
 import type {
   BrowserBuildIdentity,
   BrowserCallGraph,
@@ -3699,11 +3699,13 @@ function highlightCSharp(value: string) {
   return escapeHtml(source);
 }
 
-function bindStatusBarToggle() {
-  document.querySelectorAll<HTMLElement>("[data-status-bar-toggle-button]").forEach(button => button.addEventListener("click", () => {
-    state.statusBarExpanded = !state.statusBarExpanded;
-    render();
-  }));
+function bindStatusBarEvents() {
+  bindStatusBar(document, {
+    onToggle: () => {
+      state.statusBarExpanded = !state.statusBarExpanded;
+      render();
+    },
+  });
 }
 
 function bindTypePanelEvents() {
@@ -3903,7 +3905,7 @@ function bindAnnotatedSourceEvents() {
 }
 
 function bindEvents() {
-  bindStatusBarToggle();
+  bindStatusBarEvents();
   packageBar.bind(document);
   bindTypePanelEvents();
   bindScopeBarEvents();
@@ -5646,7 +5648,7 @@ function homeArtSvg() {
 }
 
 function bindHomeEvents() {
-  bindStatusBarToggle();
+  bindStatusBarEvents();
   document.querySelector("#home-theme")?.addEventListener("click", toggleTheme);
   document.querySelector("#home-settings")?.addEventListener("click", () => openSettings("home"));
   document.querySelector("#dismiss-notice")?.addEventListener("click", () => {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -79,6 +79,14 @@ import {
   type PlatformLibraryLens,
 } from "./library-controls.ts";
 import {
+  bindHomeShell,
+  bindLoadErrorShell,
+  bindWorkbenchShell,
+  type HomeShellBindingActions,
+  type LoadErrorShellBindingActions,
+  type WorkbenchShellBindingActions,
+} from "./shell-controls.ts";
+import {
   createSourceInspectionCoordinator,
   type GraphSourceRequest,
 } from "./source-inspection.ts";
@@ -4219,6 +4227,31 @@ function bindAnnotatedSourceEvents() {
   });
 }
 
+const workbenchShellActions: WorkbenchShellBindingActions = {
+  onDismissNotice: () => {
+    state.queryNotice = "";
+    state.queryNoticeRetryAction = null;
+    render();
+  },
+  onDismissPackageNotice: () => {
+    currentPackage().inspectionError = "";
+    render();
+  },
+  onGoHome: goHome,
+  onHelp: () => showToast(
+    "⌘K command · ⌘P / type to find a type · ⌘F filter · "
+    + "1—5 lenses · ↑↓ types · Alt+←/→ back/forward · "
+    + "graph: wheel zoom, click node to open, +/− zoom, 0 fit, arrows pan"),
+  onNavigateBack: navBack,
+  onNavigateForward: navForward,
+  onRetryNotice: () => {
+    const retryAction = state.queryNoticeRetryAction;
+    if (retryAction) observeAction(retryAction, "Retrying the inspection");
+  },
+  onShare: () => void share(),
+  onToggleTheme: toggleTheme,
+};
+
 function bindEvents() {
   bindStatusBarEvents();
   packageBar.bind(document);
@@ -4232,32 +4265,14 @@ function bindEvents() {
   bindAnnotatedSourceEvents();
   bindPackageViewEvents();
   bindLibraryControlsEvents();
+  bindWorkbenchShell(document, workbenchShellActions);
   observeAsync(ensurePackageVersions(state.package), "Loading package versions");
   if (state.package?.isRuntimePack)
     observeAsync(ensureDotnetReleases(), "Loading .NET release information");
   if (state.spotlightOpen) spotlight.bind(document, "modal");
-  document.querySelector("#share")?.addEventListener("click", () => void share());
   document.querySelector("[data-graph-back]")?.addEventListener(
     "click",
     popPlatformDrill);
-  document.querySelector("#dismiss-notice")?.addEventListener("click", () => {
-    state.queryNotice = "";
-    state.queryNoticeRetryAction = null;
-    render();
-  });
-  document.querySelector("#retry-notice")?.addEventListener("click", () => {
-    const retryAction = state.queryNoticeRetryAction;
-    if (retryAction) observeAction(retryAction, "Retrying the inspection");
-  });
-  document.querySelector("#dismiss-package-notice")?.addEventListener("click", () => {
-    currentPackage().inspectionError = "";
-    render();
-  });
-  document.querySelector("#nav-back")?.addEventListener("click", navBack);
-  document.querySelector("#nav-forward")?.addEventListener("click", navForward);
-  document.querySelector("#go-home")?.addEventListener("click", goHome);
-  document.querySelector("#theme-toggle")?.addEventListener("click", toggleTheme);
-  document.querySelector("#help")?.addEventListener("click", () => showToast("⌘K command · ⌘P / type to find a type · ⌘F filter · 1—5 lenses · ↑↓ types · Alt+←/→ back/forward · graph: wheel zoom, click node to open, +/− zoom, 0 fit, arrows pan"));
 }
 
 function toggleTheme() {
@@ -5635,23 +5650,21 @@ function homeArtSvg() {
   return `<img class="home-art-img" src="/assets/dotnet-inspect-bot.png" width="680" height="680" alt="dotnet-bot inspecting through a magnifying glass" />`;
 }
 
-function bindHomeEvents() {
-  bindStatusBarEvents();
-  bindSettingsPanelEvents();
-  document.querySelector("#home-theme")?.addEventListener("click", toggleTheme);
-  document.querySelector("#dismiss-notice")?.addEventListener("click", () => {
+const homeShellActions: HomeShellBindingActions = {
+  onDemo: runHomeDemo,
+  onDismissNotice: () => {
     state.queryNotice = "";
     state.queryNoticeRetryAction = null;
     render();
-  });
+  },
+  onToggleTheme: toggleTheme,
+};
+
+function bindHomeEvents() {
+  bindStatusBarEvents();
+  bindSettingsPanelEvents();
+  bindHomeShell(document, homeShellActions);
   spotlight.bind(document, "inline");
-  document.querySelectorAll<HTMLElement>("[data-home-demo]").forEach(button =>
-    button.addEventListener("click", () => {
-      const demo = button.dataset.homeDemo;
-      if (demo === "stj" || demo === "runtime" || demo === "callgraph") {
-        runHomeDemo(demo);
-      }
-    }));
   requestAnimationFrame(() =>
     document.querySelector<HTMLInputElement>("#spotlight-input")?.focus());
 }
@@ -5772,6 +5785,14 @@ function openPackageFromError(packageId: string, version: string) {
   observeAsync(loadPackage(packageId, version, ""), "Loading a package");
 }
 
+const loadErrorShellActions: LoadErrorShellBindingActions = {
+  onOpenPackage: openPackageFromError,
+  onRetry: () =>
+    observeAction(
+      state.retryAction ?? bootstrap,
+      "Retrying the inspection"),
+};
+
 function renderLoading() {
   app.innerHTML = `
     <div class="loading-screen">
@@ -5792,26 +5813,7 @@ function renderLoading() {
            </div>`
         : `<div class="load-progress"><img class="loading-bot" src="${interstitialBotSrc()}" width="200" height="200" alt="dotnet-bot inspector mascot" /><span class="loader"></span><strong>${escapeHtml(state.loadingMessage)}</strong><small>${state.loadingSubtitle ? escapeHtml(state.loadingSubtitle) : `${escapeHtml(state.requestedPackage)}@${escapeHtml(state.requestedVersion)} · ${escapeHtml(state.requestedFramework || "best framework")}`}</small></div>`}
     </div>`;
-  document.querySelector("#retry-load")?.addEventListener(
-    "click",
-    () => observeAction(
-      state.retryAction ?? bootstrap,
-      "Retrying the inspection"));
-  document.querySelector("#error-package-query")?.addEventListener("submit", event => {
-    event.preventDefault();
-    const input =
-      document.querySelector<HTMLInputElement>("#error-package-input");
-    const value = input?.value.trim() ?? "";
-    const separator = value.lastIndexOf("@");
-    if (!value || separator === value.length - 1) return;
-    const packageId = separator > 0 ? value.slice(0, separator) : value;
-    const version = separator > 0 ? value.slice(separator + 1) : "latest";
-    openPackageFromError(packageId, version);
-  });
-  document.querySelector("#toggle-error-detail")?.addEventListener("click", () => {
-    const pre = document.querySelector<HTMLElement>(".load-error-detail");
-    if (pre) pre.hidden = !pre.hidden;
-  });
+  bindLoadErrorShell(document, loadErrorShellActions);
 }
 
 async function loadSelectedMemberDocumentation() {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -105,10 +105,14 @@ import {
   renderScopeBar as renderScopeBarPure,
 } from "./scope-bar.ts";
 import {
+  bindDocViewer,
   renderDocViewer as renderDocViewerPure,
   type DocViewerMeta,
 } from "./doc-viewer.ts";
-import { renderGraphSource as renderGraphSourcePure } from "./graph-source.ts";
+import {
+  bindGraphSource,
+  renderGraphSource as renderGraphSourcePure,
+} from "./graph-source.ts";
 import {
   renderAnnotatedSource as renderAnnotatedSourcePure,
   type AnnotatedSourceResult,
@@ -3853,6 +3857,18 @@ function bindPackageOpportunitiesEvents() {
   });
 }
 
+function bindGraphSourceEvents() {
+  bindGraphSource(document, {
+    onClose: closeGraphSource,
+  });
+}
+
+function bindDocViewerEvents() {
+  bindDocViewer(document, {
+    onClose: closeDocViewer,
+  });
+}
+
 function bindEvents() {
   bindStatusBarToggle();
   packageBar.bind(document);
@@ -3861,6 +3877,8 @@ function bindEvents() {
   bindSettingsPanelEvents();
   bindMetadataViewerEvents();
   bindPackageOpportunitiesEvents();
+  bindGraphSourceEvents();
+  bindDocViewerEvents();
   document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
     observeAsync(
       switchPackageFramework(button.dataset.frameworkChip ?? ""),
@@ -4226,22 +4244,12 @@ function bindEvents() {
   if (state.package?.isRuntimePack)
     observeAsync(ensureDotnetReleases(), "Loading .NET release information");
   if (state.spotlightOpen) spotlight.bind(document, "modal");
-  document.querySelector("#graph-source-backdrop")?.addEventListener("mousedown", event => {
-    if (event.target instanceof HTMLElement
-        && event.target.id === "graph-source-backdrop") closeGraphSource();
-  });
-  document.querySelector("#graph-source-close")?.addEventListener("click", closeGraphSource);
   document.querySelectorAll<HTMLElement>("[data-doc-path]").forEach(button =>
     button.addEventListener(
       "click",
       () => observeAsync(
         openPackageDocument(button.dataset.docPath ?? ""),
         "Opening a package document")));
-  document.querySelector("#doc-viewer-backdrop")?.addEventListener("mousedown", event => {
-    if (event.target instanceof HTMLElement
-        && event.target.id === "doc-viewer-backdrop") closeDocViewer();
-  });
-  document.querySelector("#doc-viewer-close")?.addEventListener("click", closeDocViewer);
   document.querySelector("#taste-btn")?.addEventListener("click", event => {
     event.stopPropagation();
     state.tasteOpen = !state.tasteOpen;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -1127,6 +1127,20 @@ const packageBar = createPackageBar({
     observeAsync(openRuntimePackFromHome(), "Opening the .NET Platform"),
   openPackage: (packageId, version) =>
     observeAsync(loadPackage(packageId, version, ""), "Opening a package"),
+  selectFramework: framework =>
+    observeAsync(
+      switchPackageFramework(framework),
+      "Switching the package framework"),
+  selectVersion: version => {
+    if (state.package?.isRuntimePack)
+      observeAsync(
+        switchPlatformVersion(version),
+        "Switching the platform version");
+    else
+      observeAsync(
+        switchPackageVersion(version),
+        "Switching the package version");
+  },
   showToast,
 });
 
@@ -3915,11 +3929,6 @@ function bindEvents() {
   bindGraphSourceEvents();
   bindDocViewerEvents();
   bindAnnotatedSourceEvents();
-  document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
-    observeAsync(
-      switchPackageFramework(button.dataset.frameworkChip ?? ""),
-      "Switching the package framework");
-  }));
   document.querySelectorAll<HTMLElement>("[data-dep-group]").forEach(button => button.addEventListener("click", () => {
     const index = Number(button.dataset.depGroup);
     if (state.dependenciesGroupIndex === index) return;
@@ -4220,24 +4229,6 @@ function bindEvents() {
   bindPlatformLensPicker("data-platform-opportunities-library", "opportunities", loadPackageOpportunities);
   bindPlatformLensPicker("data-platform-analysis-library", "analysis", loadPackagePerformance);
   bindPlatformLensPicker("data-platform-metadata-library", "metadata", loadPackageMetadata);
-  const frameworkSelect = document.querySelector<HTMLSelectElement>("#framework");
-  frameworkSelect?.addEventListener("change", () => {
-    observeAsync(
-      switchPackageFramework(frameworkSelect.value),
-      "Switching the package framework");
-  });
-  const packageVersionSelect =
-    document.querySelector<HTMLSelectElement>("#package-version");
-  packageVersionSelect?.addEventListener("change", () => {
-    if (state.package?.isRuntimePack)
-      observeAsync(
-        switchPlatformVersion(packageVersionSelect.value),
-        "Switching the platform version");
-    else
-      observeAsync(
-        switchPackageVersion(packageVersionSelect.value),
-        "Switching the package version");
-  });
   observeAsync(ensurePackageVersions(state.package), "Loading package versions");
   if (state.package?.isRuntimePack)
     observeAsync(ensureDotnetReleases(), "Loading .NET release information");

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -107,6 +107,7 @@ import {
 import {
   bindDocViewer,
   renderDocViewer as renderDocViewerPure,
+  renderPackageDocuments,
   type DocViewerMeta,
 } from "./doc-viewer.ts";
 import {
@@ -3258,25 +3259,8 @@ function renderPackageOverview() {
     .join("");
   const nsOverflow = nsCounts.size > 12 ? `<span class="ns-overflow">+${nsCounts.size - 12} more</span>` : "";
 
-  // Package-shipped Markdown: README/PACKAGE at the root and skill files under skills/.
-  // Presence comes from the surface manifest; the body is fetched on demand when opened.
-  const docKindLabel: Record<string, string> =
-    { readme: "Readme", package: "Package", skill: "Skill" };
-  const docKindGlyph: Record<string, string> =
-    { readme: "▤", package: "▤", skill: "◆" };
-  const documents = (pkg.documents || [])
-    .map(doc => `<button class="doc-chip doc-${escapeHtml(doc.kind)}" data-doc-path="${escapeHtml(doc.path)}" title="${escapeHtml(doc.path)} · ${doc.size.toLocaleString()} bytes">
-        <span class="doc-glyph">${docKindGlyph[doc.kind] || "▤"}</span>
-        <span class="doc-name">${escapeHtml(doc.name)}</span>
-        <span class="doc-kind">${docKindLabel[doc.kind] || doc.kind}</span>
-      </button>`)
-    .join("");
-  const documentsSection = (pkg.documents || []).length
-    ? `<section class="document-section">
-      <div class="section-title"><h2>Documentation</h2><span>${pkg.documents.length} file${pkg.documents.length === 1 ? "" : "s"} — click to read</span></div>
-      <div class="doc-chip-list">${documents}</div>
-    </section>`
-    : "";
+  const documentsSection =
+    renderPackageDocuments(pkg.documents || [], escapeHtml);
 
   return `
     <section class="document-section">
@@ -3867,6 +3851,8 @@ function bindGraphSourceEvents() {
 function bindDocViewerEvents() {
   bindDocViewer(document, {
     onClose: closeDocViewer,
+    onOpenDocument: path =>
+      observeAsync(openPackageDocument(path), "Opening a package document"),
   });
 }
 
@@ -4254,12 +4240,6 @@ function bindEvents() {
   if (state.package?.isRuntimePack)
     observeAsync(ensureDotnetReleases(), "Loading .NET release information");
   if (state.spotlightOpen) spotlight.bind(document, "modal");
-  document.querySelectorAll<HTMLElement>("[data-doc-path]").forEach(button =>
-    button.addEventListener(
-      "click",
-      () => observeAsync(
-        openPackageDocument(button.dataset.docPath ?? ""),
-        "Opening a package document")));
   document.querySelector("#taste-btn")?.addEventListener("click", event => {
     event.stopPropagation();
     state.tasteOpen = !state.tasteOpen;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -114,6 +114,7 @@ import {
   renderGraphSource as renderGraphSourcePure,
 } from "./graph-source.ts";
 import {
+  bindAnnotatedSource,
   renderAnnotatedSource as renderAnnotatedSourcePure,
   type AnnotatedSourceResult,
 } from "./annotated-source.ts";
@@ -3869,6 +3870,52 @@ function bindDocViewerEvents() {
   });
 }
 
+function bindAnnotatedSourceEvents() {
+  bindAnnotatedSource(document, {
+    onClearSelection: () => {
+      state.memberAnnotatedFactId = null;
+      state.memberAnnotatedNodeIds = [];
+      render();
+    },
+    onCopy: () => {
+      if (state.memberAnnotated) {
+        void copyText(
+          state.memberAnnotated.document.text,
+          "annotated source copied");
+      }
+    },
+    onFactSelect: factId => {
+      state.memberAnnotatedFactId =
+        state.memberAnnotatedFactId === factId ? null : factId;
+      state.memberAnnotatedNodeIds = [];
+      render();
+    },
+    onMediumToggle: medium => {
+      if (!isAnnotatedMedium(medium)) return;
+      const typedMedium = medium;
+      const next = {
+        ...state.memberAnnotatedMedia,
+        [typedMedium]: !state.memberAnnotatedMedia[typedMedium],
+      };
+      // Both media off would look like a successful empty result.
+      if (!MEDIA.some(candidate => next[candidate])) return;
+      state.memberAnnotatedMedia = next;
+      render();
+    },
+    onOffsetSelect: offset => {
+      if (!state.memberAnnotated) return;
+      const node = nodeAtOffset(state.memberAnnotated.document, offset);
+      state.memberAnnotatedFactId = null;
+      state.memberAnnotatedNodeIds = node ? [node.id] : [];
+      const owning = node
+        ? factsForNode(state.memberAnnotated.document, node.id)
+        : [];
+      if (owning.length === 1) state.memberAnnotatedFactId = owning[0].id;
+      render();
+    },
+  });
+}
+
 function bindEvents() {
   bindStatusBarToggle();
   packageBar.bind(document);
@@ -3879,6 +3926,7 @@ function bindEvents() {
   bindPackageOpportunitiesEvents();
   bindGraphSourceEvents();
   bindDocViewerEvents();
+  bindAnnotatedSourceEvents();
   document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
     observeAsync(
       switchPackageFramework(button.dataset.frameworkChip ?? ""),
@@ -4067,44 +4115,6 @@ function bindEvents() {
   }));
   document.querySelector("#copy-source")?.addEventListener("click", () => {
     if (state.memberSource) void copyText(state.memberSource.text, "source copied");
-  });
-  document.querySelector("#copy-annotated")?.addEventListener("click", () => {
-    if (state.memberAnnotated)
-      void copyText(state.memberAnnotated.document.text, "annotated source copied");
-  });
-  document.querySelectorAll<HTMLElement>("[data-annotated-medium]").forEach(button => button.addEventListener("click", () => {
-    const medium = button.dataset.annotatedMedium;
-    if (!medium || !isAnnotatedMedium(medium)) return;
-    const typedMedium = medium;
-    const next = {
-      ...state.memberAnnotatedMedia,
-      [typedMedium]: !state.memberAnnotatedMedia[typedMedium],
-    };
-    // Both media off would render an empty document that looks like an empty result.
-    if (!MEDIA.some(candidate => next[candidate])) return;
-    state.memberAnnotatedMedia = next;
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-annotated-fact]").forEach(button => button.addEventListener("click", () => {
-    const factId = Number(button.dataset.annotatedFact);
-    state.memberAnnotatedFactId = state.memberAnnotatedFactId === factId ? null : factId;
-    state.memberAnnotatedNodeIds = [];
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-annotated-offset]").forEach(span => span.addEventListener("click", () => {
-    if (!state.memberAnnotated) return;
-    const node = nodeAtOffset(state.memberAnnotated.document, Number(span.dataset.annotatedOffset));
-    state.memberAnnotatedFactId = null;
-    state.memberAnnotatedNodeIds = node ? [node.id] : [];
-    // Selecting the text a fact is about also selects that fact when exactly one owns the node.
-    const owning = node ? factsForNode(state.memberAnnotated.document, node.id) : [];
-    if (owning.length === 1) state.memberAnnotatedFactId = owning[0].id;
-    render();
-  }));
-  document.querySelector("#annotated-clear")?.addEventListener("click", () => {
-    state.memberAnnotatedFactId = null;
-    state.memberAnnotatedNodeIds = [];
-    render();
   });
   document.querySelector("#copy-type-source")?.addEventListener("click", () => {
     if (state.typeSource) void copyText(state.typeSource.text, "source copied");

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3723,6 +3723,14 @@ function bindStatusBarEvents() {
 }
 
 function bindTypePanelEvents() {
+  const renderMemberFilterAndRestoreFocus = (selector = "") => {
+    const preserved = captureMemberFocus(document);
+    if (selector) {
+      preserved.selector = selector;
+      preserved.dataTarget = null;
+    }
+    renderWithMemberFocus(preserved);
+  };
   bindTypePanel(document, {
     onClearFilters: () => {
       state.typeFilter = "";
@@ -3744,10 +3752,52 @@ function bindTypePanelEvents() {
       render();
     },
     onListKeyDown: handleTypeKeys,
+    onMemberAccessibilityFilterSelect: value => {
+      state.memberAccessibilityFilter = value ?? "all";
+      normalizeMemberSelection();
+      renderMemberFilterAndRestoreFocus();
+    },
+    onMemberFilterChange: value => {
+      state.memberTextFilter = value;
+      normalizeMemberSelection();
+      renderPreservingMemberFocus();
+    },
+    onMemberFilterClear: () => {
+      resetMemberFilters();
+      normalizeMemberSelection();
+      renderMemberFilterAndRestoreFocus("#clear-member-filter");
+    },
+    onMemberFilterKeyDown: (event, value) => {
+      if (event.key === "Escape") {
+        if (navMode() !== "member" && value === "") return;
+        event.preventDefault();
+        if (navMode() === "member") {
+          exitMemberScope();
+        } else {
+          state.memberTextFilter = "";
+          normalizeMemberSelection();
+          renderMemberFilterAndRestoreFocus("#member-filter");
+        }
+        return;
+      }
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+      event.preventDefault();
+      stepMemberNav(event.key === "ArrowDown" ? 1 : -1, true);
+    },
+    onMemberKindFilterSelect: value => {
+      state.memberKindFilter = value ?? "all";
+      normalizeMemberSelection();
+      renderMemberFilterAndRestoreFocus();
+    },
     onMemberSelect: memberKey => {
       const group = memberGroups(selectedType())
         .find(item => item.key === memberKey);
       if (group) selectMemberNavEntry({ kind: "member", group }, false);
+    },
+    onMemberTraitFilterSelect: value => {
+      state.memberTraitFilter = value ?? "";
+      normalizeMemberSelection();
+      renderMemberFilterAndRestoreFocus();
     },
     onNamespaceSelect: namespace => {
       state.namespaceFilter = namespace;
@@ -3989,60 +4039,6 @@ function bindEvents() {
       button.dataset.perfAssembly ?? "",
       button.dataset.perfType ?? "");
   }));
-  const renderMemberFilterAndRestoreFocus = (selector = "") => {
-    const preserved = captureMemberFocus(document);
-    if (selector) {
-      preserved.selector = selector;
-      preserved.dataTarget = null;
-    }
-    renderWithMemberFocus(preserved);
-  };
-  document.querySelectorAll<HTMLElement>("[data-member-kind-filter]").forEach(button => button.addEventListener("click", () => {
-    const value = button.dataset.memberKindFilter;
-    state.memberKindFilter = value ?? "all";
-    normalizeMemberSelection();
-    renderMemberFilterAndRestoreFocus();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member-access-filter]").forEach(button => button.addEventListener("click", () => {
-    const value = button.dataset.memberAccessFilter;
-    state.memberAccessibilityFilter = value ?? "all";
-    normalizeMemberSelection();
-    renderMemberFilterAndRestoreFocus();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member-trait-filter]").forEach(button => button.addEventListener("click", () => {
-    const value = button.dataset.memberTraitFilter;
-    state.memberTraitFilter = value ?? "";
-    normalizeMemberSelection();
-    renderMemberFilterAndRestoreFocus();
-  }));
-  const memberFilter = document.querySelector<HTMLInputElement>("#member-filter");
-  memberFilter?.addEventListener("input", () => {
-    state.memberTextFilter = memberFilter.value;
-    normalizeMemberSelection();
-    renderPreservingMemberFocus();
-  });
-  memberFilter?.addEventListener("keydown", event => {
-    if (event.key === "Escape") {
-      if (navMode() !== "member" && memberFilter.value === "") return;
-      event.preventDefault();
-      if (navMode() === "member") {
-        exitMemberScope();
-      } else {
-        state.memberTextFilter = "";
-        normalizeMemberSelection();
-        renderMemberFilterAndRestoreFocus("#member-filter");
-      }
-      return;
-    }
-    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
-    event.preventDefault();
-    stepMemberNav(event.key === "ArrowDown" ? 1 : -1, true);
-  });
-  document.querySelector("#clear-member-filter")?.addEventListener("click", () => {
-    resetMemberFilters();
-    normalizeMemberSelection();
-    renderMemberFilterAndRestoreFocus("#clear-member-filter");
-  });
   const enterMemberNavigation = (action: () => void) => {
     const focusGeneration = beginSpotlightNavigation();
     action();

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -113,7 +113,10 @@ import {
   renderAnnotatedSource as renderAnnotatedSourcePure,
   type AnnotatedSourceResult,
 } from "./annotated-source.ts";
-import { renderPackageOpportunities as renderPackageOpportunitiesPure } from "./package-opportunities.ts";
+import {
+  bindPackageOpportunities,
+  renderPackageOpportunities as renderPackageOpportunitiesPure,
+} from "./package-opportunities.ts";
 import {
   bindTypePanel,
   renderMemberNav,
@@ -3831,6 +3834,25 @@ function bindSettingsPanelEvents() {
   });
 }
 
+function bindPackageOpportunitiesEvents() {
+  bindPackageOpportunities(document, {
+    onLookForSelect: openSpotlight,
+    onPackageSelect: packageId =>
+      observeAsync(
+        openDependencyPackage(packageId, ""),
+        "Opening an opportunity package"),
+    onTypeSelect: typeId => {
+      const target = currentPackage().types.find(item => item.id === typeId);
+      if (!target) {
+        openSpotlight(shortTypeName(typeId));
+        return;
+      }
+      state.atPackageRoot = false;
+      navigateToTypeByName(typeId);
+    },
+  });
+}
+
 function bindEvents() {
   bindStatusBarToggle();
   packageBar.bind(document);
@@ -3838,6 +3860,7 @@ function bindEvents() {
   bindScopeBarEvents();
   bindSettingsPanelEvents();
   bindMetadataViewerEvents();
+  bindPackageOpportunitiesEvents();
   document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
     observeAsync(
       switchPackageFramework(button.dataset.frameworkChip ?? ""),
@@ -3902,21 +3925,6 @@ function bindEvents() {
       button.dataset.perfToken ?? "",
       button.dataset.perfAssembly ?? "",
       button.dataset.perfType ?? "");
-  }));
-  document.querySelectorAll<HTMLElement>("[data-opp-type]").forEach(button => button.addEventListener("click", () => {
-    const id = button.dataset.oppType ?? "";
-    const target = currentPackage().types.find(item => item.id === id);
-    if (!target) { openSpotlight(shortTypeName(id)); return; }
-    state.atPackageRoot = false;
-    navigateToTypeByName(id);
-  }));
-  document.querySelectorAll<HTMLElement>("[data-opp-package]").forEach(button => button.addEventListener("click", () => {
-    observeAsync(
-      openDependencyPackage(button.dataset.oppPackage ?? "", ""),
-      "Opening an opportunity package");
-  }));
-  document.querySelectorAll<HTMLElement>("[data-opp-lookfor]").forEach(button => button.addEventListener("click", () => {
-    openSpotlight(button.dataset.oppLookfor ?? "");
   }));
   const renderMemberFilterAndRestoreFocus = (selector = "") => {
     const preserved = captureMemberFocus(document);

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -74,6 +74,11 @@ import {
   type PackageViewBindingActions,
 } from "./package-view.ts";
 import {
+  bindLibraryControls,
+  type LibraryControlBindingActions,
+  type PlatformLibraryLens,
+} from "./library-controls.ts";
+import {
   createSourceInspectionCoordinator,
   type GraphSourceRequest,
 } from "./source-inspection.ts";
@@ -3763,6 +3768,116 @@ const packageViewActions: PackageViewBindingActions = {
   },
 };
 
+interface NoticeRetryState {
+  action: RetryAction;
+  previous: string;
+  appended: string;
+}
+
+const libraryControlActions: LibraryControlBindingActions = {
+  onAccessibilityChipSelect: accessibility => {
+    toggleAccessibilityChip(accessibility);
+    afterLibraryScopeChange();
+  },
+  onLibraryChipSelect: library => {
+    toggleLibraryChip(library);
+    afterLibraryScopeChange();
+  },
+  onLibraryJump: library => {
+    state.libraryScope = library ? new Set([library]) : null;
+    afterLibraryScopeChange();
+  },
+  onPlatformLibrarySelect: (name, pack) =>
+    observeAsync(
+      openPlatformLibrary(name, pack),
+      "Opening a platform library"),
+  onPlatformLensLibrarySelect: (lens, name, pack) =>
+    observeAsync(
+      openPlatformLensLibrary(lens, name, pack),
+      "Opening a platform library"),
+};
+
+async function openPlatformLensLibrary(
+  lens: PlatformLibraryLens,
+  name: string,
+  selectedPack: string | undefined,
+  originPackage: AppPackage = currentPackage(),
+  noticeRetryState: NoticeRetryState | null = null,
+) {
+  if (!state.packages.includes(originPackage)
+    || !packageIdentityEquals(state.package, originPackage)
+    || state.home
+    || !state.atPackageRoot
+    || state.packageLens !== lens) {
+    return;
+  }
+  if (noticeRetryState
+    && state.queryNoticeRetryAction === noticeRetryState.action) {
+    state.queryNotice = removeAppendedNotice(
+      state.queryNotice,
+      noticeRetryState.previous,
+      noticeRetryState.appended);
+    state.queryNoticeRetryAction = null;
+  }
+  const navigationSeq = navigationSequence.begin();
+  const isCurrent = () =>
+    navigationSequence.isCurrent(navigationSeq)
+    && !state.home
+    && state.atPackageRoot
+    && state.packageLens === lens
+    && packageIdentityEquals(state.package, originPackage);
+  const key = name.replace(/\.dll$/i, "");
+  const pack = selectedPack || platformPackForAssembly(key);
+  const resident = (runtimePackPackage()?.types || [])
+    .some(type => libraryKey(type) === key);
+  if (!resident) {
+    const runtimeResult = await loadRuntimePackAssembly(
+      platformScopeTfm(),
+      `${key}.dll`,
+      pack,
+      () => state.packages.includes(originPackage));
+    const loaded = runtimeResult.packageModel;
+    if (!loaded) {
+      if (isCurrent()) {
+        const noticeState: NoticeRetryState = {
+          action: null,
+          previous: state.queryNotice,
+          appended: "",
+        };
+        const retryAction = () =>
+          openPlatformLensLibrary(
+            lens,
+            name,
+            pack,
+            originPackage,
+            noticeState);
+        noticeState.action = retryAction;
+        appendQueryNotice(
+          `Couldn’t load ${key}: ${runtimeResult.failureMessage
+            || state.runtimePackError
+            || "runtime pack acquisition failed."}`,
+          retryAction);
+        noticeState.appended = state.queryNotice;
+        render();
+      }
+      return;
+    }
+  }
+  if (!isCurrent()) return;
+  state.libraryScope = new Set([key]);
+  recordPlatformRecent(key, pack);
+  state.atPackageRoot = true;
+  state.packageLens = lens;
+  state.namespaceFilter = "";
+  state.typeFilter = "";
+  state.kindFilter = "";
+  normalizeLibrarySelection();
+  if (lens === "integrations") await loadPackageIntegrations();
+  else if (lens === "opportunities") await loadPackageOpportunities();
+  else if (lens === "analysis") await loadPackagePerformance();
+  else await loadPackageMetadata();
+}
+
 function bindPackageViewEvents() {
   bindPackageView(document, packageViewActions);
 }
@@ -3778,6 +3893,10 @@ function bindStatusBarEvents() {
       render();
     },
   });
+}
+
+function bindLibraryControlsEvents() {
+  bindLibraryControls(document, libraryControlActions);
 }
 
 function bindTypePanelEvents() {
@@ -4112,119 +4231,7 @@ function bindEvents() {
   bindDocViewerEvents();
   bindAnnotatedSourceEvents();
   bindPackageViewEvents();
-  document.querySelectorAll<HTMLElement>("[data-library-chip]").forEach(button => button.addEventListener("click", () => {
-    toggleLibraryChip(button.dataset.libraryChip ?? "");
-    afterLibraryScopeChange();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-access-chip]").forEach(button => button.addEventListener("click", () => {
-    toggleAccessibilityChip(button.dataset.accessChip ?? "");
-    afterLibraryScopeChange();
-  }));
-  const libraryJump = document.querySelector<HTMLSelectElement>("#library-jump");
-  if (libraryJump) libraryJump.addEventListener("change", () => {
-    state.libraryScope = libraryJump.value ? new Set([libraryJump.value]) : null;
-    afterLibraryScopeChange();
-  });
-  document.querySelectorAll<HTMLSelectElement>("[data-platform-library-select]").forEach(select => select.addEventListener("change", () => {
-    const name = select.value;
-    if (!name) return;
-    const pack = select.selectedOptions[0]?.dataset.pack || "netcore.app";
-    observeAsync(openPlatformLibrary(name, pack), "Opening a platform library");
-  }));
-  // The lens-scoped library pickers (Integrations, Opportunities, Analysis) scope the scan
-  // without leaving the lens: unlike the main platform selector they keep package (platform)
-  // root + the active lens, then rescan. Types are loaded too so switching to Types/Overview
-  // afterward isn't empty.
-  interface NoticeRetryState {
-    action: RetryAction;
-    previous: string;
-    appended: string;
-  }
-  const bindPlatformLensPicker = (
-    dataAttr: string,
-    lens: string,
-    loader: () => Promise<void>,
-  ) => {
-    const openLibrary = async (
-      name: string,
-      pack: string,
-      originPackage: AppPackage = currentPackage(),
-      noticeRetryState: NoticeRetryState | null = null) => {
-      if (!state.packages.includes(originPackage)
-        || !packageIdentityEquals(state.package, originPackage)
-        || state.home
-        || !state.atPackageRoot
-        || state.packageLens !== lens) {
-        return;
-      }
-      if (noticeRetryState
-        && state.queryNoticeRetryAction === noticeRetryState.action) {
-        state.queryNotice = removeAppendedNotice(
-          state.queryNotice,
-          noticeRetryState.previous,
-          noticeRetryState.appended);
-        state.queryNoticeRetryAction = null;
-      }
-      const navigationSeq = navigationSequence.begin();
-      const isCurrent = () =>
-        navigationSequence.isCurrent(navigationSeq)
-        && !state.home
-        && state.atPackageRoot
-        && state.packageLens === lens
-        && packageIdentityEquals(state.package, originPackage);
-      const key = name.replace(/\.dll$/i, "");
-      const resident = (runtimePackPackage()?.types || []).some(type => libraryKey(type) === key);
-      if (!resident) {
-        const runtimeResult = await loadRuntimePackAssembly(
-          platformScopeTfm(),
-          `${key}.dll`,
-          pack,
-          () => state.packages.includes(originPackage));
-        const loaded = runtimeResult.packageModel;
-        if (!loaded) {
-          if (isCurrent()) {
-                  const noticeState: NoticeRetryState = {
-              action: null,
-              previous: state.queryNotice,
-              appended: "",
-            };
-            const retryAction = () =>
-              openLibrary(name, pack, originPackage, noticeState);
-            noticeState.action = retryAction;
-            appendQueryNotice(
-              `Couldn’t load ${key}: ${runtimeResult.failureMessage
-                || state.runtimePackError
-                || "runtime pack acquisition failed."}`,
-              retryAction);
-            noticeState.appended = state.queryNotice;
-            render();
-          }
-          return;
-        }
-      }
-      if (!isCurrent()) return;
-      state.libraryScope = new Set([key]);
-      recordPlatformRecent(key, pack);
-      state.atPackageRoot = true;
-      state.packageLens = lens;
-      state.namespaceFilter = "";
-      state.typeFilter = "";
-      state.kindFilter = "";
-      normalizeLibrarySelection();
-      await loader();
-    };
-    document.querySelectorAll<HTMLSelectElement>(`[${dataAttr}]`).forEach(select => select.addEventListener("change", () => {
-      const name = select.value;
-      if (!name) return;
-      const key = name.replace(/\.dll$/i, "");
-      const pack = select.selectedOptions[0]?.dataset.pack || platformPackForAssembly(key);
-      observeAsync(openLibrary(name, pack), "Opening a platform library");
-    }));
-  };
-  bindPlatformLensPicker("data-platform-integrations-library", "integrations", loadPackageIntegrations);
-  bindPlatformLensPicker("data-platform-opportunities-library", "opportunities", loadPackageOpportunities);
-  bindPlatformLensPicker("data-platform-analysis-library", "analysis", loadPackagePerformance);
-  bindPlatformLensPicker("data-platform-metadata-library", "metadata", loadPackageMetadata);
+  bindLibraryControlsEvents();
   observeAsync(ensurePackageVersions(state.package), "Loading package versions");
   if (state.package?.isRuntimePack)
     observeAsync(ensureDotnetReleases(), "Loading .NET release information");

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3731,6 +3731,11 @@ function bindTypePanelEvents() {
     }
     renderWithMemberFocus(preserved);
   };
+  const enterMemberNavigation = (action: () => void) => {
+    const focusGeneration = beginSpotlightNavigation();
+    action();
+    focusTypeList(focusGeneration);
+  };
   bindTypePanel(document, {
     onClearFilters: () => {
       state.typeFilter = "";
@@ -3740,6 +3745,41 @@ function bindTypePanelEvents() {
       state.accessibilityFilter = defaultAccessibilityFilter(state.package);
       render();
       focusFilter({ immediate: true });
+    },
+    onCopyAnchor: anchor => {
+      const type = selectedType();
+      const member = selectedMember(type);
+      const overload = member?.overloads[state.selectedOverloadIndex ?? 0];
+      const values = {
+        selector: overload?.stableSelector,
+        digest: overload?.anchorDigest,
+        canonical: overload?.canonicalSignature
+      };
+      const value = anchor ? values[anchor] : undefined;
+      if (value) void copyText(value, `${anchor} copied`);
+    },
+    onCopyMemberSource: () => {
+      if (state.memberSource)
+        void copyText(state.memberSource.text, "source copied");
+    },
+    onCopyName: () => {
+      const type = selectedType();
+      if (!type) return;
+      const typeName = `${type.namespace ? `${type.namespace}.` : ""}${type.name}`;
+      const member = selectedMember(type);
+      const fullName = member ? `${typeName}.${member.name}` : typeName;
+      void copyText(fullName, "name copied");
+    },
+    onCopySignature: () => {
+      const type = selectedType();
+      const member = selectedMember(type);
+      const overload = member?.overloads[state.selectedOverloadIndex ?? 0];
+      if (overload)
+        void copyText(overload.signature, "signature copied");
+    },
+    onCopyTypeSource: () => {
+      if (state.typeSource)
+        void copyText(state.typeSource.text, "source copied");
     },
     onKindSelect: kind => {
       state.kindFilter = kind;
@@ -3756,6 +3796,31 @@ function bindTypePanelEvents() {
       state.memberAccessibilityFilter = value ?? "all";
       normalizeMemberSelection();
       renderMemberFilterAndRestoreFocus();
+    },
+    onMemberBack: drillOut,
+    onMemberCompositionAccessibilitySelect: value => {
+      enterMemberNavigation(() => {
+        resetMemberFilters();
+        state.memberAccessibilityFilter = value;
+        enterMemberScope();
+        render();
+      });
+    },
+    onMemberCompositionKindSelect: value => {
+      enterMemberNavigation(() => {
+        resetMemberFilters();
+        state.memberKindFilter = value;
+        enterMemberScope();
+        render();
+      });
+    },
+    onMemberCompositionTraitSelect: value => {
+      enterMemberNavigation(() => {
+        resetMemberFilters();
+        state.memberTraitFilter = value;
+        enterMemberScope();
+        render();
+      });
     },
     onMemberFilterChange: value => {
       state.memberTextFilter = value;
@@ -3784,11 +3849,15 @@ function bindTypePanelEvents() {
       event.preventDefault();
       stepMemberNav(event.key === "ArrowDown" ? 1 : -1, true);
     },
+    onMemberGroupOpen: memberKey => {
+      enterMemberNavigation(() => openMemberGroup(memberKey));
+    },
     onMemberKindFilterSelect: value => {
       state.memberKindFilter = value ?? "all";
       normalizeMemberSelection();
       renderMemberFilterAndRestoreFocus();
     },
+    onMemberOverloadOpen: openOverload,
     onMemberSelect: memberKey => {
       const group = memberGroups(selectedType())
         .find(item => item.key === memberKey);
@@ -4044,79 +4113,6 @@ function bindEvents() {
       button.dataset.perfAssembly ?? "",
       button.dataset.perfType ?? "");
   }));
-  const enterMemberNavigation = (action: () => void) => {
-    const focusGeneration = beginSpotlightNavigation();
-    action();
-    focusTypeList(focusGeneration);
-  };
-  document.querySelectorAll<HTMLElement>("[data-member-jump-kind]").forEach(button => button.addEventListener("click", () => {
-    enterMemberNavigation(() => {
-      resetMemberFilters();
-      state.memberKindFilter = button.dataset.memberJumpKind ?? "all";
-      enterMemberScope();
-      render();
-    });
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member-jump-access]").forEach(button => button.addEventListener("click", () => {
-    enterMemberNavigation(() => {
-      resetMemberFilters();
-      state.memberAccessibilityFilter = button.dataset.memberJumpAccess ?? "all";
-      enterMemberScope();
-      render();
-    });
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member-jump-trait]").forEach(button => button.addEventListener("click", () => {
-    enterMemberNavigation(() => {
-      resetMemberFilters();
-      state.memberTraitFilter = button.dataset.memberJumpTrait ?? "";
-      enterMemberScope();
-      render();
-    });
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member]").forEach(button => button.addEventListener("click", () => {
-    enterMemberNavigation(() => openMemberGroup(button.dataset.member ?? ""));
-  }));
-  document.querySelectorAll<HTMLElement>("[data-overload]").forEach(button => button.addEventListener("click", () => {
-    openOverload(Number(button.dataset.overload));
-  }));
-  document.querySelector("#member-back")?.addEventListener("click", () => {
-    drillOut();
-  });
-  document.querySelector("#copy-name")?.addEventListener("click", () => {
-    const type = selectedType();
-    if (!type) return;
-    const typeName = `${type.namespace ? `${type.namespace}.` : ""}${type.name}`;
-    const member = selectedMember(type);
-    const fullName = member ? `${typeName}.${member.name}` : typeName;
-    void copyText(fullName, "name copied");
-  });
-  document.querySelector("#copy-signature")?.addEventListener("click", () => {
-    const type = selectedType();
-    const member = selectedMember(type);
-    const overload = member?.overloads[state.selectedOverloadIndex ?? 0];
-    if (overload) void copyText(overload.signature, "signature copied");
-  });
-  document.querySelectorAll<HTMLElement>("[data-copy-anchor]").forEach(button => button.addEventListener("click", () => {
-    const type = selectedType();
-    const member = selectedMember(type);
-    const overload = member?.overloads[state.selectedOverloadIndex ?? 0];
-    const values = {
-      selector: overload?.stableSelector,
-      digest: overload?.anchorDigest,
-      canonical: overload?.canonicalSignature
-    };
-    const anchor = button.dataset.copyAnchor;
-    const value = anchor === "selector" || anchor === "digest" || anchor === "canonical"
-      ? values[anchor]
-      : undefined;
-    if (value) void copyText(value, `${anchor} copied`);
-  }));
-  document.querySelector("#copy-source")?.addEventListener("click", () => {
-    if (state.memberSource) void copyText(state.memberSource.text, "source copied");
-  });
-  document.querySelector("#copy-type-source")?.addEventListener("click", () => {
-    if (state.typeSource) void copyText(state.typeSource.text, "source copied");
-  });
   document.querySelectorAll<HTMLElement>("[data-library-chip]").forEach(button => button.addEventListener("click", () => {
     toggleLibraryChip(button.dataset.libraryChip ?? "");
     afterLibraryScopeChange();

--- a/prototypes/inspect-web/src/graph-interactions.ts
+++ b/prototypes/inspect-web/src/graph-interactions.ts
@@ -1,0 +1,234 @@
+export interface GraphBackBindingActions {
+  onBack: () => void;
+}
+
+export interface CallGraphNodeBinding {
+  onSelect: () => void;
+  platform?: boolean;
+}
+
+export interface GraphPanZoomBindingOptions {
+  resolveCallGraphNode?: (
+    nodeId: string,
+  ) => CallGraphNodeBinding | null;
+}
+
+export interface TypeGraphNodeBinding {
+  onSelect?: () => void;
+  unavailableLabel?: string;
+}
+
+export interface DependencyGraphNodeBinding {
+  onSelect: () => void;
+}
+
+export function bindGraphBack(
+  root: ParentNode,
+  actions: GraphBackBindingActions,
+) {
+  root.querySelector("[data-graph-back]")
+    ?.addEventListener("click", actions.onBack);
+}
+
+function mermaidNodeId(node: Element, prefix: string): string {
+  const dataId = node.getAttribute("data-id");
+  const idMatch =
+    node.id.match(new RegExp(`(?:^|flowchart-)(${prefix}\\d+)(?:-|$)`));
+  return dataId || idMatch?.[1] || "";
+}
+
+export function bindTypeGraphNodes(
+  root: ParentNode,
+  resolveNode: (nodeId: string) => TypeGraphNodeBinding | null,
+) {
+  root.querySelectorAll<SVGGElement>("g.node").forEach(node => {
+    const binding = resolveNode(mermaidNodeId(node, "t"));
+    if (!binding) return;
+    if (binding.onSelect) {
+      node.classList.add("nav-node");
+      node.style.cursor = "pointer";
+      node.addEventListener("click", binding.onSelect);
+      return;
+    }
+
+    node.classList.add("non-nav");
+    if (!binding.unavailableLabel) return;
+    const title =
+      node.ownerDocument.createElementNS("http://www.w3.org/2000/svg", "title");
+    title.textContent = binding.unavailableLabel;
+    node.insertBefore(title, node.firstChild);
+  });
+}
+
+export function bindDependencyGraphNodes(
+  root: ParentNode,
+  resolveNode: (
+    nodeId: string,
+  ) => DependencyGraphNodeBinding | null,
+) {
+  root.querySelectorAll<SVGGElement>("g.node").forEach(node => {
+    const binding = resolveNode(mermaidNodeId(node, "d"));
+    if (!binding) return;
+    node.classList.add("nav-node");
+    node.style.cursor = "pointer";
+    node.addEventListener("click", binding.onSelect);
+  });
+}
+
+export function bindGraphPanZoom(
+  container: ParentNode,
+  viewport: HTMLElement,
+  options: GraphPanZoomBindingOptions = {},
+) {
+  const svg = viewport.querySelector<SVGSVGElement>("svg");
+  if (!svg) return;
+  const renderedSvg = svg;
+
+  const box = svg.viewBox?.baseVal;
+  const naturalWidth =
+    box && box.width ? box.width : svg.getBoundingClientRect().width;
+  const naturalHeight =
+    box && box.height ? box.height : svg.getBoundingClientRect().height;
+  svg.setAttribute("width", String(naturalWidth));
+  svg.setAttribute("height", String(naturalHeight));
+
+  const minScale = 0.2;
+  const maxScale = 8;
+  const view = { scale: 1, x: 0, y: 0 };
+  const clampScale = (value: number) =>
+    Math.min(maxScale, Math.max(minScale, value));
+
+  function apply() {
+    renderedSvg.style.transform =
+      `translate(${view.x}px, ${view.y}px) scale(${view.scale})`;
+  }
+
+  function fit() {
+    const rect = viewport.getBoundingClientRect();
+    if (!naturalWidth || !naturalHeight || !rect.width) return;
+    const fitScale =
+      Math.min(rect.width / naturalWidth, rect.height / naturalHeight) * 0.92;
+    view.scale = clampScale(Math.min(fitScale, 1));
+    view.x = (rect.width - naturalWidth * view.scale) / 2;
+    view.y = (rect.height - naturalHeight * view.scale) / 2;
+    apply();
+  }
+
+  function zoomAt(px: number, py: number, factor: number) {
+    const next = clampScale(view.scale * factor);
+    const ratio = next / view.scale;
+    view.x = px - (px - view.x) * ratio;
+    view.y = py - (py - view.y) * ratio;
+    view.scale = next;
+    apply();
+  }
+
+  viewport.addEventListener("wheel", event => {
+    event.preventDefault();
+    const rect = viewport.getBoundingClientRect();
+    zoomAt(
+      event.clientX - rect.left,
+      event.clientY - rect.top,
+      Math.exp(-event.deltaY * 0.0015));
+  }, { passive: false });
+
+  let pointerId: number | null = null;
+  let moved = false;
+  let capturing = false;
+  const panThreshold = 5;
+  const start = { x: 0, y: 0, vx: 0, vy: 0 };
+  viewport.addEventListener("pointerdown", event => {
+    if (event.button !== 0) return;
+    pointerId = event.pointerId;
+    moved = false;
+    capturing = false;
+    start.x = event.clientX;
+    start.y = event.clientY;
+    start.vx = view.x;
+    start.vy = view.y;
+  });
+  viewport.addEventListener("pointermove", event => {
+    if (pointerId !== event.pointerId) return;
+    const dx = event.clientX - start.x;
+    const dy = event.clientY - start.y;
+    if (!capturing) {
+      if (Math.abs(dx) + Math.abs(dy) <= panThreshold) return;
+      capturing = true;
+      moved = true;
+      viewport.setPointerCapture(pointerId);
+      viewport.classList.add("panning");
+    }
+    view.x = start.vx + dx;
+    view.y = start.vy + dy;
+    apply();
+  });
+  function endPan(event: PointerEvent) {
+    if (pointerId !== event.pointerId) return;
+    if (capturing) {
+      viewport.releasePointerCapture(pointerId);
+      viewport.classList.remove("panning");
+    }
+    capturing = false;
+    pointerId = null;
+  }
+  viewport.addEventListener("pointerup", endPan);
+  viewport.addEventListener("pointercancel", endPan);
+
+  container.querySelectorAll<HTMLElement>(".graph-controls button")
+    .forEach(button => {
+      button.addEventListener("click", () => {
+        const rect = viewport.getBoundingClientRect();
+        const mode = button.dataset.zoom;
+        if (mode === "in")
+          zoomAt(rect.width / 2, rect.height / 2, 1.25);
+        else if (mode === "out")
+          zoomAt(rect.width / 2, rect.height / 2, 0.8);
+        else
+          fit();
+      });
+    });
+
+  viewport.tabIndex = 0;
+  viewport.addEventListener("keydown", event => {
+    const rect = viewport.getBoundingClientRect();
+    const step = 45;
+    if (event.key === "+" || event.key === "=")
+      zoomAt(rect.width / 2, rect.height / 2, 1.25);
+    else if (event.key === "-" || event.key === "_")
+      zoomAt(rect.width / 2, rect.height / 2, 0.8);
+    else if (event.key === "0")
+      fit();
+    else if (event.key === "ArrowLeft") {
+      view.x += step;
+      apply();
+    } else if (event.key === "ArrowRight") {
+      view.x -= step;
+      apply();
+    } else if (event.key === "ArrowUp") {
+      view.y += step;
+      apply();
+    } else if (event.key === "ArrowDown") {
+      view.y -= step;
+      apply();
+    } else {
+      return;
+    }
+    event.preventDefault();
+  });
+
+  if (options.resolveCallGraphNode) {
+    svg.querySelectorAll<SVGGElement>("g.node").forEach(node => {
+      const binding =
+        options.resolveCallGraphNode?.(mermaidNodeId(node, "n"));
+      if (!binding) return;
+      node.classList.add("nav-node");
+      if (binding.platform) node.classList.add("platform-node");
+      node.style.cursor = "pointer";
+      node.addEventListener("click", () => {
+        if (!moved) binding.onSelect();
+      });
+    });
+  }
+
+  fit();
+}

--- a/prototypes/inspect-web/src/graph-source.ts
+++ b/prototypes/inspect-web/src/graph-source.ts
@@ -11,6 +11,24 @@ export interface RenderGraphSourceOptions {
   highlightCSharp: (value: string) => string;
 }
 
+export interface GraphSourceBindingActions {
+  onClose: () => void;
+}
+
+export function bindGraphSource(
+  root: ParentNode,
+  actions: GraphSourceBindingActions,
+) {
+  const backdrop =
+    root.querySelector<HTMLElement>("#graph-source-backdrop");
+  backdrop?.addEventListener("mousedown", event => {
+    if (event.target === backdrop) actions.onClose();
+  });
+  root.querySelector("#graph-source-close")?.addEventListener(
+    "click",
+    actions.onClose);
+}
+
 export function renderGraphSource(options: RenderGraphSourceOptions): string {
   const { title, loading, source, error, escapeHtml, highlightCSharp } = options;
   const body = loading

--- a/prototypes/inspect-web/src/library-controls.ts
+++ b/prototypes/inspect-web/src/library-controls.ts
@@ -1,0 +1,71 @@
+// DOM bindings for library and accessibility filters plus .NET platform
+// library selectors. The application root owns all resulting state and work.
+
+export type PlatformLibraryLens =
+  | "integrations"
+  | "opportunities"
+  | "analysis"
+  | "metadata";
+
+export interface LibraryControlBindingActions {
+  onAccessibilityChipSelect: (accessibility: string) => void;
+  onLibraryChipSelect: (library: string) => void;
+  onLibraryJump: (library: string) => void;
+  onPlatformLibrarySelect: (name: string, pack: string) => void;
+  onPlatformLensLibrarySelect: (
+    lens: PlatformLibraryLens,
+    name: string,
+    pack: string | undefined,
+  ) => void;
+}
+
+const platformLensSelectors:
+  readonly [selector: string, lens: PlatformLibraryLens][] = [
+    ["[data-platform-integrations-library]", "integrations"],
+    ["[data-platform-opportunities-library]", "opportunities"],
+    ["[data-platform-analysis-library]", "analysis"],
+    ["[data-platform-metadata-library]", "metadata"],
+  ];
+
+export function bindLibraryControls(
+  root: ParentNode,
+  actions: LibraryControlBindingActions,
+) {
+  root.querySelectorAll<HTMLElement>("[data-library-chip]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onLibraryChipSelect(button.dataset.libraryChip ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-access-chip]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onAccessibilityChipSelect(
+        button.dataset.accessChip ?? "")));
+
+  const libraryJump =
+    root.querySelector<HTMLSelectElement>("#library-jump");
+  libraryJump?.addEventListener(
+    "change",
+    () => actions.onLibraryJump(libraryJump.value));
+
+  root.querySelectorAll<HTMLSelectElement>("[data-platform-library-select]")
+    .forEach(select =>
+      select.addEventListener("change", () => {
+        const name = select.value;
+        if (!name) return;
+        const pack =
+          select.selectedOptions[0]?.dataset.pack || "netcore.app";
+        actions.onPlatformLibrarySelect(name, pack);
+      }));
+
+  for (const [selector, lens] of platformLensSelectors) {
+    root.querySelectorAll<HTMLSelectElement>(selector).forEach(select =>
+      select.addEventListener("change", () => {
+        const name = select.value;
+        if (!name) return;
+        actions.onPlatformLensLibrarySelect(
+          lens,
+          name,
+          select.selectedOptions[0]?.dataset.pack);
+      }));
+  }
+}

--- a/prototypes/inspect-web/src/package-bar.ts
+++ b/prototypes/inspect-web/src/package-bar.ts
@@ -24,7 +24,32 @@ interface PackageBarOptions {
   closePackageTab: (packageKey: string) => void;
   openRuntimePack: () => void;
   openPackage: (packageId: string, version: string) => void;
+  selectFramework: (framework: string) => void;
+  selectVersion: (version: string) => void;
   showToast: (message: string) => void;
+}
+
+export interface PackageSelectionActions {
+  onFrameworkSelect: (framework: string) => void;
+  onVersionSelect: (version: string) => void;
+}
+
+export function bindPackageSelections(
+  root: ParentNode,
+  actions: PackageSelectionActions,
+): void {
+  root.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onFrameworkSelect(button.dataset.frameworkChip ?? "")));
+  const framework = root.querySelector<HTMLSelectElement>("#framework");
+  framework?.addEventListener(
+    "change",
+    () => actions.onFrameworkSelect(framework.value));
+  const version = root.querySelector<HTMLSelectElement>("#package-version");
+  version?.addEventListener(
+    "change",
+    () => actions.onVersionSelect(version.value));
 }
 
 export function packageIdentityEquals(
@@ -132,6 +157,8 @@ export function createPackageBar(options: PackageBarOptions) {
     closePackageTab,
     openRuntimePack,
     openPackage,
+    selectFramework,
+    selectVersion,
     showToast,
   } = options;
 
@@ -140,6 +167,10 @@ export function createPackageBar(options: PackageBarOptions) {
   }
 
   function bind(root: ParentNode): void {
+    bindPackageSelections(root, {
+      onFrameworkSelect: selectFramework,
+      onVersionSelect: selectVersion,
+    });
     root.querySelectorAll<HTMLElement>("[data-package-key]").forEach(tab => {
       const activate = () => {
         const target = state.packages.find(item => packageIdentityKey(item) === tab.dataset.packageKey);

--- a/prototypes/inspect-web/src/package-opportunities.ts
+++ b/prototypes/inspect-web/src/package-opportunities.ts
@@ -21,6 +21,30 @@ export interface RenderPackageOpportunitiesOptions {
   escapeHtml: (value: unknown) => string;
 }
 
+export interface PackageOpportunitiesBindingActions {
+  onLookForSelect: (query: string) => void;
+  onPackageSelect: (packageId: string) => void;
+  onTypeSelect: (typeId: string) => void;
+}
+
+export function bindPackageOpportunities(
+  root: ParentNode,
+  actions: PackageOpportunitiesBindingActions,
+) {
+  root.querySelectorAll<HTMLElement>("[data-opp-type]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onTypeSelect(button.dataset.oppType ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-opp-package]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onPackageSelect(button.dataset.oppPackage ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-opp-lookfor]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onLookForSelect(button.dataset.oppLookfor ?? "")));
+}
+
 // Splits a fully-qualified API name (e.g. "System.Collections.Generic.List<T>") into a short
 // display name and its qualifier, cutting before any generic-arity or parameter-list suffix so
 // the suffix renders alongside the short name rather than the qualifier.

--- a/prototypes/inspect-web/src/package-view.ts
+++ b/prototypes/inspect-web/src/package-view.ts
@@ -1,0 +1,79 @@
+// DOM bindings for package-level navigation surfaces. The application root owns
+// package, filter, graph, and inspection state transitions behind these callbacks.
+
+export interface PackageDependencyBindingActions {
+  onDependencyLoad: (id: string, version: string) => void;
+  onDependencyOpen: (packageKey: string) => void;
+}
+
+export interface PackagePerformanceTarget {
+  metadataToken: string;
+  assembly: string;
+  typeId: string;
+}
+
+export interface PackageViewBindingActions
+  extends PackageDependencyBindingActions {
+  onDependencyGroupSelect: (index: number) => void;
+  onGraphTypeSelect: (typeId: string) => void;
+  onKindJump: (kind: string) => void;
+  onLibraryScopeSelect: (
+    library: string | undefined,
+    kind: string,
+  ) => void;
+  onNamespaceJump: (namespace: string) => void;
+  onPerformanceMemberSelect: (target: PackagePerformanceTarget) => void;
+}
+
+export function bindPackageDependencyList(
+  root: ParentNode,
+  actions: PackageDependencyBindingActions,
+) {
+  root.querySelectorAll<HTMLElement>("[data-dep-open]").forEach(button =>
+    button.onclick = () => {
+      const key = button.dataset.depOpen;
+      if (key) actions.onDependencyOpen(key);
+    });
+  root.querySelectorAll<HTMLElement>("[data-dep-load]").forEach(button =>
+    button.onclick = () => {
+      const id = button.dataset.depLoad;
+      if (id) {
+        actions.onDependencyLoad(id, button.dataset.depVersion || "");
+      }
+    });
+}
+
+export function bindPackageView(
+  root: ParentNode,
+  actions: PackageViewBindingActions,
+) {
+  root.querySelectorAll<HTMLElement>("[data-dep-group]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onDependencyGroupSelect(Number(button.dataset.depGroup))));
+  bindPackageDependencyList(root, actions);
+  root.querySelectorAll<HTMLElement>("[data-kind-jump]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onKindJump(button.dataset.kindJump ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-namespace-jump]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onNamespaceJump(button.dataset.namespaceJump ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-lib-scope]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onLibraryScopeSelect(
+        button.dataset.libScope,
+        button.dataset.libKind || "")));
+  root.querySelectorAll<HTMLElement>("[data-graph-type]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onGraphTypeSelect(button.dataset.graphType ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-perf-token]").forEach(button =>
+    button.addEventListener("click", () => actions.onPerformanceMemberSelect({
+      metadataToken: button.dataset.perfToken ?? "",
+      assembly: button.dataset.perfAssembly ?? "",
+      typeId: button.dataset.perfType ?? "",
+    })));
+}

--- a/prototypes/inspect-web/src/settings-panel.ts
+++ b/prototypes/inspect-web/src/settings-panel.ts
@@ -30,7 +30,9 @@ type EscapeHtml = (value: unknown) => string;
 
 export interface SettingsPanelBindingActions {
   onClose: () => void;
+  onOpen: (from: "home" | "workbench") => void;
   onTasteClear: () => void;
+  onTasteOpenToggle: () => void;
   onTasteToggle: (taste: string) => void;
   onThemeSelect: (theme: "dark" | "light") => void;
 }
@@ -42,6 +44,16 @@ export function bindSettingsPanel(
   root.querySelector("#settings-close")?.addEventListener(
     "click",
     actions.onClose);
+  root.querySelector("#home-settings")?.addEventListener(
+    "click",
+    () => actions.onOpen("home"));
+  root.querySelector("#open-settings")?.addEventListener(
+    "click",
+    () => actions.onOpen("workbench"));
+  root.querySelector("#taste-btn")?.addEventListener("click", event => {
+    event.stopPropagation();
+    actions.onTasteOpenToggle();
+  });
   root.querySelectorAll<HTMLElement>(".settings-seg[data-theme]")
     .forEach(button => button.addEventListener("click", () => {
       const theme = button.dataset.theme;

--- a/prototypes/inspect-web/src/shell-controls.ts
+++ b/prototypes/inspect-web/src/shell-controls.ts
@@ -1,0 +1,89 @@
+import { parsePackageQuery } from "./package-bar.ts";
+
+export type HomeDemo = "stj" | "runtime" | "callgraph";
+
+export interface WorkbenchShellBindingActions {
+  onDismissNotice: () => void;
+  onDismissPackageNotice: () => void;
+  onGoHome: () => void;
+  onHelp: () => void;
+  onNavigateBack: () => void;
+  onNavigateForward: () => void;
+  onRetryNotice: () => void;
+  onShare: () => void;
+  onToggleTheme: () => void;
+}
+
+export interface HomeShellBindingActions {
+  onDemo: (demo: HomeDemo) => void;
+  onDismissNotice: () => void;
+  onToggleTheme: () => void;
+}
+
+export interface LoadErrorShellBindingActions {
+  onOpenPackage: (packageId: string, version: string) => void;
+  onRetry: () => void;
+}
+
+export function bindWorkbenchShell(
+  root: ParentNode,
+  actions: WorkbenchShellBindingActions,
+) {
+  root.querySelector("#share")
+    ?.addEventListener("click", actions.onShare);
+  root.querySelector("#dismiss-notice")
+    ?.addEventListener("click", actions.onDismissNotice);
+  root.querySelector("#retry-notice")
+    ?.addEventListener("click", actions.onRetryNotice);
+  root.querySelector("#dismiss-package-notice")
+    ?.addEventListener("click", actions.onDismissPackageNotice);
+  root.querySelector("#nav-back")
+    ?.addEventListener("click", actions.onNavigateBack);
+  root.querySelector("#nav-forward")
+    ?.addEventListener("click", actions.onNavigateForward);
+  root.querySelector("#go-home")
+    ?.addEventListener("click", actions.onGoHome);
+  root.querySelector("#theme-toggle")
+    ?.addEventListener("click", actions.onToggleTheme);
+  root.querySelector("#help")
+    ?.addEventListener("click", actions.onHelp);
+}
+
+export function bindHomeShell(
+  root: ParentNode,
+  actions: HomeShellBindingActions,
+) {
+  root.querySelector("#home-theme")
+    ?.addEventListener("click", actions.onToggleTheme);
+  root.querySelector("#dismiss-notice")
+    ?.addEventListener("click", actions.onDismissNotice);
+  root.querySelectorAll<HTMLElement>("[data-home-demo]").forEach(button =>
+    button.addEventListener("click", () => {
+      const demo = button.dataset.homeDemo;
+      if (demo === "stj" || demo === "runtime" || demo === "callgraph") {
+        actions.onDemo(demo);
+      }
+    }));
+}
+
+export function bindLoadErrorShell(
+  root: ParentNode,
+  actions: LoadErrorShellBindingActions,
+) {
+  root.querySelector("#retry-load")
+    ?.addEventListener("click", actions.onRetry);
+  root.querySelector("#error-package-query")
+    ?.addEventListener("submit", event => {
+      event.preventDefault();
+      const input =
+        root.querySelector<HTMLInputElement>("#error-package-input");
+      const parsed = parsePackageQuery(input?.value ?? "");
+      if (parsed) actions.onOpenPackage(parsed.packageId, parsed.version);
+    });
+  root.querySelector("#toggle-error-detail")
+    ?.addEventListener("click", () => {
+      const detail =
+        root.querySelector<HTMLElement>(".load-error-detail");
+      if (detail) detail.hidden = !detail.hidden;
+    });
+}

--- a/prototypes/inspect-web/src/status-bar.ts
+++ b/prototypes/inspect-web/src/status-bar.ts
@@ -40,6 +40,19 @@ export interface StatusBarModel {
   expanded?: boolean;
 }
 
+export interface StatusBarBindingActions {
+  onToggle: () => void;
+}
+
+export function bindStatusBar(
+  root: ParentNode,
+  actions: StatusBarBindingActions,
+): void {
+  root.querySelectorAll<HTMLElement>("[data-status-bar-toggle-button]")
+    .forEach(button =>
+      button.addEventListener("click", actions.onToggle));
+}
+
 export function fmtMs(milliseconds: number | null | undefined): string {
   if (milliseconds == null) return "—";
   return milliseconds < 1000

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -81,13 +81,26 @@ type EscapeHtml = (value: unknown) => string;
 
 export interface TypePanelBindingActions {
   onClearFilters: () => void;
+  onCopyAnchor: (
+    anchor: "selector" | "digest" | "canonical" | undefined,
+  ) => void;
+  onCopyMemberSource: () => void;
+  onCopyName: () => void;
+  onCopySignature: () => void;
+  onCopyTypeSource: () => void;
   onKindSelect: (kind: string) => void;
   onListKeyDown: (event: KeyboardEvent) => void;
   onMemberAccessibilityFilterSelect: (accessibility: string | undefined) => void;
+  onMemberBack: () => void;
+  onMemberCompositionAccessibilitySelect: (accessibility: string) => void;
+  onMemberCompositionKindSelect: (kind: string) => void;
+  onMemberCompositionTraitSelect: (trait: string) => void;
   onMemberFilterChange: (value: string) => void;
   onMemberFilterClear: () => void;
   onMemberFilterKeyDown: (event: KeyboardEvent, value: string) => void;
+  onMemberGroupOpen: (memberKey: string) => void;
   onMemberKindFilterSelect: (kind: string | undefined) => void;
+  onMemberOverloadOpen: (index: number) => void;
   onMemberSelect: (memberKey: string | undefined) => void;
   onMemberTraitFilterSelect: (trait: string | undefined) => void;
   onNamespaceSelect: (namespace: string) => void;
@@ -122,6 +135,32 @@ export function bindTypePanel(
     button.addEventListener(
       "click",
       () => actions.onOverloadSelect(Number(button.dataset.navOverload))));
+  root.querySelectorAll<HTMLElement>("[data-member-jump-kind]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberCompositionKindSelect(
+          button.dataset.memberJumpKind ?? "all")));
+  root.querySelectorAll<HTMLElement>("[data-member-jump-access]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberCompositionAccessibilitySelect(
+          button.dataset.memberJumpAccess ?? "all")));
+  root.querySelectorAll<HTMLElement>("[data-member-jump-trait]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberCompositionTraitSelect(
+          button.dataset.memberJumpTrait ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-member]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onMemberGroupOpen(button.dataset.member ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-overload]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onMemberOverloadOpen(Number(button.dataset.overload))));
   root.querySelectorAll<HTMLElement>("[data-member-kind-filter]")
     .forEach(button =>
       button.addEventListener(
@@ -149,6 +188,29 @@ export function bindTypePanel(
   root.querySelector("#clear-member-filter")?.addEventListener(
     "click",
     actions.onMemberFilterClear);
+  root.querySelector("#member-back")?.addEventListener(
+    "click",
+    actions.onMemberBack);
+  root.querySelector("#copy-name")?.addEventListener(
+    "click",
+    actions.onCopyName);
+  root.querySelector("#copy-signature")?.addEventListener(
+    "click",
+    actions.onCopySignature);
+  root.querySelectorAll<HTMLElement>("[data-copy-anchor]").forEach(button =>
+    button.addEventListener("click", () => {
+      const anchor = button.dataset.copyAnchor;
+      actions.onCopyAnchor(
+        anchor === "selector" || anchor === "digest" || anchor === "canonical"
+          ? anchor
+          : undefined);
+    }));
+  root.querySelector("#copy-source")?.addEventListener(
+    "click",
+    actions.onCopyMemberSource);
+  root.querySelector("#copy-type-source")?.addEventListener(
+    "click",
+    actions.onCopyTypeSource);
 
   const namespaceJump =
     root.querySelector<HTMLSelectElement>("#namespace-jump");

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -83,7 +83,13 @@ export interface TypePanelBindingActions {
   onClearFilters: () => void;
   onKindSelect: (kind: string) => void;
   onListKeyDown: (event: KeyboardEvent) => void;
+  onMemberAccessibilityFilterSelect: (accessibility: string | undefined) => void;
+  onMemberFilterChange: (value: string) => void;
+  onMemberFilterClear: () => void;
+  onMemberFilterKeyDown: (event: KeyboardEvent, value: string) => void;
+  onMemberKindFilterSelect: (kind: string | undefined) => void;
   onMemberSelect: (memberKey: string | undefined) => void;
+  onMemberTraitFilterSelect: (trait: string | undefined) => void;
   onNamespaceSelect: (namespace: string) => void;
   onOverloadSelect: (index: number) => void;
   onShowTypes: () => void;
@@ -116,12 +122,33 @@ export function bindTypePanel(
     button.addEventListener(
       "click",
       () => actions.onOverloadSelect(Number(button.dataset.navOverload))));
+  root.querySelectorAll<HTMLElement>("[data-member-kind-filter]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberKindFilterSelect(
+          button.dataset.memberKindFilter)));
+  root.querySelectorAll<HTMLElement>("[data-member-access-filter]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberAccessibilityFilterSelect(
+          button.dataset.memberAccessFilter)));
+  root.querySelectorAll<HTMLElement>("[data-member-trait-filter]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberTraitFilterSelect(
+          button.dataset.memberTraitFilter)));
   root.querySelector("#nav-to-types")?.addEventListener(
     "click",
     actions.onShowTypes);
   root.querySelector("#clear-filter")?.addEventListener(
     "click",
     actions.onClearFilters);
+  root.querySelector("#clear-member-filter")?.addEventListener(
+    "click",
+    actions.onMemberFilterClear);
 
   const namespaceJump =
     root.querySelector<HTMLSelectElement>("#namespace-jump");
@@ -131,6 +158,14 @@ export function bindTypePanel(
 
   const typeList = root.querySelector<HTMLElement>("#type-list");
   typeList?.addEventListener("keydown", actions.onListKeyDown);
+  const memberFilter =
+    root.querySelector<HTMLInputElement>("#member-filter");
+  memberFilter?.addEventListener(
+    "input",
+    () => actions.onMemberFilterChange(memberFilter.value));
+  memberFilter?.addEventListener(
+    "keydown",
+    event => actions.onMemberFilterKeyDown(event, memberFilter.value));
   const filter = root.querySelector<HTMLInputElement>("#type-filter");
   filter?.addEventListener(
     "input",

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -1,13 +1,129 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderAnnotatedSource } from "../src/annotated-source.ts";
-import type { AnnotatedSourceRenderResult } from "../src/annotated-source.ts";
+import {
+  bindAnnotatedSource,
+  renderAnnotatedSource,
+  type AnnotatedSourceBindingActions,
+  type AnnotatedSourceRenderResult,
+} from "../src/annotated-source.ts";
 import { validateAnnotatedSourceDocument } from "../src/annotated-source-view.ts";
 import type { AnnotatedSourceDocument } from "../src/annotated-source-view.ts";
 import { sampleDocument as sampleDocumentFixture } from "../../annotated-source-viewer/src/sample-document.js";
 
 validateAnnotatedSourceDocument(sampleDocumentFixture);
 const sampleDocument: AnnotatedSourceDocument = sampleDocumentFixture;
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({} as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+    return element;
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+    return elements;
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+function recordingActions(calls: string[]): AnnotatedSourceBindingActions {
+  return {
+    onClearSelection: () => calls.push("clear"),
+    onCopy: () => {
+      calls.push("copy");
+    },
+    onFactSelect: factId => calls.push(`fact:${factId}`),
+    onMediumToggle: medium => calls.push(`medium:${medium}`),
+    onOffsetSelect: offset => calls.push(`offset:${offset}`),
+  };
+}
+
+test("annotated source bindings dispatch every rendered control", () => {
+  const root = new FakeRoot();
+  const copy = root.add("#copy-annotated", new FakeElement());
+  const medium = new FakeElement({ annotatedMedium: "Il" });
+  root.addAll("[data-annotated-medium]", medium);
+  const fact = new FakeElement({ annotatedFact: "4" });
+  root.addAll("[data-annotated-fact]", fact);
+  const offset = new FakeElement({ annotatedOffset: "17" });
+  root.addAll("[data-annotated-offset]", offset);
+  const clear = root.add("#annotated-clear", new FakeElement());
+  const calls: string[] = [];
+  bindAnnotatedSource(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  copy.dispatch("click");
+  assert.deepEqual(calls, ["copy"]);
+  medium.dispatch("click");
+  assert.deepEqual(calls, ["copy", "medium:Il"]);
+  fact.dispatch("click");
+  assert.deepEqual(calls, ["copy", "medium:Il", "fact:4"]);
+  offset.dispatch("click");
+  assert.deepEqual(calls, ["copy", "medium:Il", "fact:4", "offset:17"]);
+  clear.dispatch("click");
+  assert.deepEqual(calls, [
+    "copy",
+    "medium:Il",
+    "fact:4",
+    "offset:17",
+    "clear",
+  ]);
+});
+
+test("annotated source bindings preserve malformed dataset values", () => {
+  const root = new FakeRoot();
+  const medium = new FakeElement();
+  root.addAll("[data-annotated-medium]", medium);
+  const fact = new FakeElement();
+  root.addAll("[data-annotated-fact]", fact);
+  const offset = new FakeElement();
+  root.addAll("[data-annotated-offset]", offset);
+  const calls: string[] = [];
+  bindAnnotatedSource(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  medium.dispatch("click");
+  assert.deepEqual(calls, ["medium:"]);
+  fact.dispatch("click");
+  assert.deepEqual(calls, ["medium:", "fact:NaN"]);
+  offset.dispatch("click");
+  assert.deepEqual(calls, ["medium:", "fact:NaN", "offset:NaN"]);
+});
 
 function escapeHtml(value: unknown) {
   return String(value)

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -9,6 +9,7 @@ import {
 import { validateAnnotatedSourceDocument } from "../src/annotated-source-view.ts";
 import type { AnnotatedSourceDocument } from "../src/annotated-source-view.ts";
 import { sampleDocument as sampleDocumentFixture } from "../../annotated-source-viewer/src/sample-document.js";
+import { fakeDom } from "./fake-dom.ts";
 
 validateAnnotatedSourceDocument(sampleDocumentFixture);
 const sampleDocument: AnnotatedSourceDocument = sampleDocumentFixture;
@@ -29,7 +30,7 @@ class FakeElement {
 
   dispatch(type: string) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({} as Event);
+      listener(fakeDom.event());
     }
   }
 }
@@ -81,7 +82,7 @@ test("annotated source bindings dispatch every rendered control", () => {
   const clear = root.add("#annotated-clear", new FakeElement());
   const calls: string[] = [];
   bindAnnotatedSource(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   assert.deepEqual(calls, []);
@@ -113,7 +114,7 @@ test("annotated source bindings preserve malformed dataset values", () => {
   root.addAll("[data-annotated-offset]", offset);
   const calls: string[] = [];
   bindAnnotatedSource(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   assert.deepEqual(calls, []);

--- a/prototypes/inspect-web/test/doc-viewer.test.ts
+++ b/prototypes/inspect-web/test/doc-viewer.test.ts
@@ -1,6 +1,57 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderDocViewer } from "../src/doc-viewer.ts";
+import {
+  bindDocViewer,
+  renderDocViewer,
+} from "../src/doc-viewer.ts";
+
+class FakeElement {
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, target: EventTarget = this as unknown as EventTarget) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly elements = new Map<string, FakeElement>();
+
+  add(selector: string, element: FakeElement) {
+    this.elements.set(selector, element);
+    return element;
+  }
+
+  querySelector(selector: string) {
+    return this.elements.get(selector) ?? null;
+  }
+}
+
+test("document viewer bindings close from the button or bare backdrop only", () => {
+  const root = new FakeRoot();
+  const backdrop = root.add("#doc-viewer-backdrop", new FakeElement());
+  const close = root.add("#doc-viewer-close", new FakeElement());
+  const inner = new FakeElement();
+  const calls: string[] = [];
+  bindDocViewer(
+    root as unknown as ParentNode,
+    { onClose: () => calls.push("close") });
+
+  assert.deepEqual(calls, []);
+  backdrop.dispatch("mousedown", inner as unknown as EventTarget);
+  assert.deepEqual(calls, []);
+  backdrop.dispatch("mousedown");
+  assert.deepEqual(calls, ["close"]);
+  close.dispatch("click");
+  assert.deepEqual(calls, ["close", "close"]);
+});
 
 function escapeHtml(value: unknown) {
   return String(value)

--- a/prototypes/inspect-web/test/doc-viewer.test.ts
+++ b/prototypes/inspect-web/test/doc-viewer.test.ts
@@ -3,9 +3,11 @@ import test from "node:test";
 import {
   bindDocViewer,
   renderDocViewer,
+  renderPackageDocuments,
 } from "../src/doc-viewer.ts";
 
 class FakeElement {
+  readonly dataset: Record<string, string | undefined> = {};
   private readonly listeners = new Map<string, EventListener[]>();
 
   addEventListener(type: string, listener: EventListener) {
@@ -22,35 +24,72 @@ class FakeElement {
 }
 
 class FakeRoot {
-  private readonly elements = new Map<string, FakeElement>();
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
 
   add(selector: string, element: FakeElement) {
-    this.elements.set(selector, element);
+    this.single.set(selector, element);
     return element;
   }
 
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+    return elements;
+  }
+
   querySelector(selector: string) {
-    return this.elements.get(selector) ?? null;
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
   }
 }
 
-test("document viewer bindings close from the button or bare backdrop only", () => {
+test("document viewer bindings open documents and close from its modal controls", () => {
   const root = new FakeRoot();
   const backdrop = root.add("#doc-viewer-backdrop", new FakeElement());
   const close = root.add("#doc-viewer-close", new FakeElement());
+  const document = new FakeElement();
+  document.dataset.docPath = "docs/CHANGELOG.md";
+  const secondDocument = new FakeElement();
+  secondDocument.dataset.docPath = "docs/README.md";
+  root.addAll("[data-doc-path]", document, secondDocument);
   const inner = new FakeElement();
   const calls: string[] = [];
   bindDocViewer(
     root as unknown as ParentNode,
-    { onClose: () => calls.push("close") });
+    {
+      onClose: () => calls.push("close"),
+      onOpenDocument: path => calls.push(`open:${path}`),
+    });
 
   assert.deepEqual(calls, []);
+  document.dispatch("click");
+  assert.deepEqual(calls, ["open:docs/CHANGELOG.md"]);
+  secondDocument.dispatch("click");
+  assert.deepEqual(calls, [
+    "open:docs/CHANGELOG.md",
+    "open:docs/README.md",
+  ]);
   backdrop.dispatch("mousedown", inner as unknown as EventTarget);
-  assert.deepEqual(calls, []);
+  assert.deepEqual(calls, [
+    "open:docs/CHANGELOG.md",
+    "open:docs/README.md",
+  ]);
   backdrop.dispatch("mousedown");
-  assert.deepEqual(calls, ["close"]);
+  assert.deepEqual(calls, [
+    "open:docs/CHANGELOG.md",
+    "open:docs/README.md",
+    "close",
+  ]);
   close.dispatch("click");
-  assert.deepEqual(calls, ["close", "close"]);
+  assert.deepEqual(calls, [
+    "open:docs/CHANGELOG.md",
+    "open:docs/README.md",
+    "close",
+    "close",
+  ]);
 });
 
 function escapeHtml(value: unknown) {
@@ -62,6 +101,61 @@ function escapeHtml(value: unknown) {
 }
 
 const doc = { name: "CHANGELOG.md", path: "docs/CHANGELOG.md" };
+
+test("package document list renders live escaped chips and file counts", () => {
+  const localizedSize = (12_345_678).toLocaleString();
+  assert.notEqual(localizedSize, "12345678");
+  const html = renderPackageDocuments([
+    {
+      kind: "readme",
+      name: "<README>.md",
+      path: "<docs>/README.md",
+      size: 12_345_678,
+    },
+    {
+      kind: "<skill>",
+      name: "SKILL.md",
+      path: "skills/widget/SKILL.md",
+      size: 42,
+    },
+    {
+      kind: "skill",
+      name: "SKILL.md",
+      path: "skills/known/SKILL.md",
+      size: 64,
+    },
+    {
+      kind: "constructor",
+      name: "CONSTRUCTOR.md",
+      path: "docs/CONSTRUCTOR.md",
+      size: 1,
+    },
+  ], escapeHtml);
+
+  assert.match(html, /Documentation<\/h2><span>4 files — click to read/);
+  assert.match(
+    html,
+    /class="doc-chip doc-readme" data-doc-path="&lt;docs&gt;\/README\.md"/);
+  assert.ok(html.includes(
+    `title="&lt;docs&gt;/README.md · ${localizedSize} bytes"`));
+  assert.match(html, /<span class="doc-name">&lt;README&gt;\.md<\/span>/);
+  assert.match(html, /<span class="doc-kind">Readme<\/span>/);
+  assert.match(html, /class="doc-chip doc-&lt;skill&gt;"/);
+  assert.match(html, /<span class="doc-kind">&lt;skill&gt;<\/span>/);
+  assert.match(html, /<span class="doc-glyph">◆<\/span>/);
+  assert.match(html, /<span class="doc-kind">Skill<\/span>/);
+  assert.match(
+    html,
+    /doc-constructor[\s\S]*?<span class="doc-glyph">▤<\/span>[\s\S]*?<span class="doc-kind">constructor<\/span>/);
+  assert.doesNotMatch(html, /<docs>/);
+  assert.doesNotMatch(html, /<README>/);
+  assert.doesNotMatch(html, /<skill>/);
+  assert.doesNotMatch(html, /function Object/);
+});
+
+test("package document list stays absent when the package ships no documents", () => {
+  assert.equal(renderPackageDocuments([], escapeHtml), "");
+});
 
 test("closed viewer with no document falls back to a generic title and empty subtitle", () => {
   const html = renderDocViewer({

--- a/prototypes/inspect-web/test/doc-viewer.test.ts
+++ b/prototypes/inspect-web/test/doc-viewer.test.ts
@@ -5,6 +5,7 @@ import {
   renderDocViewer,
   renderPackageDocuments,
 } from "../src/doc-viewer.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined> = {};
@@ -16,9 +17,9 @@ class FakeElement {
     this.listeners.set(type, listeners);
   }
 
-  dispatch(type: string, target: EventTarget = this as unknown as EventTarget) {
+  dispatch(type: string, target: EventTarget = fakeDom.eventTarget(this)) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({ target } as unknown as Event);
+      listener(fakeDom.event({ target }));
     }
   }
 }
@@ -58,7 +59,7 @@ test("document viewer bindings open documents and close from its modal controls"
   const inner = new FakeElement();
   const calls: string[] = [];
   bindDocViewer(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     {
       onClose: () => calls.push("close"),
       onOpenDocument: path => calls.push(`open:${path}`),
@@ -72,7 +73,7 @@ test("document viewer bindings open documents and close from its modal controls"
     "open:docs/CHANGELOG.md",
     "open:docs/README.md",
   ]);
-  backdrop.dispatch("mousedown", inner as unknown as EventTarget);
+  backdrop.dispatch("mousedown", fakeDom.eventTarget(inner));
   assert.deepEqual(calls, [
     "open:docs/CHANGELOG.md",
     "open:docs/README.md",

--- a/prototypes/inspect-web/test/graph-interactions.test.ts
+++ b/prototypes/inspect-web/test/graph-interactions.test.ts
@@ -6,6 +6,7 @@ import {
   bindGraphPanZoom,
   bindTypeGraphNodes,
 } from "../src/graph-interactions.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeClassList {
   private readonly values = new Set<string>();
@@ -51,11 +52,11 @@ class FakeElement {
 
   dispatch(type: string, values: Record<string, unknown> = {}) {
     let prevented = false;
-    const event = {
+    const event = fakeDom.event({
       target: this,
       preventDefault: () => prevented = true,
       ...values,
-    } as unknown as Event;
+    });
     for (const listener of this.listeners.get(type) ?? []) {
       listener(event);
     }
@@ -180,7 +181,7 @@ test("graph back binding dispatches only from the rendered control", () => {
   };
 
   bindGraphBack(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     { onBack: () => calls += 1 });
 
   assert.equal(calls, 0);
@@ -195,7 +196,7 @@ test("type and dependency nodes decode stable Mermaid identities", () => {
   const typeCalls: string[] = [];
 
   bindTypeGraphNodes(
-    new FakeNodeRoot([type, unavailable, unknown]) as unknown as ParentNode,
+    fakeDom.parentNode(new FakeNodeRoot([type, unavailable, unknown])),
     nodeId => {
       if (nodeId === "t1") {
         return { onSelect: () => typeCalls.push(nodeId) };
@@ -220,7 +221,7 @@ test("type and dependency nodes decode stable Mermaid identities", () => {
   const self = new FakeElement({ dataId: "d0" });
   const dependencyCalls: string[] = [];
   bindDependencyGraphNodes(
-    new FakeNodeRoot([dependency, self]) as unknown as ParentNode,
+    fakeDom.parentNode(new FakeNodeRoot([dependency, self])),
     nodeId => nodeId === "d7"
       ? { onSelect: () => dependencyCalls.push(nodeId) }
       : null);
@@ -249,8 +250,8 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
   const calls: string[] = [];
 
   bindGraphPanZoom(
-    container as unknown as ParentNode,
-    viewport as unknown as HTMLElement,
+    fakeDom.parentNode(container),
+    fakeDom.htmlElement(viewport),
     {
       resolveCallGraphNode: nodeId => nodeId
         ? {
@@ -382,15 +383,15 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
 });
 
 test("graph bindings tolerate missing rendered surfaces", () => {
-  const root = new FakeNodeRoot([]) as unknown as ParentNode;
+  const root = fakeDom.parentNode(new FakeNodeRoot([]));
   assert.doesNotThrow(() => bindTypeGraphNodes(root, () => null));
   assert.doesNotThrow(() => bindDependencyGraphNodes(root, () => null));
   assert.doesNotThrow(() => bindGraphBack(
-    { querySelector: () => null } as unknown as ParentNode,
+    fakeDom.parentNode({ querySelector: () => null }),
     { onBack() {} }));
   assert.doesNotThrow(() => bindGraphPanZoom(
-    new FakeContainer([]) as unknown as ParentNode,
-    {
+    fakeDom.parentNode(new FakeContainer([])),
+    fakeDom.htmlElement({
       querySelector: () => null,
-    } as unknown as HTMLElement));
+    })));
 });

--- a/prototypes/inspect-web/test/graph-interactions.test.ts
+++ b/prototypes/inspect-web/test/graph-interactions.test.ts
@@ -1,0 +1,396 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bindDependencyGraphNodes,
+  bindGraphBack,
+  bindGraphPanZoom,
+  bindTypeGraphNodes,
+} from "../src/graph-interactions.ts";
+
+class FakeClassList {
+  private readonly values = new Set<string>();
+
+  add(...tokens: string[]) {
+    for (const token of tokens) this.values.add(token);
+  }
+
+  remove(...tokens: string[]) {
+    for (const token of tokens) this.values.delete(token);
+  }
+
+  contains(token: string) {
+    return this.values.has(token);
+  }
+}
+
+class FakeElement {
+  id = "";
+  readonly classList = new FakeClassList();
+  readonly dataset: Record<string, string | undefined> = {};
+  readonly inserted: { textContent: string | null }[] = [];
+  readonly ownerDocument = {
+    createElementNS: () => ({ textContent: null as string | null }),
+  };
+  readonly style: Record<string, string> = {};
+  firstChild = null;
+  hidden = false;
+  tabIndex = -1;
+  private readonly listeners = new Map<string, EventListener[]>();
+  private dataId: string | null = null;
+
+  constructor(options: { dataId?: string; id?: string } = {}) {
+    this.dataId = options.dataId ?? null;
+    this.id = options.id ?? "";
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, values: Record<string, unknown> = {}) {
+    let prevented = false;
+    const event = {
+      target: this,
+      preventDefault: () => prevented = true,
+      ...values,
+    } as unknown as Event;
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+    return prevented;
+  }
+
+  getAttribute(name: string) {
+    return name === "data-id" ? this.dataId : null;
+  }
+
+  insertBefore(node: { textContent: string | null }) {
+    this.inserted.push(node);
+    return node;
+  }
+}
+
+class FakeNodeRoot {
+  private readonly nodes: FakeElement[];
+
+  constructor(nodes: FakeElement[]) {
+    this.nodes = nodes;
+  }
+
+  querySelectorAll(selector: string) {
+    return selector === "g.node" ? this.nodes : [];
+  }
+}
+
+class FakeSvg extends FakeElement {
+  readonly attributes = new Map<string, string>();
+  readonly viewBox = { baseVal: { width: 100, height: 50 } };
+  private readonly nodes: FakeElement[];
+
+  constructor(nodes: FakeElement[]) {
+    super();
+    this.nodes = nodes;
+  }
+
+  getBoundingClientRect() {
+    return rect(100, 50);
+  }
+
+  querySelectorAll(selector: string) {
+    return selector === "g.node" ? this.nodes : [];
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+}
+
+class FakeViewport extends FakeElement {
+  capturedPointer: number | null = null;
+  private readonly svg: FakeSvg;
+
+  constructor(svg: FakeSvg) {
+    super();
+    this.svg = svg;
+  }
+
+  getBoundingClientRect() {
+    return rect(200, 100);
+  }
+
+  querySelector(selector: string) {
+    return selector === "svg" ? this.svg : null;
+  }
+
+  releasePointerCapture(pointerId: number) {
+    if (this.capturedPointer === pointerId) this.capturedPointer = null;
+  }
+
+  setPointerCapture(pointerId: number) {
+    this.capturedPointer = pointerId;
+  }
+}
+
+class FakeContainer {
+  private readonly buttons: FakeElement[];
+
+  constructor(buttons: FakeElement[]) {
+    this.buttons = buttons;
+  }
+
+  querySelectorAll(selector: string) {
+    return selector === ".graph-controls button" ? this.buttons : [];
+  }
+}
+
+function rect(width: number, height: number) {
+  return {
+    bottom: height,
+    height,
+    left: 0,
+    right: width,
+    top: 0,
+    width,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  };
+}
+
+function graphTransform(element: FakeElement) {
+  const match =
+    /^translate\(([^p]+)px, ([^p]+)px\) scale\(([^)]+)\)$/
+      .exec(element.style.transform ?? "");
+  assert.ok(match);
+  return {
+    scale: Number(match[3]),
+    x: Number(match[1]),
+    y: Number(match[2]),
+  };
+}
+
+test("graph back binding dispatches only from the rendered control", () => {
+  const back = new FakeElement();
+  let calls = 0;
+  const root = {
+    querySelector: (selector: string) =>
+      selector === "[data-graph-back]" ? back : null,
+  };
+
+  bindGraphBack(
+    root as unknown as ParentNode,
+    { onBack: () => calls += 1 });
+
+  assert.equal(calls, 0);
+  back.dispatch("click");
+  assert.equal(calls, 1);
+});
+
+test("type and dependency nodes decode stable Mermaid identities", () => {
+  const type = new FakeElement({ dataId: "t1" });
+  const unavailable = new FakeElement({ id: "flowchart-t2-4" });
+  const unknown = new FakeElement({ id: "flowchart-x3-4" });
+  const typeCalls: string[] = [];
+
+  bindTypeGraphNodes(
+    new FakeNodeRoot([type, unavailable, unknown]) as unknown as ParentNode,
+    nodeId => {
+      if (nodeId === "t1") {
+        return { onSelect: () => typeCalls.push(nodeId) };
+      }
+      if (nodeId === "t2") {
+        return { unavailableLabel: "Hidden.Type — unavailable" };
+      }
+      return null;
+    });
+
+  assert.deepEqual(typeCalls, []);
+  assert.equal(type.classList.contains("nav-node"), true);
+  assert.equal(type.style.cursor, "pointer");
+  type.dispatch("click");
+  assert.deepEqual(typeCalls, ["t1"]);
+  assert.equal(unavailable.classList.contains("non-nav"), true);
+  assert.equal(unavailable.classList.contains("nav-node"), false);
+  assert.equal(unavailable.inserted[0]?.textContent, "Hidden.Type — unavailable");
+  assert.equal(unknown.classList.contains("nav-node"), false);
+
+  const dependency = new FakeElement({ id: "flowchart-d7-2" });
+  const self = new FakeElement({ dataId: "d0" });
+  const dependencyCalls: string[] = [];
+  bindDependencyGraphNodes(
+    new FakeNodeRoot([dependency, self]) as unknown as ParentNode,
+    nodeId => nodeId === "d7"
+      ? { onSelect: () => dependencyCalls.push(nodeId) }
+      : null);
+
+  assert.deepEqual(dependencyCalls, []);
+  assert.equal(dependency.classList.contains("nav-node"), true);
+  assert.equal(dependency.style.cursor, "pointer");
+  assert.equal(self.classList.contains("nav-node"), false);
+  dependency.dispatch("click");
+  self.dispatch("click");
+  assert.deepEqual(dependencyCalls, ["d7"]);
+});
+
+test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated", () => {
+  const regular = new FakeElement({ dataId: "n1" });
+  const platform = new FakeElement({ id: "flowchart-n2-3" });
+  const svg = new FakeSvg([regular, platform]);
+  const viewport = new FakeViewport(svg);
+  const zoomIn = new FakeElement();
+  const zoomOut = new FakeElement();
+  const reset = new FakeElement();
+  zoomIn.dataset.zoom = "in";
+  zoomOut.dataset.zoom = "out";
+  reset.dataset.zoom = "reset";
+  const container = new FakeContainer([zoomIn, zoomOut, reset]);
+  const calls: string[] = [];
+
+  bindGraphPanZoom(
+    container as unknown as ParentNode,
+    viewport as unknown as HTMLElement,
+    {
+      resolveCallGraphNode: nodeId => nodeId
+        ? {
+            onSelect: () => calls.push(nodeId),
+            platform: nodeId === "n2",
+          }
+        : null,
+    });
+
+  assert.equal(viewport.tabIndex, 0);
+  assert.equal(svg.attributes.get("width"), "100");
+  assert.equal(svg.attributes.get("height"), "50");
+  assert.equal(svg.style.transform, "translate(50px, 25px) scale(1)");
+  assert.equal(regular.classList.contains("nav-node"), true);
+  assert.equal(regular.classList.contains("platform-node"), false);
+  assert.equal(platform.classList.contains("platform-node"), true);
+  regular.dispatch("click");
+  assert.deepEqual(calls, ["n1"]);
+
+  assert.equal(viewport.dispatch("wheel", {
+    clientX: 100,
+    clientY: 50,
+    deltaY: -100,
+  }), true);
+  const zoomed = graphTransform(svg);
+  assert.ok(zoomed.scale > 1);
+  assert.ok(zoomed.x < 50);
+  assert.ok(zoomed.y < 25);
+  zoomOut.dispatch("click");
+  const zoomedOut = graphTransform(svg);
+  assert.ok(zoomedOut.scale < zoomed.scale);
+  zoomIn.dispatch("click");
+  assert.ok(graphTransform(svg).scale > zoomedOut.scale);
+  reset.dispatch("click");
+  const fitted = "translate(50px, 25px) scale(1)";
+  assert.equal(svg.style.transform, fitted);
+  for (const key of ["+", "="]) {
+    assert.equal(viewport.dispatch("keydown", { key }), true);
+    assert.ok(graphTransform(svg).scale > 1);
+    assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
+    assert.equal(svg.style.transform, fitted);
+  }
+  for (const key of ["-", "_"]) {
+    assert.equal(viewport.dispatch("keydown", { key }), true);
+    assert.ok(graphTransform(svg).scale < 1);
+    assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
+    assert.equal(svg.style.transform, fitted);
+  }
+  const arrowPositions = new Map([
+    ["ArrowLeft", { x: 95, y: 25 }],
+    ["ArrowRight", { x: 5, y: 25 }],
+    ["ArrowUp", { x: 50, y: 70 }],
+    ["ArrowDown", { x: 50, y: -20 }],
+  ]);
+  for (const [key, expected] of arrowPositions) {
+    assert.equal(viewport.dispatch("keydown", { key }), true);
+    assert.deepEqual(graphTransform(svg), { ...expected, scale: 1 });
+    assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
+  }
+  assert.equal(viewport.dispatch("keydown", { key: "x" }), false);
+
+  viewport.dispatch("pointerdown", {
+    button: 1,
+    clientX: 10,
+    clientY: 10,
+    pointerId: 6,
+  });
+  viewport.dispatch("pointermove", {
+    clientX: 30,
+    clientY: 10,
+    pointerId: 6,
+  });
+  assert.equal(viewport.capturedPointer, null);
+
+  viewport.dispatch("pointerdown", {
+    button: 0,
+    clientX: 10,
+    clientY: 10,
+    pointerId: 7,
+  });
+  viewport.dispatch("pointermove", {
+    clientX: 30,
+    clientY: 10,
+    pointerId: 70,
+  });
+  assert.equal(viewport.capturedPointer, null);
+  assert.equal(svg.style.transform, fitted);
+  viewport.dispatch("pointermove", {
+    clientX: 20,
+    clientY: 10,
+    pointerId: 7,
+  });
+  assert.equal(viewport.capturedPointer, 7);
+  assert.equal(viewport.classList.contains("panning"), true);
+  assert.deepEqual(graphTransform(svg), { scale: 1, x: 60, y: 25 });
+  viewport.dispatch("pointerup", { pointerId: 7 });
+  assert.equal(viewport.capturedPointer, null);
+  assert.equal(viewport.classList.contains("panning"), false);
+  platform.dispatch("click");
+  assert.deepEqual(calls, ["n1"]);
+
+  viewport.dispatch("pointerdown", {
+    button: 0,
+    clientX: 10,
+    clientY: 10,
+    pointerId: 8,
+  });
+  viewport.dispatch("pointermove", {
+    clientX: 10,
+    clientY: 20,
+    pointerId: 8,
+  });
+  assert.equal(viewport.capturedPointer, 8);
+  viewport.dispatch("pointercancel", { pointerId: 8 });
+  assert.equal(viewport.capturedPointer, null);
+  assert.equal(viewport.classList.contains("panning"), false);
+  platform.dispatch("click");
+  assert.deepEqual(calls, ["n1"]);
+
+  viewport.dispatch("pointerdown", {
+    button: 0,
+    clientX: 10,
+    clientY: 10,
+    pointerId: 9,
+  });
+  viewport.dispatch("pointerup", { pointerId: 9 });
+  platform.dispatch("click");
+  assert.deepEqual(calls, ["n1", "n2"]);
+});
+
+test("graph bindings tolerate missing rendered surfaces", () => {
+  const root = new FakeNodeRoot([]) as unknown as ParentNode;
+  assert.doesNotThrow(() => bindTypeGraphNodes(root, () => null));
+  assert.doesNotThrow(() => bindDependencyGraphNodes(root, () => null));
+  assert.doesNotThrow(() => bindGraphBack(
+    { querySelector: () => null } as unknown as ParentNode,
+    { onBack() {} }));
+  assert.doesNotThrow(() => bindGraphPanZoom(
+    new FakeContainer([]) as unknown as ParentNode,
+    {
+      querySelector: () => null,
+    } as unknown as HTMLElement));
+});

--- a/prototypes/inspect-web/test/graph-source.test.ts
+++ b/prototypes/inspect-web/test/graph-source.test.ts
@@ -4,6 +4,7 @@ import {
   bindGraphSource,
   renderGraphSource,
 } from "../src/graph-source.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   private readonly listeners = new Map<string, EventListener[]>();
@@ -14,9 +15,9 @@ class FakeElement {
     this.listeners.set(type, listeners);
   }
 
-  dispatch(type: string, target: EventTarget = this as unknown as EventTarget) {
+  dispatch(type: string, target: EventTarget = fakeDom.eventTarget(this)) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({ target } as unknown as Event);
+      listener(fakeDom.event({ target }));
     }
   }
 }
@@ -41,11 +42,11 @@ test("graph source bindings close from the button or bare backdrop only", () => 
   const inner = new FakeElement();
   const calls: string[] = [];
   bindGraphSource(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     { onClose: () => calls.push("close") });
 
   assert.deepEqual(calls, []);
-  backdrop.dispatch("mousedown", inner as unknown as EventTarget);
+  backdrop.dispatch("mousedown", fakeDom.eventTarget(inner));
   assert.deepEqual(calls, []);
   backdrop.dispatch("mousedown");
   assert.deepEqual(calls, ["close"]);

--- a/prototypes/inspect-web/test/graph-source.test.ts
+++ b/prototypes/inspect-web/test/graph-source.test.ts
@@ -1,6 +1,57 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderGraphSource } from "../src/graph-source.ts";
+import {
+  bindGraphSource,
+  renderGraphSource,
+} from "../src/graph-source.ts";
+
+class FakeElement {
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, target: EventTarget = this as unknown as EventTarget) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly elements = new Map<string, FakeElement>();
+
+  add(selector: string, element: FakeElement) {
+    this.elements.set(selector, element);
+    return element;
+  }
+
+  querySelector(selector: string) {
+    return this.elements.get(selector) ?? null;
+  }
+}
+
+test("graph source bindings close from the button or bare backdrop only", () => {
+  const root = new FakeRoot();
+  const backdrop = root.add("#graph-source-backdrop", new FakeElement());
+  const close = root.add("#graph-source-close", new FakeElement());
+  const inner = new FakeElement();
+  const calls: string[] = [];
+  bindGraphSource(
+    root as unknown as ParentNode,
+    { onClose: () => calls.push("close") });
+
+  assert.deepEqual(calls, []);
+  backdrop.dispatch("mousedown", inner as unknown as EventTarget);
+  assert.deepEqual(calls, []);
+  backdrop.dispatch("mousedown");
+  assert.deepEqual(calls, ["close"]);
+  close.dispatch("click");
+  assert.deepEqual(calls, ["close", "close"]);
+});
 
 function escapeHtml(value: unknown) {
   return String(value)

--- a/prototypes/inspect-web/test/library-controls.test.ts
+++ b/prototypes/inspect-web/test/library-controls.test.ts
@@ -5,6 +5,7 @@ import type {
   LibraryControlBindingActions,
   PlatformLibraryLens,
 } from "../src/library-controls.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;
@@ -24,7 +25,7 @@ class FakeElement {
 
   dispatch(type: string) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({ target: this } as unknown as Event);
+      listener(fakeDom.event({ target: this }));
     }
   }
 }
@@ -114,7 +115,7 @@ test("library controls decode every rendered selector without eager work", () =>
   const calls: string[] = [];
 
   bindLibraryControls(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   assert.deepEqual(calls, []);
@@ -152,6 +153,6 @@ test("library controls decode every rendered selector without eager work", () =>
 
 test("library control binding tolerates an inactive surface", () => {
   assert.doesNotThrow(() => bindLibraryControls(
-    new FakeRoot() as unknown as ParentNode,
+    fakeDom.parentNode(new FakeRoot()),
     recordingActions([])));
 });

--- a/prototypes/inspect-web/test/library-controls.test.ts
+++ b/prototypes/inspect-web/test/library-controls.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { bindLibraryControls } from "../src/library-controls.ts";
+import type {
+  LibraryControlBindingActions,
+  PlatformLibraryLens,
+} from "../src/library-controls.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  value = "";
+  selectedOptions: FakeElement[] = [];
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target: this } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+    return element;
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+function recordingActions(calls: string[]): LibraryControlBindingActions {
+  return {
+    onAccessibilityChipSelect: value =>
+      calls.push(`accessibility:${value}`),
+    onLibraryChipSelect: value => calls.push(`library-chip:${value}`),
+    onLibraryJump: value => calls.push(`library-jump:${value}`),
+    onPlatformLibrarySelect: (name, pack) =>
+      calls.push(`platform:${name}:${pack}`),
+    onPlatformLensLibrarySelect: (
+      lens: PlatformLibraryLens,
+      name,
+      pack,
+    ) => calls.push(`platform-lens:${lens}:${name}:${pack}`),
+  };
+}
+
+test("library controls decode every rendered selector without eager work", () => {
+  const root = new FakeRoot();
+  const libraryChip = new FakeElement({ libraryChip: "System.Text.Json" });
+  const defaultLibraryChip = new FakeElement();
+  const accessChip = new FakeElement({ accessChip: "public" });
+  const defaultAccessChip = new FakeElement();
+  root.addAll(
+    "[data-library-chip]",
+    libraryChip,
+    defaultLibraryChip);
+  root.addAll("[data-access-chip]", accessChip, defaultAccessChip);
+
+  const libraryJump = root.add("#library-jump", new FakeElement());
+  libraryJump.value = "System.Collections";
+
+  const platform = new FakeElement();
+  platform.value = "System.Private.CoreLib";
+  platform.selectedOptions = [new FakeElement({ pack: "netcore.app" })];
+  const defaultPlatformPack = new FakeElement();
+  defaultPlatformPack.value = "System.Runtime";
+  defaultPlatformPack.selectedOptions = [new FakeElement()];
+  const emptyPlatform = new FakeElement();
+  root.addAll(
+    "[data-platform-library-select]",
+    platform,
+    defaultPlatformPack,
+    emptyPlatform);
+
+  const integrations = new FakeElement();
+  integrations.value = "System.Net.Http";
+  integrations.selectedOptions = [new FakeElement({ pack: "netcore.app" })];
+  const opportunities = new FakeElement();
+  opportunities.value = "System.Text.Json";
+  opportunities.selectedOptions = [new FakeElement()];
+  const analysis = new FakeElement();
+  analysis.value = "System.Linq";
+  const emptyAnalysis = new FakeElement();
+  const metadata = new FakeElement();
+  metadata.value = "System.Console";
+  metadata.selectedOptions = [new FakeElement({ pack: "windowsdesktop.app" })];
+  root.addAll("[data-platform-integrations-library]", integrations);
+  root.addAll("[data-platform-opportunities-library]", opportunities);
+  root.addAll("[data-platform-analysis-library]", analysis, emptyAnalysis);
+  root.addAll("[data-platform-metadata-library]", metadata);
+  const calls: string[] = [];
+
+  bindLibraryControls(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  libraryChip.dispatch("click");
+  defaultLibraryChip.dispatch("click");
+  accessChip.dispatch("click");
+  defaultAccessChip.dispatch("click");
+  libraryJump.dispatch("change");
+  libraryJump.value = "";
+  libraryJump.dispatch("change");
+  platform.dispatch("change");
+  defaultPlatformPack.dispatch("change");
+  emptyPlatform.dispatch("change");
+  integrations.dispatch("change");
+  opportunities.dispatch("change");
+  analysis.dispatch("change");
+  emptyAnalysis.dispatch("change");
+  metadata.dispatch("change");
+
+  assert.deepEqual(calls, [
+    "library-chip:System.Text.Json",
+    "library-chip:",
+    "accessibility:public",
+    "accessibility:",
+    "library-jump:System.Collections",
+    "library-jump:",
+    "platform:System.Private.CoreLib:netcore.app",
+    "platform:System.Runtime:netcore.app",
+    "platform-lens:integrations:System.Net.Http:netcore.app",
+    "platform-lens:opportunities:System.Text.Json:undefined",
+    "platform-lens:analysis:System.Linq:undefined",
+    "platform-lens:metadata:System.Console:windowsdesktop.app",
+  ]);
+});
+
+test("library control binding tolerates an inactive surface", () => {
+  assert.doesNotThrow(() => bindLibraryControls(
+    new FakeRoot() as unknown as ParentNode,
+    recordingActions([])));
+});

--- a/prototypes/inspect-web/test/package-bar.test.ts
+++ b/prototypes/inspect-web/test/package-bar.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  bindPackageSelections,
+  createPackageBar,
   packageBarHtml,
   packageIdentityEquals,
   packageTabHtml,
@@ -30,6 +32,147 @@ function pkg(
 ): PackageBarPackage {
   return { id, version, activeFramework, isRuntimePack };
 }
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined> = {};
+  value = "";
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target: this } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+    return element;
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+    return elements;
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+test("package selection bindings map overview and header controls without eager dispatch", () => {
+  const root = new FakeRoot();
+  const chip = new FakeElement();
+  chip.dataset.frameworkChip = "net9.0";
+  const secondChip = new FakeElement();
+  secondChip.dataset.frameworkChip = "net8.0";
+  root.addAll("[data-framework-chip]", chip, secondChip);
+  const framework = root.add("#framework", new FakeElement());
+  framework.value = "net9.0";
+  const version = root.add("#package-version", new FakeElement());
+  version.value = "10.0.0";
+  const calls: string[] = [];
+
+  bindPackageSelections(
+    root as unknown as ParentNode,
+    {
+      onFrameworkSelect: value => calls.push(`framework:${value}`),
+      onVersionSelect: value => calls.push(`version:${value}`),
+    });
+
+  assert.deepEqual(calls, []);
+  chip.dispatch("click");
+  secondChip.dispatch("click");
+  assert.deepEqual(calls, [
+    "framework:net9.0",
+    "framework:net8.0",
+  ]);
+  framework.value = "net10.0";
+  framework.dispatch("change");
+  assert.deepEqual(calls, [
+    "framework:net9.0",
+    "framework:net8.0",
+    "framework:net10.0",
+  ]);
+  version.value = "10.0.1";
+  version.dispatch("change");
+  assert.deepEqual(calls, [
+    "framework:net9.0",
+    "framework:net8.0",
+    "framework:net10.0",
+    "version:10.0.1",
+  ]);
+});
+
+test("package selection binding tolerates an inactive surface with no controls", () => {
+  const calls: string[] = [];
+  bindPackageSelections(
+    new FakeRoot() as unknown as ParentNode,
+    {
+      onFrameworkSelect: value => calls.push(`framework:${value}`),
+      onVersionSelect: value => calls.push(`version:${value}`),
+    });
+
+  assert.deepEqual(calls, []);
+});
+
+test("package bar connects package selection controls to its typed options", () => {
+  const root = new FakeRoot();
+  const chip = new FakeElement();
+  chip.dataset.frameworkChip = "net9.0";
+  const secondChip = new FakeElement();
+  secondChip.dataset.frameworkChip = "net8.0";
+  root.addAll("[data-framework-chip]", chip, secondChip);
+  const framework = root.add("#framework", new FakeElement());
+  framework.value = "net9.0";
+  const version = root.add("#package-version", new FakeElement());
+  version.value = "10.0.0";
+  root.add("#package-query", new FakeElement());
+  const calls: string[] = [];
+  const packageBar = createPackageBar({
+    state: { packages: [], package: null },
+    escapeHtml,
+    packageIdentityKey,
+    runtimePackPackage: () => null,
+    selectPackageTab: () => {},
+    closePackageTab: () => {},
+    openRuntimePack: () => {},
+    openPackage: () => {},
+    selectFramework: value => calls.push(`framework:${value}`),
+    selectVersion: value => calls.push(`version:${value}`),
+    showToast: () => {},
+  });
+
+  packageBar.bind(root as unknown as ParentNode);
+
+  assert.deepEqual(calls, []);
+  chip.dispatch("click");
+  secondChip.dispatch("click");
+  framework.value = "net10.0";
+  framework.dispatch("change");
+  version.value = "10.0.1";
+  version.dispatch("change");
+  assert.deepEqual(calls, [
+    "framework:net9.0",
+    "framework:net8.0",
+    "framework:net10.0",
+    "version:10.0.1",
+  ]);
+});
 
 test("package identity equality compares the full coordinate", () => {
   const a = pkg("System.Text.Json");

--- a/prototypes/inspect-web/test/package-bar.test.ts
+++ b/prototypes/inspect-web/test/package-bar.test.ts
@@ -11,6 +11,7 @@ import {
   platformTabHtml,
 } from "../src/package-bar.ts";
 import type { PackageBarPackage } from "../src/package-bar.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 function escapeHtml(value: unknown) {
   return String(value)
@@ -46,7 +47,7 @@ class FakeElement {
 
   dispatch(type: string) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({ target: this } as unknown as Event);
+      listener(fakeDom.event({ target: this }));
     }
   }
 }
@@ -88,7 +89,7 @@ test("package selection bindings map overview and header controls without eager 
   const calls: string[] = [];
 
   bindPackageSelections(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     {
       onFrameworkSelect: value => calls.push(`framework:${value}`),
       onVersionSelect: value => calls.push(`version:${value}`),
@@ -121,7 +122,7 @@ test("package selection bindings map overview and header controls without eager 
 test("package selection binding tolerates an inactive surface with no controls", () => {
   const calls: string[] = [];
   bindPackageSelections(
-    new FakeRoot() as unknown as ParentNode,
+    fakeDom.parentNode(new FakeRoot()),
     {
       onFrameworkSelect: value => calls.push(`framework:${value}`),
       onVersionSelect: value => calls.push(`version:${value}`),
@@ -157,7 +158,7 @@ test("package bar connects package selection controls to its typed options", () 
     showToast: () => {},
   });
 
-  packageBar.bind(root as unknown as ParentNode);
+  packageBar.bind(fakeDom.parentNode(root));
 
   assert.deepEqual(calls, []);
   chip.dispatch("click");

--- a/prototypes/inspect-web/test/package-opportunities.test.ts
+++ b/prototypes/inspect-web/test/package-opportunities.test.ts
@@ -61,8 +61,14 @@ test("opportunity bindings dispatch type, package, and search actions", () => {
     root as unknown as ParentNode,
     recordingActions(calls));
 
+  assert.deepEqual(calls, []);
   type.dispatch("click");
+  assert.deepEqual(calls, ["type:Contoso.Widget"]);
   packageChip.dispatch("click");
+  assert.deepEqual(calls, [
+    "type:Contoso.Widget",
+    "package:Contoso.Extensions",
+  ]);
   lookFor.dispatch("click");
 
   assert.deepEqual(calls, [
@@ -85,8 +91,11 @@ test("opportunity bindings preserve empty values for malformed controls", () => 
     root as unknown as ParentNode,
     recordingActions(calls));
 
+  assert.deepEqual(calls, []);
   type.dispatch("click");
+  assert.deepEqual(calls, ["type:"]);
   packageChip.dispatch("click");
+  assert.deepEqual(calls, ["type:", "package:"]);
   lookFor.dispatch("click");
 
   assert.deepEqual(calls, ["type:", "package:", "look:"]);

--- a/prototypes/inspect-web/test/package-opportunities.test.ts
+++ b/prototypes/inspect-web/test/package-opportunities.test.ts
@@ -5,6 +5,7 @@ import {
   renderPackageOpportunities,
   type PackageOpportunitiesBindingActions,
 } from "../src/package-opportunities.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;
@@ -22,7 +23,7 @@ class FakeElement {
 
   dispatch(type: string) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({} as Event);
+      listener(fakeDom.event());
     }
   }
 }
@@ -61,7 +62,7 @@ test("opportunity bindings dispatch type, package, and search actions", () => {
   root.add("[data-opp-lookfor]", lookFor, secondLookFor);
   const calls: string[] = [];
   bindPackageOpportunities(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   assert.deepEqual(calls, []);
@@ -103,7 +104,7 @@ test("opportunity bindings preserve empty values for malformed controls", () => 
   root.add("[data-opp-lookfor]", lookFor);
   const calls: string[] = [];
   bindPackageOpportunities(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   assert.deepEqual(calls, []);

--- a/prototypes/inspect-web/test/package-opportunities.test.ts
+++ b/prototypes/inspect-web/test/package-opportunities.test.ts
@@ -51,11 +51,14 @@ function recordingActions(calls: string[]): PackageOpportunitiesBindingActions {
 test("opportunity bindings dispatch type, package, and search actions", () => {
   const root = new FakeRoot();
   const type = new FakeElement({ oppType: "Contoso.Widget" });
+  const secondType = new FakeElement({ oppType: "Contoso.Gadget" });
   const packageChip = new FakeElement({ oppPackage: "Contoso.Extensions" });
+  const secondPackage = new FakeElement({ oppPackage: "Contoso.Hosting" });
   const lookFor = new FakeElement({ oppLookfor: "AddWidgets" });
-  root.add("[data-opp-type]", type);
-  root.add("[data-opp-package]", packageChip);
-  root.add("[data-opp-lookfor]", lookFor);
+  const secondLookFor = new FakeElement({ oppLookfor: "AddGadgets" });
+  root.add("[data-opp-type]", type, secondType);
+  root.add("[data-opp-package]", packageChip, secondPackage);
+  root.add("[data-opp-lookfor]", lookFor, secondLookFor);
   const calls: string[] = [];
   bindPackageOpportunities(
     root as unknown as ParentNode,
@@ -75,6 +78,18 @@ test("opportunity bindings dispatch type, package, and search actions", () => {
     "type:Contoso.Widget",
     "package:Contoso.Extensions",
     "look:AddWidgets",
+  ]);
+  secondType.dispatch("click");
+  secondPackage.dispatch("click");
+  secondLookFor.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "type:Contoso.Widget",
+    "package:Contoso.Extensions",
+    "look:AddWidgets",
+    "type:Contoso.Gadget",
+    "package:Contoso.Hosting",
+    "look:AddGadgets",
   ]);
 });
 

--- a/prototypes/inspect-web/test/package-opportunities.test.ts
+++ b/prototypes/inspect-web/test/package-opportunities.test.ts
@@ -1,6 +1,96 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderPackageOpportunities } from "../src/package-opportunities.ts";
+import {
+  bindPackageOpportunities,
+  renderPackageOpportunities,
+  type PackageOpportunitiesBindingActions,
+} from "../src/package-opportunities.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({} as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly elements = new Map<string, FakeElement[]>();
+
+  add(selector: string, ...elements: FakeElement[]) {
+    this.elements.set(selector, elements);
+    return elements;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.elements.get(selector) ?? [];
+  }
+}
+
+function recordingActions(calls: string[]): PackageOpportunitiesBindingActions {
+  return {
+    onLookForSelect: query => calls.push(`look:${query}`),
+    onPackageSelect: packageId => calls.push(`package:${packageId}`),
+    onTypeSelect: typeId => calls.push(`type:${typeId}`),
+  };
+}
+
+test("opportunity bindings dispatch type, package, and search actions", () => {
+  const root = new FakeRoot();
+  const type = new FakeElement({ oppType: "Contoso.Widget" });
+  const packageChip = new FakeElement({ oppPackage: "Contoso.Extensions" });
+  const lookFor = new FakeElement({ oppLookfor: "AddWidgets" });
+  root.add("[data-opp-type]", type);
+  root.add("[data-opp-package]", packageChip);
+  root.add("[data-opp-lookfor]", lookFor);
+  const calls: string[] = [];
+  bindPackageOpportunities(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  type.dispatch("click");
+  packageChip.dispatch("click");
+  lookFor.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "type:Contoso.Widget",
+    "package:Contoso.Extensions",
+    "look:AddWidgets",
+  ]);
+});
+
+test("opportunity bindings preserve empty values for malformed controls", () => {
+  const root = new FakeRoot();
+  const type = new FakeElement();
+  const packageChip = new FakeElement();
+  const lookFor = new FakeElement();
+  root.add("[data-opp-type]", type);
+  root.add("[data-opp-package]", packageChip);
+  root.add("[data-opp-lookfor]", lookFor);
+  const calls: string[] = [];
+  bindPackageOpportunities(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  type.dispatch("click");
+  packageChip.dispatch("click");
+  lookFor.dispatch("click");
+
+  assert.deepEqual(calls, ["type:", "package:", "look:"]);
+});
 
 function escapeHtml(value: unknown) {
   return String(value)

--- a/prototypes/inspect-web/test/package-view.test.ts
+++ b/prototypes/inspect-web/test/package-view.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bindPackageDependencyList,
+  bindPackageView,
+} from "../src/package-view.ts";
+import type {
+  PackagePerformanceTarget,
+  PackageViewBindingActions,
+} from "../src/package-view.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  private readonly listeners = new Map<string, EventListener[]>();
+  onclick: EventListener | null = null;
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    const event = { target: this } as unknown as Event;
+    if (type === "click") this.onclick?.(event);
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+function recordingActions(calls: string[]): PackageViewBindingActions {
+  return {
+    onDependencyGroupSelect: value => calls.push(`dependency-group:${value}`),
+    onDependencyLoad: (id, version) =>
+      calls.push(`dependency-load:${id}@${version}`),
+    onDependencyOpen: value => calls.push(`dependency-open:${value}`),
+    onGraphTypeSelect: value => calls.push(`graph-type:${value}`),
+    onKindJump: value => calls.push(`kind:${value}`),
+    onLibraryScopeSelect: (library, kind) =>
+      calls.push(`library:${library}:${kind}`),
+    onNamespaceJump: value => calls.push(`namespace:${value}`),
+    onPerformanceMemberSelect: (target: PackagePerformanceTarget) =>
+      calls.push(
+        `performance:${target.metadataToken}:${target.assembly}:${target.typeId}`),
+  };
+}
+
+test("package view bindings decode navigation controls without eager work", () => {
+  const root = new FakeRoot();
+  const group = new FakeElement({ depGroup: "2" });
+  const defaultGroup = new FakeElement();
+  const open = new FakeElement({ depOpen: "Example@1.0.0::net10.0" });
+  const secondOpen = new FakeElement({ depOpen: "Other@2.0.0::net9.0" });
+  const emptyOpen = new FakeElement({ depOpen: "" });
+  const load = new FakeElement({
+    depLoad: "Other.Package",
+    depVersion: "[2.0.0,)",
+  });
+  const defaultVersion = new FakeElement({ depLoad: "Default.Package" });
+  const emptyLoad = new FakeElement({ depLoad: "" });
+  const kind = new FakeElement({ kindJump: "class" });
+  const defaultKind = new FakeElement();
+  const namespace = new FakeElement({ namespaceJump: "System.Text" });
+  const defaultNamespace = new FakeElement();
+  const library = new FakeElement({
+    libScope: "System.Text.Json",
+    libKind: "class",
+  });
+  const defaultLibrary = new FakeElement();
+  const graphType = new FakeElement({ graphType: "System.String" });
+  const defaultGraphType = new FakeElement();
+  const performance = new FakeElement({
+    perfToken: "0x06000001",
+    perfAssembly: "Example.dll",
+    perfType: "Example.Type",
+  });
+  const defaultPerformance = new FakeElement();
+  root.addAll("[data-dep-group]", group, defaultGroup);
+  root.addAll("[data-dep-open]", open, secondOpen, emptyOpen);
+  root.addAll("[data-dep-load]", load, defaultVersion, emptyLoad);
+  root.addAll("[data-kind-jump]", kind, defaultKind);
+  root.addAll("[data-namespace-jump]", namespace, defaultNamespace);
+  root.addAll("[data-lib-scope]", library, defaultLibrary);
+  root.addAll("[data-graph-type]", graphType, defaultGraphType);
+  root.addAll("[data-perf-token]", performance, defaultPerformance);
+  const calls: string[] = [];
+
+  bindPackageView(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  group.dispatch("click");
+  defaultGroup.dispatch("click");
+  open.dispatch("click");
+  secondOpen.dispatch("click");
+  emptyOpen.dispatch("click");
+  load.dispatch("click");
+  defaultVersion.dispatch("click");
+  emptyLoad.dispatch("click");
+  kind.dispatch("click");
+  defaultKind.dispatch("click");
+  namespace.dispatch("click");
+  defaultNamespace.dispatch("click");
+  library.dispatch("click");
+  defaultLibrary.dispatch("click");
+  graphType.dispatch("click");
+  defaultGraphType.dispatch("click");
+  performance.dispatch("click");
+  defaultPerformance.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "dependency-group:2",
+    "dependency-group:NaN",
+    "dependency-open:Example@1.0.0::net10.0",
+    "dependency-open:Other@2.0.0::net9.0",
+    "dependency-load:Other.Package@[2.0.0,)",
+    "dependency-load:Default.Package@",
+    "kind:class",
+    "kind:",
+    "namespace:System.Text",
+    "namespace:",
+    "library:System.Text.Json:class",
+    "library:undefined:",
+    "graph-type:System.String",
+    "graph-type:",
+    "performance:0x06000001:Example.dll:Example.Type",
+    "performance:::",
+  ]);
+});
+
+test("dependency list binding reconnects only replacement list controls", () => {
+  const root = new FakeRoot();
+  const open = new FakeElement({ depOpen: "Example@1.0.0::net10.0" });
+  const secondOpen = new FakeElement({ depOpen: "Other@2.0.0::net9.0" });
+  const load = new FakeElement({
+    depLoad: "Other.Package",
+    depVersion: "2.0.0",
+  });
+  root.addAll("[data-dep-open]", open, secondOpen);
+  root.addAll("[data-dep-load]", load);
+  const calls: string[] = [];
+
+  bindPackageDependencyList(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+  bindPackageDependencyList(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  open.dispatch("click");
+  secondOpen.dispatch("click");
+  load.dispatch("click");
+  assert.deepEqual(calls, [
+    "dependency-open:Example@1.0.0::net10.0",
+    "dependency-open:Other@2.0.0::net9.0",
+    "dependency-load:Other.Package@2.0.0",
+  ]);
+});
+
+test("package view binding tolerates an inactive surface", () => {
+  assert.doesNotThrow(() => bindPackageView(
+    new FakeRoot() as unknown as ParentNode,
+    recordingActions([])));
+});

--- a/prototypes/inspect-web/test/package-view.test.ts
+++ b/prototypes/inspect-web/test/package-view.test.ts
@@ -8,6 +8,7 @@ import type {
   PackagePerformanceTarget,
   PackageViewBindingActions,
 } from "../src/package-view.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;
@@ -25,7 +26,7 @@ class FakeElement {
   }
 
   dispatch(type: string) {
-    const event = { target: this } as unknown as Event;
+    const event = fakeDom.event({ target: this });
     if (type === "click") this.onclick?.(event);
     for (const listener of this.listeners.get(type) ?? []) {
       listener(event);
@@ -103,7 +104,7 @@ test("package view bindings decode navigation controls without eager work", () =
   const calls: string[] = [];
 
   bindPackageView(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   assert.deepEqual(calls, []);
@@ -159,10 +160,10 @@ test("dependency list binding reconnects only replacement list controls", () => 
   const calls: string[] = [];
 
   bindPackageDependencyList(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
   bindPackageDependencyList(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   assert.deepEqual(calls, []);
@@ -178,6 +179,6 @@ test("dependency list binding reconnects only replacement list controls", () => 
 
 test("package view binding tolerates an inactive surface", () => {
   assert.doesNotThrow(() => bindPackageView(
-    new FakeRoot() as unknown as ParentNode,
+    fakeDom.parentNode(new FakeRoot()),
     recordingActions([])));
 });

--- a/prototypes/inspect-web/test/settings-panel.test.ts
+++ b/prototypes/inspect-web/test/settings-panel.test.ts
@@ -62,8 +62,11 @@ class FakeRoot {
         "all:#taste-popover [data-taste]",
         "all:.settings-seg[data-theme]",
         "all:.settings-taste [data-taste]",
+        "one:#home-settings",
+        "one:#open-settings",
         "one:#settings-close",
         "one:#settings-taste-clear",
+        "one:#taste-btn",
         "one:#taste-clear",
       ].sort());
   }
@@ -114,6 +117,7 @@ test("settings bindings dispatch entry controls and contain taste clicks", () =>
   bindSettingsPanel(
     fakeDom.parentNode(root),
     recordingActions(calls));
+  root.assertSelectorQueries();
 
   assert.deepEqual(calls, []);
   home.dispatch("click");

--- a/prototypes/inspect-web/test/settings-panel.test.ts
+++ b/prototypes/inspect-web/test/settings-panel.test.ts
@@ -104,15 +104,15 @@ test("settings bindings dispatch entry controls and contain taste clicks", () =>
   const workbench = root.add("#open-settings", new FakeElement());
   const taste = root.add("#taste-btn", new FakeElement());
   const propagation = { stopped: false };
-  const event = {
+  const event = fakeDom.event({
     stopPropagation: () => {
       propagation.stopped = true;
     },
-  } as unknown as Event;
+  });
   const calls: string[] = [];
 
   bindSettingsPanel(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   assert.deepEqual(calls, []);

--- a/prototypes/inspect-web/test/settings-panel.test.ts
+++ b/prototypes/inspect-web/test/settings-panel.test.ts
@@ -23,9 +23,9 @@ class FakeElement {
     this.listeners.set(type, listeners);
   }
 
-  dispatch(type: string) {
+  dispatch(type: string, event: Event = fakeDom.event()) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener(fakeDom.event());
+      listener(event);
     }
   }
 }
@@ -72,7 +72,9 @@ class FakeRoot {
 function recordingActions(calls: string[]): SettingsPanelBindingActions {
   return {
     onClose: () => calls.push("close"),
+    onOpen: from => calls.push(`open:${from}`),
     onTasteClear: () => calls.push("clear"),
+    onTasteOpenToggle: () => calls.push("taste-open"),
     onTasteToggle: taste => calls.push(`taste:${taste}`),
     onThemeSelect: theme => calls.push(`theme:${theme}`),
   };
@@ -95,6 +97,33 @@ const styleOptions = [
   { id: "readable-locals", tier: "naming", title: "Readable local names", summary: "Synthesize readable local names.", oracle_endorsed: true },
   { id: "expanded-braces", tier: "layout", title: "Expanded braces", summary: "Always use braces." },
 ];
+
+test("settings bindings dispatch entry controls and contain taste clicks", () => {
+  const root = new FakeRoot();
+  const home = root.add("#home-settings", new FakeElement());
+  const workbench = root.add("#open-settings", new FakeElement());
+  const taste = root.add("#taste-btn", new FakeElement());
+  const propagation = { stopped: false };
+  const event = {
+    stopPropagation: () => {
+      propagation.stopped = true;
+    },
+  } as unknown as Event;
+  const calls: string[] = [];
+
+  bindSettingsPanel(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  home.dispatch("click");
+  assert.deepEqual(calls, ["open:home"]);
+  workbench.dispatch("click");
+  assert.deepEqual(calls, ["open:home", "open:workbench"]);
+  taste.dispatch("click", event);
+  assert.deepEqual(calls, ["open:home", "open:workbench", "taste-open"]);
+  assert.equal(propagation.stopped, true);
+});
 
 test("settings bindings dispatch valid settings-page controls", () => {
   const root = new FakeRoot();

--- a/prototypes/inspect-web/test/shell-controls.test.ts
+++ b/prototypes/inspect-web/test/shell-controls.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bindHomeShell,
+  bindLoadErrorShell,
+  bindWorkbenchShell,
+} from "../src/shell-controls.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  hidden = true;
+  value = "";
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    let prevented = false;
+    const event = {
+      target: this,
+      preventDefault: () => prevented = true,
+    } as unknown as Event;
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+    return prevented;
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+test("workbench shell binds every rendered control without eager work", () => {
+  const root = new FakeRoot();
+  const controls = new Map([
+    ["#share", "share"],
+    ["#dismiss-notice", "dismiss-notice"],
+    ["#retry-notice", "retry-notice"],
+    ["#dismiss-package-notice", "dismiss-package-notice"],
+    ["#nav-back", "navigate-back"],
+    ["#nav-forward", "navigate-forward"],
+    ["#go-home", "go-home"],
+    ["#theme-toggle", "toggle-theme"],
+    ["#help", "help"],
+  ]);
+  for (const selector of controls.keys()) {
+    root.add(selector, new FakeElement());
+  }
+  const calls: string[] = [];
+
+  bindWorkbenchShell(root as unknown as ParentNode, {
+    onDismissNotice: () => calls.push("dismiss-notice"),
+    onDismissPackageNotice: () => calls.push("dismiss-package-notice"),
+    onGoHome: () => calls.push("go-home"),
+    onHelp: () => calls.push("help"),
+    onNavigateBack: () => calls.push("navigate-back"),
+    onNavigateForward: () => calls.push("navigate-forward"),
+    onRetryNotice: () => calls.push("retry-notice"),
+    onShare: () => calls.push("share"),
+    onToggleTheme: () => calls.push("toggle-theme"),
+  });
+
+  assert.deepEqual(calls, []);
+  for (const [selector, call] of controls) {
+    root.querySelector(selector)?.dispatch("click");
+    assert.equal(calls.at(-1), call);
+  }
+  assert.equal(calls.length, controls.size);
+});
+
+test("home shell accepts only known demos", () => {
+  const root = new FakeRoot();
+  const theme = new FakeElement();
+  const dismiss = new FakeElement();
+  const stj = new FakeElement({ homeDemo: "stj" });
+  const runtime = new FakeElement({ homeDemo: "runtime" });
+  const callgraph = new FakeElement({ homeDemo: "callgraph" });
+  const unknown = new FakeElement({ homeDemo: "other" });
+  const absent = new FakeElement();
+  root.add("#home-theme", theme);
+  root.add("#dismiss-notice", dismiss);
+  root.addAll(
+    "[data-home-demo]",
+    stj,
+    runtime,
+    callgraph,
+    unknown,
+    absent,
+  );
+  const calls: string[] = [];
+
+  bindHomeShell(root as unknown as ParentNode, {
+    onDemo: demo => calls.push(`demo:${demo}`),
+    onDismissNotice: () => calls.push("dismiss"),
+    onToggleTheme: () => calls.push("theme"),
+  });
+
+  assert.deepEqual(calls, []);
+  theme.dispatch("click");
+  dismiss.dispatch("click");
+  stj.dispatch("click");
+  runtime.dispatch("click");
+  callgraph.dispatch("click");
+  unknown.dispatch("click");
+  absent.dispatch("click");
+  assert.deepEqual(calls, [
+    "theme",
+    "dismiss",
+    "demo:stj",
+    "demo:runtime",
+    "demo:callgraph",
+  ]);
+});
+
+test("load error shell parses replacement packages and owns local detail state", () => {
+  const root = new FakeRoot();
+  const retry = new FakeElement();
+  const form = new FakeElement();
+  const input = new FakeElement();
+  const toggle = new FakeElement();
+  const detail = new FakeElement();
+  root.add("#retry-load", retry);
+  root.add("#error-package-query", form);
+  root.add("#error-package-input", input);
+  root.add("#toggle-error-detail", toggle);
+  root.add(".load-error-detail", detail);
+  const calls: string[] = [];
+
+  bindLoadErrorShell(root as unknown as ParentNode, {
+    onOpenPackage: (id, version) => calls.push(`open:${id}@${version}`),
+    onRetry: () => calls.push("retry"),
+  });
+
+  assert.deepEqual(calls, []);
+  retry.dispatch("click");
+  input.value = " Example.Package@2.0.0 ";
+  assert.equal(form.dispatch("submit"), true);
+  input.value = "Latest.Package";
+  assert.equal(form.dispatch("submit"), true);
+  input.value = "Invalid.Package@";
+  assert.equal(form.dispatch("submit"), true);
+  input.value = " ";
+  assert.equal(form.dispatch("submit"), true);
+  toggle.dispatch("click");
+  assert.equal(detail.hidden, false);
+  toggle.dispatch("click");
+  assert.equal(detail.hidden, true);
+  assert.deepEqual(calls, [
+    "retry",
+    "open:Example.Package@2.0.0",
+    "open:Latest.Package@latest",
+  ]);
+});
+
+test("shell bindings tolerate inactive surfaces", () => {
+  const root = new FakeRoot() as unknown as ParentNode;
+  assert.doesNotThrow(() => bindWorkbenchShell(root, {
+    onDismissNotice() {},
+    onDismissPackageNotice() {},
+    onGoHome() {},
+    onHelp() {},
+    onNavigateBack() {},
+    onNavigateForward() {},
+    onRetryNotice() {},
+    onShare() {},
+    onToggleTheme() {},
+  }));
+  assert.doesNotThrow(() => bindHomeShell(root, {
+    onDemo() {},
+    onDismissNotice() {},
+    onToggleTheme() {},
+  }));
+  assert.doesNotThrow(() => bindLoadErrorShell(root, {
+    onOpenPackage() {},
+    onRetry() {},
+  }));
+});

--- a/prototypes/inspect-web/test/shell-controls.test.ts
+++ b/prototypes/inspect-web/test/shell-controls.test.ts
@@ -5,6 +5,7 @@ import {
   bindLoadErrorShell,
   bindWorkbenchShell,
 } from "../src/shell-controls.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;
@@ -24,10 +25,10 @@ class FakeElement {
 
   dispatch(type: string) {
     let prevented = false;
-    const event = {
+    const event = fakeDom.event({
       target: this,
       preventDefault: () => prevented = true,
-    } as unknown as Event;
+    });
     for (const listener of this.listeners.get(type) ?? []) {
       listener(event);
     }
@@ -74,7 +75,7 @@ test("workbench shell binds every rendered control without eager work", () => {
   }
   const calls: string[] = [];
 
-  bindWorkbenchShell(root as unknown as ParentNode, {
+  bindWorkbenchShell(fakeDom.parentNode(root), {
     onDismissNotice: () => calls.push("dismiss-notice"),
     onDismissPackageNotice: () => calls.push("dismiss-package-notice"),
     onGoHome: () => calls.push("go-home"),
@@ -115,7 +116,7 @@ test("home shell accepts only known demos", () => {
   );
   const calls: string[] = [];
 
-  bindHomeShell(root as unknown as ParentNode, {
+  bindHomeShell(fakeDom.parentNode(root), {
     onDemo: demo => calls.push(`demo:${demo}`),
     onDismissNotice: () => calls.push("dismiss"),
     onToggleTheme: () => calls.push("theme"),
@@ -152,7 +153,7 @@ test("load error shell parses replacement packages and owns local detail state",
   root.add(".load-error-detail", detail);
   const calls: string[] = [];
 
-  bindLoadErrorShell(root as unknown as ParentNode, {
+  bindLoadErrorShell(fakeDom.parentNode(root), {
     onOpenPackage: (id, version) => calls.push(`open:${id}@${version}`),
     onRetry: () => calls.push("retry"),
   });
@@ -179,7 +180,7 @@ test("load error shell parses replacement packages and owns local detail state",
 });
 
 test("shell bindings tolerate inactive surfaces", () => {
-  const root = new FakeRoot() as unknown as ParentNode;
+  const root = fakeDom.parentNode(new FakeRoot());
   assert.doesNotThrow(() => bindWorkbenchShell(root, {
     onDismissNotice() {},
     onDismissPackageNotice() {},

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -903,7 +903,7 @@ test("package opportunities owns its rendered control bindings", () => {
     ?? "";
   assert.match(
     binding,
-    /bindPackageOpportunities\(document, \{\s*onLookForSelect: openSpotlight,\s*onPackageSelect: packageId => openDependencyPackage\(packageId, ""\),\s*onTypeSelect: typeId => \{[\s\S]*currentPackage\(\)\.types\.find\(item => item\.id === typeId\)[\s\S]*openSpotlight\(shortTypeName\(typeId\)\)[\s\S]*state\.atPackageRoot = false;[\s\S]*navigateToTypeByName\(typeId\)/);
+    /bindPackageOpportunities\(document, \{\s*onLookForSelect: openSpotlight,\s*onPackageSelect: packageId => openDependencyPackage\(packageId, ""\),\s*onTypeSelect: typeId => \{[\s\S]*currentPackage\(\)\.types\.find\(item => item\.id === typeId\);\s*if \(!target\) \{[\s\S]*openSpotlight\(shortTypeName\(typeId\)\)[\s\S]*state\.atPackageRoot = false;[\s\S]*navigateToTypeByName\(typeId\)/);
   assert.equal(
     appSource.match(/\bbindPackageOpportunitiesEvents\b/g)?.length,
     2);
@@ -913,6 +913,7 @@ test("package opportunities owns its rendered control bindings", () => {
   assert.doesNotMatch(
     binding,
     /\b(?:getElementById|querySelector|querySelectorAll)\s*\(|\.addEventListener\s*\(/);
+  assert.equal(binding.match(/\bdocument\b/g)?.length, 1);
   assert.match(
     packageOpportunitiesSource,
     /export function bindPackageOpportunities\([\s\S]*\[data-opp-type\][\s\S]*\[data-opp-package\][\s\S]*\[data-opp-lookfor\]/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -901,9 +901,20 @@ test("package opportunities owns its rendered control bindings", () => {
   const binding =
     appSource.match(/function bindPackageOpportunitiesEvents\(\) \{[\s\S]*?\n}\n\nfunction bindEvents/)?.[0]
     ?? "";
+  const bindEvents =
+    appSource.match(
+      /function bindEvents\(\) \{[\s\S]*?\n}\n\n(?=(?:async )?function )/)?.[0]
+    ?? "";
   assert.match(
     binding,
-    /bindPackageOpportunities\(document, \{\s*onLookForSelect: openSpotlight,\s*onPackageSelect: packageId => openDependencyPackage\(packageId, ""\),\s*onTypeSelect: typeId => \{[\s\S]*currentPackage\(\)\.types\.find\(item => item\.id === typeId\);\s*if \(!target\) \{[\s\S]*openSpotlight\(shortTypeName\(typeId\)\)[\s\S]*state\.atPackageRoot = false;[\s\S]*navigateToTypeByName\(typeId\)/);
+    /bindPackageOpportunities\(document, \{\s*onLookForSelect: openSpotlight,\s*onPackageSelect: packageId => openDependencyPackage\(packageId, ""\),\s*onTypeSelect: typeId => \{[\s\S]*currentPackage\(\)\.types\.find\(item => item\.id === typeId\);\s*if \(!target\) \{[\s\S]*openSpotlight\(shortTypeName\(typeId\)\);\s*return;\s*\}[\s\S]*state\.atPackageRoot = false;[\s\S]*navigateToTypeByName\(typeId\)/);
+  assert.match(
+    bindEvents,
+    /^\s*bindPackageOpportunitiesEvents\(\);\s*$/m);
+  const compositionPrefix =
+    bindEvents.slice(0, bindEvents.indexOf("bindPackageOpportunitiesEvents();"));
+  assert.equal(compositionPrefix.match(/\{/g)?.length, 1);
+  assert.equal(compositionPrefix.match(/\}/g)?.length ?? 0, 0);
   assert.equal(
     appSource.match(/\bbindPackageOpportunitiesEvents\b/g)?.length,
     2);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -305,6 +305,12 @@ const memberFocusSource = readFileSync(
 const graphSource = readFileSync(
   new URL("../src/graph-mermaid.ts", import.meta.url),
   "utf8");
+const graphSourceViewerSource = readFileSync(
+  new URL("../src/graph-source.ts", import.meta.url),
+  "utf8");
+const docViewerSource = readFileSync(
+  new URL("../src/doc-viewer.ts", import.meta.url),
+  "utf8");
 const typePanelSource = readFileSync(
   new URL("../src/type-panel.ts", import.meta.url),
   "utf8");
@@ -899,7 +905,7 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
 
 test("package opportunities owns its rendered control bindings", () => {
   const binding =
-    appSource.match(/function bindPackageOpportunitiesEvents\(\) \{[\s\S]*?\n}\n\nfunction bindEvents/)?.[0]
+    appSource.match(/function bindPackageOpportunitiesEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
   const bindEvents =
     appSource.match(
@@ -932,6 +938,48 @@ test("package opportunities owns its rendered control bindings", () => {
     "[data-opp-type]",
     "[data-opp-package]",
     "[data-opp-lookfor]",
+  ]) {
+    assert.equal(appSource.split(selector).length - 1, 0, selector);
+  }
+});
+
+test("modal viewers own their rendered close bindings", () => {
+  const graphBinding =
+    appSource.match(/function bindGraphSourceEvents\(\) \{[\s\S]*?\n}\n\nfunction bindDocViewerEvents/)?.[0]
+    ?? "";
+  const docBinding =
+    appSource.match(/function bindDocViewerEvents\(\) \{[\s\S]*?\n}\n\nfunction bindEvents/)?.[0]
+    ?? "";
+  assert.match(
+    graphBinding,
+    /bindGraphSource\(document, \{\s*onClose: closeGraphSource,\s*\}\)/);
+  assert.match(
+    docBinding,
+    /bindDocViewer\(document, \{\s*onClose: closeDocViewer,\s*\}\)/);
+  assert.equal(graphBinding.match(/\bdocument\b/g)?.length, 1);
+  assert.equal(docBinding.match(/\bdocument\b/g)?.length, 1);
+  assert.match(
+    graphSourceViewerSource,
+    /export function bindGraphSource\([\s\S]*#graph-source-backdrop[\s\S]*event\.target === backdrop[\s\S]*#graph-source-close/);
+  assert.match(
+    docViewerSource,
+    /export function bindDocViewer\([\s\S]*#doc-viewer-backdrop[\s\S]*event\.target === backdrop[\s\S]*#doc-viewer-close/);
+  for (const [identifier, count] of [
+    ["bindGraphSourceEvents", 2],
+    ["bindDocViewerEvents", 2],
+    ["bindGraphSource", 2],
+    ["bindDocViewer", 2],
+  ]) {
+    assert.equal(
+      appSource.match(new RegExp(`\\b${identifier}\\b`, "g"))?.length,
+      count,
+      identifier);
+  }
+  for (const selector of [
+    "#graph-source-backdrop",
+    "#graph-source-close",
+    "#doc-viewer-backdrop",
+    "#doc-viewer-close",
   ]) {
     assert.equal(appSource.split(selector).length - 1, 0, selector);
   }

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -269,6 +270,13 @@ function statementSignature(statement) {
   return `statement:${statement.type}:${sourceText(statement)}`;
 }
 
+const sourceRoot = fileURLToPath(new URL("../src/", import.meta.url));
+const productionTypeScriptSources = readdirSync(sourceRoot, { recursive: true })
+  .filter(path => path.endsWith(".ts"))
+  .map(path => ({
+    path,
+    source: readFileSync(join(sourceRoot, path), "utf8"),
+  }));
 const workspaceNavigationSource = readFileSync(
   new URL("../src/workspace-navigation.ts", import.meta.url),
   "utf8");
@@ -351,94 +359,6 @@ const commandBarSource = readFileSync(
   new URL("../src/command-bar.ts", import.meta.url),
   "utf8");
 
-function maskNonCode(source) {
-  const masked = [...source];
-  for (let index = 0; index < source.length; index++) {
-    const quote = source[index];
-    if (quote === "/" && source[index + 1] === "/") {
-      while (index < source.length && source[index] !== "\n") {
-        masked[index++] = " ";
-      }
-    } else if (quote === "/" && source[index + 1] === "*") {
-      masked[index++] = " ";
-      while (index < source.length
-        && !(source[index] === "*" && source[index + 1] === "/")) {
-        masked[index++] = " ";
-      }
-      masked[index] = " ";
-      masked[index + 1] = " ";
-      index++;
-    } else if (quote === "\"" || quote === "'" || quote === "`") {
-      masked[index] = " ";
-      for (index++; index < source.length; index++) {
-        masked[index] = " ";
-        if (source[index] === "\\") {
-          masked[++index] = " ";
-        } else if (source[index] === quote) {
-          break;
-        }
-      }
-    }
-  }
-  return masked.join("");
-}
-
-function assertDirectCompositionCall(
-  source,
-  functionName,
-  calleeName,
-  expectedIndex,
-) {
-  const functionPrefix = `function ${functionName}() {`;
-  const functionStart = source.indexOf(functionPrefix);
-  assert.notEqual(functionStart, -1);
-  const body = source.slice(functionStart + functionPrefix.length);
-  const masked = maskNonCode(body);
-  const statements = [];
-  let depth = 0;
-  let statementStart = 0;
-  for (let index = 0; index < masked.length; index++) {
-    if (masked[index] === "{") depth++;
-    else if (masked[index] === "}") {
-      if (depth === 0) break;
-      depth--;
-    } else if (masked[index] === ";" && depth === 0) {
-      statements.push(masked.slice(statementStart, index + 1).trim());
-      statementStart = index + 1;
-    }
-  }
-  assert.equal(
-    statements[expectedIndex].replace(/\s+/g, " "),
-    `${calleeName}();`);
-}
-
-test("composition call gates distinguish direct calls from textual nesting", () => {
-  const direct = `function bind() {
-    const options = { label: "{ready}" };
-    // A brace in a comment is not composition.
-    bindTarget();
-  }`;
-  assertDirectCompositionCall(direct, "bind", "bindTarget", 1);
-  assert.throws(() =>
-    assertDirectCompositionCall(
-      "function bind() { if (false) bindTarget(); }",
-      "bind",
-      "bindTarget",
-      0));
-  assert.throws(() =>
-    assertDirectCompositionCall(
-      "function bind() { if (false) { bindTarget(); } }",
-      "bind",
-      "bindTarget",
-      0));
-  assert.throws(() =>
-    assertDirectCompositionCall(
-      "function bind() { if (false) return; bindTarget(); }",
-      "bind",
-      "bindTarget",
-      0));
-});
-
 test("typed Spotlight owns search presentation and hosts commands", () => {
   assert.match(
     appSource,
@@ -486,16 +406,12 @@ test("typed status bar owns its rendered toggle binding", () => {
     statusBarSource,
     /export function bindStatusBar\([\s\S]*\[data-status-bar-toggle-button\][\s\S]*actions\.onToggle/);
   assert.doesNotMatch(appSource, /\[data-status-bar-toggle-button\]/);
-  assertDirectCompositionCall(
+  assert.match(
     appSource,
-    "bindEvents",
-    "bindStatusBarEvents",
-    0);
-  assertDirectCompositionCall(
+    /function bindEvents\(\) \{\s*bindStatusBarEvents\(\);/);
+  assert.match(
     appSource,
-    "bindHomeEvents",
-    "bindStatusBarEvents",
-    0);
+    /function bindHomeEvents\(\) \{\s*bindStatusBarEvents\(\);/);
   assert.equal(
     appSource.match(/\bbindStatusBarEvents\(\)/g)?.length,
     3);
@@ -656,11 +572,9 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.equal(
     rootEventBinder.match(/^\s*bindTypePanelEvents\(\);$/gm)?.length,
     1);
-  assertDirectCompositionCall(
+  assert.match(
     appSource,
-    "bindEvents",
-    "bindTypePanelEvents",
-    2);
+    /function bindEvents\(\) \{\s*bindStatusBarEvents\(\);\s*packageBar\.bind\(document\);\s*bindTypePanelEvents\(\);/);
   assert.match(
     typePanelSource,
     /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);
@@ -827,6 +741,7 @@ test("typed scope bar owns its rendered control bindings", () => {
 test("typed settings panel owns its rendered control bindings", () => {
   assert.deepEqual(parsedAppSource.errors, []);
   const bindEvents = functionDeclaration("bindEvents");
+  const bindHomeEvents = functionDeclaration("bindHomeEvents");
   const renderSettings = functionDeclaration("renderSettingsViewHtml");
   const settingsEventBinder = functionDeclaration("bindSettingsPanelEvents");
   const settingsPanelImport = onlySyntaxNode(
@@ -848,16 +763,17 @@ test("typed settings panel owns its rendered control bindings", () => {
         && node.name === "bindSettingsPanel").length,
     3);
   const eventBinderCalls = callExpressionsNamed(appSyntax, "bindSettingsPanelEvents");
-  assert.equal(eventBinderCalls.length, 2);
+  assert.equal(eventBinderCalls.length, 3);
   assert.equal(
     syntaxNodes(
       appSyntax,
       node => node.type === "Identifier"
         && node.name === "bindSettingsPanelEvents").length,
-    3);
-  for (const [owner, description] of [
-    [bindEvents, "workbench settings binder"],
-    [renderSettings, "settings view binder"],
+    4);
+  for (const [owner, description, predecessor] of [
+    [bindEvents, "workbench settings binder", "bindScopeBarEvents"],
+    [bindHomeEvents, "home settings binder", "bindStatusBarEvents"],
+    [renderSettings, "settings view binder", null],
   ]) {
     assert.equal(
       callExpressionsNamed(owner, "bindSettingsPanelEvents").length,
@@ -870,6 +786,20 @@ test("typed settings panel owns its rendered control bindings", () => {
         .length,
       1,
       `${description} direct call`);
+    if (predecessor) {
+      const directCallNames = owner.body.body.map(statement => {
+        if (statement.type !== "ExpressionStatement") return null;
+        const expression = statement.expression;
+        return expression.type === "CallExpression"
+          && expression.callee?.type === "Identifier"
+          ? expression.callee.name
+          : null;
+      });
+      assert.equal(
+        directCallNames.indexOf("bindSettingsPanelEvents"),
+        directCallNames.indexOf(predecessor) + 1,
+        `${description} order`);
+    }
   }
   const directWorkbenchCalls = bindEvents.body.body.map(statement => {
     if (statement.type !== "ExpressionStatement") return null;
@@ -908,9 +838,10 @@ test("typed settings panel owns its rendered control bindings", () => {
   assert.equal(innerSettingsCall.arguments[0].name, "document");
   const actions = innerSettingsCall.arguments[1];
   assert.equal(actions.type, "ObjectExpression");
-  assert.equal(actions.properties.length, 4);
+  assert.equal(actions.properties.length, 6);
   for (const [name, value] of [
     ["onClose", "closeSettings"],
+    ["onOpen", "openSettings"],
     ["onTasteClear", "clearTaste"],
     ["onTasteToggle", "toggleTaste"],
     ["onThemeSelect", "setTheme"],
@@ -924,9 +855,51 @@ test("typed settings panel owns its rendered control bindings", () => {
     assert.equal(property.value.type, "Identifier");
     assert.equal(property.value.name, value);
   }
+  const tasteOpenToggle = callbackProperty(actions, "onTasteOpenToggle");
+  assert.deepEqual(
+    statementSignatures(tasteOpenToggle.body.body),
+    [
+      "assign:state.tasteOpen = !state.tasteOpen",
+      "call:render()",
+    ]);
+  assert.match(
+    appSource,
+    /import \{(?=[^}]*\bbindSettingsPanel,)[^}]*} from "\.\/settings-panel\.ts";/);
+  assert.doesNotMatch(
+    sourceText(settingsEventBinder),
+    /\bquerySelector(?:All)?\b|\baddEventListener\b/);
   assert.match(
     settingsPanelSource,
-    /export function bindSettingsPanel\([\s\S]*#settings-close[\s\S]*\.settings-seg\[data-theme\][\s\S]*\.settings-taste \[data-taste\][\s\S]*#settings-taste-clear[\s\S]*#taste-popover \[data-taste\][\s\S]*#taste-clear/);
+    /export function bindSettingsPanel\([\s\S]*#settings-close[\s\S]*#home-settings[\s\S]*#open-settings[\s\S]*#taste-btn[\s\S]*stopPropagation\(\)[\s\S]*\.settings-seg\[data-theme\][\s\S]*\.settings-taste \[data-taste\][\s\S]*#settings-taste-clear[\s\S]*#taste-popover \[data-taste\][\s\S]*#taste-clear/);
+  const nonSettingsPanelSource = productionTypeScriptSources
+    .filter(({ path }) => path.replaceAll("\\", "/") !== "settings-panel.ts")
+    .map(({ source }) => source)
+    .join("\n");
+  const entrySelectorAccess =
+    /(?:querySelector(?:All)?\s*(?:<[^>\n]+>)?|getElementById)\s*\(\s*(["'`])#?(?:home-settings|open-settings|taste-btn)\1\s*\)/g;
+  assert.equal(nonSettingsPanelSource.match(entrySelectorAccess)?.length ?? 0, 0);
+  assert.equal(settingsPanelSource.match(entrySelectorAccess)?.length, 3);
+  for (const selector of ["#home-settings", "#open-settings"]) {
+    const selectorToken = new RegExp(`${selector}(?![-\\w])`, "g");
+    assert.equal(
+      nonSettingsPanelSource.match(selectorToken)?.length ?? 0,
+      0,
+      selector);
+    assert.equal(
+      settingsPanelSource.match(selectorToken)?.length,
+      1,
+      selector);
+  }
+  assert.equal(
+    nonSettingsPanelSource.match(/#taste-btn(?![-\w])/g)?.length,
+    1);
+  assert.equal(
+    nonSettingsPanelSource.match(
+      /\.closest\(\s*(["'`])#taste-btn\1\s*\)/g)?.length,
+    1);
+  assert.equal(
+    settingsPanelSource.match(/#taste-btn(?![-\w])/g)?.length,
+    1);
   for (const selector of [
     "#settings-close",
     ".settings-seg[data-theme]",

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -311,6 +311,9 @@ const graphSourceViewerSource = readFileSync(
 const docViewerSource = readFileSync(
   new URL("../src/doc-viewer.ts", import.meta.url),
   "utf8");
+const annotatedSourceModule = readFileSync(
+  new URL("../src/annotated-source.ts", import.meta.url),
+  "utf8");
 const typePanelSource = readFileSync(
   new URL("../src/type-panel.ts", import.meta.url),
   "utf8");
@@ -945,10 +948,10 @@ test("package opportunities owns its rendered control bindings", () => {
 
 test("modal viewers own their rendered close bindings", () => {
   const graphBinding =
-    appSource.match(/function bindGraphSourceEvents\(\) \{[\s\S]*?\n}\n\nfunction bindDocViewerEvents/)?.[0]
+    appSource.match(/function bindGraphSourceEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
   const docBinding =
-    appSource.match(/function bindDocViewerEvents\(\) \{[\s\S]*?\n}\n\nfunction bindEvents/)?.[0]
+    appSource.match(/function bindDocViewerEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
   assert.match(
     graphBinding,
@@ -980,6 +983,43 @@ test("modal viewers own their rendered close bindings", () => {
     "#graph-source-close",
     "#doc-viewer-backdrop",
     "#doc-viewer-close",
+  ]) {
+    assert.equal(appSource.split(selector).length - 1, 0, selector);
+  }
+});
+
+test("annotated source owns its rendered control bindings", () => {
+  const binding =
+    appSource.match(/function bindAnnotatedSourceEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
+  assert.match(
+    binding,
+    /bindAnnotatedSource\(document, \{[\s\S]*onClearSelection: \(\) => \{[\s\S]*memberAnnotatedFactId = null;[\s\S]*memberAnnotatedNodeIds = \[\];[\s\S]*onCopy: async \(\) => \{[\s\S]*memberAnnotated\.document\.text[\s\S]*onFactSelect: factId => \{[\s\S]*memberAnnotatedFactId === factId \? null : factId[\s\S]*onMediumToggle: medium => \{[\s\S]*MEDIA\.includes[\s\S]*MEDIA\.some\(candidate => next\[candidate\]\)[\s\S]*onOffsetSelect: offset => \{[\s\S]*nodeAtOffset\(state\.memberAnnotated\.document, offset\)[\s\S]*factsForNode/);
+  assert.match(
+    binding,
+    /\[typedMedium\]: !state\.memberAnnotatedMedia\[typedMedium\],[\s\S]*if \(!MEDIA\.some\(candidate => next\[candidate\]\)\) return;/);
+  assert.doesNotMatch(
+    binding,
+    /\b(?:getElementById|querySelector|querySelectorAll)\s*\(|\.addEventListener\s*\(/);
+  assert.equal(binding.match(/(?<!\.)\bdocument\b/g)?.length, 1);
+  assert.match(
+    annotatedSourceModule,
+    /export function bindAnnotatedSource\([\s\S]*#copy-annotated[\s\S]*\[data-annotated-medium\][\s\S]*\[data-annotated-fact\][\s\S]*\[data-annotated-offset\][\s\S]*#annotated-clear/);
+  for (const [identifier, count] of [
+    ["bindAnnotatedSourceEvents", 2],
+    ["bindAnnotatedSource", 2],
+  ]) {
+    assert.equal(
+      appSource.match(new RegExp(`\\b${identifier}\\b`, "g"))?.length,
+      count,
+      identifier);
+  }
+  for (const selector of [
+    "#copy-annotated",
+    "[data-annotated-medium]",
+    "[data-annotated-fact]",
+    "[data-annotated-offset]",
+    "#annotated-clear",
   ]) {
     assert.equal(appSource.split(selector).length - 1, 0, selector);
   }

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -501,6 +501,36 @@ test("typed status bar owns its rendered toggle binding", () => {
     3);
 });
 
+test("typed package bar owns package framework and version selection bindings", () => {
+  const packageBarCreation =
+    appSource.match(/const packageBar = createPackageBar\(\{[\s\S]*?\n}\);/)?.[0]
+    ?? "";
+  const packageBarBinding =
+    packageBarSource.match(/  function bind\(root: ParentNode\): void \{[\s\S]*?\n  }(?=\n\n  return)/)?.[0]
+    ?? "";
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
+  assert.match(
+    packageBarCreation,
+    /selectFramework: switchPackageFramework,[\s\S]*selectVersion: version => \{[\s\S]*state\.package\?\.isRuntimePack[\s\S]*switchPlatformVersion\(version\);[\s\S]*else switchPackageVersion\(version\)/);
+  assert.match(
+    packageBarSource,
+    /export function bindPackageSelections\([\s\S]*\[data-framework-chip\][\s\S]*#framework[\s\S]*#package-version/);
+  assert.match(
+    packageBarBinding,
+    /bindPackageSelections\(root, \{\s*onFrameworkSelect: selectFramework,\s*onVersionSelect: selectVersion,\s*\}\)/);
+  assert.equal(
+    workspaceBinding.match(/\bpackageBar\.bind\(document\)/g)?.length,
+    1);
+  assert.doesNotMatch(
+    workspaceBinding,
+    /document\.querySelectorAll(?:<HTMLElement>)?\("\[data-framework-chip\]"\)/);
+  assert.doesNotMatch(
+    workspaceBinding,
+    /document\.querySelector(?:<HTMLSelectElement>)?\("#(?:framework|package-version)"\)/);
+});
+
 test("typed package inspection owns package-root request coordination", () => {
   const dependenciesLoader =
     appSource.match(/async function loadPackageDependencies\(\) \{[\s\S]*?\n}/)?.[0]
@@ -2615,8 +2645,9 @@ test("closing a package removes its coordinate and selects the adjacent tab", ()
 
 test("workspace UI routes replacements and restore notices through bounded paths", () => {
   assert.match(
-    appSource,
-    /switchPackageFramework\(button\.dataset\.frameworkChip \?\? ""\)/);
+    packageBarSource,
+    /onFrameworkSelect\(button\.dataset\.frameworkChip \?\? ""\)/);
+  assert.match(appSource, /selectFramework: switchPackageFramework/);
   assert.match(appSource, /switchPackageFramework\(argument\)/);
   assert.doesNotMatch(
     appSource,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -581,12 +581,60 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.match(
     typePanelSource,
     /\[data-member-kind-filter\][\s\S]*\[data-member-access-filter\][\s\S]*\[data-member-trait-filter\][\s\S]*#clear-member-filter[\s\S]*#member-filter/);
+  assert.match(
+    typePanelSource,
+    /\[data-member-jump-kind\][\s\S]*\[data-member-jump-access\][\s\S]*\[data-member-jump-trait\][\s\S]*\[data-member\][\s\S]*\[data-overload\][\s\S]*#member-back[\s\S]*#copy-name[\s\S]*#copy-signature[\s\S]*\[data-copy-anchor\][\s\S]*#copy-source[\s\S]*#copy-type-source/);
   assert.doesNotMatch(
     appSource,
     /document\.querySelectorAll<HTMLElement>\("\[data-member-(?:kind|access|trait)-filter\]"\)/);
   assert.doesNotMatch(
     appSource,
     /document\.querySelector(?:<HTMLInputElement>)?\("#(?:member-filter|clear-member-filter)"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelectorAll<HTMLElement>\("\[data-(?:member-jump-(?:kind|access|trait)|member|overload|copy-anchor)\]"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelector\("#(?:member-back|copy-name|copy-signature|copy-source|copy-type-source)"\)/);
+  assert.match(
+    binding,
+    /const enterMemberNavigation = \(action: \(\) => void\) => \{[\s\S]*beginSpotlightNavigation\(\);[\s\S]*action\(\);[\s\S]*focusTypeList\(focusGeneration\)/);
+  const callbackSource = name =>
+    binding.match(
+      new RegExp(`    ${name}: [\\s\\S]*?(?=\\n    on[A-Z])`))?.[0]
+      ?? "";
+  for (const [name, stateField] of [
+    ["onMemberCompositionAccessibilitySelect", "memberAccessibilityFilter"],
+    ["onMemberCompositionKindSelect", "memberKindFilter"],
+    ["onMemberCompositionTraitSelect", "memberTraitFilter"],
+  ]) {
+    const source = callbackSource(name);
+    assert.match(
+      source,
+      new RegExp(
+        `enterMemberNavigation\\(\\(\\) => \\{[\\s\\S]*resetMemberFilters\\(\\);`
+        + `[\\s\\S]*state\\.${stateField} = value;`
+        + "[\\s\\S]*enterMemberScope\\(\\);[\\s\\S]*render\\(\\)"));
+    assert.equal(source.match(/\brender\(\)/g)?.length, 1);
+  }
+  assert.match(
+    binding,
+    /onMemberGroupOpen: memberKey => \{\s*enterMemberNavigation\(\(\) => openMemberGroup\(memberKey\)\)/);
+  assert.match(
+    binding,
+    /onMemberBack: drillOut[\s\S]*onMemberOverloadOpen: openOverload/);
+  assert.match(
+    binding,
+    /onCopyName: async \(\) => \{[\s\S]*const fullName = member \? `\$\{typeName\}\.\$\{member\.name\}` : typeName;[\s\S]*copyText\(fullName, "name copied"\)/);
+  assert.match(
+    binding,
+    /onCopySignature: async \(\) => \{[\s\S]*copyText\(overload\.signature, "signature copied"\)/);
+  assert.match(
+    binding,
+    /onCopyAnchor: async anchor => \{[\s\S]*selector: overload\?\.stableSelector,[\s\S]*digest: overload\?\.anchorDigest,[\s\S]*canonical: overload\?\.canonicalSignature[\s\S]*copyText\(value, `\$\{anchor\} copied`\)/);
+  assert.match(
+    binding,
+    /onCopyMemberSource: async \(\) => \{[\s\S]*copyText\(state\.memberSource\.text, "source copied"\)[\s\S]*onCopyTypeSource: async \(\) => \{[\s\S]*copyText\(state\.typeSource\.text, "source copied"\)/);
   assert.match(
     binding,
     /onMemberFilterClear: \(\) => \{[\s\S]*resetMemberFilters\(\);[\s\S]*renderMemberFilterAndRestoreFocus\("#clear-member-filter"\)/);
@@ -1477,14 +1525,14 @@ test("shared member views retain scope and filter state", () => {
 
 test("member entry controls move focus into the resulting member navigation", () => {
   const bindings =
-    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    appSource.match(/function bindTypePanelEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
   assert.match(
     bindings,
     /const enterMemberNavigation = \(action: \(\) => void\) => \{\s*const focusGeneration = beginSpotlightNavigation\(\);\s*action\(\);\s*focusTypeList\(focusGeneration\);/);
   assert.match(
     bindings,
-    /data-member-jump-kind[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*enterMemberScope\(\);[\s\S]*data-member-jump-access[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*data-member-jump-trait[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*data-member\]"\)\.forEach[\s\S]*enterMemberNavigation\(\(\) => openMemberGroup/);
+    /onMemberCompositionAccessibilitySelect: value => \{[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*enterMemberScope\(\);[\s\S]*onMemberCompositionKindSelect: value => \{[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*onMemberCompositionTraitSelect: value => \{[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*onMemberGroupOpen: memberKey => \{[\s\S]*enterMemberNavigation\(\(\) => openMemberGroup/);
 });
 
 test("package tab selection resets type-specific member filters", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -958,7 +958,7 @@ test("modal viewers own their rendered close bindings", () => {
     /bindGraphSource\(document, \{\s*onClose: closeGraphSource,\s*\}\)/);
   assert.match(
     docBinding,
-    /bindDocViewer\(document, \{\s*onClose: closeDocViewer,\s*\}\)/);
+    /bindDocViewer\(document, \{\s*onClose: closeDocViewer,\s*onOpenDocument: openPackageDocument,\s*\}\)/);
   assert.equal(graphBinding.match(/\bdocument\b/g)?.length, 1);
   assert.equal(docBinding.match(/\bdocument\b/g)?.length, 1);
   assert.match(
@@ -966,7 +966,7 @@ test("modal viewers own their rendered close bindings", () => {
     /export function bindGraphSource\([\s\S]*#graph-source-backdrop[\s\S]*event\.target === backdrop[\s\S]*#graph-source-close/);
   assert.match(
     docViewerSource,
-    /export function bindDocViewer\([\s\S]*#doc-viewer-backdrop[\s\S]*event\.target === backdrop[\s\S]*#doc-viewer-close/);
+    /export function bindDocViewer\([\s\S]*#doc-viewer-backdrop[\s\S]*event\.target === backdrop[\s\S]*#doc-viewer-close[\s\S]*\[data-doc-path\]/);
   for (const [identifier, count] of [
     ["bindGraphSourceEvents", 2],
     ["bindDocViewerEvents", 2],
@@ -983,6 +983,7 @@ test("modal viewers own their rendered close bindings", () => {
     "#graph-source-close",
     "#doc-viewer-backdrop",
     "#doc-viewer-close",
+    "[data-doc-path]",
   ]) {
     assert.equal(appSource.split(selector).length - 1, 0, selector);
   }

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -286,6 +286,9 @@ const packageAcquisitionSource = readFileSync(
 const packageInspectionSource = readFileSync(
   new URL("../src/package-inspection.ts", import.meta.url),
   "utf8");
+const packageViewSource = readFileSync(
+  new URL("../src/package-view.ts", import.meta.url),
+  "utf8");
 const sourceInspectionSource = readFileSync(
   new URL("../src/source-inspection.ts", import.meta.url),
   "utf8");
@@ -492,6 +495,86 @@ test("typed package inspection owns package-root request coordination", () => {
     packageInspectionSource,
     /async loadDependencies\(packageModel, signature\)[\s\S]*state\.packageDependenciesKey/);
   assert.doesNotMatch(dependenciesLoader, /state\.packageDependenciesKey/);
+});
+
+test("typed package view owns package navigation bindings", () => {
+  const binding =
+    appSource.match(/const packageViewActions: PackageViewBindingActions = \{[\s\S]*?\n};/)?.[0]
+    ?? "";
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
+  const packageViewBinding =
+    appSource.match(/function bindPackageViewEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction bindPackageDependencyListEvents)/)?.[0]
+    ?? "";
+  const dependencyListBinding =
+    appSource.match(/function bindPackageDependencyListEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction bindStatusBarEvents)/)?.[0]
+    ?? "";
+  const dependencyPatch =
+    appSource.match(/function patchDependenciesGroup\(\) \{[\s\S]*?\n}/)?.[0]
+    ?? "";
+  const actionSource = name =>
+    binding.match(
+      new RegExp(`  ${name}: [\\s\\S]*?(?=\\n  on[A-Z])`))?.[0]
+      ?? "";
+  assert.match(
+    packageViewSource,
+    /export function bindPackageView\([\s\S]*\[data-dep-group\][\s\S]*\[data-kind-jump\][\s\S]*\[data-namespace-jump\][\s\S]*\[data-lib-scope\][\s\S]*\[data-graph-type\][\s\S]*\[data-perf-token\]/);
+  assert.match(
+    packageViewSource,
+    /export function bindPackageDependencyList\([\s\S]*\[data-dep-open\][\s\S]*\[data-dep-load\]/);
+  assert.equal(
+    workspaceBinding.match(/\bbindPackageViewEvents\(\)/g)?.length,
+    1);
+  assert.match(
+    packageViewBinding,
+    /bindPackageView\(document, packageViewActions\)/);
+  assert.doesNotMatch(
+    packageViewBinding,
+    /\bquerySelector(?:All)?\b|\baddEventListener\b/);
+  assert.match(
+    dependencyListBinding,
+    /bindPackageDependencyList\(document, packageViewActions\)/);
+  assert.doesNotMatch(
+    dependencyListBinding,
+    /\bquerySelector(?:All)?\b|\baddEventListener\b/);
+  assert.match(
+    dependencyPatch,
+    /listSection\.outerHTML = dependencyListSectionHtml[\s\S]*bindPackageDependencyListEvents\(\);[\s\S]*renderDependencyGraph\(\)/);
+  assert.match(
+    binding,
+    /onDependencyGroupSelect: index => \{[\s\S]*state\.dependenciesGroupIndex === index[\s\S]*state\.dependenciesGroupIndex = index;[\s\S]*patchDependenciesGroup\(\)/);
+  assert.match(
+    binding,
+    /onDependencyLoad: openDependencyPackage,\s*onDependencyOpen: switchToPackageForDependencies,\s*onGraphTypeSelect: navigateToTypeByName/);
+  const kindJump = actionSource("onKindJump");
+  const libraryJump = actionSource("onLibraryScopeSelect");
+  const namespaceJump = actionSource("onNamespaceJump");
+  assert.match(
+    kindJump,
+    /state\.atPackageRoot = false;[\s\S]*state\.kindFilter = kind;[\s\S]*state\.namespaceFilter = ""/);
+  assert.match(
+    libraryJump,
+    /state\.atPackageRoot = false;[\s\S]*if \(!library\) return;[\s\S]*state\.libraryScope = new Set\(\[library\]\);[\s\S]*state\.package\?\.isRuntimePack[\s\S]*recordPlatformRecent\(library, platformPackForAssembly\(library\)\);[\s\S]*state\.kindFilter = kind;[\s\S]*state\.namespaceFilter = ""/);
+  assert.match(
+    namespaceJump,
+    /state\.atPackageRoot = false;[\s\S]*state\.namespaceFilter = namespace;[\s\S]*state\.kindFilter = ""/);
+  for (const source of [kindJump, libraryJump, namespaceJump]) {
+    assert.match(
+      source,
+      /state\.typeFilter = "";[\s\S]*state\.selectedMemberKey = "";[\s\S]*state\.memberBrowseTypeId = "";[\s\S]*resetMemberFilters\(\);[\s\S]*state\.typeCursor = 0;[\s\S]*const first = filteredTypes\(\)\[0\];[\s\S]*if \(first\) state\.selectedTypeId = first\.id;[\s\S]*render\(\)/);
+    assert.equal(source.match(/\brender\(\)/g)?.length, 1);
+  }
+  assert.match(
+    binding,
+    /onPerformanceMemberSelect: target => \{[\s\S]*drillToPerfMember\(\s*target\.metadataToken,\s*target\.assembly,\s*target\.typeId\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelectorAll<HTMLElement>\("\[data-(?:dep-group|dep-open|dep-load|kind-jump|namespace-jump|lib-scope|graph-type|perf-token)\]"\)/);
+  assert.doesNotMatch(
+    workspaceBinding,
+    /\[data-(?:dep-group|dep-open|dep-load|kind-jump|namespace-jump|lib-scope|graph-type|perf-token)\]/);
+  assert.doesNotMatch(appSource, /function bindDependencyListHandlers\(/);
 });
 
 test("typed document inspection owns package document request coordination", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -289,6 +289,9 @@ const packageInspectionSource = readFileSync(
 const packageViewSource = readFileSync(
   new URL("../src/package-view.ts", import.meta.url),
   "utf8");
+const libraryControlsSource = readFileSync(
+  new URL("../src/library-controls.ts", import.meta.url),
+  "utf8");
 const sourceInspectionSource = readFileSync(
   new URL("../src/source-inspection.ts", import.meta.url),
   "utf8");
@@ -575,6 +578,62 @@ test("typed package view owns package navigation bindings", () => {
     workspaceBinding,
     /\[data-(?:dep-group|dep-open|dep-load|kind-jump|namespace-jump|lib-scope|graph-type|perf-token)\]/);
   assert.doesNotMatch(appSource, /function bindDependencyListHandlers\(/);
+});
+
+test("typed library controls own library and Platform picker bindings", () => {
+  const binding =
+    appSource.match(/const libraryControlActions: LibraryControlBindingActions = \{[\s\S]*?\n};/)?.[0]
+    ?? "";
+  const wrapper =
+    appSource.match(/function bindLibraryControlsEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction bindTypePanelEvents)/)?.[0]
+    ?? "";
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
+  assert.match(
+    libraryControlsSource,
+    /export function bindLibraryControls\([\s\S]*\[data-library-chip\][\s\S]*\[data-access-chip\][\s\S]*#library-jump[\s\S]*\[data-platform-library-select\]/);
+  for (const lens of [
+    "integrations",
+    "opportunities",
+    "analysis",
+    "metadata",
+  ]) {
+    assert.match(
+      libraryControlsSource,
+      new RegExp(`\\[data-platform-${lens}-library\\]`));
+  }
+  assert.equal(
+    workspaceBinding.match(/\bbindLibraryControlsEvents\(\)/g)?.length,
+    1);
+  assert.match(
+    wrapper,
+    /bindLibraryControls\(document, libraryControlActions\)/);
+  assert.doesNotMatch(
+    wrapper,
+    /\bquerySelector(?:All)?\b|\baddEventListener\b/);
+  assert.match(
+    binding,
+    /onAccessibilityChipSelect: accessibility => \{[\s\S]*toggleAccessibilityChip\(accessibility\);[\s\S]*afterLibraryScopeChange\(\)/);
+  assert.match(
+    binding,
+    /onLibraryChipSelect: library => \{[\s\S]*toggleLibraryChip\(library\);[\s\S]*afterLibraryScopeChange\(\)/);
+  assert.match(
+    binding,
+    /onLibraryJump: library => \{[\s\S]*state\.libraryScope = library \? new Set\(\[library\]\) : null;[\s\S]*afterLibraryScopeChange\(\)/);
+  assert.match(
+    binding,
+    /onPlatformLibrarySelect: openPlatformLibrary/);
+  assert.match(
+    binding,
+    /onPlatformLensLibrarySelect: \(lens, name, pack\) => \{\s*void openPlatformLensLibrary\(lens, name, pack\)/);
+  assert.doesNotMatch(
+    workspaceBinding,
+    /\[data-(?:library-chip|access-chip|platform-(?:library-select|integrations-library|opportunities-library|analysis-library|metadata-library))\]|#library-jump/);
+  assert.doesNotMatch(
+    appSource,
+    /\[data-(?:library-chip|access-chip|platform-(?:library-select|integrations-library|opportunities-library|analysis-library|metadata-library))\]|#library-jump/);
+  assert.doesNotMatch(appSource, /bindPlatformLensPicker/);
 });
 
 test("typed document inspection owns package document request coordination", () => {
@@ -1691,11 +1750,11 @@ test("opening an already-resident Platform resets type-specific member filters",
 
 test("lens-scoped Platform library changes reset type-specific member state", () => {
   const picker =
-    appSource.match(/const bindPlatformLensPicker = [\s\S]*?bindPlatformLensPicker\("data-platform-integrations-library"/)?.[0]
+    appSource.match(/async function openPlatformLensLibrary\([\s\S]*?\n}/)?.[0]
     ?? "";
   assert.match(
     picker,
-    /const openLibrary = async \([\s\S]*originPackage: AppPackage = currentPackage\(\),[\s\S]*noticeRetryState: NoticeRetryState \| null = null[\s\S]*if \(!state\.packages\.includes\(originPackage\)[\s\S]*!packageIdentityEquals\(state\.package, originPackage\)[\s\S]*state\.queryNoticeRetryAction === noticeRetryState\.action[\s\S]*state\.queryNotice = removeAppendedNotice\([\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*const runtimeResult = await loadRuntimePackAssembly\([\s\S]*\(\) => state\.packages\.includes\(originPackage\)\);[\s\S]*const loaded = runtimeResult\.packageModel;[\s\S]*previous: state\.queryNotice[\s\S]*const retryAction = \(\) =>\s*openLibrary\(name, pack, originPackage, noticeState\);[\s\S]*runtimeResult\.failureMessage[\s\S]*noticeState\.appended = state\.queryNotice;[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*state\.libraryScope = new Set\(\[key\]\);[\s\S]*normalizeLibrarySelection\(\);[\s\S]*loader\(\)/);
+    /originPackage: AppPackage = currentPackage\(\),[\s\S]*noticeRetryState: NoticeRetryState \| null = null[\s\S]*if \(!state\.packages\.includes\(originPackage\)[\s\S]*!packageIdentityEquals\(state\.package, originPackage\)[\s\S]*state\.queryNoticeRetryAction === noticeRetryState\.action[\s\S]*state\.queryNotice = removeAppendedNotice\([\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*const pack = selectedPack \|\| platformPackForAssembly\(key\);[\s\S]*const runtimeResult = await loadRuntimePackAssembly\([\s\S]*\(\) => state\.packages\.includes\(originPackage\)\);[\s\S]*const loaded = runtimeResult\.packageModel;[\s\S]*previous: state\.queryNotice[\s\S]*const retryAction = \(\) =>\s*openPlatformLensLibrary\([\s\S]*noticeState\);[\s\S]*runtimeResult\.failureMessage[\s\S]*noticeState\.appended = state\.queryNotice;[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*state\.libraryScope = new Set\(\[key\]\);[\s\S]*normalizeLibrarySelection\(\);[\s\S]*lens === "integrations"[\s\S]*loadPackageIntegrations\(\)[\s\S]*lens === "opportunities"[\s\S]*loadPackageOpportunities\(\)[\s\S]*lens === "analysis"[\s\S]*loadPackagePerformance\(\)[\s\S]*loadPackageMetadata\(\)/);
   assert.doesNotMatch(picker, /select\.isConnected/);
   assert.match(
     appSource,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -295,6 +295,9 @@ const libraryControlsSource = readFileSync(
 const shellControlsSource = readFileSync(
   new URL("../src/shell-controls.ts", import.meta.url),
   "utf8");
+const graphInteractionsSource = readFileSync(
+  new URL("../src/graph-interactions.ts", import.meta.url),
+  "utf8");
 const sourceInspectionSource = readFileSync(
   new URL("../src/source-inspection.ts", import.meta.url),
   "utf8");
@@ -707,6 +710,93 @@ test("typed shell controls own workbench, home, and load-error bindings", () => 
   assert.doesNotMatch(
     loadingBinding,
     /#(?:retry-load|error-package-query|error-package-input|toggle-error-detail)|"\.load-error-detail"/);
+});
+
+test("typed graph interactions own graph controls and Mermaid node bindings", () => {
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
+  const typeGraph =
+    appSource.match(/async function renderTypeGraph\(\) \{[\s\S]*?\n}(?=\n\nfunction navigateToTypeByName)/)?.[0]
+    ?? "";
+  const dependencyGraph =
+    appSource.match(/async function renderDependencyGraph\(\) \{[\s\S]*?\n}(?=\n\nfunction switchToPackageForDependencies)/)?.[0]
+    ?? "";
+  const callGraph =
+    appSource.match(/async function renderMermaidCallGraph\(\) \{[\s\S]*?\n}(?=\n\nfunction callGraphNodeBinding)/)?.[0]
+    ?? "";
+  const callGraphBinding =
+    appSource.match(/function callGraphNodeBinding\([\s\S]*?\n}(?=\n\nfunction currentCallGraph)/)?.[0]
+    ?? "";
+  const dependencyNodeBinding =
+    graphInteractionsSource.match(/export function bindDependencyGraphNodes\([\s\S]*?\n}(?=\n\nexport function bindGraphPanZoom)/)?.[0]
+    ?? "";
+  assert.match(
+    graphInteractionsSource,
+    /export function bindGraphBack\([\s\S]*\[data-graph-back\]/);
+  assert.match(
+    graphInteractionsSource,
+    /function mermaidNodeId\([\s\S]*data-id[\s\S]*flowchart-/);
+  assert.match(
+    graphInteractionsSource,
+    /export function bindGraphPanZoom\([\s\S]*"wheel"[\s\S]*"pointerdown"[\s\S]*"pointermove"[\s\S]*"pointerup"[\s\S]*"pointercancel"[\s\S]*\.graph-controls button[\s\S]*"keydown"[\s\S]*resolveCallGraphNode/);
+  assert.match(
+    graphInteractionsSource,
+    /export function bindTypeGraphNodes\([\s\S]*"t"[\s\S]*nav-node[\s\S]*non-nav[\s\S]*createElementNS/);
+  assert.match(
+    dependencyNodeBinding,
+    /mermaidNodeId\(node, "d"\)[\s\S]*classList\.add\("nav-node"\)[\s\S]*style\.cursor = "pointer"[\s\S]*addEventListener\("click", binding\.onSelect\)/);
+  assert.match(
+    appSource,
+    /const graphBackActions: GraphBackBindingActions = \{\s*onBack: popPlatformDrill,\s*};/);
+  assert.match(
+    workspaceBinding,
+    /bindGraphBack\(document, graphBackActions\)/);
+  assert.match(
+    typeGraph,
+    /bindGraphPanZoom\(container, viewport\);[\s\S]*bindTypeGraphNodes\(viewport, nodeId => \{[\s\S]*graphNodeOf\.get\(nodeId\)[\s\S]*onSelect: \(\) => navigateToType\(target\)[\s\S]*unavailableLabel/);
+  assert.match(
+    typeGraph,
+    /const target = graphNode\.role === "self"\s*\? selectedType\(\)\s*: uniqueTypeByQueryId\(pkg\.types, fullName\)/);
+  assert.match(
+    dependencyGraph,
+    /bindGraphPanZoom\(container, viewport\);[\s\S]*bindDependencyGraphNodes\(viewport, nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)[\s\S]*switchToPackageForDependencies\(info\.packageKey\)[\s\S]*openDependencyPackage\(info\.id, info\.versionRange\)/);
+  assert.match(
+    dependencyGraph,
+    /const info = nodeId \? built\.nodeInfoById\.get\(nodeId\) : null;\s*if \(!info \|\| info\.kind === "self"\) return null/);
+  assert.match(
+    callGraph,
+    /bindGraphPanZoom\(container, viewport, \{[\s\S]*resolveCallGraphNode: nodeId =>[\s\S]*callGraphNodeBinding\(active, nodeId\)/);
+  assert.match(
+    callGraphBinding,
+    /callGraph\.targets\?\.find\(candidate => candidate\.id === nodeId\)[\s\S]*const drilled =\s*state\.platformStack\.length > 0 \|\| Boolean\(state\.package\?\.isRuntimePack\);\s*if \(drilled\) \{\s*if \(target\.id === "n0" \|\| !target\.assembly \|\| !typeId\) return null;[\s\S]*navigateOrDrillPlatform\(target\)[\s\S]*resolveLoadedGraphTargetCandidate[\s\S]*graphTargetNavigationDisposition[\s\S]*if \(disposition === "blocked" \|\| disposition === "none"\) return null;[\s\S]*navigateToMember\([\s\S]*openGraphSource\([\s\S]*navigateOrDrillPlatform\(target\)/);
+  assert.match(
+    callGraphBinding,
+    /if \(drilled\) \{[\s\S]*return \{\s*platform: true,\s*onSelect: \(\) => \{[\s\S]*navigateOrDrillPlatform\(target\)/);
+  assert.match(
+    callGraphBinding,
+    /const loaded = disposition === "loaded" && candidate\.status === "unique"\s*\? resolveLoadedGraphTarget\(target, candidate\)\s*: null/);
+  assert.match(
+    callGraphBinding,
+    /const platform = disposition === "platform";\s*return \{\s*platform,\s*onSelect:/);
+  assert.match(
+    callGraphBinding,
+    /if \(loaded\?\.group\) \{\s*navigateToMember\([\s\S]*\} else if \(loaded\) \{\s*openGraphSource\(loaded\.request, loaded\.title\);\s*\} else if \(platform\) \{\s*void navigateOrDrillPlatform\(target\);\s*\}/);
+  assert.equal(appSource.match(/\bbindGraphBack\(/g)?.length, 1);
+  assert.equal(appSource.match(/\bbindGraphPanZoom\(/g)?.length, 3);
+  assert.equal(appSource.match(/\bbindTypeGraphNodes\(/g)?.length, 1);
+  assert.equal(appSource.match(/\bbindDependencyGraphNodes\(/g)?.length, 1);
+  assert.equal(appSource.match(/\bcallGraphNodeBinding\(/g)?.length, 2);
+  assert.doesNotMatch(
+    `${typeGraph}\n${dependencyGraph}\n${callGraph}`,
+    /\.addEventListener\(|querySelectorAll<SVGGElement>\("g\.node"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /function (?:attachGraphPanZoom|graphTargetForSvgNode)\(/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelector\("\[data-graph-back\]"\)/);
+  assert.equal(appSource.match(/\.addEventListener\(/g)?.length, 4);
 });
 
 test("typed document inspection owns package document request coordination", () => {
@@ -2105,8 +2195,11 @@ test("dependency graph binds navigation to generated node identities", () => {
     graphSource,
     /const nodeInfoById = new Map<string, DependencyGraphNodeInfo>\(\);[\s\S]*for \(const key of keys\)[\s\S]*if \(id && info\) nodeInfoById\.set\(id, info\)/);
   assert.match(
+    graphInteractionsSource,
+    /const dataId = node\.getAttribute\("data-id"\);[\s\S]*return dataId \|\| idMatch\?\.\[1\] \|\| ""/);
+  assert.match(
     appSource,
-    /const nodeId = dataId \|\| idMatch\?\.\[1\];\s*const info = nodeId \? built\.nodeInfoById\.get\(nodeId\) : null/);
+    /bindDependencyGraphNodes\(viewport, nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)/);
   assert.doesNotMatch(appSource, /nodeInfoByLabel/);
   assert.match(
     appSource,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -441,7 +441,7 @@ test("typed package bar owns package framework and version selection bindings", 
     ?? "";
   assert.match(
     packageBarCreation,
-    /selectFramework: switchPackageFramework,[\s\S]*selectVersion: version => \{[\s\S]*state\.package\?\.isRuntimePack[\s\S]*switchPlatformVersion\(version\);[\s\S]*else switchPackageVersion\(version\)/);
+    /selectFramework: framework =>\s*observeAsync\(\s*switchPackageFramework\(framework\),\s*"Switching the package framework"\),[\s\S]*selectVersion: version => \{[\s\S]*state\.package\?\.isRuntimePack[\s\S]*observeAsync\(\s*switchPlatformVersion\(version\),\s*"Switching the platform version"\);[\s\S]*else\s*observeAsync\(\s*switchPackageVersion\(version\),\s*"Switching the package version"\)/);
   assert.match(
     packageBarSource,
     /export function bindPackageSelections\([\s\S]*\[data-framework-chip\][\s\S]*#framework[\s\S]*#package-version/);
@@ -555,7 +555,7 @@ test("typed package view owns package navigation bindings", () => {
     /onDependencyGroupSelect: index => \{[\s\S]*state\.dependenciesGroupIndex === index[\s\S]*state\.dependenciesGroupIndex = index;[\s\S]*patchDependenciesGroup\(\)/);
   assert.match(
     binding,
-    /onDependencyLoad: openDependencyPackage,\s*onDependencyOpen: switchToPackageForDependencies,\s*onGraphTypeSelect: navigateToTypeByName/);
+    /onDependencyLoad: \(id, version\) =>\s*observeAsync\(\s*openDependencyPackage\(id, version\),\s*"Opening a dependency package"\),\s*onDependencyOpen: switchToPackageForDependencies,\s*onGraphTypeSelect: navigateToTypeByName/);
   const kindJump = actionSource("onKindJump");
   const libraryJump = actionSource("onLibraryScopeSelect");
   const namespaceJump = actionSource("onNamespaceJump");
@@ -629,10 +629,10 @@ test("typed library controls own library and Platform picker bindings", () => {
     /onLibraryJump: library => \{[\s\S]*state\.libraryScope = library \? new Set\(\[library\]\) : null;[\s\S]*afterLibraryScopeChange\(\)/);
   assert.match(
     binding,
-    /onPlatformLibrarySelect: openPlatformLibrary/);
+    /onPlatformLibrarySelect: \(name, pack\) =>\s*observeAsync\(\s*openPlatformLibrary\(name, pack\),\s*"Opening a platform library"\)/);
   assert.match(
     binding,
-    /onPlatformLensLibrarySelect: \(lens, name, pack\) => \{\s*void openPlatformLensLibrary\(lens, name, pack\)/);
+    /onPlatformLensLibrarySelect: \(lens, name, pack\) =>\s*observeAsync\(\s*openPlatformLensLibrary\(lens, name, pack\),\s*"Opening a platform library"\)/);
   assert.doesNotMatch(
     workspaceBinding,
     /\[data-(?:library-chip|access-chip|platform-(?:library-select|integrations-library|opportunities-library|analysis-library|metadata-library))\]|#library-jump/);
@@ -693,13 +693,13 @@ test("typed shell controls own workbench, home, and load-error bindings", () => 
     /onDismissPackageNotice: \(\) => \{[\s\S]*currentPackage\(\)\.inspectionError = "";[\s\S]*render\(\);\s*\},\n  onGoHome:/);
   assert.match(
     workbenchActions,
-    /onGoHome: goHome,[\s\S]*onHelp: \(\) => showToast\([\s\S]*onNavigateBack: navBack,[\s\S]*onNavigateForward: navForward,[\s\S]*onRetryNotice: \(\) => state\.queryNoticeRetryAction\?\.\(\),[\s\S]*onShare: share,[\s\S]*onToggleTheme: toggleTheme/);
+    /onGoHome: goHome,[\s\S]*onHelp: \(\) => showToast\([\s\S]*onNavigateBack: navBack,[\s\S]*onNavigateForward: navForward,[\s\S]*onRetryNotice: \(\) => \{[\s\S]*state\.queryNoticeRetryAction;[\s\S]*if \(retryAction\) observeAction\(retryAction, "Retrying the inspection"\);[\s\S]*onShare: \(\) => void share\(\),[\s\S]*onToggleTheme: toggleTheme/);
   assert.match(
     homeActions,
     /onDemo: runHomeDemo,\s*onDismissNotice: \(\) => \{[\s\S]*state\.queryNotice = "";[\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*render\(\);\s*\},\n  onToggleTheme: toggleTheme/);
   assert.match(
     loadErrorActions,
-    /onOpenPackage: openPackageFromError,\s*onRetry: \(\) => \(state\.retryAction \?\? bootstrap\)\(\)/);
+    /onOpenPackage: openPackageFromError,\s*onRetry: \(\) =>\s*observeAction\(\s*state\.retryAction \?\? bootstrap,\s*"Retrying the inspection"\)/);
   assert.doesNotMatch(
     appSource,
     /\bquerySelector(?:All)?(?:<[^>]+>)?\("(?:#(?:share|dismiss-notice|retry-notice|dismiss-package-notice|nav-back|nav-forward|go-home|theme-toggle|help|home-theme|retry-load|error-package-query|error-package-input|toggle-error-detail)|\[data-home-demo\]|\.load-error-detail)"\)/);
@@ -772,7 +772,7 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     /callGraph\.targets\?\.find\(candidate => candidate\.id === nodeId\)[\s\S]*const drilled =\s*state\.platformStack\.length > 0 \|\| Boolean\(state\.package\?\.isRuntimePack\);\s*if \(drilled\) \{\s*if \(target\.id === "n0" \|\| !target\.assembly \|\| !typeId\) return null;[\s\S]*navigateOrDrillPlatform\(target\)[\s\S]*resolveLoadedGraphTargetCandidate[\s\S]*graphTargetNavigationDisposition[\s\S]*if \(disposition === "blocked" \|\| disposition === "none"\) return null;[\s\S]*navigateToMember\([\s\S]*openGraphSource\([\s\S]*navigateOrDrillPlatform\(target\)/);
   assert.match(
     callGraphBinding,
-    /if \(drilled\) \{[\s\S]*return \{\s*platform: true,\s*onSelect: \(\) => \{[\s\S]*navigateOrDrillPlatform\(target\)/);
+    /if \(drilled\) \{[\s\S]*return \{\s*platform: true,\s*onSelect: \(\) =>\s*observeAsync\(\s*navigateOrDrillPlatform\(target\),\s*"Opening a platform call-graph target"\)/);
   assert.match(
     callGraphBinding,
     /const loaded = disposition === "loaded" && candidate\.status === "unique"\s*\? resolveLoadedGraphTarget\(target, candidate\)\s*: null/);
@@ -781,7 +781,7 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     /const platform = disposition === "platform";\s*return \{\s*platform,\s*onSelect:/);
   assert.match(
     callGraphBinding,
-    /if \(loaded\?\.group\) \{\s*navigateToMember\([\s\S]*\} else if \(loaded\) \{\s*openGraphSource\(loaded\.request, loaded\.title\);\s*\} else if \(platform\) \{\s*void navigateOrDrillPlatform\(target\);\s*\}/);
+    /if \(loaded\?\.group\) \{\s*navigateToMember\([\s\S]*\} else if \(loaded\) \{\s*observeAsync\(\s*openGraphSource\(loaded\.request, loaded\.title\),\s*"Loading graph source"\);\s*\} else if \(platform\) \{\s*observeAsync\(\s*navigateOrDrillPlatform\(target\),\s*"Opening a platform call-graph target"\);\s*\}/);
   assert.equal(appSource.match(/\bbindGraphBack\(/g)?.length, 1);
   assert.equal(appSource.match(/\bbindGraphPanZoom\(/g)?.length, 3);
   assert.equal(appSource.match(/\bbindTypeGraphNodes\(/g)?.length, 1);
@@ -930,16 +930,16 @@ test("typed type panel owns its rendered control bindings", () => {
     /onMemberBack: drillOut[\s\S]*onMemberOverloadOpen: openOverload/);
   assert.match(
     binding,
-    /onCopyName: async \(\) => \{[\s\S]*const fullName = member \? `\$\{typeName\}\.\$\{member\.name\}` : typeName;[\s\S]*copyText\(fullName, "name copied"\)/);
+    /onCopyName: \(\) => \{[\s\S]*const fullName = member \? `\$\{typeName\}\.\$\{member\.name\}` : typeName;[\s\S]*void copyText\(fullName, "name copied"\)/);
   assert.match(
     binding,
-    /onCopySignature: async \(\) => \{[\s\S]*copyText\(overload\.signature, "signature copied"\)/);
+    /onCopySignature: \(\) => \{[\s\S]*void copyText\(overload\.signature, "signature copied"\)/);
   assert.match(
     binding,
-    /onCopyAnchor: async anchor => \{[\s\S]*selector: overload\?\.stableSelector,[\s\S]*digest: overload\?\.anchorDigest,[\s\S]*canonical: overload\?\.canonicalSignature[\s\S]*copyText\(value, `\$\{anchor\} copied`\)/);
+    /onCopyAnchor: anchor => \{[\s\S]*selector: overload\?\.stableSelector,[\s\S]*digest: overload\?\.anchorDigest,[\s\S]*canonical: overload\?\.canonicalSignature[\s\S]*void copyText\(value, `\$\{anchor\} copied`\)/);
   assert.match(
     binding,
-    /onCopyMemberSource: async \(\) => \{[\s\S]*copyText\(state\.memberSource\.text, "source copied"\)[\s\S]*onCopyTypeSource: async \(\) => \{[\s\S]*copyText\(state\.typeSource\.text, "source copied"\)/);
+    /onCopyMemberSource: \(\) => \{[\s\S]*void copyText\(state\.memberSource\.text, "source copied"\)[\s\S]*onCopyTypeSource: \(\) => \{[\s\S]*void copyText\(state\.typeSource\.text, "source copied"\)/);
   assert.match(
     binding,
     /onMemberFilterClear: \(\) => \{[\s\S]*resetMemberFilters\(\);[\s\S]*renderMemberFilterAndRestoreFocus\("#clear-member-filter"\)/);
@@ -1410,7 +1410,7 @@ test("package opportunities owns its rendered control bindings", () => {
     ?? "";
   assert.match(
     binding,
-    /bindPackageOpportunities\(document, \{\s*onLookForSelect: openSpotlight,\s*onPackageSelect: packageId => openDependencyPackage\(packageId, ""\),\s*onTypeSelect: typeId => \{[\s\S]*currentPackage\(\)\.types\.find\(item => item\.id === typeId\);\s*if \(!target\) \{[\s\S]*openSpotlight\(shortTypeName\(typeId\)\);\s*return;\s*\}[\s\S]*state\.atPackageRoot = false;[\s\S]*navigateToTypeByName\(typeId\)/);
+    /bindPackageOpportunities\(document, \{\s*onLookForSelect: openSpotlight,\s*onPackageSelect: packageId =>\s*observeAsync\(\s*openDependencyPackage\(packageId, ""\),\s*"Opening an opportunity package"\),\s*onTypeSelect: typeId => \{[\s\S]*currentPackage\(\)\.types\.find\(item => item\.id === typeId\);\s*if \(!target\) \{[\s\S]*openSpotlight\(shortTypeName\(typeId\)\);\s*return;\s*\}[\s\S]*state\.atPackageRoot = false;[\s\S]*navigateToTypeByName\(typeId\)/);
   assert.match(
     bindEvents,
     /^\s*bindPackageOpportunitiesEvents\(\);\s*$/m);
@@ -1452,9 +1452,13 @@ test("modal viewers own their rendered close bindings", () => {
     /bindGraphSource\(document, \{\s*onClose: closeGraphSource,\s*\}\)/);
   assert.match(
     docBinding,
-    /bindDocViewer\(document, \{\s*onClose: closeDocViewer,\s*onOpenDocument: openPackageDocument,\s*\}\)/);
-  assert.equal(graphBinding.match(/\bdocument\b/g)?.length, 1);
-  assert.equal(docBinding.match(/\bdocument\b/g)?.length, 1);
+    /bindDocViewer\(document, \{\s*onClose: closeDocViewer,\s*onOpenDocument: path =>\s*observeAsync\(openPackageDocument\(path\), "Opening a package document"\),\s*\}\)/);
+  assert.equal(
+    graphBinding.match(/\bbindGraphSource\(document\b/g)?.length,
+    1);
+  assert.equal(
+    docBinding.match(/\bbindDocViewer\(document\b/g)?.length,
+    1);
   assert.match(
     graphSourceViewerSource,
     /export function bindGraphSource\([\s\S]*#graph-source-backdrop[\s\S]*event\.target === backdrop[\s\S]*#graph-source-close/);
@@ -1489,7 +1493,7 @@ test("annotated source owns its rendered control bindings", () => {
     ?? "";
   assert.match(
     binding,
-    /bindAnnotatedSource\(document, \{[\s\S]*onClearSelection: \(\) => \{[\s\S]*memberAnnotatedFactId = null;[\s\S]*memberAnnotatedNodeIds = \[\];[\s\S]*onCopy: async \(\) => \{[\s\S]*memberAnnotated\.document\.text[\s\S]*onFactSelect: factId => \{[\s\S]*memberAnnotatedFactId === factId \? null : factId[\s\S]*onMediumToggle: medium => \{[\s\S]*MEDIA\.includes[\s\S]*MEDIA\.some\(candidate => next\[candidate\]\)[\s\S]*onOffsetSelect: offset => \{[\s\S]*nodeAtOffset\(state\.memberAnnotated\.document, offset\)[\s\S]*factsForNode/);
+    /bindAnnotatedSource\(document, \{[\s\S]*onClearSelection: \(\) => \{[\s\S]*memberAnnotatedFactId = null;[\s\S]*memberAnnotatedNodeIds = \[\];[\s\S]*onCopy: \(\) => \{[\s\S]*void copyText\([\s\S]*memberAnnotated\.document\.text[\s\S]*onFactSelect: factId => \{[\s\S]*memberAnnotatedFactId === factId \? null : factId[\s\S]*onMediumToggle: medium => \{[\s\S]*isAnnotatedMedium\(medium\)[\s\S]*MEDIA\.some\(candidate => next\[candidate\]\)[\s\S]*onOffsetSelect: offset => \{[\s\S]*nodeAtOffset\(state\.memberAnnotated\.document, offset\)[\s\S]*factsForNode/);
   assert.match(
     binding,
     /\[typedMedium\]: !state\.memberAnnotatedMedia\[typedMedium\],[\s\S]*if \(!MEDIA\.some\(candidate => next\[candidate\]\)\) return;/);
@@ -3003,7 +3007,9 @@ test("workspace UI routes replacements and restore notices through bounded paths
   assert.match(
     packageBarSource,
     /onFrameworkSelect\(button\.dataset\.frameworkChip \?\? ""\)/);
-  assert.match(appSource, /selectFramework: switchPackageFramework/);
+  assert.match(
+    appSource,
+    /selectFramework: framework =>\s*observeAsync\(\s*switchPackageFramework\(framework\),\s*"Switching the package framework"\)/);
   assert.match(appSource, /switchPackageFramework\(argument\)/);
   assert.doesNotMatch(
     appSource,
@@ -3031,7 +3037,7 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /state\.error = "";\s+state\.errorTitle = "";\s+state\.errorDetail = "";\s+state\.retryAction = null;\s+state\.home = true;/);
   assert.match(
     appSource,
-    /\(\) => observeAction\(\s*state\.retryAction \?\? bootstrap,\s*"Retrying the inspection"\)/);
+    /\(\) =>\s*observeAction\(\s*state\.retryAction \?\? bootstrap,\s*"Retrying the inspection"\)/);
   assert.match(
     appSource,
     /state\.retryAction = openRuntimePackFromHome/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -292,6 +292,9 @@ const packageViewSource = readFileSync(
 const libraryControlsSource = readFileSync(
   new URL("../src/library-controls.ts", import.meta.url),
   "utf8");
+const shellControlsSource = readFileSync(
+  new URL("../src/shell-controls.ts", import.meta.url),
+  "utf8");
 const sourceInspectionSource = readFileSync(
   new URL("../src/source-inspection.ts", import.meta.url),
   "utf8");
@@ -634,6 +637,76 @@ test("typed library controls own library and Platform picker bindings", () => {
     appSource,
     /\[data-(?:library-chip|access-chip|platform-(?:library-select|integrations-library|opportunities-library|analysis-library|metadata-library))\]|#library-jump/);
   assert.doesNotMatch(appSource, /bindPlatformLensPicker/);
+});
+
+test("typed shell controls own workbench, home, and load-error bindings", () => {
+  const workbenchActions =
+    appSource.match(/const workbenchShellActions: WorkbenchShellBindingActions = \{[\s\S]*?\n};/)?.[0]
+    ?? "";
+  const homeActions =
+    appSource.match(/const homeShellActions: HomeShellBindingActions = \{[\s\S]*?\n};/)?.[0]
+    ?? "";
+  const loadErrorActions =
+    appSource.match(/const loadErrorShellActions: LoadErrorShellBindingActions = \{[\s\S]*?\n};/)?.[0]
+    ?? "";
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
+  const homeBinding =
+    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\n\/\/ The two package demos)/)?.[0]
+    ?? "";
+  const loadingBinding =
+    appSource.match(/function renderLoading\(\) \{[\s\S]*?\n}(?=\n\nasync function loadSelectedMemberDocumentation)/)?.[0]
+    ?? "";
+  assert.match(
+    shellControlsSource,
+    /export function bindWorkbenchShell\([\s\S]*#share[\s\S]*#dismiss-notice[\s\S]*#retry-notice[\s\S]*#dismiss-package-notice[\s\S]*#nav-back[\s\S]*#nav-forward[\s\S]*#go-home[\s\S]*#theme-toggle[\s\S]*#help/);
+  assert.match(
+    shellControlsSource,
+    /export function bindHomeShell\([\s\S]*#home-theme[\s\S]*#dismiss-notice[\s\S]*\[data-home-demo\]/);
+  assert.match(
+    shellControlsSource,
+    /export function bindLoadErrorShell\([\s\S]*#retry-load[\s\S]*#error-package-query[\s\S]*#error-package-input[\s\S]*#toggle-error-detail[\s\S]*\.load-error-detail/);
+  assert.match(
+    shellControlsSource,
+    /import \{ parsePackageQuery \} from "\.\/package-bar\.ts"/);
+  assert.equal(
+    workspaceBinding.match(/\bbindWorkbenchShell\(\b/g)?.length,
+    1);
+  assert.match(
+    workspaceBinding,
+    /bindWorkbenchShell\(document, workbenchShellActions\)/);
+  assert.match(
+    homeBinding,
+    /bindHomeShell\(document, homeShellActions\)[\s\S]*spotlight\.bind\(document, "inline"\)[\s\S]*#spotlight-input/);
+  assert.match(
+    loadingBinding,
+    /app\.innerHTML = `[\s\S]*bindLoadErrorShell\(document, loadErrorShellActions\)/);
+  assert.match(
+    workbenchActions,
+    /onDismissNotice: \(\) => \{[\s\S]*state\.queryNotice = "";[\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*render\(\);\s*\},\n  onDismissPackageNotice:/);
+  assert.match(
+    workbenchActions,
+    /onDismissPackageNotice: \(\) => \{[\s\S]*currentPackage\(\)\.inspectionError = "";[\s\S]*render\(\);\s*\},\n  onGoHome:/);
+  assert.match(
+    workbenchActions,
+    /onGoHome: goHome,[\s\S]*onHelp: \(\) => showToast\([\s\S]*onNavigateBack: navBack,[\s\S]*onNavigateForward: navForward,[\s\S]*onRetryNotice: \(\) => state\.queryNoticeRetryAction\?\.\(\),[\s\S]*onShare: share,[\s\S]*onToggleTheme: toggleTheme/);
+  assert.match(
+    homeActions,
+    /onDemo: runHomeDemo,\s*onDismissNotice: \(\) => \{[\s\S]*state\.queryNotice = "";[\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*render\(\);\s*\},\n  onToggleTheme: toggleTheme/);
+  assert.match(
+    loadErrorActions,
+    /onOpenPackage: openPackageFromError,\s*onRetry: \(\) => \(state\.retryAction \?\? bootstrap\)\(\)/);
+  assert.doesNotMatch(
+    appSource,
+    /\bquerySelector(?:All)?(?:<[^>]+>)?\("(?:#(?:share|dismiss-notice|retry-notice|dismiss-package-notice|nav-back|nav-forward|go-home|theme-toggle|help|home-theme|retry-load|error-package-query|error-package-input|toggle-error-detail)|\[data-home-demo\]|\.load-error-detail)"\)/);
+  assert.doesNotMatch(
+    workspaceBinding,
+    /#(?:share|dismiss-notice|retry-notice|dismiss-package-notice|nav-back|nav-forward|go-home|theme-toggle|help)/);
+  assert.doesNotMatch(homeBinding, /#(?:home-theme|dismiss-notice)|\[data-home-demo\]/);
+  assert.doesNotMatch(
+    loadingBinding,
+    /#(?:retry-load|error-package-query|error-package-input|toggle-error-detail)|"\.load-error-detail"/);
 });
 
 test("typed document inspection owns package document request coordination", () => {
@@ -1322,7 +1395,7 @@ test("modal viewers own their rendered close bindings", () => {
 
 test("annotated source owns its rendered control bindings", () => {
   const binding =
-    appSource.match(/function bindAnnotatedSourceEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    appSource.match(/function bindAnnotatedSourceEvents\(\) \{[\s\S]*?\n}(?=\n\nconst workbenchShellActions)/)?.[0]
     ?? "";
   assert.match(
     binding,
@@ -1510,7 +1583,7 @@ test("bare home paints before wasm engine download", () => {
   const homePaintWait =
     appSource.match(/function waitForHomePaint\(\)[\s\S]*?\n}\n\nfunction loadStoredTaste/)?.[0] ?? "";
   const errorPackageRecovery =
-    appSource.match(/function openPackageFromError[\s\S]*?\n}\n\nfunction renderLoading/)?.[0] ?? "";
+    appSource.match(/function openPackageFromError[\s\S]*?\n}\n\nconst loadErrorShellActions/)?.[0] ?? "";
   const loadingView =
     appSource.match(/function renderLoading\(\)[\s\S]*?\n}\n\nasync function loadSelectedMemberDocumentation/)?.[0] ?? "";
   assert.doesNotMatch(appSource, /from "\/engine\.js"/);
@@ -1541,10 +1614,10 @@ test("bare home paints before wasm engine download", () => {
     /if \(!state\.engineReady\) \{[\s\S]*window\.location\.assign\(url\);[\s\S]*return;[\s\S]*\}\s*observeAsync\(loadPackage\(packageId, version, ""\)/);
   assert.match(
     loadingView,
-    /#error-package-query[\s\S]*openPackageFromError\(packageId, version\)/);
+    /id="error-package-query"[\s\S]*bindLoadErrorShell\(document, loadErrorShellActions\)/);
   assert.doesNotMatch(
     loadingView,
-    /#error-package-query[\s\S]*loadPackage\(packageId, version/);
+    /id="error-package-query"[\s\S]*(?:openPackageFromError|loadPackage)\(/);
 });
 
 test("Spotlight uses local type matches until the engine is ready", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -351,6 +351,94 @@ const commandBarSource = readFileSync(
   new URL("../src/command-bar.ts", import.meta.url),
   "utf8");
 
+function maskNonCode(source) {
+  const masked = [...source];
+  for (let index = 0; index < source.length; index++) {
+    const quote = source[index];
+    if (quote === "/" && source[index + 1] === "/") {
+      while (index < source.length && source[index] !== "\n") {
+        masked[index++] = " ";
+      }
+    } else if (quote === "/" && source[index + 1] === "*") {
+      masked[index++] = " ";
+      while (index < source.length
+        && !(source[index] === "*" && source[index + 1] === "/")) {
+        masked[index++] = " ";
+      }
+      masked[index] = " ";
+      masked[index + 1] = " ";
+      index++;
+    } else if (quote === "\"" || quote === "'" || quote === "`") {
+      masked[index] = " ";
+      for (index++; index < source.length; index++) {
+        masked[index] = " ";
+        if (source[index] === "\\") {
+          masked[++index] = " ";
+        } else if (source[index] === quote) {
+          break;
+        }
+      }
+    }
+  }
+  return masked.join("");
+}
+
+function assertDirectCompositionCall(
+  source,
+  functionName,
+  calleeName,
+  expectedIndex,
+) {
+  const functionPrefix = `function ${functionName}() {`;
+  const functionStart = source.indexOf(functionPrefix);
+  assert.notEqual(functionStart, -1);
+  const body = source.slice(functionStart + functionPrefix.length);
+  const masked = maskNonCode(body);
+  const statements = [];
+  let depth = 0;
+  let statementStart = 0;
+  for (let index = 0; index < masked.length; index++) {
+    if (masked[index] === "{") depth++;
+    else if (masked[index] === "}") {
+      if (depth === 0) break;
+      depth--;
+    } else if (masked[index] === ";" && depth === 0) {
+      statements.push(masked.slice(statementStart, index + 1).trim());
+      statementStart = index + 1;
+    }
+  }
+  assert.equal(
+    statements[expectedIndex].replace(/\s+/g, " "),
+    `${calleeName}();`);
+}
+
+test("composition call gates distinguish direct calls from textual nesting", () => {
+  const direct = `function bind() {
+    const options = { label: "{ready}" };
+    // A brace in a comment is not composition.
+    bindTarget();
+  }`;
+  assertDirectCompositionCall(direct, "bind", "bindTarget", 1);
+  assert.throws(() =>
+    assertDirectCompositionCall(
+      "function bind() { if (false) bindTarget(); }",
+      "bind",
+      "bindTarget",
+      0));
+  assert.throws(() =>
+    assertDirectCompositionCall(
+      "function bind() { if (false) { bindTarget(); } }",
+      "bind",
+      "bindTarget",
+      0));
+  assert.throws(() =>
+    assertDirectCompositionCall(
+      "function bind() { if (false) return; bindTarget(); }",
+      "bind",
+      "bindTarget",
+      0));
+});
+
 test("typed Spotlight owns search presentation and hosts commands", () => {
   assert.match(
     appSource,
@@ -384,6 +472,33 @@ test("workspace data bar receives package acquisition provenance", () => {
   assert.match(packageAcquisitionSource, /source: \{ kind: "platform" \}/);
   assert.doesNotMatch(appSource, /source: \{ kind: "(?:nuget\.org|platform)" \}/);
   assert.match(statusBarSource, /Source: \$\{escapeHtml\(packageSourceLabel\(model\.source\)\)\}/);
+});
+
+test("typed status bar owns its rendered toggle binding", () => {
+  const binding =
+    appSource.match(/function bindStatusBarEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
+  assert.match(
+    binding,
+    /bindStatusBar\(document, \{\s*onToggle: \(\) => \{[\s\S]*state\.statusBarExpanded = !state\.statusBarExpanded;[\s\S]*render\(\);[\s\S]*\},\s*\}\)/);
+  assert.equal(binding.match(/\bdocument\b/g)?.length, 1);
+  assert.match(
+    statusBarSource,
+    /export function bindStatusBar\([\s\S]*\[data-status-bar-toggle-button\][\s\S]*actions\.onToggle/);
+  assert.doesNotMatch(appSource, /\[data-status-bar-toggle-button\]/);
+  assertDirectCompositionCall(
+    appSource,
+    "bindEvents",
+    "bindStatusBarEvents",
+    0);
+  assertDirectCompositionCall(
+    appSource,
+    "bindHomeEvents",
+    "bindStatusBarEvents",
+    0);
+  assert.equal(
+    appSource.match(/\bbindStatusBarEvents\(\)/g)?.length,
+    3);
 });
 
 test("typed package inspection owns package-root request coordination", () => {
@@ -505,9 +620,14 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.equal(
     rootEventBinder.match(/\bbindTypePanelEvents\(\)/g)?.length,
     1);
-  assert.match(
-    rootEventBinder,
-    /function bindEvents\(\) \{\s*bindStatusBarToggle\(\);\s*packageBar\.bind\(document\);\s*bindTypePanelEvents\(\);/);
+  assert.equal(
+    rootEventBinder.match(/^\s*bindTypePanelEvents\(\);$/gm)?.length,
+    1);
+  assertDirectCompositionCall(
+    appSource,
+    "bindEvents",
+    "bindTypePanelEvents",
+    2);
   assert.match(
     typePanelSource,
     /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -632,17 +632,20 @@ test("typed catalog requests own release and package-version coordination", () =
 });
 
 test("typed type panel owns its rendered control bindings", () => {
+  const binding =
+    appSource.match(/function bindTypePanelEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
   const rootEventBinder =
     appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
     ?? "";
   assert.match(
-    appSource,
-    /function bindTypePanelEvents\(\) \{\s*bindTypePanel\(document, \{/);
+    binding,
+    /bindTypePanel\(document, \{/);
   assert.match(
-    appSource,
+    binding,
     /onTypeFilterChange: value => \{[\s\S]*?render\(\);\s*focusFilter\(\{ immediate: true \}\);\s*},\s*onTypeFilterEscape:/);
   assert.match(
-    appSource,
+    binding,
     /onTypeFilterEscape: \(\) => \{\s*state\.typeFilter = "";\s*render\(\);\s*focusFilter\(\{ immediate: true \}\);\s*},/);
   assert.equal(
     appSource.match(/\bbindTypePanelEvents\b/g)?.length,
@@ -661,6 +664,21 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.match(
     typePanelSource,
     /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);
+  assert.match(
+    typePanelSource,
+    /\[data-member-kind-filter\][\s\S]*\[data-member-access-filter\][\s\S]*\[data-member-trait-filter\][\s\S]*#clear-member-filter[\s\S]*#member-filter/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelectorAll<HTMLElement>\("\[data-member-(?:kind|access|trait)-filter\]"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelector(?:<HTMLInputElement>)?\("#(?:member-filter|clear-member-filter)"\)/);
+  assert.match(
+    binding,
+    /onMemberFilterClear: \(\) => \{[\s\S]*resetMemberFilters\(\);[\s\S]*renderMemberFilterAndRestoreFocus\("#clear-member-filter"\)/);
+  assert.match(
+    binding,
+    /onMemberFilterKeyDown: \(event, value\) => \{\s*if \(event\.key === "Escape"\) \{\s*if \(navMode\(\) !== "member" && value === ""\) return;\s*event\.preventDefault\(\);[\s\S]*navMode\(\) === "member"[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*event\.key !== "ArrowUp" && event\.key !== "ArrowDown"[\s\S]*event\.preventDefault\(\);\s*stepMemberNav\(event\.key === "ArrowDown" \? 1 : -1, true\)/);
   const selectorCount = selector =>
     appSource.split(selector).length - 1;
   assert.deepEqual(
@@ -1384,6 +1402,9 @@ test("loading brand links back to the site root", () => {
 });
 
 test("member filters retain accessible controls and focus across rerenders", () => {
+  const binding =
+    appSource.match(/function bindTypePanelEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
   assert.match(
     appSource,
     /id="clear-member-filter"[^>]*aria-label="Clear member filters"/);
@@ -1394,11 +1415,17 @@ test("member filters retain accessible controls and focus across rerenders", () 
     stylesSource,
     /\.type-browser:not\(\.member-nav\) \.namespace-chips, \.pane-footer \{ display: none; \}/);
   assert.match(
-    appSource,
-    /memberFilter\?\.addEventListener\("input"[\s\S]*renderPreservingMemberFocus\(\)/);
+    typePanelSource,
+    /memberFilter\?\.addEventListener\(\s*"input",\s*\(\) => actions\.onMemberFilterChange\(memberFilter\.value\)\)/);
   assert.match(
-    appSource,
-    /memberFilter\?\.addEventListener\("keydown"[\s\S]*event\.key === "Escape"[\s\S]*if \(navMode\(\) !== "member" && memberFilter\.value === ""\) return;[\s\S]*event\.preventDefault\(\);[\s\S]*if \(navMode\(\) === "member"\)[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*renderMemberFilterAndRestoreFocus\("#member-filter"\)[\s\S]*stepMemberNav/);
+    binding,
+    /onMemberFilterChange: value => \{[\s\S]*state\.memberTextFilter = value;[\s\S]*renderPreservingMemberFocus\(\)/);
+  assert.match(
+    typePanelSource,
+    /memberFilter\?\.addEventListener\(\s*"keydown",\s*event => actions\.onMemberFilterKeyDown\(event, memberFilter\.value\)\)/);
+  assert.match(
+    binding,
+    /onMemberFilterKeyDown: \(event, value\) => \{[\s\S]*event\.key === "Escape"[\s\S]*if \(navMode\(\) !== "member" && value === ""\) return;[\s\S]*if \(navMode\(\) === "member"\)[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*renderMemberFilterAndRestoreFocus\("#member-filter"\)[\s\S]*stepMemberNav/);
   assert.match(
     appSource,
     /event\.key === "Escape" && !event\.defaultPrevented && !typing[\s\S]*if \(navMode\(\) === "member"\) exitMemberScope\(\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -320,6 +320,9 @@ const packageBarSource = readFileSync(
 const metadataViewerSource = readFileSync(
   new URL("../src/metadata-viewer.ts", import.meta.url),
   "utf8");
+const packageOpportunitiesSource = readFileSync(
+  new URL("../src/package-opportunities.ts", import.meta.url),
+  "utf8");
 const applicationSources =
   `${appSource}\n${graphSource}\n${packageBarSource}\n${metadataViewerSource}`;
 const stylesSource = readFileSync(new URL("../src/styles.css", import.meta.url), "utf8");
@@ -892,6 +895,31 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
     assert.equal(appSource.split(selector).length - 1, 0, selector);
   }
   assert.equal(appSource.split("#mde-canvas").length - 1, 1);
+});
+
+test("package opportunities owns its rendered control bindings", () => {
+  const binding =
+    appSource.match(/function bindPackageOpportunitiesEvents\(\) \{[\s\S]*?\n}\n\nfunction bindEvents/)?.[0]
+    ?? "";
+  assert.match(
+    binding,
+    /bindPackageOpportunities\(document, \{\s*onLookForSelect: openSpotlight,\s*onPackageSelect: packageId => openDependencyPackage\(packageId, ""\),\s*onTypeSelect: typeId => \{[\s\S]*currentPackage\(\)\.types\.find\(item => item\.id === typeId\)[\s\S]*openSpotlight\(shortTypeName\(typeId\)\)[\s\S]*state\.atPackageRoot = false;[\s\S]*navigateToTypeByName\(typeId\)/);
+  assert.equal(
+    appSource.match(/\bbindPackageOpportunitiesEvents\b/g)?.length,
+    2);
+  assert.equal(
+    appSource.match(/\bbindPackageOpportunities\b/g)?.length,
+    2);
+  assert.match(
+    packageOpportunitiesSource,
+    /export function bindPackageOpportunities\([\s\S]*\[data-opp-type\][\s\S]*\[data-opp-package\][\s\S]*\[data-opp-lookfor\]/);
+  for (const selector of [
+    "[data-opp-type]",
+    "[data-opp-package]",
+    "[data-opp-lookfor]",
+  ]) {
+    assert.equal(appSource.split(selector).length - 1, 0, selector);
+  }
 });
 
 test("leaving package search clears its pending loading state", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -910,6 +910,9 @@ test("package opportunities owns its rendered control bindings", () => {
   assert.equal(
     appSource.match(/\bbindPackageOpportunities\b/g)?.length,
     2);
+  assert.doesNotMatch(
+    binding,
+    /\b(?:getElementById|querySelector|querySelectorAll)\s*\(|\.addEventListener\s*\(/);
   assert.match(
     packageOpportunitiesSource,
     /export function bindPackageOpportunities\([\s\S]*\[data-opp-type\][\s\S]*\[data-opp-package\][\s\S]*\[data-opp-lookfor\]/);

--- a/prototypes/inspect-web/test/status-bar.test.ts
+++ b/prototypes/inspect-web/test/status-bar.test.ts
@@ -8,6 +8,7 @@ import {
   packageSourceLabel,
   statusBarHtml,
 } from "../src/status-bar.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
   private readonly listeners = new Map<string, EventListener[]>();
@@ -20,7 +21,7 @@ class FakeElement {
 
   dispatch(type: string) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({ target: this } as unknown as Event);
+      listener(fakeDom.event({ target: this }));
     }
   }
 }
@@ -51,7 +52,7 @@ test("status bar binding dispatches each rendered toggle without eager work", ()
   let toggles = 0;
 
   bindStatusBar(
-    new FakeRoot([workspace, home]) as unknown as ParentNode,
+    fakeDom.parentNode(new FakeRoot([workspace, home])),
     { onToggle: () => toggles += 1 });
 
   assert.equal(toggles, 0);

--- a/prototypes/inspect-web/test/status-bar.test.ts
+++ b/prototypes/inspect-web/test/status-bar.test.ts
@@ -1,12 +1,41 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  bindStatusBar,
   buildIdentityHtml,
   fmtBytes,
   fmtMs,
   packageSourceLabel,
   statusBarHtml,
 } from "../src/status-bar.ts";
+
+class FakeElement {
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target: this } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly toggles: FakeElement[];
+
+  constructor(toggles: FakeElement[]) {
+    this.toggles = toggles;
+  }
+
+  querySelectorAll(selector: string) {
+    return selector === "[data-status-bar-toggle-button]" ? this.toggles : [];
+  }
+}
 
 function escapeHtml(value: unknown) {
   return String(value)
@@ -15,6 +44,22 @@ function escapeHtml(value: unknown) {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;");
 }
+
+test("status bar binding dispatches each rendered toggle without eager work", () => {
+  const workspace = new FakeElement();
+  const home = new FakeElement();
+  let toggles = 0;
+
+  bindStatusBar(
+    new FakeRoot([workspace, home]) as unknown as ParentNode,
+    { onToggle: () => toggles += 1 });
+
+  assert.equal(toggles, 0);
+  workspace.dispatch("click");
+  assert.equal(toggles, 1);
+  home.dispatch("click");
+  assert.equal(toggles, 2);
+});
 
 test("status values use stable compact units", () => {
   assert.equal(fmtMs(null), "—");

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -139,15 +139,39 @@ const jsonDocument: TypeSummary = {
 function recordingActions(calls: string[]): TypePanelBindingActions {
   return {
     onClearFilters: () => calls.push("clear"),
+    onCopyAnchor: value => {
+      calls.push(`copy-anchor:${value}`);
+    },
+    onCopyMemberSource: () => {
+      calls.push("copy-member-source");
+    },
+    onCopyName: () => {
+      calls.push("copy-name");
+    },
+    onCopySignature: () => {
+      calls.push("copy-signature");
+    },
+    onCopyTypeSource: () => {
+      calls.push("copy-type-source");
+    },
     onKindSelect: value => calls.push(`kind:${value}`),
     onListKeyDown: event => calls.push(`list:${event.key}`),
     onMemberAccessibilityFilterSelect: value =>
       calls.push(`member-access:${value}`),
+    onMemberBack: () => calls.push("member-back"),
+    onMemberCompositionAccessibilitySelect: value =>
+      calls.push(`member-jump-access:${value}`),
+    onMemberCompositionKindSelect: value =>
+      calls.push(`member-jump-kind:${value}`),
+    onMemberCompositionTraitSelect: value =>
+      calls.push(`member-jump-trait:${value}`),
     onMemberFilterChange: value => calls.push(`member-filter:${value}`),
     onMemberFilterClear: () => calls.push("member-filter-clear"),
     onMemberFilterKeyDown: (event, value) =>
       calls.push(`member-filter-key:${event.key}:${value}`),
+    onMemberGroupOpen: value => calls.push(`member-open:${value}`),
     onMemberKindFilterSelect: value => calls.push(`member-kind:${value}`),
+    onMemberOverloadOpen: value => calls.push(`member-overload:${value}`),
     onMemberSelect: value => calls.push(`member:${value}`),
     onMemberTraitFilterSelect: value => calls.push(`member-trait:${value}`),
     onNamespaceSelect: value => calls.push(`namespace:${value}`),
@@ -297,6 +321,77 @@ test("type panel bindings dispatch the rendered member navigation controls", () 
     "overload:0",
     "types",
     "list:Home",
+  ]);
+});
+
+test("type panel bindings dispatch member composition and detail controls", () => {
+  const root = new FakeRoot();
+  const jumpKind = new FakeElement({ memberJumpKind: "method" });
+  const defaultJumpKind = new FakeElement();
+  const jumpAccess = new FakeElement({ memberJumpAccess: "protected" });
+  const defaultJumpAccess = new FakeElement();
+  const jumpTrait = new FakeElement({ memberJumpTrait: "isStatic" });
+  const defaultJumpTrait = new FakeElement();
+  const member = new FakeElement({ member: "M:Parse" });
+  const defaultMember = new FakeElement();
+  const overload = new FakeElement({ overload: "2" });
+  const defaultOverload = new FakeElement();
+  const anchor = new FakeElement({ copyAnchor: "digest" });
+  const invalidAnchor = new FakeElement({ copyAnchor: "unknown" });
+  root.addAll("[data-member-jump-kind]", jumpKind, defaultJumpKind);
+  root.addAll("[data-member-jump-access]", jumpAccess, defaultJumpAccess);
+  root.addAll("[data-member-jump-trait]", jumpTrait, defaultJumpTrait);
+  root.addAll("[data-member]", member, defaultMember);
+  root.addAll("[data-overload]", overload, defaultOverload);
+  root.addAll("[data-copy-anchor]", anchor, invalidAnchor);
+  const back = root.add("#member-back", new FakeElement());
+  const copyName = root.add("#copy-name", new FakeElement());
+  const copySignature = root.add("#copy-signature", new FakeElement());
+  const copyMemberSource = root.add("#copy-source", new FakeElement());
+  const copyTypeSource = root.add("#copy-type-source", new FakeElement());
+  const calls: string[] = [];
+
+  bindTypePanel(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  jumpKind.dispatch("click");
+  defaultJumpKind.dispatch("click");
+  jumpAccess.dispatch("click");
+  defaultJumpAccess.dispatch("click");
+  jumpTrait.dispatch("click");
+  defaultJumpTrait.dispatch("click");
+  member.dispatch("click");
+  defaultMember.dispatch("click");
+  overload.dispatch("click");
+  defaultOverload.dispatch("click");
+  back.dispatch("click");
+  copyName.dispatch("click");
+  copySignature.dispatch("click");
+  anchor.dispatch("click");
+  invalidAnchor.dispatch("click");
+  copyMemberSource.dispatch("click");
+  copyTypeSource.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "member-jump-kind:method",
+    "member-jump-kind:all",
+    "member-jump-access:protected",
+    "member-jump-access:all",
+    "member-jump-trait:isStatic",
+    "member-jump-trait:",
+    "member-open:M:Parse",
+    "member-open:",
+    "member-overload:2",
+    "member-overload:NaN",
+    "member-back",
+    "copy-name",
+    "copy-signature",
+    "copy-anchor:digest",
+    "copy-anchor:undefined",
+    "copy-member-source",
+    "copy-type-source",
   ]);
 });
 

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -141,7 +141,15 @@ function recordingActions(calls: string[]): TypePanelBindingActions {
     onClearFilters: () => calls.push("clear"),
     onKindSelect: value => calls.push(`kind:${value}`),
     onListKeyDown: event => calls.push(`list:${event.key}`),
+    onMemberAccessibilityFilterSelect: value =>
+      calls.push(`member-access:${value}`),
+    onMemberFilterChange: value => calls.push(`member-filter:${value}`),
+    onMemberFilterClear: () => calls.push("member-filter-clear"),
+    onMemberFilterKeyDown: (event, value) =>
+      calls.push(`member-filter-key:${event.key}:${value}`),
+    onMemberKindFilterSelect: value => calls.push(`member-kind:${value}`),
     onMemberSelect: value => calls.push(`member:${value}`),
+    onMemberTraitFilterSelect: value => calls.push(`member-trait:${value}`),
     onNamespaceSelect: value => calls.push(`namespace:${value}`),
     onOverloadSelect: value => calls.push(`overload:${value}`),
     onShowTypes: () => calls.push("types"),
@@ -150,6 +158,59 @@ function recordingActions(calls: string[]): TypePanelBindingActions {
     onTypeSelect: value => calls.push(`type:${value}`),
   };
 }
+
+test("type panel bindings dispatch member filters without eager work", () => {
+  const root = new FakeRoot();
+  const allKinds = new FakeElement({ memberKindFilter: "all" });
+  const kind = new FakeElement({ memberKindFilter: "method" });
+  const allAccessibilities =
+    new FakeElement({ memberAccessFilter: "all" });
+  const accessibility =
+    new FakeElement({ memberAccessFilter: "protected" });
+  const allTraits = new FakeElement({ memberTraitFilter: "all" });
+  const trait = new FakeElement({ memberTraitFilter: "isStatic" });
+  root.addAll("[data-member-kind-filter]", allKinds, kind);
+  root.addAll(
+    "[data-member-access-filter]",
+    allAccessibilities,
+    accessibility);
+  root.addAll("[data-member-trait-filter]", allTraits, trait);
+  const filter = root.add("#member-filter", new FakeElement());
+  filter.value = "parse";
+  const clear = root.add("#clear-member-filter", new FakeElement());
+  const calls: string[] = [];
+
+  bindTypePanel(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  kind.dispatch("click");
+  assert.deepEqual(calls, ["member-kind:method"]);
+  accessibility.dispatch("click");
+  assert.deepEqual(calls, [
+    "member-kind:method",
+    "member-access:protected",
+  ]);
+  trait.dispatch("click");
+  assert.deepEqual(calls, [
+    "member-kind:method",
+    "member-access:protected",
+    "member-trait:isStatic",
+  ]);
+  filter.dispatch("input");
+  const arrow = keyboardEvent("ArrowDown");
+  filter.dispatch("keydown", arrow.event);
+  clear.dispatch("click");
+  assert.deepEqual(calls, [
+    "member-kind:method",
+    "member-access:protected",
+    "member-trait:isStatic",
+    "member-filter:parse",
+    "member-filter-key:ArrowDown:parse",
+    "member-filter-clear",
+  ]);
+});
 
 test("type panel bindings dispatch the rendered type navigation controls", () => {
   const root = new FakeRoot();

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -205,7 +205,7 @@ test("type panel bindings dispatch member filters without eager work", () => {
   const calls: string[] = [];
 
   bindTypePanel(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   assert.deepEqual(calls, []);
@@ -352,7 +352,7 @@ test("type panel bindings dispatch member composition and detail controls", () =
   const calls: string[] = [];
 
   bindTypePanel(
-    root as unknown as ParentNode,
+    fakeDom.parentNode(root),
     recordingActions(calls));
 
   assert.deepEqual(calls, []);


### PR DESCRIPTION
Completes the recovered inspect-web event-binding stack for #4504. The Opportunities lens plus the former descendant PRs #4524-#4536 now pair modal viewers, annotated source, package documents, status bar, package selection/navigation, member filters/navigation, settings entry, library controls, shell controls, and graph interactions with typed owners for the controls they render.

`dotnet-inspect.ts` retains authoritative application state, navigation, acquisition, async/error observation, and effect orchestration. The restack deliberately preserves current `observeAsync`/`observeAction` handling and explicit clipboard promise discard rather than restoring the older fire-and-forget callbacks.

**Stack**

- Recovery slice 5 of 5, stacked on #4522.
- Parent: #4522 (Metadata Explorer event binding).
- This head includes the already-merged descendant ranges from former PRs #4524-#4536.
- Residual: none in this recovered event-binding stack; issue closure will be assessed after the final slice lands.

**Validation**

- `npm run analyze` — Oxlint and Knip.
- `npm test` — 477/477, including strict source/test TypeScript and composition ownership gates.
- `npm run build` — production Vite bundle and site artifact verification.
- `npx markdownlint-cli prototypes/inspect-web/README.md`.
- `git diff --check`.

Progresses #4504.
