### PR TITLE
Extract package document event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -708,15 +708,17 @@ selection, ref->def jump targets, cell escaping, heap addressing and coverage
 notes, and the row inspector.
 
 `src/doc-viewer.ts` owns the package document modal (the Markdown reader
-opened from a package's documents list), including its rendered close and
-bare-backdrop bindings. `src/document-inspection.ts` owns its sequence-guarded async
-load/close lifecycle, visible failure, and frontmatter projection.
+opened from a package's documents list) and that list's markup, including its
+open, close, and bare-backdrop bindings. `src/document-inspection.ts` owns its
+sequence-guarded async load/close lifecycle, visible failure, and frontmatter
+projection.
 `dotnet-inspect.ts` validates the selected package document and supplies the
 engine, sanitized Markdown-rendering, state, and render ports.
 `test/doc-viewer.test.ts` gates the closed/no-document fallback, loading and
 error presentation, the
 frontmatter card's presence and fields, and title/subtitle/frontmatter-name
-escaping, plus button/backdrop close dispatch;
+escaping, package-document list output, open dispatch, and button/backdrop
+close dispatch;
 `test/document-inspection.test.ts` gates exact request coordinates,
 frontmatter projection, stale-stage suppression, visible failures, and close
 invalidation (the rendered document body is trusted, pre-sanitized Markdown

--- a/prototypes/inspect-web/src/doc-viewer.ts
+++ b/prototypes/inspect-web/src/doc-viewer.ts
@@ -49,16 +49,22 @@ export function renderPackageDocuments(
   escapeHtml: (value: unknown) => string,
 ): string {
   if (!documents.length) return "";
-  const kindLabels: Record<string, string> =
-    { readme: "Readme", package: "Package", skill: "Skill" };
-  const kindGlyphs: Record<string, string> =
-    { readme: "▤", package: "▤", skill: "◆" };
+  const kindLabels = new Map([
+    ["readme", "Readme"],
+    ["package", "Package"],
+    ["skill", "Skill"],
+  ]);
+  const kindGlyphs = new Map([
+    ["readme", "▤"],
+    ["package", "▤"],
+    ["skill", "◆"],
+  ]);
   const chips = documents
     .map(document => `
       <button class="doc-chip doc-${escapeHtml(document.kind)}" data-doc-path="${escapeHtml(document.path)}" title="${escapeHtml(document.path)} · ${document.size.toLocaleString()} bytes">
-        <span class="doc-glyph">${kindGlyphs[document.kind] || "▤"}</span>
+        <span class="doc-glyph">${kindGlyphs.get(document.kind) ?? "▤"}</span>
         <span class="doc-name">${escapeHtml(document.name)}</span>
-        <span class="doc-kind">${escapeHtml(kindLabels[document.kind] || document.kind)}</span>
+        <span class="doc-kind">${escapeHtml(kindLabels.get(document.kind) ?? document.kind)}</span>
       </button>`)
     .join("");
   return `<section class="document-section">

--- a/prototypes/inspect-web/src/doc-viewer.ts
+++ b/prototypes/inspect-web/src/doc-viewer.ts
@@ -1,6 +1,10 @@
 import type { BrowserPackageDocument } from "./inspect-web-engine.d.ts";
 
 export type DocViewerDocument = Pick<BrowserPackageDocument, "name" | "path">;
+export type PackageDocumentSummary = Pick<
+  BrowserPackageDocument,
+  "kind" | "name" | "path" | "size"
+>;
 
 export interface DocViewerMeta {
   name: string;
@@ -19,6 +23,7 @@ export interface RenderDocViewerOptions {
 
 export interface DocViewerBindingActions {
   onClose: () => void;
+  onOpenDocument: (path: string) => void;
 }
 
 export function bindDocViewer(
@@ -33,6 +38,33 @@ export function bindDocViewer(
   root.querySelector("#doc-viewer-close")?.addEventListener(
     "click",
     actions.onClose);
+  root.querySelectorAll<HTMLElement>("[data-doc-path]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onOpenDocument(button.dataset.docPath ?? "")));
+}
+
+export function renderPackageDocuments(
+  documents: readonly PackageDocumentSummary[],
+  escapeHtml: (value: unknown) => string,
+): string {
+  if (!documents.length) return "";
+  const kindLabels: Record<string, string> =
+    { readme: "Readme", package: "Package", skill: "Skill" };
+  const kindGlyphs: Record<string, string> =
+    { readme: "▤", package: "▤", skill: "◆" };
+  const chips = documents
+    .map(document => `
+      <button class="doc-chip doc-${escapeHtml(document.kind)}" data-doc-path="${escapeHtml(document.path)}" title="${escapeHtml(document.path)} · ${document.size.toLocaleString()} bytes">
+        <span class="doc-glyph">${kindGlyphs[document.kind] || "▤"}</span>
+        <span class="doc-name">${escapeHtml(document.name)}</span>
+        <span class="doc-kind">${escapeHtml(kindLabels[document.kind] || document.kind)}</span>
+      </button>`)
+    .join("");
+  return `<section class="document-section">
+      <div class="section-title"><h2>Documentation</h2><span>${documents.length} file${documents.length === 1 ? "" : "s"} — click to read</span></div>
+      <div class="doc-chip-list">${chips}</div>
+    </section>`;
 }
 
 export function renderDocViewer(options: RenderDocViewerOptions): string {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -112,6 +112,7 @@ import {
 import {
   bindDocViewer,
   renderDocViewer as renderDocViewerPure,
+  renderPackageDocuments,
   type DocViewerMeta,
 } from "./doc-viewer.ts";
 import {
@@ -3179,25 +3180,8 @@ function renderPackageOverview() {
     .join("");
   const nsOverflow = nsCounts.size > 12 ? `<span class="ns-overflow">+${nsCounts.size - 12} more</span>` : "";
 
-  // Package-shipped Markdown: README/PACKAGE at the root and skill files under skills/.
-  // Presence comes from the surface manifest; the body is fetched on demand when opened.
-  const docKindLabel: Record<string, string> =
-    { readme: "Readme", package: "Package", skill: "Skill" };
-  const docKindGlyph: Record<string, string> =
-    { readme: "▤", package: "▤", skill: "◆" };
-  const documents = (pkg.documents || [])
-    .map(doc => `<button class="doc-chip doc-${escapeHtml(doc.kind)}" data-doc-path="${escapeHtml(doc.path)}" title="${escapeHtml(doc.path)} · ${doc.size.toLocaleString()} bytes">
-        <span class="doc-glyph">${docKindGlyph[doc.kind] || "▤"}</span>
-        <span class="doc-name">${escapeHtml(doc.name)}</span>
-        <span class="doc-kind">${docKindLabel[doc.kind] || doc.kind}</span>
-      </button>`)
-    .join("");
-  const documentsSection = (pkg.documents || []).length
-    ? `<section class="document-section">
-      <div class="section-title"><h2>Documentation</h2><span>${pkg.documents.length} file${pkg.documents.length === 1 ? "" : "s"} — click to read</span></div>
-      <div class="doc-chip-list">${documents}</div>
-    </section>`
-    : "";
+  const documentsSection =
+    renderPackageDocuments(pkg.documents || [], escapeHtml);
 
   return `
     <section class="document-section">
@@ -3782,6 +3766,7 @@ function bindGraphSourceEvents() {
 function bindDocViewerEvents() {
   bindDocViewer(document, {
     onClose: closeDocViewer,
+    onOpenDocument: openPackageDocument,
   });
 }
 
@@ -4156,10 +4141,6 @@ function bindEvents() {
   ensurePackageVersions(state.package);
   if (state.package?.isRuntimePack) ensureDotnetReleases();
   if (state.spotlightOpen) spotlight.bind(document, "modal");
-  document.querySelectorAll<HTMLElement>("[data-doc-path]").forEach(button =>
-    button.addEventListener(
-      "click",
-      () => openPackageDocument(button.dataset.docPath ?? "")));
   document.querySelector("#taste-btn")?.addEventListener("click", event => {
     event.stopPropagation();
     state.tasteOpen = !state.tasteOpen;

--- a/prototypes/inspect-web/test/doc-viewer.test.ts
+++ b/prototypes/inspect-web/test/doc-viewer.test.ts
@@ -3,9 +3,11 @@ import test from "node:test";
 import {
   bindDocViewer,
   renderDocViewer,
+  renderPackageDocuments,
 } from "../src/doc-viewer.ts";
 
 class FakeElement {
+  readonly dataset: Record<string, string | undefined> = {};
   private readonly listeners = new Map<string, EventListener[]>();
 
   addEventListener(type: string, listener: EventListener) {
@@ -22,35 +24,53 @@ class FakeElement {
 }
 
 class FakeRoot {
-  private readonly elements = new Map<string, FakeElement>();
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
 
   add(selector: string, element: FakeElement) {
-    this.elements.set(selector, element);
+    this.single.set(selector, element);
     return element;
   }
 
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+    return elements;
+  }
+
   querySelector(selector: string) {
-    return this.elements.get(selector) ?? null;
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
   }
 }
 
-test("document viewer bindings close from the button or bare backdrop only", () => {
+test("document viewer bindings open documents and close from its modal controls", () => {
   const root = new FakeRoot();
   const backdrop = root.add("#doc-viewer-backdrop", new FakeElement());
   const close = root.add("#doc-viewer-close", new FakeElement());
+  const document = new FakeElement();
+  document.dataset.docPath = "docs/CHANGELOG.md";
+  root.addAll("[data-doc-path]", document);
   const inner = new FakeElement();
   const calls: string[] = [];
   bindDocViewer(
     root as unknown as ParentNode,
-    { onClose: () => calls.push("close") });
+    {
+      onClose: () => calls.push("close"),
+      onOpenDocument: path => calls.push(`open:${path}`),
+    });
 
   assert.deepEqual(calls, []);
+  document.dispatch("click");
+  assert.deepEqual(calls, ["open:docs/CHANGELOG.md"]);
   backdrop.dispatch("mousedown", inner as unknown as EventTarget);
-  assert.deepEqual(calls, []);
+  assert.deepEqual(calls, ["open:docs/CHANGELOG.md"]);
   backdrop.dispatch("mousedown");
-  assert.deepEqual(calls, ["close"]);
+  assert.deepEqual(calls, ["open:docs/CHANGELOG.md", "close"]);
   close.dispatch("click");
-  assert.deepEqual(calls, ["close", "close"]);
+  assert.deepEqual(calls, ["open:docs/CHANGELOG.md", "close", "close"]);
 });
 
 function escapeHtml(value: unknown) {
@@ -62,6 +82,37 @@ function escapeHtml(value: unknown) {
 }
 
 const doc = { name: "CHANGELOG.md", path: "docs/CHANGELOG.md" };
+
+test("package document list renders live escaped chips and file counts", () => {
+  const html = renderPackageDocuments([
+    {
+      kind: "readme",
+      name: "README.md",
+      path: "<docs>/README.md",
+      size: 1200,
+    },
+    {
+      kind: "<skill>",
+      name: "SKILL.md",
+      path: "skills/widget/SKILL.md",
+      size: 42,
+    },
+  ], escapeHtml);
+
+  assert.match(html, /Documentation<\/h2><span>2 files — click to read/);
+  assert.match(
+    html,
+    /class="doc-chip doc-readme" data-doc-path="&lt;docs&gt;\/README\.md"/);
+  assert.match(html, /title="&lt;docs&gt;\/README\.md · 1,200 bytes"/);
+  assert.match(html, /class="doc-chip doc-&lt;skill&gt;"/);
+  assert.match(html, /<span class="doc-kind">&lt;skill&gt;<\/span>/);
+  assert.doesNotMatch(html, /<docs>/);
+  assert.doesNotMatch(html, /<skill>/);
+});
+
+test("package document list stays absent when the package ships no documents", () => {
+  assert.equal(renderPackageDocuments([], escapeHtml), "");
+});
 
 test("closed viewer with no document falls back to a generic title and empty subtitle", () => {
   const html = renderDocViewer({

--- a/prototypes/inspect-web/test/doc-viewer.test.ts
+++ b/prototypes/inspect-web/test/doc-viewer.test.ts
@@ -52,7 +52,9 @@ test("document viewer bindings open documents and close from its modal controls"
   const close = root.add("#doc-viewer-close", new FakeElement());
   const document = new FakeElement();
   document.dataset.docPath = "docs/CHANGELOG.md";
-  root.addAll("[data-doc-path]", document);
+  const secondDocument = new FakeElement();
+  secondDocument.dataset.docPath = "docs/README.md";
+  root.addAll("[data-doc-path]", document, secondDocument);
   const inner = new FakeElement();
   const calls: string[] = [];
   bindDocViewer(
@@ -65,12 +67,29 @@ test("document viewer bindings open documents and close from its modal controls"
   assert.deepEqual(calls, []);
   document.dispatch("click");
   assert.deepEqual(calls, ["open:docs/CHANGELOG.md"]);
+  secondDocument.dispatch("click");
+  assert.deepEqual(calls, [
+    "open:docs/CHANGELOG.md",
+    "open:docs/README.md",
+  ]);
   backdrop.dispatch("mousedown", inner as unknown as EventTarget);
-  assert.deepEqual(calls, ["open:docs/CHANGELOG.md"]);
+  assert.deepEqual(calls, [
+    "open:docs/CHANGELOG.md",
+    "open:docs/README.md",
+  ]);
   backdrop.dispatch("mousedown");
-  assert.deepEqual(calls, ["open:docs/CHANGELOG.md", "close"]);
+  assert.deepEqual(calls, [
+    "open:docs/CHANGELOG.md",
+    "open:docs/README.md",
+    "close",
+  ]);
   close.dispatch("click");
-  assert.deepEqual(calls, ["open:docs/CHANGELOG.md", "close", "close"]);
+  assert.deepEqual(calls, [
+    "open:docs/CHANGELOG.md",
+    "open:docs/README.md",
+    "close",
+    "close",
+  ]);
 });
 
 function escapeHtml(value: unknown) {
@@ -84,12 +103,14 @@ function escapeHtml(value: unknown) {
 const doc = { name: "CHANGELOG.md", path: "docs/CHANGELOG.md" };
 
 test("package document list renders live escaped chips and file counts", () => {
+  const localizedSize = (12_345_678).toLocaleString();
+  assert.notEqual(localizedSize, "12345678");
   const html = renderPackageDocuments([
     {
       kind: "readme",
-      name: "README.md",
+      name: "<README>.md",
       path: "<docs>/README.md",
-      size: 1200,
+      size: 12_345_678,
     },
     {
       kind: "<skill>",
@@ -103,21 +124,33 @@ test("package document list renders live escaped chips and file counts", () => {
       path: "skills/known/SKILL.md",
       size: 64,
     },
+    {
+      kind: "constructor",
+      name: "CONSTRUCTOR.md",
+      path: "docs/CONSTRUCTOR.md",
+      size: 1,
+    },
   ], escapeHtml);
 
-  assert.match(html, /Documentation<\/h2><span>3 files — click to read/);
+  assert.match(html, /Documentation<\/h2><span>4 files — click to read/);
   assert.match(
     html,
     /class="doc-chip doc-readme" data-doc-path="&lt;docs&gt;\/README\.md"/);
   assert.ok(html.includes(
-    `title="&lt;docs&gt;/README.md · ${(1200).toLocaleString()} bytes"`));
+    `title="&lt;docs&gt;/README.md · ${localizedSize} bytes"`));
+  assert.match(html, /<span class="doc-name">&lt;README&gt;\.md<\/span>/);
   assert.match(html, /<span class="doc-kind">Readme<\/span>/);
   assert.match(html, /class="doc-chip doc-&lt;skill&gt;"/);
   assert.match(html, /<span class="doc-kind">&lt;skill&gt;<\/span>/);
   assert.match(html, /<span class="doc-glyph">◆<\/span>/);
   assert.match(html, /<span class="doc-kind">Skill<\/span>/);
+  assert.match(
+    html,
+    /doc-constructor[\s\S]*?<span class="doc-glyph">▤<\/span>[\s\S]*?<span class="doc-kind">constructor<\/span>/);
   assert.doesNotMatch(html, /<docs>/);
+  assert.doesNotMatch(html, /<README>/);
   assert.doesNotMatch(html, /<skill>/);
+  assert.doesNotMatch(html, /function Object/);
 });
 
 test("package document list stays absent when the package ships no documents", () => {

--- a/prototypes/inspect-web/test/doc-viewer.test.ts
+++ b/prototypes/inspect-web/test/doc-viewer.test.ts
@@ -97,15 +97,25 @@ test("package document list renders live escaped chips and file counts", () => {
       path: "skills/widget/SKILL.md",
       size: 42,
     },
+    {
+      kind: "skill",
+      name: "SKILL.md",
+      path: "skills/known/SKILL.md",
+      size: 64,
+    },
   ], escapeHtml);
 
-  assert.match(html, /Documentation<\/h2><span>2 files — click to read/);
+  assert.match(html, /Documentation<\/h2><span>3 files — click to read/);
   assert.match(
     html,
     /class="doc-chip doc-readme" data-doc-path="&lt;docs&gt;\/README\.md"/);
-  assert.match(html, /title="&lt;docs&gt;\/README\.md · 1,200 bytes"/);
+  assert.ok(html.includes(
+    `title="&lt;docs&gt;/README.md · ${(1200).toLocaleString()} bytes"`));
+  assert.match(html, /<span class="doc-kind">Readme<\/span>/);
   assert.match(html, /class="doc-chip doc-&lt;skill&gt;"/);
   assert.match(html, /<span class="doc-kind">&lt;skill&gt;<\/span>/);
+  assert.match(html, /<span class="doc-glyph">◆<\/span>/);
+  assert.match(html, /<span class="doc-kind">Skill<\/span>/);
   assert.doesNotMatch(html, /<docs>/);
   assert.doesNotMatch(html, /<skill>/);
 });

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -568,7 +568,7 @@ test("modal viewers own their rendered close bindings", () => {
     /bindGraphSource\(document, \{\s*onClose: closeGraphSource,\s*\}\)/);
   assert.match(
     docBinding,
-    /bindDocViewer\(document, \{\s*onClose: closeDocViewer,\s*\}\)/);
+    /bindDocViewer\(document, \{\s*onClose: closeDocViewer,\s*onOpenDocument: openPackageDocument,\s*\}\)/);
   assert.equal(graphBinding.match(/\bdocument\b/g)?.length, 1);
   assert.equal(docBinding.match(/\bdocument\b/g)?.length, 1);
   assert.match(
@@ -576,7 +576,7 @@ test("modal viewers own their rendered close bindings", () => {
     /export function bindGraphSource\([\s\S]*#graph-source-backdrop[\s\S]*event\.target === backdrop[\s\S]*#graph-source-close/);
   assert.match(
     docViewerSource,
-    /export function bindDocViewer\([\s\S]*#doc-viewer-backdrop[\s\S]*event\.target === backdrop[\s\S]*#doc-viewer-close/);
+    /export function bindDocViewer\([\s\S]*#doc-viewer-backdrop[\s\S]*event\.target === backdrop[\s\S]*#doc-viewer-close[\s\S]*\[data-doc-path\]/);
   for (const [identifier, count] of [
     ["bindGraphSourceEvents", 2],
     ["bindDocViewerEvents", 2],
@@ -593,6 +593,7 @@ test("modal viewers own their rendered close bindings", () => {
     "#graph-source-close",
     "#doc-viewer-backdrop",
     "#doc-viewer-close",
+    "[data-doc-path]",
   ]) {
     assert.equal(appSource.split(selector).length - 1, 0, selector);
   }


### PR DESCRIPTION
Moves the package document-list renderer and its `data-doc-path` binding into `doc-viewer.ts`, pairing the control that opens the document reader with its presentation owner while preserving root-owned request and state behavior.

**Stack**
- Issue: #4504
- Slice: 17
- Parent: #4525
- Base branch: `feature/4504-annotated-source-event-binding`

**Behavioral claim**
- `doc-viewer.ts` owns package-document list markup and typed open dispatch in addition to its existing modal controls.
- Empty packages still omit the section; file counts, kind glyphs/labels, paths, sizes, and on-demand open behavior remain intact.
- Unknown kind text is escaped at the new typed rendering boundary.
- The root retains document request sequencing, state, failure handling, rendering orchestration, and global Escape behavior.

**Evidence**
- `npm test` — 420/420 passed
- `npm run build`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

**Non-action boundary / residual**
This does not move package-overview state/render orchestration, document acquisition or interpretation, modal state, keyboard behavior, or engine/network work. Remaining root controls will only move in later coherent owner slices.