### PR TITLE
Extract graph interaction event binding

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -694,6 +694,15 @@ retry selection, and package loading behind typed callbacks.
 identities, replacement-package parsing, local error-detail state, inactive
 surfaces, and no eager dispatch.
 
+`src/graph-interactions.ts` owns graph-back, pan/zoom, pointer, keyboard, zoom
+button, and rendered Mermaid node bindings for type, dependency, and call
+graphs. `dotnet-inspect.ts` still owns typed graph-target resolution, package
+and member navigation, platform descent, graph rendering, and stale-render
+suppression behind callback resolvers. `test/graph-interactions.test.ts` gates
+stable Mermaid node identity decoding, navigable and informational nodes,
+drag-click suppression, every pan/zoom input, inactive surfaces, and no eager
+dispatch.
+
 `src/settings-panel.ts` owns the Settings page and the decompiler "taste"
 popover it shares its style catalog with, including each surface's rendered DOM
 bindings and the home/workbench controls that open them. `dotnet-inspect.ts`

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -118,6 +118,14 @@ import {
   buildTypeGraphMermaid
 } from "./graph-mermaid.ts";
 import {
+  bindDependencyGraphNodes,
+  bindGraphBack,
+  bindGraphPanZoom,
+  bindTypeGraphNodes,
+  type CallGraphNodeBinding,
+  type GraphBackBindingActions,
+} from "./graph-interactions.ts";
+import {
   factsForNode,
   MEDIA,
   nodeAtOffset,
@@ -4149,6 +4157,10 @@ const workbenchShellActions: WorkbenchShellBindingActions = {
   onToggleTheme: toggleTheme,
 };
 
+const graphBackActions: GraphBackBindingActions = {
+  onBack: popPlatformDrill,
+};
+
 function bindEvents() {
   bindStatusBarEvents();
   packageBar.bind(document);
@@ -4163,10 +4175,10 @@ function bindEvents() {
   bindPackageViewEvents();
   bindLibraryControlsEvents();
   bindWorkbenchShell(document, workbenchShellActions);
+  bindGraphBack(document, graphBackActions);
   ensurePackageVersions(state.package);
   if (state.package?.isRuntimePack) ensureDotnetReleases();
   if (state.spotlightOpen) spotlight.bind(document, "modal");
-  document.querySelector("[data-graph-back]")?.addEventListener("click", popPlatformDrill);
 }
 
 function toggleTheme() {
@@ -5862,31 +5874,21 @@ async function renderTypeGraph() {
       container.querySelector<HTMLElement>(".graph-viewport");
     if (!viewport) return;
     viewport.innerHTML = svg;
-    attachGraphPanZoom(container, viewport);
-    viewport.querySelectorAll<SVGGElement>("g.node").forEach(node => {
-      const dataId = node.getAttribute("data-id");
-      const idMatch = node.id.match(/(?:^|flowchart-)(t\d+)(?:-|$)/);
-      const nodeId = dataId || idMatch?.[1];
+    bindGraphPanZoom(container, viewport);
+    bindTypeGraphNodes(viewport, nodeId => {
       const graphNode = nodeId ? graphNodeOf.get(nodeId) : null;
-      if (!graphNode) return;
+      if (!graphNode) return null;
       const fullName = graphNode.id;
       const pkg = currentPackage();
       const target = graphNode.role === "self"
         ? selectedType()
         : uniqueTypeByQueryId(pkg.types, fullName);
-      if (target) {
-        node.classList.add("nav-node");
-        node.style.cursor = "pointer";
-        node.addEventListener("click", () => navigateToType(target));
-        return;
-      }
-      // Reported by metadata but not in the browsable surface (internal type or a
-      // type in another assembly). Mark it non-navigable with a native tooltip so
-      // the dead node reads as informational rather than broken.
-      node.classList.add("non-nav");
-      const title = document.createElementNS("http://www.w3.org/2000/svg", "title");
-      title.textContent = `${fullName} — not in the browsable public surface`;
-      node.insertBefore(title, node.firstChild);
+      return target
+        ? { onSelect: () => navigateToType(target) }
+        : {
+            unavailableLabel:
+              `${fullName} — not in the browsable public surface`,
+          };
     });
   } catch (error) {
     if (document.querySelector("#type-graph-diagram") === container) {
@@ -6017,21 +6019,18 @@ async function renderDependencyGraph() {
     if (!viewport) return;
     viewport.innerHTML = svg;
     container.dataset.graphDef = signature;
-    attachGraphPanZoom(container, viewport);
-    viewport.querySelectorAll<SVGGElement>("g.node").forEach(node => {
-      const dataId = node.getAttribute("data-id");
-      const idMatch = node.id.match(/(?:^|flowchart-)(d\d+)(?:-|$)/);
-      const nodeId = dataId || idMatch?.[1];
+    bindGraphPanZoom(container, viewport);
+    bindDependencyGraphNodes(viewport, nodeId => {
       const info = nodeId ? built.nodeInfoById.get(nodeId) : null;
-      if (!info || info.kind === "self") return;
-      node.classList.add("nav-node");
-      node.style.cursor = "pointer";
-      node.addEventListener("click", () => {
-        if (info.kind === "open" && info.packageKey)
-          switchToPackageForDependencies(info.packageKey);
-        else if (info.id)
-          openDependencyPackage(info.id, info.versionRange);
-      });
+      if (!info || info.kind === "self") return null;
+      return {
+        onSelect: () => {
+          if (info.kind === "open" && info.packageKey)
+            switchToPackageForDependencies(info.packageKey);
+          else if (info.id)
+            openDependencyPackage(info.id, info.versionRange);
+        },
+      };
     });
   } catch (error) {
     // Only surface the error if this is still the latest render and nothing else has drawn a graph.
@@ -6231,7 +6230,10 @@ async function renderMermaidCallGraph() {
       if (!viewport) return;
       viewport.innerHTML = svg;
       container.dataset.graphDef = active.mermaid;
-      attachGraphPanZoom(container, viewport, true, active);
+      bindGraphPanZoom(container, viewport, {
+        resolveCallGraphNode: nodeId =>
+          callGraphNodeBinding(active, nodeId),
+      });
     }
   } catch (error) {
     if (seq === callGraphRenderSeq
@@ -6247,188 +6249,60 @@ async function renderMermaidCallGraph() {
   }
 }
 
-function attachGraphPanZoom(
-  container: HTMLElement,
-  viewport: HTMLElement,
-  bindCallGraphNodes = false,
-  callGraph: BrowserCallGraph | null = null,
-) {
-  const svg = viewport.querySelector<SVGSVGElement>("svg");
-  if (!svg) return;
-  const renderedSvg = svg;
+function callGraphNodeBinding(
+  callGraph: BrowserCallGraph,
+  nodeId: string,
+): CallGraphNodeBinding | null {
+  const target =
+    callGraph.targets?.find(candidate => candidate.id === nodeId) ?? null;
+  if (!target) return null;
+  const typeId = callGraphTargetTypeId(target);
 
-  const box = svg.viewBox?.baseVal;
-  const naturalWidth = box && box.width ? box.width : svg.getBoundingClientRect().width;
-  const naturalHeight = box && box.height ? box.height : svg.getBoundingClientRect().height;
-  svg.setAttribute("width", String(naturalWidth));
-  svg.setAttribute("height", String(naturalHeight));
-
-  const minScale = 0.2;
-  const maxScale = 8;
-  const view = { scale: 1, x: 0, y: 0 };
-  const clampScale = (value: number) =>
-    Math.min(maxScale, Math.max(minScale, value));
-
-  function apply() {
-    renderedSvg.style.transform =
-      `translate(${view.x}px, ${view.y}px) scale(${view.scale})`;
+  // Inside a platform descent the whole graph lives in the runtime pack, not
+  // the workspace, so clicked callees descend through the platform graph.
+  const drilled =
+    state.platformStack.length > 0 || Boolean(state.package?.isRuntimePack);
+  if (drilled) {
+    if (target.id === "n0" || !target.assembly || !typeId) return null;
+    return {
+      platform: true,
+      onSelect: () => {
+        void navigateOrDrillPlatform(target);
+      },
+    };
   }
 
-  function fit() {
-    const rect = viewport.getBoundingClientRect();
-    if (!naturalWidth || !naturalHeight || !rect.width) return;
-    // Cap at 1:1 so a tiny graph (e.g. two nodes) renders at its natural size,
-    // centered, instead of being upscaled to fill the tall viewport.
-    const fitScale = Math.min(rect.width / naturalWidth, rect.height / naturalHeight) * 0.92;
-    view.scale = clampScale(Math.min(fitScale, 1));
-    view.x = (rect.width - naturalWidth * view.scale) / 2;
-    view.y = (rect.height - naturalHeight * view.scale) / 2;
-    apply();
-  }
-
-  function zoomAt(px: number, py: number, factor: number) {
-    const next = clampScale(view.scale * factor);
-    const ratio = next / view.scale;
-    view.x = px - (px - view.x) * ratio;
-    view.y = py - (py - view.y) * ratio;
-    view.scale = next;
-    apply();
-  }
-
-  viewport.addEventListener("wheel", event => {
-    event.preventDefault();
-    const rect = viewport.getBoundingClientRect();
-    zoomAt(event.clientX - rect.left, event.clientY - rect.top, Math.exp(-event.deltaY * 0.0015));
-  }, { passive: false });
-
-  let pointerId: number | null = null;
-  let moved = false;
-  let capturing = false;
-  const panThreshold = 5;
-  const start = { x: 0, y: 0, vx: 0, vy: 0 };
-  viewport.addEventListener("pointerdown", event => {
-    if (event.button !== 0) return;
-    pointerId = event.pointerId;
-    moved = false;
-    capturing = false;
-    start.x = event.clientX;
-    start.y = event.clientY;
-    start.vx = view.x;
-    start.vy = view.y;
-  });
-  viewport.addEventListener("pointermove", event => {
-    if (pointerId !== event.pointerId) return;
-    const dx = event.clientX - start.x;
-    const dy = event.clientY - start.y;
-    if (!capturing) {
-      if (Math.abs(dx) + Math.abs(dy) <= panThreshold) return;
-      capturing = true;
-      moved = true;
-      viewport.setPointerCapture(pointerId);
-      viewport.classList.add("panning");
-    }
-    view.x = start.vx + dx;
-    view.y = start.vy + dy;
-    apply();
-  });
-  function endPan(event: PointerEvent) {
-    if (pointerId !== event.pointerId) return;
-    if (capturing) {
-      viewport.releasePointerCapture(pointerId);
-      viewport.classList.remove("panning");
-    }
-    capturing = false;
-    pointerId = null;
-  }
-  viewport.addEventListener("pointerup", endPan);
-  viewport.addEventListener("pointercancel", endPan);
-
-  container.querySelectorAll<HTMLElement>(".graph-controls button")
-    .forEach(button => {
-    button.addEventListener("click", () => {
-      const rect = viewport.getBoundingClientRect();
-      const mode = button.dataset.zoom;
-      if (mode === "in") zoomAt(rect.width / 2, rect.height / 2, 1.25);
-      else if (mode === "out") zoomAt(rect.width / 2, rect.height / 2, 0.8);
-      else fit();
-    });
-  });
-
-  viewport.tabIndex = 0;
-  viewport.addEventListener("keydown", event => {
-    const rect = viewport.getBoundingClientRect();
-    const step = 45;
-    if (event.key === "+" || event.key === "=") zoomAt(rect.width / 2, rect.height / 2, 1.25);
-    else if (event.key === "-" || event.key === "_") zoomAt(rect.width / 2, rect.height / 2, 0.8);
-    else if (event.key === "0") fit();
-    else if (event.key === "ArrowLeft") { view.x += step; apply(); }
-    else if (event.key === "ArrowRight") { view.x -= step; apply(); }
-    else if (event.key === "ArrowUp") { view.y += step; apply(); }
-    else if (event.key === "ArrowDown") { view.y -= step; apply(); }
-    else return;
-    event.preventDefault();
-  });
-
-  if (bindCallGraphNodes) {
-    // Inside a platform descent the whole graph lives in the runtime pack, not the
-    // workspace, so a clicked callee must resolve against the active platform graph
-    // and descend further — routing it through the workspace resolvers would look the
-    // type up in the loaded package and fail (e.g. "Type 'TextWriter' is not in Markout.dll").
-    // A resident runtime pack's base member graph is itself a platform graph, so its
-    // callees descend the same way from the start.
-    const drilled = state.platformStack.length > 0 || Boolean(state.package?.isRuntimePack);
-    svg.querySelectorAll<SVGGElement>("g.node").forEach(node => {
-      const target = graphTargetForSvgNode(callGraph, node);
-      if (!target) return;
-      const typeId = callGraphTargetTypeId(target);
-      if (drilled) {
-        if (target.id === "n0" || !target.assembly || !typeId)
-          return;
-        node.classList.add("nav-node", "platform-node");
-        node.style.cursor = "pointer";
-        node.addEventListener("click", () => {
-          if (moved) return;
-          navigateOrDrillPlatform(target);
-        });
-        return;
-      }
-      const packages = [
-        state.package,
-        ...state.packages.filter(item => item !== state.package),
-      ].filter((pkg): pkg is AppPackage => pkg != null);
-      const candidate =
-        resolveLoadedGraphTargetCandidate<AppPackage, BrowserTypeSurface>(
-          packages,
+  const packages = [
+    state.package,
+    ...state.packages.filter(item => item !== state.package),
+  ].filter((pkg): pkg is AppPackage => pkg != null);
+  const candidate =
+    resolveLoadedGraphTargetCandidate<AppPackage, BrowserTypeSurface>(
+      packages,
+      target);
+  const disposition = graphTargetNavigationDisposition(candidate, target);
+  if (disposition === "blocked" || disposition === "none") return null;
+  const loaded = disposition === "loaded" && candidate.status === "unique"
+    ? resolveLoadedGraphTarget(target, candidate)
+    : null;
+  const platform = disposition === "platform";
+  return {
+    platform,
+    onSelect: () => {
+      if (loaded?.group) {
+        navigateToMember(
+          loaded.pkg,
+          loaded.type,
+          loaded.group,
+          loaded.overloadIndex,
           target);
-      const disposition = graphTargetNavigationDisposition(candidate, target);
-      if (disposition === "blocked" || disposition === "none") return;
-      const loaded = disposition === "loaded"
-        && candidate.status === "unique"
-        ? resolveLoadedGraphTarget(target, candidate)
-        : null;
-      const platform = disposition === "platform";
-      node.classList.add("nav-node");
-      if (platform) node.classList.add("platform-node");
-      node.style.cursor = "pointer";
-      node.addEventListener("click", () => {
-        if (moved) return;
-        if (loaded?.group) {
-          navigateToMember(
-            loaded.pkg,
-            loaded.type,
-            loaded.group,
-            loaded.overloadIndex,
-            target);
-        } else if (loaded) {
-          openGraphSource(loaded.request, loaded.title);
-        } else if (platform) {
-          navigateOrDrillPlatform(target);
-        }
-      });
-    });
-  }
-
-  fit();
+      } else if (loaded) {
+        openGraphSource(loaded.request, loaded.title);
+      } else if (platform) {
+        void navigateOrDrillPlatform(target);
+      }
+    },
+  };
 }
 
 function currentCallGraph() {
@@ -6442,18 +6316,6 @@ function platformCrumbTrail() {
     ? state.memberCallGraph.callees.label.replace(/\(.*$/, "")
     : "member";
   return [root, ...state.platformStack.map(entry => entry.title)].join(" › ");
-}
-
-function graphTargetForSvgNode(
-  graph: BrowserCallGraph | null,
-  node: Element,
-) {
-  const dataId = node.getAttribute("data-id");
-  const idMatch = node.id.match(/(?:^|flowchart-)(n\d+)(?:-|$)/);
-  const nodeId = dataId || idMatch?.[1];
-  return nodeId
-    ? graph?.targets?.find(target => target.id === nodeId) ?? null
-    : null;
 }
 
 function resolveLoadedGraphTarget(

--- a/prototypes/inspect-web/src/graph-interactions.ts
+++ b/prototypes/inspect-web/src/graph-interactions.ts
@@ -1,0 +1,234 @@
+export interface GraphBackBindingActions {
+  onBack: () => void;
+}
+
+export interface CallGraphNodeBinding {
+  onSelect: () => void;
+  platform?: boolean;
+}
+
+export interface GraphPanZoomBindingOptions {
+  resolveCallGraphNode?: (
+    nodeId: string,
+  ) => CallGraphNodeBinding | null;
+}
+
+export interface TypeGraphNodeBinding {
+  onSelect?: () => void;
+  unavailableLabel?: string;
+}
+
+export interface DependencyGraphNodeBinding {
+  onSelect: () => void;
+}
+
+export function bindGraphBack(
+  root: ParentNode,
+  actions: GraphBackBindingActions,
+) {
+  root.querySelector("[data-graph-back]")
+    ?.addEventListener("click", actions.onBack);
+}
+
+function mermaidNodeId(node: Element, prefix: string): string {
+  const dataId = node.getAttribute("data-id");
+  const idMatch =
+    node.id.match(new RegExp(`(?:^|flowchart-)(${prefix}\\d+)(?:-|$)`));
+  return dataId || idMatch?.[1] || "";
+}
+
+export function bindTypeGraphNodes(
+  root: ParentNode,
+  resolveNode: (nodeId: string) => TypeGraphNodeBinding | null,
+) {
+  root.querySelectorAll<SVGGElement>("g.node").forEach(node => {
+    const binding = resolveNode(mermaidNodeId(node, "t"));
+    if (!binding) return;
+    if (binding.onSelect) {
+      node.classList.add("nav-node");
+      node.style.cursor = "pointer";
+      node.addEventListener("click", binding.onSelect);
+      return;
+    }
+
+    node.classList.add("non-nav");
+    if (!binding.unavailableLabel) return;
+    const title =
+      node.ownerDocument.createElementNS("http://www.w3.org/2000/svg", "title");
+    title.textContent = binding.unavailableLabel;
+    node.insertBefore(title, node.firstChild);
+  });
+}
+
+export function bindDependencyGraphNodes(
+  root: ParentNode,
+  resolveNode: (
+    nodeId: string,
+  ) => DependencyGraphNodeBinding | null,
+) {
+  root.querySelectorAll<SVGGElement>("g.node").forEach(node => {
+    const binding = resolveNode(mermaidNodeId(node, "d"));
+    if (!binding) return;
+    node.classList.add("nav-node");
+    node.style.cursor = "pointer";
+    node.addEventListener("click", binding.onSelect);
+  });
+}
+
+export function bindGraphPanZoom(
+  container: ParentNode,
+  viewport: HTMLElement,
+  options: GraphPanZoomBindingOptions = {},
+) {
+  const svg = viewport.querySelector<SVGSVGElement>("svg");
+  if (!svg) return;
+  const renderedSvg = svg;
+
+  const box = svg.viewBox?.baseVal;
+  const naturalWidth =
+    box && box.width ? box.width : svg.getBoundingClientRect().width;
+  const naturalHeight =
+    box && box.height ? box.height : svg.getBoundingClientRect().height;
+  svg.setAttribute("width", String(naturalWidth));
+  svg.setAttribute("height", String(naturalHeight));
+
+  const minScale = 0.2;
+  const maxScale = 8;
+  const view = { scale: 1, x: 0, y: 0 };
+  const clampScale = (value: number) =>
+    Math.min(maxScale, Math.max(minScale, value));
+
+  function apply() {
+    renderedSvg.style.transform =
+      `translate(${view.x}px, ${view.y}px) scale(${view.scale})`;
+  }
+
+  function fit() {
+    const rect = viewport.getBoundingClientRect();
+    if (!naturalWidth || !naturalHeight || !rect.width) return;
+    const fitScale =
+      Math.min(rect.width / naturalWidth, rect.height / naturalHeight) * 0.92;
+    view.scale = clampScale(Math.min(fitScale, 1));
+    view.x = (rect.width - naturalWidth * view.scale) / 2;
+    view.y = (rect.height - naturalHeight * view.scale) / 2;
+    apply();
+  }
+
+  function zoomAt(px: number, py: number, factor: number) {
+    const next = clampScale(view.scale * factor);
+    const ratio = next / view.scale;
+    view.x = px - (px - view.x) * ratio;
+    view.y = py - (py - view.y) * ratio;
+    view.scale = next;
+    apply();
+  }
+
+  viewport.addEventListener("wheel", event => {
+    event.preventDefault();
+    const rect = viewport.getBoundingClientRect();
+    zoomAt(
+      event.clientX - rect.left,
+      event.clientY - rect.top,
+      Math.exp(-event.deltaY * 0.0015));
+  }, { passive: false });
+
+  let pointerId: number | null = null;
+  let moved = false;
+  let capturing = false;
+  const panThreshold = 5;
+  const start = { x: 0, y: 0, vx: 0, vy: 0 };
+  viewport.addEventListener("pointerdown", event => {
+    if (event.button !== 0) return;
+    pointerId = event.pointerId;
+    moved = false;
+    capturing = false;
+    start.x = event.clientX;
+    start.y = event.clientY;
+    start.vx = view.x;
+    start.vy = view.y;
+  });
+  viewport.addEventListener("pointermove", event => {
+    if (pointerId !== event.pointerId) return;
+    const dx = event.clientX - start.x;
+    const dy = event.clientY - start.y;
+    if (!capturing) {
+      if (Math.abs(dx) + Math.abs(dy) <= panThreshold) return;
+      capturing = true;
+      moved = true;
+      viewport.setPointerCapture(pointerId);
+      viewport.classList.add("panning");
+    }
+    view.x = start.vx + dx;
+    view.y = start.vy + dy;
+    apply();
+  });
+  function endPan(event: PointerEvent) {
+    if (pointerId !== event.pointerId) return;
+    if (capturing) {
+      viewport.releasePointerCapture(pointerId);
+      viewport.classList.remove("panning");
+    }
+    capturing = false;
+    pointerId = null;
+  }
+  viewport.addEventListener("pointerup", endPan);
+  viewport.addEventListener("pointercancel", endPan);
+
+  container.querySelectorAll<HTMLElement>(".graph-controls button")
+    .forEach(button => {
+      button.addEventListener("click", () => {
+        const rect = viewport.getBoundingClientRect();
+        const mode = button.dataset.zoom;
+        if (mode === "in")
+          zoomAt(rect.width / 2, rect.height / 2, 1.25);
+        else if (mode === "out")
+          zoomAt(rect.width / 2, rect.height / 2, 0.8);
+        else
+          fit();
+      });
+    });
+
+  viewport.tabIndex = 0;
+  viewport.addEventListener("keydown", event => {
+    const rect = viewport.getBoundingClientRect();
+    const step = 45;
+    if (event.key === "+" || event.key === "=")
+      zoomAt(rect.width / 2, rect.height / 2, 1.25);
+    else if (event.key === "-" || event.key === "_")
+      zoomAt(rect.width / 2, rect.height / 2, 0.8);
+    else if (event.key === "0")
+      fit();
+    else if (event.key === "ArrowLeft") {
+      view.x += step;
+      apply();
+    } else if (event.key === "ArrowRight") {
+      view.x -= step;
+      apply();
+    } else if (event.key === "ArrowUp") {
+      view.y += step;
+      apply();
+    } else if (event.key === "ArrowDown") {
+      view.y -= step;
+      apply();
+    } else {
+      return;
+    }
+    event.preventDefault();
+  });
+
+  if (options.resolveCallGraphNode) {
+    svg.querySelectorAll<SVGGElement>("g.node").forEach(node => {
+      const binding =
+        options.resolveCallGraphNode?.(mermaidNodeId(node, "n"));
+      if (!binding) return;
+      node.classList.add("nav-node");
+      if (binding.platform) node.classList.add("platform-node");
+      node.style.cursor = "pointer";
+      node.addEventListener("click", () => {
+        if (!moved) binding.onSelect();
+      });
+    });
+  }
+
+  fit();
+}

--- a/prototypes/inspect-web/test/graph-interactions.test.ts
+++ b/prototypes/inspect-web/test/graph-interactions.test.ts
@@ -1,0 +1,340 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bindDependencyGraphNodes,
+  bindGraphBack,
+  bindGraphPanZoom,
+  bindTypeGraphNodes,
+} from "../src/graph-interactions.ts";
+
+class FakeClassList {
+  private readonly values = new Set<string>();
+
+  add(...tokens: string[]) {
+    for (const token of tokens) this.values.add(token);
+  }
+
+  remove(...tokens: string[]) {
+    for (const token of tokens) this.values.delete(token);
+  }
+
+  contains(token: string) {
+    return this.values.has(token);
+  }
+}
+
+class FakeElement {
+  id = "";
+  readonly classList = new FakeClassList();
+  readonly dataset: Record<string, string | undefined> = {};
+  readonly inserted: { textContent: string | null }[] = [];
+  readonly ownerDocument = {
+    createElementNS: () => ({ textContent: null as string | null }),
+  };
+  readonly style: Record<string, string> = {};
+  firstChild = null;
+  hidden = false;
+  tabIndex = -1;
+  private readonly listeners = new Map<string, EventListener[]>();
+  private dataId: string | null = null;
+
+  constructor(options: { dataId?: string; id?: string } = {}) {
+    this.dataId = options.dataId ?? null;
+    this.id = options.id ?? "";
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, values: Record<string, unknown> = {}) {
+    let prevented = false;
+    const event = {
+      target: this,
+      preventDefault: () => prevented = true,
+      ...values,
+    } as unknown as Event;
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+    return prevented;
+  }
+
+  getAttribute(name: string) {
+    return name === "data-id" ? this.dataId : null;
+  }
+
+  insertBefore(node: { textContent: string | null }) {
+    this.inserted.push(node);
+    return node;
+  }
+}
+
+class FakeNodeRoot {
+  private readonly nodes: FakeElement[];
+
+  constructor(nodes: FakeElement[]) {
+    this.nodes = nodes;
+  }
+
+  querySelectorAll(selector: string) {
+    return selector === "g.node" ? this.nodes : [];
+  }
+}
+
+class FakeSvg extends FakeElement {
+  readonly attributes = new Map<string, string>();
+  readonly viewBox = { baseVal: { width: 100, height: 50 } };
+  private readonly nodes: FakeElement[];
+
+  constructor(nodes: FakeElement[]) {
+    super();
+    this.nodes = nodes;
+  }
+
+  getBoundingClientRect() {
+    return rect(100, 50);
+  }
+
+  querySelectorAll(selector: string) {
+    return selector === "g.node" ? this.nodes : [];
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+}
+
+class FakeViewport extends FakeElement {
+  capturedPointer: number | null = null;
+  private readonly svg: FakeSvg;
+
+  constructor(svg: FakeSvg) {
+    super();
+    this.svg = svg;
+  }
+
+  getBoundingClientRect() {
+    return rect(200, 100);
+  }
+
+  querySelector(selector: string) {
+    return selector === "svg" ? this.svg : null;
+  }
+
+  releasePointerCapture(pointerId: number) {
+    if (this.capturedPointer === pointerId) this.capturedPointer = null;
+  }
+
+  setPointerCapture(pointerId: number) {
+    this.capturedPointer = pointerId;
+  }
+}
+
+class FakeContainer {
+  private readonly buttons: FakeElement[];
+
+  constructor(buttons: FakeElement[]) {
+    this.buttons = buttons;
+  }
+
+  querySelectorAll(selector: string) {
+    return selector === ".graph-controls button" ? this.buttons : [];
+  }
+}
+
+function rect(width: number, height: number) {
+  return {
+    bottom: height,
+    height,
+    left: 0,
+    right: width,
+    top: 0,
+    width,
+    x: 0,
+    y: 0,
+    toJSON() {},
+  };
+}
+
+test("graph back binding dispatches only from the rendered control", () => {
+  const back = new FakeElement();
+  let calls = 0;
+  const root = {
+    querySelector: (selector: string) =>
+      selector === "[data-graph-back]" ? back : null,
+  };
+
+  bindGraphBack(
+    root as unknown as ParentNode,
+    { onBack: () => calls += 1 });
+
+  assert.equal(calls, 0);
+  back.dispatch("click");
+  assert.equal(calls, 1);
+});
+
+test("type and dependency nodes decode stable Mermaid identities", () => {
+  const type = new FakeElement({ dataId: "t1" });
+  const unavailable = new FakeElement({ id: "flowchart-t2-4" });
+  const unknown = new FakeElement({ id: "flowchart-x3-4" });
+  const typeCalls: string[] = [];
+
+  bindTypeGraphNodes(
+    new FakeNodeRoot([type, unavailable, unknown]) as unknown as ParentNode,
+    nodeId => {
+      if (nodeId === "t1") {
+        return { onSelect: () => typeCalls.push(nodeId) };
+      }
+      if (nodeId === "t2") {
+        return { unavailableLabel: "Hidden.Type — unavailable" };
+      }
+      return null;
+    });
+
+  assert.deepEqual(typeCalls, []);
+  assert.equal(type.classList.contains("nav-node"), true);
+  assert.equal(type.style.cursor, "pointer");
+  type.dispatch("click");
+  assert.deepEqual(typeCalls, ["t1"]);
+  assert.equal(unavailable.classList.contains("non-nav"), true);
+  assert.equal(unavailable.inserted[0]?.textContent, "Hidden.Type — unavailable");
+  assert.equal(unknown.classList.contains("nav-node"), false);
+
+  const dependency = new FakeElement({ id: "flowchart-d7-2" });
+  const self = new FakeElement({ dataId: "d0" });
+  const dependencyCalls: string[] = [];
+  bindDependencyGraphNodes(
+    new FakeNodeRoot([dependency, self]) as unknown as ParentNode,
+    nodeId => nodeId === "d7"
+      ? { onSelect: () => dependencyCalls.push(nodeId) }
+      : null);
+
+  assert.deepEqual(dependencyCalls, []);
+  dependency.dispatch("click");
+  self.dispatch("click");
+  assert.deepEqual(dependencyCalls, ["d7"]);
+});
+
+test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated", () => {
+  const regular = new FakeElement({ dataId: "n1" });
+  const platform = new FakeElement({ id: "flowchart-n2-3" });
+  const svg = new FakeSvg([regular, platform]);
+  const viewport = new FakeViewport(svg);
+  const zoomIn = new FakeElement();
+  const zoomOut = new FakeElement();
+  const reset = new FakeElement();
+  zoomIn.dataset.zoom = "in";
+  zoomOut.dataset.zoom = "out";
+  reset.dataset.zoom = "reset";
+  const container = new FakeContainer([zoomIn, zoomOut, reset]);
+  const calls: string[] = [];
+
+  bindGraphPanZoom(
+    container as unknown as ParentNode,
+    viewport as unknown as HTMLElement,
+    {
+      resolveCallGraphNode: nodeId => nodeId
+        ? {
+            onSelect: () => calls.push(nodeId),
+            platform: nodeId === "n2",
+          }
+        : null,
+    });
+
+  assert.equal(viewport.tabIndex, 0);
+  assert.equal(svg.attributes.get("width"), "100");
+  assert.equal(svg.attributes.get("height"), "50");
+  assert.equal(svg.style.transform, "translate(50px, 25px) scale(1)");
+  assert.equal(regular.classList.contains("nav-node"), true);
+  assert.equal(platform.classList.contains("platform-node"), true);
+  regular.dispatch("click");
+  assert.deepEqual(calls, ["n1"]);
+
+  assert.equal(viewport.dispatch("wheel", {
+    clientX: 100,
+    clientY: 50,
+    deltaY: -100,
+  }), true);
+  const zoomed = svg.style.transform;
+  assert.notEqual(zoomed, "translate(50px, 25px) scale(1)");
+  zoomOut.dispatch("click");
+  const zoomedOut = svg.style.transform;
+  assert.notEqual(zoomedOut, zoomed);
+  zoomIn.dispatch("click");
+  assert.notEqual(svg.style.transform, zoomedOut);
+  reset.dispatch("click");
+  const fitted = "translate(50px, 25px) scale(1)";
+  assert.equal(svg.style.transform, fitted);
+  for (const key of ["+", "=", "-", "_"]) {
+    assert.equal(viewport.dispatch("keydown", { key }), true);
+    assert.notEqual(svg.style.transform, fitted);
+    assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
+    assert.equal(svg.style.transform, fitted);
+  }
+  for (const key of ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"]) {
+    assert.equal(viewport.dispatch("keydown", { key }), true);
+    assert.notEqual(svg.style.transform, fitted);
+    assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
+    assert.equal(svg.style.transform, fitted);
+  }
+  assert.equal(viewport.dispatch("keydown", { key: "x" }), false);
+
+  viewport.dispatch("pointerdown", {
+    button: 1,
+    clientX: 10,
+    clientY: 10,
+    pointerId: 6,
+  });
+  viewport.dispatch("pointermove", {
+    clientX: 30,
+    clientY: 10,
+    pointerId: 6,
+  });
+  assert.equal(viewport.capturedPointer, null);
+
+  viewport.dispatch("pointerdown", {
+    button: 0,
+    clientX: 10,
+    clientY: 10,
+    pointerId: 7,
+  });
+  viewport.dispatch("pointermove", {
+    clientX: 20,
+    clientY: 10,
+    pointerId: 7,
+  });
+  assert.equal(viewport.capturedPointer, 7);
+  assert.equal(viewport.classList.contains("panning"), true);
+  viewport.dispatch("pointerup", { pointerId: 7 });
+  assert.equal(viewport.capturedPointer, null);
+  assert.equal(viewport.classList.contains("panning"), false);
+  platform.dispatch("click");
+  assert.deepEqual(calls, ["n1"]);
+
+  viewport.dispatch("pointerdown", {
+    button: 0,
+    clientX: 10,
+    clientY: 10,
+    pointerId: 8,
+  });
+  viewport.dispatch("pointerup", { pointerId: 8 });
+  platform.dispatch("click");
+  assert.deepEqual(calls, ["n1", "n2"]);
+});
+
+test("graph bindings tolerate missing rendered surfaces", () => {
+  const root = new FakeNodeRoot([]) as unknown as ParentNode;
+  assert.doesNotThrow(() => bindTypeGraphNodes(root, () => null));
+  assert.doesNotThrow(() => bindDependencyGraphNodes(root, () => null));
+  assert.doesNotThrow(() => bindGraphBack(
+    { querySelector: () => null } as unknown as ParentNode,
+    { onBack() {} }));
+  assert.doesNotThrow(() => bindGraphPanZoom(
+    new FakeContainer([]) as unknown as ParentNode,
+    {
+      querySelector: () => null,
+    } as unknown as HTMLElement));
+});

--- a/prototypes/inspect-web/test/graph-interactions.test.ts
+++ b/prototypes/inspect-web/test/graph-interactions.test.ts
@@ -212,6 +212,7 @@ test("type and dependency nodes decode stable Mermaid identities", () => {
   type.dispatch("click");
   assert.deepEqual(typeCalls, ["t1"]);
   assert.equal(unavailable.classList.contains("non-nav"), true);
+  assert.equal(unavailable.classList.contains("nav-node"), false);
   assert.equal(unavailable.inserted[0]?.textContent, "Hidden.Type — unavailable");
   assert.equal(unknown.classList.contains("nav-node"), false);
 
@@ -264,6 +265,7 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
   assert.equal(svg.attributes.get("height"), "50");
   assert.equal(svg.style.transform, "translate(50px, 25px) scale(1)");
   assert.equal(regular.classList.contains("nav-node"), true);
+  assert.equal(regular.classList.contains("platform-node"), false);
   assert.equal(platform.classList.contains("platform-node"), true);
   regular.dispatch("click");
   assert.deepEqual(calls, ["n1"]);

--- a/prototypes/inspect-web/test/graph-interactions.test.ts
+++ b/prototypes/inspect-web/test/graph-interactions.test.ts
@@ -159,6 +159,18 @@ function rect(width: number, height: number) {
   };
 }
 
+function graphTransform(element: FakeElement) {
+  const match =
+    /^translate\(([^p]+)px, ([^p]+)px\) scale\(([^)]+)\)$/
+      .exec(element.style.transform ?? "");
+  assert.ok(match);
+  return {
+    scale: Number(match[3]),
+    x: Number(match[1]),
+    y: Number(match[2]),
+  };
+}
+
 test("graph back binding dispatches only from the rendered control", () => {
   const back = new FakeElement();
   let calls = 0;
@@ -213,6 +225,9 @@ test("type and dependency nodes decode stable Mermaid identities", () => {
       : null);
 
   assert.deepEqual(dependencyCalls, []);
+  assert.equal(dependency.classList.contains("nav-node"), true);
+  assert.equal(dependency.style.cursor, "pointer");
+  assert.equal(self.classList.contains("nav-node"), false);
   dependency.dispatch("click");
   self.dispatch("click");
   assert.deepEqual(dependencyCalls, ["d7"]);
@@ -258,27 +273,40 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
     clientY: 50,
     deltaY: -100,
   }), true);
-  const zoomed = svg.style.transform;
-  assert.notEqual(zoomed, "translate(50px, 25px) scale(1)");
+  const zoomed = graphTransform(svg);
+  assert.ok(zoomed.scale > 1);
+  assert.ok(zoomed.x < 50);
+  assert.ok(zoomed.y < 25);
   zoomOut.dispatch("click");
-  const zoomedOut = svg.style.transform;
-  assert.notEqual(zoomedOut, zoomed);
+  const zoomedOut = graphTransform(svg);
+  assert.ok(zoomedOut.scale < zoomed.scale);
   zoomIn.dispatch("click");
-  assert.notEqual(svg.style.transform, zoomedOut);
+  assert.ok(graphTransform(svg).scale > zoomedOut.scale);
   reset.dispatch("click");
   const fitted = "translate(50px, 25px) scale(1)";
   assert.equal(svg.style.transform, fitted);
-  for (const key of ["+", "=", "-", "_"]) {
+  for (const key of ["+", "="]) {
     assert.equal(viewport.dispatch("keydown", { key }), true);
-    assert.notEqual(svg.style.transform, fitted);
+    assert.ok(graphTransform(svg).scale > 1);
     assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
     assert.equal(svg.style.transform, fitted);
   }
-  for (const key of ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"]) {
+  for (const key of ["-", "_"]) {
     assert.equal(viewport.dispatch("keydown", { key }), true);
-    assert.notEqual(svg.style.transform, fitted);
+    assert.ok(graphTransform(svg).scale < 1);
     assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
     assert.equal(svg.style.transform, fitted);
+  }
+  const arrowPositions = new Map([
+    ["ArrowLeft", { x: 95, y: 25 }],
+    ["ArrowRight", { x: 5, y: 25 }],
+    ["ArrowUp", { x: 50, y: 70 }],
+    ["ArrowDown", { x: 50, y: -20 }],
+  ]);
+  for (const [key, expected] of arrowPositions) {
+    assert.equal(viewport.dispatch("keydown", { key }), true);
+    assert.deepEqual(graphTransform(svg), { ...expected, scale: 1 });
+    assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
   }
   assert.equal(viewport.dispatch("keydown", { key: "x" }), false);
 
@@ -302,12 +330,20 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
     pointerId: 7,
   });
   viewport.dispatch("pointermove", {
+    clientX: 30,
+    clientY: 10,
+    pointerId: 70,
+  });
+  assert.equal(viewport.capturedPointer, null);
+  assert.equal(svg.style.transform, fitted);
+  viewport.dispatch("pointermove", {
     clientX: 20,
     clientY: 10,
     pointerId: 7,
   });
   assert.equal(viewport.capturedPointer, 7);
   assert.equal(viewport.classList.contains("panning"), true);
+  assert.deepEqual(graphTransform(svg), { scale: 1, x: 60, y: 25 });
   viewport.dispatch("pointerup", { pointerId: 7 });
   assert.equal(viewport.capturedPointer, null);
   assert.equal(viewport.classList.contains("panning"), false);
@@ -320,7 +356,25 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
     clientY: 10,
     pointerId: 8,
   });
-  viewport.dispatch("pointerup", { pointerId: 8 });
+  viewport.dispatch("pointermove", {
+    clientX: 10,
+    clientY: 20,
+    pointerId: 8,
+  });
+  assert.equal(viewport.capturedPointer, 8);
+  viewport.dispatch("pointercancel", { pointerId: 8 });
+  assert.equal(viewport.capturedPointer, null);
+  assert.equal(viewport.classList.contains("panning"), false);
+  platform.dispatch("click");
+  assert.deepEqual(calls, ["n1"]);
+
+  viewport.dispatch("pointerdown", {
+    button: 0,
+    clientX: 10,
+    clientY: 10,
+    pointerId: 9,
+  });
+  viewport.dispatch("pointerup", { pointerId: 9 });
   platform.dispatch("click");
   assert.deepEqual(calls, ["n1", "n2"]);
 });

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -651,6 +651,11 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
   assert.match(
     callGraphBinding,
     /callGraph\.targets\?\.find\(candidate => candidate\.id === nodeId\)[\s\S]*state\.platformStack\.length > 0[\s\S]*target\.id === "n0"[\s\S]*navigateOrDrillPlatform\(target\)[\s\S]*resolveLoadedGraphTargetCandidate[\s\S]*graphTargetNavigationDisposition[\s\S]*navigateToMember\([\s\S]*openGraphSource\([\s\S]*navigateOrDrillPlatform\(target\)/);
+  assert.equal(appSource.match(/\bbindGraphBack\(/g)?.length, 1);
+  assert.equal(appSource.match(/\bbindGraphPanZoom\(/g)?.length, 3);
+  assert.equal(appSource.match(/\bbindTypeGraphNodes\(/g)?.length, 1);
+  assert.equal(appSource.match(/\bbindDependencyGraphNodes\(/g)?.length, 1);
+  assert.equal(appSource.match(/\bcallGraphNodeBinding\(/g)?.length, 2);
   assert.doesNotMatch(
     `${typeGraph}\n${dependencyGraph}\n${callGraph}`,
     /\.addEventListener\(|querySelectorAll<SVGGElement>\("g\.node"\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -671,7 +671,7 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     /const platform = disposition === "platform";\s*return \{\s*platform,\s*onSelect:/);
   assert.match(
     callGraphBinding,
-    /if \(loaded\?\.group\) \{\s*navigateToMember\(/);
+    /if \(loaded\?\.group\) \{\s*navigateToMember\([\s\S]*\} else if \(loaded\) \{\s*openGraphSource\(loaded\.request, loaded\.title\);\s*\} else if \(platform\) \{\s*void navigateOrDrillPlatform\(target\);\s*\}/);
   assert.equal(appSource.match(/\bbindGraphBack\(/g)?.length, 1);
   assert.equal(appSource.match(/\bbindGraphPanZoom\(/g)?.length, 3);
   assert.equal(appSource.match(/\bbindTypeGraphNodes\(/g)?.length, 1);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -660,6 +660,18 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
   assert.match(
     callGraphBinding,
     /callGraph\.targets\?\.find\(candidate => candidate\.id === nodeId\)[\s\S]*const drilled =\s*state\.platformStack\.length > 0 \|\| Boolean\(state\.package\?\.isRuntimePack\);\s*if \(drilled\) \{\s*if \(target\.id === "n0" \|\| !target\.assembly \|\| !typeId\) return null;[\s\S]*navigateOrDrillPlatform\(target\)[\s\S]*resolveLoadedGraphTargetCandidate[\s\S]*graphTargetNavigationDisposition[\s\S]*if \(disposition === "blocked" \|\| disposition === "none"\) return null;[\s\S]*navigateToMember\([\s\S]*openGraphSource\([\s\S]*navigateOrDrillPlatform\(target\)/);
+  assert.match(
+    callGraphBinding,
+    /if \(drilled\) \{[\s\S]*return \{\s*platform: true,\s*onSelect: \(\) => \{[\s\S]*navigateOrDrillPlatform\(target\)/);
+  assert.match(
+    callGraphBinding,
+    /const loaded = disposition === "loaded" && candidate\.status === "unique"\s*\? resolveLoadedGraphTarget\(target, candidate\)\s*: null/);
+  assert.match(
+    callGraphBinding,
+    /const platform = disposition === "platform";\s*return \{\s*platform,\s*onSelect:/);
+  assert.match(
+    callGraphBinding,
+    /if \(loaded\?\.group\) \{\s*navigateToMember\(/);
   assert.equal(appSource.match(/\bbindGraphBack\(/g)?.length, 1);
   assert.equal(appSource.match(/\bbindGraphPanZoom\(/g)?.length, 3);
   assert.equal(appSource.match(/\bbindTypeGraphNodes\(/g)?.length, 1);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -618,6 +618,9 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
   const callGraphBinding =
     appSource.match(/function callGraphNodeBinding\([\s\S]*?\n}(?=\n\nfunction currentCallGraph)/)?.[0]
     ?? "";
+  const dependencyNodeBinding =
+    graphInteractionsSource.match(/export function bindDependencyGraphNodes\([\s\S]*?\n}(?=\n\nexport function bindGraphPanZoom)/)?.[0]
+    ?? "";
   assert.match(
     graphInteractionsSource,
     /export function bindGraphBack\([\s\S]*\[data-graph-back\]/);
@@ -631,8 +634,8 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     graphInteractionsSource,
     /export function bindTypeGraphNodes\([\s\S]*"t"[\s\S]*nav-node[\s\S]*non-nav[\s\S]*createElementNS/);
   assert.match(
-    graphInteractionsSource,
-    /export function bindDependencyGraphNodes\([\s\S]*"d"[\s\S]*nav-node/);
+    dependencyNodeBinding,
+    /mermaidNodeId\(node, "d"\)[\s\S]*classList\.add\("nav-node"\)[\s\S]*style\.cursor = "pointer"[\s\S]*addEventListener\("click", binding\.onSelect\)/);
   assert.match(
     appSource,
     /const graphBackActions: GraphBackBindingActions = \{\s*onBack: popPlatformDrill,\s*};/);
@@ -643,14 +646,20 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     typeGraph,
     /bindGraphPanZoom\(container, viewport\);[\s\S]*bindTypeGraphNodes\(viewport, nodeId => \{[\s\S]*graphNodeOf\.get\(nodeId\)[\s\S]*onSelect: \(\) => navigateToType\(target\)[\s\S]*unavailableLabel/);
   assert.match(
+    typeGraph,
+    /const target = graphNode\.role === "self"\s*\? selectedType\(\)\s*: uniqueTypeByQueryId\(pkg\.types, fullName\)/);
+  assert.match(
     dependencyGraph,
     /bindGraphPanZoom\(container, viewport\);[\s\S]*bindDependencyGraphNodes\(viewport, nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)[\s\S]*switchToPackageForDependencies\(info\.packageKey\)[\s\S]*openDependencyPackage\(info\.id, info\.versionRange\)/);
+  assert.match(
+    dependencyGraph,
+    /const info = nodeId \? built\.nodeInfoById\.get\(nodeId\) : null;\s*if \(!info \|\| info\.kind === "self"\) return null/);
   assert.match(
     callGraph,
     /bindGraphPanZoom\(container, viewport, \{[\s\S]*resolveCallGraphNode: nodeId =>[\s\S]*callGraphNodeBinding\(active, nodeId\)/);
   assert.match(
     callGraphBinding,
-    /callGraph\.targets\?\.find\(candidate => candidate\.id === nodeId\)[\s\S]*state\.platformStack\.length > 0[\s\S]*target\.id === "n0"[\s\S]*navigateOrDrillPlatform\(target\)[\s\S]*resolveLoadedGraphTargetCandidate[\s\S]*graphTargetNavigationDisposition[\s\S]*navigateToMember\([\s\S]*openGraphSource\([\s\S]*navigateOrDrillPlatform\(target\)/);
+    /callGraph\.targets\?\.find\(candidate => candidate\.id === nodeId\)[\s\S]*const drilled =\s*state\.platformStack\.length > 0 \|\| Boolean\(state\.package\?\.isRuntimePack\);\s*if \(drilled\) \{\s*if \(target\.id === "n0" \|\| !target\.assembly \|\| !typeId\) return null;[\s\S]*navigateOrDrillPlatform\(target\)[\s\S]*resolveLoadedGraphTargetCandidate[\s\S]*graphTargetNavigationDisposition[\s\S]*if \(disposition === "blocked" \|\| disposition === "none"\) return null;[\s\S]*navigateToMember\([\s\S]*openGraphSource\([\s\S]*navigateOrDrillPlatform\(target\)/);
   assert.equal(appSource.match(/\bbindGraphBack\(/g)?.length, 1);
   assert.equal(appSource.match(/\bbindGraphPanZoom\(/g)?.length, 3);
   assert.equal(appSource.match(/\bbindTypeGraphNodes\(/g)?.length, 1);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -185,6 +185,9 @@ const libraryControlsSource = readFileSync(
 const shellControlsSource = readFileSync(
   new URL("../src/shell-controls.ts", import.meta.url),
   "utf8");
+const graphInteractionsSource = readFileSync(
+  new URL("../src/graph-interactions.ts", import.meta.url),
+  "utf8");
 const sourceInspectionSource = readFileSync(
   new URL("../src/source-inspection.ts", import.meta.url),
   "utf8");
@@ -597,6 +600,67 @@ test("typed shell controls own workbench, home, and load-error bindings", () => 
   assert.doesNotMatch(
     loadingBinding,
     /#(?:retry-load|error-package-query|error-package-input|toggle-error-detail)|"\.load-error-detail"/);
+});
+
+test("typed graph interactions own graph controls and Mermaid node bindings", () => {
+  const workspaceBinding =
+    appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
+    ?? "";
+  const typeGraph =
+    appSource.match(/async function renderTypeGraph\(\) \{[\s\S]*?\n}(?=\n\nfunction navigateToTypeByName)/)?.[0]
+    ?? "";
+  const dependencyGraph =
+    appSource.match(/async function renderDependencyGraph\(\) \{[\s\S]*?\n}(?=\n\nfunction switchToPackageForDependencies)/)?.[0]
+    ?? "";
+  const callGraph =
+    appSource.match(/async function renderMermaidCallGraph\(\) \{[\s\S]*?\n}(?=\n\nfunction callGraphNodeBinding)/)?.[0]
+    ?? "";
+  const callGraphBinding =
+    appSource.match(/function callGraphNodeBinding\([\s\S]*?\n}(?=\n\nfunction currentCallGraph)/)?.[0]
+    ?? "";
+  assert.match(
+    graphInteractionsSource,
+    /export function bindGraphBack\([\s\S]*\[data-graph-back\]/);
+  assert.match(
+    graphInteractionsSource,
+    /function mermaidNodeId\([\s\S]*data-id[\s\S]*flowchart-/);
+  assert.match(
+    graphInteractionsSource,
+    /export function bindGraphPanZoom\([\s\S]*"wheel"[\s\S]*"pointerdown"[\s\S]*"pointermove"[\s\S]*"pointerup"[\s\S]*"pointercancel"[\s\S]*\.graph-controls button[\s\S]*"keydown"[\s\S]*resolveCallGraphNode/);
+  assert.match(
+    graphInteractionsSource,
+    /export function bindTypeGraphNodes\([\s\S]*"t"[\s\S]*nav-node[\s\S]*non-nav[\s\S]*createElementNS/);
+  assert.match(
+    graphInteractionsSource,
+    /export function bindDependencyGraphNodes\([\s\S]*"d"[\s\S]*nav-node/);
+  assert.match(
+    appSource,
+    /const graphBackActions: GraphBackBindingActions = \{\s*onBack: popPlatformDrill,\s*};/);
+  assert.match(
+    workspaceBinding,
+    /bindGraphBack\(document, graphBackActions\)/);
+  assert.match(
+    typeGraph,
+    /bindGraphPanZoom\(container, viewport\);[\s\S]*bindTypeGraphNodes\(viewport, nodeId => \{[\s\S]*graphNodeOf\.get\(nodeId\)[\s\S]*onSelect: \(\) => navigateToType\(target\)[\s\S]*unavailableLabel/);
+  assert.match(
+    dependencyGraph,
+    /bindGraphPanZoom\(container, viewport\);[\s\S]*bindDependencyGraphNodes\(viewport, nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)[\s\S]*switchToPackageForDependencies\(info\.packageKey\)[\s\S]*openDependencyPackage\(info\.id, info\.versionRange\)/);
+  assert.match(
+    callGraph,
+    /bindGraphPanZoom\(container, viewport, \{[\s\S]*resolveCallGraphNode: nodeId =>[\s\S]*callGraphNodeBinding\(active, nodeId\)/);
+  assert.match(
+    callGraphBinding,
+    /callGraph\.targets\?\.find\(candidate => candidate\.id === nodeId\)[\s\S]*state\.platformStack\.length > 0[\s\S]*target\.id === "n0"[\s\S]*navigateOrDrillPlatform\(target\)[\s\S]*resolveLoadedGraphTargetCandidate[\s\S]*graphTargetNavigationDisposition[\s\S]*navigateToMember\([\s\S]*openGraphSource\([\s\S]*navigateOrDrillPlatform\(target\)/);
+  assert.doesNotMatch(
+    `${typeGraph}\n${dependencyGraph}\n${callGraph}`,
+    /\.addEventListener\(|querySelectorAll<SVGGElement>\("g\.node"\)/);
+  assert.doesNotMatch(
+    appSource,
+    /function (?:attachGraphPanZoom|graphTargetForSvgNode)\(/);
+  assert.doesNotMatch(
+    appSource,
+    /document\.querySelector\("\[data-graph-back\]"\)/);
+  assert.equal(appSource.match(/\.addEventListener\(/g)?.length, 4);
 });
 
 test("typed document inspection owns package document request coordination", () => {
@@ -1685,8 +1749,11 @@ test("dependency graph binds navigation to generated node identities", () => {
     graphSource,
     /const nodeInfoById = new Map\(\s+keys\.map\(key => \[idOf\.get\(key\), nodeInfo\.get\(key\)\]\)\)/);
   assert.match(
+    graphInteractionsSource,
+    /const dataId = node\.getAttribute\("data-id"\);[\s\S]*return dataId \|\| idMatch\?\.\[1\] \|\| ""/);
+  assert.match(
     appSource,
-    /const nodeId = dataId \|\| idMatch\?\.\[1\];\s*const info = nodeId \? built\.nodeInfoById\.get\(nodeId\) : null/);
+    /bindDependencyGraphNodes\(viewport, nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)/);
   assert.doesNotMatch(appSource, /nodeInfoByLabel/);
   assert.match(
     appSource,


### PR DESCRIPTION
## Summary

- add a typed graph-interactions owner for graph-back, pan/zoom, pointer,
  keyboard, zoom-button, and rendered Mermaid node bindings
- preserve stable Mermaid node identity and call-graph drag-click suppression
- keep graph-target resolution, package/member navigation, platform descent,
  rendering, and stale-render suppression in `dotnet-inspect.ts`

## Stack

Slice 26 of the issue #4504 stack.

Parent: #4535

Residual after this slice: none within the planned ownership extraction. Global
application keyboard, outside-click, metadata resize, and browser-history
coordination remain intentionally in the mutable composition root.

## Validation

- `npm test` - 447/447
- `npm run build`
- focused typecheck and graph/composition tests - 104/104
- duplicate binder, direction, cancel, dependency-style, and routing mutations killed
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

Exact base: `06d3b4cffc1cac5e92c84d1a0b457679407a111f`
Exact head: `2f8682933bf94e91bf459e22d8faa3013631a2b5`

Part of #4504.