### PR TITLE
Extract package navigation event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -670,6 +670,13 @@ runtime pack — so the component acquires no engine or workspace authority.
 `test/package-bar.test.ts` gates tab markup, active/close state, escaping,
 open-package query parsing, and package selection dispatch.
 
+`src/package-view.ts` owns package-level dependency, overview, type-graph, and
+performance navigation bindings. `dotnet-inspect.ts` still owns package and
+filter state, in-place dependency updates, navigation effects, and member
+inspection effects behind typed callbacks. `test/package-view.test.ts` gates
+dataset decoding, missing values, replacement dependency-list binding, inactive
+surfaces, and no eager dispatch.
+
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM
 bindings and the home/workbench controls that open them. `dotnet-inspect.ts`

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -73,6 +73,11 @@ import {
   type PackagePerformance,
 } from "./package-inspection.ts";
 import {
+  bindPackageDependencyList,
+  bindPackageView,
+  type PackageViewBindingActions,
+} from "./package-view.ts";
+import {
   createSourceInspectionCoordinator,
   type GraphSourceRequest,
 } from "./source-inspection.ts";
@@ -2364,23 +2369,8 @@ function patchDependenciesGroup() {
       "active",
       Number(button.dataset.depGroup) === selectedGroupIndex));
   listSection.outerHTML = dependencyListSectionHtml(groups, selectedGroupIndex);
-  bindDependencyListHandlers();
+  bindPackageDependencyListEvents();
   renderDependencyGraph();
