### PR TITLE
Extract member filter event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -647,8 +647,9 @@ Symbol/PDB acquisition status is not yet surfaced here — no backend contract
 reports it today — and is a tracked fast-follow.
 
 `src/type-panel.ts` owns the type selector (the "PUBLIC TYPES" / "MEMBERS" nav
-pane), its rendered DOM control bindings, and the type viewer (the type
-heading, metadata, and source sections shown for the "type" scope).
+pane), its rendered DOM control bindings (including member filters), and the
+type viewer (the type heading, metadata, and source sections shown for the
+"type" scope).
 `dotnet-inspect.ts` still owns the type index, filtering, member grouping, and
 navigation state transitions, and supplies them through typed callbacks; the
 shared text helpers used well beyond the type panel (`kindIcon`, `shortKind`,

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3633,6 +3633,14 @@ function bindStatusBarEvents() {
 }
 
 function bindTypePanelEvents() {
+  const renderMemberFilterAndRestoreFocus = (selector = "") => {
+    const preserved = captureMemberFocus(document);
+    if (selector) {
+      preserved.selector = selector;
+      preserved.dataTarget = null;
+    }
+    renderWithMemberFocus(preserved);
+  };
   bindTypePanel(document, {
     onClearFilters: () => {
       state.typeFilter = "";
@@ -3654,10 +3662,51 @@ function bindTypePanelEvents() {
       render();
     },
     onListKeyDown: handleTypeKeys,
+    onMemberAccessibilityFilterSelect: value => {
+      state.memberAccessibilityFilter = value ?? "all";
+      normalizeMemberSelection();
+      renderMemberFilterAndRestoreFocus();
+    },
+    onMemberFilterChange: value => {
+      state.memberTextFilter = value;
+      normalizeMemberSelection();
+      renderPreservingMemberFocus();
+    },
+    onMemberFilterClear: () => {
+      resetMemberFilters();
+      normalizeMemberSelection();
+      renderMemberFilterAndRestoreFocus("#clear-member-filter");
+    },
+    onMemberFilterKeyDown: event => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        if (navMode() === "member") {
+          exitMemberScope();
+        } else {
+          state.memberTextFilter = "";
+          normalizeMemberSelection();
+          renderMemberFilterAndRestoreFocus("#member-filter");
+        }
+        return;
+      }
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
+      event.preventDefault();
+      stepMemberNav(event.key === "ArrowDown" ? 1 : -1, true);
+    },
+    onMemberKindFilterSelect: value => {
+      state.memberKindFilter = value ?? "all";
+      normalizeMemberSelection();
+      renderMemberFilterAndRestoreFocus();
+    },
     onMemberSelect: memberKey => {
       const group = memberGroups(selectedType())
         .find(item => item.key === memberKey);
       if (group) selectMemberNavEntry({ kind: "member", group }, false);
+    },
+    onMemberTraitFilterSelect: value => {
+      state.memberTraitFilter = value ?? "";
+      normalizeMemberSelection();
+      renderMemberFilterAndRestoreFocus();
     },
     onNamespaceSelect: namespace => {
       state.namespaceFilter = namespace;
@@ -3894,59 +3943,6 @@ function bindEvents() {
       button.dataset.perfAssembly ?? "",
       button.dataset.perfType ?? "");
   }));
-  const renderMemberFilterAndRestoreFocus = (selector = "") => {
-    const preserved = captureMemberFocus(document);
-    if (selector) {
-      preserved.selector = selector;
-      preserved.dataTarget = null;
-    }
-    renderWithMemberFocus(preserved);
-  };
-  document.querySelectorAll<HTMLElement>("[data-member-kind-filter]").forEach(button => button.addEventListener("click", () => {
-    const value = button.dataset.memberKindFilter;
-    state.memberKindFilter = value ?? "all";
-    normalizeMemberSelection();
-    renderMemberFilterAndRestoreFocus();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member-access-filter]").forEach(button => button.addEventListener("click", () => {
-    const value = button.dataset.memberAccessFilter;
-    state.memberAccessibilityFilter = value ?? "all";
-    normalizeMemberSelection();
-    renderMemberFilterAndRestoreFocus();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member-trait-filter]").forEach(button => button.addEventListener("click", () => {
-    const value = button.dataset.memberTraitFilter;
-    state.memberTraitFilter = value ?? "";
-    normalizeMemberSelection();
-    renderMemberFilterAndRestoreFocus();
-  }));
-  const memberFilter = document.querySelector<HTMLInputElement>("#member-filter");
-  memberFilter?.addEventListener("input", event => {
-    state.memberTextFilter = memberFilter.value;
-    normalizeMemberSelection();
-    renderPreservingMemberFocus();
-  });
-  memberFilter?.addEventListener("keydown", event => {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      if (navMode() === "member") {
-        exitMemberScope();
-      } else {
-        state.memberTextFilter = "";
-        normalizeMemberSelection();
-        renderMemberFilterAndRestoreFocus("#member-filter");
-      }
-      return;
-    }
-    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
-    event.preventDefault();
-    stepMemberNav(event.key === "ArrowDown" ? 1 : -1, true);
-  });
-  document.querySelector("#clear-member-filter")?.addEventListener("click", () => {
-    resetMemberFilters();
-    normalizeMemberSelection();
-    renderMemberFilterAndRestoreFocus("#clear-member-filter");
-  });
   const enterMemberNavigation = (action: () => void) => {
     const focusGeneration = beginSpotlightNavigation();
     action();

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -83,7 +83,13 @@ export interface TypePanelBindingActions {
   onClearFilters: () => void;
   onKindSelect: (kind: string) => void;
   onListKeyDown: (event: KeyboardEvent) => void;
+  onMemberAccessibilityFilterSelect: (accessibility: string | undefined) => void;
+  onMemberFilterChange: (value: string) => void;
+  onMemberFilterClear: () => void;
+  onMemberFilterKeyDown: (event: KeyboardEvent) => void;
+  onMemberKindFilterSelect: (kind: string | undefined) => void;
   onMemberSelect: (memberKey: string | undefined) => void;
+  onMemberTraitFilterSelect: (trait: string | undefined) => void;
   onNamespaceSelect: (namespace: string) => void;
   onOverloadSelect: (index: number) => void;
   onShowTypes: () => void;
@@ -116,12 +122,33 @@ export function bindTypePanel(
     button.addEventListener(
       "click",
       () => actions.onOverloadSelect(Number(button.dataset.navOverload))));
+  root.querySelectorAll<HTMLElement>("[data-member-kind-filter]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberKindFilterSelect(
+          button.dataset.memberKindFilter)));
+  root.querySelectorAll<HTMLElement>("[data-member-access-filter]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberAccessibilityFilterSelect(
+          button.dataset.memberAccessFilter)));
+  root.querySelectorAll<HTMLElement>("[data-member-trait-filter]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberTraitFilterSelect(
+          button.dataset.memberTraitFilter)));
   root.querySelector("#nav-to-types")?.addEventListener(
     "click",
     actions.onShowTypes);
   root.querySelector("#clear-filter")?.addEventListener(
     "click",
     actions.onClearFilters);
