### PR TITLE
Extract shell control event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -685,6 +685,15 @@ callbacks. `test/library-controls.test.ts` gates selector mapping, pack
 provenance/defaults, empty selections, inactive surfaces, and no eager
 dispatch.
 
+`src/shell-controls.ts` owns the rendered workbench chrome, home demo/theme
+controls, and load-error retry/query/detail bindings. It reuses the package
+query grammar from `package-bar.ts`; `dotnet-inspect.ts` still owns notice and
+package state, navigation/history, sharing, theme effects, demo orchestration,
+retry selection, and package loading behind typed callbacks.
+`test/shell-controls.test.ts` gates every selector, valid and invalid home demo
+identities, replacement-package parsing, local error-detail state, inactive
+surfaces, and no eager dispatch.
+
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM
 bindings and the home/workbench controls that open them. `dotnet-inspect.ts`

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -83,6 +83,14 @@ import {
   type PlatformLibraryLens,
 } from "./library-controls.ts";
 import {
+  bindHomeShell,
+  bindLoadErrorShell,
+  bindWorkbenchShell,
+  type HomeShellBindingActions,
+  type LoadErrorShellBindingActions,
+  type WorkbenchShellBindingActions,
+} from "./shell-controls.ts";
+import {
   createSourceInspectionCoordinator,
   type GraphSourceRequest,
 } from "./source-inspection.ts";
@@ -4119,6 +4127,28 @@ function bindAnnotatedSourceEvents() {
   });
 }
 
