### PR TITLE
Extract package selection event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -661,11 +661,12 @@ package/library fields, the metadata- and source-signature cache keys, and the
 metadata/source panels' loading, error, and loaded states.
 
 `src/package-bar.ts` owns the package tab strip (including the always-present
-Platform tab), the open-package query form, and their keyboard/mouse/wheel
-interaction. `dotnet-inspect.ts` supplies the workspace effects — selecting, closing, and
-opening a package or the runtime pack — so the component acquires no engine or
-workspace authority. `test/package-bar.test.ts` gates tab markup, active/close
-state, escaping, and open-package query parsing.
+Platform tab), the open-package query form, package framework/version controls,
+and their keyboard/mouse/wheel interaction. `dotnet-inspect.ts` supplies the
+workspace effects — selecting, closing, opening, or changing a package or the
+runtime pack — so the component acquires no engine or workspace authority.
+`test/package-bar.test.ts` gates tab markup, active/close state, escaping,
+open-package query parsing, and package selection dispatch.
 
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -1072,6 +1072,11 @@ const packageBar = createPackageBar({
   closePackageTab,
   openRuntimePack: openRuntimePackFromHome,
   openPackage: (packageId, version) => loadPackage(packageId, version, ""),
+  selectFramework: switchPackageFramework,
+  selectVersion: version => {
+    if (state.package?.isRuntimePack) switchPlatformVersion(version);
+    else switchPackageVersion(version);
+  },
   showToast,
 });
 
