### PR TITLE
Extract annotated source event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -735,15 +735,17 @@ escaping in both the header and loading status, plus button/backdrop close
 dispatch.
 
 `src/annotated-source.ts` owns the annotated source result (the
-fact-annotated C#/IL dual view shown for a member overload) as a pure,
-dependency-injected render function; it composes `annotated-source-view.ts`'s
-`buildAnnotatedView` projection into markup. `member-detail-inspection.ts` owns
-the sequence-guarded async load lifecycle; `dotnet-inspect.ts` still owns
-`state` and the medium-toggle/fact-selection event handlers, and passes each
-computed slice in explicitly.
+fact-annotated C#/IL dual view shown for a member overload), including its
+rendered copy, medium, fact, source-offset, and clear-selection bindings; it
+composes `annotated-source-view.ts`'s `buildAnnotatedView` projection into
+markup. `member-detail-inspection.ts` owns the sequence-guarded async load
+lifecycle; `dotnet-inspect.ts` still owns `state`, document interpretation,
+copy/render effects, and the selection transitions, supplying them through
+typed callbacks.
 `test/annotated-source.test.ts` gates the rejected-document fallback, the
 medium toggles and hidden-line count, the context-limitation notice, anchored
-versus unanchored fact rendering, selection state, and source-text escaping.
+versus unanchored fact rendering, selection state, binding dispatch and
+malformed dataset behavior, and source-text escaping.
 
 `src/package-opportunities.ts` owns the package/platform "Integration
 opportunities" lens (the ecosystem auth/cloud/config/database/AI-client

--- a/prototypes/inspect-web/src/annotated-source.ts
+++ b/prototypes/inspect-web/src/annotated-source.ts
@@ -27,6 +27,38 @@ export interface RenderAnnotatedSourceOptions {
   escapeHtml: (value: unknown) => string;
 }
 
+export interface AnnotatedSourceBindingActions {
+  onClearSelection: () => void;
+  onCopy: () => void | Promise<void>;
+  onFactSelect: (factId: number) => void;
+  onMediumToggle: (medium: string) => void;
+  onOffsetSelect: (offset: number) => void;
+}
+
+export function bindAnnotatedSource(
+  root: ParentNode,
+  actions: AnnotatedSourceBindingActions,
+) {
+  root.querySelector("#copy-annotated")?.addEventListener(
+    "click",
+    actions.onCopy);
+  root.querySelectorAll<HTMLElement>("[data-annotated-medium]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onMediumToggle(button.dataset.annotatedMedium ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-annotated-fact]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onFactSelect(Number(button.dataset.annotatedFact))));
+  root.querySelectorAll<HTMLElement>("[data-annotated-offset]").forEach(span =>
+    span.addEventListener(
+      "click",
+      () => actions.onOffsetSelect(Number(span.dataset.annotatedOffset))));
+  root.querySelector("#annotated-clear")?.addEventListener(
+    "click",
+    actions.onClearSelection);
+}
+
 export function renderAnnotatedSource(options: RenderAnnotatedSourceOptions): string {
   const { result, media, selectedFactId, selectedNodeIds, escapeHtml } = options;
   let view;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -119,6 +119,7 @@ import {
   renderGraphSource as renderGraphSourcePure,
 } from "./graph-source.ts";
 import {
+  bindAnnotatedSource,
   renderAnnotatedSource as renderAnnotatedSourcePure,
   type AnnotatedSourceResult,
 } from "./annotated-source.ts";
@@ -3784,6 +3785,52 @@ function bindDocViewerEvents() {
   });
 }
 
+function bindAnnotatedSourceEvents() {
+  bindAnnotatedSource(document, {
+    onClearSelection: () => {
+      state.memberAnnotatedFactId = null;
+      state.memberAnnotatedNodeIds = [];
+      render();
+    },
+    onCopy: async () => {
+      if (state.memberAnnotated) {
+        await copyText(
+          state.memberAnnotated.document.text,
+          "annotated source copied");
+      }
+    },
+    onFactSelect: factId => {
+      state.memberAnnotatedFactId =
+        state.memberAnnotatedFactId === factId ? null : factId;
+      state.memberAnnotatedNodeIds = [];
+      render();
+    },
+    onMediumToggle: medium => {
+      if (!medium || !MEDIA.includes(medium as (typeof MEDIA)[number])) return;
+      const typedMedium = medium as (typeof MEDIA)[number];
+      const next = {
+        ...state.memberAnnotatedMedia,
+        [typedMedium]: !state.memberAnnotatedMedia[typedMedium],
+      };
+      // Both media off would look like a successful empty result.
+      if (!MEDIA.some(candidate => next[candidate])) return;
+      state.memberAnnotatedMedia = next;
+      render();
+    },
+    onOffsetSelect: offset => {
+      if (!state.memberAnnotated) return;
+      const node = nodeAtOffset(state.memberAnnotated.document, offset);
+      state.memberAnnotatedFactId = null;
+      state.memberAnnotatedNodeIds = node ? [node.id] : [];
+      const owning = node
+        ? factsForNode(state.memberAnnotated.document, node.id)
+        : [];
+      if (owning.length === 1) state.memberAnnotatedFactId = owning[0].id;
+      render();
+    },
+  });
+}
+
 function bindEvents() {
   bindStatusBarToggle();
   packageBar.bind(document);
@@ -3794,6 +3841,7 @@ function bindEvents() {
   bindPackageOpportunitiesEvents();
   bindGraphSourceEvents();
   bindDocViewerEvents();
+  bindAnnotatedSourceEvents();
   document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
     switchPackageFramework(button.dataset.frameworkChip ?? "");
   }));
