### PR TITLE
Promote runtime evidence to aggregate scan triage

### DIFF
--- a/docs/design/allocation-triage-prefilters.md
+++ b/docs/design/allocation-triage-prefilters.md
@@ -176,11 +176,21 @@ RunFaster promotes allocation evidence from a raw library row to a
 coordinate-bearing scan aggregate only when the raw row has the same build and
 coordinate and exactly one supporting aggregate claims that coordinate. The
 raw site's predicted type need not match the sampled type: GC allocation ticks
-are attributed to the nearest preceding IL allocation site. The raw row is then
-`superseded-by-triage`; otherwise it retains the evidence.
+are attributed to the nearest preceding IL allocation site. Supporting
+coordinates are indexed separately: RunFaster selects the nearest raw
+allocation first and attaches only support at that exact offset, so a later
+non-allocation scan call cannot shadow the raw evidence. If an exact triage row
+also projects the same raw site, the unique aggregate support owns the
+observation and the exact row is superseded rather than sharing bytes. The raw
+row is then `superseded-by-triage`; otherwise it retains the evidence.
 `Correlate_AggregateSupportingCallSite_PromotesExactLibraryEvidence` and
-`Correlate_AmbiguousAggregateSupports_DoNotClaimLibraryEvidence` are the
-non-vacuity gates for those outcomes.
+`Correlate_AmbiguousAggregateSupports_DoNotClaimLibraryEvidence`,
+`Correlate_NonAllocationSupport_DoesNotShadowNearestLibrarySite`, and
+`Correlate_ExactAndAggregateSameSite_PrefersAggregateSupport` are the
+non-vacuity gates for those outcomes. The flattened projection gate
+`FlattenedPerformanceTriageJsonl_RetainsSupportingCallSite` keeps all five
+`Supporting*` fields available in JSONL and tabular output as well as nested
+JSON.
 
 ## Opt-in allocation fanout
 

--- a/docs/design/allocation-triage-prefilters.md
+++ b/docs/design/allocation-triage-prefilters.md
@@ -155,12 +155,32 @@ This separates two joins that have different stability contracts. `Candidate`
 is exact within one assembly build and is the key for runtime/static trace
 correlation. Cross-version onset still uses the producer-native
 `diff --finding` or `timeline --finding` matcher, where IL offsets and metadata
-tokens remain provenance rather than correspondence identity. Aggregate rows
-such as `allocation-hotspot` have no exact source occurrence and therefore use
-`Provenance=aggregate` while keeping their `Finding`, `Operation`, and `Token`
-fields empty. Candidate IDs are checked for uniqueness when an index is built;
-a truncated-prefix collision is deterministically lengthened rather than
-creating an ambiguous join.
+tokens remain provenance rather than correspondence identity. Aggregate rows such as `allocation-hotspot` have no exact source occurrence and
+therefore use `Provenance=aggregate` while keeping their `Finding`, `Operation`,
+`Token`, and `IL` fields empty. A composite repeated-scan judgment may retain
+one exact local call in the separately typed `SupportingCallSite` coordinate:
+the argument-producing allocation call when one directly feeds the scan,
+otherwise the scan call itself. It projects as `SupportingFinding`,
+`SupportingOperation`,
+`SupportingToken`, `SupportingEvidenceMethod`, and `SupportingIL`. This
+supporting coordinate enables same-build runtime correspondence without
+changing aggregate provenance, candidate identity, confidence, or rank.
+`OptimizationOpportunities_FlagsImmediateLazyQueryTerminalInvokedInCallerLoop`
+pins the allocation-producing `Where` call for the composed scan case, while
+`OptimizationOpportunities_DoNotChooseAmbiguousScanSupport` requires multiple
+local scans to remain coordinate-free. Candidate IDs are checked for uniqueness
+when an index is built; a truncated-prefix collision is deterministically
+lengthened rather than creating an ambiguous join.
+
+RunFaster promotes allocation evidence from a raw library row to a
+coordinate-bearing scan aggregate only when the raw row has the same build and
+coordinate and exactly one supporting aggregate claims that coordinate. The
+raw site's predicted type need not match the sampled type: GC allocation ticks
+are attributed to the nearest preceding IL allocation site. The raw row is then
+`superseded-by-triage`; otherwise it retains the evidence.
+`Correlate_AggregateSupportingCallSite_PromotesExactLibraryEvidence` and
+`Correlate_AmbiguousAggregateSupports_DoNotClaimLibraryEvidence` are the
+non-vacuity gates for those outcomes.
 
 ## Opt-in allocation fanout
 

--- a/docs/design/allocation-triage-prefilters.md
+++ b/docs/design/allocation-triage-prefilters.md
@@ -174,9 +174,11 @@ lengthened rather than creating an ambiguous join.
 
 RunFaster promotes allocation evidence from a raw library row to a
 coordinate-bearing scan aggregate only when the raw row has the same build and
-coordinate and exactly one supporting aggregate claims that coordinate. The
-raw site's predicted type need not match the sampled type: GC allocation ticks
-are attributed to the nearest preceding IL allocation site. Supporting
+coordinate and exactly one supporting aggregate in that build claims that
+coordinate. Each build applies that precedence independently before
+cross-build ambiguity attribution. The raw site's predicted type need not match
+the sampled type: GC allocation ticks are attributed to the nearest preceding
+IL allocation site. Supporting
 coordinates are indexed separately: RunFaster selects the nearest raw
 allocation first and attaches only support at that exact offset, so a later
 non-allocation scan call cannot shadow the raw evidence. If an exact triage row
@@ -194,7 +196,8 @@ evidence.
 non-vacuity gates for those outcomes. The flattened projection gate
 `FlattenedPerformanceTriageJsonl_RetainsSupportingCallSite` keeps all five
 `Supporting*` fields available in JSONL and tabular output as well as nested
-JSON.
+JSON. `ApplyAcceptedSupportPrecedence_IsIndependentPerBuild` pins the
+multi-build grouping boundary.
 
 ## Opt-in allocation fanout
 

--- a/docs/design/allocation-triage-prefilters.md
+++ b/docs/design/allocation-triage-prefilters.md
@@ -182,11 +182,15 @@ allocation first and attaches only support at that exact offset, so a later
 non-allocation scan call cannot shadow the raw evidence. If an exact triage row
 also projects the same raw site, the unique aggregate support owns the
 observation and the exact row is superseded rather than sharing bytes. The raw
-row is then `superseded-by-triage`; otherwise it retains the evidence.
+row is then `superseded-by-triage`; an exact row at a different offset or from
+a different build remains independent. Support anchors are allocation-only:
+method-name or CPU samples may establish method heat on the aggregate but
+cannot supersede its raw allocation row. Otherwise the raw row retains the
+evidence.
 `Correlate_AggregateSupportingCallSite_PromotesExactLibraryEvidence` and
 `Correlate_AmbiguousAggregateSupports_DoNotClaimLibraryEvidence`,
 `Correlate_NonAllocationSupport_DoesNotShadowNearestLibrarySite`, and
-`Correlate_ExactAndAggregateSameSite_PrefersAggregateSupport` are the
+`Correlate_ExactAndAggregateSites_RespectCoordinateAndBuild` are the
 non-vacuity gates for those outcomes. The flattened projection gate
 `FlattenedPerformanceTriageJsonl_RetainsSupportingCallSite` keeps all five
 `Supporting*` fields available in JSONL and tabular output as well as nested

--- a/docs/design/finding-adoption.md
+++ b/docs/design/finding-adoption.md
@@ -214,7 +214,16 @@ rows rather than relying on empty fields as an implicit signal. `Candidate` is
 therefore useful for a runtime/static join within one build, while
 `diff --finding` and `timeline --finding` remain the cross-version
 correspondence paths. Aggregate judgments such as `allocation-hotspot`
-deliberately have no exact source Finding.
+deliberately have no exact source Finding. A composite repeated-scan judgment
+can retain one native `analysis.call-site` observation in the separately typed
+`SupportingCallSite` relation. Its projected `Supporting*` fields are an exact
+runtime correspondence coordinate; they do not populate the row's own
+`Finding`, `Operation`, `Token`, or `IL`, change `Provenance=aggregate`, or enter
+the aggregate candidate identity.
+`OptimizationOpportunities_FlagsImmediateLazyQueryTerminalInvokedInCallerLoop`
+and `OptimizationOpportunities_DoNotChooseAmbiguousScanSupport` enforce that
+separation and fail closed when more than one local scan could supply the
+coordinate.
 
 `Resource Triage` follows the same rule. Exact
 `analysis.resource-lifecycle` observations remain policy-free; the

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -208,8 +208,12 @@ an allocation observation only when the same build has a raw library allocation
 at that coordinate and exactly one aggregate support claims it. The raw site is
 the attribution anchor; sampled allocation types can differ
 because GC allocation ticks resolve to the nearest preceding IL allocation
-site. Otherwise the aggregate remains cold for the workload and the raw row
-keeps the evidence.
+site. RunFaster resolves the nearest raw allocation first, then attaches support
+at that exact coordinate; a later non-allocation scan-call support therefore
+cannot hide the raw site. When an exact triage row and one aggregate support
+both project the same raw site, the aggregate carries the evidence and the
+exact row is superseded rather than splitting bytes. Otherwise the aggregate
+remains cold for the workload and the raw row keeps the evidence.
 Type-level ambiguity and its site cap count the shared coordinate once unless
 several library MVIDs make an older MVID-less triage row's module version
 ambiguous.

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -205,8 +205,9 @@ candidate, the shape-compatible triage row carries the runtime evidence.
 The raw library row is marked `superseded-by-triage`, not workload-cold.
 For a repeated-scan aggregate with a supporting call site, `runfaster` promotes
 an allocation observation only when the same build has a raw library allocation
-at that coordinate and exactly one aggregate support claims it. The raw site is
-the attribution anchor; sampled allocation types can differ
+at that coordinate and exactly one aggregate support in that build claims it.
+Each build resolves independently before cross-build ambiguity attribution.
+The raw site is the attribution anchor; sampled allocation types can differ
 because GC allocation ticks resolve to the nearest preceding IL allocation
 site. RunFaster resolves the nearest raw allocation first, then attaches support
 at that exact coordinate; a later non-allocation scan-call support therefore

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -167,7 +167,12 @@ needed. `--top` and `--order-by` do not compose with Body Shapes; use `--rows`
 to limit rendered syntax matches.
 
 Aggregate rows such as `allocation-hotspot` use `Provenance=aggregate` and have
-a `pt~` candidate id but no exact source Finding, operation, or token.
+a `pt~` candidate id but no exact source Finding, operation, or token. A
+composite repeated-scan judgment can separately retain the exact local call
+that supports it in `SupportingFinding`, `SupportingOperation`,
+`SupportingToken`, `SupportingEvidenceMethod`, and `SupportingIL`. Those fields
+are a runtime correspondence coordinate, not the aggregate row's source
+Finding or candidate identity.
 `Provenance=unmatched` flags an instruction-level row that did not join to the
 expected producer census.
 
@@ -198,6 +203,13 @@ represented assembly; it does not walk past an unexported in-assembly callee
 and credit an outer caller. If `--library` and `--triage` name the same physical
 candidate, the shape-compatible triage row carries the runtime evidence.
 The raw library row is marked `superseded-by-triage`, not workload-cold.
+For a repeated-scan aggregate with a supporting call site, `runfaster` promotes
+an allocation observation only when the same build has a raw library allocation
+at that coordinate and exactly one aggregate support claims it. The raw site is
+the attribution anchor; sampled allocation types can differ
+because GC allocation ticks resolve to the nearest preceding IL allocation
+site. Otherwise the aggregate remains cold for the workload and the raw row
+keeps the evidence.
 Type-level ambiguity and its site cap count the shared coordinate once unless
 several library MVIDs make an older MVID-less triage row's module version
 ambiguous.

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -212,8 +212,11 @@ site. RunFaster resolves the nearest raw allocation first, then attaches support
 at that exact coordinate; a later non-allocation scan-call support therefore
 cannot hide the raw site. When an exact triage row and one aggregate support
 both project the same raw site, the aggregate carries the evidence and the
-exact row is superseded rather than splitting bytes. Otherwise the aggregate
-remains cold for the workload and the raw row keeps the evidence.
+exact row is superseded rather than splitting bytes. An exact row at another
+offset or from another build remains independent. Method-name and CPU samples
+can mark the aggregate method hot, but only an accepted allocation-coordinate
+join supersedes its raw allocation anchor. Otherwise the aggregate remains cold
+for the workload and the raw row keeps the evidence.
 Type-level ambiguity and its site cap count the shared coordinate once unless
 several library MVIDs make an older MVID-less triage row's module version
 ambiguous.

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -8829,6 +8829,76 @@ public class LibraryBodyIndexTests
         Assert.Equal("low", op.Confidence);
         Assert.Contains("Where+FirstOrDefault", op.Evidence, StringComparison.Ordinal);
         Assert.Contains(nameof(OptimizationOpportunityFixtures.CallsComposedScanHelperInLoop), op.Evidence, StringComparison.Ordinal);
