### PR TITLE
Plumb trusted introduced-arity into TypeNodeProvider/TypeNode

### DIFF
--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -369,6 +369,7 @@ internal sealed class GenericTypeNode(
             result = TypeResolver.ApplyGenericArguments(
                 metadataName.Segments,
                 renderedArguments,
+                metadataName.IntroducedTypeParameterCounts,
                 preserveMismatchedArguments: canonicalTuples);
             if (metadataName.Namespace.Length > 0)
                 result = $"{metadataName.Namespace}.{result}";

--- a/src/ILInspector.Metadata/TypeNodeProvider.cs
+++ b/src/ILInspector.Metadata/TypeNodeProvider.cs
@@ -60,7 +60,7 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
             out string? name,
             out RelationshipTraversalRejection? rejection);
         MetadataTypeNameParts? metadataName = resolved
-            ? TypeResolver.GetTypeNamePartsFromDefinition(reader, handle)
+            ? WithTrustedArity(reader, handle, TypeResolver.GetTypeNamePartsFromDefinition(reader, handle))
             : null;
         var read = new NamedTypeRead(
             resolved,
@@ -70,6 +70,35 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
             materializationWork);
         Cache(reader, handle, read);
         return ReadNamedType(read, rawTypeKind);
+    }
+
+    /// <summary>
+    /// Attaches metadata-verified, per-segment introduced generic-parameter
+    /// counts along <paramref name="handle"/>'s declaring chain, so nested-type
+    /// rendering can recover a segment's true arity even when its raw name lacks
+    /// a canonical <c>`N</c> suffix (#4507). Scoped to <see cref="TypeDefinitionHandle"/>
+    /// (a local declaration): a <see cref="TypeReferenceHandle"/> has no
+    /// equivalent trusted source without loading the referenced assembly, which
+    /// this product does not do.
+    /// </summary>
+    static MetadataTypeNameParts WithTrustedArity(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        MetadataTypeNameParts metadataName)
+    {
+        try
+        {
+            List<int> counts = MetadataDeclarationQuery.GetIntroducedTypeParameterCounts(reader, handle);
+            return metadataName.WithIntroducedTypeParameterCounts(counts);
+        }
+        catch (BadImageFormatException)
+        {
+            // A malformed declaring/generic-parameter relationship here does not
+            // change what TryGetTypeNameFromDefinition already resolved; fall
+            // back to raw-name-only arity rather than rejecting a name the
+            // caller already trusts.
+            return metadataName;
+        }
     }
 
     public TypeNode GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)

--- a/src/ILInspector.MetadataPrimitives/TypeResolver.cs
+++ b/src/ILInspector.MetadataPrimitives/TypeResolver.cs
@@ -1006,15 +1006,51 @@ public static class TypeResolver
         IReadOnlyList<string> metadataNameSegments,
         IReadOnlyList<string> typeArguments,
         bool preserveMismatchedArguments = false)