@@ -3977,43 +4025,6 @@ function bindEvents() {
   }));
   document.querySelector("#copy-source")?.addEventListener("click", async () => {
     if (state.memberSource) await copyText(state.memberSource.text, "source copied");
-  });
-  document.querySelector("#copy-annotated")?.addEventListener("click", async () => {
-    if (state.memberAnnotated) await copyText(state.memberAnnotated.document.text, "annotated source copied");
-  });
-  document.querySelectorAll<HTMLElement>("[data-annotated-medium]").forEach(button => button.addEventListener("click", () => {
-    const medium = button.dataset.annotatedMedium;
-    if (!medium || !MEDIA.includes(medium as (typeof MEDIA)[number])) return;
-    const typedMedium = medium as (typeof MEDIA)[number];
-    const next = {
-      ...state.memberAnnotatedMedia,
-      [typedMedium]: !state.memberAnnotatedMedia[typedMedium],
-    };
-    // Both media off would render an empty document that looks like an empty result.
-    if (!MEDIA.some(candidate => next[candidate])) return;
-    state.memberAnnotatedMedia = next;
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-annotated-fact]").forEach(button => button.addEventListener("click", () => {
-    const factId = Number(button.dataset.annotatedFact);
-    state.memberAnnotatedFactId = state.memberAnnotatedFactId === factId ? null : factId;
-    state.memberAnnotatedNodeIds = [];
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-annotated-offset]").forEach(span => span.addEventListener("click", () => {
-    if (!state.memberAnnotated) return;
-    const node = nodeAtOffset(state.memberAnnotated.document, Number(span.dataset.annotatedOffset));
-    state.memberAnnotatedFactId = null;
-    state.memberAnnotatedNodeIds = node ? [node.id] : [];
-    // Selecting the text a fact is about also selects that fact when exactly one owns the node.
-    const owning = node ? factsForNode(state.memberAnnotated.document, node.id) : [];
-    if (owning.length === 1) state.memberAnnotatedFactId = owning[0].id;
-    render();
-  }));
-  document.querySelector("#annotated-clear")?.addEventListener("click", () => {
-    state.memberAnnotatedFactId = null;
-    state.memberAnnotatedNodeIds = [];
-    render();
   });
   document.querySelector("#copy-type-source")?.addEventListener("click", async () => {
     if (state.typeSource) await copyText(state.typeSource.text, "source copied");

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -1,13 +1,129 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { renderAnnotatedSource } from "../src/annotated-source.ts";
-import type { AnnotatedSourceRenderResult } from "../src/annotated-source.ts";
+import {
+  bindAnnotatedSource,
+  renderAnnotatedSource,
+  type AnnotatedSourceBindingActions,
+  type AnnotatedSourceRenderResult,
+} from "../src/annotated-source.ts";
 import { validateAnnotatedSourceDocument } from "../src/annotated-source-view.ts";
 import type { AnnotatedSourceDocument } from "../src/annotated-source-view.ts";
 import { sampleDocument as sampleDocumentFixture } from "../../annotated-source-viewer/src/sample-document.js";
 
 validateAnnotatedSourceDocument(sampleDocumentFixture);
 const sampleDocument: AnnotatedSourceDocument = sampleDocumentFixture;
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({} as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+    return element;
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+    return elements;
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+function recordingActions(calls: string[]): AnnotatedSourceBindingActions {
+  return {
+    onClearSelection: () => calls.push("clear"),
+    onCopy: () => {
+      calls.push("copy");
+    },
+    onFactSelect: factId => calls.push(`fact:${factId}`),
+    onMediumToggle: medium => calls.push(`medium:${medium}`),
+    onOffsetSelect: offset => calls.push(`offset:${offset}`),
+  };
+}
+
+test("annotated source bindings dispatch every rendered control", () => {
+  const root = new FakeRoot();
+  const copy = root.add("#copy-annotated", new FakeElement());
+  const medium = new FakeElement({ annotatedMedium: "Il" });
+  root.addAll("[data-annotated-medium]", medium);
+  const fact = new FakeElement({ annotatedFact: "4" });
+  root.addAll("[data-annotated-fact]", fact);
+  const offset = new FakeElement({ annotatedOffset: "17" });
+  root.addAll("[data-annotated-offset]", offset);
+  const clear = root.add("#annotated-clear", new FakeElement());
+  const calls: string[] = [];
+  bindAnnotatedSource(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  copy.dispatch("click");
+  assert.deepEqual(calls, ["copy"]);
+  medium.dispatch("click");
+  assert.deepEqual(calls, ["copy", "medium:Il"]);
+  fact.dispatch("click");
+  assert.deepEqual(calls, ["copy", "medium:Il", "fact:4"]);
+  offset.dispatch("click");
+  assert.deepEqual(calls, ["copy", "medium:Il", "fact:4", "offset:17"]);
+  clear.dispatch("click");
+  assert.deepEqual(calls, [
+    "copy",
+    "medium:Il",
+    "fact:4",
+    "offset:17",
+    "clear",
+  ]);
+});
+
+test("annotated source bindings preserve malformed dataset values", () => {
+  const root = new FakeRoot();
+  const medium = new FakeElement();
+  root.addAll("[data-annotated-medium]", medium);
+  const fact = new FakeElement();
+  root.addAll("[data-annotated-fact]", fact);
+  const offset = new FakeElement();
+  root.addAll("[data-annotated-offset]", offset);
+  const calls: string[] = [];
+  bindAnnotatedSource(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  medium.dispatch("click");
+  assert.deepEqual(calls, ["medium:"]);
+  fact.dispatch("click");
+  assert.deepEqual(calls, ["medium:", "fact:NaN"]);
+  offset.dispatch("click");
+  assert.deepEqual(calls, ["medium:", "fact:NaN", "offset:NaN"]);
+});
 
 function escapeHtml(value: unknown) {
   return String(value)

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -201,6 +201,9 @@ const graphSourceViewerSource = readFileSync(
 const docViewerSource = readFileSync(
   new URL("../src/doc-viewer.ts", import.meta.url),
   "utf8");
+const annotatedSourceModule = readFileSync(
+  new URL("../src/annotated-source.ts", import.meta.url),
+  "utf8");
 const typePanelSource = readFileSync(
   new URL("../src/type-panel.ts", import.meta.url),
   "utf8");
@@ -555,10 +558,10 @@ test("package opportunities owns its rendered control bindings", () => {
 
 test("modal viewers own their rendered close bindings", () => {
   const graphBinding =
-    appSource.match(/function bindGraphSourceEvents\(\) \{[\s\S]*?\n}\n\nfunction bindDocViewerEvents/)?.[0]
+    appSource.match(/function bindGraphSourceEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
   const docBinding =
-    appSource.match(/function bindDocViewerEvents\(\) \{[\s\S]*?\n}\n\nfunction bindEvents/)?.[0]
+    appSource.match(/function bindDocViewerEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
   assert.match(
     graphBinding,
@@ -590,6 +593,40 @@ test("modal viewers own their rendered close bindings", () => {
     "#graph-source-close",
     "#doc-viewer-backdrop",
     "#doc-viewer-close",
+  ]) {
+    assert.equal(appSource.split(selector).length - 1, 0, selector);
+  }
+});
+
+test("annotated source owns its rendered control bindings", () => {
+  const binding =
+    appSource.match(/function bindAnnotatedSourceEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
+  assert.match(
+    binding,
+    /bindAnnotatedSource\(document, \{[\s\S]*onClearSelection: \(\) => \{[\s\S]*memberAnnotatedFactId = null;[\s\S]*memberAnnotatedNodeIds = \[\];[\s\S]*onCopy: async \(\) => \{[\s\S]*memberAnnotated\.document\.text[\s\S]*onFactSelect: factId => \{[\s\S]*memberAnnotatedFactId === factId \? null : factId[\s\S]*onMediumToggle: medium => \{[\s\S]*MEDIA\.includes[\s\S]*MEDIA\.some\(candidate => next\[candidate\]\)[\s\S]*onOffsetSelect: offset => \{[\s\S]*nodeAtOffset\(state\.memberAnnotated\.document, offset\)[\s\S]*factsForNode/);
+  assert.doesNotMatch(
+    binding,
+    /\b(?:getElementById|querySelector|querySelectorAll)\s*\(|\.addEventListener\s*\(/);
+  assert.equal(binding.match(/(?<!\.)\bdocument\b/g)?.length, 1);
+  assert.match(
+    annotatedSourceModule,
+    /export function bindAnnotatedSource\([\s\S]*#copy-annotated[\s\S]*\[data-annotated-medium\][\s\S]*\[data-annotated-fact\][\s\S]*\[data-annotated-offset\][\s\S]*#annotated-clear/);
+  for (const [identifier, count] of [
+    ["bindAnnotatedSourceEvents", 2],
+    ["bindAnnotatedSource", 2],
+  ]) {
+    assert.equal(
+      appSource.match(new RegExp(`\\b${identifier}\\b`, "g"))?.length,
+      count,
+      identifier);
+  }
+  for (const selector of [
+    "#copy-annotated",
+    "[data-annotated-medium]",
+    "[data-annotated-fact]",
+    "[data-annotated-offset]",
+    "#annotated-clear",
   ]) {
     assert.equal(appSource.split(selector).length - 1, 0, selector);
   }

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -605,6 +605,9 @@ test("annotated source owns its rendered control bindings", () => {
   assert.match(
     binding,
     /bindAnnotatedSource\(document, \{[\s\S]*onClearSelection: \(\) => \{[\s\S]*memberAnnotatedFactId = null;[\s\S]*memberAnnotatedNodeIds = \[\];[\s\S]*onCopy: async \(\) => \{[\s\S]*memberAnnotated\.document\.text[\s\S]*onFactSelect: factId => \{[\s\S]*memberAnnotatedFactId === factId \? null : factId[\s\S]*onMediumToggle: medium => \{[\s\S]*MEDIA\.includes[\s\S]*MEDIA\.some\(candidate => next\[candidate\]\)[\s\S]*onOffsetSelect: offset => \{[\s\S]*nodeAtOffset\(state\.memberAnnotated\.document, offset\)[\s\S]*factsForNode/);
+  assert.match(
+    binding,
+    /\[typedMedium\]: !state\.memberAnnotatedMedia\[typedMedium\],[\s\S]*if \(!MEDIA\.some\(candidate => next\[candidate\]\)\) return;/);
   assert.doesNotMatch(
     binding,
     /\b(?:getElementById|querySelector|querySelectorAll)\s*\(|\.addEventListener\s*\(/);


### PR DESCRIPTION
Moves rendered annotated-source DOM binding into the typed presentation owner while leaving media validation, selection state, copy behavior, document interpretation, and render effects in the composition root.

**Stack**
- Issue: #4504
- Slice: 16
- Parent: #4524
- Base branch: `feature/4504-modal-viewer-event-binding`

**Behavioral claim**
- `annotated-source.ts` owns copy, medium-toggle, fact-selection, source-offset, and clear-selection DOM decoding.
- Binding is inert until an event and dispatches typed actions incrementally.
- The root remains the single mutable authority and retains the at-least-one-medium invariant and all effects.

**Evidence**
- `npm test` — 418/418 passed
- `npm run build`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

**Non-action boundary / residual**
This does not move state, rendering orchestration, media validation, source interpretation, copying, keyboard behavior, or engine/network work. Remaining rendered-control ownership is limited to later coherent component slices.