### PR TITLE
Restructure round guidance around its decision points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -575,7 +575,9 @@ Three consequences follow, and they are the ones most often missed:
   always implies at least one more round.
 - Merge readiness requires a review-clean review **at the current head**. An
   author who wants to stop while the last round pushed a fix is asking for a
-  waiver, not making a judgment call. Ask for it explicitly.
+  waiver, not making a judgment call. Ask for it explicitly. An approved
+  carry-forward integration is the one move that *transfers* review-clean status
+  to a head no reviewer saw; nothing else does.
 - A review-clean round ends adversarial review. Do not move the head merely to
   buy another pass.
 
@@ -674,11 +676,17 @@ produced no change and the integration discarded the value of the locked-head
 result.
 
 The user may then approve carrying the clean reviews forward across a
-non-interacting base integration, without another round. That is the sole
-default path that integrates the base when no conflict, review-driven fix,
-author change, current-head merge-path failure, required cascading restack, or
-explicit user workflow adjustment has ended the candidate. The procedure, and
-the analysis to bring to the user, are in
+non-interacting base integration, without another round. **The integrated head
+inherits the review-clean status**, and is merge-ready on that basis — that
+transfer is the whole point, and without it the integration would strand the PR
+at a head no review covers. It rests on the approved analysis, not on the merge
+being mechanical: the reviews carry because the landed range was shown not to
+interact and the user accepted that finding.
+
+Carrying forward is the sole default path that integrates the base when no
+conflict, review-driven fix, author change, current-head merge-path failure,
+required cascading restack, or explicit user workflow adjustment has ended the
+candidate. The procedure, and the analysis to bring to the user, are in
 [carry-forward after clean reviews](docs/round-orchestration.md#carry-forward-after-clean-reviews).
 
 Evaluate eligibility from the *latest* review-clean result: an earlier finding

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -526,7 +526,8 @@ reconciliation.
 6. **Push.** That head is the candidate, and the lock begins here.
 7. **Confirm zero conflicts and green current-head `ci-required`** — unless the
    round's row below leaves them pending, or the user authorized reviewing in
-   parallel with CI.
+   parallel with CI. A conflict or a failed check here does not mean waiting
+   longer; take the matching [recovery transition](#recovery-transitions).
 8. **Review**: dispatch every required reviewer at that exact head.
 9. **Reconcile** the feedback publicly. The lock ends here. If the
    reconciliation produced fixes, the next round begins at step 1.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,10 +487,9 @@ These are the binding invariants. The rest of this section explains them;
 driving the loop is
 [round orchestration](docs/round-orchestration.md).
 
-1. **One frozen head per round.** The lock begins at the push and ends at
-   public reconciliation. Do not edit a head while it is held; fixes belong to
-   the next cycle. Reconciliation frees you to *fix*; it does not *complete* the
-   round — see invariant 6.
+1. **One frozen head per round.** The lock begins at the push and ends when the
+   round closes — reconciled *and* green. Do not edit a head while it is held;
+   fixes belong to the next cycle.
 2. **A candidate includes its effective base.** Integrate twice before pushing
    — once before fixing, once after — because the fix window is long enough for
    `main` to move.
@@ -500,11 +499,11 @@ driving the loop is
    can earn that.
 5. **Do not post `Ready to merge` until every required review at the current
    head is review-clean.**
-6. **A round is not complete until its gates are green.** Reconciliation
-   releases the lock; the round itself ends only once every required
-   current-head check and post-push gate has succeeded. Until then the round
-   number does not advance — a check that goes red first makes the next push a
-   failed-gate restart at the *same* number, not the next round.
+6. **A round closes only when reconciled and green.** Both: the feedback is
+   publicly reconciled, and every required current-head check and post-push gate
+   has succeeded. Until then the round number does not advance — a check that
+   goes red first makes the next push a failed-gate restart at the *same*
+   number, not the next round.
 7. **Six rounds, then stop** and ask for another block.
 8. **Never merge without explicit user authorization** for that specific PR.
    Auto-merge armed at the user's direction is that authorization; see
@@ -518,8 +517,8 @@ reviewer, stack, or readiness detail without redefining these transitions.
 
 #### The round cycle
 
-Steps 1-5 run with no lock held. The lock begins at the push and ends at
-reconciliation.
+Steps 1-5 run with no lock held. The lock begins at the push and ends when the
+round closes at step 10.
 
 1. **Integrate** the effective base, so the work is written against current
    `main` rather than against history.
@@ -536,13 +535,12 @@ reconciliation.
    parallel with CI. A conflict or a failed check here does not mean waiting
    longer; take the matching [recovery transition](#recovery-transitions).
 8. **Review**: dispatch every required reviewer at that exact head.
-9. **Reconcile** the feedback publicly. The lock ends here — you may begin
-   fixing. The round does not end here; it ends when its gates go green
-   (invariant 6).
-10. **Report.** Emit the round report as your visible response before starting
-    the next round. It is required, and the format is in [the round
-    report](docs/round-orchestration.md#the-round-report). If the reconciliation
-    produced fixes, the next round begins at step 1.
+9. **Reconcile** the feedback publicly.
+10. **Close the round** once it is also green (invariant 6). The lock ends here,
+    and only here is the round number spent. Emit the round report as your
+    visible response — required, format in [the round
+    report](docs/round-orchestration.md#the-round-report) — and if the
+    reconciliation produced fixes, the next round begins at step 1.
 
 **Two integrations per round, both before the push.** The first makes the work
 current; the second closes the window the fix itself opened, which can be an
@@ -566,10 +564,10 @@ The user may direct that a round run in parallel with CI, waiving the green
 `ci-required` requirement in the rows above; see [Standing
 adjustments](#standing-adjustments).
 
-The head lock ends at public reconciliation, which frees you to fix. The round
-ends later, when current-head zero-conflict evidence is confirmed and every
-required current-head check and concurrent local gate has succeeded. The fixed
-replacement is a new candidate and its review is a new round.
+The head lock ends when the round closes: reconciled, current-head
+zero-conflict evidence confirmed, and every required current-head check and
+concurrent local gate succeeded. The fixed replacement is a new candidate and
+its review is a new round.
 
 #### Review-clean, and what it gates
 
@@ -709,6 +707,14 @@ Carrying forward is the sole default path that integrates the base when no
 conflict, review-driven fix, author change, current-head merge-path failure,
 required cascading restack, or explicit user workflow adjustment has ended the
 candidate.
+
+**Carry forward only a non-interacting range.** If the analyzed range cannot
+affect the change and the user approves, integrate it and carry the clean
+reviews without another round; if the live tip moves before you integrate,
+analyze the additional range and obtain renewed approval. **If it can affect the
+change**, carry-forward is unavailable: keep the reviewed head, say the PR is
+not merge-ready, and ask whether to adjust the workflow to integrate,
+re-validate, and re-review the replacement head, or to leave the PR blocked.
 
 **Repeat it whenever the base moves again**; a carried-forward head is
 review-clean, and each pass needs its own analysis and its own approval. **A

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,12 +486,14 @@ the replacement head. Everything below serves that loop.
 These are the binding invariants. The rest of this section explains them; the
 mechanics live in [`docs/adversarial-review.md`](docs/adversarial-review.md).
 
-1. **One frozen head per round.** Do not edit a head while its lock is held.
-2. **A candidate includes its effective base.** Integrate before validating —
-   and again whenever a conflict, an author change, or a review finding moves
-   the head.
-3. **Base movement alone never invalidates a candidate**, and never justifies
-   another round.
+1. **One frozen head per round.** The lock begins at the push and ends at
+   public reconciliation. Do not edit a head while it is held; fixes belong to
+   the next cycle.
+2. **A candidate includes its effective base.** Integrate twice before pushing
+   — once before fixing, once after — because the fix window is long enough for
+   `main` to move.
+3. **Base movement alone never invalidates a pushed candidate**, and never
+   justifies another round.
 4. **A round that pushes a fix is not review-clean.** Only the replacement head
    can earn that.
 5. **Do not post `Ready to merge` until every required review at the current
@@ -506,6 +508,34 @@ mechanics live in [`docs/adversarial-review.md`](docs/adversarial-review.md).
 This section is the sole source of truth for candidate formation, round
 eligibility, head locking, supersession, and recovery. Other sections add
 reviewer, stack, or readiness detail without redefining these transitions.
+
+#### The round cycle
+
+Steps 1-5 run with no lock held. The lock begins at the push and ends at
+reconciliation.
+
+1. **Integrate** the effective base, so the work is written against current
+   `main` rather than against history.
+2. **Fix** — the review-driven changes, or the initial authoring for round 1.
+3. **Validate** the fix with the focused gate.
+4. **Integrate again.** Fixing takes real time, and `main` moves during it.
+5. **Validate again**, enough to prove the integration did not break the fix.
+   Scope it by the rerun rule under [Evidence and
+   validation](#evidence-and-validation): focused gates for whatever the landed
+   range can interact with, not the broad suite again.
+6. **Push.** That head is the candidate, and the lock begins here.
+7. **Confirm zero conflicts and green current-head `ci-required`** — unless the
+   round's row below leaves them pending, or the user authorized reviewing in
+   parallel with CI.
+8. **Review**: dispatch every required reviewer at that exact head.
+9. **Reconcile** the feedback publicly. The lock ends here. If the
+   reconciliation produced fixes, the next round begins at step 1.
+
+**Two integrations per round, both before the push.** The first makes the work
+current; the second closes the window the fix itself opened, which can be an
+hour wide and several merges deep. After the push, base movement does not
+reopen the candidate — that is invariant 3, and it is what stops the cycle from
+running forever.
 
 | Attempt | Required before reviewer dispatch | May remain pending |
 | --- | --- | --- |
@@ -591,16 +621,15 @@ subsequent round:
   an author change is the exception: it supersedes the incomplete attempt and
   releases the lock. Conflict recovery pushes immediately; failed-gate recovery
   pushes the fix and waits for the ordinary subsequent-round status gate.
-- **The candidate includes its effective base.** Immediately before focused
-  validation, fetch and integrate the effective base and record the integrated
-  tip. That head is the candidate: keep it fixed through broader validation,
-  push, CI, and review. Do **not** refetch merely because the base advances
-  during those steps; that creates an integrate-validate-integrate loop without
-  making the review more useful.
+- **The candidate includes its effective base.** Integrate twice, per [the round
+  cycle](#the-round-cycle): once before fixing, once after, recording the tip
+  you finally integrated. That head is the candidate — keep it fixed through
+  push, CI, and review. Do **not** refetch once it is pushed; that restarts the
+  cycle without making the review more useful.
 - **Re-integrate whenever the head moves.** When a conflict, an author change,
-  or a review finding ends a candidate, integrate the then-current effective
-  base while forming the replacement. A multi-round PR therefore picks up `main`
-  once per round that produced a fix — not never, and not continuously.
+  or a review finding ends a candidate, the replacement is formed by running the
+  cycle again. A multi-round PR therefore picks up `main` on each round that
+  produced a fix — not never, and not continuously while a head is frozen.
 - **Before merge, the PR is mergeable and green.** One consolidated status
   query answers both; see
   [status discovery](docs/adversarial-review.md#status-discovery) for the query,
@@ -626,9 +655,9 @@ subsequent round:
   that is a scheduling bug to investigate — a PR that triggers no workflow
   leaves `ci-required` nothing to block on and displays as MERGEABLE and CLEAN.
 
-Once a candidate is formed, do not fetch or integrate the base while validation,
-CI, or review is in progress. After a review-clean result, a non-mutating fetch
-is permitted solely to inspect the landed range for the carry-forward decision
+Once the candidate is pushed, do not fetch or integrate the base while CI or
+review is in progress. After a review-clean result, a non-mutating fetch is
+permitted solely to inspect the landed range for the carry-forward decision
 below.
 
 ### Clean reviews are not spent by main moving

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -593,8 +593,7 @@ subsequent round:
   green. Re-query after the registration window, following the status-discovery
   cadence, and verify the current head; if no matching workflow run appears,
   that is a scheduling bug to investigate — a PR that triggers no workflow
-  leaves `ci-required` nothing to block on and displays as MERGEABLE and CLEAN
-  (#3706).
+  leaves `ci-required` nothing to block on and displays as MERGEABLE and CLEAN.
 
 Once a candidate is formed, do not fetch or integrate the base while validation,
 CI, or review is in progress. After a review-clean result, a non-mutating fetch
@@ -619,6 +618,18 @@ author change, current-head merge-path failure, required cascading restack, or
 explicit user workflow adjustment has ended the candidate. The procedure, and
 the analysis to bring to the user, are in
 [carry-forward after clean reviews](docs/adversarial-review.md#carry-forward-after-clean-reviews).
+
+Evaluate eligibility from the *latest* review-clean result: an earlier finding
+that was fixed and then reviewed clean does not disqualify it. Carry-forward
+does not apply, and the head must be reviewed normally, when a finding remains
+unresolved, or when the head moved after that result because of an author
+change, conflict resolution, or a restack.
+
+This is the one place the settled-branch rule yields, and it has to, or the
+budget is unbounded: on a busy `main`, a round takes longer than the interval
+between commits, so integrate-and-re-review by reflex never converges. A pair of
+clean reviews is a result. Unrelated commits landing behind it do not retract
+it.
 
 ### A quick read is not a round
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,9 +487,9 @@ These are the binding invariants. The rest of this section explains them;
 driving the loop is
 [round orchestration](docs/round-orchestration.md).
 
-1. **One frozen head per round.** The lock begins at the push and ends when the
-   round closes — reconciled *and* green. Do not edit a head while it is held;
-   fixes belong to the next cycle.
+1. **One frozen head per round.** The lock begins at the push and ends two ways
+   only: the round closes — reconciled *and* green — or recovery supersedes the
+   attempt. Do not edit a head while it is held; fixes belong to the next cycle.
 2. **A candidate includes its effective base.** Integrate twice before pushing
    — once before fixing, once after — because the fix window is long enough for
    `main` to move.
@@ -517,8 +517,9 @@ reviewer, stack, or readiness detail without redefining these transitions.
 
 #### The round cycle
 
-Steps 1-5 run with no lock held. The lock begins at the push and ends when the
-round closes at step 10.
+Steps 1-5 run with no lock held. The lock begins at the push, and ends at step
+10 unless a [recovery transition](#recovery-transitions) supersedes the attempt
+first.
 
 1. **Integrate** the effective base, so the work is written against current
    `main` rather than against history.
@@ -566,8 +567,9 @@ adjustments](#standing-adjustments).
 
 The head lock ends when the round closes: reconciled, current-head
 zero-conflict evidence confirmed, and every required current-head check and
-concurrent local gate succeeded. The fixed replacement is a new candidate and
-its review is a new round.
+concurrent local gate succeeded. A superseded attempt is the other exit — it
+releases the lock through recovery, spends no round number, and never reaches
+closure. The fixed replacement is a new candidate and its review is a new round.
 
 #### Review-clean, and what it gates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -713,12 +713,13 @@ candidate.
 **Carry forward only a non-interacting range.** If the analyzed range cannot
 affect the change and the user approves, integrate it and carry the clean
 reviews without another round; if the live tip moves before you integrate,
-analyze the additional range and obtain renewed approval. **If it can affect the
+analyze the additional range and obtain renewed approval. A decline keeps the
+reviewed head and leaves the PR blocked there. **If it can affect the
 change**, carry-forward is unavailable: keep the reviewed head, say the PR is
 not merge-ready, and ask whether to adjust the workflow to integrate,
 re-validate, and re-review the replacement head, or to leave the PR blocked.
-Approving that adjustment buys a **re-review**, never a carried one. A decline
-leaves the PR blocked at the reviewed head; do not ask again.
+Approving that adjustment buys a **re-review**, never a carried one. Declining
+it leaves the PR blocked at the reviewed head. Do not re-ask either decline.
 
 **Repeat it whenever the base moves again**; a carried-forward head is
 review-clean, and each pass needs its own analysis and its own approval. **A

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -717,6 +717,8 @@ analyze the additional range and obtain renewed approval. **If it can affect the
 change**, carry-forward is unavailable: keep the reviewed head, say the PR is
 not merge-ready, and ask whether to adjust the workflow to integrate,
 re-validate, and re-review the replacement head, or to leave the PR blocked.
+Approving that adjustment buys a **re-review**, never a carried one. A decline
+leaves the PR blocked at the reviewed head; do not ask again.
 
 **Repeat it whenever the base moves again**; a carried-forward head is
 review-clean, and each pass needs its own analysis and its own approval. **A

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ change ready to merge.
 | Decompiler harness-only behavior | `docs/decompiler-correctness-pipeline.md`, then the owning harness README |
 | Skills | `taste/skill-guidance.md` |
 | Stacked PRs and restacking | `docs/stacked-prs.md` |
+| Adversarial review mechanics | `docs/adversarial-review.md` |
 | Release and publishing | `docs/release-workflow.md` |
 | Changes spanning Markout and this repo | `docs/markout-co-development.md` |
 
@@ -453,6 +454,26 @@ npx markdownlint-cli <file>
 
 ## Adversarial review
 
+Review is a locked-head feedback loop: freeze and push one exact head, review
+that head, reconcile the feedback publicly, make any resulting fixes, and freeze
+the replacement head. Everything below serves that loop.
+
+These are the binding invariants. The rest of this section explains them; the
+mechanics live in [`docs/adversarial-review.md`](docs/adversarial-review.md).
+
+1. **One frozen head per round.** Do not edit a head while its lock is held.
+2. **A candidate includes its effective base.** Integrate before validating —
+   and again whenever a conflict, an author change, or a review finding moves
+   the head.
+3. **Base movement alone never invalidates a candidate**, and never justifies
+   another round.
+4. **A round that pushes a fix is not review-clean.** Only the replacement head
+   can earn that.
+5. **Do not post `Ready to merge` until every required review at the current
+   head is review-clean.**
+6. **Six rounds, then stop** and ask for another block.
+7. **Never merge without explicit user authorization** for that specific PR.
+
 ### Canonical round flow
 
 This section is the sole source of truth for candidate formation, round
@@ -471,21 +492,34 @@ gate. A documentation conflict-recovery attempt instead lints after the
 resolution push; it may start review immediately, but cannot reconcile or
 complete until lint succeeds.
 
-Review is a locked-head feedback loop: freeze and push one exact head, review
-that head, reconcile the feedback, make any resulting fixes, and freeze the
-replacement head. Do not edit a head while its head lock is held. The lock ends
-when both reviewers have returned, their feedback has been reconciled for
-action, current-head zero-conflict evidence is confirmed, and every required
-current-head check and local gate allowed to run concurrently has succeeded.
-The fixed replacement is a new candidate and its review is a new round.
+The head lock ends when both reviewers have returned, their feedback has been
+reconciled for action, current-head zero-conflict evidence is confirmed, and
+every required current-head check and local gate allowed to run concurrently has
+succeeded. The fixed replacement is a new candidate and its review is a new
+round.
+
+#### Review-clean, and what it gates
 
 A fixed-head review is **review-clean** when its public reconciliation leaves no
 finding unresolved **and the reviewed head did not move in response to that
 round**. A justified dismissal counts as a resolution only when the reason is
-recorded publicly. A round that pushes a fix is complete but is not
-review-clean; only the replacement head can earn that status. The report
-classification `clean` is narrower: use it only when the reviewers returned no
-findings.
+recorded publicly.
+
+Three consequences follow, and they are the ones most often missed:
+
+- A round that pushes a fix is *complete* but not review-clean. Only the
+  replacement head can earn that status, which means a fix-producing round
+  always implies at least one more round.
+- Merge readiness requires a review-clean review **at the current head**. An
+  author who wants to stop while the last round pushed a fix is asking for a
+  waiver, not making a judgment call. Ask for it explicitly.
+- A review-clean round ends adversarial review. Do not move the head merely to
+  buy another pass.
+
+The report classification `clean` is narrower than review-clean: use it only
+when the reviewers returned no findings at all.
+
+#### Recovery transitions
 
 Apply one transition when the locked head becomes invalid:
 
@@ -505,28 +539,19 @@ A superseded attempt consumes no round number and receives no completion
 report. Let its reviewers finish or cancel them explicitly. Before completing
 the restarted round, wait for every superseded reviewer to finish or have its
 cancellation acknowledged, carry forward every returned finding, and
-disposition each one publicly.
+disposition each one publicly. Supersession never retires a finding.
 
-Absent an actual conflict, a round that produces no review-driven fix and then
-integrates newer `main` to create another round on the agent's own initiative
-is a failed round: the review produced no change and the integration discarded
-the value of the locked-head result. A review-clean round ends adversarial
-review; do not move the head merely to buy another pass. The sole default
-base-only integration after clean reviews is the explicitly approved
-carry-forward path in
-[Clean reviews are not spent by main
-moving](#clean-reviews-are-not-spent-by-main-moving), which preserves the clean
-reviews and does not open another round. An explicit user workflow adjustment
-may instead authorize interacting-base integration followed by validation and
-a new review round.
+### Forming a candidate
 
 Adversarial review is scarce, but serial wall-clock time is also a cost. Spend
 review only on a named frozen head with focused local evidence, then accept the
 bounded risk that later CI may supersede it. A branch whose head is unpushed or
-still moving, whose candidate was formed without integrating its effective
-base, or whose PR has a known failure or conflict has no single answer to "what
-am I reviewing?" Form and freeze one candidate before the first round, and do
-so again before every subsequent round:
+still moving, whose candidate was formed without integrating its effective base,
+or whose PR has a known failure or conflict has no single answer to "what am I
+reviewing?"
+
+Form and freeze one candidate before the first round, and again before every
+subsequent round:
 
 - **The head is pushed, named, and settled.** Reviewers get an exact base and
   head, not a branch that moves under them. Finish your own edits first, and do
@@ -537,197 +562,63 @@ so again before every subsequent round:
   pushes the fix and waits for the ordinary subsequent-round status gate.
 - **The candidate includes its effective base.** Immediately before focused
   validation, fetch and integrate the effective base and record the integrated
-  tip. The resulting head is the candidate: keep it fixed through broader
-  validation, push, CI, and review. Do **not** refetch or integrate the base
-  merely because it advances during those steps; doing so creates an
-  integrate-validate-integrate loop without making the review more useful.
-  Base movement alone does not invalidate a candidate. It remains eligible
-  while its exact pushed head has no known failure or conflict. If it becomes
-  conflicting, or an author change or review finding moves the head, end that
-  candidate and integrate the then-current effective base while forming the
-  replacement. Once the reviews are clean, see
-  [Clean reviews are not spent by main
-  moving](#clean-reviews-are-not-spent-by-main-moving).
-- **Before merge, the PR is mergeable and green** — two questions, one
-  consolidated status query. The first attempt at round 1 and conflict-recovery
-  rounds do not wait for this result, but a failed-gate restart, an ordinary
-  subsequent round, and merge readiness do. Use a single
-  `gh api graphql` request that returns the PR's
-  `headRefOid`, `baseRefOid`, `baseRef { target { oid } }`, `isDraft`,
-  `mergeable`, `mergeStateStatus`, `statusCheckRollup` state and contexts with
-  `pageInfo`, and the query's `rateLimit` cost, remaining quota, and reset time.
-  Request enough contexts for the normal check matrix; if
-  `pageInfo.hasNextPage` is true and `ci-required` is absent, fetch the
-  remaining context pages before concluding that it is missing. Confirm that
-  `headRefOid` is the pushed head, `isDraft` is false, `mergeable` is
-  `MERGEABLE`, and the current head's `ci-required` check run completed
-  successfully. Treat `mergeStateStatus` values `BLOCKED` and `DRAFT` as
-  independent readiness blockers: identify and clear the blocker before
-  posting `Ready to merge`. A `CONFLICTING` mergeability result blocks, and
-  `UNKNOWN` means GitHub has not finished computing the merge. When the exact
-  head's `ci-required` is already
-  `SUCCESS` and mergeability is the only unknown, immediately make one REST
-  `GET /repos/{owner}/{repo}/pulls/{number}` request for `head.sha`,
-  `mergeable`, and `mergeable_state`. That endpoint triggers GitHub's
-  mergeability computation and often returns the definite answer while GraphQL
-  still says `UNKNOWN`. Accept it only when `head.sha` is the expected head:
-  `mergeable: true` satisfies the mergeability half of the gate, while
-  `mergeable: false` blocks. A null REST result is still computing; yield for
-  five minutes with small random jitter, then re-run the consolidated GraphQL
-  query and the REST fallback if it remains `UNKNOWN`. Continue that
-  five-minute self-recovery until GitHub returns a definite result; do not ask
-  the user to report CI or mergeability.
+  tip. That head is the candidate: keep it fixed through broader validation,
+  push, CI, and review. Do **not** refetch merely because the base advances
+  during those steps; that creates an integrate-validate-integrate loop without
+  making the review more useful.
+- **Re-integrate whenever the head moves.** When a conflict, an author change,
+  or a review finding ends a candidate, integrate the then-current effective
+  base while forming the replacement. A multi-round PR therefore picks up `main`
+  once per round that produced a fix — not never, and not continuously.
+- **Before merge, the PR is mergeable and green.** One consolidated status
+  query answers both; see
+  [status discovery](docs/adversarial-review.md#status-discovery) for the query,
+  the traps it avoids, and the polling cadence. The first attempt at round 1 and
+  conflict-recovery rounds do not wait for this result; a failed-gate restart,
+  an ordinary subsequent round, and merge readiness do.
+- **Every PR in a stack meets the applicable conditions**, not only the slice
+  under review. A known-conflicted or known-red parent blocks review of
+  everything above it. A pending parent does not block a slice's first or
+  conflict-recovery round, provided each layer has a settled pushed head and
+  passed focused local evidence. A conflict-recovery round is scoped to the
+  recovered slice; do not review an upper slice until its own conflicts are
+  recovered. Before any ordinary subsequent round, a current-head aggregate
+  check for every open layer must confirm zero conflicts and green
+  `ci-required`. A slice rebases onto its parent, never onto `main`: only the
+  bottom open slice takes `origin/main` as its base, and rebasing an upper slice
+  onto `main` pulls in work its parent has not landed and makes the slice's diff
+  report its parent's changes as its own. `ci.yml` applies no base-branch
+  filter, so every non-documentation slice schedules the same CI wherever it
+  targets; a non-documentation slice reporting *no* checks is therefore not
+  green. Re-query after the registration window, following the status-discovery
+  cadence, and verify the current head; if no matching workflow run appears,
+  that is a scheduling bug to investigate — a PR that triggers no workflow
+  leaves `ci-required` nothing to block on and displays as MERGEABLE and CLEAN
+  (#3706).
 
-  Do not infer mergeability from green CI: #4032 reported successful checks
-  while GitHub reported `CONFLICTING`/`DIRTY`. Do not read `mergeStateStatus` as
-  check state either: it is a composite, and it reports `CLEAN` for a PR with
-  no checks at all (#3706). A missing `ci-required` is likewise inconclusive:
-  the aggregate may not have registered yet. Inspect all returned contexts; no
-  PR is green until its current-head `ci-required` has completed with a
-  `SUCCESS` conclusion. A subordinate check run with status `COMPLETED` and
-  conclusion `SKIPPED` does not block, but it is also not evidence: never cite
-  a skipped job as validation, and if a change should have triggered a job
-  that skipped, the path filter is the bug.
-
-  Status discovery must conserve the shared GitHub API budget. After every
-  push, schedule one status check for five minutes later; do not hold a
-  synchronous shell or agent turn open with `sleep`. The first check verifies
-  the expected head and detects merge conflicts early:
-
-  - If `mergeable` is `CONFLICTING`, integrate the effective base, resolve the
-    conflict, push the replacement head, start its conflict-recovery review
-    round immediately if its round number is authorized, and schedule a new
-    five-minute check. Do not wait for CI before starting an authorized
-    conflict-recovery round.
-  - If `mergeable` is `UNKNOWN`, it does not satisfy the zero-conflict gate. If
-    current-head `ci-required` is already green, use the REST fallback above;
-    a null result follows its five-minute recovery cadence. If `ci-required` is
-    pending or missing, schedule the documentation-only follow-up for at least
-    10 minutes plus small random jitter after the five-minute check, or the
-    non-documentation follow-up for the expected 35-minute completion point. If
-    both mergeability and CI remain unresolved at that follow-up, continue with
-    at least 10 minutes plus small random jitter between aggregate queries.
-    Switch to the five-minute REST-backed recovery cadence once `ci-required`
-    is green and mergeability is the only unknown.
-  - If `mergeable` is `MERGEABLE` and the PR is documentation-only, use that
-    five-minute result as the expected CI completion check. Do not schedule a
-    longer planned wait; documentation CI should be complete by then. If it is
-    unexpectedly pending or `ci-required` is missing, wait at least 10 minutes
-    plus small random jitter before querying again.
-  - If `mergeable` is `MERGEABLE` and the PR is not documentation-only, expect
-    CI to take about 35 minutes from the push. Schedule the next status check
-    for about 30 minutes after the five-minute conflict check. If CI is still
-    pending or `ci-required` is missing, wait at least 10 minutes plus small
-    random jitter before querying again.
-
-  An ordinary subsequent round cannot start until one of these checks confirms
-  both zero merge conflicts and green current-head `ci-required`. Apply the
-  short REST-backed recovery above when mergeability is the only unknown.
-  Yield the session or schedule a delayed wake-up between checks. Do not use
-  `gh run watch`, `gh pr checks --watch`, or a polling loop for long-running PR
-  checks.
-
-  Every status check must re-query the PR aggregate and compare its current
-  `headRefOid`; a run or check identifier is pinned to one commit and cannot
-  detect a later push. Retain the expected head SHA locally, and reuse returned
-  identifiers only for one-off detail or log queries after the aggregate has
-  confirmed that head. Separate discovery calls are prohibited; additional
-  calls are only for required context pagination or one-off details after the
-  aggregate has confirmed the head. If the query reports low remaining quota,
-  yield until its reported reset time rather than sleeping or continuing to
-  query. These intervals are minimums, not targets: wait longer when no
-  decision depends on an immediate result.
-- **Before merge, every PR in a stack meets the applicable conditions above**,
-  not only the slice under review. A known-conflicted or known-red parent blocks
-  review of everything above it. A pending parent does not block a slice's
-  first or conflict-recovery round, provided each layer has a settled pushed
-  head and passed focused local evidence. A conflict-recovery round is scoped
-  to the recovered slice and may start while that slice's post-push local
-  validation and affected descendant restacks are pending; do not review an
-  upper slice until its own conflicts are recovered. Before any ordinary
-  subsequent round, a current-head aggregate check for every open stack layer
-  must confirm zero merge conflicts and green `ci-required`. A slice rebases
-  onto its parent, never onto `main`: only the stack's bottom open slice takes
-  `origin/main` as its base, and rebasing an upper slice onto `main` pulls in
-  work its parent has not landed and makes the slice's diff report its parent's
-  changes as its own. `ci.yml` applies no base-branch filter, so every
-  non-documentation slice schedules the same CI wherever it targets; a
-  non-documentation slice reporting *no* checks is therefore not green.
-  Re-query after the registration window, following the status-discovery
-  cadence above, and verify the current head; if no matching workflow run
-  appears, that is a scheduling bug to investigate, since a PR that triggers no
-  workflow leaves `ci-required` nothing to block on and displays as MERGEABLE
-  and CLEAN (#3706).
-
-Do not fetch or integrate the base after the candidate is formed while
-validation, CI, or review is in progress. After a review-clean result, the
-consolidated status query's `baseRef.target.oid` may reveal that the effective
-base moved; `baseRefOid` identifies the base commit recorded for the PR and is
-not the live branch tip. At that point a non-mutating fetch is permitted solely
-to inspect the exact landed range for the carry-forward decision below. Do not
-integrate unless that decision or another candidate-ending trigger authorizes
-it. When an author change, review fix, or conflict requires a replacement
-candidate, say so on the PR and name the base tip and merge commit, so the next
-review reads as a confirmation rather than an unexplained second full pass. Do
-not form a replacement candidate from base movement alone unless the user
-approved the clean-review carry-forward path, explicitly adjusted the workflow
-to integrate and re-review an interacting range, or the slice requires a
-cascading restack onto its moved parent.
+Once a candidate is formed, do not fetch or integrate the base while validation,
+CI, or review is in progress. After a review-clean result, a non-mutating fetch
+is permitted solely to inspect the landed range for the carry-forward decision
+below.
 
 ### Clean reviews are not spent by main moving
 
-For a PR that targets `main` — including the bottom slice of a stack — when its
-required fixed-head review is review-clean at the current head and `origin/main`
-has since moved, **stop and ask.** Do not integrate main, and do not open
-another round on your own initiative. Evaluate this from the latest
-review-clean result: an earlier finding that was fixed and then reviewed clean
-does not disqualify it. If a finding remains unresolved, or the head changed
-after that review-clean result because of an author change, conflict resolution,
-or restack, the exception does not apply: resolve or restack, integrate the
-effective base, and review the new head normally.
+When a PR's required review is review-clean at the current head and `origin/main`
+has since moved, **stop and ask.** Do not integrate, and do not open another
+round on your own initiative.
 
-Detect movement by comparing the candidate's recorded base tip with the live
-tip in `baseRef.target.oid` from the consolidated status query. If they differ
-after the review-clean result, record that live tip, fetch the effective base
-without integrating it, and analyze the exact old-to-new range.
+Absent an actual conflict, a round that produces no review-driven fix and then
+integrates newer `main` to create another round is a failed round: the review
+produced no change and the integration discarded the value of the locked-head
+result.
 
-Ask with an analysis of what actually landed: which commits touch files this
-change touches, which behavior this change relies on that they alter, and any
-conflict a textual merge would resolve silently but wrongly. Say plainly when
-the answer is that nothing in the range interacts with this change — that is the
-common case and it is the most useful thing you can report.
-
-If the range is non-interacting, the user may direct you to integrate the
-approved base tip, re-run the claimed validation and current-head CI, and carry
-the clean reviews forward without another round. Integrate that exact analyzed
-tip by SHA, not a moving branch ref. If the live base tip changes before
-integration, analyze the additional range and obtain renewed approval before
-carrying the reviews forward. Record the reviewed head, old and approved new
-main tips, the non-interaction analysis, and the user's decision on the PR.
-
-If the range can affect the change, report that the carry-forward path is not
-available and keep the reviewed head. The PR is not merge-ready in that state:
-do not post `Ready to merge`. Do not integrate merely because the base moved,
-and do not open another round unless an actual conflict, review-driven fix,
-author change, or explicit user workflow adjustment creates a replacement
-candidate. Ask the user whether to make a workflow adjustment that integrates
-the base and re-validates and re-reviews the replacement head, or to leave the
-PR blocked.
-
-The carry-forward continuation is the sole exception that carries clean reviews
-across a base integration without opening another round. It does not authorize
-carrying reviews across author changes, conflict-resolution changes, or a
-restack that occurred after the recorded reviewed head. It is also the sole
-default path that permits integrating the base when no actual conflict,
-review-driven fix, author change, current-head merge-path failure, or explicit
-user workflow adjustment has ended the candidate and no required cascading
-restack has moved its effective base.
-
-This is the one place the settled-branch rule yields, and it has to, or the
-budget is unbounded: on a busy `main`, a round takes longer than the interval
-between commits, so integrate-and-re-review by reflex never converges. A pair of
-clean reviews is a result. Unrelated commits landing behind it do not retract
-it.
+The user may then approve carrying the clean reviews forward across a
+non-interacting base integration, without another round. That is the sole
+default path that integrates the base when no conflict, review-driven fix,
+author change, current-head merge-path failure, required cascading restack, or
+explicit user workflow adjustment has ended the candidate. The procedure, and
+the analysis to bring to the user, are in
+[carry-forward after clean reviews](docs/adversarial-review.md#carry-forward-after-clean-reviews).
 
 ### A quick read is not a round
 
@@ -780,66 +671,27 @@ every missing seat from the user. An out-of-roster model may provide a quick
 read but does not fill a seat.
 
 A **round** evaluates one settled head with every reviewer its tier requires.
-Two reviewers in the same round count as one round, not two. The round remains
-locked until both reviewers return and their feedback is reconciled.
+Two reviewers in the same round count as one round, not two.
 
 ### Running the round
-
-Give each reviewer the same self-contained prompt: exact base and head, design
-intent, relevant diff, concrete attack points, and required real-run evidence.
-Isolate every reviewer in a separate linked review worktree under the primary
-checkout's `.worktrees/` directory or an operating-system temporary directory;
-never place it at the root of the user's home directory or detach the primary
-checkout for review. Require scratch work under `/tmp/` and prohibit `git
-reset`, `git add`, and commits in review trees. Before acting on a blocking
-finding, reproduce it on a clean exact-head review worktree.
-
-Reconcile the reviews publicly on the PR: attribute findings, state what was
-verified or dismissed, and link resolution commits or explain explicit
-non-actions. Address actionable findings only after the locked-head reviews
-finish. If fixes move the head, push the replacement candidate, wait for its
-zero-conflict and green-CI gate, and re-review it as the next numbered round.
-Do not mark the PR ready until every required fixed-head review at the current
-head is review-clean.
 
 A round starts when its reviewers are dispatched. It ends when all current and
 carried feedback is publicly reconciled, every resulting fix is committed and
 pushed, current-head zero-conflict evidence is confirmed, and every required
 current-head check and post-push local gate for that round has completed
-successfully. A no-fix round with publicly justified dismissals can therefore
-end review-clean; a round that pushes fixes is complete but not review-clean,
-and its replacement head still requires the next numbered review.
+successfully.
 
-Superseded attempts follow [Canonical round flow](#canonical-round-flow);
-supersession never retires a finding.
+Every reviewer gets the same self-contained prompt and its own isolated
+worktree; findings are reproduced before they are acted on and reconciled
+publicly on the PR. Address actionable findings only after the locked-head
+reviews finish. See
+[running a round](docs/adversarial-review.md#running-a-round) for dispatch,
+reconciliation, and the required round report.
 
-After every completed round and before starting the next one, emit this report
-as the assistant's visible user-facing response in the terminal, filling every
-field and choosing exactly one feedback classification. Do not emit it through
-a shell command such as `printf`, leave it only in tool output, collapse it
-behind a tool-call summary, or replace it with a shorter completion summary:
-
-```text
-Round <n> is complete for PR <number>.
-- Review models <model-a> and <model-b> were used for adversarial review.
-- Review feedback is: [converging, diverging, neutral, clean].
-- Round start: <datetime>.
-- Round end: <datetime>.
-- Round duration: <hours:minutes>
-
-Fix description: <prose description of changes made in response to the round>.
-```
-
-Use `Fix description` to state the concrete review-driven changes. For a clean
-classification, say that no findings or fixes were produced and that the locked
-head remained unchanged. For a no-fix round with dismissed findings, use
-`converging`, `diverging`, or `neutral` and explain the dismissals in the public
-reconciliation. Do not integrate the base after a review-clean result except
-through the approved carry-forward path or when a conflict, author change,
-current-head merge-path failure, required cascading restack, or explicit user
-workflow adjustment ends the candidate. The same report may also be posted on
-the PR; the public reconciliation may include more detail when the findings or
-fixes warrant it.
+Review the whole head. An author may not declare a subsystem out of scope for a
+round — including a test harness the previous rounds have already hardened —
+without explicit user approval, because a round narrowed by the author is not
+evidence about the head.
 
 ### Keep review proportional to the contract
 
@@ -875,12 +727,26 @@ conflict immediately so CI starts, but if its review would begin a new
 unauthorized block, request approval before dispatching reviewers. Once
 approved, start that conflict-recovery round without waiting for CI.
 
-Before requesting each six-round block, present an analysis of why the prior
-six rounds did not converge. In particular, determine whether the repeated
-findings expose an architectural problem, missing test coverage, or reviewers
-expanding the contract beyond the intended threat model. State the proposed
-architectural or test remedy, or explain why the remaining concern should be
-dismissed, before spending another block.
+Before requesting each block, present an analysis of why the prior rounds did
+not converge. Classify the repeated findings as one of:
+
+- an architectural problem in the change;
+- missing test coverage;
+- reviewers expanding the contract beyond the intended threat model; or
+- **findings confined to the change's own test harness** while the product diff
+  goes unchallenged.
+
+State the proposed architectural or test remedy, or explain why the remaining
+concern should be dismissed, before spending another block.
+
+The fourth case deserves its own judgment, because it looks like convergence and
+behaves like a ratchet. When successive rounds find only new ways to strengthen
+a test generator, each finding is real and each fix is cheap, so the loop can run
+indefinitely on a product diff nobody has disputed. Say so plainly when you see
+it: report how many consecutive rounds produced no product finding, and
+recommend either a final round or stopping. Stopping still needs the user's
+waiver under invariant 5 — but asking for one, with that evidence, is the
+correct move rather than opening another round by reflex.
 
 ## PR and CI discipline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -633,10 +633,10 @@ subsequent round:
   produced a fix — not never, and not continuously while a head is frozen.
 - **Before merge, the PR is mergeable and green.** One status check answers
   both; see [status discovery](docs/adversarial-review.md#status-discovery) for
-  the REST and GraphQL forms, how to choose between their separate budgets, the
-  traps each result carries, and the polling cadence. The first attempt at round
-  1 and conflict-recovery rounds do not wait for this result; a failed-gate
-  restart, an ordinary subsequent round, and merge readiness do.
+  the REST default, when GraphQL is worth a point, the traps each result
+  carries, and the polling cadence. The first attempt at round 1 and
+  conflict-recovery rounds do not wait for this result; a failed-gate restart,
+  an ordinary subsequent round, and merge readiness do.
 - **Every PR in a stack meets the applicable conditions**, not only the slice
   under review. A known-conflicted or known-red parent blocks review of
   everything above it. A pending parent does not block a slice's first or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ review the new head, and ask again.
 | Decompiler harness-only behavior | `docs/decompiler-correctness-pipeline.md`, then the owning harness README |
 | Skills | `taste/skill-guidance.md` |
 | Stacked PRs and restacking | `docs/stacked-prs.md` |
-| Adversarial review mechanics | `docs/adversarial-review.md` |
+| Running a review round, or checking PR status | `docs/round-orchestration.md` |
 | Release and publishing | `docs/release-workflow.md` |
 | Changes spanning Markout and this repo | `docs/markout-co-development.md` |
 
@@ -483,8 +483,9 @@ Review is a locked-head feedback loop: freeze and push one exact head, review
 that head, reconcile the feedback publicly, make any resulting fixes, and freeze
 the replacement head. Everything below serves that loop.
 
-These are the binding invariants. The rest of this section explains them; the
-mechanics live in [`docs/adversarial-review.md`](docs/adversarial-review.md).
+These are the binding invariants. The rest of this section explains them;
+driving the loop is
+[round orchestration](docs/round-orchestration.md).
 
 1. **One frozen head per round.** The lock begins at the push and ends at
    public reconciliation. Do not edit a head while it is held; fixes belong to
@@ -632,7 +633,7 @@ subsequent round:
   cycle again. A multi-round PR therefore picks up `main` on each round that
   produced a fix — not never, and not continuously while a head is frozen.
 - **Before merge, the PR is mergeable and green.** One status check answers
-  both; see [status discovery](docs/adversarial-review.md#status-discovery) for
+  both; see [status discovery](docs/round-orchestration.md#status-discovery) for
   the REST default, when GraphQL is worth a point, the traps each result
   carries, and the polling cadence. The first attempt at round 1 and
   conflict-recovery rounds do not wait for this result; a failed-gate restart,
@@ -678,7 +679,7 @@ default path that integrates the base when no conflict, review-driven fix,
 author change, current-head merge-path failure, required cascading restack, or
 explicit user workflow adjustment has ended the candidate. The procedure, and
 the analysis to bring to the user, are in
-[carry-forward after clean reviews](docs/adversarial-review.md#carry-forward-after-clean-reviews).
+[carry-forward after clean reviews](docs/round-orchestration.md#carry-forward-after-clean-reviews).
 
 Evaluate eligibility from the *latest* review-clean result: an earlier finding
 that was fixed and then reviewed clean does not disqualify it. Carry-forward
@@ -757,7 +758,7 @@ Every reviewer gets the same self-contained prompt and its own isolated
 worktree; findings are reproduced before they are acted on and reconciled
 publicly on the PR. Address actionable findings only after the locked-head
 reviews finish. See
-[running a round](docs/adversarial-review.md#running-a-round) for dispatch,
+[running a round](docs/round-orchestration.md#running-a-round) for dispatch,
 reconciliation, and the required round report.
 
 Review the whole head. An author may not declare a subsystem out of scope for a
@@ -831,6 +832,10 @@ correct move rather than opening another round by reflex.
   first, then push the frozen candidate promptly. Run broader local validation,
   CI, and eligible fixed-head review concurrently, subject to the per-round CI
   and conflict gates above.
+- Check PR state through [status
+  discovery](docs/round-orchestration.md#status-discovery) — REST by default,
+  GraphQL when breadth pays for the point, and a scheduled check rather than a
+  watch loop. That applies to any PR, not only one under review.
 - A settled candidate should spend wall-clock time in parallel. If an hour
   passes without an authored change while an eligible independent gate has not
   started, stop and correct the sequencing or record the concrete blocker. Do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,7 +489,8 @@ driving the loop is
 
 1. **One frozen head per round.** The lock begins at the push and ends at
    public reconciliation. Do not edit a head while it is held; fixes belong to
-   the next cycle.
+   the next cycle. Reconciliation frees you to *fix*; it does not *complete* the
+   round — see invariant 6.
 2. **A candidate includes its effective base.** Integrate twice before pushing
    — once before fixing, once after — because the fix window is long enough for
    `main` to move.
@@ -499,8 +500,13 @@ driving the loop is
    can earn that.
 5. **Do not post `Ready to merge` until every required review at the current
    head is review-clean.**
-6. **Six rounds, then stop** and ask for another block.
-7. **Never merge without explicit user authorization** for that specific PR.
+6. **A round is not complete until its gates are green.** Reconciliation
+   releases the lock; the round itself ends only once every required
+   current-head check and post-push gate has succeeded. Until then the round
+   number does not advance — a check that goes red first makes the next push a
+   failed-gate restart at the *same* number, not the next round.
+7. **Six rounds, then stop** and ask for another block.
+8. **Never merge without explicit user authorization** for that specific PR.
    Auto-merge armed at the user's direction is that authorization; see
    [Standing adjustments](#standing-adjustments).
 
@@ -530,8 +536,13 @@ reconciliation.
    parallel with CI. A conflict or a failed check here does not mean waiting
    longer; take the matching [recovery transition](#recovery-transitions).
 8. **Review**: dispatch every required reviewer at that exact head.
-9. **Reconcile** the feedback publicly. The lock ends here. If the
-   reconciliation produced fixes, the next round begins at step 1.
+9. **Reconcile** the feedback publicly. The lock ends here — you may begin
+   fixing. The round does not end here; it ends when its gates go green
+   (invariant 6).
+10. **Report.** Emit the round report as your visible response before starting
+    the next round. It is required, and the format is in [the round
+    report](docs/round-orchestration.md#the-round-report). If the reconciliation
+    produced fixes, the next round begins at step 1.
 
 **Two integrations per round, both before the push.** The first makes the work
 current; the second closes the window the fix itself opened, which can be an
@@ -555,11 +566,10 @@ The user may direct that a round run in parallel with CI, waiving the green
 `ci-required` requirement in the rows above; see [Standing
 adjustments](#standing-adjustments).
 
-The head lock ends when both reviewers have returned, their feedback has been
-reconciled for action, current-head zero-conflict evidence is confirmed, and
-every required current-head check and local gate allowed to run concurrently has
-succeeded. The fixed replacement is a new candidate and its review is a new
-round.
+The head lock ends at public reconciliation, which frees you to fix. The round
+ends later, when current-head zero-conflict evidence is confirmed and every
+required current-head check and concurrent local gate has succeeded. The fixed
+replacement is a new candidate and its review is a new round.
 
 #### Review-clean, and what it gates
 
@@ -634,12 +644,17 @@ subsequent round:
   or a review finding ends a candidate, the replacement is formed by running the
   cycle again. A multi-round PR therefore picks up `main` on each round that
   produced a fix — not never, and not continuously while a head is frozen.
-- **Before merge, the PR is mergeable and green.** One status check answers
-  both; see [status discovery](docs/round-orchestration.md#status-discovery) for
-  the REST default, when GraphQL is worth a point, the traps each result
-  carries, and the polling cadence. The first attempt at round 1 and
-  conflict-recovery rounds do not wait for this result; a failed-gate restart,
-  an ordinary subsequent round, and merge readiness do.
+- **Before merge, the PR is mergeable and green.** That means four things at
+  once: the returned head is the pushed head, the PR is not a draft,
+  mergeability is positive, and the current head's `ci-required` completed with
+  a `SUCCESS` conclusion. A `BLOCKED` or `DRAFT` merge state is an independent
+  readiness blocker — clear it before posting `Ready to merge`. One status check
+  answers all of it; see [status
+  discovery](docs/round-orchestration.md#status-discovery) for the REST default,
+  when GraphQL is worth a point, the traps each result carries, and the polling
+  cadence. The first attempt at round 1 and conflict-recovery rounds do not wait
+  for this result; a failed-gate restart, an ordinary subsequent round, and merge
+  readiness do.
 - **Every PR in a stack meets the applicable conditions**, not only the slice
   under review. A known-conflicted or known-red parent blocks review of
   everything above it. A pending parent does not block a slice's first or
@@ -666,9 +681,16 @@ below.
 
 ### Clean reviews are not spent by main moving
 
-When a PR's required review is review-clean at the current head and `origin/main`
+For a PR that targets `main` — including the bottom open slice of a stack —
+when its required review is review-clean at the current head and `origin/main`
 has since moved, **stop and ask.** Do not integrate, and do not open another
 round on your own initiative.
+
+**This path does not apply to an upper stack slice.** Its effective base is its
+parent branch, so `origin/main` moving is not base movement for it, and the
+carry-forward procedure would compare against the parent instead. When a parent
+does move, that is a restack, and a restack requires a review-clean round at the
+resulting head.
 
 Absent an actual conflict, a round that produces no review-driven fix and then
 integrates newer `main` to create another round is a failed round: the review
@@ -686,7 +708,17 @@ interact and the user accepted that finding.
 Carrying forward is the sole default path that integrates the base when no
 conflict, review-driven fix, author change, current-head merge-path failure,
 required cascading restack, or explicit user workflow adjustment has ended the
-candidate. The procedure, and the analysis to bring to the user, are in
+candidate.
+
+**Repeat it whenever the base moves again**; a carried-forward head is
+review-clean, and each pass needs its own analysis and its own approval. **A
+failure in the post-integration validation or CI ends the candidate**: it is a
+current-head merge-path failure, so the reviews do not carry, the fix is an
+author change, and the replacement head owes a normal round. Carry-forward
+transfers a clean result across an integration; it does not survive that
+integration going wrong.
+
+The procedure, and the analysis to bring to the user, are in
 [carry-forward after clean reviews](docs/round-orchestration.md#carry-forward-after-clean-reviews).
 
 Evaluate eligibility from the *latest* review-clean result: an earlier finding

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -631,12 +631,12 @@ subsequent round:
   or a review finding ends a candidate, the replacement is formed by running the
   cycle again. A multi-round PR therefore picks up `main` on each round that
   produced a fix — not never, and not continuously while a head is frozen.
-- **Before merge, the PR is mergeable and green.** One consolidated status
-  query answers both; see
-  [status discovery](docs/adversarial-review.md#status-discovery) for the query,
-  the traps it avoids, and the polling cadence. The first attempt at round 1 and
-  conflict-recovery rounds do not wait for this result; a failed-gate restart,
-  an ordinary subsequent round, and merge readiness do.
+- **Before merge, the PR is mergeable and green.** One status check answers
+  both; see [status discovery](docs/adversarial-review.md#status-discovery) for
+  the REST and GraphQL forms, how to choose between their separate budgets, the
+  traps each result carries, and the polling cadence. The first attempt at round
+  1 and conflict-recovery rounds do not wait for this result; a failed-gate
+  restart, an ordinary subsequent round, and merge readiness do.
 - **Every PR in a stack meets the applicable conditions**, not only the slice
   under review. A known-conflicted or known-red parent blocks review of
   everything above it. A pending parent does not block a slice's first or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,31 @@ change moves it, apply the fixed-head rules to the new head. A user-directed
 adjustment does not turn failed validation into success or make an unmergeable
 change ready to merge.
 
+### Standing adjustments
+
+Two are common enough to name. Both still need the user's word for the specific
+PR; naming them means treating them as expected requests rather than exceptions
+to be argued about.
+
+**Review in parallel with CI.** The eligibility table makes an ordinary
+subsequent round wait for green current-head `ci-required`. When the user
+directs it, dispatch that round while CI runs. Sequencing changes, nothing else:
+a CI failure needing an author change still supersedes the attempt under
+[Recovery transitions](#recovery-transitions), and a superseded round's findings
+still carry forward.
+
+**Auto-merge on the final push.** Once every required review is review-clean and
+a push is intended to be the last, the user may direct that auto-merge be armed,
+letting GitHub merge when the required checks pass. **The agent may ask for
+this** — it is the one merge-related request to raise on its own initiative, and
+asking is not merging.
+
+Arming auto-merge authorizes the merge of the reviewed head; it is not a
+standing grant for the branch. GitHub keeps it armed across later pushes, so
+anything pushed afterward merges unreviewed once checks pass. If the head moves
+after arming — a review finding, a conflict resolution, a restack — disarm it,
+review the new head, and ask again.
+
 ## Before changing files
 
 - `main` is protected. Keep the primary repository checkout attached to
@@ -473,6 +498,8 @@ mechanics live in [`docs/adversarial-review.md`](docs/adversarial-review.md).
    head is review-clean.**
 6. **Six rounds, then stop** and ask for another block.
 7. **Never merge without explicit user authorization** for that specific PR.
+   Auto-merge armed at the user's direction is that authorization; see
+   [Standing adjustments](#standing-adjustments).
 
 ### Canonical round flow
 
@@ -491,6 +518,10 @@ Documentation-only ordinary candidates use Markdown linting as their focused
 gate. A documentation conflict-recovery attempt instead lints after the
 resolution push; it may start review immediately, but cannot reconcile or
 complete until lint succeeds.
+
+The user may direct that a round run in parallel with CI, waiving the green
+`ci-required` requirement in the rows above; see [Standing
+adjustments](#standing-adjustments).
 
 The head lock ends when both reviewers have returned, their feedback has been
 reconciled for action, current-head zero-conflict evidence is confirmed, and
@@ -790,7 +821,10 @@ correct move rather than opening another round by reflex.
 - Agents are not authorized to merge pull requests unless the user explicitly
   directs them to merge that specific PR. A clean review, green CI, mergeable
   state, `Ready to merge` comment, or general request to prepare or finish a PR
-  is not merge authorization.
+  is not merge authorization. Arming auto-merge at the user's direction is, for
+  the reviewed head only — see [Standing
+  adjustments](#standing-adjustments). Asking whether to arm it is always
+  permitted.
 - When all merge-blocking validation, CI, and required review are complete, post
   a PR comment that says `Ready to merge`. Label later work as non-blocking
   follow-up so readiness remains unambiguous.

--- a/docs/adversarial-review.md
+++ b/docs/adversarial-review.md
@@ -16,28 +16,44 @@ Two questions — is the PR mergeable, and is it green. What varies is which API
 you spend answering them. Which attempts must wait for the answer is the
 eligibility table in [Canonical round flow](../AGENTS.md#canonical-round-flow).
 
-### Two budgets, not one
+### Which API to spend
 
-REST and GraphQL have separate hourly limits, so spending one does not touch the
-other. Check before choosing:
+Default to REST. Reach for GraphQL when its capability is worth a point.
+
+The two draw on separate hourly limits, so spending one does not touch the
+other:
 
 ```bash
 gh api rate_limit --jq '.resources|{graphql,core}'
 ```
 
-They are not interchangeable in practice. Measured while writing this document:
-GraphQL sat at 4,077 of 5,000 consumed and fell a further 55 points across 45
-seconds in which this session issued no query at all, while REST core held
-steady at 6 of 5,000. Concurrent agents share these buckets, and GraphQL is
-routinely the contended one.
+Measured an hour apart, in two different rate windows: GraphQL sat at 4,077 and
+then 4,287 of 5,000 consumed, once falling 55 points across 45 seconds in which
+this session issued no query at all. REST core held at 6 of 5,000 throughout.
+Concurrent agents share these buckets, and GraphQL is persistently the contended
+one.
 
-Spend the bucket that has budget. Neither transport is the default, and a
-per-call cost comparison is the wrong measure — what matters is which bucket is
-near exhaustion when you need an answer.
+The cost models differ in the way that decides the rule. A REST call costs one
+request whatever it returns, so a wide question costs a call per object. A
+GraphQL query is priced by node count, but the floor dominates in practice: the
+routine status query at 101 nodes and a deliberately wide one at 701 nodes — PR
+fields, live base tip, 50 review threads with their comments, 50 reviews, 100
+check contexts — both cost **1 point**.
+
+GraphQL's value per point therefore rises with breadth, while REST's cost rises
+with it. Spend a point when you are buying breadth:
+
+- **Quick checks — REST.** Is this head mergeable, did `ci-required` pass. Two
+  calls, from a bucket with thousands to spare.
+- **Wide or graph-shaped reads — GraphQL.** The whole PR at one instant, review
+  threads with their comments, anything needing the live base tip beside other
+  fields. One point buys what would be five or ten REST calls.
+- **Either bucket near exhaustion — use the other**, whatever the question.
 
 ### The REST pair
 
-Two calls, the second pinned to the sha the first returned:
+The default for a routine status check. Two calls, the second pinned to the sha
+the first returned:
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/{n} \
@@ -53,9 +69,9 @@ endpoint also triggers mergeability computation, which is why it resolves
 
 ### The GraphQL query
 
-One request, one point, and the only cheap way to read the live base tip that
-the carry-forward decision needs. Prefer it when REST is the contended bucket,
-when a single atomic answer matters, or when you need that base tip.
+One request, one point, and one consistent snapshot. Prefer it when you need
+breadth — the live base tip that carry-forward reads, review threads, or the
+whole PR at a single instant — or when REST is the contended bucket.
 
 Return `headRefOid`, `baseRefOid`, `baseRef { target { oid } }`, `isDraft`,
 `mergeable`, `mergeStateStatus`, `statusCheckRollup` state and contexts with

--- a/docs/adversarial-review.md
+++ b/docs/adversarial-review.md
@@ -1,0 +1,198 @@
+# Adversarial review mechanics
+
+`AGENTS.md` owns the binding rules for adversarial review: what a candidate is,
+when a round may start, what makes a review review-clean, and when to stop. This
+document owns the mechanics those rules depend on — how to query PR status, how
+to dispatch and reconcile a round, and the carry-forward procedure after clean
+reviews.
+
+Read [Adversarial review](../AGENTS.md#adversarial-review) first. Where the two
+disagree, `AGENTS.md` wins.
+
+## Status discovery
+
+Two questions — is the PR mergeable, and is it green — answered by one
+consolidated query. The first attempt at round 1 and conflict-recovery rounds do
+not wait for the result; a failed-gate restart, an ordinary subsequent round, and
+merge readiness do.
+
+### The consolidated query
+
+Use a single `gh api graphql` request returning the PR's `headRefOid`,
+`baseRefOid`, `baseRef { target { oid } }`, `isDraft`, `mergeable`,
+`mergeStateStatus`, `statusCheckRollup` state and contexts with `pageInfo`, and
+the query's `rateLimit` cost, remaining quota, and reset time.
+
+Request enough contexts for the normal check matrix. If `pageInfo.hasNextPage`
+is true and `ci-required` is absent, fetch the remaining context pages before
+concluding that it is missing.
+
+Confirm that `headRefOid` is the pushed head, `isDraft` is false, `mergeable` is
+`MERGEABLE`, and the current head's `ci-required` check run completed
+successfully. Treat `mergeStateStatus` values `BLOCKED` and `DRAFT` as
+independent readiness blockers: identify and clear the blocker before posting
+`Ready to merge`.
+
+Every status check must re-query the aggregate and compare its current
+`headRefOid`; a run or check identifier is pinned to one commit and cannot detect
+a later push. Retain the expected head SHA locally. Separate discovery calls are
+prohibited — additional calls are only for required context pagination or
+one-off details after the aggregate has confirmed the head.
+
+### Four traps, each paid for once
+
+- **Green CI does not imply mergeable.** #4032 reported successful checks while
+  GitHub reported `CONFLICTING`/`DIRTY`.
+- **`mergeStateStatus` is not check state.** It is a composite, and it reports
+  `CLEAN` for a PR with no checks at all (#3706).
+- **A missing `ci-required` is inconclusive**, not green: the aggregate may not
+  have registered yet. No PR is green until its current-head `ci-required` has
+  completed with a `SUCCESS` conclusion.
+- **A skipped job is not evidence.** `COMPLETED`/`SKIPPED` does not block, but
+  never cite it as validation. If a change should have triggered a job that
+  skipped, the path filter is the bug.
+
+### The REST fallback for `UNKNOWN`
+
+`UNKNOWN` means GitHub has not finished computing the merge, and it does not
+satisfy the zero-conflict gate. When the exact head's `ci-required` is already
+`SUCCESS` and mergeability is the only unknown, immediately make one REST
+`GET /repos/{owner}/{repo}/pulls/{number}` request for `head.sha`, `mergeable`,
+and `mergeable_state`. That endpoint triggers the computation and often returns
+a definite answer while GraphQL still says `UNKNOWN`.
+
+Accept it only when `head.sha` is the expected head. `mergeable: true` satisfies
+the mergeability half of the gate; `mergeable: false` blocks. A null result is
+still computing: yield five minutes with small random jitter, then re-run both
+queries. Continue that self-recovery until GitHub returns a definite result. Do
+not ask the user to report CI or mergeability.
+
+### Cadence
+
+Status discovery must conserve the shared GitHub API budget. After every push,
+schedule one status check for five minutes later; do not hold a synchronous shell
+or agent turn open with `sleep`. That first check verifies the expected head and
+detects conflicts early.
+
+| First check says | Do this |
+| --- | --- |
+| `CONFLICTING` | Integrate the effective base, resolve, push, start the conflict-recovery round if its number is authorized, and schedule a new five-minute check. Do not wait for CI. |
+| `UNKNOWN`, CI green | Use the REST fallback above. |
+| `UNKNOWN`, CI pending or missing | Follow up at 10 minutes plus jitter for documentation-only, or at the 35-minute mark otherwise. |
+| `MERGEABLE`, documentation-only | Treat it as the expected CI completion check. If CI is unexpectedly pending, wait 10 minutes plus jitter. |
+| `MERGEABLE`, not documentation-only | Expect CI at about 35 minutes from the push; schedule the next check about 30 minutes out. |
+
+If both mergeability and CI remain unresolved, keep at least 10 minutes plus
+small random jitter between aggregate queries. Switch to the five-minute
+REST-backed cadence once CI is green and mergeability is the only unknown.
+
+If the query reports low remaining quota, yield until its reported reset time
+rather than sleeping or continuing to query. These intervals are minimums, not
+targets: wait longer when no decision depends on an immediate result. Yield the
+session or schedule a delayed wake-up between checks. Do not use `gh run watch`,
+`gh pr checks --watch`, or a polling loop.
+
+## Running a round
+
+### Dispatch
+
+Give each reviewer the same self-contained prompt: exact base and head, design
+intent, relevant diff, concrete attack points, and required real-run evidence.
+
+State plainly that reporting CLEAN is an acceptable outcome. A prompt that only
+rewards findings will produce findings.
+
+Isolate every reviewer in a separate linked review worktree under the primary
+checkout's `.worktrees/` directory or an operating-system temporary directory;
+never place it at the root of the user's home directory, and never detach the
+primary checkout for review. Require scratch work under `/tmp/` and prohibit
+`git reset`, `git add`, and commits in review trees.
+
+Before acting on a blocking finding, reproduce it on a clean exact-head review
+worktree. A reviewer's own probe can be vacuous — an added rule clause that
+changes nothing for an already-entitled input looks green for the wrong reason —
+so reproduce the finding and measure it before accepting its severity.
+
+### Reconciliation
+
+Reconcile the reviews publicly on the PR: attribute findings, state what was
+verified or dismissed, and link resolution commits or explain explicit
+non-actions. Address actionable findings only after the locked-head reviews
+finish.
+
+When a replacement candidate is required, say so on the PR and name the base tip
+and merge commit, so the next review reads as a confirmation rather than an
+unexplained second full pass.
+
+### The round report
+
+After every completed round and before starting the next one, emit this report as
+the assistant's visible user-facing response in the terminal, filling every field
+and choosing exactly one feedback classification. Do not emit it through a shell
+command such as `printf`, leave it only in tool output, collapse it behind a
+tool-call summary, or replace it with a shorter completion summary:
+
+```text
+Round <n> is complete for PR <number>.
+- Review models <model-a> and <model-b> were used for adversarial review.
+- Review feedback is: [converging, diverging, neutral, clean].
+- Round start: <datetime>.
+- Round end: <datetime>.
+- Round duration: <hours:minutes>
+
+Fix description: <prose description of changes made in response to the round>.
+```
+
+Use `Fix description` to state the concrete review-driven changes. For a `clean`
+classification, say that no findings or fixes were produced and that the locked
+head remained unchanged. For a no-fix round with dismissed findings, use
+`converging`, `diverging`, or `neutral` and explain the dismissals in the public
+reconciliation.
+
+The same report may also be posted on the PR; the public reconciliation may
+include more detail when the findings or fixes warrant it.
+
+## Carry-forward after clean reviews
+
+This is the sole default path that integrates the base without opening another
+round. `AGENTS.md` states the rule; this is the procedure.
+
+It applies when a PR targeting `main` — including the bottom slice of a stack —
+has a review-clean required review at the current head and `origin/main` has
+since moved. Evaluate from the latest review-clean result: an earlier finding
+that was fixed and then reviewed clean does not disqualify it.
+
+It does **not** apply, and the head must be reviewed normally, when a finding
+remains unresolved or the head changed after that review-clean result because of
+an author change, conflict resolution, or restack.
+
+1. **Detect movement.** Compare the candidate's recorded base tip with the live
+   tip in `baseRef.target.oid`. `baseRefOid` is the base commit recorded for the
+   PR, not the live branch tip.
+2. **Inspect without integrating.** A non-mutating fetch is permitted solely to
+   read the exact landed range.
+3. **Analyze and ask.** Report which commits touch files this change touches,
+   which behavior this change relies on that they alter, and any conflict a
+   textual merge would resolve silently but wrongly. Say plainly when nothing in
+   the range interacts — that is the common case and the most useful thing you
+   can report.
+4. **If non-interacting and the user approves**, integrate that exact analyzed
+   tip by SHA, not a moving branch ref. Re-run the claimed validation and
+   current-head CI, and carry the clean reviews forward without another round.
+   If the live tip moves before integration, analyze the additional range and
+   obtain renewed approval.
+5. **If interacting**, report that carry-forward is unavailable and keep the
+   reviewed head. The PR is not merge-ready: do not post `Ready to merge`. Ask
+   whether to make a workflow adjustment that integrates, re-validates, and
+   re-reviews the replacement head, or to leave the PR blocked.
+
+Record the reviewed head, the old and approved new tips, the non-interaction
+analysis, and the user's decision on the PR.
+
+Carry-forward does not authorize carrying reviews across author changes,
+conflict-resolution changes, or a restack after the recorded reviewed head.
+
+This is the one place the settled-branch rule yields, and it has to, or the
+budget is unbounded: on a busy `main`, a round takes longer than the interval
+between commits, so integrate-and-re-review by reflex never converges. A pair of
+clean reviews is a result. Unrelated commits landing behind it do not retract it.

--- a/docs/adversarial-review.md
+++ b/docs/adversarial-review.md
@@ -78,11 +78,16 @@ detects conflicts early.
 
 | First check says | Do this |
 | --- | --- |
+| `ci-required` failed or was cancelled | Stop polling and apply the matching [recovery transition](../AGENTS.md#recovery-transitions): a failure needing an author change supersedes the attempt, while a cancelled or evidenced-transient one keeps the head and re-runs the check. A settled red result is an answer, not something to wait out. |
 | `CONFLICTING` | Apply the conflict transition in [Canonical round flow](../AGENTS.md#canonical-round-flow), then schedule a new five-minute check. |
 | `UNKNOWN`, CI green | Use the REST fallback above. |
 | `UNKNOWN`, CI pending or missing | Follow up at 10 minutes plus jitter for documentation-only, or at the 35-minute mark otherwise. |
 | `MERGEABLE`, documentation-only | Treat it as the expected CI completion check. If CI is unexpectedly pending, wait 10 minutes plus jitter. |
 | `MERGEABLE`, not documentation-only | Expect CI at about 35 minutes from the push; schedule the next check about 30 minutes out. |
+
+Read the table top-down: the first matching row wins. A failed or cancelled
+check outranks every mergeability value, because `MERGEABLE` describes the merge
+path and never means green.
 
 If both mergeability and CI remain unresolved, keep at least 10 minutes plus
 small random jitter between aggregate queries. Switch to the five-minute

--- a/docs/adversarial-review.md
+++ b/docs/adversarial-review.md
@@ -12,32 +12,71 @@ than restating it, so the two cannot drift apart.
 
 ## Status discovery
 
-Two questions — is the PR mergeable, and is it green — answered by one
-consolidated query. Which attempts must wait for the answer is the eligibility
-table in [Canonical round flow](../AGENTS.md#canonical-round-flow).
+Two questions — is the PR mergeable, and is it green. What varies is which API
+you spend answering them. Which attempts must wait for the answer is the
+eligibility table in [Canonical round flow](../AGENTS.md#canonical-round-flow).
 
-### The consolidated query
+### Two budgets, not one
 
-Use a single `gh api graphql` request returning the PR's `headRefOid`,
-`baseRefOid`, `baseRef { target { oid } }`, `isDraft`, `mergeable`,
-`mergeStateStatus`, `statusCheckRollup` state and contexts with `pageInfo`, and
-the query's `rateLimit` cost, remaining quota, and reset time.
+REST and GraphQL have separate hourly limits, so spending one does not touch the
+other. Check before choosing:
 
-Request enough contexts for the normal check matrix. If `pageInfo.hasNextPage`
-is true and `ci-required` is absent, fetch the remaining context pages before
+```bash
+gh api rate_limit --jq '.resources|{graphql,core}'
+```
+
+They are not interchangeable in practice. Measured while writing this document:
+GraphQL sat at 4,077 of 5,000 consumed and fell a further 55 points across 45
+seconds in which this session issued no query at all, while REST core held
+steady at 6 of 5,000. Concurrent agents share these buckets, and GraphQL is
+routinely the contended one.
+
+Spend the bucket that has budget. Neither transport is the default, and a
+per-call cost comparison is the wrong measure — what matters is which bucket is
+near exhaustion when you need an answer.
+
+### The REST pair
+
+Two calls, the second pinned to the sha the first returned:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{n} \
+  --jq '{head:.head.sha,draft,mergeable,mergeable_state}'
+gh api "repos/{owner}/{repo}/commits/{sha}/check-runs?per_page=100" \
+  --jq '[.check_runs[]|select(.name=="ci-required")|{status,conclusion}]'
+```
+
+The pin is an advantage, not merely a second call: check state is read for an
+explicit commit rather than for whatever GitHub considers the latest one. The PR
+endpoint also triggers mergeability computation, which is why it resolves
+`UNKNOWN` when GraphQL does not.
+
+### The GraphQL query
+
+One request, one point, and the only cheap way to read the live base tip that
+the carry-forward decision needs. Prefer it when REST is the contended bucket,
+when a single atomic answer matters, or when you need that base tip.
+
+Return `headRefOid`, `baseRefOid`, `baseRef { target { oid } }`, `isDraft`,
+`mergeable`, `mergeStateStatus`, `statusCheckRollup` state and contexts with
+`pageInfo`, and the query's own `rateLimit` cost, remaining quota, and reset
+time. Request enough contexts for the normal check matrix; if
+`pageInfo.hasNextPage` is true and `ci-required` is absent, page before
 concluding that it is missing.
 
-Confirm that `headRefOid` is the pushed head, `isDraft` is false, `mergeable` is
-`MERGEABLE`, and the current head's `ci-required` check run completed
-successfully. Treat `mergeStateStatus` values `BLOCKED` and `DRAFT` as
-independent readiness blockers: identify and clear the blocker before posting
-`Ready to merge`.
+### Reading either result
 
-Every status check must re-query the aggregate and compare its current
-`headRefOid`; a run or check identifier is pinned to one commit and cannot detect
-a later push. Retain the expected head SHA locally. Separate discovery calls are
-prohibited — additional calls are only for required context pagination or
-one-off details after the aggregate has confirmed the head.
+Confirm that the returned head is the pushed head, the PR is not a draft,
+mergeability is positive, and the current head's `ci-required` completed with a
+`SUCCESS` conclusion. Treat `mergeStateStatus` `BLOCKED` and `DRAFT` — or
+`mergeable_state` `blocked` and `draft` — as independent readiness blockers:
+clear the blocker before posting `Ready to merge`.
+
+Every status check re-reads the head and compares it. A run or check identifier
+is pinned to one commit and cannot detect a later push, so retain the expected
+head SHA locally. Do not scatter discovery beyond the pair or the single query;
+additional calls are for pagination and one-off details, after the head is
+confirmed.
 
 ### Four traps in the result
 
@@ -54,20 +93,18 @@ one-off details after the aggregate has confirmed the head.
   never cite it as validation. If a change should have triggered a job that
   skipped, the path filter is the bug.
 
-### The REST fallback for `UNKNOWN`
+### Resolving `UNKNOWN`
 
 `UNKNOWN` means GitHub has not finished computing the merge, and it does not
-satisfy the zero-conflict gate. When the exact head's `ci-required` is already
-`SUCCESS` and mergeability is the only unknown, immediately make one REST
-`GET /repos/{owner}/{repo}/pulls/{number}` request for `head.sha`, `mergeable`,
-and `mergeable_state`. That endpoint triggers the computation and often returns
-a definite answer while GraphQL still says `UNKNOWN`.
+satisfy the zero-conflict gate. It is a GraphQL answer; the REST PR endpoint
+triggers the computation, so reaching for the REST pair often returns a definite
+result while GraphQL still says `UNKNOWN`.
 
 Accept it only when `head.sha` is the expected head. `mergeable: true` satisfies
 the mergeability half of the gate; `mergeable: false` blocks. A null result is
-still computing: yield five minutes with small random jitter, then re-run both
-queries. Continue that self-recovery until GitHub returns a definite result. Do
-not ask the user to report CI or mergeability.
+still computing: yield five minutes with small random jitter, then ask again.
+Continue that self-recovery until GitHub returns a definite result. Do not ask
+the user to report CI or mergeability.
 
 ### Cadence
 
@@ -80,7 +117,7 @@ detects conflicts early.
 | --- | --- |
 | `ci-required` failed or was cancelled | Stop polling and apply the matching [recovery transition](../AGENTS.md#recovery-transitions): a failure needing an author change supersedes the attempt, while a cancelled or evidenced-transient one keeps the head and re-runs the check. A settled red result is an answer, not something to wait out. |
 | `CONFLICTING` | Apply the conflict transition in [Canonical round flow](../AGENTS.md#canonical-round-flow), then schedule a new five-minute check. |
-| `UNKNOWN`, CI green | Use the REST fallback above. |
+| `UNKNOWN`, CI green | Ask REST, which triggers the computation; see [resolving `UNKNOWN`](#resolving-unknown). |
 | `UNKNOWN`, CI pending or missing | Follow up at 10 minutes plus jitter for documentation-only, or at the 35-minute mark otherwise. |
 | `MERGEABLE`, documentation-only | Treat it as the expected CI completion check. If CI is unexpectedly pending, wait 10 minutes plus jitter. |
 | `MERGEABLE`, not documentation-only | Expect CI at about 35 minutes from the push; schedule the next check about 30 minutes out. |
@@ -90,14 +127,15 @@ check outranks every mergeability value, because `MERGEABLE` describes the merge
 path and never means green.
 
 If both mergeability and CI remain unresolved, keep at least 10 minutes plus
-small random jitter between aggregate queries. Switch to the five-minute
-REST-backed cadence once CI is green and mergeability is the only unknown.
+small random jitter between status checks. Switch to the five-minute cadence
+once CI is green and mergeability is the only unknown.
 
-If the query reports low remaining quota, yield until its reported reset time
-rather than sleeping or continuing to query. These intervals are minimums, not
-targets: wait longer when no decision depends on an immediate result. Yield the
-session or schedule a delayed wake-up between checks. Do not use `gh run watch`,
-`gh pr checks --watch`, or a polling loop.
+If the bucket you are spending is near exhaustion, switch to the other one; if
+both are low, yield until the earlier reset rather than sleeping or continuing
+to query. These intervals are minimums, not targets: wait longer when no
+decision depends on an immediate result. Yield the session or schedule a delayed
+wake-up between checks. Do not use `gh run watch`, `gh pr checks --watch`, or a
+polling loop.
 
 ## Running a round
 

--- a/docs/adversarial-review.md
+++ b/docs/adversarial-review.md
@@ -6,15 +6,15 @@ document owns the mechanics those rules depend on — how to query PR status, ho
 to dispatch and reconcile a round, and the carry-forward procedure after clean
 reviews.
 
-Read [Adversarial review](../AGENTS.md#adversarial-review) first. Where the two
-disagree, `AGENTS.md` wins.
+Read [Adversarial review](../AGENTS.md#adversarial-review) first. This document
+states no rules of its own: where it needs a condition, it cites the rule rather
+than restating it, so the two cannot drift apart.
 
 ## Status discovery
 
 Two questions — is the PR mergeable, and is it green — answered by one
-consolidated query. The first attempt at round 1 and conflict-recovery rounds do
-not wait for the result; a failed-gate restart, an ordinary subsequent round, and
-merge readiness do.
+consolidated query. Which attempts must wait for the answer is the eligibility
+table in [Canonical round flow](../AGENTS.md#canonical-round-flow).
 
 ### The consolidated query
 
@@ -39,12 +39,14 @@ a later push. Retain the expected head SHA locally. Separate discovery calls are
 prohibited — additional calls are only for required context pagination or
 one-off details after the aggregate has confirmed the head.
 
-### Four traps, each paid for once
+### Four traps in the result
 
-- **Green CI does not imply mergeable.** #4032 reported successful checks while
-  GitHub reported `CONFLICTING`/`DIRTY`.
+- **Green CI does not imply mergeable.** The two are independent; a PR can
+  report every check successful while GitHub reports `CONFLICTING`/`DIRTY`.
+  Read mergeability from the mergeability fields, never inferred from checks.
 - **`mergeStateStatus` is not check state.** It is a composite, and it reports
-  `CLEAN` for a PR with no checks at all (#3706).
+  `CLEAN` for a PR with no checks at all — so `CLEAN` alone never establishes
+  that anything ran.
 - **A missing `ci-required` is inconclusive**, not green: the aggregate may not
   have registered yet. No PR is green until its current-head `ci-required` has
   completed with a `SUCCESS` conclusion.
@@ -76,7 +78,7 @@ detects conflicts early.
 
 | First check says | Do this |
 | --- | --- |
-| `CONFLICTING` | Integrate the effective base, resolve, push, start the conflict-recovery round if its number is authorized, and schedule a new five-minute check. Do not wait for CI. |
+| `CONFLICTING` | Apply the conflict transition in [Canonical round flow](../AGENTS.md#canonical-round-flow), then schedule a new five-minute check. |
 | `UNKNOWN`, CI green | Use the REST fallback above. |
 | `UNKNOWN`, CI pending or missing | Follow up at 10 minutes plus jitter for documentation-only, or at the 35-minute mark otherwise. |
 | `MERGEABLE`, documentation-only | Treat it as the expected CI completion check. If CI is unexpectedly pending, wait 10 minutes plus jitter. |
@@ -154,17 +156,9 @@ include more detail when the findings or fixes warrant it.
 
 ## Carry-forward after clean reviews
 
-This is the sole default path that integrates the base without opening another
-round. `AGENTS.md` states the rule; this is the procedure.
-
-It applies when a PR targeting `main` — including the bottom slice of a stack —
-has a review-clean required review at the current head and `origin/main` has
-since moved. Evaluate from the latest review-clean result: an earlier finding
-that was fixed and then reviewed clean does not disqualify it.
-
-It does **not** apply, and the head must be reviewed normally, when a finding
-remains unresolved or the head changed after that review-clean result because of
-an author change, conflict resolution, or restack.
+[Clean reviews are not spent by main
+moving](../AGENTS.md#clean-reviews-are-not-spent-by-main-moving) states when this
+path applies and when it does not. This is the procedure once it does.
 
 1. **Detect movement.** Compare the candidate's recorded base tip with the live
    tip in `baseRef.target.oid`. `baseRefOid` is the base commit recorded for the
@@ -182,17 +176,9 @@ an author change, conflict resolution, or restack.
    If the live tip moves before integration, analyze the additional range and
    obtain renewed approval.
 5. **If interacting**, report that carry-forward is unavailable and keep the
-   reviewed head. The PR is not merge-ready: do not post `Ready to merge`. Ask
-   whether to make a workflow adjustment that integrates, re-validates, and
-   re-reviews the replacement head, or to leave the PR blocked.
+   reviewed head. Ask whether to make a workflow adjustment that integrates,
+   re-validates, and re-reviews the replacement head, or to leave the PR
+   blocked.
 
 Record the reviewed head, the old and approved new tips, the non-interaction
 analysis, and the user's decision on the PR.
-
-Carry-forward does not authorize carrying reviews across author changes,
-conflict-resolution changes, or a restack after the recorded reviewed head.
-
-This is the one place the settled-branch rule yields, and it has to, or the
-budget is unbounded: on a busy `main`, a round takes longer than the interval
-between commits, so integrate-and-re-review by reflex never converges. A pair of
-clean reviews is a result. Unrelated commits landing behind it do not retract it.

--- a/docs/adversarial-review.md
+++ b/docs/adversarial-review.md
@@ -21,17 +21,29 @@ eligibility table in [Canonical round flow](../AGENTS.md#canonical-round-flow).
 Default to REST. Reach for GraphQL when its capability is worth a point.
 
 The two draw on separate hourly limits, so spending one does not touch the
-other:
+other. Checking is free: the `rate_limit` endpoint is not itself rate limited,
+verified by three consecutive calls leaving both counters unchanged.
 
 ```bash
-gh api rate_limit --jq '.resources|{graphql,core}'
+gh api rate_limit --jq '.resources|to_entries[]
+  |select(.key=="core" or .key=="graphql")
+  |"\(.key)\tused=\(.value.used)/\(.value.limit)\treset=\(.value.reset|todate)"'
 ```
 
-Measured an hour apart, in two different rate windows: GraphQL sat at 4,077 and
-then 4,287 of 5,000 consumed, once falling 55 points across 45 seconds in which
-this session issued no query at all. REST core held at 6 of 5,000 throughout.
-Concurrent agents share these buckets, and GraphQL is persistently the contended
-one.
+```text
+core     used=10/5000     reset=2026-08-21T22:55:53Z
+graphql  used=335/5000    reset=2026-08-21T23:12:28Z
+```
+
+Read the reset, not just the remaining count. That sample looks like GraphQL has
+plenty left, but it was taken three minutes into a fresh window. Concurrent
+agents were burning roughly 77 points per minute, which projects to about 4,600
+of the 5,000 before it resets — consistent with two earlier readings that caught
+the same window late, at 4,077 and 4,287 consumed. REST core stayed at single
+digits throughout.
+
+So GraphQL is reliably contended and REST reliably is not, but a spot check
+early in a window will tell you the opposite.
 
 The cost models differ in the way that decides the rule. A REST call costs one
 request whatever it returns, so a wide question costs a call per object. A

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -246,15 +246,10 @@ path applies and when it does not. This is the procedure once it does.
    textual merge would resolve silently but wrongly. Say plainly when nothing in
    the range interacts — that is the common case and the most useful thing you
    can report.
-4. **If non-interacting and the user approves**, integrate that exact analyzed
-   tip by SHA, not a moving branch ref. Re-run the claimed validation and
-   current-head CI, and carry the clean reviews forward without another round.
-   If the live tip moves before integration, analyze the additional range and
-   obtain renewed approval.
-5. **If interacting**, report that carry-forward is unavailable and keep the
-   reviewed head. Ask whether to make a workflow adjustment that integrates,
-   re-validates, and re-reviews the replacement head, or to leave the PR
-   blocked.
+4. **If the user approves**, integrate that exact analyzed tip by SHA, not a
+   moving branch ref. Re-run the claimed validation and current-head CI.
+5. **If not**, keep the reviewed head and follow the rule's interacting-range
+   branch.
 
 Record the reviewed head, the old and approved new tips, the non-interaction
 analysis, and the user's decision on the PR.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -249,8 +249,8 @@ path applies and when it does not. This is the procedure once it does.
 4. **Execute the rule's decision.** Exactly one of its outcomes runs here: when
    it authorizes carry-forward, integrate that exact analyzed tip by SHA, not a
    moving branch ref, and re-run the claimed validation and current-head CI.
-   Every other outcome — declined, interacting, or that re-run failing — keeps
-   the reviewed head and is resolved by the rule, not by this document.
+   Every other outcome — declined, interacting, or that re-run failing — returns
+   to the rule for its terminal action, which this document does not restate.
 
-Record the reviewed head, the old and approved new tips, the non-interaction
-analysis, and the user's decision on the PR.
+For an approved carry-forward, record the reviewed head, the old and approved
+new tips, the non-interaction analysis, and the user's decision on the PR.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -253,3 +253,11 @@ path applies and when it does not. This is the procedure once it does.
 
 Record the reviewed head, the old and approved new tips, the non-interaction
 analysis, and the user's decision on the PR.
+
+Two things the numbered steps do not say. **Repeat this whenever the base moves
+again** — a carried-forward head is review-clean, so a later move re-enters at
+step 1, and each pass needs its own analysis and its own approval. And **a
+failure in step 4's validation or CI ends the candidate**: it is a current-head
+merge-path failure, so the reviews do not carry, the fix is an author change,
+and the replacement head owes a normal round. Carry-forward transfers a clean
+result across an integration; it does not survive that integration going wrong.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -1,10 +1,10 @@
-# Adversarial review mechanics
+# Round orchestration
 
 `AGENTS.md` owns the binding rules for adversarial review: what a candidate is,
 when a round may start, what makes a review review-clean, and when to stop. This
-document owns the mechanics those rules depend on — how to query PR status, how
-to dispatch and reconcile a round, and the carry-forward procedure after clean
-reviews.
+document owns the operational side — how to find out where the round stands, how
+to dispatch and reconcile it, and what to do when the base moves under a clean
+result.
 
 Read [Adversarial review](../AGENTS.md#adversarial-review) first. This document
 states no rules of its own: where it needs a condition, it cites the rule rather

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -246,10 +246,11 @@ path applies and when it does not. This is the procedure once it does.
    textual merge would resolve silently but wrongly. Say plainly when nothing in
    the range interacts — that is the common case and the most useful thing you
    can report.
-4. **If the user approves**, integrate that exact analyzed tip by SHA, not a
-   moving branch ref. Re-run the claimed validation and current-head CI.
-5. **If approval is declined**, keep the reviewed head. If the range interacts,
-   additionally follow the rule's interacting-range branch.
+4. **Execute the rule's decision.** Exactly one of its outcomes runs here: when
+   it authorizes carry-forward, integrate that exact analyzed tip by SHA, not a
+   moving branch ref, and re-run the claimed validation and current-head CI.
+   Every other outcome — declined, interacting, or that re-run failing — keeps
+   the reviewed head and is resolved by the rule, not by this document.
 
 Record the reviewed head, the old and approved new tips, the non-interaction
 analysis, and the user's decision on the PR.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -248,8 +248,8 @@ path applies and when it does not. This is the procedure once it does.
    can report.
 4. **If the user approves**, integrate that exact analyzed tip by SHA, not a
    moving branch ref. Re-run the claimed validation and current-head CI.
-5. **If not**, keep the reviewed head and follow the rule's interacting-range
-   branch.
+5. **If approval is declined**, keep the reviewed head. If the range interacts,
+   additionally follow the rule's interacting-range branch.
 
 Record the reviewed head, the old and approved new tips, the non-interaction
 analysis, and the user's decision on the PR.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -7,8 +7,11 @@ to dispatch and reconcile it, and what to do when the base moves under a clean
 result.
 
 Read [Adversarial review](../AGENTS.md#adversarial-review) first. This document
-states no rules of its own: where it needs a condition, it cites the rule rather
-than restating it, so the two cannot drift apart.
+owns procedure, never round state: it decides no question of eligibility,
+recovery, completion, or carry-forward, and where it needs one of those
+conditions it cites the rule rather than restating it, so the two cannot drift
+apart. Its own imperatives — which API to spend, how to set up a reviewer, what
+the report looks like — are the mechanics it exists to hold.
 
 ## Status discovery
 
@@ -21,8 +24,10 @@ eligibility table in [Canonical round flow](../AGENTS.md#canonical-round-flow).
 Default to REST. Reach for GraphQL when its capability is worth a point.
 
 The two draw on separate hourly limits, so spending one does not touch the
-other. Checking is free: the `rate_limit` endpoint is not itself rate limited,
-verified by three consecutive calls leaving both counters unchanged.
+other. Checking is cheap: `rate_limit` does not consume the `core` or `graphql`
+quota it reports, verified by three consecutive calls leaving both counters
+unchanged. It is not unlimited — GitHub's secondary rate limits still apply — so
+read it when you need it, not in a loop.
 
 ```bash
 gh api rate_limit --jq '.resources|to_entries[]
@@ -94,11 +99,8 @@ concluding that it is missing.
 
 ### Reading either result
 
-Confirm that the returned head is the pushed head, the PR is not a draft,
-mergeability is positive, and the current head's `ci-required` completed with a
-`SUCCESS` conclusion. Treat `mergeStateStatus` `BLOCKED` and `DRAFT` — or
-`mergeable_state` `blocked` and `draft` — as independent readiness blockers:
-clear the blocker before posting `Ready to merge`.
+Confirm the readiness conditions in [before merge, the PR is mergeable and
+green](../AGENTS.md#forming-a-candidate) against this result.
 
 Every status check re-reads the head and compares it. A run or check identifier
 is pinned to one commit and cannot detect a later push, so retain the expected
@@ -143,8 +145,9 @@ detects conflicts early.
 
 | First check says | Do this |
 | --- | --- |
-| `ci-required` failed or was cancelled | Stop polling and apply the matching [recovery transition](../AGENTS.md#recovery-transitions): a failure needing an author change supersedes the attempt, while a cancelled or evidenced-transient one keeps the head and re-runs the check. A settled red result is an answer, not something to wait out. |
+| `ci-required` failed or was cancelled | Stop polling. Classify it and apply the applicable [recovery transition](../AGENTS.md#recovery-transitions). A settled red result is an answer, not something to wait out. |
 | `CONFLICTING` | Apply the conflict transition in [Canonical round flow](../AGENTS.md#canonical-round-flow), then schedule a new five-minute check. |
+| `MERGEABLE`, `ci-required` green at this head | **Done. Stop polling** and proceed to whatever waited on the answer. |
 | `UNKNOWN`, CI green | Ask REST, which triggers the computation; see [resolving `UNKNOWN`](#resolving-unknown). |
 | `UNKNOWN`, CI pending or missing | Follow up at 10 minutes plus jitter for documentation-only, or at the 35-minute mark otherwise. |
 | `MERGEABLE`, documentation-only | Treat it as the expected CI completion check. If CI is unexpectedly pending, wait 10 minutes plus jitter. |
@@ -152,7 +155,9 @@ detects conflicts early.
 
 Read the table top-down: the first matching row wins. A failed or cancelled
 check outranks every mergeability value, because `MERGEABLE` describes the merge
-path and never means green.
+path and never means green. The green row is the exit: every other row schedules
+another check, so polling stops only by reaching it or by leaving for a recovery
+transition.
 
 If both mergeability and CI remain unresolved, keep at least 10 minutes plus
 small random jitter between status checks. Switch to the five-minute cadence
@@ -190,8 +195,7 @@ so reproduce the finding and measure it before accepting its severity.
 
 Reconcile the reviews publicly on the PR: attribute findings, state what was
 verified or dismissed, and link resolution commits or explain explicit
-non-actions. Address actionable findings only after the locked-head reviews
-finish.
+non-actions.
 
 When a replacement candidate is required, say so on the PR and name the base tip
 and merge commit, so the next review reads as a confirmation rather than an
@@ -199,11 +203,12 @@ unexplained second full pass.
 
 ### The round report
 
-After every completed round and before starting the next one, emit this report as
-the assistant's visible user-facing response in the terminal, filling every field
-and choosing exactly one feedback classification. Do not emit it through a shell
-command such as `printf`, leave it only in tool output, collapse it behind a
-tool-call summary, or replace it with a shorter completion summary:
+After every [completed round](../AGENTS.md#canonical-round-flow) and before
+starting the next one, emit this report as the assistant's visible user-facing
+response in the terminal, filling every field and choosing exactly one feedback
+classification. Do not emit it through a shell command such as `printf`, leave
+it only in tool output, collapse it behind a tool-call summary, or replace it
+with a shorter completion summary:
 
 ```text
 Round <n> is complete for PR <number>.
@@ -253,11 +258,3 @@ path applies and when it does not. This is the procedure once it does.
 
 Record the reviewed head, the old and approved new tips, the non-interaction
 analysis, and the user's decision on the PR.
-
-Two things the numbered steps do not say. **Repeat this whenever the base moves
-again** — a carried-forward head is review-clean, so a later move re-enters at
-step 1, and each pass needs its own analysis and its own approval. And **a
-failure in step 4's validation or CI ends the candidate**: it is a current-head
-merge-path failure, so the reviews do not carry, the fix is an author change,
-and the replacement head owes a normal round. Carry-forward transfers a clean
-result across an integration; it does not survive that integration going wrong.


### PR DESCRIPTION
Documentation only. `AGENTS.md` plus a new `docs/round-orchestration.md`.

## Why

The adversarial-review section was 431 lines — **45% of `AGENTS.md`**. Length
was not the real problem; shape was. Binding invariants, operational recipes,
and rationale sat interleaved at the same level, so neither reading worked well:
scanning for *what must be true*, the recipes are noise; executing a recipe, the
invariants are.

Two failures in a single session (PR #4500, five review rounds) traced to that:

- **The base re-integration rule was missed twice.** "If … an author change or
  review finding moves the head, end that candidate and integrate the
  then-current effective base" is a subordinate clause in the middle of a bullet
  nominally about something else. Two review-driven head moves went without
  integrating `main`.
- **The readiness chain was read as a choice.** "A fix-producing round is not
  review-clean" and "do not mark ready until review-clean at the current head"
  are three passages apart, so the conclusion got reconstructed as a judgment
  call instead of read as a requirement.

The one rule applied correctly all session was the round eligibility **table**.
Both misses were prose. That is the signal this PR acts on.

## One defect class, found seven times

Every subsequent review of this PR found the same shape: **a rule that existed
but was unreachable from the decision point where it was needed.** None was a
missing rule. Each fix moved a rule to where the question gets asked.

| Decision point | What an agent would have done |
| --- | --- |
| Fixing a review finding | Not integrated the base — the rule was a subordinate clause |
| Deciding to stop reviewing | Treated a requirement as a judgment call — three passages apart |
| CI goes red | Matched **no row** in the polling table, then fallen into rows advising a longer wait for a finished check |
| Round in flight, base moves | Followed a blanket "do not refetch" that forbade the second integrate a slow fix requires |
| Checking PR status | Spent a scarce GraphQL point where REST was free, guided by a rule written when they looked like one budget |
| Reviews clean, main moved | Had no way to reach merge — carry-forward produced a head no reviewer saw, which merge readiness forbids |

The last one is the sharpest: read literally, the path whose entire purpose is
reaching merge without another round **terminated in a permanently unmergeable
PR**. The transfer of review-clean status across an approved carry-forward was
always the intent and was never written down.

## What changed

**Structure.** The section opens with binding invariants, then a numbered round
cycle with the head-lock boundaries marked, then review-clean and its
consequences, then recovery transitions. The round cycle exists because the
invariants alone never said *when* fixes happen or *when the lock releases*.

**Two integrations per round, deliberately.** Integrate → fix → validate →
integrate → validate → push. A fix can take an hour, and `main` moves. The old
text forbade the second integrate outright; that prohibition now applies only
after the push, where the unbounded loop it was written against actually lives.

**Mechanics move out**, into `docs/round-orchestration.md` — status discovery,
dispatch, reconciliation, the round report, carry-forward. Named for what it is:
`AGENTS.md` states what must be true of a round, this states how to drive one.
Half of it answers questions any PR raises, so `## PR and CI discipline` links to
it directly.

**Status discovery is now empirical.** REST and GraphQL are separate hourly
buckets; `gh api rate_limit` is free; a 701-node GraphQL query costs the same
single point as a 101-node one. So: REST by default, GraphQL when breadth pays
for the point. Measured, with the reasoning shown — including the trap that a
spot check early in a window reports the opposite of steady state.

## The split carries no precedence rule

The mechanics doc initially ended with *"where the two disagree, `AGENTS.md`
wins."* That line is not a safeguard, it is an admission — a precedence rule is
only needed if two documents can answer the same question differently, and if
they can, the split is drawn wrong.

Three passages were the reason it felt necessary: the doc restated which
attempts may start with CI pending, restated the conflict transition, and
restated when carry-forward applies. Each was a drift site.

The doc now states **no rules**. Where it needs a condition it cites the rule in
`AGENTS.md` rather than paraphrasing, so there is nothing to disagree about and
the precedence line is gone.

## Issue citations removed

The old text justified two rules with PR numbers — `#4032` for "green CI does
not imply mergeable", `#3706` for "`mergeStateStatus: CLEAN` is not check
state". Both PRs are merged and healthy today. An agent following either link
finds nothing wrong and concludes the rule is unfounded: **the citations argued
against their own rules.** Both traps are now stated as checkable properties of
the GitHub API. Zero `#NNNN` references remain in `AGENTS.md`.

## This did not come out shorter

`AGENTS.md` 962 → 916 lines, plus a new 263-line doc: **1,179 across two files,
up 217.** The section itself went 431 → 352.

The brief was "trim where we can," and the first commit did — the section landed
near 300. It grew back because six of the seven defects above were found *after*
that, and each fix added text. Reshaping was the win; the reduction was not
real, and the earlier version of this description overstated it.

## Validation

Markdown lint clean on both files. All cross-document anchors resolve
(scripted). No stale references to the pre-rename filename.
