### PR TITLE
Convert inspect-web presentation tests to TypeScript (batch 2)

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -532,7 +532,7 @@ scope/result rendering, selection, and keyboard interaction.
 `src/command-bar.ts` supplies its typed Commands-scope grammar and results;
 `dotnet-inspect.ts` retains package queries, navigation, network acquisition, and command
 effects so the components do not acquire engine or workspace authority.
-`test/spotlight.test.js` and `test/command-bar.test.ts` gate both presentation
+`test/spotlight.test.ts` and `test/command-bar.test.ts` gate both presentation
 modes, scope ownership, completion and replacement behavior, bounded results,
 command metadata, and escaping.
 

--- a/prototypes/inspect-web/test/annotated-source-view.test.ts
+++ b/prototypes/inspect-web/test/annotated-source-view.test.ts
@@ -4,8 +4,13 @@ import {
   buildAnnotatedView,
   factsForNode,
   nodeAtOffset,
+  validateAnnotatedSourceDocument,
 } from "../src/annotated-source-view.ts";
-import { sampleDocument } from "../../annotated-source-viewer/src/sample-document.js";
+import type { AnnotatedSourceDocument } from "../src/annotated-source-view.ts";
+import { sampleDocument as sampleDocumentFixture } from "../../annotated-source-viewer/src/sample-document.js";
+
+validateAnnotatedSourceDocument(sampleDocumentFixture);
+const sampleDocument: AnnotatedSourceDocument = sampleDocumentFixture;
 
 test("an invalid document is refused rather than rendered", () => {
   assert.throws(
@@ -100,9 +105,9 @@ test("facts with no targets stay visible as explicitly unanchored", () => {
 test("clicking text selects the tightest node and its facts", () => {
   const offset = sampleDocument.text.indexOf("new object()");
 
-  assert.equal(nodeAtOffset(sampleDocument, offset).id, 1);
+  assert.equal(nodeAtOffset(sampleDocument, offset)!.id, 1);
   assert.deepEqual(factsForNode(sampleDocument, 1).map(fact => fact.descriptor), ["alloc.new"]);
-  assert.equal(nodeAtOffset(sampleDocument, sampleDocument.text.indexOf("for (")).id, 0);
+  assert.equal(nodeAtOffset(sampleDocument, sampleDocument.text.indexOf("for ("))!.id, 0);
   assert.equal(nodeAtOffset(sampleDocument, sampleDocument.text.length), null);
 });
 

--- a/prototypes/inspect-web/test/member-filtering.test.ts
+++ b/prototypes/inspect-web/test/member-filtering.test.ts
@@ -13,6 +13,7 @@ import {
   restoreLibraryScope,
   restoreMemberHistoryState,
 } from "../src/member-filtering.ts";
+import type { BodyTarget } from "../src/member-filtering.ts";
 
 test("body targets must identify the selected overload or one of its accessor bodies", () => {
   const member = { name: "Value" };
@@ -43,7 +44,7 @@ test("body targets must identify the selected overload or one of its accessor bo
       member,
       overload),
     false);
-  assert.equal(bodyTargetMatchesOverload({}, member, overload), false);
+  assert.equal(bodyTargetMatchesOverload({} as BodyTarget, member, overload), false);
 });
 
 test("body targets round-trip through the compact rich-packet tuple", () => {
@@ -249,7 +250,7 @@ test("library scope round-trips only within the restored package", () => {
       "System.Console",
       "System.Private.CoreLib",
       "System.Runtime",
-    ])],
+    ])!],
     captured);
   assert.equal(
     restoreLibraryScope(["System.Private.CoreLib"], ["Newtonsoft.Json"]),

--- a/prototypes/inspect-web/test/member-focus.test.ts
+++ b/prototypes/inspect-web/test/member-focus.test.ts
@@ -2,22 +2,73 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  captureMemberFocus,
-  createMemberFocusRestorer,
+  captureMemberFocus as captureMemberFocusImpl,
+  createMemberFocusRestorer as createMemberFocusRestorerImpl,
   resolveMemberFocusSnapshot,
-  restoreMemberFocus,
+  restoreMemberFocus as restoreMemberFocusImpl,
 } from "../src/member-focus.ts";
+import type { MemberFocusSnapshot } from "../src/member-focus.ts";
+
+interface MockElement {
+  id: string;
+  dataset: Record<string, string | undefined>;
+  isConnected: boolean;
+  scrollTop: number;
+  selectionStart?: number | null;
+  selectionEnd?: number | null;
+  selectionDirection?: "forward" | "backward" | "none" | null;
+  setSelectionRange?(start: number | null, end: number | null, direction?: string | null): void;
+  focus(): void;
+}
+
+// The library owns the real `Document`/`Element` contract; this harness models only the
+// mutable pieces member-focus.ts reads and writes, and the wrappers below present that shape
+// as `Document`/`Element` at the one boundary where the library calls through.
+interface MockDocument {
+  activeElement: MockElement | null;
+  body: MockElement;
+  querySelector(selector: string): MockElement | null;
+  querySelectorAll(selector: string): MockElement[];
+}
+
+function captureMemberFocus(document: MockDocument): MemberFocusSnapshot {
+  return captureMemberFocusImpl(document as unknown as Document);
+}
+
+function restoreMemberFocus(
+  document: MockDocument,
+  snapshot: MemberFocusSnapshot,
+  requestFrame: (callback: FrameRequestCallback) => number,
+  isCurrent?: () => boolean,
+): void {
+  restoreMemberFocusImpl(document as unknown as Document, snapshot, requestFrame, isCurrent);
+}
+
+function createMemberFocusRestorer() {
+  const restorer = createMemberFocusRestorerImpl();
+  return {
+    resolve: (current: MemberFocusSnapshot, fallback: MemberFocusSnapshot | null) =>
+      restorer.resolve(current, fallback),
+    schedule(
+      document: MockDocument,
+      snapshot: MemberFocusSnapshot,
+      requestFrame: (callback: FrameRequestCallback) => number,
+    ) {
+      restorer.schedule(document as unknown as Document, snapshot, requestFrame);
+    },
+  };
+}
 
 function createDocument() {
-  const body = { id: "", dataset: {}, isConnected: true };
-  const elements = new Map();
-  const document = {
+  const body: MockElement = { id: "", dataset: {}, isConnected: true, scrollTop: 0, focus() {} };
+  const elements = new Map<string, MockElement>();
+  const document: MockDocument = {
     activeElement: body,
     body,
-    querySelector(selector) {
+    querySelector(selector: string) {
       return elements.get(selector) ?? null;
     },
-    querySelectorAll(selector) {
+    querySelectorAll(selector: string) {
       const key = selector.match(/^\[data-([a-z-]+)\]$/)?.[1]
         ?.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
       return key
@@ -26,8 +77,8 @@ function createDocument() {
         : [];
     },
   };
-  const element = (selector, properties = {}) => {
-    const value = {
+  const element = (selector: string, properties: Partial<MockElement> = {}) => {
+    const value: MockElement = {
       id: "",
       dataset: {},
       isConnected: true,
@@ -86,7 +137,7 @@ test("navigation focus and scroll survive completion before loading focus restor
   );
   assert.equal(current.selector, "#unrelated");
   assert.equal(current.focusLost, false);
-  assert.equal(elements.get("#type-list").scrollTop, 87);
+  assert.equal(elements.get("#type-list")!.scrollTop, 87);
 });
 
 test("navigation scroll is not copied into a different list scope", () => {
@@ -217,7 +268,7 @@ test("stable workbench controls survive a replacement render", () => {
 });
 
 test("scope and lens controls survive a replacement render", () => {
-  const cases = [
+  const cases: [string, Record<string, string>][] = [
     ["[data-scope=\"member\"]", { scope: "member" }],
     ["[data-lens=\"metadata\"]", { lens: "metadata" }],
     ["[data-member-section=\"facts\"]", { memberSection: "facts" }],
@@ -242,7 +293,7 @@ test("scope and lens controls survive a replacement render", () => {
 });
 
 test("member and overload rows survive activation renders", () => {
-  const cases = [
+  const cases: [string, Record<string, string>][] = [
     ["[data-nav-member=\"method:Build\"]", { navMember: "method:Build" }],
     ["[data-nav-overload=\"1\"]", { navOverload: "1" }],
   ];
@@ -289,8 +340,8 @@ test("deferred restoration does not steal intentionally moved focus", () => {
   const { document, element } = createDocument();
   const initialInput = element("#member-filter", { id: "member-filter" });
   document.activeElement = initialInput;
-  const snapshot = captureMemberFocus(document, value => value);
-  const callbacks = [];
+  const snapshot = captureMemberFocus(document);
+  const callbacks: FrameRequestCallback[] = [];
   restoreMemberFocus(document, snapshot, callback => {
     callbacks.push(callback);
     return callbacks.length;
@@ -298,25 +349,25 @@ test("deferred restoration does not steal intentionally moved focus", () => {
 
   const unrelated = element("#unrelated", { id: "unrelated" });
   unrelated.focus();
-  callbacks.shift()(0);
+  callbacks.shift()!(0);
 
   assert.equal(document.activeElement, unrelated);
 });
 
 test("newer caret restoration invalidates older queued callbacks", () => {
   const { document, element } = createDocument();
-  let restoredSelection = null;
+  let restoredSelection: { start: number | null; end: number | null; direction: string | null } | null = null;
   const input = element("#member-filter", {
     id: "member-filter",
     selectionStart: 1,
     selectionEnd: 1,
     selectionDirection: "none",
     setSelectionRange(start, end, direction) {
-      restoredSelection = { start, end, direction };
+      restoredSelection = { start, end, direction: direction ?? null };
     },
   });
-  const callbacks = [];
-  const requestFrame = callback => {
+  const callbacks: FrameRequestCallback[] = [];
+  const requestFrame = (callback: FrameRequestCallback) => {
     callbacks.push(callback);
     return callbacks.length;
   };

--- a/prototypes/inspect-web/test/spotlight.test.ts
+++ b/prototypes/inspect-web/test/spotlight.test.ts
@@ -7,13 +7,54 @@ import {
   nextSpotlightSelection,
   visibleSpotlightPackageHits,
 } from "../src/spotlight.ts";
+import type { SpotlightResult, SpotlightState } from "../src/spotlight.ts";
+import type { CommandContext } from "../src/command-bar.ts";
 
-function escapeHtml(value) {
+function escapeHtml(value: unknown) {
   return String(value)
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;");
+}
+
+interface HarnessOptions {
+  scope?: string;
+  query?: string;
+  commandContext?: CommandContext | null;
+  focusAfterDismiss?: () => void;
+  searchResults?: () => SpotlightResult[];
+}
+
+// The library owns the real DOM event/element contract; this harness models only the
+// mutable pieces spotlight.ts reads, and callers cast to the real DOM types at the one
+// boundary where the library calls through.
+interface MockKeyboardEvent {
+  key: string;
+  currentTarget: unknown;
+  shiftKey?: boolean;
+  preventDefault(): void;
+}
+
+interface MockInputElement {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+  addEventListener(name: string, listener: (event: MockKeyboardEvent) => void): void;
+  focus(): void;
+  setAttribute(): void;
+  setSelectionRange(): void;
+}
+
+interface MockElement {
+  classList?: { toggle(className: string, force?: boolean): void };
+  scrollIntoView?(): void;
+  setAttribute?(): void;
+}
+
+interface MockParentNode {
+  querySelector(selector: string): MockInputElement | MockElement | null;
+  querySelectorAll(selector: string): MockElement[];
 }
 
 function createHarness({
@@ -22,8 +63,8 @@ function createHarness({
   commandContext = null,
   focusAfterDismiss = () => {},
   searchResults = () => [],
-} = {}) {
-  const state = {
+}: HarnessOptions = {}) {
+  const state: SpotlightState = {
     spotlightOpen: false,
     spotlightQuery: query,
     spotlightIndex: 0,
@@ -52,7 +93,7 @@ function createHarness({
   return { spotlight, state };
 }
 
-const packageContext = {
+const packageContext: CommandContext["package"] = {
   id: "Example.Package",
   activeFramework: "net10.0",
   types: [{
@@ -83,19 +124,19 @@ test("NuGet hits are visible only for their resolved query and survive a query r
 
 test("Spotlight keeps the selected result when async rows are inserted before it", () => {
   const pkg = { id: "Example.Package", version: "1.0.0" };
-  const first = {
+  const first: SpotlightResult = {
     kind: "type",
     pkg,
     type: { id: "Example.First", name: "First", kind: "class" },
     ranges: [],
   };
-  const selected = {
+  const selected: SpotlightResult = {
     kind: "type",
     pkg,
     type: { id: "Example.Selected", name: "Selected", kind: "class" },
     ranges: [],
   };
-  let results = [first, selected];
+  let results: SpotlightResult[] = [first, selected];
   const { spotlight, state } = createHarness({
     query: "Example",
     searchResults: () => results,
@@ -119,7 +160,7 @@ test("Spotlight keeps the selected result when async rows are inserted before it
 
 test("modal arrow navigation reuses rendered results", () => {
   const pkg = { id: "Example.Package", version: "1.0.0" };
-  const rows = ["First", "Second", "Third"].map(name => ({
+  const rows: SpotlightResult[] = ["First", "Second", "Third"].map(name => ({
     kind: "type",
     pkg,
     type: { id: `Example.${name}`, name, kind: "class" },
@@ -135,56 +176,65 @@ test("modal arrow navigation reuses rendered results", () => {
   });
   spotlight.modalHtml();
 
-  const listeners = new Map();
-  const input = {
+  const listeners = new Map<string, (event: MockKeyboardEvent) => void>();
+  const input: MockInputElement = {
     value: "Example",
     selectionStart: 7,
     selectionEnd: 7,
-    addEventListener: (name, listener) => listeners.set(name, listener),
+    addEventListener: (name, listener) => {
+      listeners.set(name, listener as (event: MockKeyboardEvent) => void);
+    },
     focus: () => {},
     setAttribute: () => {},
     setSelectionRange: () => {},
   };
-  const domRows = rows.map(() => ({
+  const domRows: MockElement[] = rows.map(() => ({
     classList: { toggle: () => {} },
     scrollIntoView: () => {},
     setAttribute: () => {},
   }));
-  const container = {
+  const container: MockParentNode = {
     querySelector: () => null,
     querySelectorAll: selector => selector === ".spotlight-item" ? domRows : [],
   };
-  const root = {
+  const root: MockParentNode = {
     querySelector: selector => selector === "#spotlight-input" ? input : null,
     querySelectorAll: () => [],
   };
-  const previousDocument = globalThis.document;
-  const previousRequestAnimationFrame = globalThis.requestAnimationFrame;
-  globalThis.document = {
-    querySelector: selector => {
+  const globals = globalThis as unknown as {
+    document?: Document;
+    requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+  };
+  const previousDocument = globals.document;
+  const previousRequestAnimationFrame = globals.requestAnimationFrame;
+  globals.document = {
+    querySelector: (selector: string) => {
       if (selector === "#spotlight-input") return input;
       if (selector === "#spotlight-results") return container;
       return null;
     },
+  } as unknown as Document;
+  globals.requestAnimationFrame = (callback: FrameRequestCallback) => {
+    callback(0);
+    return 0;
   };
-  globalThis.requestAnimationFrame = callback => callback();
 
   try {
-    spotlight.bind(root, "modal");
+    spotlight.bind(root as unknown as ParentNode, "modal");
     for (let index = 0; index < 4; index++) {
-      listeners.get("keydown")({
+      listeners.get("keydown")!({
         key: "ArrowDown",
         currentTarget: input,
         preventDefault: () => {},
       });
     }
   } finally {
-    if (previousDocument === undefined) delete globalThis.document;
-    else globalThis.document = previousDocument;
+    if (previousDocument === undefined) delete globals.document;
+    else globals.document = previousDocument;
     if (previousRequestAnimationFrame === undefined) {
-      delete globalThis.requestAnimationFrame;
+      delete globals.requestAnimationFrame;
     } else {
-      globalThis.requestAnimationFrame = previousRequestAnimationFrame;
+      globals.requestAnimationFrame = previousRequestAnimationFrame;
     }
   }
 
@@ -250,3 +300,4 @@ test("command queries and command metadata are escaped in Spotlight markup", () 
   assert.doesNotMatch(html, /<script/);
   assert.match(html, /find &lt;script class=&quot;x&quot;&gt;/);
 });
+


### PR DESCRIPTION
## Summary

- convert the four remaining presentation-component suites from JavaScript to
  strict TypeScript: `annotated-source-view`, `member-filtering`,
  `member-focus`, and `spotlight`
- type-check test fixtures against exported frontend contracts (`SpotlightState`,
  `SpotlightResult`, `CommandContext`, `AnnotatedSourceDocument`, `BodyTarget`, ...)
- model the two DOM-mock harnesses (member-focus's fake `Document`, spotlight's
  fake input/root/global `document`) with narrow local interfaces, casting to
  the real DOM types only at the one boundary where the library calls through
- `README.md`: fix a stale `.js` extension in the spotlight/command-bar
  cross-reference

The production bundle remains byte-identical (test-only changes).

## Sequence

- Batch 2 of the inspect-web presentation-test TypeScript conversion, follow-up
  to #4505 (batch 1)
- Every JS test file is now converted, except `spotlight-identity.test.js` and
  `toolchain.test.js`, which remain JavaScript source/toolchain canaries by
  design (unchanged from batch 1's description)
- Checked the open `feature/4504-*` extraction stack: none of those PRs touch
  `member-filtering.ts`, `member-focus.ts`, `spotlight.ts`,
  `annotated-source-view.ts`, or these four test files, so this should merge
  independently of that stack

## Note

While converting `member-focus.test.js`, found a pre-existing, unrelated
authoring bug: a `test()` call is nested inside another test's `for` loop
body, so it never runs as an independent top-level test. Filed as #4542
rather than folding a behavioral fix into this conversion's diff.

## Validation

- `npm test` — 259 passed
- `npm run build`
- `npx markdownlint-cli --config ../../.markdownlint.yaml README.md`