+        var support = Assert.IsType<OptimizationSupportingCallSite>(
+            op.SupportingCallSite);
+        var whereCall = Assert.Single(
+            index.GetDirectCallsByCaller()[
+                    op.Method.MetadataToken]
+                .Where(call =>
+                    call.Callee.Name == "Where"));
+        var supportCall = Assert.Single(
+            index.GetDirectCallsByCaller()[
+                    op.Method.MetadataToken]
+                .Where(call =>
+                    call.Kind == CallKind.NewObject
+                    && call.ReturnAddress
+                        == whereCall.ILOffset));
+        Assert.Equal(
+            supportCall.EvidenceMethod.MetadataToken,
+            support.EvidenceMethodToken);
+        Assert.Equal(
+            supportCall.ILOffset,
+            support.ILOffset);
+        Assert.Equal(
+            AnalysisFindings.CallSiteDescriptor.Id,
+            support.SourceFinding);
+        Assert.Equal(
+            supportCall.Opcode,
+            support.Operation);
+        Assert.Equal(
+            supportCall.OperandToken,
+            support.OperandToken);
+        Assert.Null(op.ILOffset);
+        Assert.Null(op.SourceFinding);
+        Assert.Equal(
+            PerformanceTriageProvenance.Aggregate,
+            op.Provenance);
+        Assert.Equal(
+            PerformanceTriageCandidateId.Create(
+                op,
+                descriptor: null,
+                findingKey: null,
+                ordinal: null),
+            PerformanceTriageCandidateId.Create(
+                op with
+                {
+                    SupportingCallSite = null,
+                },
+                descriptor: null,
+                findingKey: null,
+                ordinal: null));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_DoNotChooseAmbiguousScanSupport()
+    {
+        var index = LibraryBodyIndex.Open(
+            typeof(OptimizationOpportunityFixtures)
+                .Assembly.Location);
+
+        var op = Assert.Single(
+            index.OptimizationOpportunities.Where(o =>
+                o.Method.Name
+                    == nameof(
+                        OptimizationOpportunityFixtures
+                            .ContainsEither)
+                && o.Shape
+                    == "scan-method-in-loop-call"));
+
+        Assert.Null(op.SupportingCallSite);
+        Assert.Equal(
+            PerformanceTriageProvenance.Aggregate,
+            op.Provenance);
     }
 
     [Fact]
@@ -13132,6 +13202,31 @@ public class OptimizationOpportunityFixtures
         foreach (var key in keys)
         {
             n += FilterThenFirstOrDefault(source, key);
+        }
+        return n;
+    }
+
+    public static bool ContainsEither(
+        System.Collections.Generic.IEnumerable<int> source,
+        int first,
+        int second)
+        => System.Linq.Enumerable.Any(
+                source,
+                x => x == first)
+            || System.Linq.Enumerable.Any(
+                source,
+                x => x == second);
+
+    public static int CallsAmbiguousScanHelperInLoop(
+        System.Collections.Generic.IEnumerable<int> source,
+        int[] keys)
+    {
+        var n = 0;
+        foreach (var key in keys)
+        {
+            n += ContainsEither(source, key, key + 1)
+                ? 1
+                : 0;
         }
         return n;
     }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -385,6 +385,7 @@ public sealed class LibraryBodyIndex
         {
             Finding<AllocationOccurrence>? allocation = null;
             Finding<DirectCall>? callSite = null;
+            Finding<DirectCall>? supportingCallSite = null;
             bool attachFinding =
                 opportunity.Shape != "generic-parameter-object-box";
             if (attachFinding && opportunity.ILOffset is { } offset)
@@ -438,6 +439,29 @@ public sealed class LibraryBodyIndex
                 }
             }
 
+            if (opportunity.SupportingCallSite is { } supportSite
+                && physicalCallsByCaller.TryGetValue(
+                    supportSite.EvidenceMethodToken,
+                    out var supportingCalls))
+            {
+                if (!callSiteFindings.TryGetValue(
+                        supportSite.EvidenceMethodToken,
+                        out var findings))
+                {
+                    findings = AnalysisFindings.InspectCallSites(
+                        supportingCalls,
+                        FindingSubjectFor(
+                            supportingCalls[0].Caller));
+                    callSiteFindings[
+                        supportSite.EvidenceMethodToken] =
+                        findings;
+                }
+                supportingCallSite = SingleFindingAtOffset(
+                    findings,
+                    supportSite.ILOffset,
+                    static call => call.ILOffset);
+            }
+
             string? sourceFinding = allocation?.Descriptor.Id ?? callSite?.Descriptor.Id ?? opportunity.SourceFinding;
             FindingKey? findingKey = allocation?.Key ?? callSite?.Key;
             int? ordinal = allocation?.Ordinal ?? callSite?.Ordinal;
@@ -471,6 +495,22 @@ public sealed class LibraryBodyIndex
                     ? CallOperation(callSite?.Payload)
                     : AllocationOperation(allocation.Payload),
                 OperandToken = allocation?.Payload.OperandToken ?? callSite?.Payload.OperandToken,
+                SupportingCallSite =
+                    opportunity.SupportingCallSite is not
+                        { } supportCoordinate
+                        ? null
+                        : supportCoordinate with
+                        {
+                            SourceFinding =
+                                supportingCallSite
+                                    ?.Descriptor.Id,
+                            Operation = CallOperation(
+                                supportingCallSite
+                                    ?.Payload),
+                            OperandToken =
+                                supportingCallSite
+                                    ?.Payload.OperandToken,
+                        },
                 Provenance = opportunity.Provenance != PerformanceTriageProvenance.Unknown
                     ? opportunity.Provenance
                     : sourceFinding is not null

--- a/src/ILInspector.Analysis/OptimizationOpportunity.cs
+++ b/src/ILInspector.Analysis/OptimizationOpportunity.cs
@@ -8,6 +8,19 @@ public enum PerformanceTriageProvenance
     Unmatched,
 }
 
+/// <summary>
+/// Exact call site that supports a composite Performance Triage judgment without
+/// becoming the judgment's own source Finding or candidate identity.
+/// </summary>
+public sealed record OptimizationSupportingCallSite(
+    int EvidenceMethodToken,
+    int ILOffset)
+{
+    public string? SourceFinding { get; init; }
+    public string? Operation { get; init; }
+    public int? OperandToken { get; init; }
+}
+
 public sealed record OptimizationOpportunity(
     MethodIdentity Method,
     string Shape,
@@ -62,6 +75,12 @@ public sealed record OptimizationOpportunity(
 
     /// <summary>Whether this row has exact, aggregate, or unresolved producer provenance.</summary>
     public PerformanceTriageProvenance Provenance { get; init; }
+
+    /// <summary>
+    /// Exact local call site supporting an aggregate judgment. This coordinate is correspondence
+    /// evidence for runtime joins; it does not replace the aggregate row's provenance or identity.
+    /// </summary>
+    public OptimizationSupportingCallSite? SupportingCallSite { get; init; }
 
     /// <summary>
     /// Source-authored method that owns a lifted local-function or lambda body.

--- a/src/ILInspector.Analysis/RepeatedScanAnalysis.cs
+++ b/src/ILInspector.Analysis/RepeatedScanAnalysis.cs
@@ -127,23 +127,44 @@ internal static class RepeatedScanAnalysis
         foreach (var method in methods)
             methodByToken[method.MetadataToken] = method;
 
-        var scanningMethods = new Dictionary<int, string>();
+        var scanningMethods =
+            new Dictionary<int, ScanMethodEvidence>();
         var inAssemblyCallees = new Dictionary<int, HashSet<int>>();
-        var lazyReturning = new Dictionary<int, string>();
+        var lazyReturning =
+            new Dictionary<int, ScanMethodEvidence>();
         var immediateLazyProducers =
-            new Dictionary<(int MethodToken, int NextOffset), string>();
+            new Dictionary<
+                (int MethodToken, int NextOffset),
+                (string Operation, DirectCall Call)>();
+        var immediateObjectProducers =
+            new Dictionary<
+                (int MethodToken, int NextOffset),
+                DirectCall>();
         foreach (var call in directCalls)
         {
             if (!IsInvocation(call))
                 continue;
 
+            if (call.Kind == CallKind.NewObject
+                && call.ReturnAddress is { } objectNextOffset)
+            {
+                immediateObjectProducers.TryAdd(
+                    (
+                        call.Caller.MetadataToken,
+                        objectNextOffset),
+                    call);
+            }
+
             if (IsLinqMembershipScan(
                     call.Callee,
                     out var membershipOperation))
             {
-                scanningMethods.TryAdd(
+                AddScanEvidence(
+                    scanningMethods,
                     call.Caller.MetadataToken,
-                    membershipOperation);
+                    new ScanMethodEvidence(
+                        membershipOperation,
+                        SupportingCall(call)));
             }
             else if (IsLinqLazyProducer(
                     call.Callee,
@@ -154,16 +175,21 @@ internal static class RepeatedScanAnalysis
                 {
                     immediateLazyProducers.TryAdd(
                         (call.Caller.MetadataToken, nextOffset),
-                        lazyOperation);
+                        (
+                            lazyOperation,
+                            SupportingCall(call)));
                 }
                 if (methodByToken.TryGetValue(
                         call.Caller.MetadataToken,
                         out var producer)
                     && ReturnsEnumerableSequence(producer.ReturnType))
                 {
-                    lazyReturning.TryAdd(
+                    AddScanEvidence(
+                        lazyReturning,
                         call.Caller.MetadataToken,
-                        lazyOperation);
+                        new ScanMethodEvidence(
+                            lazyOperation,
+                            SupportingCall(call)));
                 }
             }
             else if (IsLinqParameterlessTerminal(
@@ -171,11 +197,14 @@ internal static class RepeatedScanAnalysis
                     out var terminalOperation)
                 && immediateLazyProducers.TryGetValue(
                     (call.Caller.MetadataToken, call.ILOffset),
-                    out var producerOperation))
+                    out var producer))
             {
-                scanningMethods.TryAdd(
+                AddScanEvidence(
+                    scanningMethods,
                     call.Caller.MetadataToken,
-                    $"{producerOperation}+{terminalOperation}");
+                    new ScanMethodEvidence(
+                        $"{producer.Operation}+{terminalOperation}",
+                        producer.Call));
             }
 
             if (methodByToken.ContainsKey(call.CalleeDefinitionToken))
@@ -190,6 +219,15 @@ internal static class RepeatedScanAnalysis
                 callees.Add(call.CalleeDefinitionToken);
             }
         }
+
+        DirectCall SupportingCall(DirectCall scanCall)
+            => immediateObjectProducers.TryGetValue(
+                    (
+                        scanCall.Caller.MetadataToken,
+                        scanCall.ILOffset),
+                    out var producer)
+                ? producer
+                : scanCall;
 
         for (var changed = true; changed;)
         {
@@ -209,9 +247,12 @@ internal static class RepeatedScanAnalysis
                 {
                     if (lazyReturning.TryGetValue(
                             callee,
-                            out var operation))
+                            out var evidence))
                     {
-                        lazyReturning[callerToken] = operation;
+                        lazyReturning[callerToken] =
+                            new ScanMethodEvidence(
+                                evidence.Operation,
+                                null);
                         changed = true;
                         break;
                     }
@@ -219,8 +260,13 @@ internal static class RepeatedScanAnalysis
             }
         }
 
-        foreach (var (token, operation) in lazyReturning)
-            scanningMethods.TryAdd(token, operation);
+        foreach (var (token, evidence) in lazyReturning)
+        {
+            AddScanEvidence(
+                scanningMethods,
+                token,
+                evidence);
+        }
 
         var methodMap = MethodDefinitionMap.Create(methods);
         var recursiveTraversalTokens = directCalls
@@ -250,7 +296,7 @@ internal static class RepeatedScanAnalysis
             int calleeToken = call.CalleeDefinitionToken;
             if (!scanningMethods.TryGetValue(
                     calleeToken,
-                    out var operation)
+                    out var scan)
                 || !methodByToken.TryGetValue(calleeToken, out var method)
                 || suppressedMethodTokens.Contains(calleeToken)
                 || inMethodScanLoopTokens.Contains(calleeToken)