@@ -3829,9 +3834,6 @@ function bindEvents() {
   bindGraphSourceEvents();
   bindDocViewerEvents();
   bindAnnotatedSourceEvents();
-  document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
-    switchPackageFramework(button.dataset.frameworkChip ?? "");
-  }));
   document.querySelectorAll<HTMLElement>("[data-dep-group]").forEach(button => button.addEventListener("click", () => {
     const index = Number(button.dataset.depGroup);
     if (state.dependenciesGroupIndex === index) return;
@@ -4129,17 +4131,6 @@ function bindEvents() {
   bindPlatformLensPicker("data-platform-opportunities-library", "opportunities", loadPackageOpportunities);
   bindPlatformLensPicker("data-platform-analysis-library", "analysis", loadPackagePerformance);
   bindPlatformLensPicker("data-platform-metadata-library", "metadata", loadPackageMetadata);
-  const frameworkSelect = document.querySelector<HTMLSelectElement>("#framework");
-  frameworkSelect?.addEventListener("change", () => {
-    switchPackageFramework(frameworkSelect.value);
-  });
-  const packageVersionSelect =
-    document.querySelector<HTMLSelectElement>("#package-version");
-  packageVersionSelect?.addEventListener("change", () => {
-    if (state.package?.isRuntimePack)
-      switchPlatformVersion(packageVersionSelect.value);
-    else switchPackageVersion(packageVersionSelect.value);
-  });
   ensurePackageVersions(state.package);
   if (state.package?.isRuntimePack) ensureDotnetReleases();
   if (state.spotlightOpen) spotlight.bind(document, "modal");

--- a/prototypes/inspect-web/src/package-bar.ts
+++ b/prototypes/inspect-web/src/package-bar.ts
@@ -24,7 +24,32 @@ interface PackageBarOptions {
   closePackageTab: (packageKey: string) => void;
   openRuntimePack: () => void;
   openPackage: (packageId: string, version: string) => void;
+  selectFramework: (framework: string) => void;
+  selectVersion: (version: string) => void;
   showToast: (message: string) => void;
+}
+
+export interface PackageSelectionActions {
+  onFrameworkSelect: (framework: string) => void;
+  onVersionSelect: (version: string) => void;
+}
+
+export function bindPackageSelections(
+  root: ParentNode,
+  actions: PackageSelectionActions,
+): void {
+  root.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onFrameworkSelect(button.dataset.frameworkChip ?? "")));
+  const framework = root.querySelector<HTMLSelectElement>("#framework");
+  framework?.addEventListener(
+    "change",
+    () => actions.onFrameworkSelect(framework.value));
+  const version = root.querySelector<HTMLSelectElement>("#package-version");
+  version?.addEventListener(
+    "change",
+    () => actions.onVersionSelect(version.value));
 }
 
 export function packageIdentityEquals(
@@ -132,6 +157,8 @@ export function createPackageBar(options: PackageBarOptions) {
     closePackageTab,
     openRuntimePack,
     openPackage,
+    selectFramework,
+    selectVersion,
     showToast,
   } = options;
 
@@ -140,6 +167,10 @@ export function createPackageBar(options: PackageBarOptions) {
   }
 
   function bind(root: ParentNode): void {
+    bindPackageSelections(root, {
+      onFrameworkSelect: selectFramework,
+      onVersionSelect: selectVersion,
+    });
     root.querySelectorAll<HTMLElement>("[data-package-key]").forEach(tab => {
       const activate = () => {
         const target = state.packages.find(item => packageIdentityKey(item) === tab.dataset.packageKey);

--- a/prototypes/inspect-web/test/package-bar.test.ts
+++ b/prototypes/inspect-web/test/package-bar.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   bindPackageSelections,
+  createPackageBar,
   packageBarHtml,
   packageIdentityEquals,
   packageTabHtml,
@@ -114,6 +115,44 @@ test("package selection binding tolerates an inactive surface with no controls",
     });
 
   assert.deepEqual(calls, []);
+});
+
+test("package bar connects package selection controls to its typed options", () => {
+  const root = new FakeRoot();
+  const chip = new FakeElement();
+  chip.dataset.frameworkChip = "net9.0";
+  root.addAll("[data-framework-chip]", chip);
+  const framework = root.add("#framework", new FakeElement());
+  framework.value = "net10.0";
+  const version = root.add("#package-version", new FakeElement());
+  version.value = "10.0.1";
+  root.add("#package-query", new FakeElement());
+  const calls: string[] = [];
+  const packageBar = createPackageBar({
+    state: { packages: [], package: null },
+    escapeHtml,
+    packageIdentityKey,
+    runtimePackPackage: () => null,
+    selectPackageTab: () => {},
+    closePackageTab: () => {},
+    openRuntimePack: () => {},
+    openPackage: () => {},
+    selectFramework: value => calls.push(`framework:${value}`),
+    selectVersion: value => calls.push(`version:${value}`),
+    showToast: () => {},
+  });
+
+  packageBar.bind(root as unknown as ParentNode);
+
+  assert.deepEqual(calls, []);
+  chip.dispatch("click");
+  framework.dispatch("change");
+  version.dispatch("change");
+  assert.deepEqual(calls, [
+    "framework:net9.0",
+    "framework:net10.0",
+    "version:10.0.1",
+  ]);
 });
 
 test("package identity equality compares the full coordinate", () => {

--- a/prototypes/inspect-web/test/package-bar.test.ts
+++ b/prototypes/inspect-web/test/package-bar.test.ts
@@ -78,11 +78,13 @@ test("package selection bindings map overview and header controls without eager 
   const root = new FakeRoot();
   const chip = new FakeElement();
   chip.dataset.frameworkChip = "net9.0";
-  root.addAll("[data-framework-chip]", chip);
+  const secondChip = new FakeElement();
+  secondChip.dataset.frameworkChip = "net8.0";
+  root.addAll("[data-framework-chip]", chip, secondChip);
   const framework = root.add("#framework", new FakeElement());
-  framework.value = "net10.0";
+  framework.value = "net9.0";
   const version = root.add("#package-version", new FakeElement());
-  version.value = "10.0.1";
+  version.value = "10.0.0";
   const calls: string[] = [];
 
   bindPackageSelections(
@@ -94,12 +96,23 @@ test("package selection bindings map overview and header controls without eager 
 
   assert.deepEqual(calls, []);
   chip.dispatch("click");
-  assert.deepEqual(calls, ["framework:net9.0"]);
+  secondChip.dispatch("click");
+  assert.deepEqual(calls, [
+    "framework:net9.0",
+    "framework:net8.0",
+  ]);
+  framework.value = "net10.0";
   framework.dispatch("change");
-  assert.deepEqual(calls, ["framework:net9.0", "framework:net10.0"]);
+  assert.deepEqual(calls, [
+    "framework:net9.0",
+    "framework:net8.0",
+    "framework:net10.0",
+  ]);
+  version.value = "10.0.1";
   version.dispatch("change");
   assert.deepEqual(calls, [
     "framework:net9.0",
+    "framework:net8.0",
     "framework:net10.0",
     "version:10.0.1",
   ]);
@@ -121,11 +134,13 @@ test("package bar connects package selection controls to its typed options", () 
   const root = new FakeRoot();
   const chip = new FakeElement();
   chip.dataset.frameworkChip = "net9.0";
-  root.addAll("[data-framework-chip]", chip);
+  const secondChip = new FakeElement();
+  secondChip.dataset.frameworkChip = "net8.0";
+  root.addAll("[data-framework-chip]", chip, secondChip);
   const framework = root.add("#framework", new FakeElement());
-  framework.value = "net10.0";
+  framework.value = "net9.0";
   const version = root.add("#package-version", new FakeElement());
-  version.value = "10.0.1";
+  version.value = "10.0.0";
   root.add("#package-query", new FakeElement());
   const calls: string[] = [];
   const packageBar = createPackageBar({
@@ -146,10 +161,14 @@ test("package bar connects package selection controls to its typed options", () 
 
   assert.deepEqual(calls, []);
   chip.dispatch("click");
+  secondChip.dispatch("click");
+  framework.value = "net10.0";
   framework.dispatch("change");
+  version.value = "10.0.1";
   version.dispatch("change");
   assert.deepEqual(calls, [
     "framework:net9.0",
+    "framework:net8.0",
     "framework:net10.0",
     "version:10.0.1",
   ]);

--- a/prototypes/inspect-web/test/package-bar.test.ts
+++ b/prototypes/inspect-web/test/package-bar.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  bindPackageSelections,
   packageBarHtml,
   packageIdentityEquals,
   packageTabHtml,
@@ -30,6 +31,90 @@ function pkg(
 ): PackageBarPackage {
   return { id, version, activeFramework, isRuntimePack };
 }
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined> = {};
+  value = "";
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target: this } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+    return element;
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+    return elements;
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+test("package selection bindings map overview and header controls without eager dispatch", () => {
+  const root = new FakeRoot();
+  const chip = new FakeElement();
+  chip.dataset.frameworkChip = "net9.0";
+  root.addAll("[data-framework-chip]", chip);
+  const framework = root.add("#framework", new FakeElement());
+  framework.value = "net10.0";
+  const version = root.add("#package-version", new FakeElement());
+  version.value = "10.0.1";
+  const calls: string[] = [];
+
+  bindPackageSelections(
+    root as unknown as ParentNode,
+    {
+      onFrameworkSelect: value => calls.push(`framework:${value}`),
+      onVersionSelect: value => calls.push(`version:${value}`),
+    });
+
+  assert.deepEqual(calls, []);
+  chip.dispatch("click");
+  assert.deepEqual(calls, ["framework:net9.0"]);
+  framework.dispatch("change");
+  assert.deepEqual(calls, ["framework:net9.0", "framework:net10.0"]);
+  version.dispatch("change");
+  assert.deepEqual(calls, [
+    "framework:net9.0",
+    "framework:net10.0",
+    "version:10.0.1",
+  ]);
+});
+
+test("package selection binding tolerates an inactive surface with no controls", () => {
+  const calls: string[] = [];
+  bindPackageSelections(
+    new FakeRoot() as unknown as ParentNode,
+    {
+      onFrameworkSelect: value => calls.push(`framework:${value}`),
+      onVersionSelect: value => calls.push(`version:${value}`),
+    });
+
+  assert.deepEqual(calls, []);
+});
 
 test("package identity equality compares the full coordinate", () => {
   const a = pkg("System.Text.Json");

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -391,6 +391,24 @@ test("typed status bar owns its rendered toggle binding", () => {
     3);
 });
 
+test("typed package bar owns package framework and version selection bindings", () => {
+  const packageBarCreation =
+    appSource.match(/const packageBar = createPackageBar\(\{[\s\S]*?\n}\);/)?.[0]
+    ?? "";
+  assert.match(
+    packageBarCreation,
+    /selectFramework: switchPackageFramework,[\s\S]*selectVersion: version => \{[\s\S]*state\.package\?\.isRuntimePack[\s\S]*switchPlatformVersion\(version\);[\s\S]*else switchPackageVersion\(version\)/);
+  assert.match(
+    packageBarSource,
+    /export function bindPackageSelections\([\s\S]*\[data-framework-chip\][\s\S]*#framework[\s\S]*#package-version/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelectorAll<HTMLElement>\("\[data-framework-chip\]"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelector<HTMLSelectElement>\("#(?:framework|package-version)"\)/);
+});
+
 test("typed package inspection owns package-root request coordination", () => {
   const dependenciesLoader =
     appSource.match(/async function loadPackageDependencies\(\) \{[\s\S]*?\n}/)?.[0]
@@ -2220,8 +2238,9 @@ test("closing a package removes its coordinate and selects the adjacent tab", ()
 
 test("workspace UI routes replacements and restore notices through bounded paths", () => {
   assert.match(
-    appSource,
-    /switchPackageFramework\(button\.dataset\.frameworkChip \?\? ""\)/);
+    packageBarSource,
+    /onFrameworkSelect\(button\.dataset\.frameworkChip \?\? ""\)/);
+  assert.match(appSource, /selectFramework: switchPackageFramework/);
   assert.match(appSource, /switchPackageFramework\(argument\)/);
   assert.doesNotMatch(
     appSource,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -395,18 +395,30 @@ test("typed package bar owns package framework and version selection bindings", 
   const packageBarCreation =
     appSource.match(/const packageBar = createPackageBar\(\{[\s\S]*?\n}\);/)?.[0]
     ?? "";
+  const packageBarBinding =
+    packageBarSource.match(/  function bind\(root: ParentNode\): void \{[\s\S]*?\n  }(?=\n\n  return)/)?.[0]
+    ?? "";
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
   assert.match(
     packageBarCreation,
     /selectFramework: switchPackageFramework,[\s\S]*selectVersion: version => \{[\s\S]*state\.package\?\.isRuntimePack[\s\S]*switchPlatformVersion\(version\);[\s\S]*else switchPackageVersion\(version\)/);
   assert.match(
     packageBarSource,
     /export function bindPackageSelections\([\s\S]*\[data-framework-chip\][\s\S]*#framework[\s\S]*#package-version/);
+  assert.match(
+    packageBarBinding,
+    /bindPackageSelections\(root, \{\s*onFrameworkSelect: selectFramework,\s*onVersionSelect: selectVersion,\s*\}\)/);
+  assert.equal(
+    workspaceBinding.match(/\bpackageBar\.bind\(document\)/g)?.length,
+    1);
   assert.doesNotMatch(
-    appSource,
-    /document\.querySelectorAll<HTMLElement>\("\[data-framework-chip\]"\)/);
+    workspaceBinding,
+    /document\.querySelectorAll(?:<HTMLElement>)?\("\[data-framework-chip\]"\)/);
   assert.doesNotMatch(
-    appSource,
-    /document\.querySelector<HTMLSelectElement>\("#(?:framework|package-version)"\)/);
+    workspaceBinding,
+    /document\.querySelector(?:<HTMLSelectElement>)?\("#(?:framework|package-version)"\)/);
 });
 
 test("typed package inspection owns package-root request coordination", () => {


### PR DESCRIPTION
Moves package framework/version control binding into the existing package-bar owner while preserving the composition root as the authority for package/runtime-pack replacement and acquisition.

**Stack**
- Issue: #4504
- Slice: 19
- Parent: #4527
- Base branch: `feature/4504-status-bar-event-binding`

**Behavioral claim**
- `package-bar.ts` owns overview framework chips plus header framework/version selectors.
- Binding performs no eager dispatch and maps each control to typed framework/version actions.
- The root retains normal-package versus runtime-pack version routing, acquisition, state replacement, failures, and rendering.

**Evidence**
- `npm test` — 425/425 passed
- `npm run build`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

**Non-action boundary / residual**
This does not move package/runtime acquisition, workspace replacement, version catalog requests, package overview rendering, dependency selection, or engine/network work.