-}
-
-function bindDependencyListHandlers() {
-  document.querySelectorAll<HTMLElement>("[data-dep-open]").forEach(button => {
-    button.onclick = () => {
-      const key = button.dataset.depOpen;
-      if (key) switchToPackageForDependencies(key);
-    };
-  });
-  document.querySelectorAll<HTMLElement>("[data-dep-load]").forEach(button => {
-    button.onclick = () => {
-      const id = button.dataset.depLoad;
-      if (id) openDependencyPackage(id, button.dataset.depVersion || "");
-    };
-  });
 }
 
 function resolveDependenciesGroupIndex(
@@ -3623,6 +3613,74 @@ function highlightCSharp(value: unknown) {
   return escapeHtml(source);
 }
 
+const packageViewActions: PackageViewBindingActions = {
+  onDependencyGroupSelect: index => {
+    if (state.dependenciesGroupIndex === index) return;
+    state.dependenciesGroupIndex = index;
+    patchDependenciesGroup();
+  },
+  onDependencyLoad: openDependencyPackage,
+  onDependencyOpen: switchToPackageForDependencies,
+  onGraphTypeSelect: navigateToTypeByName,
+  onKindJump: kind => {
+    state.atPackageRoot = false;
+    state.kindFilter = kind;
+    state.namespaceFilter = "";
+    state.typeFilter = "";
+    state.selectedMemberKey = "";
+    state.memberBrowseTypeId = "";
+    resetMemberFilters();
+    state.typeCursor = 0;
+    const first = filteredTypes()[0];
+    if (first) state.selectedTypeId = first.id;
+    render();
+  },
+  onLibraryScopeSelect: (library, kind) => {
+    state.atPackageRoot = false;
+    if (!library) return;
+    state.libraryScope = new Set([library]);
+    if (state.package?.isRuntimePack)
+      recordPlatformRecent(library, platformPackForAssembly(library));
+    state.kindFilter = kind;
+    state.namespaceFilter = "";
+    state.typeFilter = "";
+    state.selectedMemberKey = "";
+    state.memberBrowseTypeId = "";
+    resetMemberFilters();
+    state.typeCursor = 0;
+    const first = filteredTypes()[0];
+    if (first) state.selectedTypeId = first.id;
+    render();
+  },
+  onNamespaceJump: namespace => {
+    state.atPackageRoot = false;
+    state.namespaceFilter = namespace;
+    state.kindFilter = "";
+    state.typeFilter = "";
+    state.selectedMemberKey = "";
+    state.memberBrowseTypeId = "";
+    resetMemberFilters();
+    state.typeCursor = 0;
+    const first = filteredTypes()[0];
+    if (first) state.selectedTypeId = first.id;
+    render();
+  },
+  onPerformanceMemberSelect: target => {
+    drillToPerfMember(
+      target.metadataToken,
+      target.assembly,
+      target.typeId);
+  },
+};
+
+function bindPackageViewEvents() {
+  bindPackageView(document, packageViewActions);
+}
+
+function bindPackageDependencyListEvents() {
+  bindPackageDependencyList(document, packageViewActions);
+}
+
 function bindStatusBarEvents() {
   bindStatusBar(document, {
     onToggle: () => {
@@ -3957,66 +4015,7 @@ function bindEvents() {
   bindGraphSourceEvents();
   bindDocViewerEvents();
   bindAnnotatedSourceEvents();
-  document.querySelectorAll<HTMLElement>("[data-dep-group]").forEach(button => button.addEventListener("click", () => {
-    const index = Number(button.dataset.depGroup);
-    if (state.dependenciesGroupIndex === index) return;
-    state.dependenciesGroupIndex = index;
-    patchDependenciesGroup();
-  }));
-  bindDependencyListHandlers();
-  document.querySelectorAll<HTMLElement>("[data-kind-jump]").forEach(button => button.addEventListener("click", () => {
-    state.atPackageRoot = false;
-    state.kindFilter = button.dataset.kindJump ?? "";
-    state.namespaceFilter = "";
-    state.typeFilter = "";
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    state.typeCursor = 0;
-    const first = filteredTypes()[0];
-    if (first) state.selectedTypeId = first.id;
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-namespace-jump]").forEach(button => button.addEventListener("click", () => {
-    state.atPackageRoot = false;
-    state.namespaceFilter = button.dataset.namespaceJump ?? "";
-    state.kindFilter = "";
-    state.typeFilter = "";
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    state.typeCursor = 0;
-    const first = filteredTypes()[0];
-    if (first) state.selectedTypeId = first.id;
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-lib-scope]").forEach(button => button.addEventListener("click", () => {
-    state.atPackageRoot = false;
-    const library = button.dataset.libScope;
-    if (!library) return;
-    state.libraryScope = new Set([library]);
-    if (state.package?.isRuntimePack)
-      recordPlatformRecent(library, platformPackForAssembly(library));
-    state.kindFilter = button.dataset.libKind || "";
-    state.namespaceFilter = "";
-    state.typeFilter = "";
-    state.selectedMemberKey = "";
-    state.memberBrowseTypeId = "";
-    resetMemberFilters();
-    state.typeCursor = 0;
-    const first = filteredTypes()[0];
-    if (first) state.selectedTypeId = first.id;
-    render();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-graph-type]").forEach(button => button.addEventListener("click", () => {
-    navigateToTypeByName(button.dataset.graphType ?? "");
-  }));
-  document.querySelectorAll<HTMLElement>("[data-perf-token]").forEach(button => button.addEventListener("click", () => {
-    drillToPerfMember(
-      button.dataset.perfToken ?? "",
-      button.dataset.perfAssembly ?? "",
-      button.dataset.perfType ?? "");
-  }));
+  bindPackageViewEvents();
   document.querySelectorAll<HTMLElement>("[data-library-chip]").forEach(button => button.addEventListener("click", () => {
     toggleLibraryChip(button.dataset.libraryChip ?? "");
     afterLibraryScopeChange();

--- a/prototypes/inspect-web/src/package-view.ts
+++ b/prototypes/inspect-web/src/package-view.ts
@@ -1,0 +1,79 @@
+// DOM bindings for package-level navigation surfaces. The application root owns
+// package, filter, graph, and inspection state transitions behind these callbacks.
+
+export interface PackageDependencyBindingActions {
+  onDependencyLoad: (id: string, version: string) => void;
+  onDependencyOpen: (packageKey: string) => void;
+}
+
+export interface PackagePerformanceTarget {
+  metadataToken: string;
+  assembly: string;
+  typeId: string;
+}
+
+export interface PackageViewBindingActions
+  extends PackageDependencyBindingActions {
+  onDependencyGroupSelect: (index: number) => void;
+  onGraphTypeSelect: (typeId: string) => void;
+  onKindJump: (kind: string) => void;
+  onLibraryScopeSelect: (
+    library: string | undefined,
+    kind: string,
+  ) => void;
+  onNamespaceJump: (namespace: string) => void;
+  onPerformanceMemberSelect: (target: PackagePerformanceTarget) => void;
+}
+
+export function bindPackageDependencyList(
+  root: ParentNode,
+  actions: PackageDependencyBindingActions,
+) {
+  root.querySelectorAll<HTMLElement>("[data-dep-open]").forEach(button =>
+    button.addEventListener("click", () => {
+      const key = button.dataset.depOpen;
+      if (key) actions.onDependencyOpen(key);
+    }));
+  root.querySelectorAll<HTMLElement>("[data-dep-load]").forEach(button =>
+    button.addEventListener("click", () => {
+      const id = button.dataset.depLoad;
+      if (id) {
+        actions.onDependencyLoad(id, button.dataset.depVersion || "");
+      }
+    }));
+}
+
+export function bindPackageView(
+  root: ParentNode,
+  actions: PackageViewBindingActions,
+) {
+  root.querySelectorAll<HTMLElement>("[data-dep-group]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onDependencyGroupSelect(Number(button.dataset.depGroup))));
+  bindPackageDependencyList(root, actions);
+  root.querySelectorAll<HTMLElement>("[data-kind-jump]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onKindJump(button.dataset.kindJump ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-namespace-jump]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onNamespaceJump(button.dataset.namespaceJump ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-lib-scope]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onLibraryScopeSelect(
+        button.dataset.libScope,
+        button.dataset.libKind || "")));
+  root.querySelectorAll<HTMLElement>("[data-graph-type]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onGraphTypeSelect(button.dataset.graphType ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-perf-token]").forEach(button =>
+    button.addEventListener("click", () => actions.onPerformanceMemberSelect({
+      metadataToken: button.dataset.perfToken ?? "",
+      assembly: button.dataset.perfAssembly ?? "",
+      typeId: button.dataset.perfType ?? "",
+    })));
+}

--- a/prototypes/inspect-web/src/package-view.ts
+++ b/prototypes/inspect-web/src/package-view.ts
@@ -30,17 +30,17 @@ export function bindPackageDependencyList(
   actions: PackageDependencyBindingActions,
 ) {
   root.querySelectorAll<HTMLElement>("[data-dep-open]").forEach(button =>
-    button.addEventListener("click", () => {
+    button.onclick = () => {
       const key = button.dataset.depOpen;
       if (key) actions.onDependencyOpen(key);
-    }));
+    });
   root.querySelectorAll<HTMLElement>("[data-dep-load]").forEach(button =>
-    button.addEventListener("click", () => {
+    button.onclick = () => {
       const id = button.dataset.depLoad;
       if (id) {
         actions.onDependencyLoad(id, button.dataset.depVersion || "");
       }
-    }));
+    });
 }
 
 export function bindPackageView(

--- a/prototypes/inspect-web/test/package-view.test.ts
+++ b/prototypes/inspect-web/test/package-view.test.ts
@@ -12,6 +12,7 @@ import type {
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;
   private readonly listeners = new Map<string, EventListener[]>();
+  onclick: EventListener | null = null;
 
   constructor(dataset: Record<string, string | undefined> = {}) {
     this.dataset = dataset;
@@ -24,8 +25,10 @@ class FakeElement {
   }
 
   dispatch(type: string) {
+    const event = { target: this } as unknown as Event;
+    if (type === "click") this.onclick?.(event);
     for (const listener of this.listeners.get(type) ?? []) {
-      listener({ target: this } as unknown as Event);
+      listener(event);
     }
   }
 }
@@ -64,6 +67,7 @@ test("package view bindings decode navigation controls without eager work", () =
   const group = new FakeElement({ depGroup: "2" });
   const defaultGroup = new FakeElement();
   const open = new FakeElement({ depOpen: "Example@1.0.0::net10.0" });
+  const secondOpen = new FakeElement({ depOpen: "Other@2.0.0::net9.0" });
   const emptyOpen = new FakeElement({ depOpen: "" });
   const load = new FakeElement({
     depLoad: "Other.Package",
@@ -89,7 +93,7 @@ test("package view bindings decode navigation controls without eager work", () =
   });
   const defaultPerformance = new FakeElement();
   root.addAll("[data-dep-group]", group, defaultGroup);
-  root.addAll("[data-dep-open]", open, emptyOpen);
+  root.addAll("[data-dep-open]", open, secondOpen, emptyOpen);
   root.addAll("[data-dep-load]", load, defaultVersion, emptyLoad);
   root.addAll("[data-kind-jump]", kind, defaultKind);
   root.addAll("[data-namespace-jump]", namespace, defaultNamespace);
@@ -106,6 +110,7 @@ test("package view bindings decode navigation controls without eager work", () =
   group.dispatch("click");
   defaultGroup.dispatch("click");
   open.dispatch("click");
+  secondOpen.dispatch("click");
   emptyOpen.dispatch("click");
   load.dispatch("click");
   defaultVersion.dispatch("click");
@@ -125,6 +130,7 @@ test("package view bindings decode navigation controls without eager work", () =
     "dependency-group:2",
     "dependency-group:NaN",
     "dependency-open:Example@1.0.0::net10.0",
+    "dependency-open:Other@2.0.0::net9.0",
     "dependency-load:Other.Package@[2.0.0,)",
     "dependency-load:Default.Package@",
     "kind:class",
@@ -143,23 +149,29 @@ test("package view bindings decode navigation controls without eager work", () =
 test("dependency list binding reconnects only replacement list controls", () => {
   const root = new FakeRoot();
   const open = new FakeElement({ depOpen: "Example@1.0.0::net10.0" });
+  const secondOpen = new FakeElement({ depOpen: "Other@2.0.0::net9.0" });
   const load = new FakeElement({
     depLoad: "Other.Package",
     depVersion: "2.0.0",
   });
-  root.addAll("[data-dep-open]", open);
+  root.addAll("[data-dep-open]", open, secondOpen);
   root.addAll("[data-dep-load]", load);
   const calls: string[] = [];
 
   bindPackageDependencyList(
     root as unknown as ParentNode,
     recordingActions(calls));
+  bindPackageDependencyList(
+    root as unknown as ParentNode,
+    recordingActions(calls));
 
   assert.deepEqual(calls, []);
   open.dispatch("click");
+  secondOpen.dispatch("click");
   load.dispatch("click");
   assert.deepEqual(calls, [
     "dependency-open:Example@1.0.0::net10.0",
+    "dependency-open:Other@2.0.0::net9.0",
     "dependency-load:Other.Package@2.0.0",
   ]);
 });

--- a/prototypes/inspect-web/test/package-view.test.ts
+++ b/prototypes/inspect-web/test/package-view.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bindPackageDependencyList,
+  bindPackageView,
+} from "../src/package-view.ts";
+import type {
+  PackagePerformanceTarget,
+  PackageViewBindingActions,
+} from "../src/package-view.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target: this } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+function recordingActions(calls: string[]): PackageViewBindingActions {
+  return {
+    onDependencyGroupSelect: value => calls.push(`dependency-group:${value}`),
+    onDependencyLoad: (id, version) =>
+      calls.push(`dependency-load:${id}@${version}`),
+    onDependencyOpen: value => calls.push(`dependency-open:${value}`),
+    onGraphTypeSelect: value => calls.push(`graph-type:${value}`),
+    onKindJump: value => calls.push(`kind:${value}`),
+    onLibraryScopeSelect: (library, kind) =>
+      calls.push(`library:${library}:${kind}`),
+    onNamespaceJump: value => calls.push(`namespace:${value}`),
+    onPerformanceMemberSelect: (target: PackagePerformanceTarget) =>
+      calls.push(
+        `performance:${target.metadataToken}:${target.assembly}:${target.typeId}`),
+  };
+}
+
+test("package view bindings decode navigation controls without eager work", () => {
+  const root = new FakeRoot();
+  const group = new FakeElement({ depGroup: "2" });
+  const defaultGroup = new FakeElement();
+  const open = new FakeElement({ depOpen: "Example@1.0.0::net10.0" });
+  const emptyOpen = new FakeElement({ depOpen: "" });
+  const load = new FakeElement({
+    depLoad: "Other.Package",
+    depVersion: "[2.0.0,)",
+  });
+  const defaultVersion = new FakeElement({ depLoad: "Default.Package" });
+  const emptyLoad = new FakeElement({ depLoad: "" });
+  const kind = new FakeElement({ kindJump: "class" });
+  const defaultKind = new FakeElement();
+  const namespace = new FakeElement({ namespaceJump: "System.Text" });
+  const defaultNamespace = new FakeElement();
+  const library = new FakeElement({
+    libScope: "System.Text.Json",
+    libKind: "class",
+  });
+  const defaultLibrary = new FakeElement();
+  const graphType = new FakeElement({ graphType: "System.String" });
+  const defaultGraphType = new FakeElement();
+  const performance = new FakeElement({
+    perfToken: "0x06000001",
+    perfAssembly: "Example.dll",
+    perfType: "Example.Type",
+  });
+  const defaultPerformance = new FakeElement();
+  root.addAll("[data-dep-group]", group, defaultGroup);
+  root.addAll("[data-dep-open]", open, emptyOpen);
+  root.addAll("[data-dep-load]", load, defaultVersion, emptyLoad);
+  root.addAll("[data-kind-jump]", kind, defaultKind);
+  root.addAll("[data-namespace-jump]", namespace, defaultNamespace);
+  root.addAll("[data-lib-scope]", library, defaultLibrary);
+  root.addAll("[data-graph-type]", graphType, defaultGraphType);
+  root.addAll("[data-perf-token]", performance, defaultPerformance);
+  const calls: string[] = [];
+
+  bindPackageView(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  group.dispatch("click");
+  defaultGroup.dispatch("click");
+  open.dispatch("click");
+  emptyOpen.dispatch("click");
+  load.dispatch("click");
+  defaultVersion.dispatch("click");
+  emptyLoad.dispatch("click");
+  kind.dispatch("click");
+  defaultKind.dispatch("click");
+  namespace.dispatch("click");
+  defaultNamespace.dispatch("click");
+  library.dispatch("click");
+  defaultLibrary.dispatch("click");
+  graphType.dispatch("click");
+  defaultGraphType.dispatch("click");
+  performance.dispatch("click");
+  defaultPerformance.dispatch("click");
+
+  assert.deepEqual(calls, [
+    "dependency-group:2",
+    "dependency-group:NaN",
+    "dependency-open:Example@1.0.0::net10.0",
+    "dependency-load:Other.Package@[2.0.0,)",
+    "dependency-load:Default.Package@",
+    "kind:class",
+    "kind:",
+    "namespace:System.Text",
+    "namespace:",
+    "library:System.Text.Json:class",
+    "library:undefined:",
+    "graph-type:System.String",
+    "graph-type:",
+    "performance:0x06000001:Example.dll:Example.Type",
+    "performance:::",
+  ]);
+});
+
+test("dependency list binding reconnects only replacement list controls", () => {
+  const root = new FakeRoot();
+  const open = new FakeElement({ depOpen: "Example@1.0.0::net10.0" });
+  const load = new FakeElement({
+    depLoad: "Other.Package",
+    depVersion: "2.0.0",
+  });
+  root.addAll("[data-dep-open]", open);
+  root.addAll("[data-dep-load]", load);
+  const calls: string[] = [];
+
+  bindPackageDependencyList(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  open.dispatch("click");
+  load.dispatch("click");
+  assert.deepEqual(calls, [
+    "dependency-open:Example@1.0.0::net10.0",
+    "dependency-load:Other.Package@2.0.0",
+  ]);
+});
+
+test("package view binding tolerates an inactive surface", () => {
+  assert.doesNotThrow(() => bindPackageView(
+    new FakeRoot() as unknown as ParentNode,
+    recordingActions([])));
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -403,6 +403,10 @@ test("typed package view owns package navigation bindings", () => {
   const dependencyPatch =
     appSource.match(/function patchDependenciesGroup\(\) \{[\s\S]*?\n}/)?.[0]
     ?? "";
+  const actionSource = name =>
+    binding.match(
+      new RegExp(`  ${name}: [\\s\\S]*?(?=\\n  on[A-Z])`))?.[0]
+      ?? "";
   assert.match(
     packageViewSource,
     /export function bindPackageView\([\s\S]*\[data-dep-group\][\s\S]*\[data-kind-jump\][\s\S]*\[data-namespace-jump\][\s\S]*\[data-lib-scope\][\s\S]*\[data-graph-type\][\s\S]*\[data-perf-token\]/);
@@ -433,15 +437,24 @@ test("typed package view owns package navigation bindings", () => {
   assert.match(
     binding,
     /onDependencyLoad: openDependencyPackage,\s*onDependencyOpen: switchToPackageForDependencies,\s*onGraphTypeSelect: navigateToTypeByName/);
+  const kindJump = actionSource("onKindJump");
+  const libraryJump = actionSource("onLibraryScopeSelect");
+  const namespaceJump = actionSource("onNamespaceJump");
   assert.match(
-    binding,
-    /onKindJump: kind => \{[\s\S]*state\.atPackageRoot = false;[\s\S]*state\.kindFilter = kind;[\s\S]*resetMemberFilters\(\);[\s\S]*render\(\)/);
+    kindJump,
+    /state\.atPackageRoot = false;[\s\S]*state\.kindFilter = kind;[\s\S]*state\.namespaceFilter = ""/);
   assert.match(
-    binding,
-    /onLibraryScopeSelect: \(library, kind\) => \{[\s\S]*state\.atPackageRoot = false;[\s\S]*if \(!library\) return;[\s\S]*state\.libraryScope = new Set\(\[library\]\);[\s\S]*state\.kindFilter = kind;[\s\S]*render\(\)/);
+    libraryJump,
+    /state\.atPackageRoot = false;[\s\S]*if \(!library\) return;[\s\S]*state\.libraryScope = new Set\(\[library\]\);[\s\S]*state\.package\?\.isRuntimePack[\s\S]*recordPlatformRecent\(library, platformPackForAssembly\(library\)\);[\s\S]*state\.kindFilter = kind;[\s\S]*state\.namespaceFilter = ""/);
   assert.match(
-    binding,
-    /onNamespaceJump: namespace => \{[\s\S]*state\.atPackageRoot = false;[\s\S]*state\.namespaceFilter = namespace;[\s\S]*resetMemberFilters\(\);[\s\S]*render\(\)/);
+    namespaceJump,
+    /state\.atPackageRoot = false;[\s\S]*state\.namespaceFilter = namespace;[\s\S]*state\.kindFilter = ""/);
+  for (const source of [kindJump, libraryJump, namespaceJump]) {
+    assert.match(
+      source,
+      /state\.typeFilter = "";[\s\S]*state\.selectedMemberKey = "";[\s\S]*state\.memberBrowseTypeId = "";[\s\S]*resetMemberFilters\(\);[\s\S]*state\.typeCursor = 0;[\s\S]*const first = filteredTypes\(\)\[0\];[\s\S]*if \(first\) state\.selectedTypeId = first\.id;[\s\S]*render\(\)/);
+    assert.equal(source.match(/\brender\(\)/g)?.length, 1);
+  }
   assert.match(
     binding,
     /onPerformanceMemberSelect: target => \{[\s\S]*drillToPerfMember\(\s*target\.metadataToken,\s*target\.assembly,\s*target\.typeId\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -394,6 +394,12 @@ test("typed package view owns package navigation bindings", () => {
   const workspaceBinding =
     appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
     ?? "";
+  const packageViewBinding =
+    appSource.match(/function bindPackageViewEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction bindPackageDependencyListEvents)/)?.[0]
+    ?? "";
+  const dependencyListBinding =
+    appSource.match(/function bindPackageDependencyListEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction bindStatusBarEvents)/)?.[0]
+    ?? "";
   const dependencyPatch =
     appSource.match(/function patchDependenciesGroup\(\) \{[\s\S]*?\n}/)?.[0]
     ?? "";
@@ -406,6 +412,18 @@ test("typed package view owns package navigation bindings", () => {
   assert.equal(
     workspaceBinding.match(/\bbindPackageViewEvents\(\)/g)?.length,
     1);
+  assert.match(
+    packageViewBinding,
+    /bindPackageView\(document, packageViewActions\)/);
+  assert.doesNotMatch(
+    packageViewBinding,
+    /\bquerySelector(?:All)?\b|\baddEventListener\b/);
+  assert.match(
+    dependencyListBinding,
+    /bindPackageDependencyList\(document, packageViewActions\)/);
+  assert.doesNotMatch(
+    dependencyListBinding,
+    /\bquerySelector(?:All)?\b|\baddEventListener\b/);
   assert.match(
     dependencyPatch,
     /listSection\.outerHTML = dependencyListSectionHtml[\s\S]*bindPackageDependencyListEvents\(\);[\s\S]*renderDependencyGraph\(\)/);
@@ -430,6 +448,9 @@ test("typed package view owns package navigation bindings", () => {
   assert.doesNotMatch(
     appSource,
     /document\.querySelectorAll<HTMLElement>\("\[data-(?:dep-group|dep-open|dep-load|kind-jump|namespace-jump|lib-scope|graph-type|perf-token)\]"\)/);
+  assert.doesNotMatch(
+    workspaceBinding,
+    /\[data-(?:dep-group|dep-open|dep-load|kind-jump|namespace-jump|lib-scope|graph-type|perf-token)\]/);
   assert.doesNotMatch(appSource, /function bindDependencyListHandlers\(/);
 });
 

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -176,6 +176,9 @@ const packageAcquisitionSource = readFileSync(
 const packageInspectionSource = readFileSync(
   new URL("../src/package-inspection.ts", import.meta.url),
   "utf8");
+const packageViewSource = readFileSync(
+  new URL("../src/package-view.ts", import.meta.url),
+  "utf8");
 const sourceInspectionSource = readFileSync(
   new URL("../src/source-inspection.ts", import.meta.url),
   "utf8");
@@ -382,6 +385,52 @@ test("typed package inspection owns package-root request coordination", () => {
     packageInspectionSource,
     /async loadDependencies\(packageModel, signature\)[\s\S]*state\.packageDependenciesKey/);
   assert.doesNotMatch(dependenciesLoader, /state\.packageDependenciesKey/);
+});
+
+test("typed package view owns package navigation bindings", () => {
+  const binding =
+    appSource.match(/const packageViewActions: PackageViewBindingActions = \{[\s\S]*?\n};/)?.[0]
+    ?? "";
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
+  const dependencyPatch =
+    appSource.match(/function patchDependenciesGroup\(\) \{[\s\S]*?\n}/)?.[0]
+    ?? "";
+  assert.match(
+    packageViewSource,
+    /export function bindPackageView\([\s\S]*\[data-dep-group\][\s\S]*\[data-kind-jump\][\s\S]*\[data-namespace-jump\][\s\S]*\[data-lib-scope\][\s\S]*\[data-graph-type\][\s\S]*\[data-perf-token\]/);
+  assert.match(
+    packageViewSource,
+    /export function bindPackageDependencyList\([\s\S]*\[data-dep-open\][\s\S]*\[data-dep-load\]/);
+  assert.equal(
+    workspaceBinding.match(/\bbindPackageViewEvents\(\)/g)?.length,
+    1);
+  assert.match(
+    dependencyPatch,
+    /listSection\.outerHTML = dependencyListSectionHtml[\s\S]*bindPackageDependencyListEvents\(\);[\s\S]*renderDependencyGraph\(\)/);
+  assert.match(
+    binding,
+    /onDependencyGroupSelect: index => \{[\s\S]*state\.dependenciesGroupIndex === index[\s\S]*state\.dependenciesGroupIndex = index;[\s\S]*patchDependenciesGroup\(\)/);
+  assert.match(
+    binding,
+    /onDependencyLoad: openDependencyPackage,\s*onDependencyOpen: switchToPackageForDependencies,\s*onGraphTypeSelect: navigateToTypeByName/);
+  assert.match(
+    binding,
+    /onKindJump: kind => \{[\s\S]*state\.atPackageRoot = false;[\s\S]*state\.kindFilter = kind;[\s\S]*resetMemberFilters\(\);[\s\S]*render\(\)/);
+  assert.match(
+    binding,
+    /onLibraryScopeSelect: \(library, kind\) => \{[\s\S]*state\.atPackageRoot = false;[\s\S]*if \(!library\) return;[\s\S]*state\.libraryScope = new Set\(\[library\]\);[\s\S]*state\.kindFilter = kind;[\s\S]*render\(\)/);
+  assert.match(
+    binding,
+    /onNamespaceJump: namespace => \{[\s\S]*state\.atPackageRoot = false;[\s\S]*state\.namespaceFilter = namespace;[\s\S]*resetMemberFilters\(\);[\s\S]*render\(\)/);
+  assert.match(
+    binding,
+    /onPerformanceMemberSelect: target => \{[\s\S]*drillToPerfMember\(\s*target\.metadataToken,\s*target\.assembly,\s*target\.typeId\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelectorAll<HTMLElement>\("\[data-(?:dep-group|dep-open|dep-load|kind-jump|namespace-jump|lib-scope|graph-type|perf-token)\]"\)/);
+  assert.doesNotMatch(appSource, /function bindDependencyListHandlers\(/);
 });
 
 test("typed document inspection owns package document request coordination", () => {


### PR DESCRIPTION
## Summary

- add a typed package-view binding owner for dependency group/list controls,
  package overview jumps, type-graph navigation, and performance-member
  navigation
- reconnect only the replaced dependency-list controls after an in-place
  framework update, without rebinding the unchanged package surface
- keep package/filter mutation, dependency patching, navigation, and inspection
  effects in `dotnet-inspect.ts` behind explicit callbacks

## Stack

Slice 23 of the issue #4504 stack.

Parent: #4532

Residual after this slice: platform/library controls, shell/home/error controls,
and graph interaction binding. Global application keyboard and history
coordination remain intentionally in the composition root.

## Validation

- `npm test` - 433/433
- `npm run build`
- package navigation callback mutations killed by callback-bounded ownership gates
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

Exact base: `825de1759a99bf8c96969bd0015f6730cfa99696`
Exact head: `63de141342ab6791ba9f7b6f22f7e0fe7c729215`

Part of #4504.