@@ -263,13 +309,17 @@ internal static class RepeatedScanAnalysis
             opportunities.Add(new OptimizationOpportunity(
                 method,
                 "scan-method-in-loop-call",
-                $"Linearly scans a sequence (Enumerable.{operation}); invoked inside a loop by {call.Caller.DeclaringType.ToQualifiedDisplayString()}::{call.Caller.Name}",
+                $"Linearly scans a sequence (Enumerable.{scan.Operation}); invoked inside a loop by {call.Caller.DeclaringType.ToQualifiedDisplayString()}::{call.Caller.Name}",
                 "A method that linearly scans a sequence is called on every iteration of a caller's loop; precompute an index the caller can reuse, or hoist the scan out of the loop.",
                 "low",
                 true,
                 null,
                 "Quadratic only if the scanned sequence grows with the caller's loop; confirm the sequence is the loop-variant collection and not small/constant.",
-                reachByToken.GetValueOrDefault(calleeToken)));
+                reachByToken.GetValueOrDefault(calleeToken))
+            {
+                SupportingCallSite =
+                    CreateSupportingCallSite(scan.Call),
+            });
         }
 
         foreach (var call in directCalls)
@@ -278,7 +328,7 @@ internal static class RepeatedScanAnalysis
             if (!IsInvocation(call)
                 || !recursiveTraversalTokens.Contains(
                     call.Caller.MetadataToken)
-                || !scanningMethods.TryGetValue(calleeToken, out var operation)
+                || !scanningMethods.TryGetValue(calleeToken, out var scan)
                 || !methodByToken.TryGetValue(calleeToken, out var method)
                 || suppressedMethodTokens.Contains(calleeToken)
                 || inMethodScanLoopTokens.Contains(calleeToken)
@@ -291,17 +341,52 @@ internal static class RepeatedScanAnalysis
             opportunities.Add(new OptimizationOpportunity(
                 method,
                 "scan-method-in-recursive-traversal",
-                $"Linearly scans a sequence (Enumerable.{operation}); invoked once per recursive traversal node by {call.Caller.DeclaringType.ToQualifiedDisplayString()}::{call.Caller.Name}",
+                $"Linearly scans a sequence (Enumerable.{scan.Operation}); invoked once per recursive traversal node by {call.Caller.DeclaringType.ToQualifiedDisplayString()}::{call.Caller.Name}",
                 "If the scan source is shared across recursive calls, build an index before recursion and reuse it; otherwise keep the node-local scan.",
                 "low",
                 true,
                 null,
                 "Potentially superlinear only when each recursive step scans the same growing sequence; static analysis has not proved source identity.",
-                reachByToken.GetValueOrDefault(calleeToken)));
+                reachByToken.GetValueOrDefault(calleeToken))
+            {
+                SupportingCallSite =
+                    CreateSupportingCallSite(scan.Call),
+            });
         }
 
         return opportunities.ToImmutable();
     }
+
+    static void AddScanEvidence(
+        Dictionary<int, ScanMethodEvidence> scanningMethods,
+        int methodToken,
+        ScanMethodEvidence evidence)
+    {
+        if (!scanningMethods.TryGetValue(
+                methodToken,
+                out var existing))
+        {
+            scanningMethods.Add(
+                methodToken,
+                evidence);
+            return;
+        }
+
+        scanningMethods[methodToken] =
+            existing with { Call = null };
+    }
+
+    static OptimizationSupportingCallSite?
+        CreateSupportingCallSite(DirectCall? call)
+        => call is null
+            ? null
+            : new(
+                call.EvidenceMethod.MetadataToken,
+                call.ILOffset);
+
+    sealed record ScanMethodEvidence(
+        string Operation,
+        DirectCall? Call);
 
     static bool IsInvocation(DirectCall call) =>
         call.Kind is

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -599,6 +599,56 @@ public class OutputFormatterTests
         Assert.Null(projected.ModuleVersionId);
     }
 
+    [Fact]
+    public void ProjectOptimizationOpportunity_SeparatesAggregateSupportCoordinate()
+    {
+        var opportunity = Opp(
+            "AggregateScan",
+            inLoop: true,
+            confidence: "low",
+            rootReach: 1,
+            shape: "scan-method-in-loop-call") with
+        {
+            Provenance =
+                PerformanceTriageProvenance.Aggregate,
+            SupportingCallSite =
+                new OptimizationSupportingCallSite(
+                    0x06000002,
+                    0x001F)
+                {
+                    SourceFinding =
+                        AnalysisFindings
+                            .CallSiteDescriptor.Id,
+                    Operation = "call",
+                    OperandToken = 0x0A000001,
+                },
+        };
+
+        var projected =
+            LibraryMetadataService
+                .ProjectOptimizationOpportunity(
+                    opportunity);
+
+        Assert.Equal("aggregate", projected.Provenance);
+        Assert.Null(projected.Finding);
+        Assert.Null(projected.IL);
+        Assert.Equal(
+            AnalysisFindings.CallSiteDescriptor.Id,
+            projected.SupportingFinding);
+        Assert.Equal(
+            "0x06000002",
+            projected.SupportingEvidenceMethod);
+        Assert.Equal(
+            "IL_001F",
+            projected.SupportingIL);
+        Assert.Equal(
+            "call",
+            projected.SupportingOperation);
+        Assert.Equal(
+            "0x0A000001",
+            projected.SupportingToken);
+    }
+
     // #1623 rung 5: a labeled, non-vacuous ranking guard for the Performance Triage
     // model. Unlike the monotonicity check above (which re-derives the production key and
     // only proves self-consistency), this asserts the model's intended priority on seeded

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -1570,6 +1570,23 @@ internal static class LibraryMetadataService
             Token = FormatToken(opportunity.OperandToken),
             EvidenceMethod = FormatToken(
                 opportunity.EvidenceMethodToken),