+        => ApplyGenericArguments(
+            metadataNameSegments,
+            typeArguments,
+            introducedTypeParameterCounts: null,
+            preserveMismatchedArguments);
+
+    /// <summary>
+    /// As <see cref="ApplyGenericArguments(IReadOnlyList{string}, IReadOnlyList{string}, bool)"/>,
+    /// but for a segment whose raw name declares no canonical arity suffix,
+    /// <paramref name="introducedTypeParameterCounts"/> — one metadata-verified
+    /// introduced-parameter count per segment, when its length matches
+    /// <paramref name="metadataNameSegments"/> — supplies that segment's true
+    /// arity instead of treating it as zero. This lets a local nested generic
+    /// type whose name lacks (or disagrees with) its canonical <c>`N</c> suffix
+    /// still place arguments on the correct declaring-chain segment, mirroring
+    /// <c>TypeRef.EffectiveSegmentArity</c>. A segment that already declares a
+    /// suffix keeps that declared arity; the trusted count only fills a gap.
+    /// </summary>
+    public static string ApplyGenericArguments(
+        IReadOnlyList<string> metadataNameSegments,
+        IReadOnlyList<string> typeArguments,
+        IReadOnlyList<int>? introducedTypeParameterCounts,
+        bool preserveMismatchedArguments = false)
     {
         ArgumentNullException.ThrowIfNull(metadataNameSegments);
         ArgumentNullException.ThrowIfNull(typeArguments);
 
-        long declaredArity = 0;
-        foreach (string segment in metadataNameSegments)
+        bool hasTrustedCounts =
+            introducedTypeParameterCounts is not null
+            && introducedTypeParameterCounts.Count == metadataNameSegments.Count;
+
+        int EffectiveSegmentArity(int index, string segment)
         {
+            int declared = MetadataNameArity.OfSegment(segment);
+            return declared == 0 && hasTrustedCounts
+                ? introducedTypeParameterCounts![index]
+                : declared;
+        }
+
+        long declaredArity = 0;
+        for (int index = 0; index < metadataNameSegments.Count; index++)
+        {
+            string segment = metadataNameSegments[index];
             ArgumentNullException.ThrowIfNull(segment);
-            declaredArity += MetadataNameArity.OfSegment(segment);
+            declaredArity += EffectiveSegmentArity(index, segment);
         }
 
         string rawName = string.Join('.', metadataNameSegments);
@@ -1045,8 +1081,35 @@ public static class TypeResolver
             if (segmentIndex > 0)
                 result.Append('.');
 
+            string segment = metadataNameSegments[segmentIndex];
+            int declaredSegmentArity = MetadataNameArity.OfSegment(segment);
+            if (declaredSegmentArity == 0)
+            {
+                // No canonical suffix on this segment: append its trusted arity
+                // (if any) directly rather than rewriting a marker that isn't
+                // there, matching TypeRef.RenderNestedDefinition's handling of an
+                // implicit outer-segment arity.
+                int trustedArity = EffectiveSegmentArity(segmentIndex, segment);
+                result.Append(segment);
+                if (trustedArity > 0)
+                {
+                    result.Append('<');
+                    for (int k = 0; k < trustedArity; k++)
+                    {
+                        if (k > 0)
+                            result.Append(", ");
+                        result.Append(argIndex < typeArguments.Count
+                            ? typeArguments[argIndex]
+                            : $"T{argIndex + 1}");
+                        argIndex++;
+                    }
+                    result.Append('>');
+                }
+                continue;
+            }
+
             result.Append(RewriteAritySegments(
-                metadataNameSegments[segmentIndex],
+                segment,
                 (int arity, StringBuilder builder) =>
                 {
                     builder.Append('<');
@@ -1644,10 +1707,35 @@ public static class TypeResolver
         => Malformed<string>(exception, subject, consumedNodes).GetValueOrThrow();
 }
 
-internal sealed class MetadataTypeNameParts(string @namespace, string[] segments)
+internal sealed class MetadataTypeNameParts(
+    string @namespace,
+    string[] segments,
+    IReadOnlyList<int>? introducedTypeParameterCounts = null)
 {
     public string Namespace { get; } = @namespace;
     public IReadOnlyList<string> Segments { get; } = segments;
+
+    /// <summary>
+    /// Metadata-verified, per-segment introduced generic-parameter counts along
+    /// this type's declaring chain — one entry per <see cref="Segments"/> entry,
+    /// or null when unavailable (a <c>TypeReferenceHandle</c> cannot resolve this
+    /// without loading the referenced assembly). Rendering prefers this over a
+    /// segment's raw canonical-suffix arity only where the raw name declares no
+    /// suffix, mirroring <c>TypeRef.EffectiveSegmentArity</c>.
+    /// </summary>
+    public IReadOnlyList<int>? IntroducedTypeParameterCounts { get; }
+        = introducedTypeParameterCounts;
+
+    /// <summary>
+    /// A copy of these parts carrying <paramref name="introducedTypeParameterCounts"/>.
+    /// Used by a caller (such as <c>TypeNodeProvider</c>, for a local
+    /// <c>TypeDefinitionHandle</c>) that computes the trusted counts separately,
+    /// since this project does not depend on the metadata-declaration query that
+    /// produces them.
+    /// </summary>
+    public MetadataTypeNameParts WithIntroducedTypeParameterCounts(
+        IReadOnlyList<int> introducedTypeParameterCounts)
+        => new(Namespace, [.. Segments], introducedTypeParameterCounts);
 
     public string ToDottedName()
     {

--- a/tests/ILInspector.Metadata.Tests/TypeNodeProviderTrustedArityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeNodeProviderTrustedArityTests.cs
@@ -1,0 +1,138 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+// #4507: TypeRef (Decompiler layer) recovers a nested type's true generic
+// arity from GetIntroducedTypeParameterCounts when a raw metadata-name
+// segment lacks its canonical `N suffix. TypeNodeProvider/TypeNode had no
+// equivalent trusted-count fallback and derived nested-segment arity purely
+// from the raw name string, so a locally-declared nested generic type whose
+// outer segment lacks a suffix could misplace generic arguments onto the
+// wrong declaring-chain segment.
+public sealed class TypeNodeProviderTrustedArityTests
+{
+    // Outer's raw name has no canonical `N suffix even though it owns one
+    // generic parameter; Inner's raw name (Inner`1) only advertises its own
+    // introduced parameter, not the enclosing one. Metadata proves Outer owns
+    // 1 parameter and Inner introduces 1 more (cumulative 2).
+    static readonly (MetadataReader Reader, TypeDefinitionHandle Inner) Fixture = BuildFixture();
+
+    [Fact]
+    public void NestedGenericDefinition_WithMissingOuterSuffix_RendersUnboundArityOnOuterSegment()
+    {
+        TypeNode node = TypeNodeProvider.Instance.GetTypeFromDefinition(
+            Fixture.Reader,
+            Fixture.Inner,
+            rawTypeKind: 0x12);
+
+        var namedType = Assert.IsType<NamedTypeNode>(node);
+        Assert.NotNull(namedType.MetadataName);
+        Assert.Equal([1, 1], namedType.MetadataName!.IntroducedTypeParameterCounts);
+    }
+
+    [Fact]
+    public void NestedGenericInstance_WithMissingOuterSuffix_PlacesArgumentsOnCorrectSegments()
+    {
+        TypeNode node = TypeNodeProvider.Instance.GetTypeFromDefinition(
+            Fixture.Reader,
+            Fixture.Inner,
+            rawTypeKind: 0x12);
+
+        TypeNode generic = TypeNodeProvider.Instance.GetGenericInstantiation(
+            node,
+            [
+                new PrimitiveTypeNode("int", isReferenceType: false),
+                new PrimitiveTypeNode("string", isReferenceType: true),
+            ]);
+
+        // The outer segment's trusted count (1) places the first argument on
+        // Outer, and Inner's own declared suffix (`1) places the second on
+        // Inner — Outer<int>.Inner<string>, not Outer.Inner<int, string> or
+        // any other misplacement.
+        Assert.Equal("N.Outer<int>.Inner<string>", generic.Render());
+    }
+
+    static (MetadataReader, TypeDefinitionHandle) BuildFixture()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("TrustedArityFixture.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("TrustedArityFixture"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            TypeAttributes.NotPublic,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        StringHandle ns = metadata.GetOrAddString("N");
+        TypeDefinitionHandle outer = metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Class,
+            ns,
+            metadata.GetOrAddString("Outer"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddGenericParameter(
+            outer,
+            GenericParameterAttributes.None,
+            metadata.GetOrAddString("TOuter"),
+            0);
+
+        TypeDefinitionHandle inner = metadata.AddTypeDefinition(
+            TypeAttributes.NestedPublic | TypeAttributes.Class,
+            default,
+            metadata.GetOrAddString("Inner`1"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(2),
+            MetadataTokens.MethodDefinitionHandle(2));
+        metadata.AddGenericParameter(
+            inner,
+            GenericParameterAttributes.None,
+            metadata.GetOrAddString("TOuter"),
+            0);
+        metadata.AddGenericParameter(
+            inner,
+            GenericParameterAttributes.None,
+            metadata.GetOrAddString("TInner"),
+            1);
+        metadata.AddNestedType(inner, outer);
+
+        var peBuilder = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        peBuilder.Serialize(image);
+        byte[] bytes = image.ToArray();
+
+        var peReader = new PEReader(ImmutableCollectionsMarshal.AsImmutableArray(bytes));
+        MetadataReader reader = peReader.GetMetadataReader();
+
+        foreach (TypeDefinitionHandle handle in reader.TypeDefinitions)
+        {
+            TypeDefinition typeDef = reader.GetTypeDefinition(handle);
+            if (reader.GetString(typeDef.Name) == "Inner`1")
+                return (reader, handle);
+        }
+
+        throw new InvalidOperationException("Inner`1 was not found in the fixture.");
+    }
+}


### PR DESCRIPTION
## Summary

`TypeNodeProvider`/`TypeNode` (Metadata layer) now recover trusted, metadata-verified
per-segment generic arity for locally-declared nested generic types, closing a
parity gap with `TypeRef`/`TypeRefDecoder` (Decompiler layer), which already had this
fallback via `MetadataDeclarationQuery.GetIntroducedTypeParameterCounts`.

Before this change, `TypeNodeProvider` derived nested-segment arity purely from the
raw metadata-name string's canonical `` `N `` suffix. A locally-declared nested
generic type whose outer declaring-chain segment's raw name lacked (or disagreed
with) that suffix — while its own IL metadata `GenericParameters` said otherwise —
could have its generic arguments misplaced onto the wrong segment, or bail to the
raw, un-instantiated name entirely.

Fixes #4507.

## Change

- `MetadataTypeNameParts` (`TypeResolver.cs`) carries an optional per-segment
  `IntroducedTypeParameterCounts`, attached via `WithIntroducedTypeParameterCounts`
  (kept out of the constructor since `ILInspector.MetadataPrimitives` does not
  depend on `ILInspector.Metadata`, where the counts are computed).
- `TypeNodeProvider.GetTypeFromDefinition` computes trusted counts for a local
  `TypeDefinitionHandle` via the same `GetIntroducedTypeParameterCounts` helper
  `TypeRefDecoder` already uses, and attaches them (wrapped for graceful fallback on
  `BadImageFormatException`). `TypeReferenceHandle` is intentionally unchanged:
  resolving a cross-assembly reference's true arity needs the referenced assembly
  loaded, which this product does not do — `TypeRef` has the same scope limit.
- `TypeResolver.ApplyGenericArguments` gains an overload that uses a trusted count
  for a segment only when that segment's raw name declares no canonical suffix
  (declared arity 0), mirroring `TypeRef.EffectiveSegmentArity`'s exact guard. A
  segment that already declares a suffix keeps that declared arity unconditionally
  — this only fills a gap, it never overrides or flags a mismatch.
- `GenericTypeNode.Render` threads `metadataName.IntroducedTypeParameterCounts`
  through to `ApplyGenericArguments`.

## Evidence

- New regression test (`TypeNodeProviderTrustedArityTests.cs`) builds a real
  fixture via `MetadataBuilder`/`ManagedPEBuilder`: `Outer` (1 real generic
  parameter, no `` `N `` suffix in its raw name) nesting `Inner\`1`. Verified via
  `git stash` that this test fails pre-fix with the exact wrong output
  (raw, un-instantiated segmented name) and passes post-fix (arguments correctly
  placed on both segments).
- `dotnet build dotnet-inspect.slnx -c Release`: succeeds, no new warnings.
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release`: 1921/1921
  pass (1919 pre-existing + 2 new).
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`: 5864/5865
  pass, 8 skipped (environment-gated, `ilasm` unavailable). The one failure,
  `RetainedMergeStructuringTests.CoreLibOrdinalCasingCrossArmPredecessorPreservesFallbackPath(methodName: "ToLowerOrdinal")`,
  imports IR for a specific CoreLib method for retained-merge loop structuring —
  unrelated to type-name arity rendering, and this change touches no code this
  test path exercises.

## Non-action boundary

Scoped strictly to `TypeDefinitionHandle` (locally-declared types), matching the
issue's scope note. `TypeReferenceHandle` arity recovery is out of scope (would
require loading referenced assemblies). Mismatch detection/flagging
(`HasDefinitionArityMismatch`/`SegmentArityMismatch` in the Decompiler layer) is
also out of scope — this fix only fills missing arity, it does not add mismatch
diagnostics to the Metadata layer.
