### PR TITLE
Extract modal viewer event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -708,28 +708,31 @@ selection, ref->def jump targets, cell escaping, heap addressing and coverage
 notes, and the row inspector.
 
 `src/doc-viewer.ts` owns the package document modal (the Markdown reader
-opened from a package's documents list) as a pure, dependency-injected render
-function. `src/document-inspection.ts` owns its sequence-guarded async
+opened from a package's documents list), including its rendered close and
+bare-backdrop bindings. `src/document-inspection.ts` owns its sequence-guarded async
 load/close lifecycle, visible failure, and frontmatter projection.
 `dotnet-inspect.ts` validates the selected package document and supplies the
 engine, sanitized Markdown-rendering, state, and render ports.
 `test/doc-viewer.test.ts` gates the closed/no-document fallback, loading and
 error presentation, the
 frontmatter card's presence and fields, and title/subtitle/frontmatter-name
-escaping; `test/document-inspection.test.ts` gates exact request coordinates,
+escaping, plus button/backdrop close dispatch;
+`test/document-inspection.test.ts` gates exact request coordinates,
 frontmatter projection, stale-stage suppression, visible failures, and close
 invalidation (the rendered document body is trusted, pre-sanitized Markdown
 HTML and is not escaped).
 
 `src/graph-source.ts` owns the member source modal (the code viewer opened
-from a call graph node) as a pure, dependency-injected render function.
+from a call graph node), including its rendered close and bare-backdrop
+bindings.
 `source-inspection.ts` owns its sequence-guarded async lifecycle;
 `dotnet-inspect.ts` supplies `state`, the typed engine port, and the
 `highlightCSharp` Prism wrapper, and passes each computed slice explicitly.
 `test/graph-source.test.ts` gates the loading state, the
 original-versus-decompiled provenance labels, the open-source link's presence
 only when a `url` is provided, the error state's fallback message, and title
-escaping in both the header and loading status.
+escaping in both the header and loading status, plus button/backdrop close
+dispatch.
 
 `src/annotated-source.ts` owns the annotated source result (the
 fact-annotated C#/IL dual view shown for a member overload) as a pure,

--- a/prototypes/inspect-web/src/doc-viewer.ts
+++ b/prototypes/inspect-web/src/doc-viewer.ts
@@ -17,6 +17,24 @@ export interface RenderDocViewerOptions {
   escapeHtml: (value: unknown) => string;
 }
 
+export interface DocViewerBindingActions {
+  onClose: () => void;
+}
+
+export function bindDocViewer(
+  root: ParentNode,
+  actions: DocViewerBindingActions,
+) {
+  const backdrop =
+    root.querySelector<HTMLElement>("#doc-viewer-backdrop");
+  backdrop?.addEventListener("mousedown", event => {
+    if (event.target === backdrop) actions.onClose();
+  });
+  root.querySelector("#doc-viewer-close")?.addEventListener(
+    "click",
+    actions.onClose);
+}
+
 export function renderDocViewer(options: RenderDocViewerOptions): string {
   const { doc, meta, loading, error, html, escapeHtml } = options;
   const title = doc ? `${doc.name}` : "Document";

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -110,10 +110,14 @@ import {
   renderScopeBar as renderScopeBarPure,
 } from "./scope-bar.ts";
 import {
+  bindDocViewer,
   renderDocViewer as renderDocViewerPure,
   type DocViewerMeta,
 } from "./doc-viewer.ts";
-import { renderGraphSource as renderGraphSourcePure } from "./graph-source.ts";
+import {
+  bindGraphSource,
+  renderGraphSource as renderGraphSourcePure,
+} from "./graph-source.ts";
 import {
   renderAnnotatedSource as renderAnnotatedSourcePure,
   type AnnotatedSourceResult,
@@ -3768,6 +3772,18 @@ function bindPackageOpportunitiesEvents() {
   });
 }
 
+function bindGraphSourceEvents() {
+  bindGraphSource(document, {
+    onClose: closeGraphSource,
+  });
+}
+
+function bindDocViewerEvents() {
+  bindDocViewer(document, {
+    onClose: closeDocViewer,
+  });
+}
+
 function bindEvents() {
   bindStatusBarToggle();
   packageBar.bind(document);
@@ -3776,6 +3792,8 @@ function bindEvents() {
   bindSettingsPanelEvents();
   bindMetadataViewerEvents();
   bindPackageOpportunitiesEvents();
+  bindGraphSourceEvents();
+  bindDocViewerEvents();
   document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
     switchPackageFramework(button.dataset.frameworkChip ?? "");
   }));