+            SupportingFinding =
+                opportunity.SupportingCallSite
+                    ?.SourceFinding,
+            SupportingOperation =
+                opportunity.SupportingCallSite
+                    ?.Operation,
+            SupportingToken = FormatToken(
+                opportunity.SupportingCallSite
+                    ?.OperandToken),
+            SupportingEvidenceMethod = FormatToken(
+                opportunity.SupportingCallSite
+                    ?.EvidenceMethodToken),
+            SupportingIL =
+                opportunity.SupportingCallSite is
+                    { ILOffset: var supportingOffset }
+                    ? $"IL_{supportingOffset:X4}"
+                    : null,
             Evidence = opportunity.Evidence,
             Fix = opportunity.SafeFixDirection,
             Priority = TriagePriority(opportunity),

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -1265,6 +1265,16 @@ public record class OptimizationOpportunitySummary
     public string? Token { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? EvidenceMethod { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SupportingFinding { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SupportingOperation { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SupportingToken { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SupportingEvidenceMethod { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? SupportingIL { get; init; }
     public string Evidence { get; init; } = "";
     public string Fix { get; init; } = "";
     public string Priority { get; init; } = "";

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2441,6 +2441,26 @@ public static class ApiOutputFormatter
                 opportunity.EvidenceMethodToken is { } evidenceMethod
                     ? MarkoutInline.Code($"0x{evidenceMethod:X8}")
                     : null,
+                opportunity.SupportingCallSite
+                    ?.SourceFinding,
+                opportunity.SupportingCallSite
+                    ?.Operation,
+                opportunity.SupportingCallSite
+                    ?.OperandToken is { } supportingToken
+                    ? MarkoutInline.Code(
+                        $"0x{supportingToken:X8}")
+                    : null,
+                opportunity.SupportingCallSite
+                    ?.EvidenceMethodToken is
+                        { } supportingMethod
+                    ? MarkoutInline.Code(
+                        $"0x{supportingMethod:X8}")
+                    : null,
+                opportunity.SupportingCallSite is
+                    { ILOffset: var supportingOffset }
+                    ? MarkoutInline.Code(
+                        $"IL_{supportingOffset:X4}")
+                    : null,
                 MarkoutInline.Code(opportunity.Evidence),
                 opportunity.SafeFixDirection,
                 LibraryMetadataService.TriagePriority(opportunity),

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -1281,6 +1281,11 @@ public record OptimizationOpportunityRow(
     string? Operation,
     string? Token,
     string? EvidenceMethod,
+    string? SupportingFinding,
+    string? SupportingOperation,
+    string? SupportingToken,
+    string? SupportingEvidenceMethod,
+    string? SupportingIL,
     string Evidence,
     string Fix,
     string Priority,
@@ -1331,6 +1336,34 @@ public record OptimizationOpportunityRow(
     [MarkoutSkipNull]
     public string? EvidenceMethod { get; init; } =
         LibraryViewText.Contain(EvidenceMethod);
+
+    [MarkoutPropertyName("Supporting Finding")]
+    [MarkoutSkipNull]
+    public string? SupportingFinding { get; init; } =
+        LibraryViewText.Contain(SupportingFinding);
+
+    [MarkoutPropertyName("Supporting Operation")]
+    [MarkoutSkipNull]
+    public string? SupportingOperation { get; init; } =
+        LibraryViewText.Contain(
+            SupportingOperation);
+
+    [MarkoutPropertyName("Supporting Token")]
+    [MarkoutSkipNull]
+    public string? SupportingToken { get; init; } =
+        LibraryViewText.Contain(SupportingToken);
+
+    /// <inheritdoc cref="LibraryViewText"/>
+    [MarkoutPropertyName("Supporting Evidence Method")]
+    [MarkoutSkipNull]
+    public string? SupportingEvidenceMethod
+        { get; init; } = LibraryViewText.Contain(
+            SupportingEvidenceMethod);
+
+    [MarkoutPropertyName("Supporting IL")]
+    [MarkoutSkipNull]
+    public string? SupportingIL { get; init; } =
+        LibraryViewText.Contain(SupportingIL);
 
     public string Evidence { get; init; } = Evidence;
 

--- a/src/runfaster.Tests/E2EFixtureTests.cs
+++ b/src/runfaster.Tests/E2EFixtureTests.cs
@@ -2108,6 +2108,76 @@ public class E2EFixtureTests
     }
 
     [Fact]
+    public void FlattenedPerformanceTriageJsonl_RetainsSupportingCallSite()
+    {
+        string inspectDll =
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "dotnet-inspect.dll");
+        var produced = RunTool(
+            inspectDll,
+            "type",
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "runfaster.Tests.dll"),
+            "runfaster.Tests.E2EFixtureTests.FlattenedScanFixture",
+            "-S",
+            "Performance Triage",
+            "--jsonl");
+
+        Assert.Equal(0, produced.ExitCode);
+        Assert.Empty(produced.Error);
+        var rows = produced.Output.Split(
+            '\n',
+            StringSplitOptions.RemoveEmptyEntries)
+            .Select(static text =>
+                JsonDocument.Parse(text))
+            .ToArray();
+        try
+        {
+            var row = Assert.Single(
+                rows,
+                document => document.RootElement
+                    .GetProperty("shape")
+                    .GetString()
+                    == "scan-method-in-loop-call");
+            Assert.Equal(
+                "analysis.call-site",
+                row.RootElement.GetProperty(
+                        "supporting_finding")
+                    .GetString());
+            Assert.Equal(
+                "newobj",
+                row.RootElement.GetProperty(
+                        "supporting_operation")
+                    .GetString());
+            Assert.StartsWith(
+                "0x",
+                row.RootElement.GetProperty(
+                        "supporting_token")
+                    .GetString(),
+                StringComparison.Ordinal);
+            Assert.StartsWith(
+                "0x06",
+                row.RootElement.GetProperty(
+                        "supporting_evidence_method")
+                    .GetString(),
+                StringComparison.Ordinal);
+            Assert.StartsWith(
+                "IL_",
+                row.RootElement.GetProperty(
+                        "supporting_il")
+                    .GetString(),
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            foreach (var row in rows)
+                row.Dispose();
+        }
+    }
+
+    [Fact]
     public void Correlate_DoesNotTokenMatchAssemblylessFlattenedTriage()
     {
         string inspectDll =
@@ -2625,6 +2695,181 @@ public class E2EFixtureTests
     }
 
     [Fact]
+    public void Correlate_NonAllocationSupport_DoesNotShadowNearestLibrarySite()
+    {
+        string assemblyPath =
+            FixtureCatalog.RunFasterAllocation.AssemblyPath();
+        var allocateOne =
+            typeof(RunFaster.AllocationFixture.Program)
+                .GetMethod(
+                    "AllocateOne",
+                    BindingFlags.Public
+                        | BindingFlags.Static);
+        Assert.NotNull(allocateOne);
+        var occurrence = Assert.Single(
+            LibraryBodyIndex.Open(assemblyPath)
+                .GetAllocationOccurrences()[
+                    allocateOne.MetadataToken]);
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                $$$"""
+                {"performance":{"loop_hot_paths":[{"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","moduleVersionId":"{{{occurrence.Method.ModuleVersionId:D}}}","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","candidate":"pt~aggregate","shape":"scan-method-in-loop-call","provenance":"aggregate","supporting_finding":"analysis.call-site","supporting_operation":"call","supporting_token":"0x0A000001","supporting_evidence_method":"0x{{{allocateOne.MetadataToken:X8}}}","supporting_il":"IL_{{{occurrence.ILOffset + 1:X4}}}"}]}}
+                """);
+
+            var result = RunCorrelate(
+                "--library",
+                assemblyPath,
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation
+                    .AssetPath("fixture.nettrace"),
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            using var output =
+                JsonDocument.Parse(result.Output);
+            var sameMethod = output.RootElement
+                .GetProperty("candidates")
+                .EnumerateArray()
+                .Where(candidate => candidate
+                    .GetProperty("method")
+                    .GetString()!
+                    .EndsWith(
+                        ".AllocateOne()",
+                        StringComparison.Ordinal))
+                .ToArray();
+            var triage = Assert.Single(
+                sameMethod,
+                candidate => candidate
+                    .GetProperty("source")
+                    .GetString() == "triage");
+            var library = Assert.Single(
+                sameMethod,
+                candidate => candidate
+                    .GetProperty("source")
+                    .GetString() == "library");
+            Assert.Equal(
+                0,
+                triage.GetProperty("allocationBytes")
+                    .GetInt64());
+            Assert.Equal(
+                "cold-for-this-workload",
+                triage.GetProperty("status")
+                    .GetString());
+            Assert.Equal(
+                1_167_872,
+                library.GetProperty("allocationBytes")
+                    .GetInt64());
+            Assert.Equal(
+                "shape-hot",
+                library.GetProperty("status")
+                    .GetString());
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Fact]
+    public void Correlate_ExactAndAggregateSameSite_PrefersAggregateSupport()
+    {
+        string assemblyPath =
+            FixtureCatalog.RunFasterAllocation.AssemblyPath();
+        var allocateOne =
+            typeof(RunFaster.AllocationFixture.Program)
+                .GetMethod(
+                    "AllocateOne",
+                    BindingFlags.Public
+                        | BindingFlags.Static);
+        Assert.NotNull(allocateOne);
+        var occurrence = Assert.Single(
+            LibraryBodyIndex.Open(assemblyPath)
+                .GetAllocationOccurrences()[
+                    allocateOne.MetadataToken]);
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                $$$"""
+                {"performance":{"objects":[{"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","moduleVersionId":"{{{occurrence.Method.ModuleVersionId:D}}}","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","candidate":"pt~exact","shape":"object-allocation","provenance":"exact","operation":"newobj","token":"0x0A000001","il":"IL_{{{occurrence.ILOffset:X4}}}","allocation":"System.Object"}],"loop_hot_paths":[{"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","moduleVersionId":"{{{occurrence.Method.ModuleVersionId:D}}}","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","candidate":"pt~aggregate","shape":"scan-method-in-loop-call","provenance":"aggregate","supporting_finding":"analysis.call-site","supporting_operation":"newobj","supporting_token":"0x0A000001","supporting_evidence_method":"0x{{{allocateOne.MetadataToken:X8}}}","supporting_il":"IL_{{{occurrence.ILOffset:X4}}}"}]}}
+                """);
+
+            var result = RunCorrelate(
+                "--library",
+                assemblyPath,
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation
+                    .AssetPath("fixture.nettrace"),
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            using var output =
+                JsonDocument.Parse(result.Output);
+            var sameMethod = output.RootElement
+                .GetProperty("candidates")
+                .EnumerateArray()
+                .Where(candidate => candidate
+                    .GetProperty("method")
+                    .GetString()!
+                    .EndsWith(
+                        ".AllocateOne()",
+                        StringComparison.Ordinal))
+                .ToArray();
+            var aggregate = Assert.Single(
+                sameMethod,
+                candidate => candidate.TryGetProperty(
+                        "candidate",
+                        out var id)
+                    && id.GetString()
+                        == "pt~aggregate");
+            var exact = Assert.Single(
+                sameMethod,
+                candidate => candidate.TryGetProperty(
+                        "candidate",
+                        out var id)
+                    && id.GetString() == "pt~exact");
+            Assert.Equal(
+                1_167_872,
+                aggregate.GetProperty("allocationBytes")
+                    .GetInt64());
+            Assert.Equal(
+                0,
+                exact.GetProperty("allocationBytes")
+                    .GetInt64());
+            Assert.Equal(
+                "superseded-by-triage",
+                exact.GetProperty("status")
+                    .GetString());
+            Assert.DoesNotContain(
+                sameMethod,
+                candidate => candidate
+                    .GetProperty("source")
+                    .GetString() == "library"
+                    && candidate.GetProperty(
+                            "allocationBytes")
+                        .GetInt64() > 0);
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Fact]
     public void Correlate_AmbiguousAggregateSupports_DoNotClaimLibraryEvidence()
     {
         string assemblyPath =
@@ -2713,10 +2958,16 @@ public class E2EFixtureTests
         "must be supplied together")]
     [InlineData(
         "\"supporting_evidence_method\":\"not-a-token\",\"supporting_il\":\"IL_0000\"",
-        "Invalid supporting call-site coordinate")]
+        "Invalid supporting evidence method")]
     [InlineData(
         "\"supporting_evidence_method\":\"0x06000001\",\"supporting_il\":\"IL_0000\",\"il\":\"IL_0000\"",
         "cannot be combined with IL or Evidence Method")]
+    [InlineData(
+        "\"supporting_evidence_method\":\"0x06000001\",\"supportingEvidenceMethod\":\"0x06000002\",\"supporting_il\":\"IL_0000\"",
+        "Conflicting supporting evidence method values")]
+    [InlineData(
+        "\"supporting_evidence_method\":\"0x06000001\",\"supporting_il\":\"IL_0000\",\"supportingIL\":\"IL_0001\"",
+        "Conflicting supporting IL values")]
     public void Correlate_InvalidSupportingCoordinate_FailsVisibly(
         string coordinateProperties,
         string expectedError)
@@ -2987,6 +3238,31 @@ public class E2EFixtureTests
         {
             File.Delete(triagePath);
             File.Delete(logPath);
+        }
+    }
+
+    public static class FlattenedScanFixture
+    {
+        public static int FilterThenFirstOrDefault(
+            IEnumerable<int> source,
+            int key)
+            => Enumerable.FirstOrDefault(
+                Enumerable.Where(
+                    source,
+                    value => value == key));
+
+        public static int CallFilterInLoop(
+            IEnumerable<int> source,
+            int[] keys)
+        {
+            int result = 0;
+            foreach (int key in keys)
+            {
+                result += FilterThenFirstOrDefault(
+                    source,
+                    key);
+            }
+            return result;
         }
     }
 

--- a/src/runfaster.Tests/E2EFixtureTests.cs
+++ b/src/runfaster.Tests/E2EFixtureTests.cs
@@ -2519,6 +2519,245 @@ public class E2EFixtureTests
     }
 
     [Fact]
+    public void Correlate_AggregateSupportingCallSite_PromotesExactLibraryEvidence()
+    {
+        string assemblyPath =
+            FixtureCatalog.RunFasterAllocation.AssemblyPath();
+        var allocateOne =
+            typeof(RunFaster.AllocationFixture.Program)
+                .GetMethod(
+                    "AllocateOne",
+                    BindingFlags.Public
+                        | BindingFlags.Static);
+        Assert.NotNull(allocateOne);
+        var occurrence = Assert.Single(
+            LibraryBodyIndex.Open(assemblyPath)
+                .GetAllocationOccurrences()[
+                    allocateOne.MetadataToken]);
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                $$$"""
+                {"performance":{"loop_hot_paths":[{"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","moduleVersionId":"{{{occurrence.Method.ModuleVersionId:D}}}","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","candidate":"pt~aggregate","shape":"scan-method-in-loop-call","provenance":"aggregate","supporting_finding":"analysis.call-site","supporting_operation":"newobj","supporting_token":"0x0A000001","supporting_evidence_method":"0x{{{allocateOne.MetadataToken:X8}}}","supporting_il":"IL_{{{occurrence.ILOffset:X4}}}"}]}}
+                """);
+
+            var result = RunCorrelate(
+                "--library",
+                assemblyPath,
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation
+                    .AssetPath("fixture.nettrace"),
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            using var output =
+                JsonDocument.Parse(result.Output);
+            var sameMethod = output.RootElement
+                .GetProperty("candidates")
+                .EnumerateArray()
+                .Where(candidate => candidate
+                    .GetProperty("method")
+                    .GetString()!
+                    .EndsWith(
+                        ".AllocateOne()",
+                        StringComparison.Ordinal))
+                .ToArray();
+            var triage = Assert.Single(
+                sameMethod,
+                candidate => candidate
+                    .GetProperty("source")
+                    .GetString() == "triage");
+            var library = Assert.Single(
+                sameMethod,
+                candidate => candidate
+                    .GetProperty("source")
+                    .GetString() == "library");
+            Assert.Equal(
+                "supporting-call-site",
+                triage.GetProperty("coordinateRole")
+                    .GetString());
+            Assert.Equal(
+                occurrence.ILOffset,
+                triage.GetProperty(
+                    "supportingIlOffset")
+                    .GetInt32());
+            Assert.Equal(
+                allocateOne.MetadataToken,
+                triage.GetProperty(
+                    "supportingEvidenceMethodToken")
+                    .GetInt32());
+            Assert.False(
+                triage.TryGetProperty(
+                    "ilOffset",
+                    out _));
+            Assert.False(
+                triage.TryGetProperty(
+                    "operation",
+                    out _));
+            Assert.Equal(
+                1_167_872,
+                triage.GetProperty("allocationBytes")
+                    .GetInt64());
+            Assert.Equal(
+                "il-offset-hot",
+                triage.GetProperty("status")
+                    .GetString());
+            Assert.Equal(
+                0,
+                library.GetProperty("allocationBytes")
+                    .GetInt64());
+            Assert.Equal(
+                "superseded-by-triage",
+                library.GetProperty("status")
+                    .GetString());
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Fact]
+    public void Correlate_AmbiguousAggregateSupports_DoNotClaimLibraryEvidence()
+    {
+        string assemblyPath =
+            FixtureCatalog.RunFasterAllocation.AssemblyPath();
+        var allocateOne =
+            typeof(RunFaster.AllocationFixture.Program)
+                .GetMethod(
+                    "AllocateOne",
+                    BindingFlags.Public
+                        | BindingFlags.Static);
+        Assert.NotNull(allocateOne);
+        var occurrence = Assert.Single(
+            LibraryBodyIndex.Open(assemblyPath)
+                .GetAllocationOccurrences()[
+                    allocateOne.MetadataToken]);
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            string rowProperties =
+                $$$"""
+                "member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","moduleVersionId":"{{{occurrence.Method.ModuleVersionId:D}}}","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","shape":"scan-method-in-loop-call","provenance":"aggregate","supporting_finding":"analysis.call-site","supporting_operation":"newobj","supporting_token":"0x0A000001","supporting_evidence_method":"0x{{{allocateOne.MetadataToken:X8}}}","supporting_il":"IL_{{{occurrence.ILOffset:X4}}}"
+                """;
+            File.WriteAllText(
+                triagePath,
+                string.Concat(
+                    "{\"performance\":{\"loop_hot_paths\":[{",
+                    rowProperties,
+                    ",\"candidate\":\"pt~first\"},{",
+                    rowProperties,
+                    ",\"candidate\":\"pt~second\"}]}}"));
+
+            var result = RunCorrelate(
+                "--library",
+                assemblyPath,
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation
+                    .AssetPath("fixture.nettrace"),
+                "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Empty(result.Error);
+            using var output =
+                JsonDocument.Parse(result.Output);
+            var sameMethod = output.RootElement
+                .GetProperty("candidates")
+                .EnumerateArray()
+                .Where(candidate => candidate
+                    .GetProperty("method")
+                    .GetString()!
+                    .EndsWith(
+                        ".AllocateOne()",
+                        StringComparison.Ordinal))
+                .ToArray();
+            Assert.All(
+                sameMethod.Where(candidate =>
+                    candidate.GetProperty("source")
+                        .GetString() == "triage"),
+                candidate => Assert.Equal(
+                    0,
+                    candidate.GetProperty(
+                        "allocationBytes")
+                        .GetInt64()));
+            var library = Assert.Single(
+                sameMethod,
+                candidate => candidate
+                    .GetProperty("source")
+                    .GetString() == "library");
+            Assert.Equal(
+                1_167_872,
+                library.GetProperty("allocationBytes")
+                    .GetInt64());
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Theory]
+    [InlineData(
+        "\"supporting_evidence_method\":\"0x06000001\"",
+        "must be supplied together")]
+    [InlineData(
+        "\"supporting_evidence_method\":\"not-a-token\",\"supporting_il\":\"IL_0000\"",
+        "Invalid supporting call-site coordinate")]
+    [InlineData(
+        "\"supporting_evidence_method\":\"0x06000001\",\"supporting_il\":\"IL_0000\",\"il\":\"IL_0000\"",
+        "cannot be combined with IL or Evidence Method")]
+    public void Correlate_InvalidSupportingCoordinate_FailsVisibly(
+        string coordinateProperties,
+        string expectedError)
+    {
+        string triagePath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-triage-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(
+                triagePath,
+                string.Concat(
+                    "{\"performance\":{\"loop_hot_paths\":[{",
+                    "\"member\":\"RunFaster.AllocationFixture.Program.AllocateOne()\",",
+                    "\"assembly\":\"RunFaster.AllocationFixture\",",
+                    "\"method_token\":\"0x06000002\",",
+                    "\"shape\":\"scan-method-in-loop-call\",",
+                    coordinateProperties,
+                    "}]}}"));
+
+            var result = RunCorrelate(
+                "--triage",
+                triagePath,
+                "--trace",
+                FixtureCatalog.RunFasterAllocation
+                    .AssetPath("fixture.nettrace"));
+
+            Assert.Equal(1, result.ExitCode);
+            Assert.Contains(
+                expectedError,
+                result.Error,
+                StringComparison.Ordinal);
+            Assert.Empty(result.Output);
+        }
+        finally
+        {
+            File.Delete(triagePath);
+        }
+    }
+
+    [Fact]
     public void Correlate_KnownMvidMismatch_DoesNotCollapseLibrarySite()
     {
         string assemblyPath =

--- a/src/runfaster.Tests/E2EFixtureTests.cs
+++ b/src/runfaster.Tests/E2EFixtureTests.cs
@@ -2778,8 +2778,13 @@ public class E2EFixtureTests
         }
     }
 