+const workbenchShellActions: WorkbenchShellBindingActions = {
+  onDismissNotice: () => {
+    state.queryNotice = "";
+    state.queryNoticeRetryAction = null;
+    render();
+  },
+  onDismissPackageNotice: () => {
+    currentPackage().inspectionError = "";
+    render();
+  },
+  onGoHome: goHome,
+  onHelp: () => showToast(
+    "⌘K command · ⌘P / type to find a type · ⌘F filter · "
+    + "1—5 lenses · ↑↓ types · Alt+←/→ back/forward · "
+    + "graph: wheel zoom, click node to open, +/− zoom, 0 fit, arrows pan"),
+  onNavigateBack: navBack,
+  onNavigateForward: navForward,
+  onRetryNotice: () => state.queryNoticeRetryAction?.(),
+  onShare: share,
+  onToggleTheme: toggleTheme,
+};
+
 function bindEvents() {
   bindStatusBarEvents();
   packageBar.bind(document);
@@ -4132,27 +4162,11 @@ function bindEvents() {
   bindAnnotatedSourceEvents();
   bindPackageViewEvents();
   bindLibraryControlsEvents();
+  bindWorkbenchShell(document, workbenchShellActions);
   ensurePackageVersions(state.package);
   if (state.package?.isRuntimePack) ensureDotnetReleases();
   if (state.spotlightOpen) spotlight.bind(document, "modal");
-  document.querySelector("#share")?.addEventListener("click", share);
   document.querySelector("[data-graph-back]")?.addEventListener("click", popPlatformDrill);
-  document.querySelector("#dismiss-notice")?.addEventListener("click", () => {
-    state.queryNotice = "";
-    state.queryNoticeRetryAction = null;
-    render();
-  });
-  document.querySelector("#retry-notice")?.addEventListener("click", () =>
-    state.queryNoticeRetryAction?.());
-  document.querySelector("#dismiss-package-notice")?.addEventListener("click", () => {
-    currentPackage().inspectionError = "";
-    render();
-  });
-  document.querySelector("#nav-back")?.addEventListener("click", navBack);
-  document.querySelector("#nav-forward")?.addEventListener("click", navForward);
-  document.querySelector("#go-home")?.addEventListener("click", goHome);
-  document.querySelector("#theme-toggle")?.addEventListener("click", toggleTheme);
-  document.querySelector("#help")?.addEventListener("click", () => showToast("⌘K command · ⌘P / type to find a type · ⌘F filter · 1—5 lenses · ↑↓ types · Alt+←/→ back/forward · graph: wheel zoom, click node to open, +/− zoom, 0 fit, arrows pan"));
 }
 
 function toggleTheme() {
@@ -5466,23 +5480,21 @@ function homeArtSvg() {
   return `<img class="home-art-img" src="/assets/dotnet-inspect-bot.png" width="680" height="680" alt="dotnet-bot inspecting through a magnifying glass" />`;
 }
 
-function bindHomeEvents() {
-  bindStatusBarEvents();
-  bindSettingsPanelEvents();
-  document.querySelector("#home-theme")?.addEventListener("click", toggleTheme);
-  document.querySelector("#dismiss-notice")?.addEventListener("click", () => {
+const homeShellActions: HomeShellBindingActions = {
+  onDemo: runHomeDemo,
+  onDismissNotice: () => {
     state.queryNotice = "";
     state.queryNoticeRetryAction = null;
     render();
-  });
+  },
+  onToggleTheme: toggleTheme,
+};
+
+function bindHomeEvents() {
+  bindStatusBarEvents();
+  bindSettingsPanelEvents();
+  bindHomeShell(document, homeShellActions);
   spotlight.bind(document, "inline");
-  document.querySelectorAll<HTMLElement>("[data-home-demo]").forEach(button =>
-    button.addEventListener("click", () => {
-      const demo = button.dataset.homeDemo;
-      if (demo === "stj" || demo === "runtime" || demo === "callgraph") {
-        runHomeDemo(demo);
-      }
-    }));
   requestAnimationFrame(() =>
     document.querySelector<HTMLInputElement>("#spotlight-input")?.focus());
 }
@@ -5600,6 +5612,11 @@ function openPackageFromError(packageId: string, version: string) {
   loadPackage(packageId, version, "");
 }
 
+const loadErrorShellActions: LoadErrorShellBindingActions = {
+  onOpenPackage: openPackageFromError,
+  onRetry: () => (state.retryAction ?? bootstrap)(),
+};
+
 function renderLoading() {
   app.innerHTML = `
     <div class="loading-screen">
@@ -5620,24 +5637,7 @@ function renderLoading() {
            </div>`
         : `<div class="load-progress"><img class="loading-bot" src="${interstitialBotSrc()}" width="200" height="200" alt="dotnet-bot inspector mascot" /><span class="loader"></span><strong>${escapeHtml(state.loadingMessage)}</strong><small>${state.loadingSubtitle ? escapeHtml(state.loadingSubtitle) : `${escapeHtml(state.requestedPackage)}@${escapeHtml(state.requestedVersion)} · ${escapeHtml(state.requestedFramework || "best framework")}`}</small></div>`}
     </div>`;
-  document.querySelector("#retry-load")?.addEventListener(
-    "click",
-    () => (state.retryAction ?? bootstrap)());
-  document.querySelector("#error-package-query")?.addEventListener("submit", event => {
-    event.preventDefault();
-    const input =
-      document.querySelector<HTMLInputElement>("#error-package-input");
-    const value = input?.value.trim() ?? "";
-    const separator = value.lastIndexOf("@");
-    if (!value || separator === value.length - 1) return;
-    const packageId = separator > 0 ? value.slice(0, separator) : value;
-    const version = separator > 0 ? value.slice(separator + 1) : "latest";
-    openPackageFromError(packageId, version);
-  });
-  document.querySelector("#toggle-error-detail")?.addEventListener("click", () => {
-    const pre = document.querySelector<HTMLElement>(".load-error-detail");
-    if (pre) pre.hidden = !pre.hidden;
-  });
+  bindLoadErrorShell(document, loadErrorShellActions);
 }
 
 async function loadSelectedMemberDocumentation() {

--- a/prototypes/inspect-web/src/shell-controls.ts
+++ b/prototypes/inspect-web/src/shell-controls.ts
@@ -1,0 +1,89 @@
+import { parsePackageQuery } from "./package-bar.ts";
+
+export type HomeDemo = "stj" | "runtime" | "callgraph";
+
+export interface WorkbenchShellBindingActions {
+  onDismissNotice: () => void;
+  onDismissPackageNotice: () => void;
+  onGoHome: () => void;
+  onHelp: () => void;
+  onNavigateBack: () => void;
+  onNavigateForward: () => void;
+  onRetryNotice: () => void;
+  onShare: () => void;
+  onToggleTheme: () => void;
+}
+
+export interface HomeShellBindingActions {
+  onDemo: (demo: HomeDemo) => void;
+  onDismissNotice: () => void;
+  onToggleTheme: () => void;
+}
+
+export interface LoadErrorShellBindingActions {
+  onOpenPackage: (packageId: string, version: string) => void;
+  onRetry: () => void;
+}
+
+export function bindWorkbenchShell(
+  root: ParentNode,
+  actions: WorkbenchShellBindingActions,
+) {
+  root.querySelector("#share")
+    ?.addEventListener("click", actions.onShare);
+  root.querySelector("#dismiss-notice")
+    ?.addEventListener("click", actions.onDismissNotice);
+  root.querySelector("#retry-notice")
+    ?.addEventListener("click", actions.onRetryNotice);
+  root.querySelector("#dismiss-package-notice")
+    ?.addEventListener("click", actions.onDismissPackageNotice);
+  root.querySelector("#nav-back")
+    ?.addEventListener("click", actions.onNavigateBack);
+  root.querySelector("#nav-forward")
+    ?.addEventListener("click", actions.onNavigateForward);
+  root.querySelector("#go-home")
+    ?.addEventListener("click", actions.onGoHome);
+  root.querySelector("#theme-toggle")
+    ?.addEventListener("click", actions.onToggleTheme);
+  root.querySelector("#help")
+    ?.addEventListener("click", actions.onHelp);
+}
+
+export function bindHomeShell(
+  root: ParentNode,
+  actions: HomeShellBindingActions,
+) {
+  root.querySelector("#home-theme")
+    ?.addEventListener("click", actions.onToggleTheme);
+  root.querySelector("#dismiss-notice")
+    ?.addEventListener("click", actions.onDismissNotice);
+  root.querySelectorAll<HTMLElement>("[data-home-demo]").forEach(button =>
+    button.addEventListener("click", () => {
+      const demo = button.dataset.homeDemo;
+      if (demo === "stj" || demo === "runtime" || demo === "callgraph") {
+        actions.onDemo(demo);
+      }
+    }));
+}
+
+export function bindLoadErrorShell(
+  root: ParentNode,
+  actions: LoadErrorShellBindingActions,
+) {
+  root.querySelector("#retry-load")
+    ?.addEventListener("click", actions.onRetry);
+  root.querySelector("#error-package-query")
+    ?.addEventListener("submit", event => {
+      event.preventDefault();
+      const input =
+        root.querySelector<HTMLInputElement>("#error-package-input");
+      const parsed = parsePackageQuery(input?.value ?? "");
+      if (parsed) actions.onOpenPackage(parsed.packageId, parsed.version);
+    });
+  root.querySelector("#toggle-error-detail")
+    ?.addEventListener("click", () => {
+      const detail =
+        root.querySelector<HTMLElement>(".load-error-detail");
+      if (detail) detail.hidden = !detail.hidden;
+    });
+}

--- a/prototypes/inspect-web/test/shell-controls.test.ts
+++ b/prototypes/inspect-web/test/shell-controls.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bindHomeShell,
+  bindLoadErrorShell,
+  bindWorkbenchShell,
+} from "../src/shell-controls.ts";
+
+class FakeElement {
+  readonly dataset: Record<string, string | undefined>;
+  hidden = true;
+  value = "";
+  private readonly listeners = new Map<string, EventListener[]>();
+
+  constructor(dataset: Record<string, string | undefined> = {}) {
+    this.dataset = dataset;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string) {
+    let prevented = false;
+    const event = {
+      target: this,
+      preventDefault: () => prevented = true,
+    } as unknown as Event;
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+    return prevented;
+  }
+}
+
+class FakeRoot {
+  private readonly single = new Map<string, FakeElement>();
+  private readonly multiple = new Map<string, FakeElement[]>();
+
+  add(selector: string, element: FakeElement) {
+    this.single.set(selector, element);
+  }
+
+  addAll(selector: string, ...elements: FakeElement[]) {
+    this.multiple.set(selector, elements);
+  }
+
+  querySelector(selector: string) {
+    return this.single.get(selector) ?? null;
+  }
+
+  querySelectorAll(selector: string) {
+    return this.multiple.get(selector) ?? [];
+  }
+}
+
+test("workbench shell binds every rendered control without eager work", () => {
+  const root = new FakeRoot();
+  const controls = new Map([
+    ["#share", "share"],
+    ["#dismiss-notice", "dismiss-notice"],
+    ["#retry-notice", "retry-notice"],
+    ["#dismiss-package-notice", "dismiss-package-notice"],
+    ["#nav-back", "navigate-back"],
+    ["#nav-forward", "navigate-forward"],
+    ["#go-home", "go-home"],
+    ["#theme-toggle", "toggle-theme"],
+    ["#help", "help"],
+  ]);
+  for (const selector of controls.keys()) {
+    root.add(selector, new FakeElement());
+  }
+  const calls: string[] = [];
+
+  bindWorkbenchShell(root as unknown as ParentNode, {
+    onDismissNotice: () => calls.push("dismiss-notice"),
+    onDismissPackageNotice: () => calls.push("dismiss-package-notice"),
+    onGoHome: () => calls.push("go-home"),
+    onHelp: () => calls.push("help"),
+    onNavigateBack: () => calls.push("navigate-back"),
+    onNavigateForward: () => calls.push("navigate-forward"),
+    onRetryNotice: () => calls.push("retry-notice"),
+    onShare: () => calls.push("share"),
+    onToggleTheme: () => calls.push("toggle-theme"),
+  });
+
+  assert.deepEqual(calls, []);
+  for (const [selector, call] of controls) {
+    root.querySelector(selector)?.dispatch("click");
+    assert.equal(calls.at(-1), call);
+  }
+  assert.equal(calls.length, controls.size);
+});
+
+test("home shell accepts only known demos", () => {
+  const root = new FakeRoot();
+  const theme = new FakeElement();
+  const dismiss = new FakeElement();
+  const stj = new FakeElement({ homeDemo: "stj" });
+  const runtime = new FakeElement({ homeDemo: "runtime" });
+  const callgraph = new FakeElement({ homeDemo: "callgraph" });
+  const unknown = new FakeElement({ homeDemo: "other" });
+  const absent = new FakeElement();
+  root.add("#home-theme", theme);
+  root.add("#dismiss-notice", dismiss);
+  root.addAll(
+    "[data-home-demo]",
+    stj,
+    runtime,
+    callgraph,
+    unknown,
+    absent,
+  );
+  const calls: string[] = [];
+
+  bindHomeShell(root as unknown as ParentNode, {
+    onDemo: demo => calls.push(`demo:${demo}`),
+    onDismissNotice: () => calls.push("dismiss"),
+    onToggleTheme: () => calls.push("theme"),
+  });
+
+  assert.deepEqual(calls, []);
+  theme.dispatch("click");
+  dismiss.dispatch("click");
+  stj.dispatch("click");
+  runtime.dispatch("click");
+  callgraph.dispatch("click");
+  unknown.dispatch("click");
+  absent.dispatch("click");
+  assert.deepEqual(calls, [
+    "theme",
+    "dismiss",
+    "demo:stj",
+    "demo:runtime",
+    "demo:callgraph",
+  ]);
+});
+
+test("load error shell parses replacement packages and owns local detail state", () => {
+  const root = new FakeRoot();
+  const retry = new FakeElement();
+  const form = new FakeElement();
+  const input = new FakeElement();
+  const toggle = new FakeElement();
+  const detail = new FakeElement();
+  root.add("#retry-load", retry);
+  root.add("#error-package-query", form);
+  root.add("#error-package-input", input);
+  root.add("#toggle-error-detail", toggle);
+  root.add(".load-error-detail", detail);
+  const calls: string[] = [];
+
+  bindLoadErrorShell(root as unknown as ParentNode, {
+    onOpenPackage: (id, version) => calls.push(`open:${id}@${version}`),
+    onRetry: () => calls.push("retry"),
+  });
+
+  assert.deepEqual(calls, []);
+  retry.dispatch("click");
+  input.value = " Example.Package@2.0.0 ";
+  assert.equal(form.dispatch("submit"), true);
+  input.value = "Latest.Package";
+  assert.equal(form.dispatch("submit"), true);
+  input.value = "Invalid.Package@";
+  assert.equal(form.dispatch("submit"), true);
+  input.value = " ";
+  assert.equal(form.dispatch("submit"), true);
+  toggle.dispatch("click");
+  assert.equal(detail.hidden, false);
+  toggle.dispatch("click");
+  assert.equal(detail.hidden, true);
+  assert.deepEqual(calls, [
+    "retry",
+    "open:Example.Package@2.0.0",
+    "open:Latest.Package@latest",
+  ]);
+});
+
+test("shell bindings tolerate inactive surfaces", () => {
+  const root = new FakeRoot() as unknown as ParentNode;
+  assert.doesNotThrow(() => bindWorkbenchShell(root, {
+    onDismissNotice() {},
+    onDismissPackageNotice() {},
+    onGoHome() {},
+    onHelp() {},
+    onNavigateBack() {},
+    onNavigateForward() {},
+    onRetryNotice() {},
+    onShare() {},
+    onToggleTheme() {},
+  }));
+  assert.doesNotThrow(() => bindHomeShell(root, {
+    onDemo() {},
+    onDismissNotice() {},
+    onToggleTheme() {},
+  }));
+  assert.doesNotThrow(() => bindLoadErrorShell(root, {
+    onOpenPackage() {},
+    onRetry() {},
+  }));
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -182,6 +182,9 @@ const packageViewSource = readFileSync(
 const libraryControlsSource = readFileSync(
   new URL("../src/library-controls.ts", import.meta.url),
   "utf8");
+const shellControlsSource = readFileSync(
+  new URL("../src/shell-controls.ts", import.meta.url),
+  "utf8");
 const sourceInspectionSource = readFileSync(
   new URL("../src/source-inspection.ts", import.meta.url),
   "utf8");
@@ -524,6 +527,72 @@ test("typed library controls own library and Platform picker bindings", () => {
     appSource,
     /\[data-(?:library-chip|access-chip|platform-(?:library-select|integrations-library|opportunities-library|analysis-library|metadata-library))\]|#library-jump/);
   assert.doesNotMatch(appSource, /bindPlatformLensPicker/);
+});
+
+test("typed shell controls own workbench, home, and load-error bindings", () => {
+  const workbenchActions =
+    appSource.match(/const workbenchShellActions: WorkbenchShellBindingActions = \{[\s\S]*?\n};/)?.[0]
+    ?? "";
+  const homeActions =
+    appSource.match(/const homeShellActions: HomeShellBindingActions = \{[\s\S]*?\n};/)?.[0]
+    ?? "";
+  const loadErrorActions =
+    appSource.match(/const loadErrorShellActions: LoadErrorShellBindingActions = \{[\s\S]*?\n};/)?.[0]
+    ?? "";
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
+  const homeBinding =
+    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\n\/\/ The two package demos)/)?.[0]
+    ?? "";
+  const loadingBinding =
+    appSource.match(/function renderLoading\(\) \{[\s\S]*?\n}(?=\n\nasync function loadSelectedMemberDocumentation)/)?.[0]
+    ?? "";
+  assert.match(
+    shellControlsSource,
+    /export function bindWorkbenchShell\([\s\S]*#share[\s\S]*#dismiss-notice[\s\S]*#retry-notice[\s\S]*#dismiss-package-notice[\s\S]*#nav-back[\s\S]*#nav-forward[\s\S]*#go-home[\s\S]*#theme-toggle[\s\S]*#help/);
+  assert.match(
+    shellControlsSource,
+    /export function bindHomeShell\([\s\S]*#home-theme[\s\S]*#dismiss-notice[\s\S]*\[data-home-demo\]/);
+  assert.match(
+    shellControlsSource,
+    /export function bindLoadErrorShell\([\s\S]*#retry-load[\s\S]*#error-package-query[\s\S]*#error-package-input[\s\S]*#toggle-error-detail[\s\S]*\.load-error-detail/);
+  assert.match(
+    shellControlsSource,
+    /import \{ parsePackageQuery \} from "\.\/package-bar\.ts"/);
+  assert.equal(
+    workspaceBinding.match(/\bbindWorkbenchShell\(\b/g)?.length,
+    1);
+  assert.match(
+    workspaceBinding,
+    /bindWorkbenchShell\(document, workbenchShellActions\)/);
+  assert.match(
+    homeBinding,
+    /bindHomeShell\(document, homeShellActions\)[\s\S]*spotlight\.bind\(document, "inline"\)[\s\S]*#spotlight-input/);
+  assert.match(
+    loadingBinding,
+    /app\.innerHTML = `[\s\S]*bindLoadErrorShell\(document, loadErrorShellActions\)/);
+  assert.match(
+    workbenchActions,
+    /onDismissNotice: \(\) => \{[\s\S]*state\.queryNotice = "";[\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*render\(\);\s*\},\n  onDismissPackageNotice:/);
+  assert.match(
+    workbenchActions,
+    /onDismissPackageNotice: \(\) => \{[\s\S]*currentPackage\(\)\.inspectionError = "";[\s\S]*render\(\);\s*\},\n  onGoHome:/);
+  assert.match(
+    workbenchActions,
+    /onGoHome: goHome,[\s\S]*onHelp: \(\) => showToast\([\s\S]*onNavigateBack: navBack,[\s\S]*onNavigateForward: navForward,[\s\S]*onRetryNotice: \(\) => state\.queryNoticeRetryAction\?\.\(\),[\s\S]*onShare: share,[\s\S]*onToggleTheme: toggleTheme/);
+  assert.match(
+    homeActions,
+    /onDemo: runHomeDemo,\s*onDismissNotice: \(\) => \{[\s\S]*state\.queryNotice = "";[\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*render\(\);\s*\},\n  onToggleTheme: toggleTheme/);
+  assert.match(
+    loadErrorActions,
+    /onOpenPackage: openPackageFromError,\s*onRetry: \(\) => \(state\.retryAction \?\? bootstrap\)\(\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelector(?:<[^>]+>)?\("#(?:share|dismiss-notice|retry-notice|dismiss-package-notice|nav-back|nav-forward|go-home|theme-toggle|help|home-theme|retry-load|error-package-query|error-package-input|toggle-error-detail)"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelectorAll<HTMLElement>\("\[data-home-demo\]"\)/);
 });
 
 test("typed document inspection owns package document request coordination", () => {
@@ -907,7 +976,7 @@ test("modal viewers own their rendered close bindings", () => {
 
 test("annotated source owns its rendered control bindings", () => {
   const binding =
-    appSource.match(/function bindAnnotatedSourceEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]
+    appSource.match(/function bindAnnotatedSourceEvents\(\) \{[\s\S]*?\n}(?=\n\nconst workbenchShellActions)/)?.[0]
     ?? "";
   assert.match(
     binding,
@@ -1092,7 +1161,7 @@ test("bare home paints before wasm engine download", () => {
   const homePaintWait =
     appSource.match(/function waitForHomePaint\(\)[\s\S]*?\n}\n\nfunction loadStoredTaste/)?.[0] ?? "";
   const errorPackageRecovery =
-    appSource.match(/function openPackageFromError[\s\S]*?\n}\n\nfunction renderLoading/)?.[0] ?? "";
+    appSource.match(/function openPackageFromError[\s\S]*?\n}\n\nconst loadErrorShellActions/)?.[0] ?? "";
   const loadingView =
     appSource.match(/function renderLoading\(\)[\s\S]*?\n}\n\nasync function loadSelectedMemberDocumentation/)?.[0] ?? "";
   assert.doesNotMatch(appSource, /from "\/engine\.js"/);
@@ -1123,10 +1192,10 @@ test("bare home paints before wasm engine download", () => {
     /if \(!state\.engineReady\) \{[\s\S]*window\.location\.assign\(url\);[\s\S]*return;[\s\S]*\}\s*loadPackage\(packageId, version, ""\)/);
   assert.match(
     loadingView,
-    /#error-package-query[\s\S]*openPackageFromError\(packageId, version\)/);
+    /id="error-package-query"[\s\S]*bindLoadErrorShell\(document, loadErrorShellActions\)/);
   assert.doesNotMatch(
     loadingView,
-    /#error-package-query[\s\S]*loadPackage\(packageId, version/);
+    /id="error-package-query"[\s\S]*(?:openPackageFromError|loadPackage)\(/);
 });
 
 test("Spotlight uses local type matches until the engine is ready", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -589,10 +589,14 @@ test("typed shell controls own workbench, home, and load-error bindings", () => 
     /onOpenPackage: openPackageFromError,\s*onRetry: \(\) => \(state\.retryAction \?\? bootstrap\)\(\)/);
   assert.doesNotMatch(
     appSource,
-    /document\.querySelector(?:<[^>]+>)?\("#(?:share|dismiss-notice|retry-notice|dismiss-package-notice|nav-back|nav-forward|go-home|theme-toggle|help|home-theme|retry-load|error-package-query|error-package-input|toggle-error-detail)"\)/);
+    /\bquerySelector(?:All)?(?:<[^>]+>)?\("(?:#(?:share|dismiss-notice|retry-notice|dismiss-package-notice|nav-back|nav-forward|go-home|theme-toggle|help|home-theme|retry-load|error-package-query|error-package-input|toggle-error-detail)|\[data-home-demo\]|\.load-error-detail)"\)/);
   assert.doesNotMatch(
-    appSource,
-    /document\.querySelectorAll<HTMLElement>\("\[data-home-demo\]"\)/);
+    workspaceBinding,
+    /#(?:share|dismiss-notice|retry-notice|dismiss-package-notice|nav-back|nav-forward|go-home|theme-toggle|help)/);
+  assert.doesNotMatch(homeBinding, /#(?:home-theme|dismiss-notice)|\[data-home-demo\]/);
+  assert.doesNotMatch(
+    loadingBinding,
+    /#(?:retry-load|error-package-query|error-package-input|toggle-error-detail)|"\.load-error-detail"/);
 });
 
 test("typed document inspection owns package document request coordination", () => {


### PR DESCRIPTION
## Summary

- add a typed shell-controls owner for workbench chrome, home demo/theme
  controls, and load-error retry/query/detail bindings
- reuse the package query grammar already owned by `package-bar.ts`
- keep notice/package state, navigation/history, sharing, theme effects, demo
  orchestration, retry selection, and package loading in `dotnet-inspect.ts`

## Stack

Slice 25 of the issue #4504 stack.

Parent: #4534

Residual after this slice: graph interaction binding. Global application
keyboard, outside-click, resize, and history coordination remain intentionally
in the composition root.

## Validation

- `npm test` - 441/441
- `npm run build`
- focused typecheck and shell/composition tests - 103/103
- duplicate Back and home-demo mutations killed by the ownership gate
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

Exact base: `38a3ad19059d57aecf9f104626a8216d8ecb6dbe`
Exact head: `829d829f222dce8cf2b19bba360327a66f660b00`

Part of #4504.