@@ -4127,20 +4145,10 @@ function bindEvents() {
   ensurePackageVersions(state.package);
   if (state.package?.isRuntimePack) ensureDotnetReleases();
   if (state.spotlightOpen) spotlight.bind(document, "modal");
-  document.querySelector("#graph-source-backdrop")?.addEventListener("mousedown", event => {
-    if (event.target instanceof HTMLElement
-        && event.target.id === "graph-source-backdrop") closeGraphSource();
-  });
-  document.querySelector("#graph-source-close")?.addEventListener("click", closeGraphSource);
   document.querySelectorAll<HTMLElement>("[data-doc-path]").forEach(button =>
     button.addEventListener(
       "click",
       () => openPackageDocument(button.dataset.docPath ?? "")));
-  document.querySelector("#doc-viewer-backdrop")?.addEventListener("mousedown", event => {
-    if (event.target instanceof HTMLElement
-        && event.target.id === "doc-viewer-backdrop") closeDocViewer();
-  });
-  document.querySelector("#doc-viewer-close")?.addEventListener("click", closeDocViewer);
   document.querySelector("#taste-btn")?.addEventListener("click", event => {
     event.stopPropagation();
     state.tasteOpen = !state.tasteOpen;

--- a/prototypes/inspect-web/src/graph-source.ts
+++ b/prototypes/inspect-web/src/graph-source.ts
@@ -11,6 +11,24 @@ export interface RenderGraphSourceOptions {
   highlightCSharp: (value: unknown) => string;
 }
 
+export interface GraphSourceBindingActions {
+  onClose: () => void;
+}
+
+export function bindGraphSource(
+  root: ParentNode,
+  actions: GraphSourceBindingActions,
+) {
+  const backdrop =
+    root.querySelector<HTMLElement>("#graph-source-backdrop");
+  backdrop?.addEventListener("mousedown", event => {
+    if (event.target === backdrop) actions.onClose();
+  });
+  root.querySelector("#graph-source-close")?.addEventListener(
+    "click",
+    actions.onClose);
+}
+
 export function renderGraphSource(options: RenderGraphSourceOptions): string {
   const { title, loading, source, error, escapeHtml, highlightCSharp } = options;
   const body = loading

--- a/prototypes/inspect-web/test/doc-viewer.test.ts
+++ b/prototypes/inspect-web/test/doc-viewer.test.ts
@@ -1,6 +1,57 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderDocViewer } from "../src/doc-viewer.ts";
+import {
+  bindDocViewer,
+  renderDocViewer,
+} from "../src/doc-viewer.ts";
+
+class FakeElement {
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, target: EventTarget = this as unknown as EventTarget) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly elements = new Map<string, FakeElement>();
+
+  add(selector: string, element: FakeElement) {
+    this.elements.set(selector, element);
+    return element;
+  }
+
+  querySelector(selector: string) {
+    return this.elements.get(selector) ?? null;
+  }
+}
+
+test("document viewer bindings close from the button or bare backdrop only", () => {
+  const root = new FakeRoot();
+  const backdrop = root.add("#doc-viewer-backdrop", new FakeElement());
+  const close = root.add("#doc-viewer-close", new FakeElement());
+  const inner = new FakeElement();
+  const calls: string[] = [];
+  bindDocViewer(
+    root as unknown as ParentNode,
+    { onClose: () => calls.push("close") });
+
+  assert.deepEqual(calls, []);
+  backdrop.dispatch("mousedown", inner as unknown as EventTarget);
+  assert.deepEqual(calls, []);
+  backdrop.dispatch("mousedown");
+  assert.deepEqual(calls, ["close"]);
+  close.dispatch("click");
+  assert.deepEqual(calls, ["close", "close"]);
+});
 
 function escapeHtml(value: unknown) {
   return String(value)

--- a/prototypes/inspect-web/test/graph-source.test.ts
+++ b/prototypes/inspect-web/test/graph-source.test.ts
@@ -1,6 +1,57 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderGraphSource } from "../src/graph-source.ts";
+import {
+  bindGraphSource,
+  renderGraphSource,
+} from "../src/graph-source.ts";
+
+class FakeElement {
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, target: EventTarget = this as unknown as EventTarget) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly elements = new Map<string, FakeElement>();
+
+  add(selector: string, element: FakeElement) {
+    this.elements.set(selector, element);
+    return element;
+  }
+
+  querySelector(selector: string) {
+    return this.elements.get(selector) ?? null;
+  }
+}
+
+test("graph source bindings close from the button or bare backdrop only", () => {
+  const root = new FakeRoot();
+  const backdrop = root.add("#graph-source-backdrop", new FakeElement());
+  const close = root.add("#graph-source-close", new FakeElement());
+  const inner = new FakeElement();
+  const calls: string[] = [];
+  bindGraphSource(
+    root as unknown as ParentNode,
+    { onClose: () => calls.push("close") });
+
+  assert.deepEqual(calls, []);
+  backdrop.dispatch("mousedown", inner as unknown as EventTarget);
+  assert.deepEqual(calls, []);
+  backdrop.dispatch("mousedown");
+  assert.deepEqual(calls, ["close"]);
+  close.dispatch("click");
+  assert.deepEqual(calls, ["close", "close"]);
+});
 
 function escapeHtml(value: unknown) {
   return String(value)

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -195,6 +195,12 @@ const memberFocusSource = readFileSync(
 const graphSource = readFileSync(
   new URL("../src/graph-mermaid.ts", import.meta.url),
   "utf8");
+const graphSourceViewerSource = readFileSync(
+  new URL("../src/graph-source.ts", import.meta.url),
+  "utf8");
+const docViewerSource = readFileSync(
+  new URL("../src/doc-viewer.ts", import.meta.url),
+  "utf8");
 const typePanelSource = readFileSync(
   new URL("../src/type-panel.ts", import.meta.url),
   "utf8");
@@ -509,7 +515,7 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
 
 test("package opportunities owns its rendered control bindings", () => {
   const binding =
-    appSource.match(/function bindPackageOpportunitiesEvents\(\) \{[\s\S]*?\n}\n\nfunction bindEvents/)?.[0]
+    appSource.match(/function bindPackageOpportunitiesEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
   const bindEvents =
     appSource.match(
@@ -542,6 +548,48 @@ test("package opportunities owns its rendered control bindings", () => {
     "[data-opp-type]",
     "[data-opp-package]",
     "[data-opp-lookfor]",
+  ]) {
+    assert.equal(appSource.split(selector).length - 1, 0, selector);
+  }
+});
+
+test("modal viewers own their rendered close bindings", () => {
+  const graphBinding =
+    appSource.match(/function bindGraphSourceEvents\(\) \{[\s\S]*?\n}\n\nfunction bindDocViewerEvents/)?.[0]
+    ?? "";
+  const docBinding =
+    appSource.match(/function bindDocViewerEvents\(\) \{[\s\S]*?\n}\n\nfunction bindEvents/)?.[0]
+    ?? "";
+  assert.match(
+    graphBinding,
+    /bindGraphSource\(document, \{\s*onClose: closeGraphSource,\s*\}\)/);
+  assert.match(
+    docBinding,
+    /bindDocViewer\(document, \{\s*onClose: closeDocViewer,\s*\}\)/);
+  assert.equal(graphBinding.match(/\bdocument\b/g)?.length, 1);
+  assert.equal(docBinding.match(/\bdocument\b/g)?.length, 1);
+  assert.match(
+    graphSourceViewerSource,
+    /export function bindGraphSource\([\s\S]*#graph-source-backdrop[\s\S]*event\.target === backdrop[\s\S]*#graph-source-close/);
+  assert.match(
+    docViewerSource,
+    /export function bindDocViewer\([\s\S]*#doc-viewer-backdrop[\s\S]*event\.target === backdrop[\s\S]*#doc-viewer-close/);
+  for (const [identifier, count] of [
+    ["bindGraphSourceEvents", 2],
+    ["bindDocViewerEvents", 2],
+    ["bindGraphSource", 2],
+    ["bindDocViewer", 2],
+  ]) {
+    assert.equal(
+      appSource.match(new RegExp(`\\b${identifier}\\b`, "g"))?.length,
+      count,
+      identifier);
+  }
+  for (const selector of [
+    "#graph-source-backdrop",
+    "#graph-source-close",
+    "#doc-viewer-backdrop",
+    "#doc-viewer-close",
   ]) {
     assert.equal(appSource.split(selector).length - 1, 0, selector);
   }


### PR DESCRIPTION
Closes the next DOM-ownership slice of #4504: `graph-source.ts` and `doc-viewer.ts` now own the close-button and bare-backdrop controls each modal renders, mapping them to typed root callbacks. Modal state, close invalidation, rendering, source/document acquisition, and global Escape handling remain in `dotnet-inspect.ts` and the existing request coordinators.

Focused tests gate no eager action, inner-content mouse-down containment, bare-backdrop dismissal, and close-button dispatch for both viewers. Composition gates require one typed binder per viewer, sole root `document` use through that binder, and no direct root selector ownership.

**Stack:** slice 15 of issue #4504; stacked on #4523. Parent: #4523. Residual after this slice: continue pairing remaining rendered controls with their presentation owners; authoritative application state and effects remain root-owned.

**Validation:** `npm test` (415/415), `npm run build`, `npx markdownlint-cli prototypes/inspect-web/README.md`, and `git diff --check`.