-    [Fact]
-    public void Correlate_ExactAndAggregateSameSite_PrefersAggregateSupport()
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(2, true)]
+    [InlineData(0, false)]
+    public void Correlate_ExactAndAggregateSites_RespectCoordinateAndBuild(
+        int exactOffsetDelta,
+        bool sameBuild)
     {
         string assemblyPath =
             FixtureCatalog.RunFasterAllocation.AssemblyPath();
@@ -2799,10 +2804,14 @@ public class E2EFixtureTests
             $"runfaster-triage-{Guid.NewGuid():N}.json");
         try
         {
+            Guid exactMvid = sameBuild
+                ? occurrence.Method.ModuleVersionId
+                : Guid.Parse(
+                    "99999999-9999-9999-9999-999999999999");
             File.WriteAllText(
                 triagePath,
                 $$$"""
-                {"performance":{"objects":[{"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","moduleVersionId":"{{{occurrence.Method.ModuleVersionId:D}}}","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","candidate":"pt~exact","shape":"object-allocation","provenance":"exact","operation":"newobj","token":"0x0A000001","il":"IL_{{{occurrence.ILOffset:X4}}}","allocation":"System.Object"}],"loop_hot_paths":[{"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","moduleVersionId":"{{{occurrence.Method.ModuleVersionId:D}}}","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","candidate":"pt~aggregate","shape":"scan-method-in-loop-call","provenance":"aggregate","supporting_finding":"analysis.call-site","supporting_operation":"newobj","supporting_token":"0x0A000001","supporting_evidence_method":"0x{{{allocateOne.MetadataToken:X8}}}","supporting_il":"IL_{{{occurrence.ILOffset:X4}}}"}]}}
+                {"performance":{"objects":[{"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","moduleVersionId":"{{{exactMvid:D}}}","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","candidate":"pt~exact","shape":"object-allocation","provenance":"exact","operation":"newobj","token":"0x0A000001","il":"IL_{{{occurrence.ILOffset + exactOffsetDelta:X4}}}","allocation":"System.Object"}],"loop_hot_paths":[{"member":"RunFaster.AllocationFixture.Program.AllocateOne()","assembly":"RunFaster.AllocationFixture","moduleVersionId":"{{{occurrence.Method.ModuleVersionId:D}}}","method_token":"0x{{{allocateOne.MetadataToken:X8}}}","candidate":"pt~aggregate","shape":"scan-method-in-loop-call","provenance":"aggregate","supporting_finding":"analysis.call-site","supporting_operation":"newobj","supporting_token":"0x0A000001","supporting_evidence_method":"0x{{{allocateOne.MetadataToken:X8}}}","supporting_il":"IL_{{{occurrence.ILOffset:X4}}}"}]}}
                 """);
 
             var result = RunCorrelate(
@@ -2842,26 +2851,53 @@ public class E2EFixtureTests
                         "candidate",
                         out var id)
                     && id.GetString() == "pt~exact");
-            Assert.Equal(
-                1_167_872,
-                aggregate.GetProperty("allocationBytes")
-                    .GetInt64());
-            Assert.Equal(
-                0,
-                exact.GetProperty("allocationBytes")
-                    .GetInt64());
-            Assert.Equal(
-                "superseded-by-triage",
-                exact.GetProperty("status")
-                    .GetString());
-            Assert.DoesNotContain(
-                sameMethod,
-                candidate => candidate
-                    .GetProperty("source")
-                    .GetString() == "library"
-                    && candidate.GetProperty(
+            if (sameBuild
+                && exactOffsetDelta == 0)
+            {
+                Assert.Equal(
+                    1_167_872,
+                    aggregate.GetProperty(
+                            "allocationBytes")
+                        .GetInt64());
+                Assert.Equal(
+                    0,
+                    exact.GetProperty("allocationBytes")
+                        .GetInt64());
+                Assert.Equal(
+                    "superseded-by-triage",
+                    exact.GetProperty("status")
+                        .GetString());
+            }
+            else if (sameBuild)
+            {
+                Assert.Equal(
+                    0,
+                    aggregate.GetProperty(
+                            "allocationBytes")
+                        .GetInt64());
+                Assert.Equal(
+                    1_167_872,
+                    exact.GetProperty("allocationBytes")
+                        .GetInt64());
+                Assert.NotEqual(
+                    "superseded-by-triage",
+                    exact.GetProperty("status")
+                        .GetString());
+            }
+            else
+            {
+                Assert.True(
+                    aggregate.GetProperty(
                             "allocationBytes")
                         .GetInt64() > 0);
+                Assert.True(
+                    exact.GetProperty("allocationBytes")
+                        .GetInt64() > 0);
+                Assert.NotEqual(
+                    "superseded-by-triage",
+                    exact.GetProperty("status")
+                        .GetString());
+            }
         }
         finally
         {
@@ -2888,6 +2924,9 @@ public class E2EFixtureTests
         string triagePath = Path.Combine(
             Path.GetTempPath(),
             $"runfaster-triage-{Guid.NewGuid():N}.json");
+        string stackPath = Path.Combine(
+            Path.GetTempPath(),
+            $"runfaster-stack-{Guid.NewGuid():N}.txt");
         try
         {
             string rowProperties =
@@ -2902,6 +2941,9 @@ public class E2EFixtureTests
                     ",\"candidate\":\"pt~first\"},{",
                     rowProperties,
                     ",\"candidate\":\"pt~second\"}]}}"));
+            File.WriteAllText(
+                stackPath,
+                "RunFaster.AllocationFixture.Program.AllocateOne()");
 
             var result = RunCorrelate(
                 "--library",
@@ -2911,6 +2953,8 @@ public class E2EFixtureTests
                 "--trace",
                 FixtureCatalog.RunFasterAllocation
                     .AssetPath("fixture.nettrace"),
+                "--stack",
+                stackPath,
                 "--json");
 
             Assert.Equal(0, result.ExitCode);
@@ -2945,10 +2989,15 @@ public class E2EFixtureTests
                 1_167_872,
                 library.GetProperty("allocationBytes")
                     .GetInt64());
+            Assert.NotEqual(
+                "superseded-by-triage",
+                library.GetProperty("status")
+                    .GetString());
         }
         finally
         {
             File.Delete(triagePath);
+            File.Delete(stackPath);
         }
     }
 

--- a/src/runfaster.Tests/TypeConfirmationTests.cs
+++ b/src/runfaster.Tests/TypeConfirmationTests.cs
@@ -886,6 +886,40 @@ public class TypeConfirmationTests
     }
 
     [Fact]
+    public void FindTraceLibrariesSupersededByTriage_SupportCoordinateDoesNotRequireSampledTypeMatch()
+    {
+        Guid mvid = Guid.Parse(
+            "22222222-2222-2222-2222-222222222222");
+        var triage = CandidateWithType(
+            1,
+            "Fixture.A.M()",
+            "System.Func<System.String, bool>",
+            source: "triage",
+            moduleVersionId: mvid,
+            libraryPath: "/tmp/triage.json",
+            supportingCallSite: true);
+        var library = CandidateWithType(
+            2,
+            "Fixture.A.M()",
+            "System.Func<System.String, bool>",
+            source: "library",
+            moduleVersionId: mvid);
+
+        var superseded =
+            ProgramSupport
+                .FindTraceLibrariesSupersededByTriage(
+                    [triage, library],
+                    [triage, library],
+                    "System.Linq.Enumerable+WhereIterator<System.String>");
+
+        Assert.Collection(
+            superseded,
+            candidate => Assert.Same(
+                library,
+                candidate));
+    }
+
+    [Fact]
     public void ApplyTypeConfirmation_CollapsesOnlyMatchingTriageModuleVersion()
     {
         Guid firstMvid = Guid.Parse(
@@ -1277,7 +1311,8 @@ public class TypeConfirmationTests
         int ilOffset = 0x0010,
         Guid? moduleVersionId = null,
         string libraryPath = "/tmp/Fixture.dll",
-        int? evidenceMethodToken = null)
+        int? evidenceMethodToken = null,
+        bool supportingCallSite = false)
     {
         string methodKey = method[..method.IndexOf('(')];
         int lastDot = methodKey.LastIndexOf('.');
@@ -1310,6 +1345,7 @@ public class TypeConfirmationTests
             null,
             null,
             null,
-            evidenceMethodToken: evidenceMethodToken);
+            evidenceMethodToken: evidenceMethodToken,
+            supportingCallSite: supportingCallSite);
     }
 }

--- a/src/runfaster.Tests/TypeConfirmationTests.cs
+++ b/src/runfaster.Tests/TypeConfirmationTests.cs
@@ -920,6 +920,56 @@ public class TypeConfirmationTests
     }
 
     [Fact]