+  root.querySelector("#clear-member-filter")?.addEventListener(
+    "click",
+    actions.onMemberFilterClear);
 
   const namespaceJump =
     root.querySelector<HTMLSelectElement>("#namespace-jump");
@@ -131,6 +158,14 @@ export function bindTypePanel(
 
   const typeList = root.querySelector<HTMLElement>("#type-list");
   typeList?.addEventListener("keydown", actions.onListKeyDown);
+  const memberFilter =
+    root.querySelector<HTMLInputElement>("#member-filter");
+  memberFilter?.addEventListener(
+    "input",
+    () => actions.onMemberFilterChange(memberFilter.value));
+  memberFilter?.addEventListener(
+    "keydown",
+    actions.onMemberFilterKeyDown);
   const filter = root.querySelector<HTMLInputElement>("#type-filter");
   filter?.addEventListener(
     "input",

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -559,7 +559,10 @@ test("typed type panel owns its rendered control bindings", () => {
     /document\.querySelector(?:<HTMLInputElement>)?\("#(?:member-filter|clear-member-filter)"\)/);
   assert.match(
     binding,
-    /onMemberFilterKeyDown: event => \{[\s\S]*event\.key === "Escape"[\s\S]*navMode\(\) === "member"[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*event\.key !== "ArrowUp" && event\.key !== "ArrowDown"[\s\S]*stepMemberNav\(event\.key === "ArrowDown" \? 1 : -1, true\)/);
+    /onMemberFilterClear: \(\) => \{[\s\S]*resetMemberFilters\(\);[\s\S]*renderMemberFilterAndRestoreFocus\("#clear-member-filter"\)/);
+  assert.match(
+    binding,
+    /onMemberFilterKeyDown: event => \{\s*if \(event\.key === "Escape"\) \{\s*event\.preventDefault\(\);[\s\S]*navMode\(\) === "member"[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*event\.key !== "ArrowUp" && event\.key !== "ArrowDown"[\s\S]*event\.preventDefault\(\);\s*stepMemberNav\(event\.key === "ArrowDown" \? 1 : -1, true\)/);
   const selectorCount = selector =>
     appSource.split(selector).length - 1;
   assert.deepEqual(

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -522,12 +522,15 @@ test("typed catalog requests own release and package-version coordination", () =
 });
 
 test("typed type panel owns its rendered control bindings", () => {
+  const binding =
+    appSource.match(/function bindTypePanelEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
   const rootEventBinder =
     appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
     ?? "";
   assert.match(
-    appSource,
-    /function bindTypePanelEvents\(\) \{\s*bindTypePanel\(document, \{/);
+    binding,
+    /bindTypePanel\(document, \{/);
   assert.equal(
     appSource.match(/\bbindTypePanelEvents\b/g)?.length,
     2);
@@ -545,6 +548,18 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.match(
     typePanelSource,
     /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);
+  assert.match(
+    typePanelSource,
+    /\[data-member-kind-filter\][\s\S]*\[data-member-access-filter\][\s\S]*\[data-member-trait-filter\][\s\S]*#clear-member-filter[\s\S]*#member-filter/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelectorAll<HTMLElement>\("\[data-member-(?:kind|access|trait)-filter\]"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelector(?:<HTMLInputElement>)?\("#(?:member-filter|clear-member-filter)"\)/);
+  assert.match(
+    binding,
+    /onMemberFilterKeyDown: event => \{[\s\S]*event\.key === "Escape"[\s\S]*navMode\(\) === "member"[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*event\.key !== "ArrowUp" && event\.key !== "ArrowDown"[\s\S]*stepMemberNav\(event\.key === "ArrowDown" \? 1 : -1, true\)/);
   const selectorCount = selector =>
     appSource.split(selector).length - 1;
   assert.deepEqual(
@@ -991,6 +1006,9 @@ test("loading brand links back to the site root", () => {
 });
 
 test("member filters retain accessible controls and focus across rerenders", () => {
+  const binding =
+    appSource.match(/function bindTypePanelEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
   assert.match(
     appSource,
     /id="clear-member-filter"[^>]*aria-label="Clear member filters"/);
@@ -1001,11 +1019,17 @@ test("member filters retain accessible controls and focus across rerenders", () 
     stylesSource,
     /\.type-browser:not\(\.member-nav\) \.namespace-chips, \.pane-footer \{ display: none; \}/);
   assert.match(
-    appSource,
-    /memberFilter\?\.addEventListener\("input"[\s\S]*renderPreservingMemberFocus\(\)/);
+    typePanelSource,
+    /memberFilter\?\.addEventListener\(\s*"input",\s*\(\) => actions\.onMemberFilterChange\(memberFilter\.value\)\)/);
   assert.match(
-    appSource,
-    /memberFilter\?\.addEventListener\("keydown"[\s\S]*event\.key === "Escape"[\s\S]*if \(navMode\(\) === "member"\)[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*renderMemberFilterAndRestoreFocus\("#member-filter"\)[\s\S]*stepMemberNav/);
+    binding,
+    /onMemberFilterChange: value => \{[\s\S]*state\.memberTextFilter = value;[\s\S]*renderPreservingMemberFocus\(\)/);
+  assert.match(
+    typePanelSource,
+    /memberFilter\?\.addEventListener\(\s*"keydown",\s*actions\.onMemberFilterKeyDown\)/);
+  assert.match(
+    binding,
+    /onMemberFilterKeyDown: event => \{[\s\S]*event\.key === "Escape"[\s\S]*if \(navMode\(\) === "member"\)[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*renderMemberFilterAndRestoreFocus\("#member-filter"\)[\s\S]*stepMemberNav/);
   assert.match(
     appSource,
     /event\.key === "Escape" && !event\.defaultPrevented && !typing[\s\S]*if \(navMode\(\) === "member"\) exitMemberScope\(\)/);

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -140,7 +140,15 @@ function recordingActions(calls: string[]): TypePanelBindingActions {
     onClearFilters: () => calls.push("clear"),
     onKindSelect: value => calls.push(`kind:${value}`),
     onListKeyDown: event => calls.push(`list:${event.key}`),
+    onMemberAccessibilityFilterSelect: value =>
+      calls.push(`member-access:${value}`),
+    onMemberFilterChange: value => calls.push(`member-filter:${value}`),
+    onMemberFilterClear: () => calls.push("member-filter-clear"),
+    onMemberFilterKeyDown: event =>
+      calls.push(`member-filter-key:${event.key}`),
+    onMemberKindFilterSelect: value => calls.push(`member-kind:${value}`),
     onMemberSelect: value => calls.push(`member:${value}`),
+    onMemberTraitFilterSelect: value => calls.push(`member-trait:${value}`),
     onNamespaceSelect: value => calls.push(`namespace:${value}`),
     onOverloadSelect: value => calls.push(`overload:${value}`),
     onShowTypes: () => calls.push("types"),
@@ -149,6 +157,52 @@ function recordingActions(calls: string[]): TypePanelBindingActions {
     onTypeSelect: value => calls.push(`type:${value}`),
   };
 }
+
+test("type panel bindings dispatch member filters without eager work", () => {
+  const root = new FakeRoot();
+  const kind = new FakeElement({ memberKindFilter: "method" });
+  const accessibility =
+    new FakeElement({ memberAccessFilter: "protected" });
+  const trait = new FakeElement({ memberTraitFilter: "isStatic" });
+  root.addAll("[data-member-kind-filter]", kind);
+  root.addAll("[data-member-access-filter]", accessibility);
+  root.addAll("[data-member-trait-filter]", trait);
+  const filter = root.add("#member-filter", new FakeElement());
+  filter.value = "parse";
+  const clear = root.add("#clear-member-filter", new FakeElement());
+  const calls: string[] = [];
+
+  bindTypePanel(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  kind.dispatch("click");
+  assert.deepEqual(calls, ["member-kind:method"]);
+  accessibility.dispatch("click");
+  assert.deepEqual(calls, [
+    "member-kind:method",
+    "member-access:protected",
+  ]);
+  trait.dispatch("click");
+  assert.deepEqual(calls, [
+    "member-kind:method",
+    "member-access:protected",
+    "member-trait:isStatic",
+  ]);
+  filter.dispatch("input");
+  const arrow = keyboardEvent("ArrowDown");
+  filter.dispatch("keydown", arrow.event);
+  clear.dispatch("click");
+  assert.deepEqual(calls, [
+    "member-kind:method",
+    "member-access:protected",
+    "member-trait:isStatic",
+    "member-filter:parse",
+    "member-filter-key:ArrowDown",
+    "member-filter-clear",
+  ]);
+});
 
 test("type panel bindings dispatch the rendered type navigation controls", () => {
   const root = new FakeRoot();

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -160,13 +160,20 @@ function recordingActions(calls: string[]): TypePanelBindingActions {
 
 test("type panel bindings dispatch member filters without eager work", () => {
   const root = new FakeRoot();
+  const allKinds = new FakeElement({ memberKindFilter: "all" });
   const kind = new FakeElement({ memberKindFilter: "method" });
+  const allAccessibilities =
+    new FakeElement({ memberAccessFilter: "all" });
   const accessibility =
     new FakeElement({ memberAccessFilter: "protected" });
+  const allTraits = new FakeElement({ memberTraitFilter: "all" });
   const trait = new FakeElement({ memberTraitFilter: "isStatic" });
-  root.addAll("[data-member-kind-filter]", kind);
-  root.addAll("[data-member-access-filter]", accessibility);
-  root.addAll("[data-member-trait-filter]", trait);
+  root.addAll("[data-member-kind-filter]", allKinds, kind);
+  root.addAll(
+    "[data-member-access-filter]",
+    allAccessibilities,
+    accessibility);
+  root.addAll("[data-member-trait-filter]", allTraits, trait);
   const filter = root.add("#member-filter", new FakeElement());
   filter.value = "parse";
   const clear = root.add("#clear-member-filter", new FakeElement());


### PR DESCRIPTION
Moves rendered member-filter DOM decoding into the existing type-panel presentation owner while preserving member state, normalization, focus restoration, navigation, and rendering in the composition root.

**Stack**
- Issue: #4504
- Slice: 20
- Parent: #4528
- Base branch: `feature/4504-package-selection-event-binding`

**Behavioral claim**
- `type-panel.ts` owns member kind/accessibility/trait filter buttons, text-input/change and key dispatch, and the clear-filter control.
- Binding performs no eager work, tolerates inactive surfaces, and forwards typed dataset/value/event inputs.
- The root retains filter defaults, selection normalization, Escape member-scope behavior, Arrow navigation polarity, focus capture/restoration, and rendering.

**Evidence**
- `npm test` — 427/427 passed
- `npm run build`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`
- MAI-Code quick read — clean early signal; not counted as an adversarial round

**Non-action boundary / residual**
This does not move member/type state, filtering algorithms, focus orchestration, navigation transitions, member composition jumps, detail copy actions, or engine/request work.