### PR TITLE
Extract status bar event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -627,9 +627,10 @@ removal, and both silent transient-failure paths; the composition-root gate
 checks that network and DOM authority remain outside the coordinator.
 
 The typed `src/status-bar.ts` component renders both the full-width workspace
-data bar and the home readiness bar. The workspace bar occupies the bottom row
-formerly used by the persistent command prompt, giving the bar the full
-viewport width. By default the bar shows a compact, single-line summary in
+data bar and the home readiness bar and owns their rendered toggle binding.
+The workspace bar occupies the bottom row formerly used by the persistent
+command prompt, giving the bar the full viewport width. By default the bar
+shows a compact, single-line summary in
 priority order: app version/commit, package provenance, build date, and a
 one-line performance summary. A dedicated toggle button at the end of the bar
 (so it never overlaps the commit link) expands and collapses the view,

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -175,7 +175,7 @@ import {
   createCatalogRequests,
   type DotnetRelease,
 } from "./catalog-requests.ts";
-import { fmtBytes, statusBarHtml } from "./status-bar.ts";
+import { bindStatusBar, fmtBytes, statusBarHtml } from "./status-bar.ts";
 import type {
   BrowserAnnotatedSource,
   BrowserAssemblyReference,
@@ -3618,11 +3618,13 @@ function highlightCSharp(value: unknown) {
   return escapeHtml(source);
 }
 
-function bindStatusBarToggle() {
-  document.querySelectorAll<HTMLElement>("[data-status-bar-toggle-button]").forEach(button => button.addEventListener("click", () => {
-    state.statusBarExpanded = !state.statusBarExpanded;
-    render();
-  }));
+function bindStatusBarEvents() {
+  bindStatusBar(document, {
+    onToggle: () => {
+      state.statusBarExpanded = !state.statusBarExpanded;
+      render();
+    },
+  });
 }
 
 function bindTypePanelEvents() {
@@ -3817,7 +3819,7 @@ function bindAnnotatedSourceEvents() {
 }
 
 function bindEvents() {
-  bindStatusBarToggle();
+  bindStatusBarEvents();
   packageBar.bind(document);
   bindTypePanelEvents();
   bindScopeBarEvents();
@@ -5479,7 +5481,7 @@ function homeArtSvg() {
 }
 
 function bindHomeEvents() {
-  bindStatusBarToggle();
+  bindStatusBarEvents();
   document.querySelector("#home-theme")?.addEventListener("click", toggleTheme);
   document.querySelector("#home-settings")?.addEventListener("click", () => openSettings("home"));
   document.querySelector("#dismiss-notice")?.addEventListener("click", () => {

--- a/prototypes/inspect-web/src/status-bar.ts
+++ b/prototypes/inspect-web/src/status-bar.ts
@@ -40,6 +40,19 @@ export interface StatusBarModel {
   expanded?: boolean;
 }
 
+export interface StatusBarBindingActions {
+  onToggle: () => void;
+}
+
+export function bindStatusBar(
+  root: ParentNode,
+  actions: StatusBarBindingActions,
+): void {
+  root.querySelectorAll<HTMLElement>("[data-status-bar-toggle-button]")
+    .forEach(button =>
+      button.addEventListener("click", actions.onToggle));
+}
+
 export function fmtMs(milliseconds: number | null | undefined): string {
   if (milliseconds == null) return "—";
   return milliseconds < 1000

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -280,6 +280,12 @@ test("typed status bar owns its rendered toggle binding", () => {
   const binding =
     appSource.match(/function bindStatusBarEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
+  const homeBinding =
+    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
   assert.match(
     binding,
     /bindStatusBar\(document, \{\s*onToggle: \(\) => \{[\s\S]*state\.statusBarExpanded = !state\.statusBarExpanded;[\s\S]*render\(\);[\s\S]*\},\s*\}\)/);
@@ -288,6 +294,15 @@ test("typed status bar owns its rendered toggle binding", () => {
     statusBarSource,
     /export function bindStatusBar\([\s\S]*\[data-status-bar-toggle-button\][\s\S]*actions\.onToggle/);
   assert.doesNotMatch(appSource, /\[data-status-bar-toggle-button\]/);
+  assert.equal(
+    workspaceBinding.match(/\bbindStatusBarEvents\(\)/g)?.length,
+    1);
+  assert.equal(
+    homeBinding.match(/\bbindStatusBarEvents\(\)/g)?.length,
+    1);
+  assert.equal(
+    appSource.match(/\bbindStatusBarEvents\(\)/g)?.length,
+    3);
 });
 
 test("typed package inspection owns package-root request coordination", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -276,6 +276,20 @@ test("workspace data bar receives package acquisition provenance", () => {
   assert.match(statusBarSource, /Source: \$\{escapeHtml\(packageSourceLabel\(model\.source\)\)\}/);
 });
 
+test("typed status bar owns its rendered toggle binding", () => {
+  const binding =
+    appSource.match(/function bindStatusBarEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
+  assert.match(
+    binding,
+    /bindStatusBar\(document, \{\s*onToggle: \(\) => \{[\s\S]*state\.statusBarExpanded = !state\.statusBarExpanded;[\s\S]*render\(\);[\s\S]*\},\s*\}\)/);
+  assert.equal(binding.match(/\bdocument\b/g)?.length, 1);
+  assert.match(
+    statusBarSource,
+    /export function bindStatusBar\([\s\S]*\[data-status-bar-toggle-button\][\s\S]*actions\.onToggle/);
+  assert.doesNotMatch(appSource, /\[data-status-bar-toggle-button\]/);
+});
+
 test("typed package inspection owns package-root request coordination", () => {
   const dependenciesLoader =
     appSource.match(/async function loadPackageDependencies\(\) \{[\s\S]*?\n}/)?.[0]

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -294,12 +294,15 @@ test("typed status bar owns its rendered toggle binding", () => {
     statusBarSource,
     /export function bindStatusBar\([\s\S]*\[data-status-bar-toggle-button\][\s\S]*actions\.onToggle/);
   assert.doesNotMatch(appSource, /\[data-status-bar-toggle-button\]/);
-  assert.equal(
-    workspaceBinding.match(/\bbindStatusBarEvents\(\)/g)?.length,
-    1);
-  assert.equal(
-    homeBinding.match(/\bbindStatusBarEvents\(\)/g)?.length,
-    1);
+  for (const owner of [workspaceBinding, homeBinding]) {
+    assert.equal(
+      owner.match(/^  bindStatusBarEvents\(\);$/gm)?.length,
+      1);
+    const prefix =
+      owner.slice(0, owner.indexOf("bindStatusBarEvents();"));
+    assert.equal(prefix.match(/\{/g)?.length, 1);
+    assert.equal(prefix.match(/\}/g)?.length ?? 0, 0);
+  }
   assert.equal(
     appSource.match(/\bbindStatusBarEvents\(\)/g)?.length,
     3);
@@ -421,6 +424,12 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.equal(
     rootEventBinder.match(/^\s*bindTypePanelEvents\(\);$/gm)?.length,
     1);
+  const typePanelCompositionPrefix =
+    rootEventBinder.slice(
+      0,
+      rootEventBinder.indexOf("bindTypePanelEvents();"));
+  assert.equal(typePanelCompositionPrefix.match(/\{/g)?.length, 1);
+  assert.equal(typePanelCompositionPrefix.match(/\}/g)?.length ?? 0, 0);
   assert.match(
     typePanelSource,
     /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -418,9 +418,9 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.equal(
     rootEventBinder.match(/\bbindTypePanelEvents\(\)/g)?.length,
     1);
-  assert.match(
-    rootEventBinder,
-    /function bindEvents\(\) \{\s*bindStatusBarToggle\(\);\s*packageBar\.bind\(document\);\s*bindTypePanelEvents\(\);/);
+  assert.equal(
+    rootEventBinder.match(/^\s*bindTypePanelEvents\(\);$/gm)?.length,
+    1);
   assert.match(
     typePanelSource,
     /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -241,6 +241,94 @@ const commandBarSource = readFileSync(
   new URL("../src/command-bar.ts", import.meta.url),
   "utf8");
 
+function maskNonCode(source) {
+  const masked = [...source];
+  for (let index = 0; index < source.length; index++) {
+    const quote = source[index];
+    if (quote === "/" && source[index + 1] === "/") {
+      while (index < source.length && source[index] !== "\n") {
+        masked[index++] = " ";
+      }
+    } else if (quote === "/" && source[index + 1] === "*") {
+      masked[index++] = " ";
+      while (index < source.length
+        && !(source[index] === "*" && source[index + 1] === "/")) {
+        masked[index++] = " ";
+      }
+      masked[index] = " ";
+      masked[index + 1] = " ";
+      index++;
+    } else if (quote === "\"" || quote === "'" || quote === "`") {
+      masked[index] = " ";
+      for (index++; index < source.length; index++) {
+        masked[index] = " ";
+        if (source[index] === "\\") {
+          masked[++index] = " ";
+        } else if (source[index] === quote) {
+          break;
+        }
+      }
+    }
+  }
+  return masked.join("");
+}
+
+function assertDirectCompositionCall(
+  source,
+  functionName,
+  calleeName,
+  expectedIndex,
+) {
+  const functionPrefix = `function ${functionName}() {`;
+  const functionStart = source.indexOf(functionPrefix);
+  assert.notEqual(functionStart, -1);
+  const body = source.slice(functionStart + functionPrefix.length);
+  const masked = maskNonCode(body);
+  const statements = [];
+  let depth = 0;
+  let statementStart = 0;
+  for (let index = 0; index < masked.length; index++) {
+    if (masked[index] === "{") depth++;
+    else if (masked[index] === "}") {
+      if (depth === 0) break;
+      depth--;
+    } else if (masked[index] === ";" && depth === 0) {
+      statements.push(masked.slice(statementStart, index + 1).trim());
+      statementStart = index + 1;
+    }
+  }
+  assert.equal(
+    statements[expectedIndex].replace(/\s+/g, " "),
+    `${calleeName}();`);
+}
+
+test("composition call gates distinguish direct calls from textual nesting", () => {
+  const direct = `function bind() {
+    const options = { label: "{ready}" };
+    // A brace in a comment is not composition.
+    bindTarget();
+  }`;
+  assertDirectCompositionCall(direct, "bind", "bindTarget", 1);
+  assert.throws(() =>
+    assertDirectCompositionCall(
+      "function bind() { if (false) bindTarget(); }",
+      "bind",
+      "bindTarget",
+      0));
+  assert.throws(() =>
+    assertDirectCompositionCall(
+      "function bind() { if (false) { bindTarget(); } }",
+      "bind",
+      "bindTarget",
+      0));
+  assert.throws(() =>
+    assertDirectCompositionCall(
+      "function bind() { if (false) return; bindTarget(); }",
+      "bind",
+      "bindTarget",
+      0));
+});
+
 test("typed Spotlight owns search presentation and hosts commands", () => {
   assert.match(
     appSource,
@@ -280,12 +368,6 @@ test("typed status bar owns its rendered toggle binding", () => {
   const binding =
     appSource.match(/function bindStatusBarEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
-  const workspaceBinding =
-    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
-    ?? "";
-  const homeBinding =
-    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\n\/\/ The two package demos)/)?.[0]
-    ?? "";
   assert.match(
     binding,
     /bindStatusBar\(document, \{\s*onToggle: \(\) => \{[\s\S]*state\.statusBarExpanded = !state\.statusBarExpanded;[\s\S]*render\(\);[\s\S]*\},\s*\}\)/);
@@ -294,15 +376,16 @@ test("typed status bar owns its rendered toggle binding", () => {
     statusBarSource,
     /export function bindStatusBar\([\s\S]*\[data-status-bar-toggle-button\][\s\S]*actions\.onToggle/);
   assert.doesNotMatch(appSource, /\[data-status-bar-toggle-button\]/);
-  for (const owner of [workspaceBinding, homeBinding]) {
-    assert.equal(
-      owner.match(/^  bindStatusBarEvents\(\);$/gm)?.length,
-      1);
-    const prefix =
-      owner.slice(0, owner.indexOf("bindStatusBarEvents();"));
-    assert.equal(prefix.match(/\{/g)?.length, 1);
-    assert.equal(prefix.match(/\}/g)?.length ?? 0, 0);
-  }
+  assertDirectCompositionCall(
+    appSource,
+    "bindEvents",
+    "bindStatusBarEvents",
+    0);
+  assertDirectCompositionCall(
+    appSource,
+    "bindHomeEvents",
+    "bindStatusBarEvents",
+    0);
   assert.equal(
     appSource.match(/\bbindStatusBarEvents\(\)/g)?.length,
     3);
@@ -424,12 +507,11 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.equal(
     rootEventBinder.match(/^\s*bindTypePanelEvents\(\);$/gm)?.length,
     1);
-  const typePanelCompositionPrefix =
-    rootEventBinder.slice(
-      0,
-      rootEventBinder.indexOf("bindTypePanelEvents();"));
-  assert.equal(typePanelCompositionPrefix.match(/\{/g)?.length, 1);
-  assert.equal(typePanelCompositionPrefix.match(/\}/g)?.length ?? 0, 0);
+  assertDirectCompositionCall(
+    appSource,
+    "bindEvents",
+    "bindTypePanelEvents",
+    2);
   assert.match(
     typePanelSource,
     /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -284,7 +284,7 @@ test("typed status bar owns its rendered toggle binding", () => {
     appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
   const homeBinding =
-    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\n\/\/ The two package demos)/)?.[0]
     ?? "";
   assert.match(
     binding,

--- a/prototypes/inspect-web/test/status-bar.test.ts
+++ b/prototypes/inspect-web/test/status-bar.test.ts
@@ -1,12 +1,41 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  bindStatusBar,
   buildIdentityHtml,
   fmtBytes,
   fmtMs,
   packageSourceLabel,
   statusBarHtml,
 } from "../src/status-bar.ts";
+
+class FakeElement {
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target: this } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly toggles: FakeElement[];
+
+  constructor(toggles: FakeElement[]) {
+    this.toggles = toggles;
+  }
+
+  querySelectorAll(selector: string) {
+    return selector === "[data-status-bar-toggle-button]" ? this.toggles : [];
+  }
+}
 
 function escapeHtml(value: unknown) {
   return String(value)
@@ -15,6 +44,22 @@ function escapeHtml(value: unknown) {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;");
 }
+
+test("status bar binding dispatches each rendered toggle without eager work", () => {
+  const workspace = new FakeElement();
+  const home = new FakeElement();
+  let toggles = 0;
+
+  bindStatusBar(
+    new FakeRoot([workspace, home]) as unknown as ParentNode,
+    { onToggle: () => toggles += 1 });
+
+  assert.equal(toggles, 0);
+  workspace.dispatch("click");
+  assert.equal(toggles, 1);
+  home.dispatch("click");
+  assert.equal(toggles, 2);
+});
 
 test("status values use stable compact units", () => {
   assert.equal(fmtMs(null), "—");


### PR DESCRIPTION
Moves the shared workspace/home status-bar toggle binding into `status-bar.ts`, pairing the rendered control with its typed presentation owner while keeping expansion state and rendering in the composition root.

**Stack**
- Issue: #4504
- Slice: 18
- Parent: #4526
- Base branch: `feature/4504-package-document-event-binding`

**Behavioral claim**
- `status-bar.ts` owns `data-status-bar-toggle-button` discovery and click dispatch for both workspace and home views.
- Binding performs no eager callback and each click dispatches exactly once.
- The root retains `state.statusBarExpanded`, toggle semantics, and rendering.

**Evidence**
- `npm test` — 422/422 passed
- `npm run build`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

**Non-action boundary / residual**
This does not move expansion state, status model construction, diagnostics/provenance computation, render orchestration, or unrelated global controls.