+    public void ApplyAcceptedSupportPrecedence_IsIndependentPerBuild()
+    {
+        Guid firstMvid = Guid.Parse(
+            "11111111-1111-1111-1111-111111111111");
+        Guid secondMvid = Guid.Parse(
+            "22222222-2222-2222-2222-222222222222");
+        var firstExact = CandidateWithType(
+            1,
+            "Fixture.A.M()",
+            "System.Object",
+            source: "triage",
+            moduleVersionId: firstMvid);
+        var firstSupport = CandidateWithType(
+            2,
+            "Fixture.A.M()",
+            "System.Object",
+            source: "triage",
+            moduleVersionId: firstMvid,
+            supportingCallSite: true);
+        var secondExact = CandidateWithType(
+            3,
+            "Fixture.A.M()",
+            "System.Object",
+            source: "triage",
+            moduleVersionId: secondMvid);
+        var secondSupport = CandidateWithType(
+            4,
+            "Fixture.A.M()",
+            "System.Object",
+            source: "triage",
+            moduleVersionId: secondMvid,
+            supportingCallSite: true);
+
+        var selected = ProgramSupport
+            .ApplyAcceptedSupportPrecedence(
+                [
+                    firstExact,
+                    firstSupport,
+                    secondExact,
+                    secondSupport,
+                ]);
+
+        Assert.Equal(
+            [firstSupport, secondSupport],
+            selected);
+        Assert.True(firstExact.SupersededByTriage);
+        Assert.True(secondExact.SupersededByTriage);
+    }
+
+    [Fact]
     public void ApplyTypeConfirmation_CollapsesOnlyMatchingTriageModuleVersion()
     {
         Guid firstMvid = Guid.Parse(

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -1126,16 +1126,24 @@ static bool TryCorrelateNetTrace(
                     .ToArray();
                 if (supportingTargets.Length == 1)
                 {
+                    var support =
+                        supportingTargets[0];
                     foreach (var exactTriage
                              in matchedCandidates.Where(
-                                 static candidate =>
+                                 candidate =>
                                      !candidate
                                          .SupportingCallSite
                                      && string.Equals(
                                          candidate.Source,
                                          "triage",
                                          StringComparison
-                                             .Ordinal)))
+                                             .Ordinal)
+                                     && candidate.IlOffset
+                                         == support.IlOffset
+                                     && ProgramSupport
+                                         .SameBuild(
+                                             candidate,
+                                             support)))
                     {
                         exactTriage.SupersededByTriage =
                             true;
@@ -1143,14 +1151,21 @@ static bool TryCorrelateNetTrace(
                     matchedCandidates =
                     [
                         .. matchedCandidates.Where(
-                            static candidate =>
+                            candidate =>
                                 candidate
                                     .SupportingCallSite
-                                || string.Equals(
-                                    candidate.Source,
-                                    "library",
-                                    StringComparison
-                                        .Ordinal)),
+                                || !(
+                                    string.Equals(
+                                        candidate.Source,
+                                        "triage",
+                                        StringComparison
+                                            .Ordinal)
+                                    && candidate.IlOffset
+                                        == support.IlOffset
+                                    && ProgramSupport
+                                        .SameBuild(
+                                            candidate,
+                                            support))),
                     ];
                 }
                 var supersededLibraries =
@@ -2929,6 +2944,8 @@ sealed class AllocationCandidate(
     public bool ProjectedByTriage { get; set; }
     public List<AllocationCandidate> ProjectedLibraries
         { get; } = [];
+    public List<AllocationCandidate> SupportingLibraries
+        { get; } = [];
     public bool SupersededByTriage { get; set; }
     public void MarkProjectedLibrariesSuperseded()
     {
@@ -2936,6 +2953,15 @@ sealed class AllocationCandidate(
                  in ProjectedLibraries)
         {
             projectedLibrary.SupersededByTriage =
+                true;
+        }
+    }
+    public void MarkSupportingLibrariesSuperseded()
+    {
+        foreach (var supportingLibrary
+                 in SupportingLibraries)
+        {
+            supportingLibrary.SupersededByTriage =
                 true;
         }
     }
@@ -3470,11 +3496,11 @@ sealed class CandidateLookup
                              candidate,
                              support)))
             {
-                if (!support.ProjectedLibraries.Any(
+                if (!support.SupportingLibraries.Any(
                         projected =>
                             projected.Id == library.Id))
                 {
-                    support.ProjectedLibraries.Add(
+                    support.SupportingLibraries.Add(
                         library);
                 }
             }
@@ -3906,6 +3932,14 @@ sealed class CandidateLookup
 
         foreach (var raw in NearestByBuild(rawSearch))
         {
+            if (!result.Any(candidate =>
+                    candidate.IlOffset == raw.IlOffset
+                    && ProgramSupport.SameBuild(
+                        candidate,
+                        raw)))
+            {
+                continue;
+            }
             result.AddRange(supports.Where(support =>
                 support.IlOffset == raw.IlOffset
                 && ProgramSupport.SameBuild(
@@ -4393,6 +4427,11 @@ internal static class ProgramSupport
         candidate.ExactOffsetObserved |= exactOffset;
         candidate.AmbiguousIlOffsetJoin |= ambiguousIlJoin;
         candidate.MarkProjectedLibrariesSuperseded();
+        if (candidate.SupportingCallSite)
+        {
+            candidate
+                .MarkSupportingLibrariesSuperseded();
+        }
         if (!string.IsNullOrWhiteSpace(allocatedType))
         {
             candidate.ObservedAllocatedTypes[allocatedType] = candidate.ObservedAllocatedTypes.GetValueOrDefault(allocatedType) + sampledBytes;
@@ -4430,7 +4469,7 @@ internal static class ProgramSupport
         if (compatibleSupports != 1)
             return false;
 
-        return candidate.ProjectedLibraries.Any(
+        return candidate.SupportingLibraries.Any(
             library =>
                 library.IlOffset
                     == candidate.IlOffset
@@ -4518,6 +4557,12 @@ internal static class ProgramSupport
             {
                 AddObservedType(
                     projectedLibrary.PredictedType);
+            }
+            foreach (var supportingLibrary
+                     in candidate.SupportingLibraries)
+            {
+                AddObservedType(
+                    supportingLibrary.PredictedType);
             }
             foreach (string observedType
                      in candidate
@@ -4655,7 +4700,12 @@ internal static class ProgramSupport
             var coordinateCandidates = coordinateGroup.ToArray();
             var supersededAtCoordinate =
                 FindLibrariesSupersededByTriage(
-                    coordinateCandidates);
+                    [
+                        .. coordinateCandidates.Where(
+                            static candidate =>
+                                !candidate
+                                    .SupportingCallSite),
+                    ]);
             var supersededIds = supersededAtCoordinate
                 .Select(static candidate => candidate.Id)
                 .ToHashSet();

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -1118,56 +1118,9 @@ static bool TryCorrelateNetTrace(
                                 coordinateCandidates,
                                 data.TypeName))
                     .ToArray();
-                var supportingTargets =
-                    matchedCandidates.Where(
-                        static candidate =>
-                            candidate
-                                .SupportingCallSite)
-                    .ToArray();
-                if (supportingTargets.Length == 1)
-                {
-                    var support =
-                        supportingTargets[0];
-                    foreach (var exactTriage
-                             in matchedCandidates.Where(
-                                 candidate =>
-                                     !candidate
-                                         .SupportingCallSite
-                                     && string.Equals(
-                                         candidate.Source,
-                                         "triage",
-                                         StringComparison
-                                             .Ordinal)
-                                     && candidate.IlOffset
-                                         == support.IlOffset
-                                     && ProgramSupport
-                                         .SameBuild(
-                                             candidate,
-                                             support)))
-                    {
-                        exactTriage.SupersededByTriage =
-                            true;
-                    }
-                    matchedCandidates =
-                    [
-                        .. matchedCandidates.Where(
-                            candidate =>
-                                candidate
-                                    .SupportingCallSite
-                                || !(
-                                    string.Equals(
-                                        candidate.Source,
-                                        "triage",
-                                        StringComparison
-                                            .Ordinal)
-                                    && candidate.IlOffset
-                                        == support.IlOffset
-                                    && ProgramSupport
-                                        .SameBuild(
-                                            candidate,
-                                            support))),
-                    ];
-                }
+                matchedCandidates = ProgramSupport
+                    .ApplyAcceptedSupportPrecedence(
+                        matchedCandidates);
                 var supersededLibraries =
                     ProgramSupport.FindTraceLibrariesSupersededByTriage(
                         matchedCandidates,
@@ -4476,6 +4429,52 @@ internal static class ProgramSupport
                 && SameBuild(
                     candidate,
                     library));
+    }
+
+    public static AllocationCandidate[]
+        ApplyAcceptedSupportPrecedence(
+            AllocationCandidate[] matchedCandidates)
+    {
+        var supports = matchedCandidates
+            .Where(static candidate =>
+                candidate.SupportingCallSite)
+            .Where(support =>
+                matchedCandidates.Count(other =>
+                    other.SupportingCallSite
+                    && other.IlOffset
+                        == support.IlOffset
+                    && SameBuild(
+                        other,
+                        support)) == 1)
+            .ToArray();
+        if (supports.Length == 0)
+            return matchedCandidates;
+
+        bool IsProjectedExact(
+            AllocationCandidate candidate)
+            => !candidate.SupportingCallSite
+                && string.Equals(
+                    candidate.Source,
+                    "triage",
+                    StringComparison.Ordinal)
+                && supports.Any(support =>
+                    candidate.IlOffset
+                        == support.IlOffset
+                    && SameBuild(
+                        candidate,
+                        support));
+
+        foreach (var exactTriage
+                 in matchedCandidates.Where(
+                     IsProjectedExact))
+        {
+            exactTriage.SupersededByTriage = true;
+        }
+        return
+        [
+            .. matchedCandidates.Where(candidate =>
+                !IsProjectedExact(candidate)),
+        ];
     }
 
     public static bool SameBuild(

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -632,18 +632,10 @@ static bool TryCreateCandidateFromJson(
         "methodToken");
     int? evidenceMethodToken =
         ReadOptionalEvidenceMethodToken(element);
-    string? supportingMethodTokenText = GetJsonString(
-        element,
-        "Supporting Evidence Method",
-        "supporting_evidence_method",
-        "SupportingEvidenceMethod",
-        "supportingEvidenceMethod");
-    string? supportingOffsetText = GetJsonString(
-        element,
-        "Supporting IL",
-        "supporting_il",
-        "SupportingIL",
-        "supportingIL");
+    int? supportingMethodToken =
+        ReadOptionalSupportingMethodToken(element);
+    int? supportingOffset =
+        ReadOptionalSupportingIlOffset(element);
     string? operandTokenText = GetJsonString(
         element,
         "MetadataToken",
@@ -666,48 +658,25 @@ static bool TryCreateCandidateFromJson(
         ? parsedOperandToken
         : null;
     int offset = TryParseFlexibleInt(offsetText, out var parsedOffset) ? parsedOffset : -1;
-    bool supportingMethodSupplied =
-        !string.IsNullOrWhiteSpace(
-            supportingMethodTokenText);
-    bool supportingOffsetSupplied =
-        !string.IsNullOrWhiteSpace(
-            supportingOffsetText);
-    bool hasSupportingMethod =
-        TryParseFlexibleInt(
-            supportingMethodTokenText,
-            out var supportingMethodToken);
-    bool hasSupportingOffset =
-        TryParseFlexibleInt(
-            supportingOffsetText,
-            out var supportingOffset);
-    if (supportingMethodSupplied
-        != supportingOffsetSupplied)
+    if (supportingMethodToken.HasValue
+        != supportingOffset.HasValue)
     {
         throw new InvalidDataException(
             "Supporting Evidence Method and Supporting IL "
             + "must be supplied together.");
     }
-    if (supportingMethodSupplied
-        && (!hasSupportingMethod
-            || !hasSupportingOffset
-            || !ProgramSupport.IsMethodDefinitionToken(
-                supportingMethodToken)
-            || supportingOffset < 0))
+    if (supportingMethodToken is int supportMethod
+        && supportingOffset is int supportIl)
     {
-        throw new InvalidDataException(
-            "Invalid supporting call-site coordinate.");
-    }
-    if (hasSupportingMethod)
-    {
-        if (offset >= 0
+        if (!string.IsNullOrWhiteSpace(offsetText)
             || evidenceMethodToken is not null)
         {
             throw new InvalidDataException(
                 "A supporting call-site coordinate cannot "
                 + "be combined with IL or Evidence Method.");
         }
-        evidenceMethodToken = supportingMethodToken;
-        offset = supportingOffset;
+        evidenceMethodToken = supportMethod;
+        offset = supportIl;
     }
     Guid? moduleVersionId =
         ReadOptionalModuleVersionId(element);
@@ -746,7 +715,7 @@ static bool TryCreateCandidateFromJson(
         GetJsonString(element, "Post Dominance", "post_dominance", "postDominance"),
         candidateId: GetJsonString(element, "Candidate", "candidate"),
         provenance: GetJsonString(element, "Provenance", "provenance"),
-        operation: hasSupportingMethod
+        operation: supportingMethodToken is not null
             ? GetJsonString(
                 element,
                 "Supporting Operation",
@@ -757,7 +726,7 @@ static bool TryCreateCandidateFromJson(
                 element,
                 "Operation",
                 "operation"),
-        operandToken: hasSupportingMethod
+        operandToken: supportingMethodToken is not null
             ? ReadOptionalFlexibleInt(
                 element,
                 "Supporting Token",
@@ -766,7 +735,8 @@ static bool TryCreateCandidateFromJson(
                 "supportingToken")
             : operandToken,
         evidenceMethodToken: evidenceMethodToken,
-        supportingCallSite: hasSupportingMethod);
+        supportingCallSite:
+            supportingMethodToken is not null);
     return true;
 }
 
@@ -836,6 +806,86 @@ static bool IsEvidenceMethodProperty(
         or "evidence_method"
         or "EvidenceMethod"
         or "evidenceMethod";
+
+static int? ReadOptionalSupportingMethodToken(
+    JsonElement element)
+    => ReadOptionalSupportingCoordinatePart(
+        element,
+        IsSupportingEvidenceMethodProperty,
+        "supporting evidence method",
+        static value =>
+            ProgramSupport.IsMethodDefinitionToken(value));
+
+static int? ReadOptionalSupportingIlOffset(
+    JsonElement element)
+    => ReadOptionalSupportingCoordinatePart(
+        element,
+        IsSupportingIlProperty,
+        "supporting IL",
+        static value => value >= 0);
+
+static int? ReadOptionalSupportingCoordinatePart(
+    JsonElement element,
+    Func<string, bool> isProperty,
+    string description,
+    Func<int, bool> isValid)
+{
+    int? result = null;
+    foreach (var property in element.EnumerateObject())
+    {
+        if (!isProperty(property.Name))
+            continue;
+        if (property.Value.ValueKind
+                == JsonValueKind.Null
+            || (property.Value.ValueKind
+                    == JsonValueKind.String
+                && string.IsNullOrWhiteSpace(
+                    property.Value.GetString())))
+        {
+            continue;
+        }
+
+        string? text =
+            property.Value.ValueKind switch
+            {
+                JsonValueKind.String =>
+                    property.Value.GetString(),
+                JsonValueKind.Number =>
+                    property.Value.GetRawText(),
+                _ => null,
+            };
+        if (!TryParseFlexibleInt(text, out int parsed)
+            || !isValid(parsed))
+        {
+            throw new InvalidDataException(
+                $"Invalid {description} in "
+                + $"'{property.Name}'.");
+        }
+        if (result is int existing
+            && existing != parsed)
+        {
+            throw new InvalidDataException(
+                $"Conflicting {description} values "
+                + "were supplied.");
+        }
+        result = parsed;
+    }
+    return result;
+}
+
+static bool IsSupportingEvidenceMethodProperty(
+    string name)
+    => name is "Supporting Evidence Method"
+        or "supporting_evidence_method"
+        or "SupportingEvidenceMethod"
+        or "supportingEvidenceMethod";
+
+static bool IsSupportingIlProperty(
+    string name)
+    => name is "Supporting IL"
+        or "supporting_il"
+        or "SupportingIL"
+        or "supportingIL";
 
 static Guid? ReadOptionalModuleVersionId(
     JsonElement element)
@@ -1068,6 +1118,41 @@ static bool TryCorrelateNetTrace(
                                 coordinateCandidates,
                                 data.TypeName))
                     .ToArray();
+                var supportingTargets =
+                    matchedCandidates.Where(
+                        static candidate =>
+                            candidate
+                                .SupportingCallSite)
+                    .ToArray();
+                if (supportingTargets.Length == 1)
+                {
+                    foreach (var exactTriage
+                             in matchedCandidates.Where(
+                                 static candidate =>
+                                     !candidate
+                                         .SupportingCallSite
+                                     && string.Equals(
+                                         candidate.Source,
+                                         "triage",
+                                         StringComparison
+                                             .Ordinal)))
+                    {
+                        exactTriage.SupersededByTriage =
+                            true;
+                    }
+                    matchedCandidates =
+                    [
+                        .. matchedCandidates.Where(
+                            static candidate =>
+                                candidate
+                                    .SupportingCallSite
+                                || string.Equals(
+                                    candidate.Source,
+                                    "library",
+                                    StringComparison
+                                        .Ordinal)),
+                    ];
+                }
                 var supersededLibraries =
                     ProgramSupport.FindTraceLibrariesSupersededByTriage(
                         matchedCandidates,
@@ -3094,6 +3179,10 @@ sealed class CandidateLookup
     readonly Dictionary<(int Token, int Offset), List<AllocationCandidate>> _byTokenOffset;
     readonly Dictionary<(int Token, int Offset), AllocationCandidate[]> _rejectedByTokenOffset;
     readonly Dictionary<(string Module, int Token), List<AllocationCandidate>> _byModuleMethodToken;
+    readonly Dictionary<(string Module, int Token), List<AllocationCandidate>>
+        _rawLibrariesByModuleMethodToken;
+    readonly Dictionary<(string Module, int Token), List<AllocationCandidate>>
+        _supportsByModuleMethodToken;
     readonly HashSet<string> _candidateModules;
     readonly Dictionary<int, string>
         _stableAttributionKeys = [];
@@ -3114,6 +3203,10 @@ sealed class CandidateLookup
         Dictionary<(int Token, int Offset), List<AllocationCandidate>> byTokenOffset,
         Dictionary<(int Token, int Offset), AllocationCandidate[]> rejectedByTokenOffset,
         Dictionary<(string Module, int Token), List<AllocationCandidate>> byModuleMethodToken,
+        Dictionary<(string Module, int Token), List<AllocationCandidate>>
+            rawLibrariesByModuleMethodToken,
+        Dictionary<(string Module, int Token), List<AllocationCandidate>>
+            supportsByModuleMethodToken,
         HashSet<string> candidateModules,
         List<(
             string Fragment,
@@ -3124,6 +3217,10 @@ sealed class CandidateLookup
         _rejectedByTokenOffset =
             rejectedByTokenOffset;
         _byModuleMethodToken = byModuleMethodToken;
+        _rawLibrariesByModuleMethodToken =
+            rawLibrariesByModuleMethodToken;
+        _supportsByModuleMethodToken =
+            supportsByModuleMethodToken;
         _candidateModules = candidateModules;
         _methodFragments = methodFragments;
     }
@@ -3132,6 +3229,14 @@ sealed class CandidateLookup
     {
         var byTokenOffset = new Dictionary<(int Token, int Offset), List<AllocationCandidate>>();
         var byModuleMethodToken = new Dictionary<(string Module, int Token), List<AllocationCandidate>>();
+        var rawLibrariesByModuleMethodToken =
+            new Dictionary<
+                (string Module, int Token),
+                List<AllocationCandidate>>();
+        var supportsByModuleMethodToken =
+            new Dictionary<
+                (string Module, int Token),
+                List<AllocationCandidate>>();
         var fragments = new List<(
             string Fragment,
             AllocationCandidate Candidate,
@@ -3140,27 +3245,58 @@ sealed class CandidateLookup
         {
             if (candidate.HasRuntimeCoordinate)
             {
-                var key = (
-                    candidate.RuntimeMethodToken,
-                    candidate.IlOffset);
-                if (!byTokenOffset.TryGetValue(key, out var list))
+                if (!candidate.SupportingCallSite)
                 {
-                    list = [];
-                    byTokenOffset.Add(key, list);
+                    var key = (
+                        candidate.RuntimeMethodToken,
+                        candidate.IlOffset);
+                    if (!byTokenOffset.TryGetValue(
+                            key,
+                            out var list))
+                    {
+                        list = [];
+                        byTokenOffset.Add(key, list);
+                    }
+                    list.Add(candidate);
                 }
-                list.Add(candidate);
 
                 foreach (var moduleKey in CandidateModuleKeys(candidate))
                 {
                     var moduleTokenKey = (
                         moduleKey,
                         candidate.RuntimeMethodToken);
-                    if (!byModuleMethodToken.TryGetValue(moduleTokenKey, out var tokenList))
+                    var index = candidate.SupportingCallSite
+                        ? supportsByModuleMethodToken
+                        : byModuleMethodToken;
+                    if (!index.TryGetValue(
+                            moduleTokenKey,
+                            out var tokenList))
                     {
                         tokenList = [];
-                        byModuleMethodToken.Add(moduleTokenKey, tokenList);
+                        index.Add(
+                            moduleTokenKey,
+                            tokenList);
                     }
                     tokenList.Add(candidate);
+
+                    if (string.Equals(
+                            candidate.Source,
+                            "library",
+                            StringComparison.Ordinal))
+                    {
+                        if (!rawLibrariesByModuleMethodToken
+                            .TryGetValue(
+                                moduleTokenKey,
+                                out var rawList))
+                        {
+                            rawList = [];
+                            rawLibrariesByModuleMethodToken
+                                .Add(
+                                    moduleTokenKey,
+                                    rawList);
+                        }
+                        rawList.Add(candidate);
+                    }
                 }
             }
 
@@ -3190,6 +3326,20 @@ sealed class CandidateLookup
 
         foreach (var tokenList in byModuleMethodToken.Values)
             tokenList.Sort(static (left, right) => left.IlOffset.CompareTo(right.IlOffset));
+        foreach (var tokenList
+                 in rawLibrariesByModuleMethodToken.Values)
+        {
+            tokenList.Sort(static (left, right) =>
+                left.IlOffset.CompareTo(
+                    right.IlOffset));
+        }
+        foreach (var tokenList
+                 in supportsByModuleMethodToken.Values)
+        {
+            tokenList.Sort(static (left, right) =>
+                left.IlOffset.CompareTo(
+                    right.IlOffset));
+        }
 
         var textSupersessions =
             new List<TextSupersession>();
@@ -3299,6 +3449,37 @@ sealed class CandidateLookup
                 .ToList();
         }
 
+        foreach (var support in candidates.Where(
+                     static candidate =>
+                         candidate.SupportingCallSite))
+        {
+            foreach (var library in candidates.Where(candidate =>
+                         string.Equals(
+                             candidate.Source,
+                             "library",
+                             StringComparison.Ordinal)
+                         && string.Equals(
+                             candidate.AssemblyModuleKey,
+                             support.AssemblyModuleKey,
+                             StringComparison.OrdinalIgnoreCase)
+                         && candidate.RuntimeMethodToken
+                             == support.RuntimeMethodToken
+                         && candidate.IlOffset
+                             == support.IlOffset
+                         && ProgramSupport.SameBuild(
+                             candidate,
+                             support)))
+            {
+                if (!support.ProjectedLibraries.Any(
+                        projected =>
+                            projected.Id == library.Id))
+                {
+                    support.ProjectedLibraries.Add(
+                        library);
+                }
+            }
+        }
+
         foreach (var group in candidates
                      .Where(static candidate =>
                          !candidate.ProjectedByTriage)
@@ -3348,6 +3529,8 @@ sealed class CandidateLookup
             byTokenOffset,
             rejectedByTokenOffset,
             byModuleMethodToken,
+            rawLibrariesByModuleMethodToken,
+            supportsByModuleMethodToken,
             [.. byModuleMethodToken.Keys.Select(static key => key.Module)],
             fragments);
 
@@ -3661,28 +3844,101 @@ sealed class CandidateLookup
         if (search.Length == 0)
             return [];
 
+        var result = NearestByBuild(search)
+            .ToList();
+        var rawSearch = moduleKeys
+            .SelectMany(moduleKey =>
+                _rawLibrariesByModuleMethodToken
+                    .TryGetValue(
+                        (moduleKey, token),
+                        out var candidates)
+                    ? candidates
+                    : [])
+            .Where(candidate =>
+                candidate.IlOffset <= ilOffset)
+            .DistinctBy(static candidate =>
+                candidate.Id)
+            .ToArray();
+        var supports = moduleKeys
+            .SelectMany(moduleKey =>
+                _supportsByModuleMethodToken
+                    .TryGetValue(
+                        (moduleKey, token),
+                        out var candidates)
+                    ? candidates
+                    : [])
+            .DistinctBy(static candidate =>
+                candidate.Id)
+            .ToArray();
+        if (moduleKeys.Length == 0
+            && !string.IsNullOrWhiteSpace(methodName))
+        {
+            rawSearch =
+            [
+                .. _rawLibrariesByModuleMethodToken
+                    .Where(pair =>
+                        pair.Key.Token == token)
+                    .SelectMany(static pair =>
+                        pair.Value)
+                    .Where(candidate =>
+                        candidate.IlOffset <= ilOffset
+                        && MethodMatches(
+                            candidate,
+                            methodName))
+                    .DistinctBy(static candidate =>
+                        candidate.Id),
+            ];
+            supports =
+            [
+                .. _supportsByModuleMethodToken
+                    .Where(pair =>
+                        pair.Key.Token == token)
+                    .SelectMany(static pair =>
+                        pair.Value)
+                    .Where(candidate =>
+                        MethodMatches(
+                            candidate,
+                            methodName))
+                    .DistinctBy(static candidate =>
+                        candidate.Id),
+            ];
+        }
+
+        foreach (var raw in NearestByBuild(rawSearch))
+        {
+            result.AddRange(supports.Where(support =>
+                support.IlOffset == raw.IlOffset
+                && ProgramSupport.SameBuild(
+                    support,
+                    raw)));
+        }
         return
         [
-            .. search
-                .GroupBy(static candidate => (
-                    candidate.AssemblyModuleKey,
-                    BuildIdentity:
-                        candidate.ModuleVersionId
-                            ?.ToString("D")
-                        ?? candidate
-                            .UnknownBuildInputIdentity))
-                .SelectMany(static buildCandidates =>
-                {
-                    int nearest = buildCandidates.Max(
-                        static candidate =>
-                            candidate.IlOffset);
-                    return buildCandidates.Where(
-                        candidate =>
-                            candidate.IlOffset
-                                == nearest);
-                })
+            .. result.DistinctBy(
+                static candidate => candidate.Id),
         ];
     }
+
+    static IEnumerable<AllocationCandidate>
+        NearestByBuild(
+            IEnumerable<AllocationCandidate> candidates)
+        => candidates
+            .GroupBy(static candidate => (
+                candidate.AssemblyModuleKey,
+                BuildIdentity:
+                    candidate.ModuleVersionId
+                        ?.ToString("D")
+                    ?? candidate
+                        .UnknownBuildInputIdentity))
+            .SelectMany(static buildCandidates =>
+            {
+                int nearest = buildCandidates.Max(
+                    static candidate =>
+                        candidate.IlOffset);
+                return buildCandidates.Where(
+                    candidate =>
+                        candidate.IlOffset == nearest);
+            });
 
     public List<MethodTextMatch> FindByMethodText(string line)
     {
@@ -4174,21 +4430,21 @@ internal static class ProgramSupport
         if (compatibleSupports != 1)
             return false;
 
-        return coordinateCandidates.Any(library =>
-            string.Equals(
-                library.Source,
-                "library",
-                StringComparison.Ordinal)
-            && library.IlOffset == candidate.IlOffset
-            && SameBuild(candidate, library));
+        return candidate.ProjectedLibraries.Any(
+            library =>
+                library.IlOffset
+                    == candidate.IlOffset
+                && SameBuild(
+                    candidate,
+                    library));
     }
 
-    static bool SameBuild(
+    public static bool SameBuild(
         AllocationCandidate left,
         AllocationCandidate right)
     {
-        if (left.ModuleVersionId is Guid leftMvid
-            || right.ModuleVersionId is Guid)
+        if (left.ModuleVersionId is not null
+            || right.ModuleVersionId is not null)
         {
             return left.ModuleVersionId
                 == right.ModuleVersionId;

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -632,6 +632,18 @@ static bool TryCreateCandidateFromJson(
         "methodToken");
     int? evidenceMethodToken =
         ReadOptionalEvidenceMethodToken(element);
+    string? supportingMethodTokenText = GetJsonString(
+        element,
+        "Supporting Evidence Method",
+        "supporting_evidence_method",
+        "SupportingEvidenceMethod",
+        "supportingEvidenceMethod");
+    string? supportingOffsetText = GetJsonString(
+        element,
+        "Supporting IL",
+        "supporting_il",
+        "SupportingIL",
+        "supportingIL");
     string? operandTokenText = GetJsonString(
         element,
         "MetadataToken",
@@ -654,6 +666,49 @@ static bool TryCreateCandidateFromJson(
         ? parsedOperandToken
         : null;
     int offset = TryParseFlexibleInt(offsetText, out var parsedOffset) ? parsedOffset : -1;
+    bool supportingMethodSupplied =
+        !string.IsNullOrWhiteSpace(
+            supportingMethodTokenText);
+    bool supportingOffsetSupplied =
+        !string.IsNullOrWhiteSpace(
+            supportingOffsetText);
+    bool hasSupportingMethod =
+        TryParseFlexibleInt(
+            supportingMethodTokenText,
+            out var supportingMethodToken);
+    bool hasSupportingOffset =
+        TryParseFlexibleInt(
+            supportingOffsetText,
+            out var supportingOffset);
+    if (supportingMethodSupplied
+        != supportingOffsetSupplied)
+    {
+        throw new InvalidDataException(
+            "Supporting Evidence Method and Supporting IL "
+            + "must be supplied together.");
+    }
+    if (supportingMethodSupplied
+        && (!hasSupportingMethod
+            || !hasSupportingOffset
+            || !ProgramSupport.IsMethodDefinitionToken(
+                supportingMethodToken)
+            || supportingOffset < 0))
+    {
+        throw new InvalidDataException(
+            "Invalid supporting call-site coordinate.");
+    }
+    if (hasSupportingMethod)
+    {
+        if (offset >= 0
+            || evidenceMethodToken is not null)
+        {
+            throw new InvalidDataException(
+                "A supporting call-site coordinate cannot "
+                + "be combined with IL or Evidence Method.");
+        }
+        evidenceMethodToken = supportingMethodToken;
+        offset = supportingOffset;
+    }
     Guid? moduleVersionId =
         ReadOptionalModuleVersionId(element);
 
@@ -691,10 +746,44 @@ static bool TryCreateCandidateFromJson(
         GetJsonString(element, "Post Dominance", "post_dominance", "postDominance"),
         candidateId: GetJsonString(element, "Candidate", "candidate"),
         provenance: GetJsonString(element, "Provenance", "provenance"),
-        operation: GetJsonString(element, "Operation", "operation"),
-        operandToken: operandToken,
-        evidenceMethodToken: evidenceMethodToken);
+        operation: hasSupportingMethod
+            ? GetJsonString(
+                element,
+                "Supporting Operation",
+                "supporting_operation",
+                "SupportingOperation",
+                "supportingOperation")
+            : GetJsonString(
+                element,
+                "Operation",
+                "operation"),
+        operandToken: hasSupportingMethod
+            ? ReadOptionalFlexibleInt(
+                element,
+                "Supporting Token",
+                "supporting_token",
+                "SupportingToken",
+                "supportingToken")
+            : operandToken,
+        evidenceMethodToken: evidenceMethodToken,
+        supportingCallSite: hasSupportingMethod);
     return true;
+}
+
+static int? ReadOptionalFlexibleInt(
+    JsonElement element,
+    params string[] names)
+{
+    string? text = GetJsonString(
+        element,
+        names);
+    if (string.IsNullOrWhiteSpace(text))
+        return null;
+    if (TryParseFlexibleInt(text, out int parsed))
+        return parsed;
+
+    throw new InvalidDataException(
+        $"Invalid integer value in '{names[0]}'.");
 }
 
 static int? ReadOptionalEvidenceMethodToken(
@@ -973,8 +1062,11 @@ static bool TryCorrelateNetTrace(
                             candidate.Source,
                             "triage",
                             StringComparison.Ordinal)
-                        || candidate.MatchesAllocatedType(
-                            data.TypeName))
+                        || ProgramSupport
+                            .CanAcceptTraceAllocation(
+                                candidate,
+                                coordinateCandidates,
+                                data.TypeName))
                     .ToArray();
                 var supersededLibraries =
                     ProgramSupport.FindTraceLibrariesSupersededByTriage(
@@ -2310,19 +2402,51 @@ static void WriteCandidateJsonObject(Utf8JsonWriter writer, AllocationCandidate 
         candidate.HasRuntimeCoordinate);
     writer.WriteString("tokenIl", candidate.TokenAndOffset);
     writer.WriteNumber("methodToken", candidate.MethodToken);
-    if (candidate.EvidenceMethodToken is int evidenceMethodToken)
+    if (candidate.SupportingCallSite)
+    {
+        writer.WriteString(
+            "coordinateRole",
+            "supporting-call-site");
         writer.WriteNumber(
-            "evidenceMethodToken",
-            evidenceMethodToken);
-    writer.WriteNumber("ilOffset", candidate.IlOffset);
+            "supportingEvidenceMethodToken",
+            candidate.RuntimeMethodToken);
+        writer.WriteNumber(
+            "supportingIlOffset",
+            candidate.IlOffset);
+    }
+    else
+    {
+        if (candidate.EvidenceMethodToken is
+            int evidenceMethodToken)
+        {
+            writer.WriteNumber(
+                "evidenceMethodToken",
+                evidenceMethodToken);
+        }
+        writer.WriteNumber(
+            "ilOffset",
+            candidate.IlOffset);
+    }
     if (candidate.CandidateId is not null)
         writer.WriteString("candidate", candidate.CandidateId);
     if (candidate.Provenance is not null)
         writer.WriteString("provenance", candidate.Provenance);
     if (candidate.Operation is not null)
-        writer.WriteString("operation", candidate.Operation);
+    {
+        writer.WriteString(
+            candidate.SupportingCallSite
+                ? "supportingOperation"
+                : "operation",
+            candidate.Operation);
+    }
     if (candidate.OperandToken is int operandToken)
-        writer.WriteNumber("operandToken", operandToken);
+    {
+        writer.WriteNumber(
+            candidate.SupportingCallSite
+                ? "supportingOperandToken"
+                : "operandToken",
+            operandToken);
+    }
     writer.WriteString("kind", candidate.AllocationKind);
     if (candidate.EscapeKind is not null)
         writer.WriteString("escapeKind", candidate.EscapeKind);
@@ -2629,7 +2753,8 @@ sealed class AllocationCandidate(
     string? provenance = null,
     string? operation = null,
     int? operandToken = null,
-    int? evidenceMethodToken = null)
+    int? evidenceMethodToken = null,
+    bool supportingCallSite = false)
 {
     public int Id { get; } = id;
     public string Source { get; } = source;
@@ -2658,6 +2783,8 @@ sealed class AllocationCandidate(
     public string? Provenance { get; } = provenance;
     public string? Operation { get; } = operation;
     public int? OperandToken { get; } = operandToken;
+    public bool SupportingCallSite { get; } =
+        supportingCallSite;
     public string Method { get; } = method;
     public string MethodKey { get; } = methodKey;
     public string MethodStackKey { get; } = methodStackKey;
@@ -4026,6 +4153,53 @@ internal static class ProgramSupport
         }
     }
 
+    public static bool CanAcceptTraceAllocation(
+        AllocationCandidate candidate,
+        IReadOnlyList<AllocationCandidate>
+            coordinateCandidates,
+        string allocatedType)
+    {
+        if (!candidate.SupportingCallSite)
+        {
+            return candidate.MatchesAllocatedType(
+                allocatedType);
+        }
+
+        int compatibleSupports =
+            coordinateCandidates.Count(other =>
+                other.SupportingCallSite
+                && other.IlOffset
+                    == candidate.IlOffset
+                && SameBuild(candidate, other));
+        if (compatibleSupports != 1)
+            return false;
+
+        return coordinateCandidates.Any(library =>
+            string.Equals(
+                library.Source,
+                "library",
+                StringComparison.Ordinal)
+            && library.IlOffset == candidate.IlOffset
+            && SameBuild(candidate, library));
+    }
+
+    static bool SameBuild(
+        AllocationCandidate left,
+        AllocationCandidate right)
+    {
+        if (left.ModuleVersionId is Guid leftMvid
+            || right.ModuleVersionId is Guid)
+        {
+            return left.ModuleVersionId
+                == right.ModuleVersionId;
+        }
+
+        return string.Equals(
+            left.UnknownBuildInputIdentity,
+            right.UnknownBuildInputIdentity,
+            StringComparison.Ordinal);
+    }
+
     // Backstop the site-join with type-level confirmation (issue #2264). When a small allocating
     // method is inlined, its GCAllocationTick leaf frame belongs to the inliner, so the IL-offset
     // site-join misses it — but the allocated type is still realized-hot. For each unobserved
@@ -4417,9 +4591,11 @@ internal static class ProgramSupport
                             "triage",
                             StringComparison.Ordinal)
                         && triage.IlOffset ==
-                            candidate.IlOffset)
-                    && candidate.MatchesAllocatedType(
-                        allocatedType)))
+                            candidate.IlOffset
+                        && (triage.SupportingCallSite
+                            || candidate
+                                .MatchesAllocatedType(
+                                    allocatedType)))))
                 .DistinctBy(static candidate => candidate.Id)
                 .ToArray());
     }


### PR DESCRIPTION
## Outcome

Coordinate-bearing repeated-scan aggregates now receive matching RunFaster allocation evidence without changing static rank, confidence, provenance, or candidate identity. Aspire's `OtlpSpan.GetParentSpan` aggregate carries all 102 sampled allocation ticks / 10,873,200 bytes at `IL_001F`; the raw library row is superseded rather than splitting the evidence.

## Implementation

- retain one typed `SupportingCallSite` on unambiguous local repeated scans, preferring an argument-producing allocation call that directly feeds the scan;
- project that relation through distinct `Supporting*` fields while keeping the row's own `Finding`, `Operation`, `Token`, and `IL` empty under `Provenance=aggregate`;
- promote same-build RunFaster evidence only when one aggregate support and a raw library allocation share the coordinate; duplicate support claims fail closed;
- leave true aggregates such as `allocation-hotspot`, propagated inner-callee scans, static ordering, and candidate identity unchanged.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `ILInspector.Analysis.Tests`: 1,100 total, 0 failed, 8 corpus skips
- `runfaster.Tests`: 175 total, 0 failed, 0 skipped
- `dotnet-inspect.Tests`: 4,290 total, 0 failed, 14 environment-specific skips
- Markdown lint passed for all changed documents
- Aspire 8.0.0-preview.2 no-inline trace canary: `GetParentSpan` triage row = `il-offset-hot`, 102 ticks, 10,873,200 bytes at `0x060004F2+IL_001F`

Candidate head: `85d6889b80be4a5e75a25c54c89511b2ede9d367`
Integrated base: `6efd98d6c8a6c0e3e9be045520b57d13d6c3d06a`