### PR TITLE
Extract library control event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -677,6 +677,14 @@ inspection effects behind typed callbacks. `test/package-view.test.ts` gates
 dataset decoding, missing values, replacement dependency-list binding, inactive
 surfaces, and no eager dispatch.
 
+`src/library-controls.ts` owns library/accessibility filters, the primary
+Platform library selector, and the lens-scoped Platform library selectors.
+`dotnet-inspect.ts` still owns filter mutation, runtime-pack acquisition,
+generation checks, visible retry state, and lens reload effects behind typed
+callbacks. `test/library-controls.test.ts` gates selector mapping, pack
+provenance/defaults, empty selections, inactive surfaces, and no eager
+dispatch.
+
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM
 bindings and the home/workbench controls that open them. `dotnet-inspect.ts`

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -78,6 +78,11 @@ import {
   type PackageViewBindingActions,
 } from "./package-view.ts";
 import {
+  bindLibraryControls,
+  type LibraryControlBindingActions,
+  type PlatformLibraryLens,
+} from "./library-controls.ts";
+import {
   createSourceInspectionCoordinator,
   type GraphSourceRequest,
 } from "./source-inspection.ts";
@@ -3673,6 +3678,112 @@ const packageViewActions: PackageViewBindingActions = {
   },
 };
 
+interface NoticeRetryState {
+  action: RetryAction;
+  previous: string;
+  appended: string;
+}
+
+const libraryControlActions: LibraryControlBindingActions = {
+  onAccessibilityChipSelect: accessibility => {
+    toggleAccessibilityChip(accessibility);
+    afterLibraryScopeChange();
+  },
+  onLibraryChipSelect: library => {
+    toggleLibraryChip(library);
+    afterLibraryScopeChange();
+  },
+  onLibraryJump: library => {
+    state.libraryScope = library ? new Set([library]) : null;
+    afterLibraryScopeChange();
+  },
+  onPlatformLibrarySelect: openPlatformLibrary,
+  onPlatformLensLibrarySelect: (lens, name, pack) => {
+    void openPlatformLensLibrary(lens, name, pack);
+  },
+};
+
+async function openPlatformLensLibrary(
+  lens: PlatformLibraryLens,
+  name: string,
+  selectedPack: string | undefined,
+  originPackage: AppPackage = currentPackage(),
+  noticeRetryState: NoticeRetryState | null = null,
+) {
+  if (!state.packages.includes(originPackage)
+    || !packageIdentityEquals(state.package, originPackage)
+    || state.home
+    || !state.atPackageRoot
+    || state.packageLens !== lens) {
+    return;
+  }
+  if (noticeRetryState
+    && state.queryNoticeRetryAction === noticeRetryState.action) {
+    state.queryNotice = removeAppendedNotice(
+      state.queryNotice,
+      noticeRetryState.previous,
+      noticeRetryState.appended);
+    state.queryNoticeRetryAction = null;
+  }
+  const navigationSeq = navigationSequence.begin();
+  const isCurrent = () =>
+    navigationSequence.isCurrent(navigationSeq)
+    && !state.home
+    && state.atPackageRoot
+    && state.packageLens === lens
+    && packageIdentityEquals(state.package, originPackage);
+  const key = name.replace(/\.dll$/i, "");
+  const pack = selectedPack || platformPackForAssembly(key);
+  const resident = (runtimePackPackage()?.types || [])
+    .some(type => libraryKey(type) === key);
+  if (!resident) {
+    const runtimeResult = await loadRuntimePackAssembly(
+      platformScopeTfm(),
+      `${key}.dll`,
+      pack,
+      () => state.packages.includes(originPackage));
+    const loaded = runtimeResult.packageModel;
+    if (!loaded) {
+      if (isCurrent()) {
+        const noticeState: NoticeRetryState = {
+          action: null,
+          previous: state.queryNotice,
+          appended: "",
+        };
+        const retryAction = () =>
+          openPlatformLensLibrary(
+            lens,
+            name,
+            pack,
+            originPackage,
+            noticeState);
+        noticeState.action = retryAction;
+        appendQueryNotice(
+          `Couldn’t load ${key}: ${runtimeResult.failureMessage
+            || state.runtimePackError
+            || "runtime pack acquisition failed."}`,
+          retryAction);
+        noticeState.appended = state.queryNotice;
+        render();
+      }
+      return;
+    }
+  }
+  if (!isCurrent()) return;
+  state.libraryScope = new Set([key]);
+  recordPlatformRecent(key, pack);
+  state.atPackageRoot = true;
+  state.packageLens = lens;
+  state.namespaceFilter = "";
+  state.typeFilter = "";
+  state.kindFilter = "";
+  normalizeLibrarySelection();
+  if (lens === "integrations") loadPackageIntegrations();
+  else if (lens === "opportunities") loadPackageOpportunities();
+  else if (lens === "analysis") loadPackagePerformance();
+  else loadPackageMetadata();
+}
+
 function bindPackageViewEvents() {
   bindPackageView(document, packageViewActions);
 }
