### PR TITLE
Extract settings entry event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -671,8 +671,9 @@ open-package query parsing, and package selection dispatch.
 
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM
-bindings. `dotnet-inspect.ts` still owns `state`, localStorage persistence, and
-the theme/taste/close effects, supplying those actions through typed callbacks.
+bindings and the home/workbench controls that open them. `dotnet-inspect.ts`
+still owns `state`, localStorage persistence, and the
+theme/taste/open/close effects, supplying those actions through typed callbacks.
 `test/settings-panel.test.ts` gates the mutually exclusive Settings and popover
 binding shapes, input validation, the style catalog's tier grouping,
 byte-divergent badges and checked state, the taste popover's active/default

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3791,7 +3791,12 @@ function bindScopeBarEvents() {
 function bindSettingsPanelEvents() {
   bindSettingsPanel(document, {
     onClose: closeSettings,
+    onOpen: openSettings,
     onTasteClear: clearTaste,
+    onTasteOpenToggle: () => {
+      state.tasteOpen = !state.tasteOpen;
+      render();
+    },
     onTasteToggle: toggleTaste,
     onThemeSelect: setTheme,
   });
@@ -4130,11 +4135,6 @@ function bindEvents() {
   ensurePackageVersions(state.package);
   if (state.package?.isRuntimePack) ensureDotnetReleases();
   if (state.spotlightOpen) spotlight.bind(document, "modal");
-  document.querySelector("#taste-btn")?.addEventListener("click", event => {
-    event.stopPropagation();
-    state.tasteOpen = !state.tasteOpen;
-    render();
-  });
   document.querySelector("#share")?.addEventListener("click", share);
   document.querySelector("[data-graph-back]")?.addEventListener("click", popPlatformDrill);
   document.querySelector("#dismiss-notice")?.addEventListener("click", () => {
@@ -4152,7 +4152,6 @@ function bindEvents() {
   document.querySelector("#nav-forward")?.addEventListener("click", navForward);
   document.querySelector("#go-home")?.addEventListener("click", goHome);
   document.querySelector("#theme-toggle")?.addEventListener("click", toggleTheme);
-  document.querySelector("#open-settings")?.addEventListener("click", () => openSettings("workbench"));
   document.querySelector("#help")?.addEventListener("click", () => showToast("⌘K command · ⌘P / type to find a type · ⌘F filter · 1—5 lenses · ↑↓ types · Alt+←/→ back/forward · graph: wheel zoom, click node to open, +/− zoom, 0 fit, arrows pan"));
 }
 
@@ -5469,8 +5468,8 @@ function homeArtSvg() {
 
 function bindHomeEvents() {
   bindStatusBarEvents();
+  bindSettingsPanelEvents();
   document.querySelector("#home-theme")?.addEventListener("click", toggleTheme);
-  document.querySelector("#home-settings")?.addEventListener("click", () => openSettings("home"));
   document.querySelector("#dismiss-notice")?.addEventListener("click", () => {
     state.queryNotice = "";
     state.queryNoticeRetryAction = null;

--- a/prototypes/inspect-web/src/settings-panel.ts
+++ b/prototypes/inspect-web/src/settings-panel.ts
@@ -30,7 +30,9 @@ type EscapeHtml = (value: unknown) => string;
 
 export interface SettingsPanelBindingActions {
   onClose: () => void;
+  onOpen: (from: "home" | "workbench") => void;
   onTasteClear: () => void;
+  onTasteOpenToggle: () => void;
   onTasteToggle: (taste: string) => void;
   onThemeSelect: (theme: "dark" | "light") => void;
 }
@@ -42,6 +44,16 @@ export function bindSettingsPanel(
   root.querySelector("#settings-close")?.addEventListener(
     "click",
     actions.onClose);
+  root.querySelector("#home-settings")?.addEventListener(
+    "click",
+    () => actions.onOpen("home"));
+  root.querySelector("#open-settings")?.addEventListener(
+    "click",
+    () => actions.onOpen("workbench"));
+  root.querySelector("#taste-btn")?.addEventListener("click", event => {
+    event.stopPropagation();
+    actions.onTasteOpenToggle();
+  });
   root.querySelectorAll<HTMLElement>(".settings-seg[data-theme]")
     .forEach(button => button.addEventListener("click", () => {
       const theme = button.dataset.theme;

--- a/prototypes/inspect-web/test/settings-panel.test.ts
+++ b/prototypes/inspect-web/test/settings-panel.test.ts
@@ -22,9 +22,9 @@ class FakeElement {
     this.listeners.set(type, listeners);
   }
 
-  dispatch(type: string) {
+  dispatch(type: string, event: Event = {} as Event) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({} as Event);
+      listener(event);
     }
   }
 }
@@ -55,7 +55,9 @@ class FakeRoot {
 function recordingActions(calls: string[]): SettingsPanelBindingActions {
   return {
     onClose: () => calls.push("close"),
+    onOpen: from => calls.push(`open:${from}`),
     onTasteClear: () => calls.push("clear"),
+    onTasteOpenToggle: () => calls.push("taste-open"),
     onTasteToggle: taste => calls.push(`taste:${taste}`),
     onThemeSelect: theme => calls.push(`theme:${theme}`),
   };
@@ -78,6 +80,33 @@ const styleOptions = [
   { id: "readable-locals", tier: "naming", title: "Readable local names", summary: "Synthesize readable local names.", oracle_endorsed: true },
   { id: "expanded-braces", tier: "layout", title: "Expanded braces", summary: "Always use braces." },
 ];
+
+test("settings bindings dispatch entry controls and contain taste clicks", () => {
+  const root = new FakeRoot();
+  const home = root.add("#home-settings", new FakeElement());
+  const workbench = root.add("#open-settings", new FakeElement());
+  const taste = root.add("#taste-btn", new FakeElement());
+  const propagation = { stopped: false };
+  const event = {
+    stopPropagation: () => {
+      propagation.stopped = true;
+    },
+  } as unknown as Event;
+  const calls: string[] = [];
+
+  bindSettingsPanel(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  home.dispatch("click");
+  assert.deepEqual(calls, ["open:home"]);
+  workbench.dispatch("click");
+  assert.deepEqual(calls, ["open:home", "open:workbench"]);
+  taste.dispatch("click", event);
+  assert.deepEqual(calls, ["open:home", "open:workbench", "taste-open"]);
+  assert.equal(propagation.stopped, true);
+});
 
 test("settings bindings dispatch valid settings-page controls", () => {
   const root = new FakeRoot();

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -523,11 +523,10 @@ test("typed scope bar owns its rendered control bindings", () => {
 
 test("typed settings panel owns its rendered control bindings", () => {
   const binding =
-    appSource.match(/function bindSettingsPanelEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction bindPackageOpportunitiesEvents)/)?.[0]
+    appSource.match(
+      /function bindSettingsPanelEvents\(\) \{\s*bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onOpen: openSettings,\s*onTasteClear: clearTaste,\s*onTasteOpenToggle: \(\) => \{\s*state\.tasteOpen = !state\.tasteOpen;\s*render\(\);\s*},\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,\s*}\);\s*}(?=\s*function bindPackageOpportunitiesEvents\(\))/)?.[0]
     ?? "";
-  assert.match(
-    binding,
-    /bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onOpen: openSettings,\s*onTasteClear: clearTaste,\s*onTasteOpenToggle: \(\) => \{[\s\S]*state\.tasteOpen = !state\.tasteOpen;[\s\S]*render\(\);[\s\S]*\},\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,/);
+  assert.notEqual(binding, "");
   assert.doesNotMatch(
     binding,
     /\bquerySelector(?:All)?\b|\baddEventListener\b/);
@@ -558,18 +557,26 @@ test("typed settings panel owns its rendered control bindings", () => {
   assert.equal(nonSettingsPanelSource.match(entrySelectorAccess)?.length ?? 0, 0);
   assert.equal(settingsPanelSource.match(entrySelectorAccess)?.length, 3);
   for (const selector of ["#home-settings", "#open-settings"]) {
-    const literal = new RegExp(`(["'\`])${selector}\\1`, "g");
-    assert.equal(nonSettingsPanelSource.match(literal)?.length ?? 0, 0, selector);
-    assert.equal(settingsPanelSource.match(literal)?.length, 1, selector);
+    const selectorToken = new RegExp(`${selector}(?![-\\w])`, "g");
+    assert.equal(
+      nonSettingsPanelSource.match(selectorToken)?.length ?? 0,
+      0,
+      selector);
+    assert.equal(
+      settingsPanelSource.match(selectorToken)?.length,
+      1,
+      selector);
   }
   assert.equal(
-    nonSettingsPanelSource.match(/(["'`])#taste-btn\1/g)?.length,
+    nonSettingsPanelSource.match(/#taste-btn(?![-\w])/g)?.length,
     1);
   assert.equal(
     nonSettingsPanelSource.match(
       /\.closest\(\s*(["'`])#taste-btn\1\s*\)/g)?.length,
     1);
-  assert.equal(settingsPanelSource.match(/(["'`])#taste-btn\1/g)?.length, 1);
+  assert.equal(
+    settingsPanelSource.match(/#taste-btn(?![-\w])/g)?.length,
+    1);
   for (const selector of [
     "#settings-close",
     ".settings-seg[data-theme]",

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -608,6 +608,9 @@ test("typed scope bar owns its rendered control bindings", () => {
 });
 
 test("typed settings panel owns its rendered control bindings", () => {
+  const binding =
+    appSource.match(/function bindSettingsPanelEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction bindPackageOpportunitiesEvents)/)?.[0]
+    ?? "";
   const bindEvents =
     appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
     ?? "";
@@ -615,11 +618,14 @@ test("typed settings panel owns its rendered control bindings", () => {
     appSource.match(/function renderSettingsViewHtml\(\) \{[\s\S]*?\n}\n\nfunction renderGraphSource/)?.[0]
     ?? "";
   const bindHomeEvents =
-    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\n\/\/ The two package demos)/)?.[0]
     ?? "";
   assert.match(
-    appSource,
-    /function bindSettingsPanelEvents\(\) \{\s*bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onOpen: openSettings,\s*onTasteClear: clearTaste,\s*onTasteOpenToggle: \(\) => \{[\s\S]*state\.tasteOpen = !state\.tasteOpen;[\s\S]*render\(\);[\s\S]*\},\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,/);
+    binding,
+    /bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onOpen: openSettings,\s*onTasteClear: clearTaste,\s*onTasteOpenToggle: \(\) => \{[\s\S]*state\.tasteOpen = !state\.tasteOpen;[\s\S]*render\(\);[\s\S]*\},\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,/);
+  assert.doesNotMatch(
+    binding,
+    /\bquerySelector(?:All)?\b|\baddEventListener\b/);
   assert.equal(
     appSource.match(/\bbindSettingsPanelEvents\b/g)?.length,
     4);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -241,6 +241,19 @@ const commandBarSource = readFileSync(
   new URL("../src/command-bar.ts", import.meta.url),
   "utf8");
 
+function startsRegexLiteral(source, index) {
+  if (source[index + 1] === "=") return false;
+  let cursor = index - 1;
+  while (cursor >= 0 && /\s/.test(source[cursor])) cursor--;
+  if (cursor < 0) return true;
+  if ("([{=,:;!&|?+-*%^~<>".includes(source[cursor])) return true;
+  const wordEnd = cursor + 1;
+  while (cursor >= 0 && /[$\w]/.test(source[cursor])) cursor--;
+  const word = source.slice(cursor + 1, wordEnd);
+  return /^(?:await|case|delete|in|instanceof|of|return|throw|typeof|void|yield)$/
+    .test(word);
+}
+
 function maskNonCode(source) {
   const masked = [...source];
   for (let index = 0; index < source.length; index++) {
@@ -258,6 +271,26 @@ function maskNonCode(source) {
       masked[index] = " ";
       masked[index + 1] = " ";
       index++;
+    } else if (quote === "/" && startsRegexLiteral(source, index)) {
+      masked[index] = " ";
+      let inCharacterClass = false;
+      for (index++; index < source.length; index++) {
+        masked[index] = " ";
+        if (source[index] === "\\") {
+          masked[++index] = " ";
+        } else if (source[index] === "[") {
+          inCharacterClass = true;
+        } else if (source[index] === "]") {
+          inCharacterClass = false;
+        } else if (source[index] === "/" && !inCharacterClass) {
+          while (/[A-Za-z]/.test(source[index + 1] ?? "")) {
+            masked[++index] = " ";
+          }
+          break;
+        } else if (source[index] === "\n") {
+          break;
+        }
+      }
     } else if (quote === "\"" || quote === "'" || quote === "`") {
       masked[index] = " ";
       for (index++; index < source.length; index++) {
@@ -305,10 +338,12 @@ function assertDirectCompositionCall(
 test("composition call gates distinguish direct calls from textual nesting", () => {
   const direct = `function bind() {
     const options = { label: "{ready}" };
+    const pattern = /[{};]/g;
+    const quotient = 8 / 2;
     // A brace in a comment is not composition.
     bindTarget();
   }`;
-  assertDirectCompositionCall(direct, "bind", "bindTarget", 1);
+  assertDirectCompositionCall(direct, "bind", "bindTarget", 3);
   assert.throws(() =>
     assertDirectCompositionCall(
       "function bind() { if (false) bindTarget(); }",
@@ -321,6 +356,12 @@ test("composition call gates distinguish direct calls from textual nesting", () 
       "bind",
       "bindTarget",
       0));
+  assert.throws(() =>
+    assertDirectCompositionCall(
+      "function bind() { if (false) { /}/; bindTarget(); } }",
+      "bind",
+      "bindTarget",
+      1));
   assert.throws(() =>
     assertDirectCompositionCall(
       "function bind() { if (false) return; bindTarget(); }",
@@ -614,9 +655,6 @@ test("typed settings panel owns its rendered control bindings", () => {
   const bindEvents =
     appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
     ?? "";
-  const bindHomeEvents =
-    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\n\/\/ The two package demos)/)?.[0]
-    ?? "";
   assert.match(
     binding,
     /bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onOpen: openSettings,\s*onTasteClear: clearTaste,\s*onTasteOpenToggle: \(\) => \{[\s\S]*state\.tasteOpen = !state\.tasteOpen;[\s\S]*render\(\);[\s\S]*\},\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,/);
@@ -648,11 +686,11 @@ test("typed settings panel owns its rendered control bindings", () => {
     settingsPanelSource,
     /export function bindSettingsPanel\([\s\S]*#settings-close[\s\S]*#home-settings[\s\S]*#open-settings[\s\S]*#taste-btn[\s\S]*stopPropagation\(\)[\s\S]*\.settings-seg\[data-theme\][\s\S]*\.settings-taste \[data-taste\][\s\S]*#settings-taste-clear[\s\S]*#taste-popover \[data-taste\][\s\S]*#taste-clear/);
   assert.doesNotMatch(
-    bindEvents,
-    /querySelector\("#(?:open-settings|taste-btn)"\)/);
+    appSource,
+    /querySelector\("#(?:home-settings|open-settings)"\)/);
   assert.doesNotMatch(
-    bindHomeEvents,
-    /querySelector\("#home-settings"\)/);
+    bindEvents,
+    /querySelector\("#taste-btn"\)/);
   for (const selector of [
     "#settings-close",
     ".settings-seg[data-theme]",

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -241,135 +241,6 @@ const commandBarSource = readFileSync(
   new URL("../src/command-bar.ts", import.meta.url),
   "utf8");
 
-function startsRegexLiteral(source, index) {
-  if (source[index + 1] === "=") return false;
-  let cursor = index - 1;
-  while (cursor >= 0 && /\s/.test(source[cursor])) cursor--;
-  if (cursor < 0) return true;
-  if ("([{=,:;!&|?+-*%^~<>".includes(source[cursor])) return true;
-  const wordEnd = cursor + 1;
-  while (cursor >= 0 && /[$\w]/.test(source[cursor])) cursor--;
-  const word = source.slice(cursor + 1, wordEnd);
-  return /^(?:await|case|delete|in|instanceof|of|return|throw|typeof|void|yield)$/
-    .test(word);
-}
-
-function maskNonCode(source) {
-  const masked = [...source];
-  for (let index = 0; index < source.length; index++) {
-    const quote = source[index];
-    if (quote === "/" && source[index + 1] === "/") {
-      while (index < source.length && source[index] !== "\n") {
-        masked[index++] = " ";
-      }
-    } else if (quote === "/" && source[index + 1] === "*") {
-      masked[index++] = " ";
-      while (index < source.length
-        && !(source[index] === "*" && source[index + 1] === "/")) {
-        masked[index++] = " ";
-      }
-      masked[index] = " ";
-      masked[index + 1] = " ";
-      index++;
-    } else if (quote === "/" && startsRegexLiteral(source, index)) {
-      masked[index] = " ";
-      let inCharacterClass = false;
-      for (index++; index < source.length; index++) {
-        masked[index] = " ";
-        if (source[index] === "\\") {
-          masked[++index] = " ";
-        } else if (source[index] === "[") {
-          inCharacterClass = true;
-        } else if (source[index] === "]") {
-          inCharacterClass = false;
-        } else if (source[index] === "/" && !inCharacterClass) {
-          while (/[A-Za-z]/.test(source[index + 1] ?? "")) {
-            masked[++index] = " ";
-          }
-          break;
-        } else if (source[index] === "\n") {
-          break;
-        }
-      }
-    } else if (quote === "\"" || quote === "'" || quote === "`") {
-      masked[index] = " ";
-      for (index++; index < source.length; index++) {
-        masked[index] = " ";
-        if (source[index] === "\\") {
-          masked[++index] = " ";
-        } else if (source[index] === quote) {
-          break;
-        }
-      }
-    }
-  }
-  return masked.join("");
-}
-
-function assertDirectCompositionCall(
-  source,
-  functionName,
-  calleeName,
-  expectedIndex,
-) {
-  const functionPrefix = `function ${functionName}() {`;
-  const functionStart = source.indexOf(functionPrefix);
-  assert.notEqual(functionStart, -1);
-  const body = source.slice(functionStart + functionPrefix.length);
-  const masked = maskNonCode(body);
-  const statements = [];
-  let depth = 0;
-  let statementStart = 0;
-  for (let index = 0; index < masked.length; index++) {
-    if (masked[index] === "{") depth++;
-    else if (masked[index] === "}") {
-      if (depth === 0) break;
-      depth--;
-    } else if (masked[index] === ";" && depth === 0) {
-      statements.push(masked.slice(statementStart, index + 1).trim());
-      statementStart = index + 1;
-    }
-  }
-  assert.equal(
-    statements[expectedIndex].replace(/\s+/g, " "),
-    `${calleeName}();`);
-}
-
-test("composition call gates distinguish direct calls from textual nesting", () => {
-  const direct = `function bind() {
-    const options = { label: "{ready}" };
-    const pattern = /[{};]/g;
-    const quotient = 8 / 2;
-    // A brace in a comment is not composition.
-    bindTarget();
-  }`;
-  assertDirectCompositionCall(direct, "bind", "bindTarget", 3);
-  assert.throws(() =>
-    assertDirectCompositionCall(
-      "function bind() { if (false) bindTarget(); }",
-      "bind",
-      "bindTarget",
-      0));
-  assert.throws(() =>
-    assertDirectCompositionCall(
-      "function bind() { if (false) { bindTarget(); } }",
-      "bind",
-      "bindTarget",
-      0));
-  assert.throws(() =>
-    assertDirectCompositionCall(
-      "function bind() { if (false) { /}/; bindTarget(); } }",
-      "bind",
-      "bindTarget",
-      1));
-  assert.throws(() =>
-    assertDirectCompositionCall(
-      "function bind() { if (false) return; bindTarget(); }",
-      "bind",
-      "bindTarget",
-      0));
-});
-
 test("typed Spotlight owns search presentation and hosts commands", () => {
   assert.match(
     appSource,
@@ -417,16 +288,12 @@ test("typed status bar owns its rendered toggle binding", () => {
     statusBarSource,
     /export function bindStatusBar\([\s\S]*\[data-status-bar-toggle-button\][\s\S]*actions\.onToggle/);
   assert.doesNotMatch(appSource, /\[data-status-bar-toggle-button\]/);
-  assertDirectCompositionCall(
+  assert.match(
     appSource,
-    "bindEvents",
-    "bindStatusBarEvents",
-    0);
-  assertDirectCompositionCall(
+    /function bindEvents\(\) \{\s*bindStatusBarEvents\(\);/);
+  assert.match(
     appSource,
-    "bindHomeEvents",
-    "bindStatusBarEvents",
-    0);
+    /function bindHomeEvents\(\) \{\s*bindStatusBarEvents\(\);/);
   assert.equal(
     appSource.match(/\bbindStatusBarEvents\(\)/g)?.length,
     3);
@@ -581,11 +448,9 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.equal(
     rootEventBinder.match(/^\s*bindTypePanelEvents\(\);$/gm)?.length,
     1);
-  assertDirectCompositionCall(
+  assert.match(
     appSource,
-    "bindEvents",
-    "bindTypePanelEvents",
-    2);
+    /function bindEvents\(\) \{\s*bindStatusBarEvents\(\);\s*packageBar\.bind\(document\);\s*bindTypePanelEvents\(\);/);
   assert.match(
     typePanelSource,
     /export function bindTypePanel\([\s\S]*\[data-type\][\s\S]*\[data-namespace\][\s\S]*\[data-kind-filter\][\s\S]*\[data-nav-member\][\s\S]*\[data-nav-overload\][\s\S]*#nav-to-types[\s\S]*#clear-filter[\s\S]*#namespace-jump[\s\S]*#type-list[\s\S]*#type-filter/);
@@ -652,9 +517,6 @@ test("typed settings panel owns its rendered control bindings", () => {
   const binding =
     appSource.match(/function bindSettingsPanelEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction bindPackageOpportunitiesEvents)/)?.[0]
     ?? "";
-  const bindEvents =
-    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
-    ?? "";
   assert.match(
     binding,
     /bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onOpen: openSettings,\s*onTasteClear: clearTaste,\s*onTasteOpenToggle: \(\) => \{[\s\S]*state\.tasteOpen = !state\.tasteOpen;[\s\S]*render\(\);[\s\S]*\},\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,/);
@@ -667,30 +529,32 @@ test("typed settings panel owns its rendered control bindings", () => {
   assert.equal(
     appSource.match(/\bbindSettingsPanel\b/g)?.length,
     2);
-  assertDirectCompositionCall(
+  assert.match(
     appSource,
-    "bindEvents",
-    "bindSettingsPanelEvents",
-    4);
-  assertDirectCompositionCall(
+    /function bindEvents\(\) \{\s*bindStatusBarEvents\(\);\s*packageBar\.bind\(document\);\s*bindTypePanelEvents\(\);\s*bindScopeBarEvents\(\);\s*bindSettingsPanelEvents\(\);/);
+  assert.match(
     appSource,
-    "renderSettingsViewHtml",
-    "bindSettingsPanelEvents",
-    1);
-  assertDirectCompositionCall(
+    /function bindHomeEvents\(\) \{\s*bindStatusBarEvents\(\);\s*bindSettingsPanelEvents\(\);/);
+  assert.match(
     appSource,
-    "bindHomeEvents",
-    "bindSettingsPanelEvents",
-    1);
+    /function renderSettingsViewHtml\(\) \{[\s\S]*\n  bindSettingsPanelEvents\(\);\n}\n\nfunction renderGraphSource\(/);
   assert.match(
     settingsPanelSource,
     /export function bindSettingsPanel\([\s\S]*#settings-close[\s\S]*#home-settings[\s\S]*#open-settings[\s\S]*#taste-btn[\s\S]*stopPropagation\(\)[\s\S]*\.settings-seg\[data-theme\][\s\S]*\.settings-taste \[data-taste\][\s\S]*#settings-taste-clear[\s\S]*#taste-popover \[data-taste\][\s\S]*#taste-clear/);
-  assert.doesNotMatch(
-    appSource,
-    /querySelector\("#(?:home-settings|open-settings)"\)/);
-  assert.doesNotMatch(
-    bindEvents,
-    /querySelector\("#taste-btn"\)/);
+  const entrySelectorAccess =
+    /(?:querySelector(?:All)?(?:<[^>\n]+>)?|getElementById)\(\s*["']#?(?:home-settings|open-settings|taste-btn)["']\s*\)/g;
+  assert.equal(appSource.match(entrySelectorAccess)?.length ?? 0, 0);
+  assert.equal(settingsPanelSource.match(entrySelectorAccess)?.length, 3);
+  for (const selector of ["#home-settings", "#open-settings"]) {
+    assert.equal(appSource.split(`"${selector}"`).length - 1, 0, selector);
+    assert.equal(
+      settingsPanelSource.split(`"${selector}"`).length - 1,
+      1,
+      selector);
+  }
+  assert.equal(appSource.match(/["']#taste-btn["']/g)?.length, 1);
+  assert.equal(appSource.match(/\.closest\(["']#taste-btn["']\)/g)?.length, 1);
+  assert.equal(settingsPanelSource.match(/["']#taste-btn["']/g)?.length, 1);
   for (const selector of [
     "#settings-close",
     ".settings-seg[data-theme]",

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -522,6 +522,9 @@ test("typed scope bar owns its rendered control bindings", () => {
 });
 
 test("typed settings panel owns its rendered control bindings", () => {
+  assert.match(
+    appSource,
+    /import \{(?=[^}]*\bbindSettingsPanel,)[^}]*} from "\.\/settings-panel\.ts";/);
   const binding =
     appSource.match(
       /function bindSettingsPanelEvents\(\) \{\s*bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onOpen: openSettings,\s*onTasteClear: clearTaste,\s*onTasteOpenToggle: \(\) => \{\s*state\.tasteOpen = !state\.tasteOpen;\s*render\(\);\s*},\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,\s*}\);\s*}(?=\s*function bindPackageOpportunitiesEvents\(\))/)?.[0]
@@ -553,7 +556,7 @@ test("typed settings panel owns its rendered control bindings", () => {
     .map(({ source }) => source)
     .join("\n");
   const entrySelectorAccess =
-    /(?:querySelector(?:All)?(?:<[^>\n]+>)?|getElementById)\(\s*(["'`])#?(?:home-settings|open-settings|taste-btn)\1\s*\)/g;
+    /(?:querySelector(?:All)?\s*(?:<[^>\n]+>)?|getElementById)\s*\(\s*(["'`])#?(?:home-settings|open-settings|taste-btn)\1\s*\)/g;
   assert.equal(nonSettingsPanelSource.match(entrySelectorAccess)?.length ?? 0, 0);
   assert.equal(settingsPanelSource.match(entrySelectorAccess)?.length, 3);
   for (const selector of ["#home-settings", "#open-settings"]) {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -159,6 +160,13 @@ test("normalizing a history entry keeps its consumed position and later entries"
 });
 
 const appSource = readFileSync(new URL("../src/dotnet-inspect.ts", import.meta.url), "utf8");
+const sourceRoot = fileURLToPath(new URL("../src/", import.meta.url));
+const productionTypeScriptSources = readdirSync(sourceRoot, { recursive: true })
+  .filter(path => path.endsWith(".ts"))
+  .map(path => ({
+    path,
+    source: readFileSync(join(sourceRoot, path), "utf8"),
+  }));
 const workspaceNavigationSource = readFileSync(
   new URL("../src/workspace-navigation.ts", import.meta.url),
   "utf8");
@@ -537,24 +545,31 @@ test("typed settings panel owns its rendered control bindings", () => {
     /function bindHomeEvents\(\) \{\s*bindStatusBarEvents\(\);\s*bindSettingsPanelEvents\(\);/);
   assert.match(
     appSource,
-    /function renderSettingsViewHtml\(\) \{[\s\S]*\n  bindSettingsPanelEvents\(\);\n}\n\nfunction renderGraphSource\(/);
+    /function renderSettingsViewHtml\(\) \{\s*app\.innerHTML = renderSettingsView\(\{\s*theme: state\.theme,\s*settingsReturn: state\.settingsReturn,\s*styleCatalog: \{\s*styleTiers: state\.styleTiers,\s*styleOptions: state\.styleOptions,\s*styleCatalogError: state\.styleCatalogError,\s*taste: state\.taste,\s*},\s*escapeHtml,\s*}\);\s*bindSettingsPanelEvents\(\);\s*}\s*function renderGraphSource\(\)/);
   assert.match(
     settingsPanelSource,
     /export function bindSettingsPanel\([\s\S]*#settings-close[\s\S]*#home-settings[\s\S]*#open-settings[\s\S]*#taste-btn[\s\S]*stopPropagation\(\)[\s\S]*\.settings-seg\[data-theme\][\s\S]*\.settings-taste \[data-taste\][\s\S]*#settings-taste-clear[\s\S]*#taste-popover \[data-taste\][\s\S]*#taste-clear/);
+  const nonSettingsPanelSource = productionTypeScriptSources
+    .filter(({ path }) => path.replaceAll("\\", "/") !== "settings-panel.ts")
+    .map(({ source }) => source)
+    .join("\n");
   const entrySelectorAccess =
-    /(?:querySelector(?:All)?(?:<[^>\n]+>)?|getElementById)\(\s*["']#?(?:home-settings|open-settings|taste-btn)["']\s*\)/g;
-  assert.equal(appSource.match(entrySelectorAccess)?.length ?? 0, 0);
+    /(?:querySelector(?:All)?(?:<[^>\n]+>)?|getElementById)\(\s*(["'`])#?(?:home-settings|open-settings|taste-btn)\1\s*\)/g;
+  assert.equal(nonSettingsPanelSource.match(entrySelectorAccess)?.length ?? 0, 0);
   assert.equal(settingsPanelSource.match(entrySelectorAccess)?.length, 3);
   for (const selector of ["#home-settings", "#open-settings"]) {
-    assert.equal(appSource.split(`"${selector}"`).length - 1, 0, selector);
-    assert.equal(
-      settingsPanelSource.split(`"${selector}"`).length - 1,
-      1,
-      selector);
+    const literal = new RegExp(`(["'\`])${selector}\\1`, "g");
+    assert.equal(nonSettingsPanelSource.match(literal)?.length ?? 0, 0, selector);
+    assert.equal(settingsPanelSource.match(literal)?.length, 1, selector);
   }
-  assert.equal(appSource.match(/["']#taste-btn["']/g)?.length, 1);
-  assert.equal(appSource.match(/\.closest\(["']#taste-btn["']\)/g)?.length, 1);
-  assert.equal(settingsPanelSource.match(/["']#taste-btn["']/g)?.length, 1);
+  assert.equal(
+    nonSettingsPanelSource.match(/(["'`])#taste-btn\1/g)?.length,
+    1);
+  assert.equal(
+    nonSettingsPanelSource.match(
+      /\.closest\(\s*(["'`])#taste-btn\1\s*\)/g)?.length,
+    1);
+  assert.equal(settingsPanelSource.match(/(["'`])#taste-btn\1/g)?.length, 1);
   for (const selector of [
     "#settings-close",
     ".settings-seg[data-theme]",

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -614,9 +614,6 @@ test("typed settings panel owns its rendered control bindings", () => {
   const bindEvents =
     appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
     ?? "";
-  const renderSettings =
-    appSource.match(/function renderSettingsViewHtml\(\) \{[\s\S]*?\n}\n\nfunction renderGraphSource/)?.[0]
-    ?? "";
   const bindHomeEvents =
     appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\n\/\/ The two package demos)/)?.[0]
     ?? "";
@@ -632,14 +629,20 @@ test("typed settings panel owns its rendered control bindings", () => {
   assert.equal(
     appSource.match(/\bbindSettingsPanel\b/g)?.length,
     2);
-  assert.equal(
-    bindEvents.match(/\bbindSettingsPanelEvents\(\)/g)?.length,
+  assertDirectCompositionCall(
+    appSource,
+    "bindEvents",
+    "bindSettingsPanelEvents",
+    4);
+  assertDirectCompositionCall(
+    appSource,
+    "renderSettingsViewHtml",
+    "bindSettingsPanelEvents",
     1);
-  assert.equal(
-    renderSettings.match(/\bbindSettingsPanelEvents\(\)/g)?.length,
-    1);
-  assert.equal(
-    bindHomeEvents.match(/\bbindSettingsPanelEvents\(\)/g)?.length,
+  assertDirectCompositionCall(
+    appSource,
+    "bindHomeEvents",
+    "bindSettingsPanelEvents",
     1);
   assert.match(
     settingsPanelSource,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -614,12 +614,15 @@ test("typed settings panel owns its rendered control bindings", () => {
   const renderSettings =
     appSource.match(/function renderSettingsViewHtml\(\) \{[\s\S]*?\n}\n\nfunction renderGraphSource/)?.[0]
     ?? "";
+  const bindHomeEvents =
+    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    ?? "";
   assert.match(
     appSource,
-    /function bindSettingsPanelEvents\(\) \{\s*bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onTasteClear: clearTaste,\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,/);
+    /function bindSettingsPanelEvents\(\) \{\s*bindSettingsPanel\(document, \{\s*onClose: closeSettings,\s*onOpen: openSettings,\s*onTasteClear: clearTaste,\s*onTasteOpenToggle: \(\) => \{[\s\S]*state\.tasteOpen = !state\.tasteOpen;[\s\S]*render\(\);[\s\S]*\},\s*onTasteToggle: toggleTaste,\s*onThemeSelect: setTheme,/);
   assert.equal(
     appSource.match(/\bbindSettingsPanelEvents\b/g)?.length,
-    3);
+    4);
   assert.equal(
     appSource.match(/\bbindSettingsPanel\b/g)?.length,
     2);
@@ -629,9 +632,18 @@ test("typed settings panel owns its rendered control bindings", () => {
   assert.equal(
     renderSettings.match(/\bbindSettingsPanelEvents\(\)/g)?.length,
     1);
+  assert.equal(
+    bindHomeEvents.match(/\bbindSettingsPanelEvents\(\)/g)?.length,
+    1);
   assert.match(
     settingsPanelSource,
-    /export function bindSettingsPanel\([\s\S]*#settings-close[\s\S]*\.settings-seg\[data-theme\][\s\S]*\.settings-taste \[data-taste\][\s\S]*#settings-taste-clear[\s\S]*#taste-popover \[data-taste\][\s\S]*#taste-clear/);
+    /export function bindSettingsPanel\([\s\S]*#settings-close[\s\S]*#home-settings[\s\S]*#open-settings[\s\S]*#taste-btn[\s\S]*stopPropagation\(\)[\s\S]*\.settings-seg\[data-theme\][\s\S]*\.settings-taste \[data-taste\][\s\S]*#settings-taste-clear[\s\S]*#taste-popover \[data-taste\][\s\S]*#taste-clear/);
+  assert.doesNotMatch(
+    bindEvents,
+    /querySelector\("#(?:open-settings|taste-btn)"\)/);
+  assert.doesNotMatch(
+    bindHomeEvents,
+    /querySelector\("#home-settings"\)/);
   for (const selector of [
     "#settings-close",
     ".settings-seg[data-theme]",


### PR DESCRIPTION
Moves home/workbench Settings entry and the taste-popover entry control into the existing settings-panel binder while preserving settings/taste state and render effects in the composition root.

**Stack**
- Issue: #4504
- Slice: 21
- Parent: #4529
- Base branch: `feature/4504-member-filter-event-binding`

**Behavioral claim**
- `settings-panel.ts` owns `#home-settings`, `#open-settings`, and `#taste-btn` DOM dispatch in addition to its existing panel/popover controls.
- Home/workbench origins remain distinct, taste clicks still stop propagation, and binding performs no eager work.
- The root retains settings return state, taste-open polarity, localStorage effects, and rendering.

**Evidence**
- `npm test` — 428/428 passed
- `npm run build`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

**Non-action boundary / residual**
This does not move settings/taste state, persistence, global Escape/outside-click dismissal, theme effects, rendering, or unrelated home/workbench controls.