### PR TITLE
Extract member navigation event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -647,7 +647,8 @@ Symbol/PDB acquisition status is not yet surfaced here — no backend contract
 reports it today — and is a tracked fast-follow.
 
 `src/type-panel.ts` owns the type selector (the "PUBLIC TYPES" / "MEMBERS" nav
-pane), its rendered DOM control bindings (including member filters), and the
+pane), its rendered DOM control bindings (including member filters,
+composition jumps, member navigation, and member/type copy controls), and the
 type viewer (the type heading, metadata, and source sections shown for the
 "type" scope).
 `dotnet-inspect.ts` still owns the type index, filtering, member grouping, and

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3641,6 +3641,11 @@ function bindTypePanelEvents() {
     }
     renderWithMemberFocus(preserved);
   };
+  const enterMemberNavigation = (action: () => void) => {
+    const focusGeneration = beginSpotlightNavigation();
+    action();
+    focusTypeList(focusGeneration);
+  };
   bindTypePanel(document, {
     onClearFilters: () => {
       state.typeFilter = "";
@@ -3650,6 +3655,41 @@ function bindTypePanelEvents() {
       state.accessibilityFilter = defaultAccessibilityFilter(state.package);
       render();
       focusFilter();
+    },
+    onCopyAnchor: async anchor => {
+      const type = selectedType();
+      const member = selectedMember(type);
+      const overload = member?.overloads[state.selectedOverloadIndex ?? 0];
+      const values = {
+        selector: overload?.stableSelector,
+        digest: overload?.anchorDigest,
+        canonical: overload?.canonicalSignature
+      };
+      const value = anchor ? values[anchor] : undefined;
+      if (value) await copyText(value, `${anchor} copied`);
+    },
+    onCopyMemberSource: async () => {
+      if (state.memberSource)
+        await copyText(state.memberSource.text, "source copied");
+    },
+    onCopyName: async () => {
+      const type = selectedType();
+      if (!type) return;
+      const typeName = `${type.namespace ? `${type.namespace}.` : ""}${type.name}`;
+      const member = selectedMember(type);
+      const fullName = member ? `${typeName}.${member.name}` : typeName;
+      await copyText(fullName, "name copied");
+    },
+    onCopySignature: async () => {
+      const type = selectedType();
+      const member = selectedMember(type);
+      const overload = member?.overloads[state.selectedOverloadIndex ?? 0];
+      if (overload)
+        await copyText(overload.signature, "signature copied");
+    },
+    onCopyTypeSource: async () => {
+      if (state.typeSource)
+        await copyText(state.typeSource.text, "source copied");
     },
     onKindSelect: kind => {
       state.kindFilter = kind;
@@ -3666,6 +3706,31 @@ function bindTypePanelEvents() {
       state.memberAccessibilityFilter = value ?? "all";
       normalizeMemberSelection();
       renderMemberFilterAndRestoreFocus();
+    },
+    onMemberBack: drillOut,
+    onMemberCompositionAccessibilitySelect: value => {
+      enterMemberNavigation(() => {
+        resetMemberFilters();
+        state.memberAccessibilityFilter = value;
+        enterMemberScope();
+        render();
+      });
+    },
+    onMemberCompositionKindSelect: value => {
+      enterMemberNavigation(() => {
+        resetMemberFilters();
+        state.memberKindFilter = value;
+        enterMemberScope();
+        render();
+      });
+    },
+    onMemberCompositionTraitSelect: value => {
+      enterMemberNavigation(() => {
+        resetMemberFilters();
+        state.memberTraitFilter = value;
+        enterMemberScope();
+        render();
+      });
     },
     onMemberFilterChange: value => {
       state.memberTextFilter = value;
@@ -3693,11 +3758,15 @@ function bindTypePanelEvents() {
       event.preventDefault();
       stepMemberNav(event.key === "ArrowDown" ? 1 : -1, true);
     },
+    onMemberGroupOpen: memberKey => {
+      enterMemberNavigation(() => openMemberGroup(memberKey));
+    },
     onMemberKindFilterSelect: value => {
       state.memberKindFilter = value ?? "all";
       normalizeMemberSelection();
       renderMemberFilterAndRestoreFocus();
     },
+    onMemberOverloadOpen: openOverload,
     onMemberSelect: memberKey => {
       const group = memberGroups(selectedType())
         .find(item => item.key === memberKey);
@@ -3948,77 +4017,6 @@ function bindEvents() {
       button.dataset.perfAssembly ?? "",
       button.dataset.perfType ?? "");
   }));
-  const enterMemberNavigation = (action: () => void) => {
-    const focusGeneration = beginSpotlightNavigation();
-    action();
-    focusTypeList(focusGeneration);
-  };
-  document.querySelectorAll<HTMLElement>("[data-member-jump-kind]").forEach(button => button.addEventListener("click", () => {
-    enterMemberNavigation(() => {
-      resetMemberFilters();
-      state.memberKindFilter = button.dataset.memberJumpKind ?? "all";
-      enterMemberScope();
-      render();
-    });
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member-jump-access]").forEach(button => button.addEventListener("click", () => {
-    enterMemberNavigation(() => {
-      resetMemberFilters();
-      state.memberAccessibilityFilter = button.dataset.memberJumpAccess ?? "all";
-      enterMemberScope();
-      render();
-    });
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member-jump-trait]").forEach(button => button.addEventListener("click", () => {
-    enterMemberNavigation(() => {
-      resetMemberFilters();
-      state.memberTraitFilter = button.dataset.memberJumpTrait ?? "";
-      enterMemberScope();
-      render();
-    });
-  }));
-  document.querySelectorAll<HTMLElement>("[data-member]").forEach(button => button.addEventListener("click", () => {
-    enterMemberNavigation(() => openMemberGroup(button.dataset.member ?? ""));
-  }));
-  document.querySelectorAll<HTMLElement>("[data-overload]").forEach(button => button.addEventListener("click", () => {
-    openOverload(Number(button.dataset.overload));
-  }));
-  document.querySelector("#member-back")?.addEventListener("click", () => {
-    drillOut();
-  });
-  document.querySelector("#copy-name")?.addEventListener("click", async () => {
-    const type = selectedType();
-    if (!type) return;
-    const typeName = `${type.namespace ? `${type.namespace}.` : ""}${type.name}`;
-    const member = selectedMember(type);
-    const fullName = member ? `${typeName}.${member.name}` : typeName;
-    await copyText(fullName, "name copied");
-  });
-  document.querySelector("#copy-signature")?.addEventListener("click", async () => {
-    const type = selectedType();
-    const member = selectedMember(type);
-    const overload = member?.overloads[state.selectedOverloadIndex ?? 0];
-    if (overload) await copyText(overload.signature, "signature copied");
-  });
-  document.querySelectorAll<HTMLElement>("[data-copy-anchor]").forEach(button => button.addEventListener("click", async () => {
-    const type = selectedType();
-    const member = selectedMember(type);
-    const overload = member?.overloads[state.selectedOverloadIndex ?? 0];
-    const values = {
-      selector: overload?.stableSelector,
-      digest: overload?.anchorDigest,
-      canonical: overload?.canonicalSignature
-    };
-    const anchor = button.dataset.copyAnchor as keyof typeof values | undefined;
-    const value = anchor ? values[anchor] : undefined;
-    if (value) await copyText(value, `${anchor} copied`);
-  }));
-  document.querySelector("#copy-source")?.addEventListener("click", async () => {
-    if (state.memberSource) await copyText(state.memberSource.text, "source copied");
-  });
-  document.querySelector("#copy-type-source")?.addEventListener("click", async () => {
-    if (state.typeSource) await copyText(state.typeSource.text, "source copied");
-  });
   document.querySelectorAll<HTMLElement>("[data-library-chip]").forEach(button => button.addEventListener("click", () => {
     toggleLibraryChip(button.dataset.libraryChip ?? "");
     afterLibraryScopeChange();

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -81,13 +81,26 @@ type EscapeHtml = (value: unknown) => string;
 
 export interface TypePanelBindingActions {
   onClearFilters: () => void;
+  onCopyAnchor: (
+    anchor: "selector" | "digest" | "canonical" | undefined,
+  ) => void | Promise<void>;
+  onCopyMemberSource: () => void | Promise<void>;
+  onCopyName: () => void | Promise<void>;
+  onCopySignature: () => void | Promise<void>;
+  onCopyTypeSource: () => void | Promise<void>;
   onKindSelect: (kind: string) => void;
   onListKeyDown: (event: KeyboardEvent) => void;
   onMemberAccessibilityFilterSelect: (accessibility: string | undefined) => void;
+  onMemberBack: () => void;
+  onMemberCompositionAccessibilitySelect: (accessibility: string) => void;
+  onMemberCompositionKindSelect: (kind: string) => void;
+  onMemberCompositionTraitSelect: (trait: string) => void;
   onMemberFilterChange: (value: string) => void;
   onMemberFilterClear: () => void;
   onMemberFilterKeyDown: (event: KeyboardEvent) => void;
+  onMemberGroupOpen: (memberKey: string) => void;
   onMemberKindFilterSelect: (kind: string | undefined) => void;
+  onMemberOverloadOpen: (index: number) => void;
   onMemberSelect: (memberKey: string | undefined) => void;
   onMemberTraitFilterSelect: (trait: string | undefined) => void;
   onNamespaceSelect: (namespace: string) => void;
@@ -122,6 +135,32 @@ export function bindTypePanel(
     button.addEventListener(
       "click",
       () => actions.onOverloadSelect(Number(button.dataset.navOverload))));
+  root.querySelectorAll<HTMLElement>("[data-member-jump-kind]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberCompositionKindSelect(
+          button.dataset.memberJumpKind ?? "all")));
+  root.querySelectorAll<HTMLElement>("[data-member-jump-access]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberCompositionAccessibilitySelect(
+          button.dataset.memberJumpAccess ?? "all")));
+  root.querySelectorAll<HTMLElement>("[data-member-jump-trait]")
+    .forEach(button =>
+      button.addEventListener(
+        "click",
+        () => actions.onMemberCompositionTraitSelect(
+          button.dataset.memberJumpTrait ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-member]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onMemberGroupOpen(button.dataset.member ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-overload]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onMemberOverloadOpen(Number(button.dataset.overload))));
   root.querySelectorAll<HTMLElement>("[data-member-kind-filter]")
     .forEach(button =>
       button.addEventListener(
@@ -149,6 +188,29 @@ export function bindTypePanel(
   root.querySelector("#clear-member-filter")?.addEventListener(
     "click",
     actions.onMemberFilterClear);
+  root.querySelector("#member-back")?.addEventListener(
+    "click",
+    actions.onMemberBack);
+  root.querySelector("#copy-name")?.addEventListener(
+    "click",
+    actions.onCopyName);
+  root.querySelector("#copy-signature")?.addEventListener(
+    "click",
+    actions.onCopySignature);
+  root.querySelectorAll<HTMLElement>("[data-copy-anchor]").forEach(button =>
+    button.addEventListener("click", () => {
+      const anchor = button.dataset.copyAnchor;
+      void actions.onCopyAnchor(
+        anchor === "selector" || anchor === "digest" || anchor === "canonical"
+          ? anchor
+          : undefined);
+    }));
+  root.querySelector("#copy-source")?.addEventListener(
+    "click",
+    actions.onCopyMemberSource);
+  root.querySelector("#copy-type-source")?.addEventListener(
+    "click",
+    actions.onCopyTypeSource);
 
   const namespaceJump =
     root.querySelector<HTMLSelectElement>("#namespace-jump");

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -465,12 +465,51 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.match(
     typePanelSource,
     /\[data-member-kind-filter\][\s\S]*\[data-member-access-filter\][\s\S]*\[data-member-trait-filter\][\s\S]*#clear-member-filter[\s\S]*#member-filter/);
+  assert.match(
+    typePanelSource,
+    /\[data-member-jump-kind\][\s\S]*\[data-member-jump-access\][\s\S]*\[data-member-jump-trait\][\s\S]*\[data-member\][\s\S]*\[data-overload\][\s\S]*#member-back[\s\S]*#copy-name[\s\S]*#copy-signature[\s\S]*\[data-copy-anchor\][\s\S]*#copy-source[\s\S]*#copy-type-source/);
   assert.doesNotMatch(
     appSource,
     /document\.querySelectorAll<HTMLElement>\("\[data-member-(?:kind|access|trait)-filter\]"\)/);
   assert.doesNotMatch(
     appSource,
     /document\.querySelector(?:<HTMLInputElement>)?\("#(?:member-filter|clear-member-filter)"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelectorAll<HTMLElement>\("\[data-(?:member-jump-(?:kind|access|trait)|member|overload|copy-anchor)\]"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelector\("#(?:member-back|copy-name|copy-signature|copy-source|copy-type-source)"\)/);
+  assert.match(
+    binding,
+    /const enterMemberNavigation = \(action: \(\) => void\) => \{[\s\S]*beginSpotlightNavigation\(\);[\s\S]*action\(\);[\s\S]*focusTypeList\(focusGeneration\)/);
+  assert.match(
+    binding,
+    /onMemberCompositionKindSelect: value => \{[\s\S]*resetMemberFilters\(\);[\s\S]*state\.memberKindFilter = value;[\s\S]*enterMemberScope\(\);[\s\S]*render\(\)/);
+  assert.match(
+    binding,
+    /onMemberCompositionAccessibilitySelect: value => \{[\s\S]*resetMemberFilters\(\);[\s\S]*state\.memberAccessibilityFilter = value;[\s\S]*enterMemberScope\(\);[\s\S]*render\(\)/);
+  assert.match(
+    binding,
+    /onMemberCompositionTraitSelect: value => \{[\s\S]*resetMemberFilters\(\);[\s\S]*state\.memberTraitFilter = value;[\s\S]*enterMemberScope\(\);[\s\S]*render\(\)/);
+  assert.match(
+    binding,
+    /onMemberGroupOpen: memberKey => \{\s*enterMemberNavigation\(\(\) => openMemberGroup\(memberKey\)\)/);
+  assert.match(
+    binding,
+    /onMemberBack: drillOut[\s\S]*onMemberOverloadOpen: openOverload/);
+  assert.match(
+    binding,
+    /onCopyName: async \(\) => \{[\s\S]*const fullName = member \? `\$\{typeName\}\.\$\{member\.name\}` : typeName;[\s\S]*copyText\(fullName, "name copied"\)/);
+  assert.match(
+    binding,
+    /onCopySignature: async \(\) => \{[\s\S]*copyText\(overload\.signature, "signature copied"\)/);
+  assert.match(
+    binding,
+    /onCopyAnchor: async anchor => \{[\s\S]*selector: overload\?\.stableSelector,[\s\S]*digest: overload\?\.anchorDigest,[\s\S]*canonical: overload\?\.canonicalSignature[\s\S]*copyText\(value, `\$\{anchor\} copied`\)/);
+  assert.match(
+    binding,
+    /onCopyMemberSource: async \(\) => \{[\s\S]*copyText\(state\.memberSource\.text, "source copied"\)[\s\S]*onCopyTypeSource: async \(\) => \{[\s\S]*copyText\(state\.typeSource\.text, "source copied"\)/);
   assert.match(
     binding,
     /onMemberFilterClear: \(\) => \{[\s\S]*resetMemberFilters\(\);[\s\S]*renderMemberFilterAndRestoreFocus\("#clear-member-filter"\)/);
@@ -1057,14 +1096,14 @@ test("shared member views retain scope and filter state", () => {
 
 test("member entry controls move focus into the resulting member navigation", () => {
   const bindings =
-    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    appSource.match(/function bindTypePanelEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
     ?? "";
   assert.match(
     bindings,
     /const enterMemberNavigation = \(action: \(\) => void\) => \{\s*const focusGeneration = beginSpotlightNavigation\(\);\s*action\(\);\s*focusTypeList\(focusGeneration\);/);
   assert.match(
     bindings,
-    /data-member-jump-kind[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*enterMemberScope\(\);[\s\S]*data-member-jump-access[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*data-member-jump-trait[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*data-member\]"\)\.forEach[\s\S]*enterMemberNavigation\(\(\) => openMemberGroup/);
+    /onMemberCompositionAccessibilitySelect: value => \{[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*enterMemberScope\(\);[\s\S]*onMemberCompositionKindSelect: value => \{[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*onMemberCompositionTraitSelect: value => \{[\s\S]*enterMemberNavigation\(\(\) => \{[\s\S]*onMemberGroupOpen: memberKey => \{[\s\S]*enterMemberNavigation\(\(\) => openMemberGroup/);
 });
 
 test("package tab selection resets type-specific member filters", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -483,15 +483,24 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.match(
     binding,
     /const enterMemberNavigation = \(action: \(\) => void\) => \{[\s\S]*beginSpotlightNavigation\(\);[\s\S]*action\(\);[\s\S]*focusTypeList\(focusGeneration\)/);
-  assert.match(
-    binding,
-    /onMemberCompositionKindSelect: value => \{[\s\S]*resetMemberFilters\(\);[\s\S]*state\.memberKindFilter = value;[\s\S]*enterMemberScope\(\);[\s\S]*render\(\)/);
-  assert.match(
-    binding,
-    /onMemberCompositionAccessibilitySelect: value => \{[\s\S]*resetMemberFilters\(\);[\s\S]*state\.memberAccessibilityFilter = value;[\s\S]*enterMemberScope\(\);[\s\S]*render\(\)/);
-  assert.match(
-    binding,
-    /onMemberCompositionTraitSelect: value => \{[\s\S]*resetMemberFilters\(\);[\s\S]*state\.memberTraitFilter = value;[\s\S]*enterMemberScope\(\);[\s\S]*render\(\)/);
+  const callbackSource = name =>
+    binding.match(
+      new RegExp(`    ${name}: [\\s\\S]*?(?=\\n    on[A-Z])`))?.[0]
+      ?? "";
+  for (const [name, stateField] of [
+    ["onMemberCompositionAccessibilitySelect", "memberAccessibilityFilter"],
+    ["onMemberCompositionKindSelect", "memberKindFilter"],
+    ["onMemberCompositionTraitSelect", "memberTraitFilter"],
+  ]) {
+    const source = callbackSource(name);
+    assert.match(
+      source,
+      new RegExp(
+        `enterMemberNavigation\\(\\(\\) => \\{[\\s\\S]*resetMemberFilters\\(\\);`
+        + `[\\s\\S]*state\\.${stateField} = value;`
+        + "[\\s\\S]*enterMemberScope\\(\\);[\\s\\S]*render\\(\\)"));
+    assert.equal(source.match(/\brender\(\)/g)?.length, 1);
+  }
   assert.match(
     binding,
     /onMemberGroupOpen: memberKey => \{\s*enterMemberNavigation\(\(\) => openMemberGroup\(memberKey\)\)/);

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -138,15 +138,39 @@ const jsonDocument: TypeSummary = {
 function recordingActions(calls: string[]): TypePanelBindingActions {
   return {
     onClearFilters: () => calls.push("clear"),
+    onCopyAnchor: value => {
+      calls.push(`copy-anchor:${value}`);
+    },
+    onCopyMemberSource: () => {
+      calls.push("copy-member-source");
+    },
+    onCopyName: () => {
+      calls.push("copy-name");
+    },
+    onCopySignature: () => {
+      calls.push("copy-signature");
+    },
+    onCopyTypeSource: () => {
+      calls.push("copy-type-source");
+    },
     onKindSelect: value => calls.push(`kind:${value}`),
     onListKeyDown: event => calls.push(`list:${event.key}`),
     onMemberAccessibilityFilterSelect: value =>
       calls.push(`member-access:${value}`),
+    onMemberBack: () => calls.push("member-back"),
+    onMemberCompositionAccessibilitySelect: value =>
+      calls.push(`member-jump-access:${value}`),
+    onMemberCompositionKindSelect: value =>
+      calls.push(`member-jump-kind:${value}`),
+    onMemberCompositionTraitSelect: value =>
+      calls.push(`member-jump-trait:${value}`),
     onMemberFilterChange: value => calls.push(`member-filter:${value}`),
     onMemberFilterClear: () => calls.push("member-filter-clear"),
     onMemberFilterKeyDown: event =>
       calls.push(`member-filter-key:${event.key}`),
+    onMemberGroupOpen: value => calls.push(`member-open:${value}`),
     onMemberKindFilterSelect: value => calls.push(`member-kind:${value}`),
+    onMemberOverloadOpen: value => calls.push(`member-overload:${value}`),
     onMemberSelect: value => calls.push(`member:${value}`),
     onMemberTraitFilterSelect: value => calls.push(`member-trait:${value}`),
     onNamespaceSelect: value => calls.push(`namespace:${value}`),
@@ -296,6 +320,77 @@ test("type panel bindings dispatch the rendered member navigation controls", () 
     "overload:0",
     "types",
     "list:Home",
+  ]);
+});
+
+test("type panel bindings dispatch member composition and detail controls", () => {
+  const root = new FakeRoot();
+  const jumpKind = new FakeElement({ memberJumpKind: "method" });
+  const defaultJumpKind = new FakeElement();
+  const jumpAccess = new FakeElement({ memberJumpAccess: "protected" });
+  const defaultJumpAccess = new FakeElement();
+  const jumpTrait = new FakeElement({ memberJumpTrait: "isStatic" });
+  const defaultJumpTrait = new FakeElement();
+  const member = new FakeElement({ member: "M:Parse" });
+  const defaultMember = new FakeElement();
+  const overload = new FakeElement({ overload: "2" });
+  const defaultOverload = new FakeElement();
+  const anchor = new FakeElement({ copyAnchor: "digest" });
+  const invalidAnchor = new FakeElement({ copyAnchor: "unknown" });
+  root.addAll("[data-member-jump-kind]", jumpKind, defaultJumpKind);
+  root.addAll("[data-member-jump-access]", jumpAccess, defaultJumpAccess);
+  root.addAll("[data-member-jump-trait]", jumpTrait, defaultJumpTrait);
+  root.addAll("[data-member]", member, defaultMember);
+  root.addAll("[data-overload]", overload, defaultOverload);
+  root.addAll("[data-copy-anchor]", anchor, invalidAnchor);
+  const back = root.add("#member-back", new FakeElement());
+  const copyName = root.add("#copy-name", new FakeElement());
+  const copySignature = root.add("#copy-signature", new FakeElement());
+  const copyMemberSource = root.add("#copy-source", new FakeElement());
+  const copyTypeSource = root.add("#copy-type-source", new FakeElement());
+  const calls: string[] = [];
+
+  bindTypePanel(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  jumpKind.dispatch("click");
+  defaultJumpKind.dispatch("click");
+  jumpAccess.dispatch("click");
+  defaultJumpAccess.dispatch("click");
+  jumpTrait.dispatch("click");
+  defaultJumpTrait.dispatch("click");
+  member.dispatch("click");
+  defaultMember.dispatch("click");
+  overload.dispatch("click");
+  defaultOverload.dispatch("click");
+  back.dispatch("click");
+  copyName.dispatch("click");
+  copySignature.dispatch("click");
+  anchor.dispatch("click");
+  invalidAnchor.dispatch("click");
+  copyMemberSource.dispatch("click");
+  copyTypeSource.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "member-jump-kind:method",
+    "member-jump-kind:all",
+    "member-jump-access:protected",
+    "member-jump-access:all",
+    "member-jump-trait:isStatic",
+    "member-jump-trait:",
+    "member-open:M:Parse",
+    "member-open:",
+    "member-overload:2",
+    "member-overload:NaN",
+    "member-back",
+    "copy-name",
+    "copy-signature",
+    "copy-anchor:digest",
+    "copy-anchor:undefined",
+    "copy-member-source",
+    "copy-type-source",
   ]);
 });
 


### PR DESCRIPTION
## Summary

- extend the typed type-panel binding owner across member composition jumps,
  group/overload navigation, back navigation, and member/type copy controls
- keep navigation, selection, clipboard, focus, and mutable application-state
  effects in `dotnet-inspect.ts` behind explicit callbacks
- gate selector decoding, malformed datasets, no eager dispatch, root callback
  semantics, sole selector ownership, and the production composition call site

## Stack

Slice 22 of the issue #4504 stack.

Parent: #4530

Residual after this slice: package/dependency/type jumps, platform/library
controls, shell/home/error controls, and graph interaction binding. Global
application keyboard and history coordination remain intentionally in the
composition root.

## Validation

- `npm test` - 429/429
- `npm run build`
- composition-jump render mutations killed by callback-bounded gates
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

Exact base: `dbebf2b51e5fe88817c07c3b3fb7a31174e88ade`
Exact head: `825de1759a99bf8c96969bd0015f6730cfa99696`

Part of #4504.