@@ -3688,6 +3799,10 @@ function bindStatusBarEvents() {
       render();
     },
   });
+}
+
+function bindLibraryControlsEvents() {
+  bindLibraryControls(document, libraryControlActions);
 }
 
 function bindTypePanelEvents() {
@@ -4016,119 +4131,7 @@ function bindEvents() {
   bindDocViewerEvents();
   bindAnnotatedSourceEvents();
   bindPackageViewEvents();
-  document.querySelectorAll<HTMLElement>("[data-library-chip]").forEach(button => button.addEventListener("click", () => {
-    toggleLibraryChip(button.dataset.libraryChip ?? "");
-    afterLibraryScopeChange();
-  }));
-  document.querySelectorAll<HTMLElement>("[data-access-chip]").forEach(button => button.addEventListener("click", () => {
-    toggleAccessibilityChip(button.dataset.accessChip ?? "");
-    afterLibraryScopeChange();
-  }));
-  const libraryJump = document.querySelector<HTMLSelectElement>("#library-jump");
-  if (libraryJump) libraryJump.addEventListener("change", () => {
-    state.libraryScope = libraryJump.value ? new Set([libraryJump.value]) : null;
-    afterLibraryScopeChange();
-  });
-  document.querySelectorAll<HTMLSelectElement>("[data-platform-library-select]").forEach(select => select.addEventListener("change", () => {
-    const name = select.value;
-    if (!name) return;
-    const pack = select.selectedOptions[0]?.dataset.pack || "netcore.app";
-    openPlatformLibrary(name, pack);
-  }));
-  // The lens-scoped library pickers (Integrations, Opportunities, Analysis) scope the scan
-  // without leaving the lens: unlike the main platform selector they keep package (platform)
-  // root + the active lens, then rescan. Types are loaded too so switching to Types/Overview
-  // afterward isn't empty.
-  interface NoticeRetryState {
-    action: RetryAction;
-    previous: string;
-    appended: string;
-  }
-  const bindPlatformLensPicker = (
-    dataAttr: string,
-    lens: string,
-    loader: () => unknown,
-  ) => {
-    const openLibrary = async (
-      name: string,
-      pack: string,
-      originPackage: AppPackage = currentPackage(),
-      noticeRetryState: NoticeRetryState | null = null) => {
-      if (!state.packages.includes(originPackage)
-        || !packageIdentityEquals(state.package, originPackage)
-        || state.home
-        || !state.atPackageRoot
-        || state.packageLens !== lens) {
-        return;
-      }
-      if (noticeRetryState
-        && state.queryNoticeRetryAction === noticeRetryState.action) {
-        state.queryNotice = removeAppendedNotice(
-          state.queryNotice,
-          noticeRetryState.previous,
-          noticeRetryState.appended);
-        state.queryNoticeRetryAction = null;
-      }
-      const navigationSeq = navigationSequence.begin();
-      const isCurrent = () =>
-        navigationSequence.isCurrent(navigationSeq)
-        && !state.home
-        && state.atPackageRoot
-        && state.packageLens === lens
-        && packageIdentityEquals(state.package, originPackage);
-      const key = name.replace(/\.dll$/i, "");
-      const resident = (runtimePackPackage()?.types || []).some(type => libraryKey(type) === key);
-      if (!resident) {
-        const runtimeResult = await loadRuntimePackAssembly(
-          platformScopeTfm(),
-          `${key}.dll`,
-          pack,
-          () => state.packages.includes(originPackage));
-        const loaded = runtimeResult.packageModel;
-        if (!loaded) {
-          if (isCurrent()) {
-                  const noticeState: NoticeRetryState = {
-              action: null,
-              previous: state.queryNotice,
-              appended: "",
-            };
-            const retryAction = () =>
-              openLibrary(name, pack, originPackage, noticeState);
-            noticeState.action = retryAction;
-            appendQueryNotice(
-              `Couldn’t load ${key}: ${runtimeResult.failureMessage
-                || state.runtimePackError
-                || "runtime pack acquisition failed."}`,
-              retryAction);
-            noticeState.appended = state.queryNotice;
-            render();
-          }
-          return;
-        }
-      }
-      if (!isCurrent()) return;
-      state.libraryScope = new Set([key]);
-      recordPlatformRecent(key, pack);
-      state.atPackageRoot = true;
-      state.packageLens = lens;
-      state.namespaceFilter = "";
-      state.typeFilter = "";
-      state.kindFilter = "";
-      normalizeLibrarySelection();
-      loader();
-    };
-    document.querySelectorAll<HTMLSelectElement>(`[${dataAttr}]`).forEach(select => select.addEventListener("change", () => {
-      const name = select.value;
-      if (!name) return;
-      const key = name.replace(/\.dll$/i, "");
-      const pack = select.selectedOptions[0]?.dataset.pack || platformPackForAssembly(key);
-      openLibrary(name, pack);
-    }));
-  };
-  bindPlatformLensPicker("data-platform-integrations-library", "integrations", loadPackageIntegrations);
-  bindPlatformLensPicker("data-platform-opportunities-library", "opportunities", loadPackageOpportunities);
-  bindPlatformLensPicker("data-platform-analysis-library", "analysis", loadPackagePerformance);
-  bindPlatformLensPicker("data-platform-metadata-library", "metadata", loadPackageMetadata);
+  bindLibraryControlsEvents();
   ensurePackageVersions(state.package);
   if (state.package?.isRuntimePack) ensureDotnetReleases();
   if (state.spotlightOpen) spotlight.bind(document, "modal");

--- a/prototypes/inspect-web/src/library-controls.ts
+++ b/prototypes/inspect-web/src/library-controls.ts
@@ -1,0 +1,71 @@
+// DOM bindings for library and accessibility filters plus .NET platform
+// library selectors. The application root owns all resulting state and work.
+
+export type PlatformLibraryLens =
+  | "integrations"
+  | "opportunities"
+  | "analysis"
+  | "metadata";
+
+export interface LibraryControlBindingActions {
+  onAccessibilityChipSelect: (accessibility: string) => void;
+  onLibraryChipSelect: (library: string) => void;
+  onLibraryJump: (library: string) => void;
+  onPlatformLibrarySelect: (name: string, pack: string) => void;
+  onPlatformLensLibrarySelect: (
+    lens: PlatformLibraryLens,
+    name: string,
+    pack: string | undefined,
+  ) => void;
+}
+
+const platformLensSelectors:
+  readonly [selector: string, lens: PlatformLibraryLens][] = [
+    ["[data-platform-integrations-library]", "integrations"],
+    ["[data-platform-opportunities-library]", "opportunities"],
+    ["[data-platform-analysis-library]", "analysis"],
+    ["[data-platform-metadata-library]", "metadata"],
+  ];
+
+export function bindLibraryControls(
+  root: ParentNode,
+  actions: LibraryControlBindingActions,
+) {
+  root.querySelectorAll<HTMLElement>("[data-library-chip]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onLibraryChipSelect(button.dataset.libraryChip ?? "")));
+  root.querySelectorAll<HTMLElement>("[data-access-chip]").forEach(button =>
+    button.addEventListener(
+      "click",
+      () => actions.onAccessibilityChipSelect(
+        button.dataset.accessChip ?? "")));
+
+  const libraryJump =
+    root.querySelector<HTMLSelectElement>("#library-jump");
+  libraryJump?.addEventListener(
+    "change",
+    () => actions.onLibraryJump(libraryJump.value));
+
+  root.querySelectorAll<HTMLSelectElement>("[data-platform-library-select]")
+    .forEach(select =>
+      select.addEventListener("change", () => {
+        const name = select.value;
+        if (!name) return;
+        const pack =
+          select.selectedOptions[0]?.dataset.pack || "netcore.app";
+        actions.onPlatformLibrarySelect(name, pack);
+      }));
+
+  for (const [selector, lens] of platformLensSelectors) {
+    root.querySelectorAll<HTMLSelectElement>(selector).forEach(select =>
+      select.addEventListener("change", () => {
+        const name = select.value;
+        if (!name) return;
+        actions.onPlatformLensLibrarySelect(
+          lens,
+          name,
+          select.selectedOptions[0]?.dataset.pack);
+      }));
+  }
+}

--- a/prototypes/inspect-web/test/library-controls.test.ts
+++ b/prototypes/inspect-web/test/library-controls.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { bindLibraryControls } from "../src/library-controls.ts";
+import type {
+  LibraryControlBindingActions,
+  PlatformLibraryLens,
+} from "../src/library-controls.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  value = "";
+  selectedOptions: FakeElement[] = [];
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener({ target: this } as unknown as Event);
+    }
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+    return element;
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+function recordingActions(calls: string[]): LibraryControlBindingActions {
+  return {
+    onAccessibilityChipSelect: value =>
+      calls.push(`accessibility:${value}`),
+    onLibraryChipSelect: value => calls.push(`library-chip:${value}`),
+    onLibraryJump: value => calls.push(`library-jump:${value}`),
+    onPlatformLibrarySelect: (name, pack) =>
+      calls.push(`platform:${name}:${pack}`),
+    onPlatformLensLibrarySelect: (
+      lens: PlatformLibraryLens,
+      name,
+      pack,
+    ) => calls.push(`platform-lens:${lens}:${name}:${pack}`),
+  };
+}
+
+test("library controls decode every rendered selector without eager work", () => {
+  const root = new FakeRoot();
+  const libraryChip = new FakeElement({ libraryChip: "System.Text.Json" });
+  const defaultLibraryChip = new FakeElement();
+  const accessChip = new FakeElement({ accessChip: "public" });
+  const defaultAccessChip = new FakeElement();
+  root.addAll(
+    "[data-library-chip]",
+    libraryChip,
+    defaultLibraryChip);
+  root.addAll("[data-access-chip]", accessChip, defaultAccessChip);
+
+  const libraryJump = root.add("#library-jump", new FakeElement());
+  libraryJump.value = "System.Collections";
+
+  const platform = new FakeElement();
+  platform.value = "System.Private.CoreLib";
+  platform.selectedOptions = [new FakeElement({ pack: "netcore.app" })];
+  const defaultPlatformPack = new FakeElement();
+  defaultPlatformPack.value = "System.Runtime";
+  defaultPlatformPack.selectedOptions = [new FakeElement()];
+  const emptyPlatform = new FakeElement();
+  root.addAll(
+    "[data-platform-library-select]",
+    platform,
+    defaultPlatformPack,
+    emptyPlatform);
+
+  const integrations = new FakeElement();
+  integrations.value = "System.Net.Http";
+  integrations.selectedOptions = [new FakeElement({ pack: "netcore.app" })];
+  const opportunities = new FakeElement();
+  opportunities.value = "System.Text.Json";
+  opportunities.selectedOptions = [new FakeElement()];
+  const analysis = new FakeElement();
+  analysis.value = "System.Linq";
+  const emptyAnalysis = new FakeElement();
+  const metadata = new FakeElement();
+  metadata.value = "System.Console";
+  metadata.selectedOptions = [new FakeElement({ pack: "windowsdesktop.app" })];
+  root.addAll("[data-platform-integrations-library]", integrations);
+  root.addAll("[data-platform-opportunities-library]", opportunities);
+  root.addAll("[data-platform-analysis-library]", analysis, emptyAnalysis);
+  root.addAll("[data-platform-metadata-library]", metadata);
+  const calls: string[] = [];
+
+  bindLibraryControls(
+    root as unknown as ParentNode,
+    recordingActions(calls));
+
+  assert.deepEqual(calls, []);
+  libraryChip.dispatch("click");
+  defaultLibraryChip.dispatch("click");
+  accessChip.dispatch("click");
+  defaultAccessChip.dispatch("click");
+  libraryJump.dispatch("change");
+  libraryJump.value = "";
+  libraryJump.dispatch("change");
+  platform.dispatch("change");
+  defaultPlatformPack.dispatch("change");
+  emptyPlatform.dispatch("change");
+  integrations.dispatch("change");
+  opportunities.dispatch("change");
+  analysis.dispatch("change");
+  emptyAnalysis.dispatch("change");
+  metadata.dispatch("change");
+
+  assert.deepEqual(calls, [
+    "library-chip:System.Text.Json",
+    "library-chip:",
+    "accessibility:public",
+    "accessibility:",
+    "library-jump:System.Collections",
+    "library-jump:",
+    "platform:System.Private.CoreLib:netcore.app",
+    "platform:System.Runtime:netcore.app",
+    "platform-lens:integrations:System.Net.Http:netcore.app",
+    "platform-lens:opportunities:System.Text.Json:undefined",
+    "platform-lens:analysis:System.Linq:undefined",
+    "platform-lens:metadata:System.Console:windowsdesktop.app",
+  ]);
+});
+
+test("library control binding tolerates an inactive surface", () => {
+  assert.doesNotThrow(() => bindLibraryControls(
+    new FakeRoot() as unknown as ParentNode,
+    recordingActions([])));
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -179,6 +179,9 @@ const packageInspectionSource = readFileSync(
 const packageViewSource = readFileSync(
   new URL("../src/package-view.ts", import.meta.url),
   "utf8");
+const libraryControlsSource = readFileSync(
+  new URL("../src/library-controls.ts", import.meta.url),
+  "utf8");
 const sourceInspectionSource = readFileSync(
   new URL("../src/source-inspection.ts", import.meta.url),
   "utf8");
@@ -465,6 +468,59 @@ test("typed package view owns package navigation bindings", () => {
     workspaceBinding,
     /\[data-(?:dep-group|dep-open|dep-load|kind-jump|namespace-jump|lib-scope|graph-type|perf-token)\]/);
   assert.doesNotMatch(appSource, /function bindDependencyListHandlers\(/);
+});
+
+test("typed library controls own library and Platform picker bindings", () => {
+  const binding =
+    appSource.match(/const libraryControlActions: LibraryControlBindingActions = \{[\s\S]*?\n};/)?.[0]
+    ?? "";
+  const wrapper =
+    appSource.match(/function bindLibraryControlsEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction bindTypePanelEvents)/)?.[0]
+    ?? "";
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
+  assert.match(
+    libraryControlsSource,
+    /export function bindLibraryControls\([\s\S]*\[data-library-chip\][\s\S]*\[data-access-chip\][\s\S]*#library-jump[\s\S]*\[data-platform-library-select\]/);
+  for (const lens of [
+    "integrations",
+    "opportunities",
+    "analysis",
+    "metadata",
+  ]) {
+    assert.match(
+      libraryControlsSource,
+      new RegExp(`\\[data-platform-${lens}-library\\]`));
+  }
+  assert.equal(
+    workspaceBinding.match(/\bbindLibraryControlsEvents\(\)/g)?.length,
+    1);
+  assert.match(
+    wrapper,
+    /bindLibraryControls\(document, libraryControlActions\)/);
+  assert.doesNotMatch(
+    wrapper,
+    /\bquerySelector(?:All)?\b|\baddEventListener\b/);
+  assert.match(
+    binding,
+    /onAccessibilityChipSelect: accessibility => \{[\s\S]*toggleAccessibilityChip\(accessibility\);[\s\S]*afterLibraryScopeChange\(\)/);
+  assert.match(
+    binding,
+    /onLibraryChipSelect: library => \{[\s\S]*toggleLibraryChip\(library\);[\s\S]*afterLibraryScopeChange\(\)/);
+  assert.match(
+    binding,
+    /onLibraryJump: library => \{[\s\S]*state\.libraryScope = library \? new Set\(\[library\]\) : null;[\s\S]*afterLibraryScopeChange\(\)/);
+  assert.match(
+    binding,
+    /onPlatformLibrarySelect: openPlatformLibrary/);
+  assert.match(
+    binding,
+    /onPlatformLensLibrarySelect: \(lens, name, pack\) => \{\s*void openPlatformLensLibrary\(lens, name, pack\)/);
+  assert.doesNotMatch(
+    workspaceBinding,
+    /\[data-(?:library-chip|access-chip|platform-(?:library-select|integrations-library|opportunities-library|analysis-library|metadata-library))\]|#library-jump/);
+  assert.doesNotMatch(appSource, /bindPlatformLensPicker/);
 });
 
 test("typed document inspection owns package document request coordination", () => {
@@ -1271,11 +1327,11 @@ test("opening an already-resident Platform resets type-specific member filters",
 
 test("lens-scoped Platform library changes reset type-specific member state", () => {
   const picker =
-    appSource.match(/const bindPlatformLensPicker = [\s\S]*?bindPlatformLensPicker\("data-platform-integrations-library"/)?.[0]
+    appSource.match(/async function openPlatformLensLibrary\([\s\S]*?\n}/)?.[0]
     ?? "";
   assert.match(
     picker,
-    /const openLibrary = async \([\s\S]*originPackage: AppPackage = currentPackage\(\),[\s\S]*noticeRetryState: NoticeRetryState \| null = null[\s\S]*if \(!state\.packages\.includes\(originPackage\)[\s\S]*!packageIdentityEquals\(state\.package, originPackage\)[\s\S]*state\.queryNoticeRetryAction === noticeRetryState\.action[\s\S]*state\.queryNotice = removeAppendedNotice\([\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*const runtimeResult = await loadRuntimePackAssembly\([\s\S]*\(\) => state\.packages\.includes\(originPackage\)\);[\s\S]*const loaded = runtimeResult\.packageModel;[\s\S]*previous: state\.queryNotice[\s\S]*const retryAction = \(\) =>\s*openLibrary\(name, pack, originPackage, noticeState\);[\s\S]*runtimeResult\.failureMessage[\s\S]*noticeState\.appended = state\.queryNotice;[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*state\.libraryScope = new Set\(\[key\]\);[\s\S]*normalizeLibrarySelection\(\);[\s\S]*loader\(\)/);
+    /originPackage: AppPackage = currentPackage\(\),[\s\S]*noticeRetryState: NoticeRetryState \| null = null[\s\S]*if \(!state\.packages\.includes\(originPackage\)[\s\S]*!packageIdentityEquals\(state\.package, originPackage\)[\s\S]*state\.queryNoticeRetryAction === noticeRetryState\.action[\s\S]*state\.queryNotice = removeAppendedNotice\([\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*const pack = selectedPack \|\| platformPackForAssembly\(key\);[\s\S]*const runtimeResult = await loadRuntimePackAssembly\([\s\S]*\(\) => state\.packages\.includes\(originPackage\)\);[\s\S]*const loaded = runtimeResult\.packageModel;[\s\S]*previous: state\.queryNotice[\s\S]*const retryAction = \(\) =>\s*openPlatformLensLibrary\([\s\S]*noticeState\);[\s\S]*runtimeResult\.failureMessage[\s\S]*noticeState\.appended = state\.queryNotice;[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*state\.libraryScope = new Set\(\[key\]\);[\s\S]*normalizeLibrarySelection\(\);[\s\S]*lens === "integrations"[\s\S]*loadPackageIntegrations\(\)[\s\S]*lens === "opportunities"[\s\S]*loadPackageOpportunities\(\)[\s\S]*lens === "analysis"[\s\S]*loadPackagePerformance\(\)[\s\S]*loadPackageMetadata\(\)/);
   assert.doesNotMatch(picker, /select\.isConnected/);
   assert.match(
     appSource,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -520,6 +520,9 @@ test("typed library controls own library and Platform picker bindings", () => {
   assert.doesNotMatch(
     workspaceBinding,
     /\[data-(?:library-chip|access-chip|platform-(?:library-select|integrations-library|opportunities-library|analysis-library|metadata-library))\]|#library-jump/);
+  assert.doesNotMatch(
+    appSource,
+    /\[data-(?:library-chip|access-chip|platform-(?:library-select|integrations-library|opportunities-library|analysis-library|metadata-library))\]|#library-jump/);
   assert.doesNotMatch(appSource, /bindPlatformLensPicker/);
 });
 


### PR DESCRIPTION
## Summary

- add a typed library-controls binding owner for library/accessibility filters,
  the primary Platform selector, and lens-scoped Platform selectors
- preserve raw runtime-pack provenance at the presentation boundary so the
  composition root retains fallback selection and stale-request suppression
- keep AppState mutation, library loading, retry state, and lens-specific reload
  effects in `dotnet-inspect.ts` behind explicit callbacks

## Stack

Slice 24 of the issue #4504 stack.

Parent: #4533

Residual after this slice: shell/home/error controls and graph interaction
binding. Global application keyboard, outside-click, resize, and history
coordination remain intentionally in the composition root.

## Validation

- `npm test` - 436/436
- `npm run build`
- focused typecheck and library/composition tests - 100/100
- duplicate-selector mutation killed by the ownership gate
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

Exact base: `63de141342ab6791ba9f7b6f22f7e0fe7c729215`
Exact head: `38a3ad19059d57aecf9f104626a8216d8ecb6dbe`

Part of #4504.